### PR TITLE
[CBRO] Fix errors and inconsistencies for CBRO master reading order and events

### DIFF
--- a/Marvel/Events/CBRO/2005-2009 - Part 8/[Marvel] Civil War (WEB-CBRO).cbl
+++ b/Marvel/Events/CBRO/2005-2009 - Part 8/[Marvel] Civil War (WEB-CBRO).cbl
@@ -252,7 +252,7 @@
 <Book Series="The Amazing Spider-Man" Number="535" Volume="1963" Year="2006">
 <Database Name="cv" Series="2127" Issue="105556" />
 </Book>
-<Book Series="Civil War" Number="5" Volume="2007" Year="2006">
+<Book Series="Civil War" Number="5" Volume="2006" Year="2006">
 <Database Name="cv" Series="18023" Issue="106999" />
 </Book>
 <Book Series="The Amazing Spider-Man" Number="536" Volume="1963" Year="2006">

--- a/Marvel/Events/CBRO/2011-2012 - Part 10/[Marvel] Avengers vs. X-Men (WEB-CBRO).cbl
+++ b/Marvel/Events/CBRO/2011-2012 - Part 10/[Marvel] Avengers vs. X-Men (WEB-CBRO).cbl
@@ -174,10 +174,10 @@
 <Book Series="Wolverine &#38; the X-Men" Number="14" Volume="2011" Year="2012">
 <Database Name="cv" Series="43539" Issue="347208" />
 </Book>
-<Book Series="Avengers Vs X-Men" Number="9" Volume="2013" Year="2012">
+<Book Series="Avengers Vs X-Men" Number="9" Volume="2012" Year="2012">
 <Database Name="cv" Series="47331" Issue="348054" />
 </Book>
-<Book Series="Avengers Vs X-Men" Number="10" Volume="2013" Year="2012">
+<Book Series="Avengers Vs X-Men" Number="10" Volume="2012" Year="2012">
 <Database Name="cv" Series="47331" Issue="351068" />
 </Book>
 <Book Series="Wolverine &#38; the X-Men" Number="15" Volume="2011" Year="2012">
@@ -186,13 +186,13 @@
 <Book Series="Wolverine &#38; the X-Men" Number="16" Volume="2011" Year="2012">
 <Database Name="cv" Series="43539" Issue="356779" />
 </Book>
-<Book Series="Avengers Vs X-Men" Number="11" Volume="2013" Year="2012">
+<Book Series="Avengers Vs X-Men" Number="11" Volume="2012" Year="2012">
 <Database Name="cv" Series="47331" Issue="356764" />
 </Book>
 <Book Series="Uncanny X-Men" Number="18" Volume="2013" Year="2014">
 <Database Name="cv" Series="57181" Issue="446998" />
 </Book>
-<Book Series="Avengers Vs X-Men" Number="12" Volume="2013" Year="2012">
+<Book Series="Avengers Vs X-Men" Number="12" Volume="2012" Year="2012">
 <Database Name="cv" Series="47331" Issue="359916" />
 </Book>
 <Book Series="Uncanny X-Men" Number="19" Volume="2013" Year="2014">

--- a/Marvel/Events/CBRO/2022-2023 - Part 13/[Marvel] Dark Web (WEB-CBRO).cbl
+++ b/Marvel/Events/CBRO/2022-2023 - Part 13/[Marvel] Dark Web (WEB-CBRO).cbl
@@ -21,7 +21,7 @@
 <Book Series="Dark Web: Ms. Marvel" Number="2" Volume="2023" Year="2023">
 <Database Name="cv" Series="146986" Issue="963978" />
 </Book>
-<Book Series="Gold Goblin" Number="2" Volume="2023" Year="2023">
+<Book Series="Gold Goblin" Number="2" Volume="2022" Year="2023">
 <Database Name="cv" Series="146113" Issue="960978" />
 </Book>
 <Book Series="The Amazing Spider-Man" Number="16" Volume="2022" Year="2023">
@@ -45,7 +45,7 @@
 <Book Series="Mary Jane &#38; Black Cat" Number="4" Volume="2023" Year="2023">
 <Database Name="cv" Series="146987" Issue="975702" />
 </Book>
-<Book Series="Gold Goblin" Number="3" Volume="2023" Year="2023">
+<Book Series="Gold Goblin" Number="3" Volume="2022" Year="2023">
 <Database Name="cv" Series="146113" Issue="962847" />
 </Book>
 <Book Series="Dark Web: X-Men" Number="3" Volume="2022" Year="2023">

--- a/Marvel/Events/CBRO/[Marvel] Jonathan Hickman's Marvel (WEB-CBRO).cbl
+++ b/Marvel/Events/CBRO/[Marvel] Jonathan Hickman's Marvel (WEB-CBRO).cbl
@@ -489,10 +489,10 @@
 <Book Series="Wolverine &#38; the X-Men" Number="14" Volume="2011" Year="2012">
 <Database Name="cv" Series="43539" Issue="347208" />
 </Book>
-<Book Series="Avengers Vs X-Men" Number="9" Volume="2013" Year="2012">
+<Book Series="Avengers Vs X-Men" Number="9" Volume="2012" Year="2012">
 <Database Name="cv" Series="47331" Issue="348054" />
 </Book>
-<Book Series="Avengers Vs X-Men" Number="10" Volume="2013" Year="2012">
+<Book Series="Avengers Vs X-Men" Number="10" Volume="2012" Year="2012">
 <Database Name="cv" Series="47331" Issue="351068" />
 </Book>
 <Book Series="Wolverine &#38; the X-Men" Number="15" Volume="2011" Year="2012">
@@ -501,13 +501,13 @@
 <Book Series="Wolverine &#38; the X-Men" Number="16" Volume="2011" Year="2012">
 <Database Name="cv" Series="43539" Issue="356779" />
 </Book>
-<Book Series="Avengers Vs X-Men" Number="11" Volume="2013" Year="2012">
+<Book Series="Avengers Vs X-Men" Number="11" Volume="2012" Year="2012">
 <Database Name="cv" Series="47331" Issue="356764" />
 </Book>
 <Book Series="Uncanny X-Men" Number="18" Volume="2013" Year="2014">
 <Database Name="cv" Series="57181" Issue="446998" />
 </Book>
-<Book Series="Avengers Vs X-Men" Number="12" Volume="2013" Year="2012">
+<Book Series="Avengers Vs X-Men" Number="12" Volume="2012" Year="2012">
 <Database Name="cv" Series="47331" Issue="359916" />
 </Book>
 <Book Series="Uncanny X-Men" Number="19" Volume="2013" Year="2014">

--- a/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #01 (WEB-CBRO).cbl
+++ b/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #01 (WEB-CBRO).cbl
@@ -640,7 +640,7 @@
 <Database Name="cv" Series="19112" Issue="134019" />
 </Book>
 <Book Series="Avengers: Season One" Number="1" Volume="2013" Year="2013">
-<Database Name="cv" Series="57442" Issue="414196" />
+<Database Name="cv" Series="64453" Issue="386970" />
 </Book>
 <Book Series="Avengers Origins: Scarlet Witch &#38; Quicksilver" Number="1" Volume="2012" Year="2012">
 <Database Name="cv" Series="44148" Issue="303673" />

--- a/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #03 (WEB-CBRO).cbl
+++ b/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #03 (WEB-CBRO).cbl
@@ -2091,7 +2091,7 @@
 <Book Series="The Uncanny X-Men" Number="199" Volume="1981" Year="1985">
 <Database Name="cv" Series="3092" Issue="26105" />
 </Book>
-<Book Series="Uncanny X-Men Annual" Number="9" Volume="2006" Year="1985">
+<Book Series="X-Men Annual" Number="9" Volume="1970" Year="1985">
 <Database Name="cv" Series="22988" Issue="111575" />
 </Book>
 <Book Series="The Uncanny X-Men" Number="200" Volume="1981" Year="1985">

--- a/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #04 (WEB-CBRO).cbl
+++ b/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #04 (WEB-CBRO).cbl
@@ -3273,8 +3273,8 @@
 <Book Series="X-Men" Number="14" Volume="1991" Year="1992">
 <Database Name="cv" Series="4605" Issue="106566" />
 </Book>
-<Book Series="X-Force" Number="16" Volume="2019" Year="2021">
-<Database Name="cv" Series="122668" Issue="825509" />
+<Book Series="X-Force" Number="16" Volume="1991" Year="1992">
+<Database Name="cv" Series="4604" Issue="107129" />
 </Book>
 <Book Series="The Uncanny X-Men" Number="295" Volume="1981" Year="1992">
 <Database Name="cv" Series="3092" Issue="107067" />
@@ -3285,8 +3285,8 @@
 <Book Series="X-Men" Number="15" Volume="1991" Year="1992">
 <Database Name="cv" Series="4605" Issue="106567" />
 </Book>
-<Book Series="X-Force" Number="17" Volume="2019" Year="2021">
-<Database Name="cv" Series="122668" Issue="828200" />
+<Book Series="X-Force" Number="17" Volume="1991" Year="1992">
+<Database Name="cv" Series="4604" Issue="107130" />
 </Book>
 <Book Series="The Uncanny X-Men" Number="296" Volume="1981" Year="1993">
 <Database Name="cv" Series="3092" Issue="107087" />
