### PR TITLE
Fixed X-Force 2020 series start year

### DIFF
--- a/Marvel/Events/Official/[Marvel] (2020-09) X of Swords (Official).cbl
+++ b/Marvel/Events/Official/[Marvel] (2020-09) X of Swords (Official).cbl
@@ -19,7 +19,7 @@
         <Book Series="Wolverine" Number="6" Volume="2020" Year="2020">
             <Database Name="cv" Series="125121" Issue="807579" />
         </Book>
-        <Book Series="X-Force" Number="13" Volume="2019" Year="2020">
+        <Book Series="X-Force" Number="13" Volume="2020" Year="2020">
             <Database Name="cv" Series="122668" Issue="807580" />
         </Book>
         <Book Series="Marauders" Number="13" Volume="2019" Year="2020">
@@ -58,7 +58,7 @@
         <Book Series="Wolverine" Number="7" Volume="2020" Year="2021">
             <Database Name="cv" Series="125121" Issue="817706" />
         </Book>
-        <Book Series="X-Force" Number="14" Volume="2019" Year="2021">
+        <Book Series="X-Force" Number="14" Volume="2020" Year="2021">
             <Database Name="cv" Series="122668" Issue="819097" />
         </Book>
         <Book Series="Hellions" Number="6" Volume="2020" Year="2021">

--- a/Marvel/Events/Official/[Marvel] (2021-06) Hellfire Gala (Official).cbl
+++ b/Marvel/Events/Official/[Marvel] (2021-06) Hellfire Gala (Official).cbl
@@ -7,7 +7,7 @@
         <Book Series="Marauders" Number="21" Volume="2019" Year="2021">
             <Database Name="cv" Series="122218" Issue="857597" />
         </Book>
-        <Book Series="X-Force" Number="20" Volume="2019" Year="2021">
+        <Book Series="X-Force" Number="20" Volume="2020" Year="2021">
             <Database Name="cv" Series="122668" Issue="857598" />
         </Book>
         <Book Series="Hellions" Number="12" Volume="2020" Year="2021">

--- a/Marvel/Events/Official/[Marvel] (2022-08) AXE Judgment Day (Official).cbl
+++ b/Marvel/Events/Official/[Marvel] (2022-08) AXE Judgment Day (Official).cbl
@@ -24,7 +24,7 @@
         <Book Series="A.X.E.: Death to the Mutants" Number="1" Volume="2022" Year="2022">
             <Database Name="cv" Series="144577" Issue="942722" />
         </Book>
-        <Book Series="X-Force" Number="30" Volume="2019" Year="2022">
+        <Book Series="X-Force" Number="30" Volume="2020" Year="2022">
             <Database Name="cv" Series="122668" Issue="942706" />
         </Book>
         <Book Series="X-Men" Number="13" Volume="2021" Year="2022">
@@ -36,7 +36,7 @@
         <Book Series="Wolverine" Number="24" Volume="2020" Year="2022">
             <Database Name="cv" Series="125121" Issue="946208" />
         </Book>
-        <Book Series="X-Force" Number="31" Volume="2019" Year="2022">
+        <Book Series="X-Force" Number="31" Volume="2020" Year="2022">
             <Database Name="cv" Series="122668" Issue="944669" />
         </Book>
         <Book Series="X-Men" Number="14" Volume="2021" Year="2022">
@@ -57,7 +57,7 @@
         <Book Series="A.X.E.: Judgment Day" Number="4" Volume="2022" Year="2022">
             <Database Name="cv" Series="144123" Issue="946709" />
         </Book>
-        <Book Series="X-Force" Number="32" Volume="2019" Year="2022">
+        <Book Series="X-Force" Number="32" Volume="2020" Year="2022">
             <Database Name="cv" Series="122668" Issue="950383" />
         </Book>
         <Book Series="X-Men: Red" Number="6" Volume="2022" Year="2022">
