### PR TITLE
Added TMNT Laird Canon Volume 1

### DIFF
--- a/Other/unsorted/Mirage TMNT vol 1 (Laird canon) reading list.cbl
+++ b/Other/unsorted/Mirage TMNT vol 1 (Laird canon) reading list.cbl
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Name>TMNT vol 1 (Laird canon) reading list</Name>
+<NumIssues>50</NumIssues>
+<Books>
+<Book Series="Teenage Mutant Ninja Turtles" Number="9" Volume="1984" Year="1986">
+<Database Name="cv" Series="20281" Issue="124336" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="1" Volume="1984" Year="1984">
+<Database Name="cv" Series="20281" Issue="121041" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="2" Volume="1984" Year="1984">
+<Database Name="cv" Series="20281" Issue="121062" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="3" Volume="1984" Year="1985">
+<Database Name="cv" Series="20281" Issue="121153" />
+</Book>
+<Book Series="Raphael Teenage Mutant Ninja Turtle" Number="1" Volume="1985" Year="1985">
+<Database Name="cv" Series="21094" Issue="126659" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="4" Volume="1984" Year="1985">
+<Database Name="cv" Series="20281" Issue="121164" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="5" Volume="1984" Year="1985">
+<Database Name="cv" Series="20281" Issue="121149" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="6" Volume="1984" Year="1986">
+<Database Name="cv" Series="20281" Issue="121282" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="7" Volume="1984" Year="1986">
+<Database Name="cv" Series="20281" Issue="121067" />
+</Book>
+<Book Series="Michaelangelo" Number="1" Volume="1985" Year="1985">
+<Database Name="cv" Series="34166" Issue="222889" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="8" Volume="1984" Year="1986">
+<Database Name="cv" Series="20281" Issue="124335" />
+</Book>
+<Book Series="Donatello" Number="1" Volume="1986" Year="1986">
+<Database Name="cv" Series="33152" Issue="213995" />
+</Book>
+<Book Series="Tales of the Teenage Mutant Ninja Turtles" Number="5" Volume="1987" Year="1988">
+<Database Name="cv" Series="18790" Issue="111089" />
+</Book>
+<Book Series="Tales of the Teenage Mutant Ninja Turtles" Number="6" Volume="1987" Year="1988">
+<Database Name="cv" Series="18790" Issue="111090" />
+</Book>
+<Book Series="Tales of the Teenage Mutant Ninja Turtles" Number="7" Volume="1987" Year="1989">
+<Database Name="cv" Series="18790" Issue="111091" />
+</Book>
+<Book Series="Tales of the Teenage Mutant Ninja Turtles" Number="3" Volume="1987" Year="1987">
+<Database Name="cv" Series="18790" Issue="111087" />
+</Book>
+<Book Series="Leonardo" Number="1" Volume="1986" Year="1986">
+<Database Name="cv" Series="28420" Issue="175027" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="10" Volume="1984" Year="1987">
+<Database Name="cv" Series="20281" Issue="124339" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="11" Volume="1984" Year="1987">
+<Database Name="cv" Series="20281" Issue="126363" />
+</Book>
+<Book Series="Tales of the Teenage Mutant Ninja Turtles" Number="1" Volume="1987" Year="1987">
+<Database Name="cv" Series="18790" Issue="111061" />
+</Book>
+<Book Series="Tales of the Teenage Mutant Ninja Turtles" Number="2" Volume="1987" Year="1987">
+<Database Name="cv" Series="18790" Issue="111086" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="12" Volume="1984" Year="1987">
+<Database Name="cv" Series="20281" Issue="126367" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="13" Volume="1984" Year="1988">
+<Database Name="cv" Series="20281" Issue="126898" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="14" Volume="1984" Year="1988">
+<Database Name="cv" Series="20281" Issue="126899" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="15" Volume="1984" Year="1988">
+<Database Name="cv" Series="20281" Issue="126902" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="17" Volume="1984" Year="1988">
+<Database Name="cv" Series="20281" Issue="126904" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="19" Volume="1984" Year="1989">
+<Database Name="cv" Series="20281" Issue="127089" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="20" Volume="1984" Year="1989">
+<Database Name="cv" Series="20281" Issue="127090" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="21" Volume="1984" Year="1989">
+<Database Name="cv" Series="20281" Issue="127091" />
+</Book>
+<Book Series="Tales of the Teenage Mutant Ninja Turtles" Number="4" Volume="1987" Year="1988">
+<Database Name="cv" Series="18790" Issue="111088" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="24" Volume="1984" Year="1989">
+<Database Name="cv" Series="20281" Issue="127095" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="25" Volume="1984" Year="1989">
+<Database Name="cv" Series="20281" Issue="127092" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="26" Volume="1984" Year="1989">
+<Database Name="cv" Series="20281" Issue="127096" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="27" Volume="1984" Year="1989">
+<Database Name="cv" Series="20281" Issue="159022" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="28" Volume="1984" Year="1990">
+<Database Name="cv" Series="20281" Issue="159027" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="48" Volume="1984" Year="1992">
+<Database Name="cv" Series="20281" Issue="159054" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="49" Volume="1984" Year="1992">
+<Database Name="cv" Series="20281" Issue="159059" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="50" Volume="1984" Year="1992">
+<Database Name="cv" Series="20281" Issue="159060" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="51" Volume="1984" Year="1992">
+<Database Name="cv" Series="20281" Issue="159061" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="52" Volume="1984" Year="1992">
+<Database Name="cv" Series="20281" Issue="159062" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="53" Volume="1984" Year="1992">
+<Database Name="cv" Series="20281" Issue="159063" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="54" Volume="1984" Year="1992">
+<Database Name="cv" Series="20281" Issue="121070" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="55" Volume="1984" Year="1993">
+<Database Name="cv" Series="20281" Issue="159064" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="56" Volume="1984" Year="1993">
+<Database Name="cv" Series="20281" Issue="159065" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="57" Volume="1984" Year="1993">
+<Database Name="cv" Series="20281" Issue="159066" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="58" Volume="1984" Year="1993">
+<Database Name="cv" Series="20281" Issue="159067" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="59" Volume="1984" Year="1993">
+<Database Name="cv" Series="20281" Issue="159068" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="60" Volume="1984" Year="1993">
+<Database Name="cv" Series="20281" Issue="159069" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="61" Volume="1984" Year="1993">
+<Database Name="cv" Series="20281" Issue="159070" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles" Number="62" Volume="1984" Year="1993">
+<Database Name="cv" Series="20281" Issue="159071" />
+</Book>
+</Books>
+<Matchers />
+</ReadingList>


### PR DESCRIPTION
TMNT has a confusing and fractured history, even prior to IDW. Peter Laird has gone on record to say he only considers the stories by him and Eastman to be canon from the original volume 1 and Tales volume 1. I've compiled this into a chronological order story-wise with a deviation of #24-26 they are referenced in the Laird/Eastman books after so it must be canon even by his standard.