@@ -3297,8 +3297,8 @@
 <Book Series="X-Men" Number="16" Volume="1991" Year="1993">
 <Database Name="cv" Series="4605" Issue="106568" />
 </Book>
-<Book Series="X-Force" Number="18" Volume="2019" Year="2021">
-<Database Name="cv" Series="122668" Issue="838891" />
+<Book Series="X-Force" Number="18" Volume="1991" Year="1992">
+<Database Name="cv" Series="4604" Issue="107133" />
 </Book>
 <Book Series="The Uncanny X-Men" Number="297" Volume="1981" Year="1993">
 <Database Name="cv" Series="3092" Issue="107105" />

--- a/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #06 (WEB-CBRO).cbl
+++ b/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #06 (WEB-CBRO).cbl
@@ -2160,7 +2160,7 @@
 <Book Series="New X-Men" Number="116" Volume="2001" Year="2001">
 <Database Name="cv" Series="9121" Issue="66994" />
 </Book>
-<Book Series="New X-Men 2001" Number="1" Volume="2001" Year="2001">
+<Book Series="X-Men 2001" Number="1" Volume="2001" Year="2001">
 <Database Name="cv" Series="21334" Issue="128914" />
 </Book>
 <Book Series="New X-Men" Number="117" Volume="2001" Year="2001">

--- a/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #08 (WEB-CBRO).cbl
+++ b/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #08 (WEB-CBRO).cbl
@@ -726,7 +726,7 @@
 <Book Series="The Amazing Spider-Man" Number="535" Volume="1963" Year="2006">
 <Database Name="cv" Series="2127" Issue="105556" />
 </Book>
-<Book Series="Civil War" Number="5" Volume="2007" Year="2006">
+<Book Series="Civil War" Number="5" Volume="2006" Year="2006">
 <Database Name="cv" Series="18023" Issue="106999" />
 </Book>
 <Book Series="The Amazing Spider-Man" Number="536" Volume="1963" Year="2006">

--- a/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #10 (WEB-CBRO).cbl
+++ b/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #10 (WEB-CBRO).cbl
@@ -2463,10 +2463,10 @@
 <Book Series="Wolverine &#38; the X-Men" Number="14" Volume="2011" Year="2012">
 <Database Name="cv" Series="43539" Issue="347208" />
 </Book>
-<Book Series="Avengers Vs X-Men" Number="9" Volume="2013" Year="2012">
+<Book Series="Avengers Vs X-Men" Number="9" Volume="2012" Year="2012">
 <Database Name="cv" Series="47331" Issue="348054" />
 </Book>
-<Book Series="Avengers Vs X-Men" Number="10" Volume="2013" Year="2012">
+<Book Series="Avengers Vs X-Men" Number="10" Volume="2012" Year="2012">
 <Database Name="cv" Series="47331" Issue="351068" />
 </Book>
 <Book Series="Wolverine &#38; the X-Men" Number="15" Volume="2011" Year="2012">
@@ -2475,13 +2475,13 @@
 <Book Series="Wolverine &#38; the X-Men" Number="16" Volume="2011" Year="2012">
 <Database Name="cv" Series="43539" Issue="356779" />
 </Book>
-<Book Series="Avengers Vs X-Men" Number="11" Volume="2013" Year="2012">
+<Book Series="Avengers Vs X-Men" Number="11" Volume="2012" Year="2012">
 <Database Name="cv" Series="47331" Issue="356764" />
 </Book>
 <Book Series="Uncanny X-Men" Number="18" Volume="2013" Year="2014">
 <Database Name="cv" Series="57181" Issue="446998" />
 </Book>
-<Book Series="Avengers Vs X-Men" Number="12" Volume="2013" Year="2012">
+<Book Series="Avengers Vs X-Men" Number="12" Volume="2012" Year="2012">
 <Database Name="cv" Series="47331" Issue="359916" />
 </Book>
 <Book Series="Uncanny X-Men" Number="19" Volume="2013" Year="2014">

--- a/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #11 (WEB-CBRO).cbl
+++ b/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #11 (WEB-CBRO).cbl
@@ -42,19 +42,19 @@
 <Book Series="X-Men" Number="1" Volume="2019" Year="2019">
 <Database Name="cv" Series="122077" Issue="723121" />
 </Book>
-<Book Series="New Mutants" Number="1" Volume="2019" Year="2020">
+<Book Series="New Mutants" Number="1" Volume="2020" Year="2020">
 <Database Name="cv" Series="122666" Issue="726210" />
 </Book>
-<Book Series="New Mutants" Number="2" Volume="2019" Year="2020">
+<Book Series="New Mutants" Number="2" Volume="2020" Year="2020">
 <Database Name="cv" Series="122666" Issue="728977" />
 </Book>
-<Book Series="New Mutants" Number="3" Volume="2019" Year="2020">
+<Book Series="New Mutants" Number="3" Volume="2020" Year="2020">
 <Database Name="cv" Series="122666" Issue="730341" />
 </Book>
-<Book Series="New Mutants" Number="4" Volume="2019" Year="2020">
+<Book Series="New Mutants" Number="4" Volume="2020" Year="2020">
 <Database Name="cv" Series="122666" Issue="731522" />
 </Book>
-<Book Series="New Mutants" Number="6" Volume="2019" Year="2020">
+<Book Series="New Mutants" Number="6" Volume="2020" Year="2020">
 <Database Name="cv" Series="122666" Issue="735526" />
 </Book>
 <Book Series="Marauders" Number="1" Volume="2019" Year="2019">
@@ -81,7 +81,7 @@
 <Book Series="X-Men/Fantastic Four" Number="4" Volume="2020" Year="2020">
 <Database Name="cv" Series="124822" Issue="781439" />
 </Book>
-<Book Series="X-Force" Number="1" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="1" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="726217" />
 </Book>
 <Book Series="Fallen Angels" Number="1" Volume="2019" Year="2020">
@@ -108,40 +108,40 @@
 <Book Series="X-Men" Number="3" Volume="2019" Year="2020">
 <Database Name="cv" Series="122077" Issue="729692" />
 </Book>
-<Book Series="New Mutants" Number="5" Volume="2019" Year="2020">
+<Book Series="New Mutants" Number="5" Volume="2020" Year="2020">
 <Database Name="cv" Series="122666" Issue="732887" />
 </Book>
-<Book Series="New Mutants" Number="7" Volume="2019" Year="2020">
+<Book Series="New Mutants" Number="7" Volume="2020" Year="2020">
 <Database Name="cv" Series="122666" Issue="737761" />
 </Book>
-<Book Series="New Mutants" Number="8" Volume="2019" Year="2020">
+<Book Series="New Mutants" Number="8" Volume="2020" Year="2020">
 <Database Name="cv" Series="122666" Issue="738614" />
 </Book>
-<Book Series="New Mutants" Number="9" Volume="2019" Year="2020">
+<Book Series="New Mutants" Number="9" Volume="2020" Year="2020">
 <Database Name="cv" Series="122666" Issue="740822" />
 </Book>
-<Book Series="New Mutants" Number="10" Volume="2019" Year="2020">
+<Book Series="New Mutants" Number="10" Volume="2020" Year="2020">
 <Database Name="cv" Series="122666" Issue="767932" />
 </Book>
-<Book Series="New Mutants" Number="11" Volume="2019" Year="2020">
+<Book Series="New Mutants" Number="11" Volume="2020" Year="2020">
 <Database Name="cv" Series="122666" Issue="781436" />
 </Book>
-<Book Series="X-Force" Number="2" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="2" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="728984" />
 </Book>
-<Book Series="X-Force" Number="3" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="3" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="730351" />
 </Book>
 <Book Series="X-Men" Number="4" Volume="2019" Year="2020">
 <Database Name="cv" Series="122077" Issue="731983" />
 </Book>
-<Book Series="X-Force" Number="4" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="4" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="731530" />
 </Book>
-<Book Series="X-Force" Number="5" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="5" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="732895" />
 </Book>
-<Book Series="X-Force" Number="6" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="6" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="735534" />
 </Book>
 <Book Series="Fallen Angels" Number="5" Volume="2019" Year="2020">
@@ -1488,10 +1488,10 @@
 <Book Series="X-Men" Number="9" Volume="2019" Year="2020">
 <Database Name="cv" Series="122077" Issue="743453" />
 </Book>
-<Book Series="X-Force" Number="7" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="7" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="737172" />
 </Book>
-<Book Series="X-Force" Number="8" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="8" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="738622" />
 </Book>
 <Book Series="Excalibur" Number="7" Volume="2019" Year="2020">
@@ -1500,10 +1500,10 @@
 <Book Series="Excalibur" Number="8" Volume="2019" Year="2020">
 <Database Name="cv" Series="122488" Issue="739558" />
 </Book>
-<Book Series="X-Force" Number="9" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="9" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="742380" />
 </Book>
-<Book Series="X-Force" Number="10" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="10" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="775013" />
 </Book>
 <Book Series="X-Factor" Number="1" Volume="2020" Year="2020">