@@ -99,7 +99,7 @@
         <Book Series="Immortal X-Men" Number="7" Volume="2022" Year="2022">
             <Database Name="cv" Series="142053" Issue="950483" />
         </Book>
-        <Book Series="X-Force" Number="33" Volume="2019" Year="2022">
+        <Book Series="X-Force" Number="33" Volume="2020" Year="2022">
             <Database Name="cv" Series="122668" Issue="951451" />
         </Book>
         <Book Series="X-Men: Red" Number="7" Volume="2022" Year="2022">

--- a/Marvel/Master Reading Order/Marvel Guides/2018-2021 Fresh Start/Part 09 Dawn of X/[Marvel] 2018-2021 Part 9.2 Brave New World (MG).cbl
+++ b/Marvel/Master Reading Order/Marvel Guides/2018-2021 Fresh Start/Part 09 Dawn of X/[Marvel] 2018-2021 Part 9.2 Brave New World (MG).cbl
@@ -31,7 +31,7 @@
         <Book Series="New Mutants" Number="1" Volume="2019" Year="2020">
             <Database Name="cv" Series="122666" Issue="726210" />
         </Book>
-        <Book Series="X-Force" Number="1" Volume="2019" Year="2020">
+        <Book Series="X-Force" Number="1" Volume="2020" Year="2020">
             <Database Name="cv" Series="122668" Issue="726217" />
         </Book>
         <Book Series="Marauders" Number="2" Volume="2019" Year="2020">
@@ -55,10 +55,10 @@
         <Book Series="Fallen Angels" Number="4" Volume="2019" Year="2020">
             <Database Name="cv" Series="122814" Issue="731511" />
         </Book>
-        <Book Series="X-Force" Number="2" Volume="2019" Year="2020">
+        <Book Series="X-Force" Number="2" Volume="2020" Year="2020">
             <Database Name="cv" Series="122668" Issue="728984" />
         </Book>
-        <Book Series="X-Force" Number="3" Volume="2019" Year="2020">
+        <Book Series="X-Force" Number="3" Volume="2020" Year="2020">
             <Database Name="cv" Series="122668" Issue="730351" />
         </Book>
         <Book Series="New Mutants" Number="2" Volume="2019" Year="2020">
@@ -124,25 +124,25 @@
         <Book Series="New Mutants" Number="11" Volume="2019" Year="2020">
             <Database Name="cv" Series="122666" Issue="781436" />
         </Book>
-        <Book Series="X-Force" Number="4" Volume="2019" Year="2020">
+        <Book Series="X-Force" Number="4" Volume="2020" Year="2020">
             <Database Name="cv" Series="122668" Issue="731530" />
         </Book>
-        <Book Series="X-Force" Number="5" Volume="2019" Year="2020">
+        <Book Series="X-Force" Number="5" Volume="2020" Year="2020">
             <Database Name="cv" Series="122668" Issue="732895" />
         </Book>
-        <Book Series="X-Force" Number="6" Volume="2019" Year="2020">
+        <Book Series="X-Force" Number="6" Volume="2020" Year="2020">
             <Database Name="cv" Series="122668" Issue="735534" />
         </Book>
-        <Book Series="X-Force" Number="7" Volume="2019" Year="2020">
+        <Book Series="X-Force" Number="7" Volume="2020" Year="2020">
             <Database Name="cv" Series="122668" Issue="737172" />
         </Book>
-        <Book Series="X-Force" Number="8" Volume="2019" Year="2020">
+        <Book Series="X-Force" Number="8" Volume="2020" Year="2020">
             <Database Name="cv" Series="122668" Issue="738622" />
         </Book>
-        <Book Series="X-Force" Number="9" Volume="2019" Year="2020">
+        <Book Series="X-Force" Number="9" Volume="2020" Year="2020">
             <Database Name="cv" Series="122668" Issue="742380" />
         </Book>
