### PR TITLE
Fixed Captain Marvel volume in Marvel CBRO with events part 6

### DIFF
--- a/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #06 (WEB-CBRO).cbl
+++ b/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #06 (WEB-CBRO).cbl
@@ -609,11 +609,11 @@
 <Book Series="Black Panther" Number="25" Volume="1998" Year="2000">
 <Database Name="cv" Series="6496" Issue="50809" />
 </Book>
-<Book Series="Captain Marvel" Number="12" Volume="2000" Year="2000">
-<Database Name="cv" Series="6458" Issue="80550" />
+<Book Series="Captain Marvel" Number="12" Volume="2002" Year="2003">
+<Database Name="cv" Series="18296" Issue="152552" />
 </Book>
-<Book Series="Captain Marvel" Number="13" Volume="2000" Year="2001">
-<Database Name="cv" Series="6458" Issue="80551" />
+<Book Series="Captain Marvel" Number="13" Volume="2002" Year="2003">
+<Database Name="cv" Series="18296" Issue="152553" />
 </Book>
 <Book Series="Incredible Hulk" Number="21" Volume="2000" Year="2000">
 <Database Name="cv" Series="6558" Issue="46840" />


### PR DESCRIPTION
From event: https://comicbookreadingorders.com/marvel/events/maximum-security-reading-order/
![изображение](https://github.com/user-attachments/assets/8bc2c5e5-26f3-40e2-ac25-4e7afd0e4f91)

Vol 4 is https://comicvine.gamespot.com/captain-marvel/4050-18296/

After it leads to this in part 6 https://comicbookreadingorders.com/marvel/marvel-master-reading-order-part-6/
![изображение](https://github.com/user-attachments/assets/de4bc9d5-2d28-45ad-bb75-410bc42fb45c)