@@ -1542,7 +1542,7 @@
 <Book Series="Giant-Size X-Men: Nightcrawler" Number="1" Volume="2020" Year="2020">
 <Database Name="cv" Series="126014" Issue="743439" />
 </Book>
-<Book Series="New Mutants" Number="12" Volume="2019" Year="2020">
+<Book Series="New Mutants" Number="12" Volume="2020" Year="2020">
 <Database Name="cv" Series="122666" Issue="797246" />
 </Book>
 <Book Series="Marvel's Voices" Number="1" Volume="2020" Year="2020">
@@ -1722,16 +1722,16 @@
 <Book Series="X-Factor" Number="3" Volume="2020" Year="2020">
 <Database Name="cv" Series="129097" Issue="797986" />
 </Book>
-<Book Series="X-Force" Number="11" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="11" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="791931" />
 </Book>
-<Book Series="X-Force" Number="12" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="12" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="797987" />
 </Book>
-<Book Series="X-Force" Number="15" Volume="2019" Year="2021">
+<Book Series="X-Force" Number="15" Volume="2020" Year="2021">
 <Database Name="cv" Series="122668" Issue="821504" />
 </Book>
-<Book Series="X-Force" Number="16" Volume="2019" Year="2021">
+<Book Series="X-Force" Number="16" Volume="2020" Year="2021">
 <Database Name="cv" Series="122668" Issue="825509" />
 </Book>
 <Book Series="Excalibur" Number="9" Volume="2019" Year="2020">
@@ -1758,7 +1758,7 @@
 <Book Series="Wolverine" Number="6" Volume="2020" Year="2020">
 <Database Name="cv" Series="125121" Issue="807579" />
 </Book>
-<Book Series="X-Force" Number="13" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="13" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="807580" />
 </Book>
 <Book Series="Marauders" Number="13" Volume="2019" Year="2020">
@@ -1767,7 +1767,7 @@
 <Book Series="Hellions" Number="5" Volume="2020" Year="2020">
 <Database Name="cv" Series="126015" Issue="810727" />
 </Book>
-<Book Series="New Mutants" Number="13" Volume="2019" Year="2020">
+<Book Series="New Mutants" Number="13" Volume="2020" Year="2020">
 <Database Name="cv" Series="122666" Issue="810730" />
 </Book>
 <Book Series="Cable" Number="5" Volume="2020" Year="2020">
@@ -1797,7 +1797,7 @@
 <Book Series="Wolverine" Number="7" Volume="2020" Year="2021">
 <Database Name="cv" Series="125121" Issue="817706" />
 </Book>
-<Book Series="X-Force" Number="14" Volume="2019" Year="2021">
+<Book Series="X-Force" Number="14" Volume="2020" Year="2021">
 <Database Name="cv" Series="122668" Issue="819097" />
 </Book>
 <Book Series="Hellions" Number="6" Volume="2020" Year="2021">

--- a/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #12 (WEB-CBRO).cbl
+++ b/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #12 (WEB-CBRO).cbl
@@ -486,13 +486,13 @@
 <Book Series="Marauders" Number="16" Volume="2019" Year="2021">
 <Database Name="cv" Series="122218" Issue="820747" />
 </Book>
-<Book Series="New Mutants" Number="14" Volume="2019" Year="2021">
+<Book Series="New Mutants" Number="14" Volume="2020" Year="2021">
 <Database Name="cv" Series="122666" Issue="821499" />
 </Book>
 <Book Series="X-Factor" Number="6" Volume="2020" Year="2021">
 <Database Name="cv" Series="129097" Issue="824036" />
 </Book>
-<Book Series="New Mutants" Number="15" Volume="2019" Year="2021">
+<Book Series="New Mutants" Number="15" Volume="2020" Year="2021">
 <Database Name="cv" Series="122666" Issue="826560" />
 </Book>
 <Book Series="X-Men" Number="17" Volume="2019" Year="2021">
@@ -537,22 +537,22 @@
 <Book Series="Juggernaut" Number="5" Volume="2020" Year="2021">
 <Database Name="cv" Series="130568" Issue="824028" />
 </Book>
-<Book Series="X-Force" Number="17" Volume="2019" Year="2021">
+<Book Series="X-Force" Number="17" Volume="2020" Year="2021">
 <Database Name="cv" Series="122668" Issue="828200" />
 </Book>
-<Book Series="X-Force" Number="18" Volume="2019" Year="2021">
+<Book Series="X-Force" Number="18" Volume="2020" Year="2021">
 <Database Name="cv" Series="122668" Issue="838891" />
 </Book>
-<Book Series="X-Force" Number="19" Volume="2019" Year="2021">
+<Book Series="X-Force" Number="19" Volume="2020" Year="2021">
 <Database Name="cv" Series="122668" Issue="844977" />
 </Book>
 <Book Series="Children of the Atom" Number="3" Volume="2021" Year="2021">
 <Database Name="cv" Series="134388" Issue="848848" />
 </Book>
-<Book Series="New Mutants" Number="16" Volume="2019" Year="2021">
+<Book Series="New Mutants" Number="16" Volume="2020" Year="2021">
 <Database Name="cv" Series="122666" Issue="830031" />
 </Book>
-<Book Series="New Mutants" Number="17" Volume="2019" Year="2021">
+<Book Series="New Mutants" Number="17" Volume="2020" Year="2021">
 <Database Name="cv" Series="122666" Issue="846089" />
 </Book>
 <Book Series="X-Men" Number="18" Volume="2019" Year="2021">
@@ -561,7 +561,7 @@
 <Book Series="X-Men" Number="19" Volume="2019" Year="2021">
 <Database Name="cv" Series="122077" Issue="840961" />
 </Book>
-<Book Series="New Mutants" Number="18" Volume="2019" Year="2021">
+<Book Series="New Mutants" Number="18" Volume="2020" Year="2021">
 <Database Name="cv" Series="122666" Issue="855632" />
 </Book>
 <Book Series="Excalibur" Number="17" Volume="2019" Year="2021">
@@ -636,7 +636,7 @@
 <Book Series="Marauders" Number="21" Volume="2019" Year="2021">
 <Database Name="cv" Series="122218" Issue="857597" />
 </Book>
-<Book Series="X-Force" Number="20" Volume="2019" Year="2021">
+<Book Series="X-Force" Number="20" Volume="2020" Year="2021">
 <Database Name="cv" Series="122668" Issue="857598" />
 </Book>
 <Book Series="Hellions" Number="12" Volume="2020" Year="2021">
@@ -651,7 +651,7 @@
 <Book Series="Planet-Size X-Men" Number="1" Volume="2021" Year="2021">
 <Database Name="cv" Series="136937" Issue="861642" />
 </Book>
-<Book Series="New Mutants" Number="19" Volume="2019" Year="2021">
+<Book Series="New Mutants" Number="19" Volume="2020" Year="2021">
 <Database Name="cv" Series="122666" Issue="861639" />
 </Book>
 <Book Series="Children of the Atom" Number="6" Volume="2021" Year="2021">
@@ -828,7 +828,7 @@
 <Book Series="Black Cat" Number="10" Volume="2020" Year="2021">
 <Database Name="cv" Series="132631" Issue="886958" />
 </Book>
-<Book Series="Giant-Sized Black Cat: Infinity Score" Number="1" Volume="2021" Year="2022">
+<Book Series="Giant-Size Black Cat: Infinity Score" Number="1" Volume="2021" Year="2022">
 <Database Name="cv" Series="140355" Issue="897333" />
 </Book>
 <Book Series="Shang-Chi" Number="1" Volume="2021" Year="2021">
@@ -1440,16 +1440,16 @@
 <Book Series="X-Men" Number="1" Volume="2021" Year="2021">
 <Database Name="cv" Series="137402" Issue="868602" />
 </Book>
-<Book Series="New Mutants" Number="20" Volume="2019" Year="2021">
+<Book Series="New Mutants" Number="20" Volume="2020" Year="2021">
 <Database Name="cv" Series="122666" Issue="872877" />
 </Book>
-<Book Series="New Mutants" Number="21" Volume="2019" Year="2021">
+<Book Series="New Mutants" Number="21" Volume="2020" Year="2021">
 <Database Name="cv" Series="122666" Issue="882897" />
 </Book>
-<Book Series="New Mutants" Number="22" Volume="2019" Year="2021">
+<Book Series="New Mutants" Number="22" Volume="2020" Year="2021">
 <Database Name="cv" Series="122666" Issue="888638" />
 </Book>
-<Book Series="New Mutants" Number="23" Volume="2019" Year="2022">
+<Book Series="New Mutants" Number="23" Volume="2020" Year="2022">
 <Database Name="cv" Series="122666" Issue="896124" />
 </Book>
 <Book Series="X-Men: The Trial of Magneto" Number="1" Volume="2021" Year="2021">
@@ -1503,7 +1503,7 @@
 <Book Series="X-Men: The Trial of Magneto" Number="5" Volume="2021" Year="2022">
 <Database Name="cv" Series="138343" Issue="899168" />
 </Book>
