### PR TITLE
new mutants 2019 to 2020 fix

### DIFF
--- a/Marvel/Events/CBRO/1986-1993 - Part 4/[Marvel] X-Cutioner's Song (WEB-CBRO).cbl
+++ b/Marvel/Events/CBRO/1986-1993 - Part 4/[Marvel] X-Cutioner's Song (WEB-CBRO).cbl
@@ -12,8 +12,8 @@
 <Book Series="X-Men" Number="14" Volume="1991" Year="1992">
 <Database Name="cv" Series="4605" Issue="106566" />
 </Book>
-<Book Series="X-Force" Number="16" Volume="2019" Year="2021">
-<Database Name="cv" Series="122668" Issue="825509" />
+<Book Series="X-Force" Number="16" Volume="1991" Year="1992">
+<Database Name="cv" Series="4604" Issue="107129" />
 </Book>
 <Book Series="The Uncanny X-Men" Number="295" Volume="1981" Year="1992">
 <Database Name="cv" Series="3092" Issue="107067" />
@@ -24,8 +24,8 @@
 <Book Series="X-Men" Number="15" Volume="1991" Year="1992">
 <Database Name="cv" Series="4605" Issue="106567" />
 </Book>
-<Book Series="X-Force" Number="17" Volume="2019" Year="2021">
-<Database Name="cv" Series="122668" Issue="828200" />
+<Book Series="X-Force" Number="17" Volume="1991" Year="1992">
+<Database Name="cv" Series="4604" Issue="107130" />
 </Book>
 <Book Series="The Uncanny X-Men" Number="296" Volume="1981" Year="1993">
 <Database Name="cv" Series="3092" Issue="107087" />
@@ -36,8 +36,8 @@
 <Book Series="X-Men" Number="16" Volume="1991" Year="1993">
 <Database Name="cv" Series="4605" Issue="106568" />
 </Book>
-<Book Series="X-Force" Number="18" Volume="2019" Year="2021">
-<Database Name="cv" Series="122668" Issue="838891" />
+<Book Series="X-Force" Number="18" Volume="1991" Year="1993">
+<Database Name="cv" Series="4604" Issue="107133" />
 </Book>
 <Book Series="The Uncanny X-Men" Number="297" Volume="1981" Year="1993">
 <Database Name="cv" Series="3092" Issue="107105" />

--- a/Marvel/Events/CBRO/2019-2021 - Part 11/[Marvel] X of Swords (WEB-CBRO).cbl
+++ b/Marvel/Events/CBRO/2019-2021 - Part 11/[Marvel] X of Swords (WEB-CBRO).cbl
@@ -12,7 +12,7 @@
 <Book Series="Wolverine" Number="6" Volume="2020" Year="2020">
 <Database Name="cv" Series="125121" Issue="807579" />
 </Book>
-<Book Series="X-Force" Number="13" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="13" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="807580" />
 </Book>
 <Book Series="Marauders" Number="13" Volume="2019" Year="2020">
@@ -21,7 +21,7 @@
 <Book Series="Hellions" Number="5" Volume="2020" Year="2020">
 <Database Name="cv" Series="126015" Issue="810727" />
 </Book>
-<Book Series="New Mutants" Number="13" Volume="2019" Year="2020">
+<Book Series="New Mutants" Number="13" Volume="2020" Year="2020">
 <Database Name="cv" Series="122666" Issue="810730" />
 </Book>
 <Book Series="Cable" Number="5" Volume="2020" Year="2020">
@@ -51,7 +51,7 @@
 <Book Series="Wolverine" Number="7" Volume="2020" Year="2021">
 <Database Name="cv" Series="125121" Issue="817706" />
 </Book>
-<Book Series="X-Force" Number="14" Volume="2019" Year="2021">
+<Book Series="X-Force" Number="14" Volume="2020" Year="2021">
 <Database Name="cv" Series="122668" Issue="819097" />
 </Book>
 <Book Series="Hellions" Number="6" Volume="2020" Year="2021">

