### PR TITLE
Marvel Guides: update Timeless Part 1 lists to match site

### DIFF
--- a/Marvel/Master Reading Order/Marvel Guides/2021-2023 Timeless/Part 01 Once and Future/[Marvel] 2021-2023 Part 1.1 For All Time (MG).cbl
+++ b/Marvel/Master Reading Order/Marvel Guides/2021-2023 Timeless/Part 01 Once and Future/[Marvel] 2021-2023 Part 1.1 For All Time (MG).cbl
@@ -2,7 +2,7 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Name>[Marvel] 2021-2023 Part 1.1 For All Time (MG)</Name>
-    <NumIssues>31</NumIssues>
+    <NumIssues>32</NumIssues>
     <Books>
         <Book Series="Kang the Conqueror" Number="1" Volume="2021" Year="2021">
             <Database Name="cv" Series="138345" Issue="880929" />
@@ -18,6 +18,9 @@
         </Book>
         <Book Series="Kang the Conqueror" Number="5" Volume="2021" Year="2022">
             <Database Name="cv" Series="138345" Issue="899165" />
+        </Book>
+        <Book Series="Avengers 1,000,000 B.C." Number="1" Volume="2022" Year="2022">
+            <Database Name="cv" Series="144579" Issue="942726" />
         </Book>
         <Book Series="Fantastic Four" Number="32" Volume="2018" Year="2021">
             <Database Name="cv" Series="112685" Issue="848849" />

--- a/Marvel/Master Reading Order/Marvel Guides/2021-2023 Timeless/Part 01 Once and Future/[Marvel] 2021-2023 Part 1.2 Heroes of the People (MG).cbl
+++ b/Marvel/Master Reading Order/Marvel Guides/2021-2023 Timeless/Part 01 Once and Future/[Marvel] 2021-2023 Part 1.2 Heroes of the People (MG).cbl
@@ -2,7 +2,7 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Name>[Marvel] 2021-2023 Part 1.2 Heroes of the People (MG)</Name>
-    <NumIssues>49</NumIssues>
+    <NumIssues>43</NumIssues>
     <Books>
         <Book Series="The United States of Captain America" Number="1" Volume="2021" Year="2021">
             <Database Name="cv" Series="137256" Issue="866598" />
@@ -132,24 +132,6 @@
         </Book>
         <Book Series="Captain America: Symbol of Truth" Number="5" Volume="2022" Year="2022">
             <Database Name="cv" Series="142840" Issue="949151" />
-        </Book>
-        <Book Series="Captain America: Sentinel of Liberty" Number="1" Volume="2022" Year="2022">
-            <Database Name="cv" Series="143632" Issue="930977" />
-        </Book>
-        <Book Series="Captain America: Sentinel of Liberty" Number="2" Volume="2022" Year="2022">
-            <Database Name="cv" Series="143632" Issue="934988" />
-        </Book>
-        <Book Series="Captain America: Sentinel of Liberty" Number="3" Volume="2022" Year="2022">
-            <Database Name="cv" Series="143632" Issue="941559" />
-        </Book>
-        <Book Series="Captain America: Sentinel of Liberty" Number="4" Volume="2022" Year="2022">
-            <Database Name="cv" Series="143632" Issue="946160" />
-        </Book>
-        <Book Series="Captain America: Sentinel of Liberty" Number="5" Volume="2022" Year="2022">
-            <Database Name="cv" Series="143632" Issue="949636" />
-        </Book>
-        <Book Series="Captain America: Sentinel of Liberty" Number="6" Volume="2022" Year="2023">
-            <Database Name="cv" Series="143632" Issue="953982" />
         </Book>
     </Books>
     <Matchers />

--- a/Marvel/Master Reading Order/Marvel Guides/2021-2023 Timeless/Part 01 Once and Future/[Marvel] 2021-2023 Part 1.3 Reckoning War (MG).cbl
+++ b/Marvel/Master Reading Order/Marvel Guides/2021-2023 Timeless/Part 01 Once and Future/[Marvel] 2021-2023 Part 1.3 Reckoning War (MG).cbl
@@ -2,7 +2,7 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Name>[Marvel] 2021-2023 Part 1.3 Reckoning War (MG)</Name>
-    <NumIssues>20</NumIssues>
+    <NumIssues>25</NumIssues>
     <Books>
         <Book Series="She-Hulk" Number="1" Volume="2022" Year="2022">
             <Database Name="cv" Series="141329" Issue="903916" />