-<Book Series="New Mutants" Number="24" Volume="2019" Year="2022">
+<Book Series="New Mutants" Number="24" Volume="2020" Year="2022">
 <Database Name="cv" Series="122666" Issue="906634" />
 </Book>
 <Book Series="X-Men" Number="2" Volume="2021" Year="2021">
@@ -2070,10 +2070,10 @@
 <Book Series="Devil's Reign: Omega" Number="1" Volume="2022" Year="2022">
 <Database Name="cv" Series="130207" Issue="926189" />
 </Book>
-<Book Series="X-Force" Number="21" Volume="2019" Year="2021">
+<Book Series="X-Force" Number="21" Volume="2020" Year="2021">
 <Database Name="cv" Series="122668" Issue="868600" />
 </Book>
-<Book Series="X-Force" Number="22" Volume="2019" Year="2021">
+<Book Series="X-Force" Number="22" Volume="2020" Year="2021">
 <Database Name="cv" Series="122668" Issue="878792" />
 </Book>
 <Book Series="Wolverine" Number="17" Volume="2020" Year="2021">
@@ -2082,19 +2082,19 @@
 <Book Series="Wolverine" Number="18" Volume="2020" Year="2022">
 <Database Name="cv" Series="125121" Issue="895337" />
 </Book>
-<Book Series="X-Force" Number="23" Volume="2019" Year="2021">
+<Book Series="X-Force" Number="23" Volume="2020" Year="2021">
 <Database Name="cv" Series="122668" Issue="884069" />
 </Book>
-<Book Series="X-Force" Number="24" Volume="2019" Year="2021">
+<Book Series="X-Force" Number="24" Volume="2020" Year="2021">
 <Database Name="cv" Series="122668" Issue="889465" />
 </Book>
 <Book Series="Inferno" Number="2" Volume="2021" Year="2021">
 <Database Name="cv" Series="139289" Issue="891562" />
 </Book>
-<Book Series="X-Force" Number="25" Volume="2019" Year="2022">
+<Book Series="X-Force" Number="25" Volume="2020" Year="2022">
 <Database Name="cv" Series="122668" Issue="894133" />
 </Book>
-<Book Series="X-Force" Number="26" Volume="2019" Year="2022">
+<Book Series="X-Force" Number="26" Volume="2020" Year="2022">
 <Database Name="cv" Series="122668" Issue="898353" />
 </Book>
 <Book Series="Wolverine" Number="19" Volume="2020" Year="2022">

--- a/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #13 (WEB-CBRO).cbl
+++ b/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #13 (WEB-CBRO).cbl
@@ -231,7 +231,7 @@
 <Book Series="Iron Fist" Number="5" Volume="2022" Year="2022">
 <Database Name="cv" Series="141631" Issue="945044" />
 </Book>
-<Book Series="Captain America" Number="0" Volume="2023" Year="2022">
+<Book Series="Captain America" Number="0" Volume="2022" Year="2022">
 <Database Name="cv" Series="142485" Issue="918720" />
 </Book>
 <Book Series="Carnage Forever" Number="1" Volume="2022" Year="2022">
@@ -1281,31 +1281,31 @@
 <Book Series="Marauders" Number="10" Volume="2022" Year="2023">
 <Database Name="cv" Series="142135" Issue="962851" />
 </Book>
-<Book Series="New Mutants" Number="25" Volume="2019" Year="2022">
+<Book Series="New Mutants" Number="25" Volume="2020" Year="2022">
 <Database Name="cv" Series="122666" Issue="924785" />
 </Book>
-<Book Series="New Mutants" Number="26" Volume="2019" Year="2022">
+<Book Series="New Mutants" Number="26" Volume="2020" Year="2022">
 <Database Name="cv" Series="122666" Issue="931631" />
 </Book>
-<Book Series="New Mutants" Number="27" Volume="2019" Year="2022">
+<Book Series="New Mutants" Number="27" Volume="2020" Year="2022">
 <Database Name="cv" Series="122666" Issue="935764" />
 </Book>
-<Book Series="New Mutants" Number="28" Volume="2019" Year="2022">
+<Book Series="New Mutants" Number="28" Volume="2020" Year="2022">
 <Database Name="cv" Series="122666" Issue="942712" />
 </Book>
-<Book Series="New Mutants" Number="29" Volume="2019" Year="2022">
+<Book Series="New Mutants" Number="29" Volume="2020" Year="2022">
 <Database Name="cv" Series="122666" Issue="946211" />
 </Book>
-<Book Series="New Mutants" Number="30" Volume="2019" Year="2022">
+<Book Series="New Mutants" Number="30" Volume="2020" Year="2022">
 <Database Name="cv" Series="122666" Issue="948113" />
 </Book>
-<Book Series="New Mutants" Number="31" Volume="2019" Year="2022">
+<Book Series="New Mutants" Number="31" Volume="2020" Year="2022">
 <Database Name="cv" Series="122666" Issue="952303" />
 </Book>
-<Book Series="New Mutants" Number="32" Volume="2019" Year="2023">
+<Book Series="New Mutants" Number="32" Volume="2020" Year="2023">
 <Database Name="cv" Series="122666" Issue="958986" />
 </Book>
-<Book Series="New Mutants" Number="33" Volume="2019" Year="2023">
+<Book Series="New Mutants" Number="33" Volume="2020" Year="2023">
 <Database Name="cv" Series="122666" Issue="961943" />
 </Book>
 <Book Series="Bishop: War College" Number="1" Volume="2023" Year="2023">
@@ -1725,25 +1725,25 @@
 <Book Series="Avengers: War Across Time" Number="5" Volume="2023" Year="2023">
 <Database Name="cv" Series="147434" Issue="987228" />
 </Book>
-<Book Series="Black Panther" Number="9" Volume="2023" Year="2022">
+<Book Series="Black Panther" Number="9" Volume="2022" Year="2022">
 <Database Name="cv" Series="140222" Issue="946213" />
 </Book>
-<Book Series="Black Panther" Number="10" Volume="2023" Year="2022">
+<Book Series="Black Panther" Number="10" Volume="2022" Year="2022">
 <Database Name="cv" Series="140222" Issue="950789" />
 </Book>
-<Book Series="Black Panther" Number="11" Volume="2023" Year="2023">
+<Book Series="Black Panther" Number="11" Volume="2022" Year="2023">
 <Database Name="cv" Series="140222" Issue="953001" />
 </Book>
-<Book Series="Black Panther" Number="12" Volume="2023" Year="2023">
+<Book Series="Black Panther" Number="12" Volume="2022" Year="2023">
 <Database Name="cv" Series="140222" Issue="960976" />
 </Book>
-<Book Series="Black Panther" Number="13" Volume="2023" Year="2023">
+<Book Series="Black Panther" Number="13" Volume="2022" Year="2023">
 <Database Name="cv" Series="140222" Issue="963983" />
 </Book>
-<Book Series="Black Panther" Number="14" Volume="2023" Year="2023">
+<Book Series="Black Panther" Number="14" Volume="2022" Year="2023">
 <Database Name="cv" Series="140222" Issue="969379" />
 </Book>
-<Book Series="Black Panther" Number="15" Volume="2023" Year="2023">
+<Book Series="Black Panther" Number="15" Volume="2022" Year="2023">
 <Database Name="cv" Series="140222" Issue="975705" />
 </Book>
 <Book Series="Wasp" Number="1" Volume="2023" Year="2023">
@@ -1896,8 +1896,8 @@
 <Book Series="Moon Girl and Devil Dinosaur" Number="5" Volume="2022" Year="2023">
 <Database Name="cv" Series="146733" Issue="984328" />
 </Book>
-<Book Series="Gold Goblin" Number="1" Volume="2023" Year="2023">
-<Database Name="cv" Series="151517" Issue="996028" />
+<Book Series="Gold Goblin" Number="1" Volume="2022" Year="2023">
+<Database Name="cv" Series="146113" Issue="955122" />
 </Book>
 <Book Series="The Amazing Spider-Man" Number="14" Volume="2022" Year="2023">
 <Database Name="cv" Series="142577" Issue="956770" />
@@ -1923,7 +1923,7 @@
 <Book Series="Dark Web: Ms. Marvel" Number="2" Volume="2023" Year="2023">
 <Database Name="cv" Series="146986" Issue="963978" />
 </Book>
-<Book Series="Gold Goblin" Number="2" Volume="2023" Year="2023">
+<Book Series="Gold Goblin" Number="2" Volume="2022" Year="2023">
 <Database Name="cv" Series="146113" Issue="960978" />
 </Book>
 <Book Series="The Amazing Spider-Man" Number="16" Volume="2022" Year="2023">
@@ -1947,7 +1947,7 @@
 <Book Series="Mary Jane &#38; Black Cat" Number="4" Volume="2023" Year="2023">
 <Database Name="cv" Series="146987" Issue="975702" />
 </Book>
-<Book Series="Gold Goblin" Number="3" Volume="2023" Year="2023">
+<Book Series="Gold Goblin" Number="3" Volume="2022" Year="2023">
 <Database Name="cv" Series="146113" Issue="962847" />
 </Book>
 <Book Series="Dark Web: X-Men" Number="3" Volume="2022" Year="2023">
