### PR TITLE
Army of darkness/Evil Dead 2 (3 seperate PRs rolled into one)

### DIFF
--- a/Other/unsorted/Chaos! Universe 1993 - 2002.cbl
+++ b/Other/unsorted/Chaos! Universe 1993 - 2002.cbl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-<Name>Chaos! Universe 1993 - 2002</Name>
+<Name>Chaos Universe</Name>
 <NumIssues>248</NumIssues>
 <Books>
 <Book Series="Evil Ernie" Number="1" Volume="1991" Year="1991">
@@ -36,13 +36,13 @@
 <Book Series="Evil Ernie: Revenge" Number="1" Volume="1994" Year="1994">
 <Database Name="cv" Series="20018" Issue="119543" />
 </Book>
-<Book Series="Evil Ernie: Revenge" Number="2" Volume="1995" Year="1994">
+<Book Series="Evil Ernie: Revenge" Number="2" Volume="1994" Year="1994">
 <Database Name="cv" Series="20018" Issue="127176" />
 </Book>
-<Book Series="Evil Ernie: Revenge" Number="3" Volume="1995" Year="1995">
+<Book Series="Evil Ernie: Revenge" Number="3" Volume="1994" Year="1995">
 <Database Name="cv" Series="20018" Issue="127178" />
 </Book>
-<Book Series="Evil Ernie: Revenge" Number="4" Volume="1995" Year="1995">
+<Book Series="Evil Ernie: Revenge" Number="4" Volume="1994" Year="1995">
 <Database Name="cv" Series="20018" Issue="127179" />
 </Book>
 <Book Series="Lady Death" Number="1" Volume="1994" Year="1994">

