### PR TITLE
Adjusted spider-verse volumes in CBRO part 10 with events

### DIFF
--- a/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #10 (WEB-CBRO).cbl
+++ b/Marvel/Master Reading Order/CBRO - With Events/[Marvel] Marvel Master Reading Order Part #10 (WEB-CBRO).cbl
@@ -5256,11 +5256,11 @@
 <Book Series="Spider-Verse Team-Up" Number="1" Volume="2014" Year="2015">
 <Database Name="cv" Series="77941" Issue="469497" />
 </Book>
-<Book Series="Spider-Verse" Number="1" Volume="2015" Year="2015">
-<Database Name="cv" Series="82108" Issue="489327" />
+<Book Series="Spider-Verse" Number="1" Volume="2014" Year="2015">
+<Database Name="cv" Series="78047" Issue="469842" />
 </Book>
-<Book Series="Spider-Verse" Number="2" Volume="2015" Year="2015">
-<Database Name="cv" Series="82108" Issue="491530" />
+<Book Series="Spider-Verse" Number="2" Volume="2014" Year="2015">
+<Database Name="cv" Series="78047" Issue="475945" />
 </Book>
 <Book Series="The Amazing Spider-Man" Number="9" Volume="2014" Year="2015">
 <Database Name="cv" Series="73420" Issue="469487" />


### PR DESCRIPTION
First we have this: https://comicbookreadingorders.com/marvel/events/spider-verse-reading-order/
Then we have this: https://comicbookreadingorders.com/marvel/events/secret-wars-2015-reading-order/

First one meant to be: https://comicvine.gamespot.com/spider-verse/4050-78047/
Changed as it should be