### PR TITLE
Skullkickers Reading order (Image, 2010-2015)

### DIFF
--- a/Image/Master Reading Order/[Image] [2010-2015] Skullkickers (Community-contributed).cbl
+++ b/Image/Master Reading Order/[Image] [2010-2015] Skullkickers (Community-contributed).cbl
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Name>[Image] Skullkickers (2010-2015)</Name>
+<NumIssues>35</NumIssues>
+<Books>
+<Book Series="Skullkickers" Number="0" Volume="2010" Year="2012">
+<Database Name="cv" Series="35602" Issue="335754" />
+</Book>
+<Book Series="Skullkickers" Number="1" Volume="2010" Year="2010">
+<Database Name="cv" Series="35602" Issue="235391" />
+</Book>
+<Book Series="Skullkickers" Number="2" Volume="2010" Year="2010">
+<Database Name="cv" Series="35602" Issue="239022" />
+</Book>
+<Book Series="Skullkickers" Number="3" Volume="2010" Year="2010">
+<Database Name="cv" Series="35602" Issue="246496" />
+</Book>
+<Book Series="Skullkickers" Number="4" Volume="2010" Year="2010">
+<Database Name="cv" Series="35602" Issue="250143" />
+</Book>
+<Book Series="Skullkickers" Number="5" Volume="2010" Year="2011">
+<Database Name="cv" Series="35602" Issue="259402" />
+</Book>
+<Book Series="Skullkickers" Number="6" Volume="2010" Year="2011">
+<Database Name="cv" Series="35602" Issue="263981" />
+</Book>
+<Book Series="Skullkickers" Number="7" Volume="2010" Year="2011">
+<Database Name="cv" Series="35602" Issue="272280" />
+</Book>
+<Book Series="Skullkickers" Number="8" Volume="2010" Year="2011">
+<Database Name="cv" Series="35602" Issue="276845" />
+</Book>
+<Book Series="Skullkickers" Number="9" Volume="2010" Year="2011">
+<Database Name="cv" Series="35602" Issue="281929" />
+</Book>
+<Book Series="Skullkickers" Number="10" Volume="2010" Year="2011">
+<Database Name="cv" Series="35602" Issue="290941" />
+</Book>
+<Book Series="Skullkickers" Number="11" Volume="2010" Year="2011">
+<Database Name="cv" Series="35602" Issue="294321" />
+</Book>
+<Book Series="Skullkickers" Number="12" Volume="2010" Year="2011">
+<Database Name="cv" Series="35602" Issue="304658" />
+</Book>
+<Book Series="Skullkickers" Number="13" Volume="2010" Year="2012">
+<Database Name="cv" Series="35602" Issue="327097" />
+</Book>
+<Book Series="Skullkickers" Number="14" Volume="2010" Year="2012">
+<Database Name="cv" Series="35602" Issue="335040" />
+</Book>
+<Book Series="Skullkickers" Number="15" Volume="2010" Year="2012">
+<Database Name="cv" Series="35602" Issue="340741" />
+</Book>
+<Book Series="Skullkickers" Number="16" Volume="2010" Year="2012">
+<Database Name="cv" Series="35602" Issue="346364" />
+</Book>
+<Book Series="Skullkickers" Number="17" Volume="2010" Year="2012">
+<Database Name="cv" Series="35602" Issue="354191" />
+</Book>
+<Book Series="Skullkickers" Number="18" Volume="2010" Year="2012">
+<Database Name="cv" Series="35602" Issue="358867" />
+</Book>
+<Book Series="Uncanny Skullkickers" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="57961" Issue="388575" />
+</Book>
+<Book Series="Savage Skullkickers" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="59371" Issue="395302" />
+</Book>
+<Book Series="Mighty Skullkickers" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="60316" Issue="399112" />
+</Book>
+<Book Series="The All-New Secret Skullkickers" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="62880" Issue="409006" />
+</Book>
+<Book Series="Dark Skullkickers Dark" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="64689" Issue="415248" />
+</Book>
+<Book Series="Skullkickers" Number="24" Volume="2010" Year="2013">
+<Database Name="cv" Series="35602" Issue="423718" />
+</Book>
+<Book Series="Skullkickers" Number="25" Volume="2010" Year="2014">
+<Database Name="cv" Series="35602" Issue="449016" />
+</Book>
+<Book Series="Skullkickers" Number="26" Volume="2010" Year="2014">
+<Database Name="cv" Series="35602" Issue="451135" />
+</Book>
+<Book Series="Skullkickers" Number="27" Volume="2010" Year="2014">
+<Database Name="cv" Series="35602" Issue="454132" />
+</Book>
+<Book Series="Skullkickers" Number="28" Volume="2010" Year="2014">
+<Database Name="cv" Series="35602" Issue="457683" />
+</Book>
+<Book Series="Skullkickers" Number="29" Volume="2010" Year="2014">
+<Database Name="cv" Series="35602" Issue="460348" />
+</Book>
+<Book Series="Skullkickers" Number="30" Volume="2010" Year="2014">
+<Database Name="cv" Series="35602" Issue="462298" />
+</Book>
+<Book Series="Skullkickers" Number="31" Volume="2010" Year="2015">
+<Database Name="cv" Series="35602" Issue="483412" />
+</Book>
+<Book Series="Skullkickers" Number="32" Volume="2010" Year="2015">
+<Database Name="cv" Series="35602" Issue="487245" />
+</Book>
+<Book Series="Skullkickers" Number="33" Volume="2010" Year="2015">
+<Database Name="cv" Series="35602" Issue="495400" />
+</Book>
+</Books>
+<Matchers />
+</ReadingList>


### PR DESCRIPTION
Added a reading order for the Skullkickers series by Image comics, deemed it worth, since CV and Metron split the issues 19-23 off because they are titled weirdly by Image (e. g. Skullkickers #23: Dark Skullkickers Dark #1)...

Imports fine on my test sets.