### PR TITLE
Fix for Excalibur volume and duplicate

### DIFF
--- a/Marvel/Teams/X-Men/Ultimate X-Men Reading Order/[2003-2006] X-Men Era Thirteen House of X, House of M (UXRO).cbl
+++ b/Marvel/Teams/X-Men/Ultimate X-Men Reading Order/[2003-2006] X-Men Era Thirteen House of X, House of M (UXRO).cbl
@@ -291,8 +291,8 @@
 <Book Series="Excalibur" Number="10" Volume="2004" Year="2005">
 <Database Name="cv" Series="11292" Issue="101044" />
 </Book>
-<Book Series="Excalibur" Number="11" Volume="1988" Year="1989">
-<Database Name="cv" Series="4052" Issue="66342" />
+<Book Series="Excalibur" Number="11" Volume="2004" Year="2005">
+<Database Name="cv" Series="11292" Issue="101045" />
 </Book>
 <Book Series="X-Men/Fantastic Four" Number="1" Volume="2005" Year="2005">
 <Database Name="cv" Series="29576" Issue="182338" />
@@ -590,9 +590,6 @@
 </Book>
 <Book Series="Black Panther" Number="9" Volume="2005" Year="2005">
 <Database Name="cv" Series="11502" Issue="126180" />
-</Book>
-<Book Series="Excalibur" Number="11" Volume="2004" Year="2005">
-<Database Name="cv" Series="11292" Issue="101045" />
 </Book>
 <Book Series="Excalibur" Number="12" Volume="2004" Year="2005">
 <Database Name="cv" Series="11292" Issue="101046" />

--- a/Marvel/Teams/X-Men/Ultimate X-Men Reading Order/[2008-2009] X-Men Era Fifteen Manifest Destiny (UXRO).cbl
+++ b/Marvel/Teams/X-Men/Ultimate X-Men Reading Order/[2008-2009] X-Men Era Fifteen Manifest Destiny (UXRO).cbl
@@ -678,8 +678,8 @@
 <Book Series="X-Men: Legacy" Number="225" Volume="2008" Year="2009">
 <Database Name="cv" Series="20691" Issue="160536" />
 </Book>
-<Book Series="Avengers/X-Men: Utopia" Number="1" Volume="2009" Year="2009">
-<Database Name="cv" Series="30200" Issue="186229" />
+<Book Series="Dark Avengers/Uncanny X-Men: Utopia" Number="1" Volume="2009" Year="2009">
+<Database Name="cv" Series="26888" Issue="161518" />
 </Book>
 <Book Series="X-Men: Legacy" Number="226" Volume="2008" Year="2009">
 <Database Name="cv" Series="20691" Issue="163253" />


### PR DESCRIPTION
Excalibur #11 was in the list twice.  The first listing was the wrong volume.  That was changed to the correct volume and the second listing was removed.  Looking at the site, https://ultimatexmenreadingorder.com/x-men-era-thirteen-house-of-x-house-of-m-2003-2006/ it is listed to read half at one point in the list and the second half later in the list.  So per our discord discussion, I just selected the first issue.

Also removed TPB on Utopia