@@ -1974,10 +1974,10 @@
 <Book Series="The Amazing Spider-Man" Number="20" Volume="2022" Year="2023">
 <Database Name="cv" Series="142577" Issue="973034" />
 </Book>
-<Book Series="Gold Goblin" Number="4" Volume="2023" Year="2023">
+<Book Series="Gold Goblin" Number="4" Volume="2022" Year="2023">
 <Database Name="cv" Series="146113" Issue="969384" />
 </Book>
-<Book Series="Gold Goblin" Number="5" Volume="2023" Year="2023">
+<Book Series="Gold Goblin" Number="5" Volume="2022" Year="2023">
 <Database Name="cv" Series="146113" Issue="976906" />
 </Book>
 <Book Series="Daredevil" Number="6" Volume="2022" Year="2023">

--- a/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order- A Fresh Start (WEB-CBRO).cbl
+++ b/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order- A Fresh Start (WEB-CBRO).cbl
@@ -1257,7 +1257,7 @@
 <Book Series="Silver Surfer: The Best Defense" Number="1" Volume="2018" Year="2019">
 <Database Name="cv" Series="115905" Issue="694921" />
 </Book>
-<Book Series="Defenders: The Best Defense" Number="1" Volume="2019" Year="2019">
+<Book Series="Defenders: The Best Defense" Number="1" Volume="2018" Year="2019">
     <Database Name="cv" Series="116067" Issue="695631" />
 </Book>
 <Book Series="Shuri" Number="1" Volume="2018" Year="2018">
@@ -2331,22 +2331,22 @@
 <Book Series="Shuri" Number="7" Volume="2018" Year="2019">
 <Database Name="cv" Series="114421" Issue="706416" />
 </Book>
-<Book Series="X-Force" Number="1" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="1" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="726217" />
 </Book>
-<Book Series="X-Force" Number="2" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="2" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="728984" />
 </Book>
-<Book Series="X-Force" Number="3" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="3" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="730351" />
 </Book>
-<Book Series="X-Force" Number="4" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="4" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="731530" />
 </Book>
-<Book Series="X-Force" Number="5" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="5" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="732895" />
 </Book>
-<Book Series="X-Force" Number="6" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="6" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="735534" />
 </Book>
 <Book Series="Captain America &#38; the Invaders: Bahamas Triangle" Number="1" Volume="2019" Year="2019">
@@ -2808,16 +2808,16 @@
 <Book Series="Guardians of the Galaxy Annual" Number="1" Volume="2019" Year="2019">
 <Database Name="cv" Series="119535" Issue="710681" />
 </Book>
-<Book Series="X-Force" Number="7" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="7" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="737172" />
 </Book>
-<Book Series="X-Force" Number="8" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="8" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="738622" />
 </Book>
-<Book Series="X-Force" Number="9" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="9" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="742380" />
 </Book>
-<Book Series="X-Force" Number="10" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="10" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="775013" />
 </Book>
 <Book Series="Fantastic Four: 4 Yancy Street" Number="1" Volume="2019" Year="2019">

--- a/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order- Marvel Legacy (WEB-CBRO).cbl
+++ b/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order- Marvel Legacy (WEB-CBRO).cbl
@@ -1308,17 +1308,17 @@
 <Book Series="Legion" Number="1" Volume="2018" Year="2018">
 <Database Name="cv" Series="108105" Issue="655505" />
 </Book>
-<Book Series="The Legion" Number="2" Volume="2001" Year="2002">
-<Database Name="cv" Series="7226" Issue="51465" />
+<Book Series="Legion" Number="2" Volume="2018" Year="2018">
+<Database Name="cv" Series="108105" Issue="661152" />
 </Book>
-<Book Series="The Legion" Number="3" Volume="2001" Year="2002">
-<Database Name="cv" Series="7226" Issue="51466" />
+<Book Series="Legion" Number="3" Volume="2018" Year="2018">
+<Database Name="cv" Series="108105" Issue="664301" />
 </Book>
-<Book Series="The Legion" Number="4" Volume="2001" Year="2002">
-<Database Name="cv" Series="7226" Issue="51467" />
+<Book Series="Legion" Number="4" Volume="2018" Year="2018">
+<Database Name="cv" Series="108105" Issue="667645" />
 </Book>
-<Book Series="The Legion" Number="5" Volume="2001" Year="2002">
-<Database Name="cv" Series="7226" Issue="73452" />
+<Book Series="Legion" Number="5" Volume="2018" Year="2018">
+<Database Name="cv" Series="108105" Issue="670748" />
 </Book>
 <Book Series="Spider-Man/Deadpool" Number="29" Volume="2016" Year="2018">
 <Database Name="cv" Series="87182" Issue="662753" />

--- a/Marvel/Master Reading Order/CBRO/[Marvel] Marvel Master Reading Order Part #01 (WEB-CBRO).cbl
+++ b/Marvel/Master Reading Order/CBRO/[Marvel] Marvel Master Reading Order Part #01 (WEB-CBRO).cbl
@@ -640,7 +640,7 @@
 <Database Name="cv" Series="19112" Issue="134019" />
 </Book>
 <Book Series="Avengers: Season One" Number="1" Volume="2013" Year="2013">
-<Database Name="cv" Series="57442" Issue="414196" />
+<Database Name="cv" Series="64453" Issue="386970" />
 </Book>
 <Book Series="Avengers Origins: Scarlet Witch &#38; Quicksilver" Number="1" Volume="2012" Year="2012">
 <Database Name="cv" Series="44148" Issue="303673" />

--- a/Marvel/Master Reading Order/CBRO/[Marvel] Marvel Master Reading Order Part #03 (WEB-CBRO).cbl
+++ b/Marvel/Master Reading Order/CBRO/[Marvel] Marvel Master Reading Order Part #03 (WEB-CBRO).cbl
@@ -1860,7 +1860,7 @@
 <Book Series="The Uncanny X-Men" Number="199" Volume="1981" Year="1985">
 <Database Name="cv" Series="3092" Issue="26105" />
 </Book>
-<Book Series="Uncanny X-Men Annual" Number="9" Volume="2006" Year="1985">
+<Book Series="X-Men Annual" Number="9" Volume="1970" Year="1985">
 <Database Name="cv" Series="22988" Issue="111575" />
 </Book>
 <Book Series="The Uncanny X-Men" Number="200" Volume="1981" Year="1985">

--- a/Marvel/Master Reading Order/CBRO/[Marvel] Marvel Master Reading Order Part #06 (WEB-CBRO).cbl
+++ b/Marvel/Master Reading Order/CBRO/[Marvel] Marvel Master Reading Order Part #06 (WEB-CBRO).cbl
@@ -1680,7 +1680,7 @@
 <Book Series="New X-Men" Number="116" Volume="2001" Year="2001">
 <Database Name="cv" Series="9121" Issue="66994" />
 </Book>
-<Book Series="New X-Men 2001" Number="1" Volume="2001" Year="2001">
+<Book Series="X-Men 2001" Number="1" Volume="2001" Year="2001">
 <Database Name="cv" Series="21334" Issue="128914" />
 </Book>
 <Book Series="New X-Men" Number="117" Volume="2001" Year="2001">

--- a/Marvel/Master Reading Order/CBRO/[Marvel] Marvel Master Reading Order Part #11 (WEB-CBRO).cbl
+++ b/Marvel/Master Reading Order/CBRO/[Marvel] Marvel Master Reading Order Part #11 (WEB-CBRO).cbl
@@ -42,19 +42,19 @@
 <Book Series="X-Men" Number="1" Volume="2019" Year="2019">
 <Database Name="cv" Series="122077" Issue="723121" />
 </Book>
-<Book Series="New Mutants" Number="1" Volume="2019" Year="2020">
+<Book Series="New Mutants" Number="1" Volume="2020" Year="2020">
 <Database Name="cv" Series="122666" Issue="726210" />
 </Book>
-<Book Series="New Mutants" Number="2" Volume="2019" Year="2020">
+<Book Series="New Mutants" Number="2" Volume="2020" Year="2020">
 <Database Name="cv" Series="122666" Issue="728977" />
 </Book>
-<Book Series="New Mutants" Number="3" Volume="2019" Year="2020">
+<Book Series="New Mutants" Number="3" Volume="2020" Year="2020">
 <Database Name="cv" Series="122666" Issue="730341" />
 </Book>
-<Book Series="New Mutants" Number="4" Volume="2019" Year="2020">
+<Book Series="New Mutants" Number="4" Volume="2020" Year="2020">
 <Database Name="cv" Series="122666" Issue="731522" />
 </Book>
-<Book Series="New Mutants" Number="6" Volume="2019" Year="2020">
+<Book Series="New Mutants" Number="6" Volume="2020" Year="2020">
 <Database Name="cv" Series="122666" Issue="735526" />
 </Book>
 <Book Series="Marauders" Number="1" Volume="2019" Year="2019">
@@ -81,7 +81,7 @@
 <Book Series="X-Men/Fantastic Four" Number="4" Volume="2020" Year="2020">
 <Database Name="cv" Series="124822" Issue="781439" />
 </Book>
