### PR TITLE
Adjusted deadpool mercs for money in cbro with events

### DIFF
--- a/Marvel/Master Reading Order/CBRO - With Events/[Marvel] All-New, All Different Marvel- All-New, All-Different Marvel Part #1 (WEB-CBRO).cbl
+++ b/Marvel/Master Reading Order/CBRO - With Events/[Marvel] All-New, All Different Marvel- All-New, All-Different Marvel Part #1 (WEB-CBRO).cbl
@@ -2029,19 +2029,19 @@
 <Database Name="cv" Series="85311" Issue="551316" />
 </Book>
 <Book Series="Deadpool &#38; The Mercs For Money" Number="1" Volume="2016" Year="2016">
-<Database Name="cv" Series="87793" Issue="513645" />
+<Database Name="cv" Series="92360" Issue="540074" />
 </Book>
 <Book Series="Deadpool &#38; The Mercs For Money" Number="2" Volume="2016" Year="2016">
-<Database Name="cv" Series="87793" Issue="520200" />
+<Database Name="cv" Series="92360" Issue="543751" />
 </Book>
 <Book Series="Deadpool &#38; The Mercs For Money" Number="3" Volume="2016" Year="2016">
-<Database Name="cv" Series="87793" Issue="526049" />
+<Database Name="cv" Series="92360" Issue="548574" />
 </Book>
 <Book Series="Deadpool &#38; The Mercs For Money" Number="4" Volume="2016" Year="2016">
-<Database Name="cv" Series="87793" Issue="530727" />
+<Database Name="cv" Series="92360" Issue="552156" />
 </Book>
 <Book Series="Deadpool &#38; The Mercs For Money" Number="5" Volume="2016" Year="2016">
-<Database Name="cv" Series="87793" Issue="534285" />
+<Database Name="cv" Series="92360" Issue="556470" />
 </Book>
 <Book Series="Deadpool &#38; The Mercs For Money" Number="6" Volume="2016" Year="2017">
 <Database Name="cv" Series="92360" Issue="569328" />


### PR DESCRIPTION
There is this: https://comicvine.gamespot.com/deadpool-the-mercs-for-money/4050-87793/
And this: https://comicvine.gamespot.com/deadpool-the-mercs-for-money/4050-92360/

First 5 issues already present in CBL, next 5 had incorrect matching to first one still, but shall belong to second one
Issue 6 match is correct tho