### PR TITLE
Marvel - Symbiosis Necrosis added

### DIFF
--- a/Marvel/Events/unsorted/[Marvel] [2024] Symbiosis Necrosis (Community-Contributed).cbl
+++ b/Marvel/Events/unsorted/[Marvel] [2024] Symbiosis Necrosis (Community-Contributed).cbl
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Name>[Marvel] [2024] Symbiosis Necrosis (Community-Contributed)</Name>
+<NumIssues>4</NumIssues>
+<Books>
+<Book Series="Venom" Number="31" Volume="2021" Year="2024">
+<Database Name="cv" Series="140084" Issue="1047093" />
+</Book>
+<Book Series="Carnage" Number="5" Volume="2024" Year="2024">
+<Database Name="cv" Series="154836" Issue="1047945" />
+</Book>
+<Book Series="Venom" Number="32" Volume="2021" Year="2024">
+<Database Name="cv" Series="140084" Issue="1050578" />
+</Book>
+<Book Series="Carnage" Number="6" Volume="2024" Year="2024">
+<Database Name="cv" Series="154836" Issue="1051120" />
+</Book>
+</Books>
+<Matchers />
+</ReadingList>


### PR DESCRIPTION
Added Event Reading List for Symbiosis Necrosis by Marvel. Created based on the titles of the issues, cross-verified with [Marvel's announcement](https://www.marvel.com/articles/comics/symbiosis-necrosis-venom-carnage-crossover-eddie-dylan-brock-cletus-kasady). Placed the file in unsorted as I 'hand-crafted' it.

Import verified on my test sets.