-<Book Series="X-Force" Number="1" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="1" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="726217" />
 </Book>
 <Book Series="Fallen Angels" Number="1" Volume="2019" Year="2020">
@@ -108,40 +108,40 @@
 <Book Series="X-Men" Number="3" Volume="2019" Year="2020">
 <Database Name="cv" Series="122077" Issue="729692" />
 </Book>
-<Book Series="New Mutants" Number="5" Volume="2019" Year="2020">
+<Book Series="New Mutants" Number="5" Volume="2020" Year="2020">
 <Database Name="cv" Series="122666" Issue="732887" />
 </Book>
-<Book Series="New Mutants" Number="7" Volume="2019" Year="2020">
+<Book Series="New Mutants" Number="7" Volume="2020" Year="2020">
 <Database Name="cv" Series="122666" Issue="737761" />
 </Book>
-<Book Series="New Mutants" Number="8" Volume="2019" Year="2020">
+<Book Series="New Mutants" Number="8" Volume="2020" Year="2020">
 <Database Name="cv" Series="122666" Issue="738614" />
 </Book>
-<Book Series="New Mutants" Number="9" Volume="2019" Year="2020">
+<Book Series="New Mutants" Number="9" Volume="2020" Year="2020">
 <Database Name="cv" Series="122666" Issue="740822" />
 </Book>
-<Book Series="New Mutants" Number="10" Volume="2019" Year="2020">
+<Book Series="New Mutants" Number="10" Volume="2020" Year="2020">
 <Database Name="cv" Series="122666" Issue="767932" />
 </Book>
-<Book Series="New Mutants" Number="11" Volume="2019" Year="2020">
+<Book Series="New Mutants" Number="11" Volume="2020" Year="2020">
 <Database Name="cv" Series="122666" Issue="781436" />
 </Book>
-<Book Series="X-Force" Number="2" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="2" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="728984" />
 </Book>
-<Book Series="X-Force" Number="3" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="3" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="730351" />
 </Book>
 <Book Series="X-Men" Number="4" Volume="2019" Year="2020">
 <Database Name="cv" Series="122077" Issue="731983" />
 </Book>
-<Book Series="X-Force" Number="4" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="4" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="731530" />
 </Book>
-<Book Series="X-Force" Number="5" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="5" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="732895" />
 </Book>
-<Book Series="X-Force" Number="6" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="6" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="735534" />
 </Book>
 <Book Series="Fallen Angels" Number="5" Volume="2019" Year="2020">
@@ -1374,10 +1374,10 @@
 <Book Series="X-Men" Number="9" Volume="2019" Year="2020">
 <Database Name="cv" Series="122077" Issue="743453" />
 </Book>
-<Book Series="X-Force" Number="7" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="7" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="737172" />
 </Book>
-<Book Series="X-Force" Number="8" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="8" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="738622" />
 </Book>
 <Book Series="Excalibur" Number="7" Volume="2019" Year="2020">
@@ -1386,10 +1386,10 @@
 <Book Series="Excalibur" Number="8" Volume="2019" Year="2020">
 <Database Name="cv" Series="122488" Issue="739558" />
 </Book>
-<Book Series="X-Force" Number="9" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="9" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="742380" />
 </Book>
-<Book Series="X-Force" Number="10" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="10" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="775013" />
 </Book>
 <Book Series="X-Factor" Number="1" Volume="2020" Year="2020">
@@ -1428,7 +1428,7 @@
 <Book Series="Giant-Size X-Men: Nightcrawler" Number="1" Volume="2020" Year="2020">
 <Database Name="cv" Series="126014" Issue="743439" />
 </Book>
-<Book Series="New Mutants" Number="12" Volume="2019" Year="2020">
+<Book Series="New Mutants" Number="12" Volume="2020" Year="2020">
 <Database Name="cv" Series="122666" Issue="797246" />
 </Book>
 <Book Series="Marvel's Voices" Number="1" Volume="2020" Year="2020">
@@ -1494,16 +1494,16 @@
 <Book Series="X-Factor" Number="3" Volume="2020" Year="2020">
 <Database Name="cv" Series="129097" Issue="797986" />
 </Book>
-<Book Series="X-Force" Number="11" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="11" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="791931" />
 </Book>
-<Book Series="X-Force" Number="12" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="12" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="797987" />
 </Book>
-<Book Series="X-Force" Number="15" Volume="2019" Year="2021">
+<Book Series="X-Force" Number="15" Volume="2020" Year="2021">
 <Database Name="cv" Series="122668" Issue="821504" />
 </Book>
-<Book Series="X-Force" Number="16" Volume="2019" Year="2021">
+<Book Series="X-Force" Number="16" Volume="2020" Year="2021">
 <Database Name="cv" Series="122668" Issue="825509" />
 </Book>
 <Book Series="Excalibur" Number="9" Volume="2019" Year="2020">

--- a/Marvel/Master Reading Order/CBRO/[Marvel] Marvel Master Reading Order Part #12 (WEB-CBRO).cbl
+++ b/Marvel/Master Reading Order/CBRO/[Marvel] Marvel Master Reading Order Part #12 (WEB-CBRO).cbl
@@ -432,13 +432,13 @@
 <Book Series="Marauders" Number="16" Volume="2019" Year="2021">
 <Database Name="cv" Series="122218" Issue="820747" />
 </Book>
-<Book Series="New Mutants" Number="14" Volume="2019" Year="2021">
+<Book Series="New Mutants" Number="14" Volume="2020" Year="2021">
 <Database Name="cv" Series="122666" Issue="821499" />
 </Book>
 <Book Series="X-Factor" Number="6" Volume="2020" Year="2021">
 <Database Name="cv" Series="129097" Issue="824036" />
 </Book>
-<Book Series="New Mutants" Number="15" Volume="2019" Year="2021">
+<Book Series="New Mutants" Number="15" Volume="2020" Year="2021">
 <Database Name="cv" Series="122666" Issue="826560" />
 </Book>
 <Book Series="X-Men" Number="17" Volume="2019" Year="2021">
@@ -483,22 +483,22 @@
 <Book Series="Juggernaut" Number="5" Volume="2020" Year="2021">
 <Database Name="cv" Series="130568" Issue="824028" />
 </Book>
-<Book Series="X-Force" Number="17" Volume="2019" Year="2021">
+<Book Series="X-Force" Number="17" Volume="2020" Year="2021">
 <Database Name="cv" Series="122668" Issue="828200" />
 </Book>
-<Book Series="X-Force" Number="18" Volume="2019" Year="2021">
+<Book Series="X-Force" Number="18" Volume="2020" Year="2021">
 <Database Name="cv" Series="122668" Issue="838891" />
 </Book>
-<Book Series="X-Force" Number="19" Volume="2019" Year="2021">
+<Book Series="X-Force" Number="19" Volume="2020" Year="2021">
 <Database Name="cv" Series="122668" Issue="844977" />
 </Book>
 <Book Series="Children of the Atom" Number="3" Volume="2021" Year="2021">
 <Database Name="cv" Series="134388" Issue="848848" />
 </Book>
-<Book Series="New Mutants" Number="16" Volume="2019" Year="2021">
+<Book Series="New Mutants" Number="16" Volume="2020" Year="2021">
 <Database Name="cv" Series="122666" Issue="830031" />
 </Book>
-<Book Series="New Mutants" Number="17" Volume="2019" Year="2021">
+<Book Series="New Mutants" Number="17" Volume="2020" Year="2021">
 <Database Name="cv" Series="122666" Issue="846089" />
 </Book>
 <Book Series="X-Men" Number="18" Volume="2019" Year="2021">
@@ -507,7 +507,7 @@
 <Book Series="X-Men" Number="19" Volume="2019" Year="2021">
 <Database Name="cv" Series="122077" Issue="840961" />
 </Book>
-<Book Series="New Mutants" Number="18" Volume="2019" Year="2021">
+<Book Series="New Mutants" Number="18" Volume="2020" Year="2021">
 <Database Name="cv" Series="122666" Issue="855632" />
 </Book>
 <Book Series="Excalibur" Number="17" Volume="2019" Year="2021">
@@ -735,7 +735,7 @@
 <Book Series="Black Cat" Number="10" Volume="2020" Year="2021">
 <Database Name="cv" Series="132631" Issue="886958" />
 </Book>
-<Book Series="Giant-Sized Black Cat: Infinity Score" Number="1" Volume="2021" Year="2022">
+<Book Series="Giant-Size Black Cat: Infinity Score" Number="1" Volume="2021" Year="2022">
 <Database Name="cv" Series="140355" Issue="897333" />
 </Book>
 <Book Series="Shang-Chi" Number="1" Volume="2021" Year="2021">
@@ -1311,16 +1311,16 @@
 <Book Series="X-Men" Number="1" Volume="2021" Year="2021">
 <Database Name="cv" Series="137402" Issue="868602" />
 </Book>
-<Book Series="New Mutants" Number="20" Volume="2019" Year="2021">
+<Book Series="New Mutants" Number="20" Volume="2020" Year="2021">
 <Database Name="cv" Series="122666" Issue="872877" />
 </Book>
