### PR TITLE
Adolescent Radioactive Black Belt Hamsters 1st run

### DIFF
--- a/Other/unsorted/Adolescent Radioactive Black Belt Hamsters (original run).cbl
+++ b/Other/unsorted/Adolescent Radioactive Black Belt Hamsters (original run).cbl
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Name>Adolescent Radioactive Black Belt Hamsters (original run)</Name>
+<NumIssues>20</NumIssues>
+<Books>
+<Book Series="Adolescent Radioactive Black Belt Hamsters" Number="1" Volume="1986" Year="1986">
+<Database Name="cv" Series="10993" Issue="95808" />
+</Book>
+<Book Series="Adolescent Radioactive Black Belt Hamsters" Number="2" Volume="1986" Year="1986">
+<Database Name="cv" Series="10993" Issue="95809" />
+</Book>
+<Book Series="Adolescent Radioactive Black Belt Hamsters" Number="3" Volume="1986" Year="1986">
+<Database Name="cv" Series="10993" Issue="95810" />
+</Book>
+<Book Series="Adolescent Radioactive Black Belt Hamsters 3-D" Number="1" Volume="1986" Year="1986">
+<Database Name="cv" Series="23849" Issue="142440" />
+</Book>
+<Book Series="Adolescent Radioactive Black Belt Hamsters 3-D" Number="2" Volume="1986" Year="1986">
+<Database Name="cv" Series="23849" Issue="142441" />
+</Book>
+<Book Series="Adolescent Radioactive Black Belt Hamsters" Number="4" Volume="1986" Year="1986">
+<Database Name="cv" Series="10993" Issue="95811" />
+</Book>
+<Book Series="Adolescent Radioactive Black Belt Hamsters 3-D" Number="3" Volume="1986" Year="1986">
+<Database Name="cv" Series="23849" Issue="142442" />
+</Book>
+<Book Series="Clint: The Hamster Triumphant" Number="1" Volume="1986" Year="1986">
+<Database Name="cv" Series="25498" Issue="150386" />
+</Book>
+<Book Series="Naive Inter-Dimensional Commando Koalas" Number="1" Volume="1986" Year="1986">
+<Database Name="cv" Series="24132" Issue="143404" />
+</Book>
+<Book Series="Adolescent Radioactive Black Belt Hamsters 3-D" Number="4" Volume="1986" Year="1986">
+<Database Name="cv" Series="23849" Issue="142443" />
+</Book>
+<Book Series="Adolescent Radioactive Black Belt Hamsters" Number="5" Volume="1986" Year="1987">
+<Database Name="cv" Series="10993" Issue="95812" />
+</Book>
+<Book Series="Clint: The Hamster Triumphant" Number="2" Volume="1986" Year="1987">
+<Database Name="cv" Series="25498" Issue="150390" />
+</Book>
+<Book Series="Adolescent Radioactive Black Belt Hamsters" Number="6" Volume="1986" Year="1987">
+<Database Name="cv" Series="10993" Issue="95813" />
+</Book>
+<Book Series="Adolescent Radioactive Black Belt Hamsters" Number="7" Volume="1986" Year="1987">
+<Database Name="cv" Series="10993" Issue="95814" />
+</Book>
+<Book Series="Adolescent Radioactive Black Belt Hamsters" Number="8" Volume="1986" Year="1987">
+<Database Name="cv" Series="10993" Issue="95815" />
+</Book>
+<Book Series="Adolescent Radioactive Black Belt Hamsters" Number="9" Volume="1986" Year="1988">
+<Database Name="cv" Series="10993" Issue="95816" />
+</Book>
+<Book Series="Adolescent Radioactive Black Belt Hamsters Massacre the Japanese Invasion" Number="1" Volume="1989" Year="1989">
+<Database Name="cv" Series="25039" Issue="147936" />
+</Book>
+<Book Series="Adolescent Radioactive Black Belt Hamsters - America the Beautiful" Number="1" Volume="1990" Year="0">
+<Database Name="cv" Series="47636" Issue="327582" />
+</Book>
+<Book Series="Adolescent Radioactive Black Belt Hamsters The Death of Bruce" Number="1" Volume="1992" Year="1992">
+<Database Name="cv" Series="139824" Issue="928575" />
+</Book>
+<Book Series="Adolescent Radioactive Black Belt Hamsters: Lost and Alone in New York" Number="1" Volume="1993" Year="0">
+<Database Name="cv" Series="83040" Issue="480902" />
+</Book>
+</Books>
+<Matchers />
+</ReadingList>


### PR DESCRIPTION
Added all existing comics that are part of the ARBBH continuity from Eclipse and Express Publications.  Source: ComicVine as this series just spans multiple titles but is a straight line.