-        <Book Series="X-Force" Number="10" Volume="2019" Year="2020">
+        <Book Series="X-Force" Number="10" Volume="2020" Year="2020">
             <Database Name="cv" Series="122668" Issue="775013" />
         </Book>
         <Book Series="X-Men" Number="5" Volume="2019" Year="2020">

--- a/Marvel/Master Reading Order/Marvel Guides/2018-2021 Fresh Start/Part 12 X of Swords/[Marvel] 2018-2021 Part 12.1 X of Swords (MG).cbl
+++ b/Marvel/Master Reading Order/Marvel Guides/2018-2021 Fresh Start/Part 12 X of Swords/[Marvel] 2018-2021 Part 12.1 X of Swords (MG).cbl
@@ -25,10 +25,10 @@
         <Book Series="X-Men" Number="12" Volume="2019" Year="2020">
             <Database Name="cv" Series="122077" Issue="799956" />
         </Book>
-        <Book Series="X-Force" Number="11" Volume="2019" Year="2020">
+        <Book Series="X-Force" Number="11" Volume="2020" Year="2020">
             <Database Name="cv" Series="122668" Issue="791931" />
         </Book>
-        <Book Series="X-Force" Number="12" Volume="2019" Year="2020">
+        <Book Series="X-Force" Number="12" Volume="2020" Year="2020">
             <Database Name="cv" Series="122668" Issue="797987" />
         </Book>
         <Book Series="X of Swords Handbook" Number="1" Volume="2020" Year="2020">
@@ -43,7 +43,7 @@
         <Book Series="Wolverine" Number="6" Volume="2020" Year="2020">
             <Database Name="cv" Series="125121" Issue="807579" />
         </Book>
-        <Book Series="X-Force" Number="13" Volume="2019" Year="2020">
+        <Book Series="X-Force" Number="13" Volume="2020" Year="2020">
             <Database Name="cv" Series="122668" Issue="807580" />
         </Book>
         <Book Series="Marauders" Number="13" Volume="2019" Year="2020">
@@ -82,7 +82,7 @@
         <Book Series="Wolverine" Number="7" Volume="2020" Year="2021">
             <Database Name="cv" Series="125121" Issue="817706" />
         </Book>
-        <Book Series="X-Force" Number="14" Volume="2019" Year="2021">
+        <Book Series="X-Force" Number="14" Volume="2020" Year="2021">
             <Database Name="cv" Series="122668" Issue="819097" />
         </Book>
         <Book Series="Hellions" Number="6" Volume="2020" Year="2021">

--- a/Marvel/Master Reading Order/Marvel Guides/2018-2021 Fresh Start/Part 15 Reign of X/[Marvel] 2018-2021 Part 15.1 After the Dawn Comes the Reign (MG).cbl
+++ b/Marvel/Master Reading Order/Marvel Guides/2018-2021 Fresh Start/Part 15 Reign of X/[Marvel] 2018-2021 Part 15.1 After the Dawn Comes the Reign (MG).cbl
@@ -34,10 +34,10 @@
         <Book Series="Hellions" Number="11" Volume="2020" Year="2021">
             <Database Name="cv" Series="126015" Issue="847510" />
         </Book>
-        <Book Series="X-Force" Number="15" Volume="2019" Year="2021">
+        <Book Series="X-Force" Number="15" Volume="2020" Year="2021">
             <Database Name="cv" Series="122668" Issue="821504" />
         </Book>
-        <Book Series="X-Force" Number="16" Volume="2019" Year="2021">
+        <Book Series="X-Force" Number="16" Volume="2020" Year="2021">
             <Database Name="cv" Series="122668" Issue="825509" />
         </Book>
         <Book Series="Wolverine: Black, White &#38; Blood" Number="1" Volume="2020" Year="2021">
@@ -61,13 +61,13 @@
         <Book Series="Wolverine" Number="10" Volume="2020" Year="2021">
             <Database Name="cv" Series="125121" Issue="830035" />
         </Book>
