### PR TITLE
Fixed Death of Dracula wrong entry in Marvel CBRO with events part 9

### DIFF
--- a/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #09 (WEB-CBRO).cbl
+++ b/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #09 (WEB-CBRO).cbl
@@ -3030,8 +3030,8 @@
 <Book Series="Steve Rogers: Super Soldier" Number="4" Volume="2010" Year="2010">
 <Database Name="cv" Series="34244" Issue="239042" />
 </Book>
-<Book Series="Death of Dracula" Number="1" Volume="2011" Year="2011">
-<Database Name="cv" Series="40785" Issue="275026" />
+<Book Series="Death of Dracula" Number="1" Volume="2010" Year="2010">
+<Database Name="cv" Series="34003" Issue="221774" />
 </Book>
 <Book Series="Uncanny X-Men: The Heroic Age" Number="1" Volume="2010" Year="2010">
 <Database Name="cv" Series="34412" Issue="224585" />
@@ -3884,9 +3884,6 @@
 </Book>
 <Book Series="Carnage" Number="5" Volume="2010" Year="2011">
 <Database Name="cv" Series="36240" Issue="275725" />
-</Book>
-<Book Series="Death of Dracula" Number="1" Volume="2010" Year="2010">
-<Database Name="cv" Series="34003" Issue="221774" />
 </Book>
 <Book Series="X-Men: Curse Of The Mutants Saga" Number="1" Volume="2010" Year="2010">
 <Database Name="cv" Series="34032" Issue="221891" />


### PR DESCRIPTION
There is two events in https://comicbookreadingorders.com/marvel/marvel-master-reading-order-part-9/
https://comicbookreadingorders.com/marvel/events/heroic-age-reading-order/
https://comicbookreadingorders.com/marvel/events/curse-of-the-mutants-reading-order/

They both include Death of Dracula (2010)
Removed 2011 volume of it from CBL, because it added by mistake
Left earlier entry