-<Book Series="New Mutants" Number="21" Volume="2019" Year="2021">
+<Book Series="New Mutants" Number="21" Volume="2020" Year="2021">
 <Database Name="cv" Series="122666" Issue="882897" />
 </Book>
-<Book Series="New Mutants" Number="22" Volume="2019" Year="2021">
+<Book Series="New Mutants" Number="22" Volume="2020" Year="2021">
 <Database Name="cv" Series="122666" Issue="888638" />
 </Book>
-<Book Series="New Mutants" Number="23" Volume="2019" Year="2022">
+<Book Series="New Mutants" Number="23" Volume="2020" Year="2022">
 <Database Name="cv" Series="122666" Issue="896124" />
 </Book>
 <Book Series="X-Men: The Trial of Magneto" Number="1" Volume="2021" Year="2021">
@@ -1374,7 +1374,7 @@
 <Book Series="X-Men: The Trial of Magneto" Number="5" Volume="2021" Year="2022">
 <Database Name="cv" Series="138343" Issue="899168" />
 </Book>
-<Book Series="New Mutants" Number="24" Volume="2019" Year="2022">
+<Book Series="New Mutants" Number="24" Volume="2020" Year="2022">
 <Database Name="cv" Series="122666" Issue="906634" />
 </Book>
 <Book Series="X-Men" Number="2" Volume="2021" Year="2021">
@@ -1866,10 +1866,10 @@
 <Book Series="Spider-Woman" Number="17" Volume="2020" Year="2022">
 <Database Name="cv" Series="125812" Issue="894363" />
 </Book>
-<Book Series="X-Force" Number="21" Volume="2019" Year="2021">
+<Book Series="X-Force" Number="21" Volume="2020" Year="2021">
 <Database Name="cv" Series="122668" Issue="868600" />
 </Book>
-<Book Series="X-Force" Number="22" Volume="2019" Year="2021">
+<Book Series="X-Force" Number="22" Volume="2020" Year="2021">
 <Database Name="cv" Series="122668" Issue="878792" />
 </Book>
 <Book Series="Wolverine" Number="17" Volume="2020" Year="2021">
@@ -1878,19 +1878,19 @@
 <Book Series="Wolverine" Number="18" Volume="2020" Year="2022">
 <Database Name="cv" Series="125121" Issue="895337" />
 </Book>
-<Book Series="X-Force" Number="23" Volume="2019" Year="2021">
+<Book Series="X-Force" Number="23" Volume="2020" Year="2021">
 <Database Name="cv" Series="122668" Issue="884069" />
 </Book>
-<Book Series="X-Force" Number="24" Volume="2019" Year="2021">
+<Book Series="X-Force" Number="24" Volume="2020" Year="2021">
 <Database Name="cv" Series="122668" Issue="889465" />
 </Book>
 <Book Series="Inferno" Number="2" Volume="2021" Year="2021">
 <Database Name="cv" Series="139289" Issue="891562" />
 </Book>
-<Book Series="X-Force" Number="25" Volume="2019" Year="2022">
+<Book Series="X-Force" Number="25" Volume="2020" Year="2022">
 <Database Name="cv" Series="122668" Issue="894133" />
 </Book>
-<Book Series="X-Force" Number="26" Volume="2019" Year="2022">
+<Book Series="X-Force" Number="26" Volume="2020" Year="2022">
 <Database Name="cv" Series="122668" Issue="898353" />
 </Book>
 <Book Series="Wolverine" Number="19" Volume="2020" Year="2022">

--- a/Marvel/Master Reading Order/CBRO/[Marvel] Marvel Master Reading Order Part #13 (WEB-CBRO).cbl
+++ b/Marvel/Master Reading Order/CBRO/[Marvel] Marvel Master Reading Order Part #13 (WEB-CBRO).cbl
@@ -231,7 +231,7 @@
 <Book Series="Iron Fist" Number="5" Volume="2022" Year="2022">
 <Database Name="cv" Series="141631" Issue="945044" />
 </Book>
-<Book Series="Captain America" Number="0" Volume="2023" Year="2022">
+<Book Series="Captain America" Number="0" Volume="2022" Year="2022">
 <Database Name="cv" Series="142485" Issue="918720" />
 </Book>
 <Book Series="Carnage Forever" Number="1" Volume="2022" Year="2022">
@@ -1176,31 +1176,31 @@
 <Book Series="Marauders" Number="10" Volume="2022" Year="2023">
 <Database Name="cv" Series="142135" Issue="962851" />
 </Book>
-<Book Series="New Mutants" Number="25" Volume="2019" Year="2022">
+<Book Series="New Mutants" Number="25" Volume="2020" Year="2022">
 <Database Name="cv" Series="122666" Issue="924785" />
 </Book>
-<Book Series="New Mutants" Number="26" Volume="2019" Year="2022">
+<Book Series="New Mutants" Number="26" Volume="2020" Year="2022">
 <Database Name="cv" Series="122666" Issue="931631" />
 </Book>
-<Book Series="New Mutants" Number="27" Volume="2019" Year="2022">
+<Book Series="New Mutants" Number="27" Volume="2020" Year="2022">
 <Database Name="cv" Series="122666" Issue="935764" />
 </Book>
-<Book Series="New Mutants" Number="28" Volume="2019" Year="2022">
+<Book Series="New Mutants" Number="28" Volume="2020" Year="2022">
 <Database Name="cv" Series="122666" Issue="942712" />
 </Book>
-<Book Series="New Mutants" Number="29" Volume="2019" Year="2022">
+<Book Series="New Mutants" Number="29" Volume="2020" Year="2022">
 <Database Name="cv" Series="122666" Issue="946211" />
 </Book>
-<Book Series="New Mutants" Number="30" Volume="2019" Year="2022">
+<Book Series="New Mutants" Number="30" Volume="2020" Year="2022">
 <Database Name="cv" Series="122666" Issue="948113" />
 </Book>
-<Book Series="New Mutants" Number="31" Volume="2019" Year="2022">
+<Book Series="New Mutants" Number="31" Volume="2020" Year="2022">
 <Database Name="cv" Series="122666" Issue="952303" />
 </Book>
-<Book Series="New Mutants" Number="32" Volume="2019" Year="2023">
+<Book Series="New Mutants" Number="32" Volume="2020" Year="2023">
 <Database Name="cv" Series="122666" Issue="958986" />
 </Book>
-<Book Series="New Mutants" Number="33" Volume="2019" Year="2023">
+<Book Series="New Mutants" Number="33" Volume="2020" Year="2023">
 <Database Name="cv" Series="122666" Issue="961943" />
 </Book>
 <Book Series="Bishop: War College" Number="1" Volume="2023" Year="2023">
@@ -1590,25 +1590,25 @@
 <Book Series="Avengers: War Across Time" Number="5" Volume="2023" Year="2023">
 <Database Name="cv" Series="147434" Issue="987228" />
 </Book>
-<Book Series="Black Panther" Number="9" Volume="2023" Year="2022">
+<Book Series="Black Panther" Number="9" Volume="2022" Year="2022">
 <Database Name="cv" Series="140222" Issue="946213" />
 </Book>
-<Book Series="Black Panther" Number="10" Volume="2023" Year="2022">
+<Book Series="Black Panther" Number="10" Volume="2022" Year="2022">
 <Database Name="cv" Series="140222" Issue="950789" />
 </Book>
-<Book Series="Black Panther" Number="11" Volume="2023" Year="2023">
+<Book Series="Black Panther" Number="11" Volume="2022" Year="2023">
 <Database Name="cv" Series="140222" Issue="953001" />
 </Book>
-<Book Series="Black Panther" Number="12" Volume="2023" Year="2023">
+<Book Series="Black Panther" Number="12" Volume="2022" Year="2023">
 <Database Name="cv" Series="140222" Issue="960976" />
 </Book>
-<Book Series="Black Panther" Number="13" Volume="2023" Year="2023">
+<Book Series="Black Panther" Number="13" Volume="2022" Year="2023">
 <Database Name="cv" Series="140222" Issue="963983" />
 </Book>
-<Book Series="Black Panther" Number="14" Volume="2023" Year="2023">
+<Book Series="Black Panther" Number="14" Volume="2022" Year="2023">
 <Database Name="cv" Series="140222" Issue="969379" />
 </Book>
-<Book Series="Black Panther" Number="15" Volume="2023" Year="2023">
+<Book Series="Black Panther" Number="15" Volume="2022" Year="2023">
 <Database Name="cv" Series="140222" Issue="975705" />
 </Book>
 <Book Series="Wasp" Number="1" Volume="2023" Year="2023">
@@ -1761,8 +1761,8 @@
 <Book Series="Moon Girl and Devil Dinosaur" Number="5" Volume="2022" Year="2023">
 <Database Name="cv" Series="146733" Issue="984328" />
 </Book>