-        <Book Series="X-Force" Number="17" Volume="2019" Year="2021">
+        <Book Series="X-Force" Number="17" Volume="2020" Year="2021">
             <Database Name="cv" Series="122668" Issue="828200" />
         </Book>
-        <Book Series="X-Force" Number="18" Volume="2019" Year="2021">
+        <Book Series="X-Force" Number="18" Volume="2020" Year="2021">
             <Database Name="cv" Series="122668" Issue="838891" />
         </Book>
-        <Book Series="X-Force" Number="19" Volume="2019" Year="2021">
+        <Book Series="X-Force" Number="19" Volume="2020" Year="2021">
             <Database Name="cv" Series="122668" Issue="844977" />
         </Book>
         <Book Series="Wolverine" Number="11" Volume="2020" Year="2021">

--- a/Marvel/Master Reading Order/Marvel Guides/2018-2021 Fresh Start/Part 15 Reign of X/[Marvel] 2018-2021 Part 15.2 Hellfire Gala (MG).cbl
+++ b/Marvel/Master Reading Order/Marvel Guides/2018-2021 Fresh Start/Part 15 Reign of X/[Marvel] 2018-2021 Part 15.2 Hellfire Gala (MG).cbl
@@ -7,7 +7,7 @@
         <Book Series="Marauders" Number="21" Volume="2019" Year="2021">
             <Database Name="cv" Series="122218" Issue="857597" />
         </Book>
-        <Book Series="X-Force" Number="20" Volume="2019" Year="2021">
+        <Book Series="X-Force" Number="20" Volume="2020" Year="2021">
             <Database Name="cv" Series="122668" Issue="857598" />
         </Book>
         <Book Series="Hellions" Number="12" Volume="2020" Year="2021">

--- a/Marvel/Master Reading Order/Marvel Guides/2018-2021 Fresh Start/Part 15 Reign of X/[Marvel] 2018-2021 Part 15.4 Trial by Fire (MG).cbl
+++ b/Marvel/Master Reading Order/Marvel Guides/2018-2021 Fresh Start/Part 15 Reign of X/[Marvel] 2018-2021 Part 15.4 Trial by Fire (MG).cbl
@@ -139,22 +139,22 @@
         <Book Series="Wolverine" Number="19" Volume="2020" Year="2022">
             <Database Name="cv" Series="125121" Issue="899167" />
         </Book>
-        <Book Series="X-Force" Number="21" Volume="2019" Year="2021">
+        <Book Series="X-Force" Number="21" Volume="2020" Year="2021">
             <Database Name="cv" Series="122668" Issue="868600" />
         </Book>
-        <Book Series="X-Force" Number="22" Volume="2019" Year="2021">
+        <Book Series="X-Force" Number="22" Volume="2020" Year="2021">
             <Database Name="cv" Series="122668" Issue="878792" />
         </Book>
-        <Book Series="X-Force" Number="23" Volume="2019" Year="2021">
+        <Book Series="X-Force" Number="23" Volume="2020" Year="2021">
             <Database Name="cv" Series="122668" Issue="884069" />
         </Book>
-        <Book Series="X-Force" Number="24" Volume="2019" Year="2021">
+        <Book Series="X-Force" Number="24" Volume="2020" Year="2021">
             <Database Name="cv" Series="122668" Issue="889465" />
         </Book>
-        <Book Series="X-Force" Number="25" Volume="2019" Year="2022">
+        <Book Series="X-Force" Number="25" Volume="2020" Year="2022">
             <Database Name="cv" Series="122668" Issue="894133" />
         </Book>
-        <Book Series="X-Force" Number="26" Volume="2019" Year="2022">
+        <Book Series="X-Force" Number="26" Volume="2020" Year="2022">
             <Database Name="cv" Series="122668" Issue="898353" />
         </Book>
         <Book Series="Excalibur" Number="22" Volume="2019" Year="2021">