@@ -21,6 +21,21 @@
         </Book>
         <Book Series="She-Hulk" Number="5" Volume="2022" Year="2022">
             <Database Name="cv" Series="141329" Issue="937735" />
+        </Book>
+        <Book Series="She-Hulk" Number="6" Volume="2022" Year="2022">
+            <Database Name="cv" Series="141329" Issue="946147" />
+        </Book>
+        <Book Series="She-Hulk" Number="7" Volume="2022" Year="2023">
+            <Database Name="cv" Series="141329" Issue="953028" />
+        </Book>
+        <Book Series="She-Hulk" Number="8" Volume="2022" Year="2023">
+            <Database Name="cv" Series="141329" Issue="955118" />
+        </Book>
+        <Book Series="She-Hulk" Number="9" Volume="2022" Year="2023">
+            <Database Name="cv" Series="141329" Issue="961946" />
+        </Book>
+        <Book Series="She-Hulk" Number="10" Volume="2022" Year="2023">
+            <Database Name="cv" Series="141329" Issue="973027" />
         </Book>
         <Book Series="Fantastic Four" Number="39" Volume="2018" Year="2022">
             <Database Name="cv" Series="112685" Issue="902683" />

--- a/Marvel/Master Reading Order/Marvel Guides/2021-2023 Timeless/Part 01 Once and Future/[Marvel] 2021-2023 Part 1.5 Fight for the Future (MG).cbl
+++ b/Marvel/Master Reading Order/Marvel Guides/2021-2023 Timeless/Part 01 Once and Future/[Marvel] 2021-2023 Part 1.5 Fight for the Future (MG).cbl
@@ -2,7 +2,7 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Name>[Marvel] 2021-2023 Part 1.5 Fight for the Future (MG)</Name>
-    <NumIssues>27</NumIssues>
+    <NumIssues>34</NumIssues>
     <Books>
         <Book Series="Shang-Chi" Number="1" Volume="2020" Year="2020">
             <Database Name="cv" Series="130763" Issue="805097" />
@@ -84,6 +84,27 @@
         </Book>
         <Book Series="Shang-Chi" Number="12" Volume="2021" Year="2022">
             <Database Name="cv" Series="136143" Issue="922401" />
+        </Book>
+        <Book Series="Shang-Chi and the Ten Rings" Number="1" Volume="2022" Year="2022">
+            <Database Name="cv" Series="144088" Issue="937505" />
+        </Book>
+        <Book Series="Shang-Chi and the Ten Rings" Number="2" Volume="2022" Year="2022">
+            <Database Name="cv" Series="144088" Issue="943715" />
+        </Book>
+        <Book Series="Shang-Chi and the Ten Rings" Number="3" Volume="2022" Year="2022">
+            <Database Name="cv" Series="144088" Issue="948985" />
+        </Book>
+        <Book Series="Shang-Chi and the Ten Rings" Number="4" Volume="2022" Year="2022">
+            <Database Name="cv" Series="144088" Issue="951439" />
+        </Book>
+        <Book Series="Shang-Chi and the Ten Rings" Number="5" Volume="2022" Year="2023">
+            <Database Name="cv" Series="144088" Issue="955117" />
+        </Book>
+        <Book Series="Shang-Chi and the Ten Rings" Number="6" Volume="2022" Year="2023">
+            <Database Name="cv" Series="144088" Issue="961947" />
+        </Book>
+        <Book Series="Shang-Chi: Master of the Ten Rings" Number="1" Volume="2023" Year="2023">
+            <Database Name="cv" Series="147225" Issue="962841" />
         </Book>
     </Books>
     <Matchers />

--- a/Marvel/Master Reading Order/Marvel Guides/2021-2023 Timeless/Part 01 Once and Future/[Marvel] 2021-2023 Part 1.6 Across the Multiverse (MG).cbl
+++ b/Marvel/Master Reading Order/Marvel Guides/2021-2023 Timeless/Part 01 Once and Future/[Marvel] 2021-2023 Part 1.6 Across the Multiverse (MG).cbl
@@ -2,7 +2,7 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Name>[Marvel] 2021-2023 Part 1.6 Across the Multiverse (MG)</Name>
-    <NumIssues>61</NumIssues>
+    <NumIssues>53</NumIssues>
     <Books>
         <Book Series="Hulkling &#38; Wiccan Infinity Comic" Number="1" Volume="2021" Year="2021">
             <Database Name="cv" Series="139919" Issue="891911" />
@@ -100,35 +100,26 @@
         <Book Series="Captain Carter" Number="5" Volume="2022" Year="2022">
             <Database Name="cv" Series="141845" Issue="941560" />
         </Book>