-<Book Series="Gold Goblin" Number="1" Volume="2023" Year="2023">
-<Database Name="cv" Series="151517" Issue="996028" />
+<Book Series="Gold Goblin" Number="1" Volume="2022" Year="2023">
+<Database Name="cv" Series="146113" Issue="955122" />
 </Book>
 <Book Series="The Amazing Spider-Man" Number="14" Volume="2022" Year="2023">
 <Database Name="cv" Series="142577" Issue="956770" />
@@ -1776,10 +1776,10 @@
 <Book Series="The Amazing Spider-Man" Number="20" Volume="2022" Year="2023">
 <Database Name="cv" Series="142577" Issue="973034" />
 </Book>
-<Book Series="Gold Goblin" Number="4" Volume="2023" Year="2023">
+<Book Series="Gold Goblin" Number="4" Volume="2022" Year="2023">
 <Database Name="cv" Series="146113" Issue="969384" />
 </Book>
-<Book Series="Gold Goblin" Number="5" Volume="2023" Year="2023">
+<Book Series="Gold Goblin" Number="5" Volume="2022" Year="2023">
 <Database Name="cv" Series="146113" Issue="976906" />
 </Book>
 <Book Series="Daredevil" Number="6" Volume="2022" Year="2023">

--- a/Marvel/Master Reading Order/CBRO/[Marvel] Marvel Master Reading Order- A Fresh Start (WEB-CBRO).cbl
+++ b/Marvel/Master Reading Order/CBRO/[Marvel] Marvel Master Reading Order- A Fresh Start (WEB-CBRO).cbl
@@ -1086,7 +1086,7 @@
 <Book Series="Silver Surfer: The Best Defense" Number="1" Volume="2018" Year="2019">
 <Database Name="cv" Series="115905" Issue="694921" />
 </Book>
-<Book Series="Defenders: The Best Defense" Number="1" Volume="2019" Year="2019">
+<Book Series="Defenders: The Best Defense" Number="1" Volume="2018" Year="2019">
 <Database Name="cv" Series="116067" Issue="695631" />
 </Book>
 <Book Series="Shuri" Number="1" Volume="2018" Year="2018">
@@ -2064,22 +2064,22 @@
 <Book Series="Shuri" Number="7" Volume="2018" Year="2019">
 <Database Name="cv" Series="114421" Issue="706416" />
 </Book>
-<Book Series="X-Force" Number="1" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="1" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="726217" />
 </Book>
-<Book Series="X-Force" Number="2" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="2" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="728984" />
 </Book>
-<Book Series="X-Force" Number="3" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="3" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="730351" />
 </Book>
-<Book Series="X-Force" Number="4" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="4" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="731530" />
 </Book>
-<Book Series="X-Force" Number="5" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="5" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="732895" />
 </Book>
-<Book Series="X-Force" Number="6" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="6" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="735534" />
 </Book>
 <Book Series="Captain America &#38; the Invaders: Bahamas Triangle" Number="1" Volume="2019" Year="2019">
@@ -2352,16 +2352,16 @@
 <Book Series="Guardians of the Galaxy Annual" Number="1" Volume="2019" Year="2019">
 <Database Name="cv" Series="119535" Issue="710681" />
 </Book>
-<Book Series="X-Force" Number="7" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="7" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="737172" />
 </Book>
-<Book Series="X-Force" Number="8" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="8" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="738622" />
 </Book>
-<Book Series="X-Force" Number="9" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="9" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="742380" />
 </Book>
-<Book Series="X-Force" Number="10" Volume="2019" Year="2020">
+<Book Series="X-Force" Number="10" Volume="2020" Year="2020">
 <Database Name="cv" Series="122668" Issue="775013" />
 </Book>
 <Book Series="Fantastic Four: 4 Yancy Street" Number="1" Volume="2019" Year="2019">


### PR DESCRIPTION
Some records have correct CV id, but different volume year or volume name, other records have correct name/year, but invalid CV id.

`Marvel/Events/CBRO/2005-2009 - Part 8/[Marvel] Civil War (WEB-CBRO).cbl`
`Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #08 (WEB-CBRO).cbl`
Series [Civil War](https://comicvine.gamespot.com/civil-war/4050-18023/), volume year was higher than the issue year, fixed to be the same as CV.

`Marvel/Events/CBRO/2011-2012 - Part 10/[Marvel] Avengers vs. X-Men (WEB-CBRO).cbl`
`Marvel/Events/CBRO/[Marvel] Jonathan Hickman's Marvel (WEB-CBRO).cbl`
`Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #10 (WEB-CBRO).cbl`
Series [Avengers Vs X-Men](https://comicvine.gamespot.com/avengers-vs-x-men/4050-47331/), volume year was higher than the issue year, fixed to be the same as CV.

`Marvel/Events/CBRO/2022-2023 - Part 13/[Marvel] Dark Web (WEB-CBRO).cbl`
`Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #13 (WEB-CBRO).cbl`
`Marvel/Master Reading Order/CBRO/[Marvel] Marvel Master Reading Order Part #13 (WEB-CBRO).cbl`
Series `Gold Goblin`, first issue was referring to [TPB](https://comicvine.gamespot.com/gold-goblin/4050-151517/) instead of [regular series](https://comicvine.gamespot.com/gold-goblin/4050-146113/), issues 2-5 were using TPB volume year instead of series volume year. 

`Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #01 (WEB-CBRO).cbl`
`Marvel/Master Reading Order/CBRO/[Marvel] Marvel Master Reading Order Part #01 (WEB-CBRO).cbl`
Series `Avengers: Season One` was referring to [Walmart promotional](https://comicvine.gamespot.com/100th-anniversary-special-avengers/4050-57442) instead of [regular GN issue](https://comicvine.gamespot.com/avengers-season-one/4050-64453/)

`Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #03 (WEB-CBRO).cbl`
`Marvel/Master Reading Order/CBRO/[Marvel] Marvel Master Reading Order Part #03 (WEB-CBRO).cbl`
Series `Uncanny X-Men Annual`, issue 9, CVID 22988/111575. Issue with such id belongs to the series [X-Men Annual](https://comicvine.gamespot.com/x-men-annual/4050-22988/) (without `Uncanny` prefix) and volume year is 1970.

`Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #04 (WEB-CBRO).cbl`
Series `X-Force` from [1992 event](https://comicbookreadingorders.com/marvel/events/x-cutioners-song-reading-order/), but records contained information about 2021 series.

`Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #06 (WEB-CBRO).cbl`
`Marvel/Master Reading Order/CBRO/[Marvel] Marvel Master Reading Order Part #06 (WEB-CBRO).cbl`
Series [New X-Men 2001](https://comicvine.gamespot.com/x-men-2001/4050-21334/), CV uses name per indicia, which is just `X-Men 2011`

`Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #11 (WEB-CBRO).cbl`
`Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #12 (WEB-CBRO).cbl`
`Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #13 (WEB-CBRO).cbl`
`Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order- A Fresh Start (WEB-CBRO).cbl`
`Marvel/Master Reading Order/CBRO/[Marvel] Marvel Master Reading Order Part #11 (WEB-CBRO).cbl`
`Marvel/Master Reading Order/CBRO/[Marvel] Marvel Master Reading Order Part #12 (WEB-CBRO).cbl`
`Marvel/Master Reading Order/CBRO/[Marvel] Marvel Master Reading Order Part #13 (WEB-CBRO).cbl`
`Marvel/Master Reading Order/CBRO/[Marvel] Marvel Master Reading Order- A Fresh Start (WEB-CBRO).cbl`
Series [New Mutants](https://comicvine.gamespot.com/new-mutants/4050-122666/) and [X-Force](https://comicvine.gamespot.com/x-force/4050-122668/) both has volume year 2020 according to CV, but records contained 2019.

`Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #12 (WEB-CBRO).cbl`
`Marvel/Master Reading Order/CBRO/[Marvel] Marvel Master Reading Order Part #12 (WEB-CBRO).cbl`
Typo in [Giant-Size Black Cat: Infinity Score](https://comicvine.gamespot.com/giant-size-black-cat-infinity-score/4050-140355/) series, it was `Giant-Sized`.

`Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #13 (WEB-CBRO).cbl`
`Marvel/Master Reading Order/CBRO/[Marvel] Marvel Master Reading Order Part #13 (WEB-CBRO).cbl`
Series [Captain America](https://comicvine.gamespot.com/captain-america/4050-142485/) with issue 0 according to CV has volume year 2022 and not 2023.
Series [Black Panther](https://mylar.home.spacecamel.net/comicDetails?ComicID=140222) with listed id according to CV has volume year 2022 and not 2023.

`Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order- A Fresh Start (WEB-CBRO).cbl`
`Marvel/Master Reading Order/CBRO/[Marvel] Marvel Master Reading Order- A Fresh Start (WEB-CBRO).cbl`
Series [Defenders: The Best Defense](https://comicvine.gamespot.com/defenders-the-best-defense/4050-116067/)  with listed id according to CV has volume year 2018 and not 2019.

`Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order- Marvel Legacy (WEB-CBRO).cbl`
Series `Legion`, first issue was referring to [2018 Marvel series](https://comicvine.gamespot.com/legion/4050-108105/), while issues 2-5 were referring to [2001 DC series](https://comicvine.gamespot.com/the-legion/4050-7226/)