--- a/Marvel/Master Reading Order/Marvel Guides/2021-2023 Timeless/Part 02 Destiny of X/[Marvel] 2021-2023 Part 2.2 Secret Pasts, Sinister Futures (MG).cbl
+++ b/Marvel/Master Reading Order/Marvel Guides/2021-2023 Timeless/Part 02 Destiny of X/[Marvel] 2021-2023 Part 2.2 Secret Pasts, Sinister Futures (MG).cbl
@@ -10,13 +10,13 @@
         <Book Series="Sabretooth" Number="5" Volume="2022" Year="2022">
             <Database Name="cv" Series="141524" Issue="934984" />
         </Book>
-        <Book Series="X-Force" Number="27" Volume="2019" Year="2022">
+        <Book Series="X-Force" Number="27" Volume="2020" Year="2022">
             <Database Name="cv" Series="122668" Issue="914648" />
         </Book>
-        <Book Series="X-Force" Number="28" Volume="2019" Year="2022">
+        <Book Series="X-Force" Number="28" Volume="2020" Year="2022">
             <Database Name="cv" Series="122668" Issue="924786" />
         </Book>
-        <Book Series="X-Force" Number="29" Volume="2019" Year="2022">
+        <Book Series="X-Force" Number="29" Volume="2020" Year="2022">
             <Database Name="cv" Series="122668" Issue="933078" />
         </Book>
         <Book Series="Wolverine" Number="20" Volume="2020" Year="2022">

--- a/Marvel/Master Reading Order/Marvel Guides/2021-2023 Timeless/Part 02 Destiny of X/[Marvel] 2021-2023 Part 2.3 Hellfire and Brimstone (MG).cbl
+++ b/Marvel/Master Reading Order/Marvel Guides/2021-2023 Timeless/Part 02 Destiny of X/[Marvel] 2021-2023 Part 2.3 Hellfire and Brimstone (MG).cbl
@@ -13,7 +13,7 @@
         <Book Series="Immortal X-Men" Number="4" Volume="2022" Year="2022">
             <Database Name="cv" Series="142053" Issue="935751" />
         </Book>
-        <Book Series="X-Force" Number="30" Volume="2019" Year="2022">
+        <Book Series="X-Force" Number="30" Volume="2020" Year="2022">
             <Database Name="cv" Series="122668" Issue="942706" />
         </Book>
         <Book Series="X-Terminators" Number="1" Volume="2022" Year="2022">

--- a/Marvel/Master Reading Order/Marvel Guides/2021-2023 Timeless/Part 03 A.X.E. Judgement Day/[Marvel] 2021-2023 Part 3.2 Rush to Judgement (MG).cbl
+++ b/Marvel/Master Reading Order/Marvel Guides/2021-2023 Timeless/Part 03 A.X.E. Judgement Day/[Marvel] 2021-2023 Part 3.2 Rush to Judgement (MG).cbl
@@ -52,13 +52,13 @@
         <Book Series="Wolverine" Number="25" Volume="2020" Year="2022">
             <Database Name="cv" Series="125121" Issue="950794" />
         </Book>
-        <Book Series="X-Force" Number="31" Volume="2019" Year="2022">
+        <Book Series="X-Force" Number="31" Volume="2020" Year="2022">
             <Database Name="cv" Series="122668" Issue="944669" />
         </Book>
-        <Book Series="X-Force" Number="32" Volume="2019" Year="2022">
+        <Book Series="X-Force" Number="32" Volume="2020" Year="2022">
             <Database Name="cv" Series="122668" Issue="950383" />
         </Book>
-        <Book Series="X-Force" Number="33" Volume="2019" Year="2022">
+        <Book Series="X-Force" Number="33" Volume="2020" Year="2022">
             <Database Name="cv" Series="122668" Issue="951451" />
         </Book>
         <Book Series="A.X.E.: Judgment Day" Number="4" Volume="2022" Year="2022">


### PR DESCRIPTION
Some lists had 2019 as the start year when it should be 2020. This was causing issues for CBL import in Komga. Series in question: https://comicvine.gamespot.com/x-force/4050-122668/