### PR TITLE
Remove Non-Batman Issue from Reading List

### DIFF
--- a/DC/Characters/Batman/Batman - Modern Age/[DC] Batman Modern Age - Part 03 Bat-Family Year One [1980-2010].cbl
+++ b/DC/Characters/Batman/Batman - Modern Age/[DC] Batman Modern Age - Part 03 Bat-Family Year One [1980-2010].cbl
@@ -84,20 +84,23 @@
 <Book Series="Batman: Legends of the Dark Knight" Number="163" Volume="1992" Year="2003">
 <Database Name="cv" Series="4720" Issue="150121" />
 </Book>
-<Book Series="Beware the Creeper" Number="1" Volume="2003" Year="2003">
-<Database Name="cv" Series="11225" Issue="98434" />
+<Book Series="The Creeper" Number="1" Volume="2006" Year="2006">
+<Database Name="cv" Series="18140" Issue="123608" />
 </Book>
-<Book Series="Beware the Creeper" Number="2" Volume="2003" Year="2003">
-<Database Name="cv" Series="11225" Issue="98435" />
+<Book Series="The Creeper" Number="2" Volume="2006" Year="2006">
+<Database Name="cv" Series="18140" Issue="135340" />
 </Book>
-<Book Series="Beware the Creeper" Number="3" Volume="2003" Year="2003">
-<Database Name="cv" Series="11225" Issue="98436" />
+<Book Series="The Creeper" Number="3" Volume="2006" Year="2006">
+<Database Name="cv" Series="18140" Issue="135343" />
 </Book>
-<Book Series="Beware the Creeper" Number="4" Volume="2003" Year="2003">
-<Database Name="cv" Series="11225" Issue="98437" />
+<Book Series="The Creeper" Number="4" Volume="2006" Year="2006">
+<Database Name="cv" Series="18140" Issue="135344" />
 </Book>
-<Book Series="Beware the Creeper" Number="5" Volume="2003" Year="2003">
-<Database Name="cv" Series="11225" Issue="98438" />
+<Book Series="The Creeper" Number="5" Volume="2006" Year="2006">
+<Database Name="cv" Series="18140" Issue="135345" />
+</Book>
+<Book Series="The Creeper" Number="6" Volume="2006" Year="2006">
+<Database Name="cv" Series="18140" Issue="106286" />
 </Book>
 <Book Series="Batman: Legends of the Dark Knight" Number="102" Volume="1992" Year="1998">
 <Database Name="cv" Series="4720" Issue="44536" />

--- a/DC/Characters/Batman/Batman - Modern Age/[DC] Batman Modern Age - Part 03 Bat-Family Year One [1980-2010].cbl
+++ b/DC/Characters/Batman/Batman - Modern Age/[DC] Batman Modern Age - Part 03 Bat-Family Year One [1980-2010].cbl
@@ -24,9 +24,6 @@
 <Book Series="Batman: Legends of the Dark Knight" Number="171" Volume="1992" Year="2003">
 <Database Name="cv" Series="4720" Issue="145369" />
 </Book>
-<Book Series="Hourman" Number="22" Volume="1999" Year="2001">
-<Database Name="cv" Series="6329" Issue="48240" />
-</Book>
 <Book Series="Batman: Legends of the Dark Knight" Number="85" Volume="1992" Year="1996">
 <Database Name="cv" Series="4720" Issue="42669" />
 </Book>


### PR DESCRIPTION
This list was originally based on one of TPBs (https://docs.google.com/spreadsheets/d/1p1Po1qYZajBMy9sSee8dJt2EoACT43sbNukdlVb7z9w/edit#gid=377939861), and the TPB for Batman: Irresistible contained the Hourman comic at the end.  The reason for its inclusion in that trade, however, was because of the common artist.  It doesn't include Batman, has no relevance to his world, and isn't even that useful as a standalone story as it's the beginning of a multipart.  Ironically, the NEXT issue in the Hourman series features a Batman of many centuries hence, but even that wouldn't sit well in this reading list.  I don't think this issue belongs here.