--- a/Other/unsorted/Dynamite/Dynamite Army of Darkness (First Continuity).cbl
+++ b/Other/unsorted/Dynamite/Dynamite Army of Darkness (First Continuity).cbl
@@ -1,0 +1,353 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Name>Dynamite Army of Darkness (First Continuity)</Name>
+<NumIssues>115</NumIssues>
+<Books>
+<Book Series="Army of Darkness: Ashes 2 Ashes" Number="1" Volume="2004" Year="2004">
+<Database Name="cv" Series="18853" Issue="111459" />
+</Book>
+<Book Series="Army of Darkness: Ashes 2 Ashes" Number="2" Volume="2004" Year="2004">
+<Database Name="cv" Series="18853" Issue="111526" />
+</Book>
+<Book Series="Army of Darkness: Ashes 2 Ashes" Number="3" Volume="2004" Year="2004">
+<Database Name="cv" Series="18853" Issue="111527" />
+</Book>
+<Book Series="Army of Darkness: Ashes 2 Ashes" Number="4" Volume="2004" Year="2004">
+<Database Name="cv" Series="18853" Issue="111528" />
+</Book>
+<Book Series="Army of Darkness: Shop Till You Drop Dead" Number="1" Volume="2005" Year="2005">
+<Database Name="cv" Series="18851" Issue="111457" />
+</Book>
+<Book Series="Army of Darkness: Shop Till You Drop Dead" Number="2" Volume="2005" Year="2005">
+<Database Name="cv" Series="18851" Issue="111529" />
+</Book>
+<Book Series="Army of Darkness: Shop Till You Drop Dead" Number="3" Volume="2005" Year="2005">
+<Database Name="cv" Series="18851" Issue="111530" />
+</Book>
+<Book Series="Army of Darkness: Shop Till You Drop Dead" Number="4" Volume="2005" Year="2005">
+<Database Name="cv" Series="18851" Issue="111531" />
+</Book>
+<Book Series="Tales of Army of Darkness" Number="1" Volume="2006" Year="2006">
+<Database Name="cv" Series="18850" Issue="111456" />
+</Book>
+<Book Series="Army of Darkness vs. Re-Animator" Number="1" Volume="2005" Year="2005">
+<Database Name="cv" Series="18852" Issue="111458" />
+</Book>
+<Book Series="Army of Darkness vs. Re-Animator" Number="2" Volume="2005" Year="2005">
+<Database Name="cv" Series="18852" Issue="111523" />
+</Book>
+<Book Series="Army of Darkness vs. Re-Animator" Number="3" Volume="2005" Year="2005">
+<Database Name="cv" Series="18852" Issue="111524" />
+</Book>
+<Book Series="Army of Darkness vs. Re-Animator" Number="4" Volume="2005" Year="2006">
+<Database Name="cv" Series="18852" Issue="111525" />
+</Book>
+<Book Series="Army of Darkness" Number="5" Volume="2006" Year="2006">
+<Database Name="cv" Series="18863" Issue="111534" />
+</Book>
+<Book Series="Army of Darkness" Number="6" Volume="2006" Year="2006">
+<Database Name="cv" Series="18863" Issue="111539" />
+</Book>
+<Book Series="Army of Darkness" Number="7" Volume="2006" Year="2006">
+<Database Name="cv" Series="18863" Issue="111540" />
+</Book>
+<Book Series="Army of Darkness" Number="8" Volume="2006" Year="2006">
+<Database Name="cv" Series="18863" Issue="111541" />
+</Book>
+<Book Series="Army of Darkness" Number="9" Volume="2006" Year="2006">
+<Database Name="cv" Series="18863" Issue="111542" />
+</Book>
+<Book Series="Army of Darkness" Number="10" Volume="2006" Year="2006">
+<Database Name="cv" Series="18863" Issue="111543" />
+</Book>
+<Book Series="Army of Darkness" Number="11" Volume="2006" Year="2007">
+<Database Name="cv" Series="18863" Issue="111544" />
+</Book>
+<Book Series="Army of Darkness" Number="12" Volume="2006" Year="2006">
+<Database Name="cv" Series="18863" Issue="111545" />
+</Book>
+<Book Series="Army of Darkness" Number="13" Volume="2006" Year="2007">
+<Database Name="cv" Series="18863" Issue="111546" />
+</Book>
+<Book Series="Marvel Zombies/Army of Darkness" Number="1" Volume="2007" Year="2007">
+<Database Name="cv" Series="18236" Issue="106791" />
+</Book>
+<Book Series="Marvel Zombies/Army of Darkness" Number="2" Volume="2007" Year="2007">
+<Database Name="cv" Series="18236" Issue="107997" />
+</Book>
+<Book Series="Marvel Zombies/Army of Darkness" Number="3" Volume="2007" Year="2007">
+<Database Name="cv" Series="18236" Issue="108930" />
+</Book>
+<Book Series="Marvel Zombies/Army of Darkness" Number="4" Volume="2007" Year="2007">
+<Database Name="cv" Series="18236" Issue="110269" />
+</Book>
+<Book Series="Marvel Zombies/Army of Darkness" Number="5" Volume="2007" Year="2007">
+<Database Name="cv" Series="18236" Issue="111498" />
+</Book>
+<Book Series="Marvel Zombies: Dead Days" Number="1" Volume="2007" Year="2007">
+<Database Name="cv" Series="18558" Issue="109272" />
+</Book>
+<Book Series="Army of Darkness" Number="1" Volume="2007" Year="2007">
+<Database Name="cv" Series="19006" Issue="113067" />
+</Book>
+<Book Series="Army of Darkness" Number="2" Volume="2007" Year="2007">
+<Database Name="cv" Series="19006" Issue="115023" />
+</Book>
+<Book Series="Army of Darkness" Number="3" Volume="2007" Year="2007">
+<Database Name="cv" Series="19006" Issue="116340" />
+</Book>
+<Book Series="Army of Darkness" Number="4" Volume="2007" Year="2007">
+<Database Name="cv" Series="19006" Issue="118649" />
+</Book>
+<Book Series="Army of Darkness" Number="5" Volume="2007" Year="2008">
+<Database Name="cv" Series="19006" Issue="121069" />
+</Book>
+<Book Series="Army of Darkness" Number="6" Volume="2007" Year="2008">
+<Database Name="cv" Series="19006" Issue="122413" />
+</Book>
+<Book Series="Army of Darkness" Number="7" Volume="2007" Year="2008">
+<Database Name="cv" Series="19006" Issue="132618" />
+</Book>
+<Book Series="Army of Darkness" Number="8" Volume="2007" Year="2008">
+<Database Name="cv" Series="19006" Issue="132619" />
+</Book>
+<Book Series="Army of Darkness" Number="9" Volume="2007" Year="2008">
+<Database Name="cv" Series="19006" Issue="357158" />
+</Book>
+<Book Series="Army of Darkness" Number="10" Volume="2007" Year="2008">
+<Database Name="cv" Series="19006" Issue="132838" />
+</Book>
+<Book Series="Army of Darkness" Number="11" Volume="2007" Year="2008">
+<Database Name="cv" Series="19006" Issue="357031" />
+</Book>
+<Book Series="Army of Darkness" Number="12" Volume="2007" Year="2008">
+<Database Name="cv" Series="19006" Issue="137435" />
+</Book>
+<Book Series="Army of Darkness" Number="13" Volume="2007" Year="2008">
+<Database Name="cv" Series="19006" Issue="139712" />
+</Book>
+<Book Series="Freddy vs Jason vs Ash (of Army of Darkness)" Number="1" Volume="2007" Year="2007">
+<Database Name="cv" Series="19563" Issue="116983" />
+</Book>
+<Book Series="Freddy vs Jason vs Ash (of Army of Darkness)" Number="2" Volume="2007" Year="2007">
+<Database Name="cv" Series="19563" Issue="118673" />
+</Book>
+<Book Series="Freddy vs Jason vs Ash (of Army of Darkness)" Number="3" Volume="2007" Year="2007">
+<Database Name="cv" Series="19563" Issue="121072" />
+</Book>
+<Book Series="Freddy vs Jason vs Ash (of Army of Darkness)" Number="4" Volume="2007" Year="2008">
+<Database Name="cv" Series="19563" Issue="123325" />
+</Book>
+<Book Series="Freddy vs Jason vs Ash (of Army of Darkness)" Number="5" Volume="2007" Year="2008">
+<Database Name="cv" Series="19563" Issue="124441" />
+</Book>
+<Book Series="Freddy vs Jason vs Ash (of Army of Darkness)" Number="6" Volume="2007" Year="2008">
+<Database Name="cv" Series="19563" Issue="126107" />
+</Book>
+<Book Series="Army of Darkness: Ash's Christmas Horror" Number="1" Volume="2008" Year="2008">
+<Database Name="cv" Series="25242" Issue="149013" />
+</Book>
+<Book Series="Freddy vs Jason vs Ash (of Army of Darkness): The Nightmare Warriors" Number="1" Volume="2009" Year="2009">
+<Database Name="cv" Series="26955" Issue="162362" />
+</Book>
+<Book Series="Freddy vs Jason vs Ash (of Army of Darkness): The Nightmare Warriors" Number="2" Volume="2009" Year="2009">
+<Database Name="cv" Series="26955" Issue="164928" />
+</Book>
+<Book Series="Freddy vs Jason vs Ash (of Army of Darkness): The Nightmare Warriors" Number="3" Volume="2009" Year="2009">
+<Database Name="cv" Series="26955" Issue="170609" />
+</Book>
+<Book Series="Freddy vs Jason vs Ash (of Army of Darkness): The Nightmare Warriors" Number="4" Volume="2009" Year="2009">
+<Database Name="cv" Series="26955" Issue="173433" />
+</Book>
+<Book Series="Freddy vs Jason vs Ash (of Army of Darkness): The Nightmare Warriors" Number="5" Volume="2009" Year="2009">
+<Database Name="cv" Series="26955" Issue="179938" />
+</Book>
+<Book Series="Freddy vs Jason vs Ash (of Army of Darkness): The Nightmare Warriors" Number="6" Volume="2009" Year="2010">
+<Database Name="cv" Series="26955" Issue="189590" />
+</Book>
+<Book Series="Army of Darkness" Number="14" Volume="2007" Year="2008">
+<Database Name="cv" Series="19006" Issue="141459" />
+</Book>
+<Book Series="Army of Darkness" Number="15" Volume="2007" Year="2008">
+<Database Name="cv" Series="19006" Issue="147891" />
+</Book>
+<Book Series="Army of Darkness" Number="16" Volume="2007" Year="2009">
+<Database Name="cv" Series="19006" Issue="151237" />
+</Book>
+<Book Series="Army of Darkness" Number="17" Volume="2007" Year="2009">
+<Database Name="cv" Series="19006" Issue="155409" />
+</Book>
+<Book Series="Army of Darkness" Number="18" Volume="2007" Year="2009">
+<Database Name="cv" Series="19006" Issue="155410" />
+</Book>
+<Book Series="Army of Darkness" Number="19" Volume="2007" Year="2009">
+<Database Name="cv" Series="19006" Issue="155338" />
+</Book>
+<Book Series="Army of Darkness" Number="20" Volume="2007" Year="2009">
+<Database Name="cv" Series="19006" Issue="156647" />
+</Book>
+<Book Series="Army of Darkness" Number="21" Volume="2007" Year="2009">
+<Database Name="cv" Series="19006" Issue="162548" />
+</Book>
+<Book Series="Army of Darkness" Number="22" Volume="2007" Year="2009">
+<Database Name="cv" Series="19006" Issue="163260" />
+</Book>
+<Book Series="Army of Darkness" Number="23" Volume="2007" Year="2009">
+<Database Name="cv" Series="19006" Issue="167680" />
+</Book>
+<Book Series="Army of Darkness" Number="24" Volume="2007" Year="2009">
+<Database Name="cv" Series="19006" Issue="169398" />
+</Book>
+<Book Series="Army of Darkness" Number="25" Volume="2007" Year="2009">
+<Database Name="cv" Series="19006" Issue="173421" />
+</Book>
+<Book Series="Army of Darkness" Number="26" Volume="2007" Year="2010">
+<Database Name="cv" Series="19006" Issue="200030" />
+</Book>
+<Book Series="Army of Darkness" Number="27" Volume="2007" Year="2010">
+<Database Name="cv" Series="19006" Issue="207826" />
+</Book>
+<Book Series="Army of Darkness / Xena" Number="1" Volume="2008" Year="2008">
+<Database Name="cv" Series="21074" Issue="126361" />
+</Book>
+<Book Series="Army of Darkness / Xena" Number="2" Volume="2008" Year="2008">
+<Database Name="cv" Series="21074" Issue="128595" />
+</Book>
+<Book Series="Army of Darkness / Xena" Number="3" Volume="2008" Year="2008">
+<Database Name="cv" Series="21074" Issue="131087" />
+</Book>
+<Book Series="Army of Darkness / Xena" Number="4" Volume="2008" Year="2008">
+<Database Name="cv" Series="21074" Issue="133060" />
+</Book>
+<Book Series="Xena / Army of Darkness: What... Again?!" Number="1" Volume="2008" Year="2008">
+<Database Name="cv" Series="23618" Issue="141592" />
+</Book>
+<Book Series="Xena / Army of Darkness: What... Again?!" Number="2" Volume="2008" Year="2008">
+<Database Name="cv" Series="23618" Issue="146064" />
+</Book>
+<Book Series="Xena / Army of Darkness: What... Again?!" Number="3" Volume="2008" Year="2008">
+<Database Name="cv" Series="23618" Issue="149894" />
+</Book>
+<Book Series="Xena / Army of Darkness: What... Again?!" Number="4" Volume="2008" Year="2009">
+<Database Name="cv" Series="23618" Issue="150750" />
+</Book>
+<Book Series="Army of Darkness" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="45874" Issue="315832" />
+</Book>
+<Book Series="Army of Darkness" Number="2" Volume="2012" Year="2012">
+<Database Name="cv" Series="45874" Issue="323125" />
+</Book>
+<Book Series="Army of Darkness" Number="3" Volume="2012" Year="2012">
+<Database Name="cv" Series="45874" Issue="333574" />
+</Book>
+<Book Series="Army of Darkness" Number="4" Volume="2012" Year="2012">
+<Database Name="cv" Series="45874" Issue="336116" />
+</Book>
+<Book Series="Army of Darkness" Number="5" Volume="2012" Year="2012">
+<Database Name="cv" Series="45874" Issue="353345" />
+</Book>
+<Book Series="Army of Darkness" Number="6" Volume="2012" Year="2012">
+<Database Name="cv" Series="45874" Issue="364175" />
+</Book>
+<Book Series="Army of Darkness" Number="7" Volume="2012" Year="2012">
+<Database Name="cv" Series="45874" Issue="372406" />
+</Book>
+<Book Series="Army of Darkness" Number="8" Volume="2012" Year="2013">
+<Database Name="cv" Series="45874" Issue="378908" />
+</Book>
+<Book Series="Army of Darkness" Number="9" Volume="2012" Year="2013">
+<Database Name="cv" Series="45874" Issue="381437" />
+</Book>
+<Book Series="Army of Darkness" Number="10" Volume="2012" Year="2013">
+<Database Name="cv" Series="45874" Issue="384999" />
+</Book>
+<Book Series="Army of Darkness" Number="11" Volume="2012" Year="2013">
+<Database Name="cv" Series="45874" Issue="388581" />
+</Book>
+<Book Series="Army of Darkness" Number="12" Volume="2012" Year="2013">
+<Database Name="cv" Series="45874" Issue="395735" />
+</Book>
+<Book Series="Army of Darkness" Number="13" Volume="2012" Year="2013">
+<Database Name="cv" Series="45874" Issue="400196" />
+</Book>
+<Book Series="Prophecy" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="49537" Issue="338983" />
+</Book>
+<Book Series="Prophecy" Number="2" Volume="2012" Year="2012">
+<Database Name="cv" Series="49537" Issue="346304" />
+</Book>
+<Book Series="Prophecy" Number="3" Volume="2012" Year="2012">
+<Database Name="cv" Series="49537" Issue="353272" />
+</Book>
+<Book Series="Prophecy" Number="4" Volume="2012" Year="2012">
+<Database Name="cv" Series="49537" Issue="362239" />
+</Book>
+<Book Series="Prophecy" Number="5" Volume="2012" Year="2012">
+<Database Name="cv" Series="49537" Issue="370328" />
+</Book>
+<Book Series="Prophecy" Number="6" Volume="2012" Year="2013">
+<Database Name="cv" Series="49537" Issue="381444" />
+</Book>
+<Book Series="Prophecy" Number="7" Volume="2012" Year="2013">
+<Database Name="cv" Series="49537" Issue="385002" />
+</Book>
+<Book Series="Army of Darkness vs. Hack/Slash" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="65598" Issue="418784" />
+</Book>
+<Book Series="Army of Darkness vs. Hack/Slash" Number="2" Volume="2013" Year="2013">
+<Database Name="cv" Series="65598" Issue="424514" />
+</Book>
+<Book Series="Army of Darkness vs. Hack/Slash" Number="3" Volume="2013" Year="2013">
+<Database Name="cv" Series="65598" Issue="432306" />
+</Book>
+<Book Series="Army of Darkness vs. Hack/Slash" Number="4" Volume="2013" Year="2013">
+<Database Name="cv" Series="65598" Issue="436161" />
+</Book>
+<Book Series="Army of Darkness vs. Hack/Slash" Number="5" Volume="2013" Year="2014">
+<Database Name="cv" Series="65598" Issue="443961" />
+</Book>
+<Book Series="Army of Darkness vs. Hack/Slash" Number="6" Volume="2013" Year="2014">
+<Database Name="cv" Series="65598" Issue="446447" />
+</Book>
+<Book Series="Army of Darkness/ReAnimator" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="68524" Issue="430771" />
+</Book>
+<Book Series="Army of Darkness/Xena: Forever... And A Day" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="94600" Issue="552176" />
+</Book>
+<Book Series="Army of Darkness/Xena: Forever... And A Day" Number="2" Volume="2016" Year="2016">
+<Database Name="cv" Series="94600" Issue="556485" />
+</Book>
+<Book Series="Army of Darkness/Xena: Forever... And A Day" Number="3" Volume="2016" Year="2016">
+<Database Name="cv" Series="94600" Issue="566728" />
+</Book>
+<Book Series="Army of Darkness/Xena: Forever... And A Day" Number="4" Volume="2016" Year="2017">
+<Database Name="cv" Series="94600" Issue="575889" />
+</Book>
+<Book Series="Army of Darkness: Furious Road" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="88549" Issue="517838" />
+</Book>
+<Book Series="Army of Darkness: Furious Road" Number="2" Volume="2016" Year="2016">
+<Database Name="cv" Series="88549" Issue="523271" />
+</Book>
+<Book Series="Army of Darkness: Furious Road" Number="3" Volume="2016" Year="2016">
+<Database Name="cv" Series="88549" Issue="528527" />
+</Book>
+<Book Series="Army of Darkness: Furious Road" Number="4" Volume="2016" Year="2016">
+<Database Name="cv" Series="88549" Issue="533044" />
+</Book>
+<Book Series="Army of Darkness: Furious Road" Number="5" Volume="2016" Year="2016">
+<Database Name="cv" Series="88549" Issue="539262" />
+</Book>
+<Book Series="Army of Darkness: Furious Road" Number="6" Volume="2016" Year="2016">
+<Database Name="cv" Series="88549" Issue="543761" />
+</Book>
+<Book Series="Army of Darkness/Xena: Forever... And A Day" Number="5" Volume="2016" Year="2017">
+<Database Name="cv" Series="94600" Issue="580768" />
+</Book>
+<Book Series="Army of Darkness/Xena: Forever... And A Day" Number="6" Volume="2016" Year="2017">
+<Database Name="cv" Series="94600" Issue="588582" />
+</Book>
+</Books>
+<Matchers />
+</ReadingList>