--- a/Marvel/Events/Official/[Marvel] (2021-06) Hellfire Gala (Official).cbl
+++ b/Marvel/Events/Official/[Marvel] (2021-06) Hellfire Gala (Official).cbl
@@ -1,51 +1,50 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <Name>[Marvel] (2021) Hellfire Gala (Official)</Name>
-    <NumIssues>14</NumIssues>
-    <Books>
-        <Book Series="Marauders" Number="21" Volume="2019" Year="2021">
-            <Database Name="cv" Series="122218" Issue="857597" />
-        </Book>
-        <Book Series="X-Force" Number="20" Volume="2019" Year="2021">
-            <Database Name="cv" Series="122668" Issue="857598" />
-        </Book>
-        <Book Series="Hellions" Number="12" Volume="2020" Year="2021">
-            <Database Name="cv" Series="126015" Issue="857596" />
-        </Book>
-        <Book Series="Excalibur" Number="21" Volume="2019" Year="2021">
-            <Database Name="cv" Series="122488" Issue="858872" />
-        </Book>
-        <Book Series="X-Men" Number="21" Volume="2019" Year="2021">
-            <Database Name="cv" Series="122077" Issue="858873" />
-        </Book>
-        <Book Series="Children of the Atom" Number="4" Volume="2021" Year="2021">
-            <Database Name="cv" Series="134388" Issue="858871" />
-        </Book>
-        <Book Series="Planet-Size X-Men" Number="1" Volume="2021" Year="2021">
-            <Database Name="cv" Series="136937" Issue="861642" />
-        </Book>
-        <Book Series="New Mutants" Number="19" Volume="2019" Year="2021">
-            <Database Name="cv" Series="122666" Issue="861639" />
-        </Book>
-        <Book Series="X-Corp" Number="2" Volume="2021" Year="2021">
-            <Database Name="cv" Series="136025" Issue="861644" />
-        </Book>
-        <Book Series="Wolverine" Number="13" Volume="2020" Year="2021">
-            <Database Name="cv" Series="125121" Issue="863865" />
-        </Book>
-        <Book Series="S.W.O.R.D." Number="6" Volume="2020" Year="2021">
-            <Database Name="cv" Series="132511" Issue="863852" />
-        </Book>
-        <Book Series="Way of X" Number="3" Volume="2021" Year="2021">
-            <Database Name="cv" Series="135583" Issue="863854" />
-        </Book>
-        <Book Series="X-Factor" Number="10" Volume="2020" Year="2021">
-            <Database Name="cv" Series="129097" Issue="866581" />
-        </Book>
-        <Book Series="Cable" Number="11" Volume="2020" Year="2021">
-            <Database Name="cv" Series="125678" Issue="866577" />
-        </Book>
-    </Books>
-    <Matchers />
+<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Name>[Marvel] (2021-06) Hellfire Gala (Official)</Name>
+<NumIssues>14</NumIssues>
+<Books>
+<Book Series="Marauders" Number="21" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="857597" />
+</Book>
+<Book Series="X-Force" Number="20" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="857598" />
+</Book>
+<Book Series="Hellions" Number="12" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="857596" />
+</Book>
+<Book Series="Excalibur" Number="21" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="858872" />
+</Book>
+<Book Series="X-Men" Number="21" Volume="2019" Year="2021">
+<Database Name="cv" Series="122077" Issue="858873" />
+</Book>
+<Book Series="Children of the Atom" Number="4" Volume="2021" Year="2021">
+<Database Name="cv" Series="134388" Issue="858871" />
+</Book>
+<Book Series="Planet-Size X-Men" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="136937" Issue="861642" />
+</Book>
+<Book Series="New Mutants" Number="19" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="861639" />
+</Book>
+<Book Series="X-Corp" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="136025" Issue="861644" />
+</Book>
+<Book Series="Wolverine" Number="13" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="863865" />
+</Book>
+<Book Series="S.W.O.R.D." Number="6" Volume="2020" Year="2021">
+<Database Name="cv" Series="132511" Issue="863852" />
+</Book>
+<Book Series="Way of X" Number="3" Volume="2021" Year="2021">
+<Database Name="cv" Series="135583" Issue="863854" />
+</Book>
+<Book Series="X-Factor" Number="10" Volume="2020" Year="2021">
+<Database Name="cv" Series="129097" Issue="866581" />
+</Book>
+<Book Series="Cable" Number="11" Volume="2020" Year="2021">
+<Database Name="cv" Series="125678" Issue="866577" />
+</Book>
+</Books>
+<Matchers />
 </ReadingList>


### PR DESCRIPTION
New mutants also changed their volume year from 2019 to 2020, as X-Force di which was fixed in a recent PR. During that search also found an issues with the wrong volume selected for one list.