### PR TITLE
Fixed Secret Wars, Too from tpb to issue in part 10 cbro events

### DIFF
--- a/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #10 (WEB-CBRO).cbl
+++ b/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #10 (WEB-CBRO).cbl
@@ -6831,8 +6831,8 @@
 <Book Series="Silver Surfer" Number="15" Volume="2014" Year="2016">
 <Database Name="cv" Series="72582" Issue="506663" />
 </Book>
-<Book Series="Secret Wars, Too" Number="1" Volume="2016" Year="2016">
-<Database Name="cv" Series="93678" Issue="547290" />
+<Book Series="Secret Wars, Too" Number="1" Volume="2015" Year="2015">
+<Database Name="cv" Series="86122" Issue="506180" />
 </Book>
 <Book Series="Deadpool Kills the Marvel Universe" Number="1" Volume="2012" Year="2012">
 <Database Name="cv" Series="50940" Issue="348047" />


### PR DESCRIPTION
Was looking at TPB here: https://comicvine.gamespot.com/secret-wars-too/4050-93678/
I changed it to actual issue: https://comicvine.gamespot.com/secret-wars-too/4050-86122/

Honestly no idea what here at the end meant to be, but I'm kinda sure issue and not TPB: https://comicbookreadingorders.com/marvel/events/secret-wars-2015-reading-order/