--- a/Other/unsorted/Dynamite/Dynamite Army of Darkness Reboot.cbl
+++ b/Other/unsorted/Dynamite/Dynamite Army of Darkness Reboot.cbl
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Name>Dynamite Army of Darkness Reboot</Name>
+<NumIssues>19</NumIssues>
+<Books>
+<Book Series="Ash and The Army of Darkness" Number="25" Volume="2014" Year="2013">
+<Database Name="cv" Series="68723" Issue="431420" />
+</Book>
+<Book Series="Ash and The Army of Darkness" Number="2" Volume="2014" Year="2013">
+<Database Name="cv" Series="68723" Issue="435594" />
+</Book>
+<Book Series="Ash and The Army of Darkness" Number="3" Volume="2014" Year="2014">
+<Database Name="cv" Series="68723" Issue="441424" />
+</Book>
+<Book Series="Ash and The Army of Darkness" Number="4" Volume="2014" Year="2014">
+<Database Name="cv" Series="68723" Issue="445825" />
+</Book>
+<Book Series="Ash and the Army of Darkness Annual" Number="1" Volume="2014" Year="2014">
+<Database Name="cv" Series="72584" Issue="448983" />
+</Book>
+<Book Series="Ash and The Army of Darkness" Number="5" Volume="2014" Year="2014">
+<Database Name="cv" Series="68723" Issue="449603" />
+</Book>
+<Book Series="Ash and The Army of Darkness" Number="6" Volume="2014" Year="2014">
+<Database Name="cv" Series="68723" Issue="451097" />
+</Book>
+<Book Series="Ash and The Army of Darkness" Number="7" Volume="2014" Year="2014">
+<Database Name="cv" Series="68723" Issue="452861" />
+</Book>
+<Book Series="Ash and The Army of Darkness" Number="8" Volume="2014" Year="2014">
+<Database Name="cv" Series="68723" Issue="456035" />
+</Book>
+<Book Series="Army Of Darkness: Ash Gets Hitched" Number="1" Volume="2015" Year="2014">
+<Database Name="cv" Series="75717" Issue="459687" />
+</Book>
+<Book Series="Army Of Darkness: Ash Gets Hitched" Number="2" Volume="2015" Year="2014">
+<Database Name="cv" Series="75717" Issue="463492" />
+</Book>
+<Book Series="Army of Darkness" Number="1992.1" Volume="2014" Year="2014">
+<Database Name="cv" Series="78049" Issue="469846" />
+</Book>
+<Book Series="Army Of Darkness: Ash Gets Hitched" Number="3" Volume="2015" Year="2014">
+<Database Name="cv" Series="75717" Issue="468094" />
+</Book>
+<Book Series="Army Of Darkness: Ash Gets Hitched" Number="4" Volume="2015" Year="2014">
+<Database Name="cv" Series="75717" Issue="470438" />
+</Book>
+<Book Series="Army of Darkness" Number="1" Volume="2014" Year="2014">
+<Database Name="cv" Series="78551" Issue="471971" />
+</Book>
+<Book Series="Army of Darkness" Number="2" Volume="2014" Year="2015">
+<Database Name="cv" Series="78551" Issue="475467" />
+</Book>
+<Book Series="Army of Darkness" Number="3" Volume="2014" Year="2015">
+<Database Name="cv" Series="78551" Issue="479269" />
+</Book>
+<Book Series="Army of Darkness" Number="4" Volume="2014" Year="2015">
+<Database Name="cv" Series="78551" Issue="481619" />
+</Book>
+<Book Series="Army of Darkness" Number="5" Volume="2014" Year="2015">
+<Database Name="cv" Series="78551" Issue="484912" />
+</Book>
+</Books>
+<Matchers />
+</ReadingList>