-        <Book Series="Spider-Gwen: Gwenverse" Number="1" Volume="2022" Year="2022">
-            <Database Name="cv" Series="141842" Issue="910617" />
+        <Book Series="Spider-Man 2099: Exodus Alpha" Number="1" Volume="2022" Year="2022">
+            <Database Name="cv" Series="142762" Issue="921065" />
         </Book>
-        <Book Series="Spider-Gwen: Gwenverse" Number="2" Volume="2022" Year="2022">
-            <Database Name="cv" Series="141842" Issue="918156" />
+        <Book Series="Spider-Man 2099: Exodus" Number="1" Volume="2022" Year="2022">
+            <Database Name="cv" Series="143301" Issue="926221" />
         </Book>
-        <Book Series="Spider-Gwen: Gwenverse" Number="3" Volume="2022" Year="2022">
-            <Database Name="cv" Series="141842" Issue="930972" />
+        <Book Series="Spider-Man 2099: Exodus" Number="2" Volume="2022" Year="2022">
+            <Database Name="cv" Series="143301" Issue="930973" />
         </Book>
-        <Book Series="Spider-Gwen: Gwenverse" Number="4" Volume="2022" Year="2022">
-            <Database Name="cv" Series="141842" Issue="937736" />
+        <Book Series="Spider-Man 2099: Exodus" Number="3" Volume="2022" Year="2022">
+            <Database Name="cv" Series="143301" Issue="933088" />
         </Book>
-        <Book Series="Spider-Gwen: Gwenverse" Number="5" Volume="2022" Year="2022">
-            <Database Name="cv" Series="141842" Issue="943905" />
+        <Book Series="Spider-Man 2099: Exodus" Number="4" Volume="2022" Year="2022">
+            <Database Name="cv" Series="143301" Issue="935746" />
         </Book>
-        <Book Series="Spider-Punk" Number="1" Volume="2022" Year="2022">
-            <Database Name="cv" Series="142144" Issue="914656" />
+        <Book Series="Spider-Man 2099: Exodus" Number="5" Volume="2022" Year="2022">
+            <Database Name="cv" Series="143301" Issue="940227" />
         </Book>
-        <Book Series="Spider-Punk" Number="2" Volume="2022" Year="2022">
-            <Database Name="cv" Series="142144" Issue="924788" />
-        </Book>
-        <Book Series="Spider-Punk" Number="3" Volume="2022" Year="2022">
-            <Database Name="cv" Series="142144" Issue="935748" />
-        </Book>
-        <Book Series="Spider-Punk" Number="4" Volume="2022" Year="2022">
-            <Database Name="cv" Series="142144" Issue="940224" />
-        </Book>
-        <Book Series="Spider-Punk" Number="5" Volume="2022" Year="2022">
-            <Database Name="cv" Series="142144" Issue="946720" />
+        <Book Series="Spider-Man 2099: Exodus Omega" Number="1" Volume="2022" Year="2022">
+            <Database Name="cv" Series="18651" Issue="946210" />
         </Book>
         <Book Series="Namor: Conquered Shores" Number="1" Volume="2022" Year="2022">
             <Database Name="cv" Series="145513" Issue="950688" />
@@ -144,21 +135,6 @@
         </Book>
         <Book Series="Namor: Conquered Shores" Number="5" Volume="2022" Year="2023">
             <Database Name="cv" Series="145513" Issue="969387" />
-        </Book>
-        <Book Series="The Variants" Number="1" Volume="2022" Year="2022">
-            <Database Name="cv" Series="143856" Issue="933080" />
-        </Book>
-        <Book Series="The Variants" Number="2" Volume="2022" Year="2022">
-            <Database Name="cv" Series="143856" Issue="939094" />
-        </Book>
-        <Book Series="The Variants" Number="3" Volume="2022" Year="2022">
-            <Database Name="cv" Series="143856" Issue="945041" />
-        </Book>
-        <Book Series="The Variants" Number="4" Volume="2022" Year="2022">
-            <Database Name="cv" Series="143856" Issue="952306" />
-        </Book>
-        <Book Series="The Variants" Number="5" Volume="2022" Year="2023">
-            <Database Name="cv" Series="143856" Issue="958993" />
         </Book>
         <Book Series="Avengers Forever" Number="1" Volume="2021" Year="2022">
             <Database Name="cv" Series="140532" Issue="899178" />


### PR DESCRIPTION
There's been some reshuffling since these lists were first created, this commit aligns the lists with the current content of the Marvel Guides site.