### PR TITLE
Add new Fantastic Four list from ComicBookHerald

### DIFF
--- a/Marvel/Teams/Fantastic Four/[Marvel] [Post-Civil War - Secret Wars] Fantastic Four (Comic Book Herald).cbl
+++ b/Marvel/Teams/Fantastic Four/[Marvel] [Post-Civil War - Secret Wars] Fantastic Four (Comic Book Herald).cbl
@@ -1,0 +1,461 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Name>[Marvel] Fantastic Four: Post-Civil War - Secret Wars (WEB-ComicBookHerald)</Name>
+<NumIssues>151</NumIssues>
+<Books>
+<Book Series="Fantastic Four" Number="544" Volume="1998" Year="2007">
+<Database Name="cv" Series="6211" Issue="107597" />
+</Book>
+<Book Series="Fantastic Four" Number="545" Volume="1998" Year="2007">
+<Database Name="cv" Series="6211" Issue="108761" />
+</Book>
+<Book Series="Fantastic Four" Number="546" Volume="1998" Year="2007">
+<Database Name="cv" Series="6211" Issue="109820" />
+</Book>
+<Book Series="Fantastic Four" Number="547" Volume="1998" Year="2007">
+<Database Name="cv" Series="6211" Issue="111033" />
+</Book>
+<Book Series="Fantastic Four" Number="548" Volume="1998" Year="2007">
+<Database Name="cv" Series="6211" Issue="112291" />
+</Book>
+<Book Series="Fantastic Four" Number="549" Volume="1998" Year="2007">
+<Database Name="cv" Series="6211" Issue="113955" />
+</Book>
+<Book Series="Fantastic Four" Number="550" Volume="1998" Year="2007">
+<Database Name="cv" Series="6211" Issue="115398" />
+</Book>
+<Book Series="Fantastic Four" Number="551" Volume="1998" Year="2008">
+<Database Name="cv" Series="6211" Issue="116918" />
+</Book>
+<Book Series="Fantastic Four" Number="552" Volume="1998" Year="2008">
+<Database Name="cv" Series="6211" Issue="119795" />
+</Book>
+<Book Series="Fantastic Four" Number="553" Volume="1998" Year="2008">
+<Database Name="cv" Series="6211" Issue="122074" />
+</Book>
+<Book Series="Fantastic Four" Number="554" Volume="1998" Year="2008">
+<Database Name="cv" Series="6211" Issue="122782" />
+</Book>
+<Book Series="Fantastic Four" Number="555" Volume="1998" Year="2008">
+<Database Name="cv" Series="6211" Issue="125171" />
+</Book>
+<Book Series="Fantastic Four" Number="556" Volume="1998" Year="2008">
+<Database Name="cv" Series="6211" Issue="127123" />
+</Book>
+<Book Series="Fantastic Four" Number="557" Volume="1998" Year="2008">
+<Database Name="cv" Series="6211" Issue="130638" />
+</Book>
+<Book Series="Fantastic Four" Number="558" Volume="1998" Year="2008">
+<Database Name="cv" Series="6211" Issue="132143" />
+</Book>
+<Book Series="Fantastic Four" Number="559" Volume="1998" Year="2008">
+<Database Name="cv" Series="6211" Issue="135468" />
+</Book>
+<Book Series="Fantastic Four" Number="560" Volume="1998" Year="2008">
+<Database Name="cv" Series="6211" Issue="139400" />
+</Book>
+<Book Series="Fantastic Four" Number="561" Volume="1998" Year="2009">
+<Database Name="cv" Series="6211" Issue="142533" />
+</Book>
+<Book Series="Secret Invasion: Fantastic Four" Number="1" Volume="2008" Year="2008">
+<Database Name="cv" Series="21574" Issue="130245" />
+</Book>
+<Book Series="Secret Invasion: Fantastic Four" Number="2" Volume="2008" Year="2008">
+<Database Name="cv" Series="21574" Issue="131504" />
+</Book>
+<Book Series="Secret Invasion: Fantastic Four" Number="3" Volume="2008" Year="2008">
+<Database Name="cv" Series="21574" Issue="134595" />
+</Book>
+<Book Series="Fantastic Four: True Story" Number="1" Volume="2008" Year="2008">
+<Database Name="cv" Series="22403" Issue="134592" />
+</Book>
+<Book Series="Fantastic Four: True Story" Number="2" Volume="2008" Year="2008">
+<Database Name="cv" Series="22403" Issue="136627" />
+</Book>
+<Book Series="Fantastic Four: True Story" Number="3" Volume="2008" Year="2008">
+<Database Name="cv" Series="22403" Issue="139427" />
+</Book>
+<Book Series="Fantastic Four: True Story" Number="4" Volume="2008" Year="2009">
+<Database Name="cv" Series="22403" Issue="142204" />
+</Book>
+<Book Series="Fantastic Four" Number="562" Volume="1998" Year="2009">
+<Database Name="cv" Series="6211" Issue="149359" />
+</Book>
+<Book Series="Fantastic Four" Number="563" Volume="1998" Year="2009">
+<Database Name="cv" Series="6211" Issue="150597" />
+</Book>
+<Book Series="Fantastic Four" Number="564" Volume="1998" Year="2009">
+<Database Name="cv" Series="6211" Issue="152711" />
+</Book>
+<Book Series="Fantastic Four" Number="565" Volume="1998" Year="2009">
+<Database Name="cv" Series="6211" Issue="153960" />
+</Book>
+<Book Series="Fantastic Four" Number="566" Volume="1998" Year="2009">
+<Database Name="cv" Series="6211" Issue="157852" />
+</Book>
+<Book Series="Fantastic Four" Number="567" Volume="1998" Year="2009">
+<Database Name="cv" Series="6211" Issue="159792" />
+</Book>
+<Book Series="Fantastic Four" Number="568" Volume="1998" Year="2009">
+<Database Name="cv" Series="6211" Issue="162547" />
+</Book>
+<Book Series="Fantastic Four" Number="569" Volume="1998" Year="2009">
+<Database Name="cv" Series="6211" Issue="165471" />
+</Book>
+<Book Series="Dark Reign: Fantastic Four" Number="1" Volume="2009" Year="2009">
+<Database Name="cv" Series="25905" Issue="153086" />
+</Book>
+<Book Series="Dark Reign: Fantastic Four" Number="2" Volume="2009" Year="2009">
+<Database Name="cv" Series="25905" Issue="154458" />
+</Book>
+<Book Series="Dark Reign: Fantastic Four" Number="3" Volume="2009" Year="2009">
+<Database Name="cv" Series="25905" Issue="157851" />
+</Book>
+<Book Series="Dark Reign: Fantastic Four" Number="4" Volume="2009" Year="2009">
+<Database Name="cv" Series="25905" Issue="160863" />
+</Book>
+<Book Series="Dark Reign: Fantastic Four" Number="5" Volume="2009" Year="2009">
+<Database Name="cv" Series="25905" Issue="164984" />
+</Book>
+<Book Series="Dr. Doom And The Masters Of Evil" Number="1" Volume="2009" Year="2009">
+<Database Name="cv" Series="25514" Issue="150513" />
+</Book>
+<Book Series="Dr. Doom And The Masters Of Evil" Number="2" Volume="2009" Year="2009">
+<Database Name="cv" Series="25514" Issue="152811" />
+</Book>
+<Book Series="Dr. Doom And The Masters Of Evil" Number="3" Volume="2009" Year="2009">
+<Database Name="cv" Series="25514" Issue="154521" />
+</Book>
+<Book Series="Dr. Doom And The Masters Of Evil" Number="4" Volume="2009" Year="2009">
+<Database Name="cv" Series="25514" Issue="156136" />
+</Book>
+<Book Series="Fantastic Four" Number="570" Volume="1998" Year="2009">
+<Database Name="cv" Series="6211" Issue="168301" />
+</Book>
+<Book Series="Fantastic Four" Number="571" Volume="1998" Year="2009">
+<Database Name="cv" Series="6211" Issue="172455" />
+</Book>
+<Book Series="Fantastic Four" Number="572" Volume="1998" Year="2009">
+<Database Name="cv" Series="6211" Issue="179211" />
+</Book>
+<Book Series="Fantastic Four" Number="573" Volume="1998" Year="2010">
+<Database Name="cv" Series="6211" Issue="184948" />
+</Book>
+<Book Series="Fantastic Four" Number="574" Volume="1998" Year="2010">
+<Database Name="cv" Series="6211" Issue="189516" />
+</Book>
+<Book Series="Fantastic Four" Number="575" Volume="1998" Year="2010">
+<Database Name="cv" Series="6211" Issue="194515" />
+</Book>
+<Book Series="Fantastic Four" Number="576" Volume="1998" Year="2010">
+<Database Name="cv" Series="6211" Issue="198348" />
+</Book>
+<Book Series="Fantastic Four" Number="577" Volume="1998" Year="2010">
+<Database Name="cv" Series="6211" Issue="202693" />
+</Book>
+<Book Series="Fantastic Four" Number="578" Volume="1998" Year="2010">
+<Database Name="cv" Series="6211" Issue="210635" />
+</Book>
+<Book Series="Fantastic Four" Number="579" Volume="1998" Year="2010">
+<Database Name="cv" Series="6211" Issue="216200" />
+</Book>
+<Book Series="Fantastic Four" Number="580" Volume="1998" Year="2010">
+<Database Name="cv" Series="6211" Issue="220744" />
+</Book>
+<Book Series="Fantastic Four" Number="581" Volume="1998" Year="2010">
+<Database Name="cv" Series="6211" Issue="226858" />
+</Book>
+<Book Series="Fantastic Four" Number="582" Volume="1998" Year="2010">
+<Database Name="cv" Series="6211" Issue="231706" />
+</Book>
+<Book Series="Fantastic Four" Number="583" Volume="1998" Year="2010">
+<Database Name="cv" Series="6211" Issue="235446" />
+</Book>
+<Book Series="Fantastic Four" Number="584" Volume="1998" Year="2010">
+<Database Name="cv" Series="6211" Issue="239851" />
+</Book>
+<Book Series="Fantastic Four" Number="585" Volume="1998" Year="2011">
+<Database Name="cv" Series="6211" Issue="246472" />
+</Book>
+<Book Series="Fantastic Four" Number="586" Volume="1998" Year="2011">
+<Database Name="cv" Series="6211" Issue="250665" />
+</Book>
+<Book Series="Fantastic Four" Number="587" Volume="1998" Year="2011">
+<Database Name="cv" Series="6211" Issue="259027" />
+</Book>
+<Book Series="Fantastic Four" Number="588" Volume="1998" Year="2011">
+<Database Name="cv" Series="6211" Issue="263599" />
+</Book>
+<Book Series="Doomwar" Number="1" Volume="2010" Year="2010">
+<Database Name="cv" Series="31608" Issue="197468" />
+</Book>
+<Book Series="Doomwar" Number="2" Volume="2010" Year="2010">
+<Database Name="cv" Series="31608" Issue="200985" />
+</Book>
+<Book Series="Doomwar" Number="3" Volume="2010" Year="2010">
+<Database Name="cv" Series="31608" Issue="208516" />
+</Book>
+<Book Series="Doomwar" Number="4" Volume="2010" Year="2010">
+<Database Name="cv" Series="31608" Issue="216227" />
+</Book>
+<Book Series="Doomwar" Number="5" Volume="2010" Year="2010">
+<Database Name="cv" Series="31608" Issue="222098" />
+</Book>
+<Book Series="Doomwar" Number="6" Volume="2010" Year="2010">
+<Database Name="cv" Series="31608" Issue="227711" />
+</Book>
+<Book Series="FF" Number="1" Volume="2011" Year="2011">
+<Database Name="cv" Series="39453" Issue="266491" />
+</Book>
+<Book Series="FF" Number="2" Volume="2011" Year="2011">
+<Database Name="cv" Series="39453" Issue="268964" />
+</Book>
+<Book Series="FF" Number="3" Volume="2011" Year="2011">
+<Database Name="cv" Series="39453" Issue="269820" />
+</Book>
+<Book Series="FF" Number="4" Volume="2011" Year="2011">
+<Database Name="cv" Series="39453" Issue="271610" />
+</Book>
+<Book Series="FF" Number="5" Volume="2011" Year="2011">
+<Database Name="cv" Series="39453" Issue="276606" />
+</Book>
+<Book Series="FF" Number="6" Volume="2011" Year="2011">
+<Database Name="cv" Series="39453" Issue="278717" />
+</Book>
+<Book Series="FF" Number="7" Volume="2011" Year="2011">
+<Database Name="cv" Series="39453" Issue="281813" />
+</Book>
+<Book Series="FF" Number="8" Volume="2011" Year="2011">
+<Database Name="cv" Series="39453" Issue="288455" />
+</Book>
+<Book Series="FF" Number="9" Volume="2011" Year="2011">
+<Database Name="cv" Series="39453" Issue="293581" />
+</Book>
+<Book Series="FF" Number="10" Volume="2011" Year="2011">
+<Database Name="cv" Series="39453" Issue="294897" />
+</Book>
+<Book Series="FF" Number="11" Volume="2011" Year="2011">
+<Database Name="cv" Series="39453" Issue="299749" />
+</Book>
+<Book Series="Fantastic Four" Number="600" Volume="1998" Year="2012">
+<Database Name="cv" Series="6211" Issue="303357" />
+</Book>
+<Book Series="Fantastic Four" Number="601" Volume="1998" Year="2012">
+<Database Name="cv" Series="6211" Issue="307697" />
+</Book>
+<Book Series="Fantastic Four" Number="602" Volume="1998" Year="2012">
+<Database Name="cv" Series="6211" Issue="312722" />
+</Book>
+<Book Series="Fantastic Four" Number="603" Volume="1998" Year="2012">
+<Database Name="cv" Series="6211" Issue="316680" />
+</Book>
+<Book Series="Fantastic Four" Number="604" Volume="1998" Year="2012">
+<Database Name="cv" Series="6211" Issue="321298" />
+</Book>
+<Book Series="FF" Number="12" Volume="2011" Year="2012">
+<Database Name="cv" Series="39453" Issue="304460" />
+</Book>
+<Book Series="FF" Number="13" Volume="2011" Year="2012">
+<Database Name="cv" Series="39453" Issue="308502" />
+</Book>
+<Book Series="FF" Number="14" Volume="2011" Year="2012">
+<Database Name="cv" Series="39453" Issue="312723" />
+</Book>
+<Book Series="FF" Number="15" Volume="2011" Year="2012">
+<Database Name="cv" Series="39453" Issue="317926" />
+</Book>
+<Book Series="FF" Number="16" Volume="2011" Year="2012">
+<Database Name="cv" Series="39453" Issue="324964" />
+</Book>
+<Book Series="Fantastic Four" Number="605.1" Volume="1998" Year="2012">
+<Database Name="cv" Series="6211" Issue="335951" />
+</Book>
+<Book Series="Fantastic Four" Number="605" Volume="1998" Year="2012">
+<Database Name="cv" Series="6211" Issue="329210" />
+</Book>
+<Book Series="Fantastic Four" Number="606" Volume="1998" Year="2012">
+<Database Name="cv" Series="6211" Issue="336592" />
+</Book>
+<Book Series="Fantastic Four" Number="607" Volume="1998" Year="2012">
+<Database Name="cv" Series="6211" Issue="340277" />
+</Book>
+<Book Series="Fantastic Four" Number="608" Volume="1998" Year="2012">
+<Database Name="cv" Series="6211" Issue="346250" />
+</Book>
+<Book Series="Fantastic Four" Number="609" Volume="1998" Year="2012">
+<Database Name="cv" Series="6211" Issue="349646" />
+</Book>
+<Book Series="FF" Number="17" Volume="2011" Year="2012">
+<Database Name="cv" Series="39453" Issue="333394" />
+</Book>
+<Book Series="FF" Number="18" Volume="2011" Year="2012">
+<Database Name="cv" Series="39453" Issue="337486" />
+</Book>
+<Book Series="FF" Number="19" Volume="2011" Year="2012">
+<Database Name="cv" Series="39453" Issue="342899" />
+</Book>
+<Book Series="FF" Number="20" Volume="2011" Year="2012">
+<Database Name="cv" Series="39453" Issue="347233" />
+</Book>
+<Book Series="FF" Number="21" Volume="2011" Year="2012">
+<Database Name="cv" Series="39453" Issue="354106" />
+</Book>
+<Book Series="FF" Number="22" Volume="2011" Year="2012">
+<Database Name="cv" Series="39453" Issue="358975" />
+</Book>
+<Book Series="FF" Number="23" Volume="2011" Year="2012">
+<Database Name="cv" Series="39453" Issue="363156" />
+</Book>
+<Book Series="Galacta: Daughter of Galactus" Number="" Volume="2010" Year="0">
+<Database Name="cv" Series="33246" Issue="33246" />
+</Book>
+<Book Series="Fantastic Four" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="53921" Issue="367696" />
+</Book>
+<Book Series="Fantastic Four" Number="2" Volume="2013" Year="2013">
+<Database Name="cv" Series="53921" Issue="372287" />
+</Book>
+<Book Series="Fantastic Four" Number="3" Volume="2013" Year="2013">
+<Database Name="cv" Series="53921" Issue="378891" />
+</Book>
+<Book Series="FF" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="54295" Issue="370244" />
+</Book>
+<Book Series="FF" Number="2" Volume="2013" Year="2013">
+<Database Name="cv" Series="54295" Issue="373301" />
+</Book>
+<Book Series="FF" Number="3" Volume="2013" Year="2013">
+<Database Name="cv" Series="54295" Issue="381414" />
+</Book>
+<Book Series="Fantastic Four" Number="4" Volume="2013" Year="2013">
+<Database Name="cv" Series="53921" Issue="386135" />
+</Book>
+<Book Series="Fantastic Four" Number="5" Volume="2013" Year="2013">
+<Database Name="cv" Series="53921" Issue="392354" />
+</Book>
+<Book Series="Fantastic Four" Number="6" Volume="2013" Year="2013">
+<Database Name="cv" Series="53921" Issue="396426" />
+</Book>
+<Book Series="Fantastic Four" Number="7" Volume="2013" Year="2013">
+<Database Name="cv" Series="53921" Issue="398983" />
+</Book>
+<Book Series="Fantastic Four" Number="8" Volume="2013" Year="2013">
+<Database Name="cv" Series="53921" Issue="404696" />
+</Book>
+<Book Series="Fantastic Four" Number="5AU" Volume="2013" Year="2013">
+<Database Name="cv" Series="53921" Issue="395247" />
+</Book>
+<Book Series="Fantastic Four" Number="9" Volume="2013" Year="2013">
+<Database Name="cv" Series="53921" Issue="411828" />
+</Book>
+<Book Series="Fantastic Four" Number="10" Volume="2013" Year="2013">
+<Database Name="cv" Series="53921" Issue="417835" />
+</Book>
+<Book Series="Fantastic Four" Number="11" Volume="2013" Year="2013">
+<Database Name="cv" Series="53921" Issue="421689" />
+</Book>
+<Book Series="Fantastic Four" Number="12" Volume="2013" Year="2013">
+<Database Name="cv" Series="53921" Issue="425026" />
+</Book>
+<Book Series="Fantastic Four" Number="13" Volume="2013" Year="2013">
+<Database Name="cv" Series="53921" Issue="428858" />
+</Book>
+<Book Series="Fantastic Four" Number="14" Volume="2013" Year="2014">
+<Database Name="cv" Series="53921" Issue="433845" />
+</Book>
+<Book Series="Fantastic Four" Number="15" Volume="2013" Year="2014">
+<Database Name="cv" Series="53921" Issue="437489" />
+</Book>
+<Book Series="Fantastic Four" Number="16" Volume="2013" Year="2014">
+<Database Name="cv" Series="53921" Issue="442167" />
+</Book>
+<Book Series="FF" Number="4" Volume="2013" Year="2013">
+<Database Name="cv" Series="54295" Issue="388555" />
+</Book>
+<Book Series="FF" Number="5" Volume="2013" Year="2013">
+<Database Name="cv" Series="54295" Issue="395248" />
+</Book>
+<Book Series="FF" Number="6" Volume="2013" Year="2013">
+<Database Name="cv" Series="54295" Issue="398984" />
+</Book>
+<Book Series="FF" Number="7" Volume="2013" Year="2013">
+<Database Name="cv" Series="54295" Issue="402286" />
+</Book>
+<Book Series="FF" Number="8" Volume="2013" Year="2013">
+<Database Name="cv" Series="54295" Issue="413657" />
+</Book>
+<Book Series="FF" Number="9" Volume="2013" Year="2013">
+<Database Name="cv" Series="54295" Issue="417836" />
+</Book>
+<Book Series="FF" Number="10" Volume="2013" Year="2013">
+<Database Name="cv" Series="54295" Issue="419968" />
+</Book>
+<Book Series="FF" Number="11" Volume="2013" Year="2013">
+<Database Name="cv" Series="54295" Issue="423674" />
+</Book>
+<Book Series="FF" Number="12" Volume="2013" Year="2013">
+<Database Name="cv" Series="54295" Issue="426874" />
+</Book>
+<Book Series="FF" Number="13" Volume="2013" Year="2013">
+<Database Name="cv" Series="54295" Issue="430753" />
+</Book>
+<Book Series="Fantastic Four" Number="1" Volume="2014" Year="2014">
+<Database Name="cv" Series="71949" Issue="446480" />
+</Book>
+<Book Series="Fantastic Four" Number="2" Volume="2014" Year="2014">
+<Database Name="cv" Series="71949" Issue="447509" />
+</Book>
+<Book Series="Fantastic Four" Number="3" Volume="2014" Year="2014">
+<Database Name="cv" Series="71949" Issue="451083" />
+</Book>
+<Book Series="Fantastic Four" Number="4" Volume="2014" Year="2014">
+<Database Name="cv" Series="71949" Issue="452852" />
+</Book>
+<Book Series="Fantastic Four" Number="5" Volume="2014" Year="2014">
+<Database Name="cv" Series="71949" Issue="454098" />
+</Book>
+<Book Series="Fantastic Four" Number="6" Volume="2014" Year="2014">
+<Database Name="cv" Series="71949" Issue="457641" />
+</Book>
+<Book Series="Fantastic Four" Number="7" Volume="2014" Year="2014">
+<Database Name="cv" Series="71949" Issue="459171" />
+</Book>
+<Book Series="Fantastic Four" Number="8" Volume="2014" Year="2014">
+<Database Name="cv" Series="71949" Issue="462250" />
+</Book>
+<Book Series="Fantastic Four" Number="9" Volume="2014" Year="2014">
+<Database Name="cv" Series="71949" Issue="463481" />
+</Book>
+<Book Series="Fantastic Four" Number="10" Volume="2014" Year="2014">
+<Database Name="cv" Series="71949" Issue="464980" />
+</Book>
+<Book Series="Fantastic Four" Number="11" Volume="2014" Year="2014">
+<Database Name="cv" Series="71949" Issue="468078" />
+</Book>
+<Book Series="Fantastic Four Annual" Number="1" Volume="2014" Year="2014">
+<Database Name="cv" Series="77247" Issue="467036" />
+</Book>
+<Book Series="Fantastic Four Annual" Number="12" Volume="2014" Year="2014">
+<Database Name="cv" Series="71949" Issue="468907" />
+</Book>
+<Book Series="Fantastic Four Annual" Number="13" Volume="2014" Year="2015">
+<Database Name="cv" Series="71949" Issue="470427" />
+</Book>
+<Book Series="Fantastic Four Annual" Number="14" Volume="2014" Year="2015">
+<Database Name="cv" Series="71949" Issue="473647" />
+</Book>
+<Book Series="Fantastic Four" Number="642" Volume="2014" Year="2015">
+<Database Name="cv" Series="71949" Issue="476785" />
+</Book>
+<Book Series="Fantastic Four" Number="643" Volume="2014" Year="2015">
+<Database Name="cv" Series="71949" Issue="480672" />
+</Book>
+<Book Series="Fantastic Four" Number="644" Volume="2014" Year="2015">
+<Database Name="cv" Series="71949" Issue="482155" />
+</Book>
+<Book Series="Fantastic Four" Number="645" Volume="2014" Year="2015">
+<Database Name="cv" Series="71949" Issue="487203" />
+</Book>
+</Books>
+<Matchers />
+</ReadingList>


### PR DESCRIPTION
Add a reading list of Fantastic Four between the Civil War and Secret Wars events as laid out by ComicBookHerald here: https://www.comicbookherald.com/fantastic-four-reading-order/ (Most of Part V + Part VI + Part VII)