--- a/Other/unsorted/Space Goat Evil Dead 2.cbl
+++ b/Other/unsorted/Space Goat Evil Dead 2.cbl
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Name>Space Goat Evil Dead 2</Name>
+<NumIssues>20</NumIssues>
+<Books>
+<Book Series="Evil Dead 2: Beyond Dead By Dawn" Number="1" Volume="2015" Year="2015">
+<Database Name="cv" Series="82869" Issue="493129" />
+</Book>
+<Book Series="Evil Dead 2: Beyond Dead By Dawn" Number="2" Volume="2015" Year="2015">
+<Database Name="cv" Series="82869" Issue="494430" />
+</Book>
+<Book Series="Evil Dead 2: Beyond Dead By Dawn" Number="3" Volume="2015" Year="2015">
+<Database Name="cv" Series="82869" Issue="505031" />
+</Book>
+<Book Series="Evil Dead 2: Revenge of Hitler" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="89158" Issue="521406" />
+</Book>
+<Book Series="Evil Dead 2: Revenge of Dracula" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="95010" Issue="554049" />
+</Book>
+<Book Series="Evil Dead 2: Revenge of the Martians" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="95011" Issue="554050" />
+</Book>
+<Book Series="Evil Dead 2: Revenge of Jack the Ripper" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="95218" Issue="555612" />
+</Book>
+<Book Series="Evil Dead 2: Revenge of Krampus" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="95592" Issue="557444" />
+</Book>
+<Book Series="Evil Dead 2: A Merry Deadite Christmas" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="96285" Issue="563798" />
+</Book>
+<Book Series="Evil Dead 2: Cradle of the Damned" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="87313" Issue="511025" />
+</Book>
+<Book Series="Evil Dead 2: Cradle of the Damned" Number="2" Volume="2016" Year="2016">
+<Database Name="cv" Series="87313" Issue="521405" />
+</Book>
+<Book Series="Evil Dead 2: Cradle of the Damned" Number="3" Volume="2016" Year="2016">
+<Database Name="cv" Series="87313" Issue="527232" />
+</Book>
+<Book Series="Evil Dead 2: Dark Ones Rising" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="95009" Issue="554048" />
+</Book>
+<Book Series="Evil Dead 2: Dark Ones Rising" Number="2" Volume="2016" Year="2016">
+<Database Name="cv" Series="95009" Issue="555611" />
+</Book>
+<Book Series="Evil Dead 2: Dark Ones Rising" Number="3" Volume="2016" Year="2016">
+<Database Name="cv" Series="95009" Issue="571745" />
+</Book>
+<Book Series="Evil Dead 2: Revenge of Evil Ed" Number="1" Volume="2017" Year="2017">
+<Database Name="cv" Series="99036" Issue="582618" />
+</Book>
+<Book Series="Evil Dead 2: Revenge of Evil Ed" Number="2" Volume="2017" Year="2017">
+<Database Name="cv" Series="99036" Issue="599948" />
+</Book>
+<Book Series="Evil Dead 2: Tales of the Ex-Mortis" Number="1" Volume="2015" Year="2015">
+<Database Name="cv" Series="84270" Issue="499115" />
+</Book>
+<Book Series="Evil Dead 2: Tales of the Ex-Mortis" Number="2" Volume="2015" Year="2015">
+<Database Name="cv" Series="84270" Issue="505032" />
+</Book>
+<Book Series="Evil Dead 2: Tales of the Ex-Mortis" Number="3" Volume="2015" Year="2016">
+<Database Name="cv" Series="84270" Issue="513733" />
+</Book>
+</Books>
+<Matchers />
+</ReadingList>


### PR DESCRIPTION
This spans 2004-2016 there's some overlap with the second continuity release year wise but none story-related. There's a good amount of crossover goodness. I did include 1 issue without Ash which takes place simultaneously with one of the Marvel Zombie crossovers and helps inform the events you'd just read. I kept that in release order as it really is more effective from a story standpoint that way. Next up is AoD Dynamite reboot continuity and then the Space Goat Evil Dead 2 books