### PR TITLE
CV ID Mapping - Marvel/Teams/unsorted/X-Men

### DIFF
--- a/Marvel/Teams/unsorted/X-Men/Alpha Flight/Alpha Flight.cbl
+++ b/Marvel/Teams/unsorted/X-Men/Alpha Flight/Alpha Flight.cbl
@@ -1,690 +1,691 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Alpha Flight</Name>
+  <NumIssues>228</NumIssues>
   <Books>
     <Book Series="The X-Men" Number="120" Volume="1963" Year="1979">
-      <Id>70f7bbb6-f0a0-4189-9ea5-eb08aca7a95a</Id>
+      <Database Name="cv" Series="2133" Issue="19455" />
     </Book>
     <Book Series="The X-Men" Number="121" Volume="1963" Year="1979">
-      <Id>87a23112-56a7-44f3-9995-6f39441e0592</Id>
+      <Database Name="cv" Series="2133" Issue="19525" />
     </Book>
     <Book Series="The X-Men" Number="139" Volume="1963" Year="1980">
-      <Id>646292c0-2c4f-45f1-bab2-9a359951fe06</Id>
+      <Database Name="cv" Series="2133" Issue="20812" />
     </Book>
     <Book Series="The X-Men" Number="140" Volume="1963" Year="1980">
-      <Id>57156028-f453-49d1-adea-b91268bfca2d</Id>
+      <Database Name="cv" Series="2133" Issue="20884" />
     </Book>
     <Book Series="Machine Man" Number="18" Volume="1978" Year="1980">
-      <Id>cd38c290-c210-473d-a707-524d50be435d</Id>
+      <Database Name="cv" Series="2956" Issue="20864" />
     </Book>
     <Book Series="Marvel Two-in-One" Number="84" Volume="1974" Year="1982">
-      <Id>e673b54c-bc4d-4d5a-b4d2-7740e1dfcdf0</Id>
+      <Database Name="cv" Series="2696" Issue="21937" />
     </Book>
     <Book Series="Alpha Flight" Number="1" Volume="1983" Year="1983">
-      <Id>8adf4fe7-b66d-4a78-af6c-1f31c5c52b0f</Id>
+      <Database Name="cv" Series="3217" Issue="23361" />
     </Book>
     <Book Series="Alpha Flight" Number="2" Volume="1983" Year="1983">
-      <Id>c144c4ef-d5a2-4f29-b4bf-8b1b456e6b4c</Id>
+      <Database Name="cv" Series="3217" Issue="23440" />
     </Book>
     <Book Series="Alpha Flight" Number="3" Volume="1983" Year="1983">
-      <Id>c00d05d7-a6df-48a5-92db-e021240d27fc</Id>
+      <Database Name="cv" Series="3217" Issue="23530" />
     </Book>
     <Book Series="Alpha Flight" Number="4" Volume="1983" Year="1983">
-      <Id>5120002d-689a-4f5a-8623-d01b508c5b13</Id>
+      <Database Name="cv" Series="3217" Issue="23613" />
     </Book>
     <Book Series="Alpha Flight" Number="5" Volume="1983" Year="1983">
-      <Id>9220f979-6dcb-477b-b376-d7961302a4ae</Id>
+      <Database Name="cv" Series="3217" Issue="23714" />
     </Book>
     <Book Series="Alpha Flight" Number="6" Volume="1983" Year="1984">
-      <Id>d2e23102-d002-498f-9985-961be785a406</Id>
+      <Database Name="cv" Series="3217" Issue="23861" />
     </Book>
     <Book Series="X-Men/Alpha Flight" Number="1" Volume="1998" Year="1998">
-      <Id>34d6b575-f5d7-4048-b839-16ba636ece89</Id>
+      <Database Name="cv" Series="9191" Issue="133134" />
     </Book>
     <Book Series="X-Men/Alpha Flight" Number="2" Volume="1998" Year="1998">
-      <Id>a3898021-e3da-4fca-8065-f29355b21fd4</Id>
+      <Database Name="cv" Series="9191" Issue="133135" />
     </Book>
     <Book Series="Alpha Flight" Number="7" Volume="1983" Year="1984">
-      <Id>0197f4c3-f4af-451b-a960-029c3448774b</Id>
+      <Database Name="cv" Series="3217" Issue="23968" />
     </Book>
     <Book Series="Alpha Flight" Number="8" Volume="1983" Year="1984">
-      <Id>c24ecca5-a8a3-4df9-8a56-c4af738f4536</Id>
+      <Database Name="cv" Series="3217" Issue="24085" />
     </Book>
     <Book Series="Alpha Flight" Number="9" Volume="1983" Year="1984">
-      <Id>8ec7f366-e9e6-4eaf-982e-6cdf564a0bad</Id>
+      <Database Name="cv" Series="3217" Issue="24190" />
     </Book>
     <Book Series="Alpha Flight" Number="10" Volume="1983" Year="1984">
-      <Id>6f1465ca-cb7c-42f7-abbf-281b132528d2</Id>
+      <Database Name="cv" Series="3217" Issue="111120" />
     </Book>
     <Book Series="Alpha Flight" Number="11" Volume="1983" Year="1984">
-      <Id>db1eb3e8-be94-458b-baa5-61e6e286708d</Id>
+      <Database Name="cv" Series="3217" Issue="24395" />
     </Book>
     <Book Series="Alpha Flight" Number="12" Volume="1983" Year="1984">
-      <Id>9af5375d-e10d-4c92-ba82-26df5ad20750</Id>
+      <Database Name="cv" Series="3217" Issue="24495" />
     </Book>
     <Book Series="Alpha Flight" Number="13" Volume="1983" Year="1984">
-      <Id>c03ab3c1-b258-4caa-830e-23ae1ca50615</Id>
+      <Database Name="cv" Series="3217" Issue="24592" />
     </Book>
     <Book Series="Marvel Team-Up Annual" Number="7" Volume="1976" Year="1984">
-      <Id>47743708-e8e5-4884-9c64-2e7167dc0673</Id>
+      <Database Name="cv" Series="2863" Issue="23785" />
     </Book>
     <Book Series="Alpha Flight" Number="14" Volume="1983" Year="1984">
-      <Id>2cf9b625-63fa-41cc-8db4-63fc79c91691</Id>
+      <Database Name="cv" Series="3217" Issue="24686" />
     </Book>
     <Book Series="Alpha Flight" Number="15" Volume="1983" Year="1984">
-      <Id>ab868e71-ede8-4ff7-8214-88fa7d1296a2</Id>
+      <Database Name="cv" Series="3217" Issue="24776" />
     </Book>
     <Book Series="Alpha Flight" Number="16" Volume="1983" Year="1984">
-      <Id>a96a8d4d-250e-4ada-bbf2-4b7a8979a09e</Id>
+      <Database Name="cv" Series="3217" Issue="24879" />
     </Book>
     <Book Series="Alpha Flight" Number="17" Volume="1983" Year="1984">
-      <Id>28ebdcde-9f19-4938-9b00-da76956261bf</Id>
+      <Database Name="cv" Series="3217" Issue="24980" />
     </Book>
     <Book Series="Alpha Flight" Number="18" Volume="1983" Year="1985">
-      <Id>049c422f-eaa1-463a-97ae-7d281d6f33b4</Id>
+      <Database Name="cv" Series="3217" Issue="25153" />
     </Book>
     <Book Series="Alpha Flight" Number="19" Volume="1983" Year="1985">
-      <Id>3b224507-5d5a-4920-8043-85a4d528cc0e</Id>
+      <Database Name="cv" Series="3217" Issue="25249" />
     </Book>
     <Book Series="X-Men/Alpha Flight" Number="1" Volume="1985" Year="1985">
-      <Id>0001da6c-cb62-4df3-a061-4506cd4009e4</Id>
+      <Database Name="cv" Series="3522" Issue="57851" />
     </Book>
     <Book Series="X-Men/Alpha Flight" Number="2" Volume="1985" Year="1986">
-      <Id>617c61f9-1079-4c49-b487-e700c8c2b6e2</Id>
+      <Database Name="cv" Series="3522" Issue="57852" />
     </Book>
     <Book Series="Alpha Flight" Number="20" Volume="1983" Year="1985">
-      <Id>a5ea63a2-7a3e-4002-9a8a-8ba40107c542</Id>
+      <Database Name="cv" Series="3217" Issue="123676" />
     </Book>
     <Book Series="Alpha Flight" Number="21" Volume="1983" Year="1985">
-      <Id>aa6edac0-0b8d-4936-8a9c-754160e143b8</Id>
+      <Database Name="cv" Series="3217" Issue="25378" />
     </Book>
     <Book Series="Alpha Flight" Number="22" Volume="1983" Year="1985">
-      <Id>aff90921-69d6-45ad-b7a9-4125a3802711</Id>
+      <Database Name="cv" Series="3217" Issue="25478" />
     </Book>
     <Book Series="Alpha Flight" Number="23" Volume="1983" Year="1985">
-      <Id>aa6dab4c-ff2c-46f4-9541-27f121e63be2</Id>
+      <Database Name="cv" Series="3217" Issue="25573" />
     </Book>
     <Book Series="Alpha Flight" Number="24" Volume="1983" Year="1985">
-      <Id>814661a5-913d-4fab-a0d8-b5f5ce576ee3</Id>
+      <Database Name="cv" Series="3217" Issue="25672" />
     </Book>
     <Book Series="Alpha Flight" Number="25" Volume="1983" Year="1985">
-      <Id>04b235cd-db10-4033-bced-7632d1151516</Id>
+      <Database Name="cv" Series="3217" Issue="25774" />
     </Book>
     <Book Series="Alpha Flight" Number="26" Volume="1983" Year="1985">
-      <Id>f989a384-8d91-4f20-a23a-d816e7d119f8</Id>
+      <Database Name="cv" Series="3217" Issue="25865" />
     </Book>
     <Book Series="Alpha Flight" Number="27" Volume="1983" Year="1985">
-      <Id>e51f554a-e5d5-49c6-a2bc-cb6e005bb3af</Id>
+      <Database Name="cv" Series="3217" Issue="25970" />
     </Book>
     <Book Series="Alpha Flight" Number="28" Volume="1983" Year="1985">
-      <Id>dbb60a3b-3c80-44e1-a6bd-8965304f0a87</Id>
+      <Database Name="cv" Series="3217" Issue="26070" />
     </Book>
     <Book Series="The Incredible Hulk" Number="313" Volume="1968" Year="1985">
-      <Id>d72d6126-245c-4b0d-8004-5e82185ab146</Id>
+      <Database Name="cv" Series="2406" Issue="26086" />
     </Book>
     <Book Series="Alpha Flight" Number="29" Volume="1983" Year="1985">
-      <Id>25200fd2-4689-4169-b3eb-8fee85e653af</Id>
+      <Database Name="cv" Series="3217" Issue="26182" />
     </Book>
     <Book Series="Alpha Flight" Number="30" Volume="1983" Year="1986">
-      <Id>3c14c2be-e698-41ba-b3d1-5207253b3491</Id>
+      <Database Name="cv" Series="3217" Issue="26386" />
     </Book>
     <Book Series="Alpha Flight" Number="31" Volume="1983" Year="1986">
-      <Id>389bee4f-0ce6-4d17-947b-c440ef323175</Id>
+      <Database Name="cv" Series="3217" Issue="26494" />
     </Book>
     <Book Series="Alpha Flight" Number="32" Volume="1983" Year="1986">
-      <Id>b2b3eb59-3544-4ab4-b52a-021f9b1582b7</Id>
+      <Database Name="cv" Series="3217" Issue="26591" />
     </Book>
     <Book Series="Alpha Flight" Number="33" Volume="1983" Year="1986">
-      <Id>05551255-25da-4b54-826a-cb969f9f100c</Id>
+      <Database Name="cv" Series="3217" Issue="26691" />
     </Book>
     <Book Series="Alpha Flight" Number="34" Volume="1983" Year="1986">
-      <Id>49d1f8c6-d45e-455e-879d-375dc954749a</Id>
+      <Database Name="cv" Series="3217" Issue="26782" />
     </Book>
     <Book Series="Marvel Fanfare" Number="28" Volume="1982" Year="1986">
-      <Id>7cbbf52d-1a94-4c08-a3bd-487855bfad4a</Id>
+      <Database Name="cv" Series="3143" Issue="27185" />
     </Book>
     <Book Series="Alpha Flight" Number="35" Volume="1983" Year="1986">
-      <Id>b5c4ab18-8b2d-400f-a75d-18b8359a9d48</Id>
+      <Database Name="cv" Series="3217" Issue="26883" />
     </Book>
     <Book Series="Alpha Flight" Number="36" Volume="1983" Year="1986">
-      <Id>5bdf5646-e3a4-45b9-96eb-852f344ef7b1</Id>
+      <Database Name="cv" Series="3217" Issue="26981" />
     </Book>
     <Book Series="Alpha Flight" Number="37" Volume="1983" Year="1986">
-      <Id>969881d1-805c-4773-a411-1925296f0969</Id>
+      <Database Name="cv" Series="3217" Issue="27075" />
     </Book>
     <Book Series="Alpha Flight" Number="38" Volume="1983" Year="1986">
-      <Id>52909ea1-b7a7-45c7-882d-8ef9ba53739d</Id>
+      <Database Name="cv" Series="3217" Issue="27173" />
     </Book>
     <Book Series="Alpha Flight" Number="39" Volume="1983" Year="1986">
-      <Id>d653f450-cec8-425c-82cd-e36e84475cbb</Id>
+      <Database Name="cv" Series="3217" Issue="27269" />
     </Book>
     <Book Series="The Avengers" Number="272" Volume="1963" Year="1986">
-      <Id>3f1f31af-fdf9-4b5c-9567-e7f377906419</Id>
+      <Database Name="cv" Series="2128" Issue="27271" />
     </Book>
     <Book Series="Alpha Flight" Number="40" Volume="1983" Year="1986">
-      <Id>2c83c87d-b9d8-44c3-8775-9ad17df81f73</Id>
+      <Database Name="cv" Series="3217" Issue="27374" />
     </Book>
     <Book Series="Alpha Flight Annual" Number="1" Volume="1986" Year="1986">
-      <Id>a8af3c72-bb12-4219-bde0-24fd5520bc4b</Id>
+      <Database Name="cv" Series="3623" Issue="26258" />
     </Book>
     <Book Series="Alpha Flight" Number="41" Volume="1983" Year="1986">
-      <Id>e4c53912-4e9c-4348-ae65-3ef7bcd92373</Id>
+      <Database Name="cv" Series="3217" Issue="27480" />
     </Book>
     <Book Series="Alpha Flight" Number="42" Volume="1983" Year="1987">
-      <Id>0b3be503-ac16-4860-a9ea-2d01299b237a</Id>
+      <Database Name="cv" Series="3217" Issue="27670" />
     </Book>
     <Book Series="Alpha Flight" Number="43" Volume="1983" Year="1987">
-      <Id>0a389d44-7596-49b5-969c-4a04b7041007</Id>
+      <Database Name="cv" Series="3217" Issue="27782" />
     </Book>
     <Book Series="Alpha Flight" Number="44" Volume="1983" Year="1987">
-      <Id>f57cb714-7ca8-4ac2-827a-57fa4f3a03c1</Id>
+      <Database Name="cv" Series="3217" Issue="27892" />
     </Book>
     <Book Series="Alpha Flight" Number="45" Volume="1983" Year="1987">
-      <Id>870e4f10-dffc-4782-8b79-150b0650f0e0</Id>
+      <Database Name="cv" Series="3217" Issue="28006" />
     </Book>
     <Book Series="Alpha Flight" Number="46" Volume="1983" Year="1987">
-      <Id>554bfe74-5ef6-40ea-be2b-f4ec90d4c71f</Id>
+      <Database Name="cv" Series="3217" Issue="28107" />
     </Book>
     <Book Series="Alpha Flight" Number="47" Volume="1983" Year="1987">
-      <Id>91112331-d9ea-439a-9ee7-611735b80d04</Id>
+      <Database Name="cv" Series="3217" Issue="28217" />
     </Book>
     <Book Series="Alpha Flight" Number="48" Volume="1983" Year="1987">
-      <Id>3f1e8eea-03f2-4b03-80ac-f5215a8a736d</Id>
+      <Database Name="cv" Series="3217" Issue="28331" />
     </Book>
     <Book Series="Alpha Flight" Number="49" Volume="1983" Year="1987">
-      <Id>1f513d10-60c0-471c-9d96-ae4bf16e138f</Id>
+      <Database Name="cv" Series="3217" Issue="28452" />
     </Book>
     <Book Series="Alpha Flight" Number="50" Volume="1983" Year="1987">
-      <Id>d5e0d532-faf2-4a5f-853a-0b4dedafeb61</Id>
+      <Database Name="cv" Series="3217" Issue="28559" />
     </Book>
     <Book Series="Alpha Flight Annual" Number="2" Volume="1986" Year="1987">
-      <Id>7d77d5a2-7e56-4120-afb1-9b147d51992d</Id>
+      <Database Name="cv" Series="3623" Issue="27560" />
     </Book>
     <Book Series="Alpha Flight" Number="51" Volume="1983" Year="1987">
-      <Id>b479e782-2220-4c1a-8e69-26cdeb95da08</Id>
+      <Database Name="cv" Series="3217" Issue="28681" />
     </Book>
     <Book Series="Alpha Flight" Number="52" Volume="1983" Year="1987">
-      <Id>f7461f82-dde5-4af4-94a6-a3b274a95fff</Id>
+      <Database Name="cv" Series="3217" Issue="28794" />
     </Book>
     <Book Series="Alpha Flight" Number="53" Volume="1983" Year="1987">
-      <Id>72cd2de8-ddd5-4ea9-909e-f6c2b2897043</Id>
+      <Database Name="cv" Series="3217" Issue="28918" />
     </Book>
     <Book Series="Alpha Flight" Number="54" Volume="1983" Year="1988">
-      <Id>676b9e69-8acc-410c-893b-7309b8993364</Id>
+      <Database Name="cv" Series="3217" Issue="29136" />
     </Book>
     <Book Series="Alpha Flight" Number="55" Volume="1983" Year="1988">
-      <Id>b111d9d4-481f-4b1c-a5a2-9d02142d130a</Id>
+      <Database Name="cv" Series="3217" Issue="29255" />
     </Book>
     <Book Series="Alpha Flight" Number="56" Volume="1983" Year="1988">
-      <Id>bc787156-6cde-411a-819a-16f02d9ecc7b</Id>
+      <Database Name="cv" Series="3217" Issue="29364" />
     </Book>
     <Book Series="Alpha Flight" Number="57" Volume="1983" Year="1988">
-      <Id>b4595382-eb6e-40d1-961a-f0790e9e918b</Id>
+      <Database Name="cv" Series="3217" Issue="29475" />
     </Book>
     <Book Series="Alpha Flight" Number="58" Volume="1983" Year="1988">
-      <Id>76e4a125-8f5d-41fa-a045-8348fdb0050a</Id>
+      <Database Name="cv" Series="3217" Issue="29583" />
     </Book>
     <Book Series="Alpha Flight" Number="59" Volume="1983" Year="1988">
-      <Id>88d784f0-b276-4517-ac12-18a3e9eb94c5</Id>
+      <Database Name="cv" Series="3217" Issue="29700" />
     </Book>
     <Book Series="Alpha Flight" Number="60" Volume="1983" Year="1988">
-      <Id>ed855edc-f8c7-40ac-986d-6cd89ddbd18c</Id>
+      <Database Name="cv" Series="3217" Issue="29818" />
     </Book>
     <Book Series="Alpha Flight" Number="61" Volume="1983" Year="1988">
-      <Id>48a69796-63cb-4f1a-97f0-6949a68c0254</Id>
+      <Database Name="cv" Series="3217" Issue="29935" />
     </Book>
     <Book Series="Alpha Flight" Number="62" Volume="1983" Year="1988">
-      <Id>c6b9b4f1-a3ab-40d7-9d9d-cbbf7f1c37d4</Id>
+      <Database Name="cv" Series="3217" Issue="30047" />
     </Book>
     <Book Series="Alpha Flight" Number="63" Volume="1983" Year="1988">
-      <Id>fa9facab-7ecb-44c8-b532-5c286f3495c1</Id>
+      <Database Name="cv" Series="3217" Issue="30172" />
     </Book>
     <Book Series="Alpha Flight" Number="64" Volume="1983" Year="1988">
-      <Id>a3113a84-b323-49ca-a607-71d046b4624a</Id>
+      <Database Name="cv" Series="3217" Issue="30300" />
     </Book>
     <Book Series="Alpha Flight" Number="65" Volume="1983" Year="1988">
-      <Id>649b09d5-c2d3-443e-bffe-634aeca2c0ba</Id>
+      <Database Name="cv" Series="3217" Issue="30422" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="52" Volume="1988" Year="1990">
-      <Id>eae784cf-8243-43e5-baf2-1049f3a2636a</Id>
+      <Database Name="cv" Series="4058" Issue="32895" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="53" Volume="1988" Year="1990">
-      <Id>1e7ed635-8f16-4078-b87c-f506b8dc296a</Id>
+      <Database Name="cv" Series="4058" Issue="32968" />
     </Book>
     <Book Series="Alpha Flight" Number="66" Volume="1983" Year="1989">
-      <Id>078d7ed0-4948-494a-96b7-022a967f5338</Id>
+      <Database Name="cv" Series="3217" Issue="30772" />
     </Book>
     <Book Series="Alpha Flight" Number="67" Volume="1983" Year="1989">
-      <Id>be4a22be-86b8-44ae-98d8-c50111a51643</Id>
+      <Database Name="cv" Series="3217" Issue="30882" />
     </Book>
     <Book Series="Alpha Flight" Number="68" Volume="1983" Year="1989">
-      <Id>a49d894e-0b52-4343-8700-0c194b1d33fd</Id>
+      <Database Name="cv" Series="3217" Issue="128723" />
     </Book>
     <Book Series="Alpha Flight" Number="69" Volume="1983" Year="1989">
-      <Id>9b7f2946-ff98-4683-a899-b92ddd52fa37</Id>
+      <Database Name="cv" Series="3217" Issue="31093" />
     </Book>
     <Book Series="Alpha Flight" Number="70" Volume="1983" Year="1989">
-      <Id>a007eb60-e273-48b2-b9b7-e30d58f5c2fb</Id>
+      <Database Name="cv" Series="3217" Issue="31206" />
     </Book>
     <Book Series="Alpha Flight" Number="71" Volume="1983" Year="1989">
-      <Id>7def9307-48ed-41a3-92c2-bca67a68d6b3</Id>
+      <Database Name="cv" Series="3217" Issue="31315" />
     </Book>
     <Book Series="Alpha Flight" Number="72" Volume="1983" Year="1989">
-      <Id>2538144a-f847-4675-af10-1b6601959aad</Id>
+      <Database Name="cv" Series="3217" Issue="31428" />
     </Book>
     <Book Series="Alpha Flight" Number="73" Volume="1983" Year="1989">
-      <Id>af7fd8a9-86c4-459e-9ced-bfc40c5158db</Id>
+      <Database Name="cv" Series="3217" Issue="31532" />
     </Book>
     <Book Series="Alpha Flight" Number="74" Volume="1983" Year="1989">
-      <Id>247ad5cc-0d16-4db4-8519-00aff933510c</Id>
+      <Database Name="cv" Series="3217" Issue="31645" />
     </Book>
     <Book Series="Alpha Flight" Number="75" Volume="1983" Year="1989">
-      <Id>d48552fa-ceba-4aa2-a6e0-bc93cb1c96bb</Id>
+      <Database Name="cv" Series="3217" Issue="31755" />
     </Book>
     <Book Series="Alpha Flight" Number="76" Volume="1983" Year="1989">
-      <Id>677cf4f6-8b15-486f-85d7-533fe3c7feb7</Id>
+      <Database Name="cv" Series="3217" Issue="31859" />
     </Book>
     <Book Series="Alpha Flight" Number="77" Volume="1983" Year="1989">
-      <Id>48003b6d-64c7-421c-8521-701fb2c855ad</Id>
+      <Database Name="cv" Series="3217" Issue="31915" />
     </Book>
     <Book Series="Alpha Flight" Number="78" Volume="1983" Year="1989">
-      <Id>62ccea0c-8859-4126-be7f-da3dccd62532</Id>
+      <Database Name="cv" Series="3217" Issue="31990" />
     </Book>
     <Book Series="Alpha Flight" Number="79" Volume="1983" Year="1989">
-      <Id>23a3cd65-89e2-4f4e-b2ca-26ec2e98ae1c</Id>
+      <Database Name="cv" Series="3217" Issue="32052" />
     </Book>
     <Book Series="Alpha Flight" Number="80" Volume="1983" Year="1990">
-      <Id>052e09aa-b7bd-4e6b-86c1-2ef6cbd8b5a4</Id>
+      <Database Name="cv" Series="3217" Issue="32314" />
     </Book>
     <Book Series="Alpha Flight" Number="81" Volume="1983" Year="1990">
-      <Id>cf8bd6de-7c77-494d-98d5-75f0fd8a74e5</Id>
+      <Database Name="cv" Series="3217" Issue="32411" />
     </Book>
     <Book Series="Alpha Flight" Number="82" Volume="1983" Year="1990">
-      <Id>1ea2f3de-bbf6-404d-ace8-f34e5517a079</Id>
+      <Database Name="cv" Series="3217" Issue="32512" />
     </Book>
     <Book Series="Alpha Flight" Number="83" Volume="1983" Year="1990">
-      <Id>fbac1986-0b6b-4cd9-8901-a5f279c66696</Id>
+      <Database Name="cv" Series="3217" Issue="32621" />
     </Book>
     <Book Series="Alpha Flight" Number="84" Volume="1983" Year="1990">
-      <Id>c1eede50-2ce3-4acb-bb45-017638e454a0</Id>
+      <Database Name="cv" Series="3217" Issue="32720" />
     </Book>
     <Book Series="Alpha Flight" Number="85" Volume="1983" Year="1990">
-      <Id>56cb0870-e414-4d5a-8aa9-478a952fd92b</Id>
+      <Database Name="cv" Series="3217" Issue="32829" />
     </Book>
     <Book Series="Alpha Flight" Number="86" Volume="1983" Year="1990">
-      <Id>396ee20f-f6ac-45c3-8f8d-3e9b35f8b02e</Id>
+      <Database Name="cv" Series="3217" Issue="32955" />
     </Book>
     <Book Series="Alpha Flight" Number="87" Volume="1983" Year="1990">
-      <Id>3953204a-833d-40fd-958f-bd292530eb9e</Id>
+      <Database Name="cv" Series="3217" Issue="33069" />
     </Book>
     <Book Series="Alpha Flight" Number="88" Volume="1983" Year="1990">
-      <Id>7e1d3d41-5514-43ce-b1b2-106706b6e598</Id>
+      <Database Name="cv" Series="3217" Issue="33185" />
     </Book>
     <Book Series="Alpha Flight" Number="89" Volume="1983" Year="1990">
-      <Id>1512c31b-9a95-4394-994e-436b1d7622e8</Id>
+      <Database Name="cv" Series="3217" Issue="33305" />
     </Book>
     <Book Series="Alpha Flight" Number="90" Volume="1983" Year="1990">
-      <Id>368dbdc2-f3f7-4b4e-94d0-37a235d8c82c</Id>
+      <Database Name="cv" Series="3217" Issue="33416" />
     </Book>
     <Book Series="The Avengers" Number="320" Volume="1963" Year="1990">
-      <Id>757b306c-3133-4b94-8026-b731fc4f5be6</Id>
+      <Database Name="cv" Series="2128" Issue="33072" />
     </Book>
     <Book Series="The Avengers" Number="321" Volume="1963" Year="1990">
-      <Id>285ba048-59e2-4887-8573-ef3836bcdb08</Id>
+      <Database Name="cv" Series="2128" Issue="33132" />
     </Book>
     <Book Series="The Avengers" Number="322" Volume="1963" Year="1990">
-      <Id>74bbfd19-64c0-4afd-a56e-d285863061f7</Id>
+      <Database Name="cv" Series="2128" Issue="33142" />
     </Book>
     <Book Series="The Avengers" Number="323" Volume="1963" Year="1990">
-      <Id>211061a0-8655-4391-8b80-4321fde22f0a</Id>
+      <Database Name="cv" Series="2128" Issue="33188" />
     </Book>
     <Book Series="The Avengers" Number="324" Volume="1963" Year="1990">
-      <Id>bfe754d7-6e3b-463f-b47a-93efb4def45b</Id>
+      <Database Name="cv" Series="2128" Issue="33308" />
     </Book>
     <Book Series="Alpha Flight" Number="91" Volume="1983" Year="1990">
-      <Id>c67945a6-edcb-4d97-95be-0a46bc17324f</Id>
+      <Database Name="cv" Series="3217" Issue="33523" />
     </Book>
     <Book Series="Alpha Flight" Number="92" Volume="1983" Year="1991">
-      <Id>1de5c795-b93c-48c3-b11f-69ee6789b485</Id>
+      <Database Name="cv" Series="3217" Issue="33767" />
     </Book>
     <Book Series="Alpha Flight" Number="93" Volume="1983" Year="1991">
-      <Id>6d24f8d5-baad-498c-94a9-f746be5460f7</Id>
+      <Database Name="cv" Series="3217" Issue="33865" />
     </Book>
     <Book Series="Alpha Flight" Number="94" Volume="1983" Year="1991">
-      <Id>34515d19-4b14-4c59-9692-4ddaac6a4325</Id>
+      <Database Name="cv" Series="3217" Issue="33982" />
     </Book>
     <Book Series="Alpha Flight" Number="95" Volume="1983" Year="1991">
-      <Id>5fc8cf96-7ea7-4ee4-bb8f-a9f2c3b8c210</Id>
+      <Database Name="cv" Series="3217" Issue="34085" />
     </Book>
     <Book Series="Alpha Flight" Number="96" Volume="1983" Year="1991">
-      <Id>25651b17-5278-454c-b256-b22a10a487c9</Id>
+      <Database Name="cv" Series="3217" Issue="34191" />
     </Book>
     <Book Series="Alpha Flight" Number="97" Volume="1983" Year="1991">
-      <Id>c6dbb846-f572-4a63-8646-4ae826e78283</Id>
+      <Database Name="cv" Series="3217" Issue="34289" />
     </Book>
     <Book Series="Alpha Flight" Number="98" Volume="1983" Year="1991">
-      <Id>38d5fd7c-f948-4fce-ae33-c49ec296df59</Id>
+      <Database Name="cv" Series="3217" Issue="34403" />
     </Book>
     <Book Series="Alpha Flight" Number="99" Volume="1983" Year="1991">
-      <Id>078a1479-0d24-483f-a61d-0f87f7127899</Id>
+      <Database Name="cv" Series="3217" Issue="34518" />
     </Book>
     <Book Series="Alpha Flight" Number="100" Volume="1983" Year="1991">
-      <Id>0a56bf9f-2e41-4da9-86e0-27e5be182683</Id>
+      <Database Name="cv" Series="3217" Issue="34636" />
     </Book>
     <Book Series="Alpha Flight" Number="101" Volume="1983" Year="1991">
-      <Id>01816d21-5687-4b87-ab17-5870589675b1</Id>
+      <Database Name="cv" Series="3217" Issue="34754" />
     </Book>
     <Book Series="Alpha Flight" Number="102" Volume="1983" Year="1991">
-      <Id>56307c70-d602-4fa5-9616-5f32fb34a127</Id>
+      <Database Name="cv" Series="3217" Issue="34870" />
     </Book>
     <Book Series="Alpha Flight" Number="103" Volume="1983" Year="1991">
-      <Id>7ec8c524-d86c-4dbd-871d-acdab761fb4c</Id>
+      <Database Name="cv" Series="3217" Issue="34992" />
     </Book>
     <Book Series="Alpha Flight" Number="104" Volume="1983" Year="1992">
-      <Id>2cecea5c-ed88-4493-ad9b-f10226ab9b2c</Id>
+      <Database Name="cv" Series="3217" Issue="35252" />
     </Book>
     <Book Series="Alpha Flight" Number="105" Volume="1983" Year="1992">
-      <Id>17648c16-040f-40bb-beaa-93ecf95c2de8</Id>
+      <Database Name="cv" Series="3217" Issue="35359" />
     </Book>
     <Book Series="Alpha Flight" Number="106" Volume="1983" Year="1992">
-      <Id>2c261732-1048-4c58-a17b-f092ebd7e2ad</Id>
+      <Database Name="cv" Series="3217" Issue="35464" />
     </Book>
     <Book Series="Alpha Flight" Number="107" Volume="1983" Year="1992">
-      <Id>0e2a381c-26a5-445b-8902-ffc74bd3d581</Id>
+      <Database Name="cv" Series="3217" Issue="35568" />
     </Book>
     <Book Series="Alpha Flight" Number="108" Volume="1983" Year="1992">
-      <Id>3de93a6b-4f81-4913-a7e0-5ad3afde6082</Id>
+      <Database Name="cv" Series="3217" Issue="35670" />
     </Book>
     <Book Series="Alpha Flight" Number="109" Volume="1983" Year="1992">
-      <Id>b2cf8305-3886-4c12-ba58-5d9474a16d38</Id>
+      <Database Name="cv" Series="3217" Issue="35775" />
     </Book>
     <Book Series="Alpha Flight" Number="110" Volume="1983" Year="1992">
-      <Id>adf93576-418f-4c37-8a51-af323fb4e4b8</Id>
+      <Database Name="cv" Series="3217" Issue="35899" />
     </Book>
     <Book Series="Alpha Flight" Number="111" Volume="1983" Year="1992">
-      <Id>2ca064a8-42f3-40d5-bd75-9256dbbf4b53</Id>
+      <Database Name="cv" Series="3217" Issue="36018" />
     </Book>
     <Book Series="Alpha Flight" Number="112" Volume="1983" Year="1992">
-      <Id>26e2dfee-a308-4046-9fa8-c8331cb2fae4</Id>
+      <Database Name="cv" Series="3217" Issue="36143" />
     </Book>
     <Book Series="Alpha Flight" Number="113" Volume="1983" Year="1992">
-      <Id>4c487f7d-03b1-456a-8f84-f06d5e75faa4</Id>
+      <Database Name="cv" Series="3217" Issue="36267" />
     </Book>
     <Book Series="Alpha Flight" Number="114" Volume="1983" Year="1992">
-      <Id>1a70c988-d67b-4e8c-8e01-bba5a9a85b5f</Id>
+      <Database Name="cv" Series="3217" Issue="36391" />
     </Book>
     <Book Series="Alpha Flight" Number="115" Volume="1983" Year="1992">
-      <Id>7ec6e193-2a6c-468c-8189-77267066057e</Id>
+      <Database Name="cv" Series="3217" Issue="36506" />
     </Book>
     <Book Series="Alpha Flight" Number="116" Volume="1983" Year="1993">
-      <Id>2a15f214-e59d-494a-a6fb-417c38279189</Id>
+      <Database Name="cv" Series="3217" Issue="36747" />
     </Book>
     <Book Series="Alpha Flight" Number="117" Volume="1983" Year="1993">
-      <Id>9f82d656-03f6-468f-90f9-d86b7e45e080</Id>
+      <Database Name="cv" Series="3217" Issue="36854" />
     </Book>
     <Book Series="Alpha Flight" Number="118" Volume="1983" Year="1993">
-      <Id>adc1da3b-7351-4df0-add4-bdbb25659eed</Id>
+      <Database Name="cv" Series="3217" Issue="36964" />
     </Book>
     <Book Series="Alpha Flight" Number="119" Volume="1983" Year="1993">
-      <Id>3a8e62e2-b0e2-4b5e-965e-cf7bc1073518</Id>
+      <Database Name="cv" Series="3217" Issue="37084" />
     </Book>
     <Book Series="Alpha Flight" Number="120" Volume="1983" Year="1993">
-      <Id>093a389b-59e2-4950-af14-52359370c14e</Id>
+      <Database Name="cv" Series="3217" Issue="37220" />
     </Book>
     <Book Series="Alpha Flight" Number="121" Volume="1983" Year="1993">
-      <Id>556337a1-b343-4d35-8071-98b8cfc99aea</Id>
+      <Database Name="cv" Series="3217" Issue="37356" />
     </Book>
     <Book Series="Alpha Flight" Number="122" Volume="1983" Year="1993">
-      <Id>ca280cb7-da7b-4082-ae87-a8459a68fc94</Id>
+      <Database Name="cv" Series="3217" Issue="37509" />
     </Book>
     <Book Series="Alpha Flight" Number="123" Volume="1983" Year="1993">
-      <Id>be064c2e-e724-496b-9249-09976d6cb0cf</Id>
+      <Database Name="cv" Series="3217" Issue="37650" />
     </Book>
     <Book Series="Alpha Flight" Number="124" Volume="1983" Year="1993">
-      <Id>8237a72a-464c-425c-9fca-ad802c1dafbb</Id>
+      <Database Name="cv" Series="3217" Issue="37788" />
     </Book>
     <Book Series="Alpha Flight" Number="125" Volume="1983" Year="1993">
-      <Id>8b68a276-5a92-446b-a8c3-2ffc3c4359d2</Id>
+      <Database Name="cv" Series="3217" Issue="37940" />
     </Book>
     <Book Series="Alpha Flight" Number="126" Volume="1983" Year="1993">
-      <Id>b83d7c59-c55e-4500-ad26-407ff941fa35</Id>
+      <Database Name="cv" Series="3217" Issue="38089" />
     </Book>
     <Book Series="Alpha Flight" Number="127" Volume="1983" Year="1993">
-      <Id>8a5efc06-3f11-4299-b225-b9cb19e32f88</Id>
+      <Database Name="cv" Series="3217" Issue="38245" />
     </Book>
     <Book Series="Alpha Flight" Number="128" Volume="1983" Year="1994">
-      <Id>11967341-5886-4280-a658-7e68f964d133</Id>
+      <Database Name="cv" Series="3217" Issue="38494" />
     </Book>
     <Book Series="Alpha Flight" Number="129" Volume="1983" Year="1994">
-      <Id>7d803b91-d0cf-461b-b1a5-082a28e50c60</Id>
+      <Database Name="cv" Series="3217" Issue="38643" />
     </Book>
     <Book Series="Alpha Flight" Number="130" Volume="1983" Year="1994">
-      <Id>621a9c58-f0a6-44df-942e-a8a830a71297</Id>
+      <Database Name="cv" Series="3217" Issue="38786" />
     </Book>
     <Book Series="Northstar" Number="1" Volume="1994" Year="1994">
-      <Id>b2e35423-a20f-4fae-b5ac-d8d248ec4044</Id>
+      <Database Name="cv" Series="5316" Issue="68371" />
     </Book>
     <Book Series="Northstar" Number="2" Volume="1994" Year="1994">
-      <Id>718380c9-c7bd-4afc-be3f-9daf7bedf6b9</Id>
+      <Database Name="cv" Series="5316" Issue="68372" />
     </Book>
     <Book Series="Northstar" Number="3" Volume="1994" Year="1994">
-      <Id>87239d1d-4211-41dc-91ac-96e7930f6a56</Id>
+      <Database Name="cv" Series="5316" Issue="68373" />
     </Book>
     <Book Series="Northstar" Number="4" Volume="1994" Year="1994">
-      <Id>8fbf84bc-07f6-4567-91be-22555ad45931</Id>
+      <Database Name="cv" Series="5316" Issue="68374" />
     </Book>
     <Book Series="Wolverine" Number="83" Volume="1988" Year="1994">
-      <Id>b7bbfba5-7f20-4a8b-880d-d5dab0595e6e</Id>
+      <Database Name="cv" Series="4250" Issue="39406" />
     </Book>
     <Book Series="Wolverine" Number="84" Volume="1988" Year="1994">
-      <Id>c03df9ff-ccd6-4403-a7f0-22516c112e8c</Id>
+      <Database Name="cv" Series="4250" Issue="39549" />
     </Book>
     <Book Series="Wolverine" Number="95" Volume="1988" Year="1995">
-      <Id>ddc30223-61cf-4123-a359-88be81417074</Id>
+      <Database Name="cv" Series="4250" Issue="41663" />
     </Book>
     <Book Series="Alpha Flight" Number="1" Volume="1997" Year="1997">
-      <Id>59f4f1eb-3099-4c32-909a-0a19cda5de9b</Id>
+      <Database Name="cv" Series="11291" Issue="99062" />
     </Book>
     <Book Series="Alpha Flight" Number="2" Volume="1997" Year="1997">
-      <Id>571d972d-f136-4f14-986d-d439b483a8c5</Id>
+      <Database Name="cv" Series="11291" Issue="99063" />
     </Book>
     <Book Series="Alpha Flight" Number="3" Volume="1997" Year="1997">
-      <Id>58243669-bf49-4476-b999-5852e6de52c5</Id>
+      <Database Name="cv" Series="11291" Issue="99064" />
     </Book>
     <Book Series="Alpha Flight" Number="4" Volume="1997" Year="1997">
-      <Id>bb3183f7-5f65-46b7-a4b2-d65f9e2746fb</Id>
+      <Database Name="cv" Series="11291" Issue="99065" />
     </Book>
     <Book Series="Alpha Flight" Number="5" Volume="1997" Year="1997">
-      <Id>fba318e7-4aa5-4155-a7b0-88526f4dba30</Id>
+      <Database Name="cv" Series="11291" Issue="99066" />
     </Book>
     <Book Series="Alpha Flight" Number="6" Volume="1997" Year="1998">
-      <Id>1406f0b8-6185-4143-9fd7-50666d5d91cf</Id>
+      <Database Name="cv" Series="11291" Issue="99067" />
     </Book>
     <Book Series="Alpha Flight" Number="7" Volume="1997" Year="1998">
-      <Id>14450b54-ded9-419d-b8e7-f7cbc7f8516e</Id>
+      <Database Name="cv" Series="11291" Issue="99068" />
     </Book>
     <Book Series="Alpha Flight" Number="8" Volume="1997" Year="1998">
-      <Id>42a5107c-4649-4f8e-857f-16b6be3e6303</Id>
+      <Database Name="cv" Series="11291" Issue="99069" />
     </Book>
     <Book Series="Alpha Flight" Number="9" Volume="1997" Year="1998">
-      <Id>221f9ac9-326e-4085-bdf0-4d56f9ff0452</Id>
+      <Database Name="cv" Series="11291" Issue="99070" />
     </Book>
     <Book Series="Alpha Flight" Number="10" Volume="1997" Year="1998">
-      <Id>df499e45-95c4-433f-8b8f-cb96e3448fc9</Id>
+      <Database Name="cv" Series="11291" Issue="99071" />
     </Book>
     <Book Series="Alpha Flight" Number="11" Volume="1997" Year="1998">
-      <Id>0f0ff389-4b5e-429a-8cf0-9b7088385193</Id>
+      <Database Name="cv" Series="11291" Issue="99072" />
     </Book>
     <Book Series="Alpha Flight" Number="12" Volume="1997" Year="1998">
-      <Id>0f86a573-0e89-48da-80bf-98224a366b21</Id>
+      <Database Name="cv" Series="11291" Issue="99073" />
     </Book>
     <Book Series="Alpha Flight" Number="13" Volume="1997" Year="1998">
-      <Id>2f3c93ac-be16-4e12-a0a6-5e5ec6953c7e</Id>
+      <Database Name="cv" Series="11291" Issue="99074" />
     </Book>
     <Book Series="Alpha Flight" Number="14" Volume="1997" Year="1998">
-      <Id>60c6615e-b1ef-4b4e-946e-a221a90ae969</Id>
+      <Database Name="cv" Series="11291" Issue="99075" />
     </Book>
     <Book Series="Alpha Flight" Number="15" Volume="1997" Year="1998">
-      <Id>489e55ff-9559-43ad-ac6e-9d073b000f2c</Id>
+      <Database Name="cv" Series="11291" Issue="99076" />
     </Book>
     <Book Series="Alpha Flight" Number="16" Volume="1997" Year="1998">
-      <Id>88602200-206c-46ec-9740-51f456c61e0f</Id>
+      <Database Name="cv" Series="11291" Issue="99077" />
     </Book>
     <Book Series="Alpha Flight / Inhumans '98" Number="1" Volume="1998" Year="1998">
-      <Id>dcbce6ee-9e70-4326-b1bc-8256da21122f</Id>
+      <Database Name="cv" Series="25658" Issue="151202" />
     </Book>
     <Book Series="Alpha Flight" Number="17" Volume="1997" Year="1998">
-      <Id>98623b27-e82a-492d-9cea-5e77af49212f</Id>
+      <Database Name="cv" Series="11291" Issue="99078" />
     </Book>
     <Book Series="Alpha Flight" Number="18" Volume="1997" Year="1999">
-      <Id>2566225a-32c7-4c36-88f0-8566bca35a84</Id>
+      <Database Name="cv" Series="11291" Issue="99079" />
     </Book>
     <Book Series="Alpha Flight" Number="19" Volume="1997" Year="1999">
-      <Id>96b1bac7-c3b3-4b91-8803-e34812f020f9</Id>
+      <Database Name="cv" Series="11291" Issue="99080" />
     </Book>
     <Book Series="Alpha Flight" Number="20" Volume="1997" Year="1999">
-      <Id>905cfbf4-b532-4644-812a-86c59f307405</Id>
+      <Database Name="cv" Series="11291" Issue="99081" />
     </Book>
     <Book Series="Wolverine" Number="142" Volume="1988" Year="1999">
-      <Id>62f0afd0-c026-46ed-9932-9df114223cff</Id>
+      <Database Name="cv" Series="4250" Issue="51209" />
     </Book>
     <Book Series="Wolverine" Number="143" Volume="1988" Year="1999">
-      <Id>09cb3bee-ba15-4de8-83e2-b5af862cb24f</Id>
+      <Database Name="cv" Series="4250" Issue="51210" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="392" Volume="1981" Year="2001">
-      <Id>f3fa173e-67ba-4bd5-af57-9ac656f63ec2</Id>
+      <Database Name="cv" Series="3092" Issue="65175" />
     </Book>
     <Book Series="X-Men" Number="112" Volume="1991" Year="2001">
-      <Id>51fb39f9-783d-47b4-ab84-3cb8a91cf91f</Id>
+      <Database Name="cv" Series="4605" Issue="65811" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="393" Volume="1981" Year="2001">
-      <Id>1c6198cb-eb47-43ab-860c-03572252ebc8</Id>
+      <Database Name="cv" Series="3092" Issue="105595" />
     </Book>
     <Book Series="X-Men" Number="113" Volume="1991" Year="2001">
-      <Id>9e26ef8a-ef7f-44ea-9f03-558633b7a86b</Id>
+      <Database Name="cv" Series="4605" Issue="65812" />
     </Book>
     <Book Series="Wolverine" Number="171" Volume="1988" Year="2002">
-      <Id>8cc3e875-fbe5-4c52-82c3-74e19310bae7</Id>
+      <Database Name="cv" Series="4250" Issue="89851" />
     </Book>
     <Book Series="Wolverine" Number="172" Volume="1988" Year="2002">
-      <Id>361c04bc-0e3b-4d56-b568-27869909d4e8</Id>
+      <Database Name="cv" Series="4250" Issue="64488" />
     </Book>
     <Book Series="Wolverine" Number="173" Volume="1988" Year="2002">
-      <Id>85163958-9f0d-46d4-b6b6-4c63de3d6afa</Id>
+      <Database Name="cv" Series="4250" Issue="64489" />
     </Book>
     <Book Series="Wolverine" Number="179" Volume="1988" Year="2002">
-      <Id>0d973c51-aa73-4488-8788-3f9f039f9564</Id>
+      <Database Name="cv" Series="4250" Issue="93790" />
     </Book>
     <Book Series="Wolverine" Number="180" Volume="1988" Year="2002">
-      <Id>70ce041f-96aa-4989-a604-f3422a7f2df5</Id>
+      <Database Name="cv" Series="4250" Issue="93791" />
     </Book>
     <Book Series="Wolverine" Number="181" Volume="1988" Year="2002">
-      <Id>4be49ac7-4f00-4bbb-bd74-a45e95d4a0d7</Id>
+      <Database Name="cv" Series="4250" Issue="93792" />
     </Book>
     <Book Series="X-Men Unlimited" Number="45" Volume="1993" Year="2003">
-      <Id>76f6a8ba-82b5-4b4c-abc3-b5cdf89830e2</Id>
+      <Database Name="cv" Series="5066" Issue="90017" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="421" Volume="1981" Year="2003">
-      <Id>4a8bb1d4-c83d-439e-811b-8730122b9ffd</Id>
+      <Database Name="cv" Series="3092" Issue="108246" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="422" Volume="1981" Year="2003">
-      <Id>445dcab7-f330-4163-83b6-9271fa4cc1b7</Id>
+      <Database Name="cv" Series="3092" Issue="113233" />
     </Book>
     <Book Series="Alpha Flight" Number="1" Volume="2004" Year="2004">
-      <Id>719dc48e-9201-41f3-ac05-2b87d5c14bfd</Id>
+      <Database Name="cv" Series="10818" Issue="92304" />
     </Book>
     <Book Series="Alpha Flight" Number="2" Volume="2004" Year="2004">
-      <Id>250ab372-41e5-4f10-a5e8-7be02857e6dc</Id>
+      <Database Name="cv" Series="10818" Issue="92305" />
     </Book>
     <Book Series="Alpha Flight" Number="3" Volume="2004" Year="2004">
-      <Id>063ec912-55f1-45f7-8cd2-3b0c879e2152</Id>
+      <Database Name="cv" Series="10818" Issue="92306" />
     </Book>
     <Book Series="Alpha Flight" Number="4" Volume="2004" Year="2004">
-      <Id>5fba4c88-e73e-4b13-95cd-0da222238ebb</Id>
+      <Database Name="cv" Series="10818" Issue="92307" />
     </Book>
     <Book Series="Alpha Flight" Number="5" Volume="2004" Year="2004">
-      <Id>97544c81-7b45-4da9-9d8b-9604ff606abd</Id>
+      <Database Name="cv" Series="10818" Issue="92308" />
     </Book>
     <Book Series="Alpha Flight" Number="6" Volume="2004" Year="2004">
-      <Id>93053a1e-3fcd-4f95-a92f-7a8903a00fc2</Id>
+      <Database Name="cv" Series="10818" Issue="92309" />
     </Book>
     <Book Series="Alpha Flight" Number="7" Volume="2004" Year="2004">
-      <Id>37c18f08-719f-47f1-954c-124e69b3ce11</Id>
+      <Database Name="cv" Series="10818" Issue="113391" />
     </Book>
     <Book Series="Alpha Flight" Number="8" Volume="2004" Year="2004">
-      <Id>f537c71f-333e-4289-a289-74c652fc925e</Id>
+      <Database Name="cv" Series="10818" Issue="113392" />
     </Book>
     <Book Series="Alpha Flight" Number="9" Volume="2004" Year="2005">
-      <Id>56f60dd4-58c3-48bd-9a12-84038f940004</Id>
+      <Database Name="cv" Series="10818" Issue="113393" />
     </Book>
     <Book Series="Alpha Flight" Number="10" Volume="2004" Year="2005">
-      <Id>0807f31e-da89-4252-a03a-a0ecfd7dbe5a</Id>
+      <Database Name="cv" Series="10818" Issue="113394" />
     </Book>
     <Book Series="Alpha Flight" Number="11" Volume="2004" Year="2005">
-      <Id>4677f6f7-78c7-4110-a71c-d5f280e9a32b</Id>
+      <Database Name="cv" Series="10818" Issue="113395" />
     </Book>
     <Book Series="Alpha Flight" Number="12" Volume="2004" Year="2005">
-      <Id>95a7479f-a691-477e-9161-7c93edeb9561</Id>
+      <Database Name="cv" Series="10818" Issue="113396" />
     </Book>
     <Book Series="Sabretooth" Number="1" Volume="2004" Year="2004">
-      <Id>984763b7-b22c-4d6a-8a64-0bcd2f1bd2d4</Id>
+      <Database Name="cv" Series="22216" Issue="133585" />
     </Book>
     <Book Series="Sabretooth" Number="2" Volume="2004" Year="2004">
-      <Id>0cdee0fd-7f7c-4585-acbd-423be883b967</Id>
+      <Database Name="cv" Series="22216" Issue="133586" />
     </Book>
     <Book Series="Sabretooth" Number="3" Volume="2004" Year="2005">
-      <Id>954ed957-d280-49ba-a9d5-2fc182459b57</Id>
+      <Database Name="cv" Series="22216" Issue="133587" />
     </Book>
     <Book Series="Sabretooth" Number="4" Volume="2004" Year="2005">
-      <Id>a3fb3791-4868-414b-a023-3c0a04d5eed1</Id>
+      <Database Name="cv" Series="22216" Issue="133588" />
     </Book>
     <Book Series="Civil War: The Initiative" Number="1" Volume="2007" Year="2007">
-      <Id>c09a5d0e-f2f2-4fd8-a1a8-a30caacf3263</Id>
+      <Database Name="cv" Series="18235" Issue="106789" />
     </Book>
     <Book Series="Omega Flight" Number="1" Volume="2007" Year="2007">
-      <Id>e45af41d-93ed-495e-8ab4-c5cc27f5e262</Id>
+      <Database Name="cv" Series="18441" Issue="108222" />
     </Book>
     <Book Series="Omega Flight" Number="2" Volume="2007" Year="2007">
-      <Id>bd45a518-4e7c-4539-8138-439a66fe6b4d</Id>
+      <Database Name="cv" Series="18441" Issue="108924" />
     </Book>
     <Book Series="Omega Flight" Number="3" Volume="2007" Year="2007">
-      <Id>ba3a22f2-1d85-4d40-a3ea-12f4f8db7b41</Id>
+      <Database Name="cv" Series="18441" Issue="110279" />
     </Book>
     <Book Series="Omega Flight" Number="4" Volume="2007" Year="2007">
-      <Id>d3bb9c5f-fca9-49ac-a438-a9f60631deb0</Id>
+      <Database Name="cv" Series="18441" Issue="111508" />
     </Book>
     <Book Series="Omega Flight" Number="5" Volume="2007" Year="2007">
-      <Id>98a981f8-fe9a-4a58-b4d9-047487a4337c</Id>
+      <Database Name="cv" Series="18441" Issue="113246" />
     </Book>
     <Book Series="Chaos War: Alpha Flight" Number="1" Volume="2011" Year="2011">
-      <Id>97d61e72-7126-4500-8d69-376e508c7742</Id>
+      <Database Name="cv" Series="36952" Issue="246466" />
     </Book>
     <Book Series="Alpha Flight" Number="0.1" Volume="2011" Year="2011">
-      <Id>437fea0c-cc16-4a0f-ba00-f28fe9b3b9be</Id>
+      <Database Name="cv" Series="40216" Issue="270433" />
     </Book>
     <Book Series="Alpha Flight" Number="1" Volume="2011" Year="2011">
-      <Id>d1cc0305-8f5e-4d74-b6ea-6f4d2743a8c7</Id>
+      <Database Name="cv" Series="40216" Issue="274228" />
     </Book>
     <Book Series="Alpha Flight" Number="2" Volume="2011" Year="2011">
-      <Id>ee99124e-68b9-4958-8c17-76b0c7d2448b</Id>
+      <Database Name="cv" Series="40216" Issue="278776" />
     </Book>
     <Book Series="Alpha Flight" Number="3" Volume="2011" Year="2011">
-      <Id>aaec1154-eab9-4032-bdb7-b8ad8aa742a3</Id>
+      <Database Name="cv" Series="40216" Issue="285357" />
     </Book>
     <Book Series="Alpha Flight" Number="4" Volume="2011" Year="2011">
-      <Id>2f3f692a-a818-45dd-b9f1-29df6b4971fa</Id>
+      <Database Name="cv" Series="40216" Issue="293356" />
     </Book>
     <Book Series="Alpha Flight" Number="5" Volume="2011" Year="2011">
-      <Id>d7a76ba1-81a4-4aea-a06f-7c1c799f8829</Id>
+      <Database Name="cv" Series="40216" Issue="295201" />
     </Book>
     <Book Series="Alpha Flight" Number="6" Volume="2011" Year="2012">
-      <Id>c1e428f0-0a04-4f4a-bace-cb17b17f022a</Id>
+      <Database Name="cv" Series="40216" Issue="303616" />
     </Book>
     <Book Series="Alpha Flight" Number="7" Volume="2011" Year="2012">
-      <Id>c1d39d63-fe62-4f56-ba15-207e68b4f3cf</Id>
+      <Database Name="cv" Series="40216" Issue="308477" />
     </Book>
     <Book Series="Alpha Flight" Number="8" Volume="2011" Year="2012">
-      <Id>a0b1fb0e-35a7-4642-9538-f8bd18f05210</Id>
+      <Database Name="cv" Series="40216" Issue="312789" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Teams/unsorted/X-Men/Alpha Flight/Alpha Flight.cbl
+++ b/Marvel/Teams/unsorted/X-Men/Alpha Flight/Alpha Flight.cbl
@@ -2,688 +2,688 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Alpha Flight</Name>
   <Books>
-    <Book Series="The X-Men" Number="120" Volume="1963" Year="1979" Format="Main Series">
+    <Book Series="The X-Men" Number="120" Volume="1963" Year="1979">
       <Id>70f7bbb6-f0a0-4189-9ea5-eb08aca7a95a</Id>
     </Book>
-    <Book Series="The X-Men" Number="121" Volume="1963" Year="1979" Format="Main Series">
+    <Book Series="The X-Men" Number="121" Volume="1963" Year="1979">
       <Id>87a23112-56a7-44f3-9995-6f39441e0592</Id>
     </Book>
-    <Book Series="The X-Men" Number="139" Volume="1963" Year="1980" Format="Main Series">
+    <Book Series="The X-Men" Number="139" Volume="1963" Year="1980">
       <Id>646292c0-2c4f-45f1-bab2-9a359951fe06</Id>
     </Book>
-    <Book Series="The X-Men" Number="140" Volume="1963" Year="1980" Format="Main Series">
+    <Book Series="The X-Men" Number="140" Volume="1963" Year="1980">
       <Id>57156028-f453-49d1-adea-b91268bfca2d</Id>
     </Book>
-    <Book Series="Machine Man" Number="18" Volume="1978" Year="1980" Format="Main Series">
+    <Book Series="Machine Man" Number="18" Volume="1978" Year="1980">
       <Id>cd38c290-c210-473d-a707-524d50be435d</Id>
     </Book>
-    <Book Series="Marvel Two-in-One" Number="84" Volume="1974" Year="1982" Format="Main Series">
+    <Book Series="Marvel Two-in-One" Number="84" Volume="1974" Year="1982">
       <Id>e673b54c-bc4d-4d5a-b4d2-7740e1dfcdf0</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="1" Volume="1983" Year="1983" Format="Main Series">
+    <Book Series="Alpha Flight" Number="1" Volume="1983" Year="1983">
       <Id>8adf4fe7-b66d-4a78-af6c-1f31c5c52b0f</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="2" Volume="1983" Year="1983" Format="Main Series">
+    <Book Series="Alpha Flight" Number="2" Volume="1983" Year="1983">
       <Id>c144c4ef-d5a2-4f29-b4bf-8b1b456e6b4c</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="3" Volume="1983" Year="1983" Format="Main Series">
+    <Book Series="Alpha Flight" Number="3" Volume="1983" Year="1983">
       <Id>c00d05d7-a6df-48a5-92db-e021240d27fc</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="4" Volume="1983" Year="1983" Format="Main Series">
+    <Book Series="Alpha Flight" Number="4" Volume="1983" Year="1983">
       <Id>5120002d-689a-4f5a-8623-d01b508c5b13</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="5" Volume="1983" Year="1983" Format="Main Series">
+    <Book Series="Alpha Flight" Number="5" Volume="1983" Year="1983">
       <Id>9220f979-6dcb-477b-b376-d7961302a4ae</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="6" Volume="1983" Year="1984" Format="Main Series">
+    <Book Series="Alpha Flight" Number="6" Volume="1983" Year="1984">
       <Id>d2e23102-d002-498f-9985-961be785a406</Id>
     </Book>
-    <Book Series="X-Men/Alpha Flight" Number="1" Volume="1998" Year="1998" Format="Limited Series">
+    <Book Series="X-Men/Alpha Flight" Number="1" Volume="1998" Year="1998">
       <Id>34d6b575-f5d7-4048-b839-16ba636ece89</Id>
     </Book>
-    <Book Series="X-Men/Alpha Flight" Number="2" Volume="1998" Year="1998" Format="Limited Series">
+    <Book Series="X-Men/Alpha Flight" Number="2" Volume="1998" Year="1998">
       <Id>a3898021-e3da-4fca-8065-f29355b21fd4</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="7" Volume="1983" Year="1984" Format="Main Series">
+    <Book Series="Alpha Flight" Number="7" Volume="1983" Year="1984">
       <Id>0197f4c3-f4af-451b-a960-029c3448774b</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="8" Volume="1983" Year="1984" Format="Main Series">
+    <Book Series="Alpha Flight" Number="8" Volume="1983" Year="1984">
       <Id>c24ecca5-a8a3-4df9-8a56-c4af738f4536</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="9" Volume="1983" Year="1984" Format="Main Series">
+    <Book Series="Alpha Flight" Number="9" Volume="1983" Year="1984">
       <Id>8ec7f366-e9e6-4eaf-982e-6cdf564a0bad</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="10" Volume="1983" Year="1984" Format="Main Series">
+    <Book Series="Alpha Flight" Number="10" Volume="1983" Year="1984">
       <Id>6f1465ca-cb7c-42f7-abbf-281b132528d2</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="11" Volume="1983" Year="1984" Format="Main Series">
+    <Book Series="Alpha Flight" Number="11" Volume="1983" Year="1984">
       <Id>db1eb3e8-be94-458b-baa5-61e6e286708d</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="12" Volume="1983" Year="1984" Format="Main Series">
+    <Book Series="Alpha Flight" Number="12" Volume="1983" Year="1984">
       <Id>9af5375d-e10d-4c92-ba82-26df5ad20750</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="13" Volume="1983" Year="1984" Format="Main Series">
+    <Book Series="Alpha Flight" Number="13" Volume="1983" Year="1984">
       <Id>c03ab3c1-b258-4caa-830e-23ae1ca50615</Id>
     </Book>
-    <Book Series="Marvel Team-Up Annual" Number="7" Volume="1976" Year="1984" Format="Annual">
+    <Book Series="Marvel Team-Up Annual" Number="7" Volume="1976" Year="1984">
       <Id>47743708-e8e5-4884-9c64-2e7167dc0673</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="14" Volume="1983" Year="1984" Format="Main Series">
+    <Book Series="Alpha Flight" Number="14" Volume="1983" Year="1984">
       <Id>2cf9b625-63fa-41cc-8db4-63fc79c91691</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="15" Volume="1983" Year="1984" Format="Main Series">
+    <Book Series="Alpha Flight" Number="15" Volume="1983" Year="1984">
       <Id>ab868e71-ede8-4ff7-8214-88fa7d1296a2</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="16" Volume="1983" Year="1984" Format="Main Series">
+    <Book Series="Alpha Flight" Number="16" Volume="1983" Year="1984">
       <Id>a96a8d4d-250e-4ada-bbf2-4b7a8979a09e</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="17" Volume="1983" Year="1984" Format="Main Series">
+    <Book Series="Alpha Flight" Number="17" Volume="1983" Year="1984">
       <Id>28ebdcde-9f19-4938-9b00-da76956261bf</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="18" Volume="1983" Year="1985" Format="Main Series">
+    <Book Series="Alpha Flight" Number="18" Volume="1983" Year="1985">
       <Id>049c422f-eaa1-463a-97ae-7d281d6f33b4</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="19" Volume="1983" Year="1985" Format="Main Series">
+    <Book Series="Alpha Flight" Number="19" Volume="1983" Year="1985">
       <Id>3b224507-5d5a-4920-8043-85a4d528cc0e</Id>
     </Book>
-    <Book Series="X-Men/Alpha Flight" Number="1" Volume="1985" Year="1985" Format="Limited Series">
+    <Book Series="X-Men/Alpha Flight" Number="1" Volume="1985" Year="1985">
       <Id>0001da6c-cb62-4df3-a061-4506cd4009e4</Id>
     </Book>
-    <Book Series="X-Men/Alpha Flight" Number="2" Volume="1985" Year="1986" Format="Limited Series">
+    <Book Series="X-Men/Alpha Flight" Number="2" Volume="1985" Year="1986">
       <Id>617c61f9-1079-4c49-b487-e700c8c2b6e2</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="20" Volume="1983" Year="1985" Format="Main Series">
+    <Book Series="Alpha Flight" Number="20" Volume="1983" Year="1985">
       <Id>a5ea63a2-7a3e-4002-9a8a-8ba40107c542</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="21" Volume="1983" Year="1985" Format="Main Series">
+    <Book Series="Alpha Flight" Number="21" Volume="1983" Year="1985">
       <Id>aa6edac0-0b8d-4936-8a9c-754160e143b8</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="22" Volume="1983" Year="1985" Format="Main Series">
+    <Book Series="Alpha Flight" Number="22" Volume="1983" Year="1985">
       <Id>aff90921-69d6-45ad-b7a9-4125a3802711</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="23" Volume="1983" Year="1985" Format="Main Series">
+    <Book Series="Alpha Flight" Number="23" Volume="1983" Year="1985">
       <Id>aa6dab4c-ff2c-46f4-9541-27f121e63be2</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="24" Volume="1983" Year="1985" Format="Main Series">
+    <Book Series="Alpha Flight" Number="24" Volume="1983" Year="1985">
       <Id>814661a5-913d-4fab-a0d8-b5f5ce576ee3</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="25" Volume="1983" Year="1985" Format="Main Series">
+    <Book Series="Alpha Flight" Number="25" Volume="1983" Year="1985">
       <Id>04b235cd-db10-4033-bced-7632d1151516</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="26" Volume="1983" Year="1985" Format="Main Series">
+    <Book Series="Alpha Flight" Number="26" Volume="1983" Year="1985">
       <Id>f989a384-8d91-4f20-a23a-d816e7d119f8</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="27" Volume="1983" Year="1985" Format="Main Series">
+    <Book Series="Alpha Flight" Number="27" Volume="1983" Year="1985">
       <Id>e51f554a-e5d5-49c6-a2bc-cb6e005bb3af</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="28" Volume="1983" Year="1985" Format="Main Series">
+    <Book Series="Alpha Flight" Number="28" Volume="1983" Year="1985">
       <Id>dbb60a3b-3c80-44e1-a6bd-8965304f0a87</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="313" Volume="1968" Year="1985" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="313" Volume="1968" Year="1985">
       <Id>d72d6126-245c-4b0d-8004-5e82185ab146</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="29" Volume="1983" Year="1985" Format="Main Series">
+    <Book Series="Alpha Flight" Number="29" Volume="1983" Year="1985">
       <Id>25200fd2-4689-4169-b3eb-8fee85e653af</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="30" Volume="1983" Year="1986" Format="Main Series">
+    <Book Series="Alpha Flight" Number="30" Volume="1983" Year="1986">
       <Id>3c14c2be-e698-41ba-b3d1-5207253b3491</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="31" Volume="1983" Year="1986" Format="Main Series">
+    <Book Series="Alpha Flight" Number="31" Volume="1983" Year="1986">
       <Id>389bee4f-0ce6-4d17-947b-c440ef323175</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="32" Volume="1983" Year="1986" Format="Main Series">
+    <Book Series="Alpha Flight" Number="32" Volume="1983" Year="1986">
       <Id>b2b3eb59-3544-4ab4-b52a-021f9b1582b7</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="33" Volume="1983" Year="1986" Format="Main Series">
+    <Book Series="Alpha Flight" Number="33" Volume="1983" Year="1986">
       <Id>05551255-25da-4b54-826a-cb969f9f100c</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="34" Volume="1983" Year="1986" Format="Main Series">
+    <Book Series="Alpha Flight" Number="34" Volume="1983" Year="1986">
       <Id>49d1f8c6-d45e-455e-879d-375dc954749a</Id>
     </Book>
-    <Book Series="Marvel Fanfare" Number="28" Volume="1982" Year="1986" Format="Main Series">
+    <Book Series="Marvel Fanfare" Number="28" Volume="1982" Year="1986">
       <Id>7cbbf52d-1a94-4c08-a3bd-487855bfad4a</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="35" Volume="1983" Year="1986" Format="Main Series">
+    <Book Series="Alpha Flight" Number="35" Volume="1983" Year="1986">
       <Id>b5c4ab18-8b2d-400f-a75d-18b8359a9d48</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="36" Volume="1983" Year="1986" Format="Main Series">
+    <Book Series="Alpha Flight" Number="36" Volume="1983" Year="1986">
       <Id>5bdf5646-e3a4-45b9-96eb-852f344ef7b1</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="37" Volume="1983" Year="1986" Format="Main Series">
+    <Book Series="Alpha Flight" Number="37" Volume="1983" Year="1986">
       <Id>969881d1-805c-4773-a411-1925296f0969</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="38" Volume="1983" Year="1986" Format="Main Series">
+    <Book Series="Alpha Flight" Number="38" Volume="1983" Year="1986">
       <Id>52909ea1-b7a7-45c7-882d-8ef9ba53739d</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="39" Volume="1983" Year="1986" Format="Main Series">
+    <Book Series="Alpha Flight" Number="39" Volume="1983" Year="1986">
       <Id>d653f450-cec8-425c-82cd-e36e84475cbb</Id>
     </Book>
-    <Book Series="The Avengers" Number="272" Volume="1963" Year="1986" Format="Main Series">
+    <Book Series="The Avengers" Number="272" Volume="1963" Year="1986">
       <Id>3f1f31af-fdf9-4b5c-9567-e7f377906419</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="40" Volume="1983" Year="1986" Format="Main Series">
+    <Book Series="Alpha Flight" Number="40" Volume="1983" Year="1986">
       <Id>2c83c87d-b9d8-44c3-8775-9ad17df81f73</Id>
     </Book>
-    <Book Series="Alpha Flight Annual" Number="1" Volume="1986" Year="1986" Format="Annual">
+    <Book Series="Alpha Flight Annual" Number="1" Volume="1986" Year="1986">
       <Id>a8af3c72-bb12-4219-bde0-24fd5520bc4b</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="41" Volume="1983" Year="1986" Format="Main Series">
+    <Book Series="Alpha Flight" Number="41" Volume="1983" Year="1986">
       <Id>e4c53912-4e9c-4348-ae65-3ef7bcd92373</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="42" Volume="1983" Year="1987" Format="Main Series">
+    <Book Series="Alpha Flight" Number="42" Volume="1983" Year="1987">
       <Id>0b3be503-ac16-4860-a9ea-2d01299b237a</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="43" Volume="1983" Year="1987" Format="Main Series">
+    <Book Series="Alpha Flight" Number="43" Volume="1983" Year="1987">
       <Id>0a389d44-7596-49b5-969c-4a04b7041007</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="44" Volume="1983" Year="1987" Format="Main Series">
+    <Book Series="Alpha Flight" Number="44" Volume="1983" Year="1987">
       <Id>f57cb714-7ca8-4ac2-827a-57fa4f3a03c1</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="45" Volume="1983" Year="1987" Format="Main Series">
+    <Book Series="Alpha Flight" Number="45" Volume="1983" Year="1987">
       <Id>870e4f10-dffc-4782-8b79-150b0650f0e0</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="46" Volume="1983" Year="1987" Format="Main Series">
+    <Book Series="Alpha Flight" Number="46" Volume="1983" Year="1987">
       <Id>554bfe74-5ef6-40ea-be2b-f4ec90d4c71f</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="47" Volume="1983" Year="1987" Format="Main Series">
+    <Book Series="Alpha Flight" Number="47" Volume="1983" Year="1987">
       <Id>91112331-d9ea-439a-9ee7-611735b80d04</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="48" Volume="1983" Year="1987" Format="Main Series">
+    <Book Series="Alpha Flight" Number="48" Volume="1983" Year="1987">
       <Id>3f1e8eea-03f2-4b03-80ac-f5215a8a736d</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="49" Volume="1983" Year="1987" Format="Main Series">
+    <Book Series="Alpha Flight" Number="49" Volume="1983" Year="1987">
       <Id>1f513d10-60c0-471c-9d96-ae4bf16e138f</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="50" Volume="1983" Year="1987" Format="Main Series">
+    <Book Series="Alpha Flight" Number="50" Volume="1983" Year="1987">
       <Id>d5e0d532-faf2-4a5f-853a-0b4dedafeb61</Id>
     </Book>
-    <Book Series="Alpha Flight Annual" Number="2" Volume="1986" Year="1987" Format="Annual">
+    <Book Series="Alpha Flight Annual" Number="2" Volume="1986" Year="1987">
       <Id>7d77d5a2-7e56-4120-afb1-9b147d51992d</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="51" Volume="1983" Year="1987" Format="Main Series">
+    <Book Series="Alpha Flight" Number="51" Volume="1983" Year="1987">
       <Id>b479e782-2220-4c1a-8e69-26cdeb95da08</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="52" Volume="1983" Year="1987" Format="Main Series">
+    <Book Series="Alpha Flight" Number="52" Volume="1983" Year="1987">
       <Id>f7461f82-dde5-4af4-94a6-a3b274a95fff</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="53" Volume="1983" Year="1987" Format="Main Series">
+    <Book Series="Alpha Flight" Number="53" Volume="1983" Year="1987">
       <Id>72cd2de8-ddd5-4ea9-909e-f6c2b2897043</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="54" Volume="1983" Year="1988" Format="Main Series">
+    <Book Series="Alpha Flight" Number="54" Volume="1983" Year="1988">
       <Id>676b9e69-8acc-410c-893b-7309b8993364</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="55" Volume="1983" Year="1988" Format="Main Series">
+    <Book Series="Alpha Flight" Number="55" Volume="1983" Year="1988">
       <Id>b111d9d4-481f-4b1c-a5a2-9d02142d130a</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="56" Volume="1983" Year="1988" Format="Main Series">
+    <Book Series="Alpha Flight" Number="56" Volume="1983" Year="1988">
       <Id>bc787156-6cde-411a-819a-16f02d9ecc7b</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="57" Volume="1983" Year="1988" Format="Main Series">
+    <Book Series="Alpha Flight" Number="57" Volume="1983" Year="1988">
       <Id>b4595382-eb6e-40d1-961a-f0790e9e918b</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="58" Volume="1983" Year="1988" Format="Main Series">
+    <Book Series="Alpha Flight" Number="58" Volume="1983" Year="1988">
       <Id>76e4a125-8f5d-41fa-a045-8348fdb0050a</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="59" Volume="1983" Year="1988" Format="Main Series">
+    <Book Series="Alpha Flight" Number="59" Volume="1983" Year="1988">
       <Id>88d784f0-b276-4517-ac12-18a3e9eb94c5</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="60" Volume="1983" Year="1988" Format="Main Series">
+    <Book Series="Alpha Flight" Number="60" Volume="1983" Year="1988">
       <Id>ed855edc-f8c7-40ac-986d-6cd89ddbd18c</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="61" Volume="1983" Year="1988" Format="Main Series">
+    <Book Series="Alpha Flight" Number="61" Volume="1983" Year="1988">
       <Id>48a69796-63cb-4f1a-97f0-6949a68c0254</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="62" Volume="1983" Year="1988" Format="Main Series">
+    <Book Series="Alpha Flight" Number="62" Volume="1983" Year="1988">
       <Id>c6b9b4f1-a3ab-40d7-9d9d-cbbf7f1c37d4</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="63" Volume="1983" Year="1988" Format="Main Series">
+    <Book Series="Alpha Flight" Number="63" Volume="1983" Year="1988">
       <Id>fa9facab-7ecb-44c8-b532-5c286f3495c1</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="64" Volume="1983" Year="1988" Format="Main Series">
+    <Book Series="Alpha Flight" Number="64" Volume="1983" Year="1988">
       <Id>a3113a84-b323-49ca-a607-71d046b4624a</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="65" Volume="1983" Year="1988" Format="Main Series">
+    <Book Series="Alpha Flight" Number="65" Volume="1983" Year="1988">
       <Id>649b09d5-c2d3-443e-bffe-634aeca2c0ba</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="52" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="52" Volume="1988" Year="1990">
       <Id>eae784cf-8243-43e5-baf2-1049f3a2636a</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="53" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="53" Volume="1988" Year="1990">
       <Id>1e7ed635-8f16-4078-b87c-f506b8dc296a</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="66" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="Alpha Flight" Number="66" Volume="1983" Year="1989">
       <Id>078d7ed0-4948-494a-96b7-022a967f5338</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="67" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="Alpha Flight" Number="67" Volume="1983" Year="1989">
       <Id>be4a22be-86b8-44ae-98d8-c50111a51643</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="68" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="Alpha Flight" Number="68" Volume="1983" Year="1989">
       <Id>a49d894e-0b52-4343-8700-0c194b1d33fd</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="69" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="Alpha Flight" Number="69" Volume="1983" Year="1989">
       <Id>9b7f2946-ff98-4683-a899-b92ddd52fa37</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="70" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="Alpha Flight" Number="70" Volume="1983" Year="1989">
       <Id>a007eb60-e273-48b2-b9b7-e30d58f5c2fb</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="71" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="Alpha Flight" Number="71" Volume="1983" Year="1989">
       <Id>7def9307-48ed-41a3-92c2-bca67a68d6b3</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="72" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="Alpha Flight" Number="72" Volume="1983" Year="1989">
       <Id>2538144a-f847-4675-af10-1b6601959aad</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="73" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="Alpha Flight" Number="73" Volume="1983" Year="1989">
       <Id>af7fd8a9-86c4-459e-9ced-bfc40c5158db</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="74" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="Alpha Flight" Number="74" Volume="1983" Year="1989">
       <Id>247ad5cc-0d16-4db4-8519-00aff933510c</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="75" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="Alpha Flight" Number="75" Volume="1983" Year="1989">
       <Id>d48552fa-ceba-4aa2-a6e0-bc93cb1c96bb</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="76" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="Alpha Flight" Number="76" Volume="1983" Year="1989">
       <Id>677cf4f6-8b15-486f-85d7-533fe3c7feb7</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="77" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="Alpha Flight" Number="77" Volume="1983" Year="1989">
       <Id>48003b6d-64c7-421c-8521-701fb2c855ad</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="78" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="Alpha Flight" Number="78" Volume="1983" Year="1989">
       <Id>62ccea0c-8859-4126-be7f-da3dccd62532</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="79" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="Alpha Flight" Number="79" Volume="1983" Year="1989">
       <Id>23a3cd65-89e2-4f4e-b2ca-26ec2e98ae1c</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="80" Volume="1983" Year="1990" Format="Main Series">
+    <Book Series="Alpha Flight" Number="80" Volume="1983" Year="1990">
       <Id>052e09aa-b7bd-4e6b-86c1-2ef6cbd8b5a4</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="81" Volume="1983" Year="1990" Format="Main Series">
+    <Book Series="Alpha Flight" Number="81" Volume="1983" Year="1990">
       <Id>cf8bd6de-7c77-494d-98d5-75f0fd8a74e5</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="82" Volume="1983" Year="1990" Format="Main Series">
+    <Book Series="Alpha Flight" Number="82" Volume="1983" Year="1990">
       <Id>1ea2f3de-bbf6-404d-ace8-f34e5517a079</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="83" Volume="1983" Year="1990" Format="Main Series">
+    <Book Series="Alpha Flight" Number="83" Volume="1983" Year="1990">
       <Id>fbac1986-0b6b-4cd9-8901-a5f279c66696</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="84" Volume="1983" Year="1990" Format="Main Series">
+    <Book Series="Alpha Flight" Number="84" Volume="1983" Year="1990">
       <Id>c1eede50-2ce3-4acb-bb45-017638e454a0</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="85" Volume="1983" Year="1990" Format="Main Series">
+    <Book Series="Alpha Flight" Number="85" Volume="1983" Year="1990">
       <Id>56cb0870-e414-4d5a-8aa9-478a952fd92b</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="86" Volume="1983" Year="1990" Format="Main Series">
+    <Book Series="Alpha Flight" Number="86" Volume="1983" Year="1990">
       <Id>396ee20f-f6ac-45c3-8f8d-3e9b35f8b02e</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="87" Volume="1983" Year="1990" Format="Main Series">
+    <Book Series="Alpha Flight" Number="87" Volume="1983" Year="1990">
       <Id>3953204a-833d-40fd-958f-bd292530eb9e</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="88" Volume="1983" Year="1990" Format="Main Series">
+    <Book Series="Alpha Flight" Number="88" Volume="1983" Year="1990">
       <Id>7e1d3d41-5514-43ce-b1b2-106706b6e598</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="89" Volume="1983" Year="1990" Format="Main Series">
+    <Book Series="Alpha Flight" Number="89" Volume="1983" Year="1990">
       <Id>1512c31b-9a95-4394-994e-436b1d7622e8</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="90" Volume="1983" Year="1990" Format="Main Series">
+    <Book Series="Alpha Flight" Number="90" Volume="1983" Year="1990">
       <Id>368dbdc2-f3f7-4b4e-94d0-37a235d8c82c</Id>
     </Book>
-    <Book Series="The Avengers" Number="320" Volume="1963" Year="1990" Format="Main Series">
+    <Book Series="The Avengers" Number="320" Volume="1963" Year="1990">
       <Id>757b306c-3133-4b94-8026-b731fc4f5be6</Id>
     </Book>
-    <Book Series="The Avengers" Number="321" Volume="1963" Year="1990" Format="Main Series">
+    <Book Series="The Avengers" Number="321" Volume="1963" Year="1990">
       <Id>285ba048-59e2-4887-8573-ef3836bcdb08</Id>
     </Book>
-    <Book Series="The Avengers" Number="322" Volume="1963" Year="1990" Format="Main Series">
+    <Book Series="The Avengers" Number="322" Volume="1963" Year="1990">
       <Id>74bbfd19-64c0-4afd-a56e-d285863061f7</Id>
     </Book>
-    <Book Series="The Avengers" Number="323" Volume="1963" Year="1990" Format="Main Series">
+    <Book Series="The Avengers" Number="323" Volume="1963" Year="1990">
       <Id>211061a0-8655-4391-8b80-4321fde22f0a</Id>
     </Book>
-    <Book Series="The Avengers" Number="324" Volume="1963" Year="1990" Format="Main Series">
+    <Book Series="The Avengers" Number="324" Volume="1963" Year="1990">
       <Id>bfe754d7-6e3b-463f-b47a-93efb4def45b</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="91" Volume="1983" Year="1990" Format="Main Series">
+    <Book Series="Alpha Flight" Number="91" Volume="1983" Year="1990">
       <Id>c67945a6-edcb-4d97-95be-0a46bc17324f</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="92" Volume="1983" Year="1991" Format="Main Series">
+    <Book Series="Alpha Flight" Number="92" Volume="1983" Year="1991">
       <Id>1de5c795-b93c-48c3-b11f-69ee6789b485</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="93" Volume="1983" Year="1991" Format="Main Series">
+    <Book Series="Alpha Flight" Number="93" Volume="1983" Year="1991">
       <Id>6d24f8d5-baad-498c-94a9-f746be5460f7</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="94" Volume="1983" Year="1991" Format="Main Series">
+    <Book Series="Alpha Flight" Number="94" Volume="1983" Year="1991">
       <Id>34515d19-4b14-4c59-9692-4ddaac6a4325</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="95" Volume="1983" Year="1991" Format="Main Series">
+    <Book Series="Alpha Flight" Number="95" Volume="1983" Year="1991">
       <Id>5fc8cf96-7ea7-4ee4-bb8f-a9f2c3b8c210</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="96" Volume="1983" Year="1991" Format="Main Series">
+    <Book Series="Alpha Flight" Number="96" Volume="1983" Year="1991">
       <Id>25651b17-5278-454c-b256-b22a10a487c9</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="97" Volume="1983" Year="1991" Format="Main Series">
+    <Book Series="Alpha Flight" Number="97" Volume="1983" Year="1991">
       <Id>c6dbb846-f572-4a63-8646-4ae826e78283</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="98" Volume="1983" Year="1991" Format="Main Series">
+    <Book Series="Alpha Flight" Number="98" Volume="1983" Year="1991">
       <Id>38d5fd7c-f948-4fce-ae33-c49ec296df59</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="99" Volume="1983" Year="1991" Format="Main Series">
+    <Book Series="Alpha Flight" Number="99" Volume="1983" Year="1991">
       <Id>078a1479-0d24-483f-a61d-0f87f7127899</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="100" Volume="1983" Year="1991" Format="Main Series">
+    <Book Series="Alpha Flight" Number="100" Volume="1983" Year="1991">
       <Id>0a56bf9f-2e41-4da9-86e0-27e5be182683</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="101" Volume="1983" Year="1991" Format="Main Series">
+    <Book Series="Alpha Flight" Number="101" Volume="1983" Year="1991">
       <Id>01816d21-5687-4b87-ab17-5870589675b1</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="102" Volume="1983" Year="1991" Format="Main Series">
+    <Book Series="Alpha Flight" Number="102" Volume="1983" Year="1991">
       <Id>56307c70-d602-4fa5-9616-5f32fb34a127</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="103" Volume="1983" Year="1991" Format="Main Series">
+    <Book Series="Alpha Flight" Number="103" Volume="1983" Year="1991">
       <Id>7ec8c524-d86c-4dbd-871d-acdab761fb4c</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="104" Volume="1983" Year="1992" Format="Main Series">
+    <Book Series="Alpha Flight" Number="104" Volume="1983" Year="1992">
       <Id>2cecea5c-ed88-4493-ad9b-f10226ab9b2c</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="105" Volume="1983" Year="1992" Format="Main Series">
+    <Book Series="Alpha Flight" Number="105" Volume="1983" Year="1992">
       <Id>17648c16-040f-40bb-beaa-93ecf95c2de8</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="106" Volume="1983" Year="1992" Format="Main Series">
+    <Book Series="Alpha Flight" Number="106" Volume="1983" Year="1992">
       <Id>2c261732-1048-4c58-a17b-f092ebd7e2ad</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="107" Volume="1983" Year="1992" Format="Main Series">
+    <Book Series="Alpha Flight" Number="107" Volume="1983" Year="1992">
       <Id>0e2a381c-26a5-445b-8902-ffc74bd3d581</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="108" Volume="1983" Year="1992" Format="Main Series">
+    <Book Series="Alpha Flight" Number="108" Volume="1983" Year="1992">
       <Id>3de93a6b-4f81-4913-a7e0-5ad3afde6082</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="109" Volume="1983" Year="1992" Format="Main Series">
+    <Book Series="Alpha Flight" Number="109" Volume="1983" Year="1992">
       <Id>b2cf8305-3886-4c12-ba58-5d9474a16d38</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="110" Volume="1983" Year="1992" Format="Main Series">
+    <Book Series="Alpha Flight" Number="110" Volume="1983" Year="1992">
       <Id>adf93576-418f-4c37-8a51-af323fb4e4b8</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="111" Volume="1983" Year="1992" Format="Main Series">
+    <Book Series="Alpha Flight" Number="111" Volume="1983" Year="1992">
       <Id>2ca064a8-42f3-40d5-bd75-9256dbbf4b53</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="112" Volume="1983" Year="1992" Format="Main Series">
+    <Book Series="Alpha Flight" Number="112" Volume="1983" Year="1992">
       <Id>26e2dfee-a308-4046-9fa8-c8331cb2fae4</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="113" Volume="1983" Year="1992" Format="Main Series">
+    <Book Series="Alpha Flight" Number="113" Volume="1983" Year="1992">
       <Id>4c487f7d-03b1-456a-8f84-f06d5e75faa4</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="114" Volume="1983" Year="1992" Format="Main Series">
+    <Book Series="Alpha Flight" Number="114" Volume="1983" Year="1992">
       <Id>1a70c988-d67b-4e8c-8e01-bba5a9a85b5f</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="115" Volume="1983" Year="1992" Format="Main Series">
+    <Book Series="Alpha Flight" Number="115" Volume="1983" Year="1992">
       <Id>7ec6e193-2a6c-468c-8189-77267066057e</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="116" Volume="1983" Year="1993" Format="Main Series">
+    <Book Series="Alpha Flight" Number="116" Volume="1983" Year="1993">
       <Id>2a15f214-e59d-494a-a6fb-417c38279189</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="117" Volume="1983" Year="1993" Format="Main Series">
+    <Book Series="Alpha Flight" Number="117" Volume="1983" Year="1993">
       <Id>9f82d656-03f6-468f-90f9-d86b7e45e080</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="118" Volume="1983" Year="1993" Format="Main Series">
+    <Book Series="Alpha Flight" Number="118" Volume="1983" Year="1993">
       <Id>adc1da3b-7351-4df0-add4-bdbb25659eed</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="119" Volume="1983" Year="1993" Format="Main Series">
+    <Book Series="Alpha Flight" Number="119" Volume="1983" Year="1993">
       <Id>3a8e62e2-b0e2-4b5e-965e-cf7bc1073518</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="120" Volume="1983" Year="1993" Format="Main Series">
+    <Book Series="Alpha Flight" Number="120" Volume="1983" Year="1993">
       <Id>093a389b-59e2-4950-af14-52359370c14e</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="121" Volume="1983" Year="1993" Format="Main Series">
+    <Book Series="Alpha Flight" Number="121" Volume="1983" Year="1993">
       <Id>556337a1-b343-4d35-8071-98b8cfc99aea</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="122" Volume="1983" Year="1993" Format="Main Series">
+    <Book Series="Alpha Flight" Number="122" Volume="1983" Year="1993">
       <Id>ca280cb7-da7b-4082-ae87-a8459a68fc94</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="123" Volume="1983" Year="1993" Format="Main Series">
+    <Book Series="Alpha Flight" Number="123" Volume="1983" Year="1993">
       <Id>be064c2e-e724-496b-9249-09976d6cb0cf</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="124" Volume="1983" Year="1993" Format="Main Series">
+    <Book Series="Alpha Flight" Number="124" Volume="1983" Year="1993">
       <Id>8237a72a-464c-425c-9fca-ad802c1dafbb</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="125" Volume="1983" Year="1993" Format="Main Series">
+    <Book Series="Alpha Flight" Number="125" Volume="1983" Year="1993">
       <Id>8b68a276-5a92-446b-a8c3-2ffc3c4359d2</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="126" Volume="1983" Year="1993" Format="Main Series">
+    <Book Series="Alpha Flight" Number="126" Volume="1983" Year="1993">
       <Id>b83d7c59-c55e-4500-ad26-407ff941fa35</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="127" Volume="1983" Year="1993" Format="Main Series">
+    <Book Series="Alpha Flight" Number="127" Volume="1983" Year="1993">
       <Id>8a5efc06-3f11-4299-b225-b9cb19e32f88</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="128" Volume="1983" Year="1994" Format="Main Series">
+    <Book Series="Alpha Flight" Number="128" Volume="1983" Year="1994">
       <Id>11967341-5886-4280-a658-7e68f964d133</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="129" Volume="1983" Year="1994" Format="Main Series">
+    <Book Series="Alpha Flight" Number="129" Volume="1983" Year="1994">
       <Id>7d803b91-d0cf-461b-b1a5-082a28e50c60</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="130" Volume="1983" Year="1994" Format="Main Series">
+    <Book Series="Alpha Flight" Number="130" Volume="1983" Year="1994">
       <Id>621a9c58-f0a6-44df-942e-a8a830a71297</Id>
     </Book>
-    <Book Series="Northstar" Number="1" Volume="1994" Year="1994" Format="Limited Series">
+    <Book Series="Northstar" Number="1" Volume="1994" Year="1994">
       <Id>b2e35423-a20f-4fae-b5ac-d8d248ec4044</Id>
     </Book>
-    <Book Series="Northstar" Number="2" Volume="1994" Year="1994" Format="Limited Series">
+    <Book Series="Northstar" Number="2" Volume="1994" Year="1994">
       <Id>718380c9-c7bd-4afc-be3f-9daf7bedf6b9</Id>
     </Book>
-    <Book Series="Northstar" Number="3" Volume="1994" Year="1994" Format="Limited Series">
+    <Book Series="Northstar" Number="3" Volume="1994" Year="1994">
       <Id>87239d1d-4211-41dc-91ac-96e7930f6a56</Id>
     </Book>
-    <Book Series="Northstar" Number="4" Volume="1994" Year="1994" Format="Limited Series">
+    <Book Series="Northstar" Number="4" Volume="1994" Year="1994">
       <Id>8fbf84bc-07f6-4567-91be-22555ad45931</Id>
     </Book>
-    <Book Series="Wolverine" Number="83" Volume="1988" Year="1994" Format="Main Series">
+    <Book Series="Wolverine" Number="83" Volume="1988" Year="1994">
       <Id>b7bbfba5-7f20-4a8b-880d-d5dab0595e6e</Id>
     </Book>
-    <Book Series="Wolverine" Number="84" Volume="1988" Year="1994" Format="Main Series">
+    <Book Series="Wolverine" Number="84" Volume="1988" Year="1994">
       <Id>c03df9ff-ccd6-4403-a7f0-22516c112e8c</Id>
     </Book>
-    <Book Series="Wolverine" Number="95" Volume="1988" Year="1995" Format="Main Series">
+    <Book Series="Wolverine" Number="95" Volume="1988" Year="1995">
       <Id>ddc30223-61cf-4123-a359-88be81417074</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="1" Volume="1997" Year="1997" Format="Main Series">
+    <Book Series="Alpha Flight" Number="1" Volume="1997" Year="1997">
       <Id>59f4f1eb-3099-4c32-909a-0a19cda5de9b</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="2" Volume="1997" Year="1997" Format="Main Series">
+    <Book Series="Alpha Flight" Number="2" Volume="1997" Year="1997">
       <Id>571d972d-f136-4f14-986d-d439b483a8c5</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="3" Volume="1997" Year="1997" Format="Main Series">
+    <Book Series="Alpha Flight" Number="3" Volume="1997" Year="1997">
       <Id>58243669-bf49-4476-b999-5852e6de52c5</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="4" Volume="1997" Year="1997" Format="Main Series">
+    <Book Series="Alpha Flight" Number="4" Volume="1997" Year="1997">
       <Id>bb3183f7-5f65-46b7-a4b2-d65f9e2746fb</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="5" Volume="1997" Year="1997" Format="Main Series">
+    <Book Series="Alpha Flight" Number="5" Volume="1997" Year="1997">
       <Id>fba318e7-4aa5-4155-a7b0-88526f4dba30</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="6" Volume="1997" Year="1998" Format="Main Series">
+    <Book Series="Alpha Flight" Number="6" Volume="1997" Year="1998">
       <Id>1406f0b8-6185-4143-9fd7-50666d5d91cf</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="7" Volume="1997" Year="1998" Format="Main Series">
+    <Book Series="Alpha Flight" Number="7" Volume="1997" Year="1998">
       <Id>14450b54-ded9-419d-b8e7-f7cbc7f8516e</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="8" Volume="1997" Year="1998" Format="Main Series">
+    <Book Series="Alpha Flight" Number="8" Volume="1997" Year="1998">
       <Id>42a5107c-4649-4f8e-857f-16b6be3e6303</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="9" Volume="1997" Year="1998" Format="Main Series">
+    <Book Series="Alpha Flight" Number="9" Volume="1997" Year="1998">
       <Id>221f9ac9-326e-4085-bdf0-4d56f9ff0452</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="10" Volume="1997" Year="1998" Format="Main Series">
+    <Book Series="Alpha Flight" Number="10" Volume="1997" Year="1998">
       <Id>df499e45-95c4-433f-8b8f-cb96e3448fc9</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="11" Volume="1997" Year="1998" Format="Main Series">
+    <Book Series="Alpha Flight" Number="11" Volume="1997" Year="1998">
       <Id>0f0ff389-4b5e-429a-8cf0-9b7088385193</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="12" Volume="1997" Year="1998" Format="Main Series">
+    <Book Series="Alpha Flight" Number="12" Volume="1997" Year="1998">
       <Id>0f86a573-0e89-48da-80bf-98224a366b21</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="13" Volume="1997" Year="1998" Format="Main Series">
+    <Book Series="Alpha Flight" Number="13" Volume="1997" Year="1998">
       <Id>2f3c93ac-be16-4e12-a0a6-5e5ec6953c7e</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="14" Volume="1997" Year="1998" Format="Main Series">
+    <Book Series="Alpha Flight" Number="14" Volume="1997" Year="1998">
       <Id>60c6615e-b1ef-4b4e-946e-a221a90ae969</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="15" Volume="1997" Year="1998" Format="Main Series">
+    <Book Series="Alpha Flight" Number="15" Volume="1997" Year="1998">
       <Id>489e55ff-9559-43ad-ac6e-9d073b000f2c</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="16" Volume="1997" Year="1998" Format="Main Series">
+    <Book Series="Alpha Flight" Number="16" Volume="1997" Year="1998">
       <Id>88602200-206c-46ec-9740-51f456c61e0f</Id>
     </Book>
-    <Book Series="Alpha Flight / Inhumans '98" Number="1" Volume="1998" Year="1998" Format="One-Shot">
+    <Book Series="Alpha Flight / Inhumans '98" Number="1" Volume="1998" Year="1998">
       <Id>dcbce6ee-9e70-4326-b1bc-8256da21122f</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="17" Volume="1997" Year="1998" Format="Main Series">
+    <Book Series="Alpha Flight" Number="17" Volume="1997" Year="1998">
       <Id>98623b27-e82a-492d-9cea-5e77af49212f</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="18" Volume="1997" Year="1999" Format="Main Series">
+    <Book Series="Alpha Flight" Number="18" Volume="1997" Year="1999">
       <Id>2566225a-32c7-4c36-88f0-8566bca35a84</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="19" Volume="1997" Year="1999" Format="Main Series">
+    <Book Series="Alpha Flight" Number="19" Volume="1997" Year="1999">
       <Id>96b1bac7-c3b3-4b91-8803-e34812f020f9</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="20" Volume="1997" Year="1999" Format="Main Series">
+    <Book Series="Alpha Flight" Number="20" Volume="1997" Year="1999">
       <Id>905cfbf4-b532-4644-812a-86c59f307405</Id>
     </Book>
-    <Book Series="Wolverine" Number="142" Volume="1988" Year="1999" Format="Main Series">
+    <Book Series="Wolverine" Number="142" Volume="1988" Year="1999">
       <Id>62f0afd0-c026-46ed-9932-9df114223cff</Id>
     </Book>
-    <Book Series="Wolverine" Number="143" Volume="1988" Year="1999" Format="Main Series">
+    <Book Series="Wolverine" Number="143" Volume="1988" Year="1999">
       <Id>09cb3bee-ba15-4de8-83e2-b5af862cb24f</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="392" Volume="1981" Year="2001" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="392" Volume="1981" Year="2001">
       <Id>f3fa173e-67ba-4bd5-af57-9ac656f63ec2</Id>
     </Book>
-    <Book Series="X-Men" Number="112" Volume="1991" Year="2001" Format="Main Series">
+    <Book Series="X-Men" Number="112" Volume="1991" Year="2001">
       <Id>51fb39f9-783d-47b4-ab84-3cb8a91cf91f</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="393" Volume="1981" Year="2001" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="393" Volume="1981" Year="2001">
       <Id>1c6198cb-eb47-43ab-860c-03572252ebc8</Id>
     </Book>
-    <Book Series="X-Men" Number="113" Volume="1991" Year="2001" Format="Main Series">
+    <Book Series="X-Men" Number="113" Volume="1991" Year="2001">
       <Id>9e26ef8a-ef7f-44ea-9f03-558633b7a86b</Id>
     </Book>
-    <Book Series="Wolverine" Number="171" Volume="1988" Year="2002" Format="Main Series">
+    <Book Series="Wolverine" Number="171" Volume="1988" Year="2002">
       <Id>8cc3e875-fbe5-4c52-82c3-74e19310bae7</Id>
     </Book>
-    <Book Series="Wolverine" Number="172" Volume="1988" Year="2002" Format="Main Series">
+    <Book Series="Wolverine" Number="172" Volume="1988" Year="2002">
       <Id>361c04bc-0e3b-4d56-b568-27869909d4e8</Id>
     </Book>
-    <Book Series="Wolverine" Number="173" Volume="1988" Year="2002" Format="Main Series">
+    <Book Series="Wolverine" Number="173" Volume="1988" Year="2002">
       <Id>85163958-9f0d-46d4-b6b6-4c63de3d6afa</Id>
     </Book>
-    <Book Series="Wolverine" Number="179" Volume="1988" Year="2002" Format="Main Series">
+    <Book Series="Wolverine" Number="179" Volume="1988" Year="2002">
       <Id>0d973c51-aa73-4488-8788-3f9f039f9564</Id>
     </Book>
-    <Book Series="Wolverine" Number="180" Volume="1988" Year="2002" Format="Main Series">
+    <Book Series="Wolverine" Number="180" Volume="1988" Year="2002">
       <Id>70ce041f-96aa-4989-a604-f3422a7f2df5</Id>
     </Book>
-    <Book Series="Wolverine" Number="181" Volume="1988" Year="2002" Format="Main Series">
+    <Book Series="Wolverine" Number="181" Volume="1988" Year="2002">
       <Id>4be49ac7-4f00-4bbb-bd74-a45e95d4a0d7</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="45" Volume="1993" Year="2003" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="45" Volume="1993" Year="2003">
       <Id>76f6a8ba-82b5-4b4c-abc3-b5cdf89830e2</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="421" Volume="1981" Year="2003" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="421" Volume="1981" Year="2003">
       <Id>4a8bb1d4-c83d-439e-811b-8730122b9ffd</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="422" Volume="1981" Year="2003" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="422" Volume="1981" Year="2003">
       <Id>445dcab7-f330-4163-83b6-9271fa4cc1b7</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="1" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Alpha Flight" Number="1" Volume="2004" Year="2004">
       <Id>719dc48e-9201-41f3-ac05-2b87d5c14bfd</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="2" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Alpha Flight" Number="2" Volume="2004" Year="2004">
       <Id>250ab372-41e5-4f10-a5e8-7be02857e6dc</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="3" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Alpha Flight" Number="3" Volume="2004" Year="2004">
       <Id>063ec912-55f1-45f7-8cd2-3b0c879e2152</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="4" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Alpha Flight" Number="4" Volume="2004" Year="2004">
       <Id>5fba4c88-e73e-4b13-95cd-0da222238ebb</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="5" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Alpha Flight" Number="5" Volume="2004" Year="2004">
       <Id>97544c81-7b45-4da9-9d8b-9604ff606abd</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="6" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Alpha Flight" Number="6" Volume="2004" Year="2004">
       <Id>93053a1e-3fcd-4f95-a92f-7a8903a00fc2</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="7" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Alpha Flight" Number="7" Volume="2004" Year="2004">
       <Id>37c18f08-719f-47f1-954c-124e69b3ce11</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="8" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Alpha Flight" Number="8" Volume="2004" Year="2004">
       <Id>f537c71f-333e-4289-a289-74c652fc925e</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="9" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Alpha Flight" Number="9" Volume="2004" Year="2005">
       <Id>56f60dd4-58c3-48bd-9a12-84038f940004</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="10" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Alpha Flight" Number="10" Volume="2004" Year="2005">
       <Id>0807f31e-da89-4252-a03a-a0ecfd7dbe5a</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="11" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Alpha Flight" Number="11" Volume="2004" Year="2005">
       <Id>4677f6f7-78c7-4110-a71c-d5f280e9a32b</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="12" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Alpha Flight" Number="12" Volume="2004" Year="2005">
       <Id>95a7479f-a691-477e-9161-7c93edeb9561</Id>
     </Book>
-    <Book Series="Sabretooth" Number="1" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Sabretooth" Number="1" Volume="2004" Year="2004">
       <Id>984763b7-b22c-4d6a-8a64-0bcd2f1bd2d4</Id>
     </Book>
-    <Book Series="Sabretooth" Number="2" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Sabretooth" Number="2" Volume="2004" Year="2004">
       <Id>0cdee0fd-7f7c-4585-acbd-423be883b967</Id>
     </Book>
-    <Book Series="Sabretooth" Number="3" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="Sabretooth" Number="3" Volume="2004" Year="2005">
       <Id>954ed957-d280-49ba-a9d5-2fc182459b57</Id>
     </Book>
-    <Book Series="Sabretooth" Number="4" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="Sabretooth" Number="4" Volume="2004" Year="2005">
       <Id>a3fb3791-4868-414b-a023-3c0a04d5eed1</Id>
     </Book>
-    <Book Series="Civil War: The Initiative" Number="1" Volume="2007" Year="2007" Format="Crossover">
+    <Book Series="Civil War: The Initiative" Number="1" Volume="2007" Year="2007">
       <Id>c09a5d0e-f2f2-4fd8-a1a8-a30caacf3263</Id>
     </Book>
-    <Book Series="Omega Flight" Number="1" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="Omega Flight" Number="1" Volume="2007" Year="2007">
       <Id>e45af41d-93ed-495e-8ab4-c5cc27f5e262</Id>
     </Book>
-    <Book Series="Omega Flight" Number="2" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="Omega Flight" Number="2" Volume="2007" Year="2007">
       <Id>bd45a518-4e7c-4539-8138-439a66fe6b4d</Id>
     </Book>
-    <Book Series="Omega Flight" Number="3" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="Omega Flight" Number="3" Volume="2007" Year="2007">
       <Id>ba3a22f2-1d85-4d40-a3ea-12f4f8db7b41</Id>
     </Book>
-    <Book Series="Omega Flight" Number="4" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="Omega Flight" Number="4" Volume="2007" Year="2007">
       <Id>d3bb9c5f-fca9-49ac-a438-a9f60631deb0</Id>
     </Book>
-    <Book Series="Omega Flight" Number="5" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="Omega Flight" Number="5" Volume="2007" Year="2007">
       <Id>98a981f8-fe9a-4a58-b4d9-047487a4337c</Id>
     </Book>
-    <Book Series="Chaos War: Alpha Flight" Number="1" Volume="2011" Year="2011" Format="One-Shot">
+    <Book Series="Chaos War: Alpha Flight" Number="1" Volume="2011" Year="2011">
       <Id>97d61e72-7126-4500-8d69-376e508c7742</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="0.1" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Alpha Flight" Number="0.1" Volume="2011" Year="2011">
       <Id>437fea0c-cc16-4a0f-ba00-f28fe9b3b9be</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="1" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Alpha Flight" Number="1" Volume="2011" Year="2011">
       <Id>d1cc0305-8f5e-4d74-b6ea-6f4d2743a8c7</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="2" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Alpha Flight" Number="2" Volume="2011" Year="2011">
       <Id>ee99124e-68b9-4958-8c17-76b0c7d2448b</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="3" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Alpha Flight" Number="3" Volume="2011" Year="2011">
       <Id>aaec1154-eab9-4032-bdb7-b8ad8aa742a3</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="4" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Alpha Flight" Number="4" Volume="2011" Year="2011">
       <Id>2f3f692a-a818-45dd-b9f1-29df6b4971fa</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="5" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Alpha Flight" Number="5" Volume="2011" Year="2011">
       <Id>d7a76ba1-81a4-4aea-a06f-7c1c799f8829</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="6" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Alpha Flight" Number="6" Volume="2011" Year="2012">
       <Id>c1e428f0-0a04-4f4a-bace-cb17b17f022a</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="7" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Alpha Flight" Number="7" Volume="2011" Year="2012">
       <Id>c1d39d63-fe62-4f56-ba15-207e68b4f3cf</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="8" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Alpha Flight" Number="8" Volume="2011" Year="2012">
       <Id>a0b1fb0e-35a7-4642-9538-f8bd18f05210</Id>
     </Book>
   </Books>

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 001 (Original Team).cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 001 (Original Team).cbl
@@ -2,454 +2,454 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>X-Men - Part 1 (Original Team)</Name>
   <Books>
-    <Book Series="The X-Men" Number="1" Volume="1963" Year="1963" Format="Main Series">
+    <Book Series="The X-Men" Number="1" Volume="1963" Year="1963">
       <Id>57d3d152-715d-45dd-ad4e-f6328909bad3</Id>
     </Book>
-    <Book Series="The X-Men" Number="2" Volume="1963" Year="1963" Format="Main Series">
+    <Book Series="The X-Men" Number="2" Volume="1963" Year="1963">
       <Id>48866c72-d148-4c7e-b801-734b36d4d02c</Id>
     </Book>
-    <Book Series="The X-Men" Number="3" Volume="1963" Year="1964" Format="Main Series">
+    <Book Series="The X-Men" Number="3" Volume="1963" Year="1964">
       <Id>884b5e07-36f9-4562-8cf1-8ad935533362</Id>
     </Book>
-    <Book Series="The X-Men" Number="4" Volume="1963" Year="1964" Format="Main Series">
+    <Book Series="The X-Men" Number="4" Volume="1963" Year="1964">
       <Id>c8d03235-513c-4568-8e58-50fdfadc53a7</Id>
     </Book>
-    <Book Series="The X-Men" Number="5" Volume="1963" Year="1964" Format="Main Series">
+    <Book Series="The X-Men" Number="5" Volume="1963" Year="1964">
       <Id>efb797c8-2c20-4127-91b4-562344c54ddf</Id>
     </Book>
-    <Book Series="The X-Men" Number="6" Volume="1963" Year="1964" Format="Main Series">
+    <Book Series="The X-Men" Number="6" Volume="1963" Year="1964">
       <Id>9f9c529a-9b31-4172-99c3-eb18355ebc03</Id>
     </Book>
-    <Book Series="The X-Men" Number="7" Volume="1963" Year="1964" Format="Main Series">
+    <Book Series="The X-Men" Number="7" Volume="1963" Year="1964">
       <Id>223c9fef-87da-4776-95d5-a535bd7e1fce</Id>
     </Book>
-    <Book Series="The X-Men" Number="8" Volume="1963" Year="1964" Format="Main Series">
+    <Book Series="The X-Men" Number="8" Volume="1963" Year="1964">
       <Id>2e5f3b37-6856-4282-a4e3-0ea688c568a3</Id>
     </Book>
-    <Book Series="The X-Men" Number="9" Volume="1963" Year="1965" Format="Main Series">
+    <Book Series="The X-Men" Number="9" Volume="1963" Year="1965">
       <Id>630332b4-5b29-4ed9-b3de-358259070e56</Id>
     </Book>
-    <Book Series="The X-Men" Number="10" Volume="1963" Year="1965" Format="Main Series">
+    <Book Series="The X-Men" Number="10" Volume="1963" Year="1965">
       <Id>791f15d7-b06f-41a9-988c-9f5188182376</Id>
     </Book>
-    <Book Series="The X-Men" Number="11" Volume="1963" Year="1965" Format="Main Series">
+    <Book Series="The X-Men" Number="11" Volume="1963" Year="1965">
       <Id>f72104ae-50dc-48d1-b534-6563f6b730b9</Id>
     </Book>
-    <Book Series="The X-Men" Number="12" Volume="1963" Year="1965" Format="Main Series">
+    <Book Series="The X-Men" Number="12" Volume="1963" Year="1965">
       <Id>8091b4e2-a024-4749-9873-a12b80b5d2e6</Id>
     </Book>
-    <Book Series="The X-Men" Number="13" Volume="1963" Year="1965" Format="Main Series">
+    <Book Series="The X-Men" Number="13" Volume="1963" Year="1965">
       <Id>b6d7a841-e10f-4222-88fc-97ade87f6532</Id>
     </Book>
-    <Book Series="The X-Men" Number="14" Volume="1963" Year="1965" Format="Main Series">
+    <Book Series="The X-Men" Number="14" Volume="1963" Year="1965">
       <Id>e7ff6978-0c22-44c7-8aca-54b06b8b26ed</Id>
     </Book>
-    <Book Series="The X-Men" Number="15" Volume="1963" Year="1965" Format="Main Series">
+    <Book Series="The X-Men" Number="15" Volume="1963" Year="1965">
       <Id>4bdf8470-93bb-4bdc-9196-02ccc046e569</Id>
     </Book>
-    <Book Series="The X-Men" Number="16" Volume="1963" Year="1966" Format="Main Series">
+    <Book Series="The X-Men" Number="16" Volume="1963" Year="1966">
       <Id>987f3411-942e-4555-a0ba-a1396fa17c85</Id>
     </Book>
-    <Book Series="The X-Men" Number="17" Volume="1963" Year="1966" Format="Main Series">
+    <Book Series="The X-Men" Number="17" Volume="1963" Year="1966">
       <Id>2b54eb95-d99e-4f2e-91f7-b8ee6e99808b</Id>
     </Book>
-    <Book Series="The X-Men" Number="18" Volume="1963" Year="1966" Format="Main Series">
+    <Book Series="The X-Men" Number="18" Volume="1963" Year="1966">
       <Id>5d4f88cf-15d1-45d6-803b-5bee06fa9a2c</Id>
     </Book>
-    <Book Series="The X-Men" Number="19" Volume="1963" Year="1966" Format="Main Series">
+    <Book Series="The X-Men" Number="19" Volume="1963" Year="1966">
       <Id>687c98ae-c12b-4960-8965-6a042849241f</Id>
     </Book>
-    <Book Series="The X-Men" Number="20" Volume="1963" Year="1966" Format="Main Series">
+    <Book Series="The X-Men" Number="20" Volume="1963" Year="1966">
       <Id>75212d43-9a71-4cb9-a60f-66db87721b85</Id>
     </Book>
-    <Book Series="The X-Men" Number="21" Volume="1963" Year="1966" Format="Main Series">
+    <Book Series="The X-Men" Number="21" Volume="1963" Year="1966">
       <Id>d88433a8-5c11-4479-94d5-5833795e34a8</Id>
     </Book>
-    <Book Series="The X-Men" Number="22" Volume="1963" Year="1966" Format="Main Series">
+    <Book Series="The X-Men" Number="22" Volume="1963" Year="1966">
       <Id>1bf16125-2fc3-4d8c-94c0-6b212e78febf</Id>
     </Book>
-    <Book Series="The X-Men" Number="23" Volume="1963" Year="1966" Format="Main Series">
+    <Book Series="The X-Men" Number="23" Volume="1963" Year="1966">
       <Id>03c62306-65c3-404d-9c4d-68315cec05e9</Id>
     </Book>
-    <Book Series="X-Men: First Class" Number="1" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="X-Men: First Class" Number="1" Volume="2006" Year="2006">
       <Id>ace1d64d-1b24-4efa-a0c6-8be35c187ded</Id>
     </Book>
-    <Book Series="X-Men: First Class" Number="2" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="X-Men: First Class" Number="2" Volume="2006" Year="2006">
       <Id>3d327bf2-67c1-4450-bc63-d446d289fe56</Id>
     </Book>
-    <Book Series="X-Men: First Class" Number="3" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="X-Men: First Class" Number="3" Volume="2006" Year="2007">
       <Id>895d3568-44e1-4fc3-9004-b3562d5ea4b7</Id>
     </Book>
-    <Book Series="X-Men: First Class" Number="4" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="X-Men: First Class" Number="4" Volume="2006" Year="2007">
       <Id>f7c8132c-0939-4609-9378-dccadb3f3d74</Id>
     </Book>
-    <Book Series="X-Men: First Class" Number="5" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="X-Men: First Class" Number="5" Volume="2006" Year="2007">
       <Id>fa903ff7-2f28-4fb0-94e6-a446d1e9d95f</Id>
     </Book>
-    <Book Series="X-Men: First Class" Number="6" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="X-Men: First Class" Number="6" Volume="2006" Year="2007">
       <Id>3fe2e675-c8e6-4578-9c03-e87ebd694900</Id>
     </Book>
-    <Book Series="X-Men: First Class" Number="7" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="X-Men: First Class" Number="7" Volume="2006" Year="2007">
       <Id>595c20af-590e-4167-bbb7-231142bc894e</Id>
     </Book>
-    <Book Series="X-Men: First Class" Number="8" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="X-Men: First Class" Number="8" Volume="2006" Year="2007">
       <Id>3f3efe28-6815-4a81-ae92-e020265a5964</Id>
     </Book>
-    <Book Series="X-Men: First Class" Number="1" Volume="2007" Year="2007" Format="Main Series">
+    <Book Series="X-Men: First Class" Number="1" Volume="2007" Year="2007">
       <Id>6f01b114-61a7-4ec1-b577-205a454e97ae</Id>
     </Book>
-    <Book Series="X-Men: First Class" Number="2" Volume="2007" Year="2007" Format="Main Series">
+    <Book Series="X-Men: First Class" Number="2" Volume="2007" Year="2007">
       <Id>2a893a54-c75c-4668-befb-f0489d8c0c34</Id>
     </Book>
-    <Book Series="X-Men: First Class" Number="3" Volume="2007" Year="2007" Format="Main Series">
+    <Book Series="X-Men: First Class" Number="3" Volume="2007" Year="2007">
       <Id>c42213de-741f-4501-a6a6-42534a1d889a</Id>
     </Book>
-    <Book Series="X-Men: First Class" Number="4" Volume="2007" Year="2007" Format="Main Series">
+    <Book Series="X-Men: First Class" Number="4" Volume="2007" Year="2007">
       <Id>319af704-436d-4d30-80c6-ff051cbed230</Id>
     </Book>
-    <Book Series="X-Men: First Class" Number="5" Volume="2007" Year="2007" Format="Main Series">
+    <Book Series="X-Men: First Class" Number="5" Volume="2007" Year="2007">
       <Id>e646ef1a-47c8-4c74-a86d-83284383ee5d</Id>
     </Book>
-    <Book Series="X-Men First Class Special" Number="1" Volume="2007" Year="2007" Format="One-Shot">
+    <Book Series="X-Men First Class Special" Number="1" Volume="2007" Year="2007">
       <Id>2d3c6099-094d-4638-8b9a-7a5e9077c03b</Id>
     </Book>
-    <Book Series="X-Men: First Class" Number="6" Volume="2007" Year="2008" Format="Main Series">
+    <Book Series="X-Men: First Class" Number="6" Volume="2007" Year="2008">
       <Id>8fe4e3a4-d544-4bfe-861f-66e4f1df7834</Id>
     </Book>
-    <Book Series="X-Men: First Class" Number="7" Volume="2007" Year="2008" Format="Main Series">
+    <Book Series="X-Men: First Class" Number="7" Volume="2007" Year="2008">
       <Id>36829b57-3ae5-49f7-bdb1-be04c90778e1</Id>
     </Book>
-    <Book Series="X-Men: First Class" Number="8" Volume="2007" Year="2008" Format="Main Series">
+    <Book Series="X-Men: First Class" Number="8" Volume="2007" Year="2008">
       <Id>e8f1e918-beb8-49e0-b148-a1ee6f5635d8</Id>
     </Book>
-    <Book Series="X-Men: First Class" Number="9" Volume="2007" Year="2008" Format="Main Series">
+    <Book Series="X-Men: First Class" Number="9" Volume="2007" Year="2008">
       <Id>9c6df0b7-c864-4c3f-be4d-dfe0177c052d</Id>
     </Book>
-    <Book Series="X-Men: First Class" Number="10" Volume="2007" Year="2008" Format="Main Series">
+    <Book Series="X-Men: First Class" Number="10" Volume="2007" Year="2008">
       <Id>19bdbdaf-006e-4697-a9f6-bb8c6b9b9dab</Id>
     </Book>
-    <Book Series="X-Men: First Class" Number="11" Volume="2007" Year="2008" Format="Main Series">
+    <Book Series="X-Men: First Class" Number="11" Volume="2007" Year="2008">
       <Id>0ee0b5c8-fc5a-49b6-8baf-cff8e84f04cb</Id>
     </Book>
-    <Book Series="X-Men: First Class" Number="12" Volume="2007" Year="2008" Format="Main Series">
+    <Book Series="X-Men: First Class" Number="12" Volume="2007" Year="2008">
       <Id>0bd15c2a-4d7d-41b4-856a-67172f509452</Id>
     </Book>
-    <Book Series="X-Men: First Class" Number="13" Volume="2007" Year="2008" Format="Main Series">
+    <Book Series="X-Men: First Class" Number="13" Volume="2007" Year="2008">
       <Id>b9e391df-7649-47cf-acb2-bf29e7871697</Id>
     </Book>
-    <Book Series="X-Men: First Class" Number="14" Volume="2007" Year="2008" Format="Main Series">
+    <Book Series="X-Men: First Class" Number="14" Volume="2007" Year="2008">
       <Id>589fe198-cd42-467e-9a06-23c19a75fee4</Id>
     </Book>
-    <Book Series="X-Men: First Class" Number="15" Volume="2007" Year="2008" Format="Main Series">
+    <Book Series="X-Men: First Class" Number="15" Volume="2007" Year="2008">
       <Id>930cc68c-61e5-41a3-8479-04516673dd80</Id>
     </Book>
-    <Book Series="X-Men: First Class" Number="16" Volume="2007" Year="2008" Format="Main Series">
+    <Book Series="X-Men: First Class" Number="16" Volume="2007" Year="2008">
       <Id>447ba10d-4b2c-4a34-97f8-f6e118f5b713</Id>
     </Book>
-    <Book Series="X-Men: First Class Giant-Sized Special" Number="1" Volume="2008" Year="2008" Format="One-Shot">
+    <Book Series="X-Men: First Class Giant-Sized Special" Number="1" Volume="2008" Year="2008">
       <Id>9454df83-e3c3-47e0-be03-de6138c3fb68</Id>
     </Book>
-    <Book Series="The X-Men" Number="24" Volume="1963" Year="1966" Format="Main Series">
+    <Book Series="The X-Men" Number="24" Volume="1963" Year="1966">
       <Id>9bdbaf3c-e6af-468f-8ca0-414e7d42b983</Id>
     </Book>
-    <Book Series="The X-Men" Number="25" Volume="1963" Year="1966" Format="Main Series">
+    <Book Series="The X-Men" Number="25" Volume="1963" Year="1966">
       <Id>b29dfccd-201d-4bba-a7c5-41d53d87ff1d</Id>
     </Book>
-    <Book Series="The X-Men" Number="26" Volume="1963" Year="1966" Format="Main Series">
+    <Book Series="The X-Men" Number="26" Volume="1963" Year="1966">
       <Id>cc84bba7-93c3-4bbe-8b84-79b0754323c1</Id>
     </Book>
-    <Book Series="The X-Men" Number="27" Volume="1963" Year="1966" Format="Main Series">
+    <Book Series="The X-Men" Number="27" Volume="1963" Year="1966">
       <Id>6e23017c-4033-44a1-a11a-b2f2cb36c914</Id>
     </Book>
-    <Book Series="The X-Men" Number="28" Volume="1963" Year="1967" Format="Main Series">
+    <Book Series="The X-Men" Number="28" Volume="1963" Year="1967">
       <Id>b48e05c9-b972-436b-a8fe-a3d30600dd3d</Id>
     </Book>
-    <Book Series="The X-Men" Number="29" Volume="1963" Year="1967" Format="Main Series">
+    <Book Series="The X-Men" Number="29" Volume="1963" Year="1967">
       <Id>f34a2e4b-2413-4b8c-ad6c-9487abcc2861</Id>
     </Book>
-    <Book Series="The X-Men" Number="30" Volume="1963" Year="1967" Format="Main Series">
+    <Book Series="The X-Men" Number="30" Volume="1963" Year="1967">
       <Id>166a20f2-6826-4068-b1c6-77d5e52d7f52</Id>
     </Book>
-    <Book Series="The X-Men" Number="31" Volume="1963" Year="1967" Format="Main Series">
+    <Book Series="The X-Men" Number="31" Volume="1963" Year="1967">
       <Id>30d7e58e-e417-4e25-9fbf-1a2282046d1b</Id>
     </Book>
-    <Book Series="The X-Men" Number="32" Volume="1963" Year="1967" Format="Main Series">
+    <Book Series="The X-Men" Number="32" Volume="1963" Year="1967">
       <Id>a67b4724-0f86-420f-b0ce-2940c2df4dad</Id>
     </Book>
-    <Book Series="The X-Men" Number="33" Volume="1963" Year="1967" Format="Main Series">
+    <Book Series="The X-Men" Number="33" Volume="1963" Year="1967">
       <Id>86a8ca50-84ba-4b0c-ad10-3f4ed2e75078</Id>
     </Book>
-    <Book Series="The X-Men" Number="34" Volume="1963" Year="1967" Format="Main Series">
+    <Book Series="The X-Men" Number="34" Volume="1963" Year="1967">
       <Id>0f2de91e-ab8e-47f1-af97-1c93c10f71d5</Id>
     </Book>
-    <Book Series="The X-Men" Number="35" Volume="1963" Year="1967" Format="Main Series">
+    <Book Series="The X-Men" Number="35" Volume="1963" Year="1967">
       <Id>8a141527-f719-4d6d-bd6d-097e094d40ba</Id>
     </Book>
-    <Book Series="The X-Men" Number="36" Volume="1963" Year="1967" Format="Main Series">
+    <Book Series="The X-Men" Number="36" Volume="1963" Year="1967">
       <Id>02297c72-d4a1-42b1-83eb-e9c7e7030ced</Id>
     </Book>
-    <Book Series="The X-Men" Number="37" Volume="1963" Year="1967" Format="Main Series">
+    <Book Series="The X-Men" Number="37" Volume="1963" Year="1967">
       <Id>c4ad09e5-4550-4c42-9eb5-54f074cd5277</Id>
     </Book>
-    <Book Series="The X-Men" Number="38" Volume="1963" Year="1967" Format="Main Series">
+    <Book Series="The X-Men" Number="38" Volume="1963" Year="1967">
       <Id>a6d6c8ca-3cb6-4602-8baf-41632f7b9b3a</Id>
     </Book>
-    <Book Series="The X-Men" Number="39" Volume="1963" Year="1967" Format="Main Series">
+    <Book Series="The X-Men" Number="39" Volume="1963" Year="1967">
       <Id>e94ed1e4-b4b4-4542-951b-e8885fb1ec2b</Id>
     </Book>
-    <Book Series="The X-Men" Number="40" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The X-Men" Number="40" Volume="1963" Year="1968">
       <Id>f4bc65c5-471a-42a5-8f33-cb3fe44cab86</Id>
     </Book>
-    <Book Series="The X-Men" Number="41" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The X-Men" Number="41" Volume="1963" Year="1968">
       <Id>5d09f5ae-33ce-45b2-a4d8-ad28e22bc115</Id>
     </Book>
-    <Book Series="The X-Men" Number="42" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The X-Men" Number="42" Volume="1963" Year="1968">
       <Id>28409ad6-6f60-4e06-8634-6dcf98c2cf8f</Id>
     </Book>
-    <Book Series="The Avengers" Number="47" Volume="1963" Year="1967" Format="Main Series">
+    <Book Series="The Avengers" Number="47" Volume="1963" Year="1967">
       <Id>ae0c7504-7769-472f-b53f-2c61cbb8bc90</Id>
     </Book>
-    <Book Series="The Avengers" Number="48" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The Avengers" Number="48" Volume="1963" Year="1968">
       <Id>3e846ef9-7fc9-4321-a98c-59f6f07943a5</Id>
     </Book>
-    <Book Series="The Avengers" Number="49" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The Avengers" Number="49" Volume="1963" Year="1968">
       <Id>06b342f4-4d6f-47ec-ae1d-3d60127399c3</Id>
     </Book>
-    <Book Series="The X-Men" Number="43" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The X-Men" Number="43" Volume="1963" Year="1968">
       <Id>acd5983a-42e2-44a4-94da-3382e876a77b</Id>
     </Book>
-    <Book Series="The X-Men" Number="44" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The X-Men" Number="44" Volume="1963" Year="1968">
       <Id>5e39f307-9ae1-48f2-8738-6cefba12a96e</Id>
     </Book>
-    <Book Series="The X-Men" Number="45" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The X-Men" Number="45" Volume="1963" Year="1968">
       <Id>4a7696d8-0f3d-465d-83c4-877c5329b2b8</Id>
     </Book>
-    <Book Series="The Avengers" Number="53" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The Avengers" Number="53" Volume="1963" Year="1968">
       <Id>119c636f-3482-40dd-bff2-805b483bd6da</Id>
     </Book>
-    <Book Series="The X-Men" Number="46" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The X-Men" Number="46" Volume="1963" Year="1968">
       <Id>4aa81c2e-729b-4e01-97da-f9b60f106ebc</Id>
     </Book>
-    <Book Series="The X-Men" Number="47" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The X-Men" Number="47" Volume="1963" Year="1968">
       <Id>170175f1-6a83-4235-ae03-63a925597c3d</Id>
     </Book>
-    <Book Series="The X-Men" Number="48" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The X-Men" Number="48" Volume="1963" Year="1968">
       <Id>f0f087bc-044c-43f5-9425-7975f4e1c281</Id>
     </Book>
-    <Book Series="Ka-Zar" Number="2" Volume="1970" Year="1970" Format="Limited Series">
+    <Book Series="Ka-Zar" Number="2" Volume="1970" Year="1970">
       <Id>db1fb3b5-f68a-47a5-bf0a-ae21c302b881</Id>
     </Book>
-    <Book Series="Ka-Zar" Number="3" Volume="1970" Year="1971" Format="Limited Series">
+    <Book Series="Ka-Zar" Number="3" Volume="1970" Year="1971">
       <Id>d9a105e5-74c5-4186-a4af-a671894cdc76</Id>
     </Book>
-    <Book Series="Marvel Tales" Number="30" Volume="1966" Year="1971" Format="Main Series">
+    <Book Series="Marvel Tales" Number="30" Volume="1966" Year="1971">
       <Id>d130f19c-5de8-4161-bc30-bb5895510bb5</Id>
     </Book>
-    <Book Series="The X-Men" Number="49" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The X-Men" Number="49" Volume="1963" Year="1968">
       <Id>c924b3b5-55f3-4ca2-9de8-d64da57e2a79</Id>
     </Book>
-    <Book Series="The X-Men" Number="50" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The X-Men" Number="50" Volume="1963" Year="1968">
       <Id>d53c4d26-2840-48d7-b88d-5557ed531199</Id>
     </Book>
-    <Book Series="The X-Men" Number="51" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The X-Men" Number="51" Volume="1963" Year="1968">
       <Id>529bb3fb-d5e1-47b9-8205-50ae34bdc715</Id>
     </Book>
-    <Book Series="The X-Men" Number="52" Volume="1963" Year="1969" Format="Main Series">
+    <Book Series="The X-Men" Number="52" Volume="1963" Year="1969">
       <Id>87e7135d-9daf-464e-af7b-f18241e00803</Id>
     </Book>
-    <Book Series="The X-Men" Number="53" Volume="1963" Year="1969" Format="Main Series">
+    <Book Series="The X-Men" Number="53" Volume="1963" Year="1969">
       <Id>a8561e7b-7285-4ad4-93cc-d47cf295698c</Id>
     </Book>
-    <Book Series="The X-Men" Number="54" Volume="1963" Year="1969" Format="Main Series">
+    <Book Series="The X-Men" Number="54" Volume="1963" Year="1969">
       <Id>b8364f8d-99c5-48e7-b857-15c75eb64598</Id>
     </Book>
-    <Book Series="The X-Men" Number="55" Volume="1963" Year="1969" Format="Main Series">
+    <Book Series="The X-Men" Number="55" Volume="1963" Year="1969">
       <Id>bb44e7d7-334c-4877-9b1e-936d85d61020</Id>
     </Book>
-    <Book Series="The X-Men" Number="56" Volume="1963" Year="1969" Format="Main Series">
+    <Book Series="The X-Men" Number="56" Volume="1963" Year="1969">
       <Id>bcf9a4d2-31a2-4825-a216-126d46999ab2</Id>
     </Book>
-    <Book Series="The X-Men" Number="57" Volume="1963" Year="1969" Format="Main Series">
+    <Book Series="The X-Men" Number="57" Volume="1963" Year="1969">
       <Id>96fe77e8-babc-45f1-9a35-4439bd966151</Id>
     </Book>
-    <Book Series="The X-Men" Number="58" Volume="1963" Year="1969" Format="Main Series">
+    <Book Series="The X-Men" Number="58" Volume="1963" Year="1969">
       <Id>8c0a9d39-7e0d-483b-be62-d5260b16a4b1</Id>
     </Book>
-    <Book Series="The X-Men" Number="59" Volume="1963" Year="1969" Format="Main Series">
+    <Book Series="The X-Men" Number="59" Volume="1963" Year="1969">
       <Id>37fd21c6-21e5-4c12-be94-9454f0246145</Id>
     </Book>
-    <Book Series="The X-Men" Number="60" Volume="1963" Year="1969" Format="Main Series">
+    <Book Series="The X-Men" Number="60" Volume="1963" Year="1969">
       <Id>59ce3899-64da-49b3-a9cd-2e8d7cbb960d</Id>
     </Book>
-    <Book Series="The X-Men" Number="61" Volume="1963" Year="1969" Format="Main Series">
+    <Book Series="The X-Men" Number="61" Volume="1963" Year="1969">
       <Id>5e357aeb-95bd-48e8-85eb-1d86722cb045</Id>
     </Book>
-    <Book Series="The X-Men" Number="62" Volume="1963" Year="1969" Format="Main Series">
+    <Book Series="The X-Men" Number="62" Volume="1963" Year="1969">
       <Id>89078578-4236-41c6-ba31-b4f0c0c01920</Id>
     </Book>
-    <Book Series="The X-Men" Number="63" Volume="1963" Year="1969" Format="Main Series">
+    <Book Series="The X-Men" Number="63" Volume="1963" Year="1969">
       <Id>0a91c60b-4d7f-4a8a-9315-da3ba48498f2</Id>
     </Book>
-    <Book Series="The X-Men" Number="64" Volume="1963" Year="1970" Format="Main Series">
+    <Book Series="The X-Men" Number="64" Volume="1963" Year="1970">
       <Id>ed6f2b75-48fe-4242-ad19-0755d5e16b61</Id>
     </Book>
-    <Book Series="The X-Men" Number="65" Volume="1963" Year="1970" Format="Main Series">
+    <Book Series="The X-Men" Number="65" Volume="1963" Year="1970">
       <Id>3b96f9c9-48ca-4e00-82ec-951ac2903f3d</Id>
     </Book>
-    <Book Series="The X-Men" Number="66" Volume="1963" Year="1970" Format="Main Series">
+    <Book Series="The X-Men" Number="66" Volume="1963" Year="1970">
       <Id>cea91505-1b12-4bf9-b355-2b05ee548e3b</Id>
     </Book>
-    <Book Series="X-Men: The Hidden Years" Number="1" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="X-Men: The Hidden Years" Number="1" Volume="1999" Year="1999">
       <Id>9fbfb5fa-d77b-474f-b430-a7d6a3d55e40</Id>
     </Book>
-    <Book Series="X-Men: The Hidden Years" Number="2" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="X-Men: The Hidden Years" Number="2" Volume="1999" Year="2000">
       <Id>903e29ba-1e5c-44ed-bceb-7bd954e9061f</Id>
     </Book>
-    <Book Series="X-Men: The Hidden Years" Number="3" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="X-Men: The Hidden Years" Number="3" Volume="1999" Year="2000">
       <Id>5a9249bf-9a49-42cd-b93d-4ffc54df1e02</Id>
     </Book>
-    <Book Series="X-Men: The Hidden Years" Number="4" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="X-Men: The Hidden Years" Number="4" Volume="1999" Year="2000">
       <Id>15a45ab0-ec82-4dd0-8a17-c8f4755755ad</Id>
     </Book>
-    <Book Series="X-Men: The Hidden Years" Number="5" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="X-Men: The Hidden Years" Number="5" Volume="1999" Year="2000">
       <Id>9d47eaed-9b09-4d04-bb2a-f154a9b4bf43</Id>
     </Book>
-    <Book Series="X-Men: The Hidden Years" Number="6" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="X-Men: The Hidden Years" Number="6" Volume="1999" Year="2000">
       <Id>fcadf9c7-c7e7-427d-8881-c26f1aff845f</Id>
     </Book>
-    <Book Series="X-Men: The Hidden Years" Number="7" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="X-Men: The Hidden Years" Number="7" Volume="1999" Year="2000">
       <Id>7ee2f766-a50c-43c7-99fa-0bae942629f8</Id>
     </Book>
-    <Book Series="X-Men: The Hidden Years" Number="8" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="X-Men: The Hidden Years" Number="8" Volume="1999" Year="2000">
       <Id>5bcd5b85-b8ea-4a4a-8022-ed519089b9bf</Id>
     </Book>
-    <Book Series="X-Men: The Hidden Years" Number="9" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="X-Men: The Hidden Years" Number="9" Volume="1999" Year="2000">
       <Id>c198e074-056e-450f-a3ec-8ec6c568dfe5</Id>
     </Book>
-    <Book Series="X-Men: The Hidden Years" Number="10" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="X-Men: The Hidden Years" Number="10" Volume="1999" Year="2000">
       <Id>8fde4c42-507b-43ca-aeb7-3c90d6db298e</Id>
     </Book>
-    <Book Series="X-Men: The Hidden Years" Number="11" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="X-Men: The Hidden Years" Number="11" Volume="1999" Year="2000">
       <Id>4096692e-834f-4bf0-ac2b-0a6bc51bf58e</Id>
     </Book>
-    <Book Series="X-Men: The Hidden Years" Number="12" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="X-Men: The Hidden Years" Number="12" Volume="1999" Year="2000">
       <Id>e55734e6-e721-4447-a4a5-e6c14e1e0f36</Id>
     </Book>
-    <Book Series="X-Men: The Hidden Years" Number="13" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="X-Men: The Hidden Years" Number="13" Volume="1999" Year="2000">
       <Id>0c779ea0-f1b7-4f9e-9ce4-4e51d820c5e7</Id>
     </Book>
-    <Book Series="X-Men: The Hidden Years" Number="14" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="X-Men: The Hidden Years" Number="14" Volume="1999" Year="2001">
       <Id>79c49eb5-411b-4f1d-8531-7ffd2db5500d</Id>
     </Book>
-    <Book Series="X-Men: The Hidden Years" Number="15" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="X-Men: The Hidden Years" Number="15" Volume="1999" Year="2001">
       <Id>515d1676-8962-418d-94b1-c4dca8151c18</Id>
     </Book>
-    <Book Series="X-Men: The Hidden Years" Number="16" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="X-Men: The Hidden Years" Number="16" Volume="1999" Year="2001">
       <Id>01a6116b-b6aa-45f4-878a-6f0440a7e00a</Id>
     </Book>
-    <Book Series="X-Men: The Hidden Years" Number="17" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="X-Men: The Hidden Years" Number="17" Volume="1999" Year="2001">
       <Id>d95010d1-c041-4f4e-954c-b68b88b40036</Id>
     </Book>
-    <Book Series="X-Men: The Hidden Years" Number="18" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="X-Men: The Hidden Years" Number="18" Volume="1999" Year="2001">
       <Id>16306685-4e6b-4d16-978c-cb294f8e97f5</Id>
     </Book>
-    <Book Series="X-Men: The Hidden Years" Number="19" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="X-Men: The Hidden Years" Number="19" Volume="1999" Year="2001">
       <Id>42d739af-203c-4400-b251-0cc0d9f9f469</Id>
     </Book>
-    <Book Series="X-Men: The Hidden Years" Number="20" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="X-Men: The Hidden Years" Number="20" Volume="1999" Year="2001">
       <Id>51bab489-6006-49b3-9b73-27810afc4e5e</Id>
     </Book>
-    <Book Series="X-Men: The Hidden Years" Number="21" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="X-Men: The Hidden Years" Number="21" Volume="1999" Year="2001">
       <Id>70d72f7f-97d8-4444-93d7-ac92118bbb88</Id>
     </Book>
-    <Book Series="X-Men: The Hidden Years" Number="22" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="X-Men: The Hidden Years" Number="22" Volume="1999" Year="2001">
       <Id>3197c5e4-8727-4f98-b1a9-c68b571b5d96</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="92" Volume="1963" Year="1971" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="92" Volume="1963" Year="1971">
       <Id>38aae8c3-2f41-44c2-8fd9-3a061f69f0c0</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="150" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="150" Volume="1968" Year="1972">
       <Id>52ae7dea-8895-4717-859d-ed57f90aca0f</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="4" Volume="1972" Year="1972" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="4" Volume="1972" Year="1972">
       <Id>af10b63a-d907-428f-b1be-bbab73cc97d3</Id>
     </Book>
-    <Book Series="Amazing Adventures" Number="11" Volume="1970" Year="1972" Format="Main Series">
+    <Book Series="Amazing Adventures" Number="11" Volume="1970" Year="1972">
       <Id>7b2bae25-64e7-48c1-8bd2-c6ed3b20f519</Id>
     </Book>
-    <Book Series="Amazing Adventures" Number="12" Volume="1970" Year="1972" Format="Main Series">
+    <Book Series="Amazing Adventures" Number="12" Volume="1970" Year="1972">
       <Id>9aec7a5c-6554-4944-9b34-224aa73c3e95</Id>
     </Book>
-    <Book Series="Amazing Adventures" Number="13" Volume="1970" Year="1972" Format="Main Series">
+    <Book Series="Amazing Adventures" Number="13" Volume="1970" Year="1972">
       <Id>570f4845-0a0a-47e1-a8ad-e31cffdd35a9</Id>
     </Book>
-    <Book Series="Amazing Adventures" Number="14" Volume="1970" Year="1972" Format="Main Series">
+    <Book Series="Amazing Adventures" Number="14" Volume="1970" Year="1972">
       <Id>4458af1c-2c64-4e9c-ad82-c92eaa35ab80</Id>
     </Book>
-    <Book Series="Amazing Adventures" Number="15" Volume="1970" Year="1972" Format="Main Series">
+    <Book Series="Amazing Adventures" Number="15" Volume="1970" Year="1972">
       <Id>eb7e8c2a-ffb2-4e52-b0b6-66912f5791fb</Id>
     </Book>
-    <Book Series="Amazing Adventures" Number="16" Volume="1970" Year="1973" Format="Main Series">
+    <Book Series="Amazing Adventures" Number="16" Volume="1970" Year="1973">
       <Id>28270061-5777-4740-a8c9-832ff40a64dc</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="161" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="161" Volume="1968" Year="1973">
       <Id>b188df38-2275-4309-a3cc-4b8efde11106</Id>
     </Book>
-    <Book Series="Amazing Adventures" Number="17" Volume="1970" Year="1973" Format="Main Series">
+    <Book Series="Amazing Adventures" Number="17" Volume="1970" Year="1973">
       <Id>2c1ab82f-c266-4a1e-b577-9ee1a1ebbaad</Id>
     </Book>
-    <Book Series="The Avengers" Number="110" Volume="1963" Year="1973" Format="Main Series">
+    <Book Series="The Avengers" Number="110" Volume="1963" Year="1973">
       <Id>6b47978f-04cd-4017-9622-4ac98bbc050c</Id>
     </Book>
-    <Book Series="The Avengers" Number="111" Volume="1963" Year="1973" Format="Main Series">
+    <Book Series="The Avengers" Number="111" Volume="1963" Year="1973">
       <Id>899e66f4-0334-4fdc-ae5c-22bc890573b6</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="172" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="172" Volume="1968" Year="1974">
       <Id>12e5801b-3710-4467-8c78-2976a34d2eb0</Id>
     </Book>
-    <Book Series="Captain America" Number="172" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="Captain America" Number="172" Volume="1968" Year="1974">
       <Id>89fe30fc-0395-4c97-bbad-a5a568aceaf0</Id>
     </Book>
-    <Book Series="Captain America" Number="173" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="Captain America" Number="173" Volume="1968" Year="1974">
       <Id>9083b981-d674-4da8-b57c-61ccc8060690</Id>
     </Book>
-    <Book Series="Captain America" Number="174" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="Captain America" Number="174" Volume="1968" Year="1974">
       <Id>6a189d49-747e-416d-b486-eec941fc1d00</Id>
     </Book>
-    <Book Series="Captain America" Number="175" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="Captain America" Number="175" Volume="1968" Year="1974">
       <Id>a4b69196-8689-41e8-80ab-3067724d7d6a</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="23" Volume="1972" Year="1974" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="23" Volume="1972" Year="1974">
       <Id>089af553-68dc-41e4-8bbe-c4d5f03db97e</Id>
     </Book>
-    <Book Series="The Defenders" Number="15" Volume="1972" Year="1974" Format="Main Series">
+    <Book Series="The Defenders" Number="15" Volume="1972" Year="1974">
       <Id>cdfb5735-d001-4918-ac00-8c8703e483f7</Id>
     </Book>
-    <Book Series="The Defenders" Number="16" Volume="1972" Year="1974" Format="Main Series">
+    <Book Series="The Defenders" Number="16" Volume="1972" Year="1974">
       <Id>a68d7bad-38a7-4449-9fa4-82328cd762c8</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="180" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="180" Volume="1968" Year="1974">
       <Id>d2096154-9573-42ae-8894-dcea6796bc02</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="181" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="181" Volume="1968" Year="1974">
       <Id>2644162f-35dc-4fd1-95a7-9f2ba9284b2f</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="182" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="182" Volume="1968" Year="1974">
       <Id>daebbed4-aeba-485b-ae56-f2c9f56da8df</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="38" Volume="1972" Year="1975" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="38" Volume="1972" Year="1975">
       <Id>4979b850-f3da-4c03-b818-f1b3969c506b</Id>
     </Book>
-    <Book Series="X-Men: First Class Finals" Number="1" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="X-Men: First Class Finals" Number="1" Volume="2009" Year="2009">
       <Id>31787260-577e-49d1-a3e4-0f31150bb1f0</Id>
     </Book>
-    <Book Series="X-Men: First Class Finals" Number="2" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="X-Men: First Class Finals" Number="2" Volume="2009" Year="2009">
       <Id>42141af0-75e5-46f0-ac31-11147e4549d5</Id>
     </Book>
-    <Book Series="X-Men: First Class Finals" Number="3" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="X-Men: First Class Finals" Number="3" Volume="2009" Year="2009">
       <Id>9cbc5fa4-6caa-4610-8ee7-6e367138c38e</Id>
     </Book>
-    <Book Series="X-Men: First Class Finals" Number="4" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="X-Men: First Class Finals" Number="4" Volume="2009" Year="2009">
       <Id>5d40ae3e-7fa7-485e-90ea-9bfc13954fe5</Id>
     </Book>
   </Books>

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 001 (Original Team).cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 001 (Original Team).cbl
@@ -1,456 +1,457 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>X-Men - Part 1 (Original Team)</Name>
+  <Name>X-Men - Part 001 (Original Team)</Name>
+  <NumIssues>150</NumIssues>
   <Books>
     <Book Series="The X-Men" Number="1" Volume="1963" Year="1963">
-      <Id>57d3d152-715d-45dd-ad4e-f6328909bad3</Id>
+      <Database Name="cv" Series="2133" Issue="6694" />
     </Book>
     <Book Series="The X-Men" Number="2" Volume="1963" Year="1963">
-      <Id>48866c72-d148-4c7e-b801-734b36d4d02c</Id>
+      <Database Name="cv" Series="2133" Issue="6787" />
     </Book>
     <Book Series="The X-Men" Number="3" Volume="1963" Year="1964">
-      <Id>884b5e07-36f9-4562-8cf1-8ad935533362</Id>
+      <Database Name="cv" Series="2133" Issue="6946" />
     </Book>
     <Book Series="The X-Men" Number="4" Volume="1963" Year="1964">
-      <Id>c8d03235-513c-4568-8e58-50fdfadc53a7</Id>
+      <Database Name="cv" Series="2133" Issue="7032" />
     </Book>
     <Book Series="The X-Men" Number="5" Volume="1963" Year="1964">
-      <Id>efb797c8-2c20-4127-91b4-562344c54ddf</Id>
+      <Database Name="cv" Series="2133" Issue="7114" />
     </Book>
     <Book Series="The X-Men" Number="6" Volume="1963" Year="1964">
-      <Id>9f9c529a-9b31-4172-99c3-eb18355ebc03</Id>
+      <Database Name="cv" Series="2133" Issue="7207" />
     </Book>
     <Book Series="The X-Men" Number="7" Volume="1963" Year="1964">
-      <Id>223c9fef-87da-4776-95d5-a535bd7e1fce</Id>
+      <Database Name="cv" Series="2133" Issue="7310" />
     </Book>
     <Book Series="The X-Men" Number="8" Volume="1963" Year="1964">
-      <Id>2e5f3b37-6856-4282-a4e3-0ea688c568a3</Id>
+      <Database Name="cv" Series="2133" Issue="7431" />
     </Book>
     <Book Series="The X-Men" Number="9" Volume="1963" Year="1965">
-      <Id>630332b4-5b29-4ed9-b3de-358259070e56</Id>
+      <Database Name="cv" Series="2133" Issue="7559" />
     </Book>
     <Book Series="The X-Men" Number="10" Volume="1963" Year="1965">
-      <Id>791f15d7-b06f-41a9-988c-9f5188182376</Id>
+      <Database Name="cv" Series="2133" Issue="7674" />
     </Book>
     <Book Series="The X-Men" Number="11" Volume="1963" Year="1965">
-      <Id>f72104ae-50dc-48d1-b534-6563f6b730b9</Id>
+      <Database Name="cv" Series="2133" Issue="7782" />
     </Book>
     <Book Series="The X-Men" Number="12" Volume="1963" Year="1965">
-      <Id>8091b4e2-a024-4749-9873-a12b80b5d2e6</Id>
+      <Database Name="cv" Series="2133" Issue="7900" />
     </Book>
     <Book Series="The X-Men" Number="13" Volume="1963" Year="1965">
-      <Id>b6d7a841-e10f-4222-88fc-97ade87f6532</Id>
+      <Database Name="cv" Series="2133" Issue="8037" />
     </Book>
     <Book Series="The X-Men" Number="14" Volume="1963" Year="1965">
-      <Id>e7ff6978-0c22-44c7-8aca-54b06b8b26ed</Id>
+      <Database Name="cv" Series="2133" Issue="8170" />
     </Book>
     <Book Series="The X-Men" Number="15" Volume="1963" Year="1965">
-      <Id>4bdf8470-93bb-4bdc-9196-02ccc046e569</Id>
+      <Database Name="cv" Series="2133" Issue="8238" />
     </Book>
     <Book Series="The X-Men" Number="16" Volume="1963" Year="1966">
-      <Id>987f3411-942e-4555-a0ba-a1396fa17c85</Id>
+      <Database Name="cv" Series="2133" Issue="8315" />
     </Book>
     <Book Series="The X-Men" Number="17" Volume="1963" Year="1966">
-      <Id>2b54eb95-d99e-4f2e-91f7-b8ee6e99808b</Id>
+      <Database Name="cv" Series="2133" Issue="8375" />
     </Book>
     <Book Series="The X-Men" Number="18" Volume="1963" Year="1966">
-      <Id>5d4f88cf-15d1-45d6-803b-5bee06fa9a2c</Id>
+      <Database Name="cv" Series="2133" Issue="8435" />
     </Book>
     <Book Series="The X-Men" Number="19" Volume="1963" Year="1966">
-      <Id>687c98ae-c12b-4960-8965-6a042849241f</Id>
+      <Database Name="cv" Series="2133" Issue="8498" />
     </Book>
     <Book Series="The X-Men" Number="20" Volume="1963" Year="1966">
-      <Id>75212d43-9a71-4cb9-a60f-66db87721b85</Id>
+      <Database Name="cv" Series="2133" Issue="8553" />
     </Book>
     <Book Series="The X-Men" Number="21" Volume="1963" Year="1966">
-      <Id>d88433a8-5c11-4479-94d5-5833795e34a8</Id>
+      <Database Name="cv" Series="2133" Issue="8621" />
     </Book>
     <Book Series="The X-Men" Number="22" Volume="1963" Year="1966">
-      <Id>1bf16125-2fc3-4d8c-94c0-6b212e78febf</Id>
+      <Database Name="cv" Series="2133" Issue="8674" />
     </Book>
     <Book Series="The X-Men" Number="23" Volume="1963" Year="1966">
-      <Id>03c62306-65c3-404d-9c4d-68315cec05e9</Id>
+      <Database Name="cv" Series="2133" Issue="8740" />
     </Book>
     <Book Series="X-Men: First Class" Number="1" Volume="2006" Year="2006">
-      <Id>ace1d64d-1b24-4efa-a0c6-8be35c187ded</Id>
+      <Database Name="cv" Series="18550" Issue="109251" />
     </Book>
     <Book Series="X-Men: First Class" Number="2" Volume="2006" Year="2006">
-      <Id>3d327bf2-67c1-4450-bc63-d446d289fe56</Id>
+      <Database Name="cv" Series="18550" Issue="109284" />
     </Book>
     <Book Series="X-Men: First Class" Number="3" Volume="2006" Year="2007">
-      <Id>895d3568-44e1-4fc3-9004-b3562d5ea4b7</Id>
+      <Database Name="cv" Series="18550" Issue="109285" />
     </Book>
     <Book Series="X-Men: First Class" Number="4" Volume="2006" Year="2007">
-      <Id>f7c8132c-0939-4609-9378-dccadb3f3d74</Id>
+      <Database Name="cv" Series="18550" Issue="109286" />
     </Book>
     <Book Series="X-Men: First Class" Number="5" Volume="2006" Year="2007">
-      <Id>fa903ff7-2f28-4fb0-94e6-a446d1e9d95f</Id>
+      <Database Name="cv" Series="18550" Issue="109287" />
     </Book>
     <Book Series="X-Men: First Class" Number="6" Volume="2006" Year="2007">
-      <Id>3fe2e675-c8e6-4578-9c03-e87ebd694900</Id>
+      <Database Name="cv" Series="18550" Issue="109214" />
     </Book>
     <Book Series="X-Men: First Class" Number="7" Volume="2006" Year="2007">
-      <Id>595c20af-590e-4167-bbb7-231142bc894e</Id>
+      <Database Name="cv" Series="18550" Issue="109288" />
     </Book>
     <Book Series="X-Men: First Class" Number="8" Volume="2006" Year="2007">
-      <Id>3f3efe28-6815-4a81-ae92-e020265a5964</Id>
+      <Database Name="cv" Series="18550" Issue="109290" />
     </Book>
     <Book Series="X-Men: First Class" Number="1" Volume="2007" Year="2007">
-      <Id>6f01b114-61a7-4ec1-b577-205a454e97ae</Id>
+      <Database Name="cv" Series="18941" Issue="121890" />
     </Book>
     <Book Series="X-Men: First Class" Number="2" Volume="2007" Year="2007">
-      <Id>2a893a54-c75c-4668-befb-f0489d8c0c34</Id>
+      <Database Name="cv" Series="18941" Issue="112057" />
     </Book>
     <Book Series="X-Men: First Class" Number="3" Volume="2007" Year="2007">
-      <Id>c42213de-741f-4501-a6a6-42534a1d889a</Id>
+      <Database Name="cv" Series="18941" Issue="113837" />
     </Book>
     <Book Series="X-Men: First Class" Number="4" Volume="2007" Year="2007">
-      <Id>319af704-436d-4d30-80c6-ff051cbed230</Id>
+      <Database Name="cv" Series="18941" Issue="115033" />
     </Book>
     <Book Series="X-Men: First Class" Number="5" Volume="2007" Year="2007">
-      <Id>e646ef1a-47c8-4c74-a86d-83284383ee5d</Id>
+      <Database Name="cv" Series="18941" Issue="121891" />
     </Book>
     <Book Series="X-Men First Class Special" Number="1" Volume="2007" Year="2007">
-      <Id>2d3c6099-094d-4638-8b9a-7a5e9077c03b</Id>
+      <Database Name="cv" Series="18585" Issue="109606" />
     </Book>
     <Book Series="X-Men: First Class" Number="6" Volume="2007" Year="2008">
-      <Id>8fe4e3a4-d544-4bfe-861f-66e4f1df7834</Id>
+      <Database Name="cv" Series="18941" Issue="118647" />
     </Book>
     <Book Series="X-Men: First Class" Number="7" Volume="2007" Year="2008">
-      <Id>36829b57-3ae5-49f7-bdb1-be04c90778e1</Id>
+      <Database Name="cv" Series="18941" Issue="121859" />
     </Book>
     <Book Series="X-Men: First Class" Number="8" Volume="2007" Year="2008">
-      <Id>e8f1e918-beb8-49e0-b148-a1ee6f5635d8</Id>
+      <Database Name="cv" Series="18941" Issue="126173" />
     </Book>
     <Book Series="X-Men: First Class" Number="9" Volume="2007" Year="2008">
-      <Id>9c6df0b7-c864-4c3f-be4d-dfe0177c052d</Id>
+      <Database Name="cv" Series="18941" Issue="126174" />
     </Book>
     <Book Series="X-Men: First Class" Number="10" Volume="2007" Year="2008">
-      <Id>19bdbdaf-006e-4697-a9f6-bb8c6b9b9dab</Id>
+      <Database Name="cv" Series="18941" Issue="126209" />
     </Book>
     <Book Series="X-Men: First Class" Number="11" Volume="2007" Year="2008">
-      <Id>0ee0b5c8-fc5a-49b6-8baf-cff8e84f04cb</Id>
+      <Database Name="cv" Series="18941" Issue="129089" />
     </Book>
     <Book Series="X-Men: First Class" Number="12" Volume="2007" Year="2008">
-      <Id>0bd15c2a-4d7d-41b4-856a-67172f509452</Id>
+      <Database Name="cv" Series="18941" Issue="131240" />
     </Book>
     <Book Series="X-Men: First Class" Number="13" Volume="2007" Year="2008">
-      <Id>b9e391df-7649-47cf-acb2-bf29e7871697</Id>
+      <Database Name="cv" Series="18941" Issue="132041" />
     </Book>
     <Book Series="X-Men: First Class" Number="14" Volume="2007" Year="2008">
-      <Id>589fe198-cd42-467e-9a06-23c19a75fee4</Id>
+      <Database Name="cv" Series="18941" Issue="134993" />
     </Book>
     <Book Series="X-Men: First Class" Number="15" Volume="2007" Year="2008">
-      <Id>930cc68c-61e5-41a3-8479-04516673dd80</Id>
+      <Database Name="cv" Series="18941" Issue="138036" />
     </Book>
     <Book Series="X-Men: First Class" Number="16" Volume="2007" Year="2008">
-      <Id>447ba10d-4b2c-4a34-97f8-f6e118f5b713</Id>
+      <Database Name="cv" Series="18941" Issue="138995" />
     </Book>
     <Book Series="X-Men: First Class Giant-Sized Special" Number="1" Volume="2008" Year="2008">
-      <Id>9454df83-e3c3-47e0-be03-de6138c3fb68</Id>
+      <Database Name="cv" Series="23733" Issue="142059" />
     </Book>
     <Book Series="The X-Men" Number="24" Volume="1963" Year="1966">
-      <Id>9bdbaf3c-e6af-468f-8ca0-414e7d42b983</Id>
+      <Database Name="cv" Series="2133" Issue="8819" />
     </Book>
     <Book Series="The X-Men" Number="25" Volume="1963" Year="1966">
-      <Id>b29dfccd-201d-4bba-a7c5-41d53d87ff1d</Id>
+      <Database Name="cv" Series="2133" Issue="8885" />
     </Book>
     <Book Series="The X-Men" Number="26" Volume="1963" Year="1966">
-      <Id>cc84bba7-93c3-4bbe-8b84-79b0754323c1</Id>
+      <Database Name="cv" Series="2133" Issue="8951" />
     </Book>
     <Book Series="The X-Men" Number="27" Volume="1963" Year="1966">
-      <Id>6e23017c-4033-44a1-a11a-b2f2cb36c914</Id>
+      <Database Name="cv" Series="2133" Issue="9025" />
     </Book>
     <Book Series="The X-Men" Number="28" Volume="1963" Year="1967">
-      <Id>b48e05c9-b972-436b-a8fe-a3d30600dd3d</Id>
+      <Database Name="cv" Series="2133" Issue="9098" />
     </Book>
     <Book Series="The X-Men" Number="29" Volume="1963" Year="1967">
-      <Id>f34a2e4b-2413-4b8c-ad6c-9487abcc2861</Id>
+      <Database Name="cv" Series="2133" Issue="9162" />
     </Book>
     <Book Series="The X-Men" Number="30" Volume="1963" Year="1967">
-      <Id>166a20f2-6826-4068-b1c6-77d5e52d7f52</Id>
+      <Database Name="cv" Series="2133" Issue="9234" />
     </Book>
     <Book Series="The X-Men" Number="31" Volume="1963" Year="1967">
-      <Id>30d7e58e-e417-4e25-9fbf-1a2282046d1b</Id>
+      <Database Name="cv" Series="2133" Issue="9302" />
     </Book>
     <Book Series="The X-Men" Number="32" Volume="1963" Year="1967">
-      <Id>a67b4724-0f86-420f-b0ce-2940c2df4dad</Id>
+      <Database Name="cv" Series="2133" Issue="9364" />
     </Book>
     <Book Series="The X-Men" Number="33" Volume="1963" Year="1967">
-      <Id>86a8ca50-84ba-4b0c-ad10-3f4ed2e75078</Id>
+      <Database Name="cv" Series="2133" Issue="9434" />
     </Book>
     <Book Series="The X-Men" Number="34" Volume="1963" Year="1967">
-      <Id>0f2de91e-ab8e-47f1-af97-1c93c10f71d5</Id>
+      <Database Name="cv" Series="2133" Issue="9493" />
     </Book>
     <Book Series="The X-Men" Number="35" Volume="1963" Year="1967">
-      <Id>8a141527-f719-4d6d-bd6d-097e094d40ba</Id>
+      <Database Name="cv" Series="2133" Issue="9565" />
     </Book>
     <Book Series="The X-Men" Number="36" Volume="1963" Year="1967">
-      <Id>02297c72-d4a1-42b1-83eb-e9c7e7030ced</Id>
+      <Database Name="cv" Series="2133" Issue="9625" />
     </Book>
     <Book Series="The X-Men" Number="37" Volume="1963" Year="1967">
-      <Id>c4ad09e5-4550-4c42-9eb5-54f074cd5277</Id>
+      <Database Name="cv" Series="2133" Issue="9695" />
     </Book>
     <Book Series="The X-Men" Number="38" Volume="1963" Year="1967">
-      <Id>a6d6c8ca-3cb6-4602-8baf-41632f7b9b3a</Id>
+      <Database Name="cv" Series="2133" Issue="9763" />
     </Book>
     <Book Series="The X-Men" Number="39" Volume="1963" Year="1967">
-      <Id>e94ed1e4-b4b4-4542-951b-e8885fb1ec2b</Id>
+      <Database Name="cv" Series="2133" Issue="9825" />
     </Book>
     <Book Series="The X-Men" Number="40" Volume="1963" Year="1968">
-      <Id>f4bc65c5-471a-42a5-8f33-cb3fe44cab86</Id>
+      <Database Name="cv" Series="2133" Issue="9888" />
     </Book>
     <Book Series="The X-Men" Number="41" Volume="1963" Year="1968">
-      <Id>5d09f5ae-33ce-45b2-a4d8-ad28e22bc115</Id>
+      <Database Name="cv" Series="2133" Issue="9945" />
     </Book>
     <Book Series="The X-Men" Number="42" Volume="1963" Year="1968">
-      <Id>28409ad6-6f60-4e06-8634-6dcf98c2cf8f</Id>
+      <Database Name="cv" Series="2133" Issue="105594" />
     </Book>
     <Book Series="The Avengers" Number="47" Volume="1963" Year="1967">
-      <Id>ae0c7504-7769-472f-b53f-2c61cbb8bc90</Id>
+      <Database Name="cv" Series="2128" Issue="9814" />
     </Book>
     <Book Series="The Avengers" Number="48" Volume="1963" Year="1968">
-      <Id>3e846ef9-7fc9-4321-a98c-59f6f07943a5</Id>
+      <Database Name="cv" Series="2128" Issue="9877" />
     </Book>
     <Book Series="The Avengers" Number="49" Volume="1963" Year="1968">
-      <Id>06b342f4-4d6f-47ec-ae1d-3d60127399c3</Id>
+      <Database Name="cv" Series="2128" Issue="9935" />
     </Book>
     <Book Series="The X-Men" Number="43" Volume="1963" Year="1968">
-      <Id>acd5983a-42e2-44a4-94da-3382e876a77b</Id>
+      <Database Name="cv" Series="2133" Issue="114499" />
     </Book>
     <Book Series="The X-Men" Number="44" Volume="1963" Year="1968">
-      <Id>5e39f307-9ae1-48f2-8738-6cefba12a96e</Id>
+      <Database Name="cv" Series="2133" Issue="114520" />
     </Book>
     <Book Series="The X-Men" Number="45" Volume="1963" Year="1968">
-      <Id>4a7696d8-0f3d-465d-83c4-877c5329b2b8</Id>
+      <Database Name="cv" Series="2133" Issue="123659" />
     </Book>
     <Book Series="The Avengers" Number="53" Volume="1963" Year="1968">
-      <Id>119c636f-3482-40dd-bff2-805b483bd6da</Id>
+      <Database Name="cv" Series="2128" Issue="113987" />
     </Book>
     <Book Series="The X-Men" Number="46" Volume="1963" Year="1968">
-      <Id>4aa81c2e-729b-4e01-97da-f9b60f106ebc</Id>
+      <Database Name="cv" Series="2133" Issue="123671" />
     </Book>
     <Book Series="The X-Men" Number="47" Volume="1963" Year="1968">
-      <Id>170175f1-6a83-4235-ae03-63a925597c3d</Id>
+      <Database Name="cv" Series="2133" Issue="123672" />
     </Book>
     <Book Series="The X-Men" Number="48" Volume="1963" Year="1968">
-      <Id>f0f087bc-044c-43f5-9425-7975f4e1c281</Id>
+      <Database Name="cv" Series="2133" Issue="123673" />
     </Book>
     <Book Series="Ka-Zar" Number="2" Volume="1970" Year="1970">
-      <Id>db1fb3b5-f68a-47a5-bf0a-ae21c302b881</Id>
+      <Database Name="cv" Series="2475" Issue="11160" />
     </Book>
     <Book Series="Ka-Zar" Number="3" Volume="1970" Year="1971">
-      <Id>d9a105e5-74c5-4186-a4af-a671894cdc76</Id>
+      <Database Name="cv" Series="2475" Issue="11329" />
     </Book>
     <Book Series="Marvel Tales" Number="30" Volume="1966" Year="1971">
-      <Id>d130f19c-5de8-4161-bc30-bb5895510bb5</Id>
+      <Database Name="cv" Series="2293" Issue="11384" />
     </Book>
     <Book Series="The X-Men" Number="49" Volume="1963" Year="1968">
-      <Id>c924b3b5-55f3-4ca2-9de8-d64da57e2a79</Id>
+      <Database Name="cv" Series="2133" Issue="123674" />
     </Book>
     <Book Series="The X-Men" Number="50" Volume="1963" Year="1968">
-      <Id>d53c4d26-2840-48d7-b88d-5557ed531199</Id>
+      <Database Name="cv" Series="2133" Issue="114340" />
     </Book>
     <Book Series="The X-Men" Number="51" Volume="1963" Year="1968">
-      <Id>529bb3fb-d5e1-47b9-8205-50ae34bdc715</Id>
+      <Database Name="cv" Series="2133" Issue="114405" />
     </Book>
     <Book Series="The X-Men" Number="52" Volume="1963" Year="1969">
-      <Id>87e7135d-9daf-464e-af7b-f18241e00803</Id>
+      <Database Name="cv" Series="2133" Issue="10002" />
     </Book>
     <Book Series="The X-Men" Number="53" Volume="1963" Year="1969">
-      <Id>a8561e7b-7285-4ad4-93cc-d47cf295698c</Id>
+      <Database Name="cv" Series="2133" Issue="10056" />
     </Book>
     <Book Series="The X-Men" Number="54" Volume="1963" Year="1969">
-      <Id>b8364f8d-99c5-48e7-b857-15c75eb64598</Id>
+      <Database Name="cv" Series="2133" Issue="10107" />
     </Book>
     <Book Series="The X-Men" Number="55" Volume="1963" Year="1969">
-      <Id>bb44e7d7-334c-4877-9b1e-936d85d61020</Id>
+      <Database Name="cv" Series="2133" Issue="10163" />
     </Book>
     <Book Series="The X-Men" Number="56" Volume="1963" Year="1969">
-      <Id>bcf9a4d2-31a2-4825-a216-126d46999ab2</Id>
+      <Database Name="cv" Series="2133" Issue="10215" />
     </Book>
     <Book Series="The X-Men" Number="57" Volume="1963" Year="1969">
-      <Id>96fe77e8-babc-45f1-9a35-4439bd966151</Id>
+      <Database Name="cv" Series="2133" Issue="10270" />
     </Book>
     <Book Series="The X-Men" Number="58" Volume="1963" Year="1969">
-      <Id>8c0a9d39-7e0d-483b-be62-d5260b16a4b1</Id>
+      <Database Name="cv" Series="2133" Issue="10317" />
     </Book>
     <Book Series="The X-Men" Number="59" Volume="1963" Year="1969">
-      <Id>37fd21c6-21e5-4c12-be94-9454f0246145</Id>
+      <Database Name="cv" Series="2133" Issue="10366" />
     </Book>
     <Book Series="The X-Men" Number="60" Volume="1963" Year="1969">
-      <Id>59ce3899-64da-49b3-a9cd-2e8d7cbb960d</Id>
+      <Database Name="cv" Series="2133" Issue="10417" />
     </Book>
     <Book Series="The X-Men" Number="61" Volume="1963" Year="1969">
-      <Id>5e357aeb-95bd-48e8-85eb-1d86722cb045</Id>
+      <Database Name="cv" Series="2133" Issue="10475" />
     </Book>
     <Book Series="The X-Men" Number="62" Volume="1963" Year="1969">
-      <Id>89078578-4236-41c6-ba31-b4f0c0c01920</Id>
+      <Database Name="cv" Series="2133" Issue="10526" />
     </Book>
     <Book Series="The X-Men" Number="63" Volume="1963" Year="1969">
-      <Id>0a91c60b-4d7f-4a8a-9315-da3ba48498f2</Id>
+      <Database Name="cv" Series="2133" Issue="10580" />
     </Book>
     <Book Series="The X-Men" Number="64" Volume="1963" Year="1970">
-      <Id>ed6f2b75-48fe-4242-ad19-0755d5e16b61</Id>
+      <Database Name="cv" Series="2133" Issue="10635" />
     </Book>
     <Book Series="The X-Men" Number="65" Volume="1963" Year="1970">
-      <Id>3b96f9c9-48ca-4e00-82ec-951ac2903f3d</Id>
+      <Database Name="cv" Series="2133" Issue="10676" />
     </Book>
     <Book Series="The X-Men" Number="66" Volume="1963" Year="1970">
-      <Id>cea91505-1b12-4bf9-b355-2b05ee548e3b</Id>
+      <Database Name="cv" Series="2133" Issue="10724" />
     </Book>
     <Book Series="X-Men: The Hidden Years" Number="1" Volume="1999" Year="1999">
-      <Id>9fbfb5fa-d77b-474f-b430-a7d6a3d55e40</Id>
+      <Database Name="cv" Series="9202" Issue="124309" />
     </Book>
     <Book Series="X-Men: The Hidden Years" Number="2" Volume="1999" Year="2000">
-      <Id>903e29ba-1e5c-44ed-bceb-7bd954e9061f</Id>
+      <Database Name="cv" Series="9202" Issue="70469" />
     </Book>
     <Book Series="X-Men: The Hidden Years" Number="3" Volume="1999" Year="2000">
-      <Id>5a9249bf-9a49-42cd-b93d-4ffc54df1e02</Id>
+      <Database Name="cv" Series="9202" Issue="70470" />
     </Book>
     <Book Series="X-Men: The Hidden Years" Number="4" Volume="1999" Year="2000">
-      <Id>15a45ab0-ec82-4dd0-8a17-c8f4755755ad</Id>
+      <Database Name="cv" Series="9202" Issue="70471" />
     </Book>
     <Book Series="X-Men: The Hidden Years" Number="5" Volume="1999" Year="2000">
-      <Id>9d47eaed-9b09-4d04-bb2a-f154a9b4bf43</Id>
+      <Database Name="cv" Series="9202" Issue="70472" />
     </Book>
     <Book Series="X-Men: The Hidden Years" Number="6" Volume="1999" Year="2000">
-      <Id>fcadf9c7-c7e7-427d-8881-c26f1aff845f</Id>
+      <Database Name="cv" Series="9202" Issue="70473" />
     </Book>
     <Book Series="X-Men: The Hidden Years" Number="7" Volume="1999" Year="2000">
-      <Id>7ee2f766-a50c-43c7-99fa-0bae942629f8</Id>
+      <Database Name="cv" Series="9202" Issue="70474" />
     </Book>
     <Book Series="X-Men: The Hidden Years" Number="8" Volume="1999" Year="2000">
-      <Id>5bcd5b85-b8ea-4a4a-8022-ed519089b9bf</Id>
+      <Database Name="cv" Series="9202" Issue="70475" />
     </Book>
     <Book Series="X-Men: The Hidden Years" Number="9" Volume="1999" Year="2000">
-      <Id>c198e074-056e-450f-a3ec-8ec6c568dfe5</Id>
+      <Database Name="cv" Series="9202" Issue="70476" />
     </Book>
     <Book Series="X-Men: The Hidden Years" Number="10" Volume="1999" Year="2000">
-      <Id>8fde4c42-507b-43ca-aeb7-3c90d6db298e</Id>
+      <Database Name="cv" Series="9202" Issue="70477" />
     </Book>
     <Book Series="X-Men: The Hidden Years" Number="11" Volume="1999" Year="2000">
-      <Id>4096692e-834f-4bf0-ac2b-0a6bc51bf58e</Id>
+      <Database Name="cv" Series="9202" Issue="70478" />
     </Book>
     <Book Series="X-Men: The Hidden Years" Number="12" Volume="1999" Year="2000">
-      <Id>e55734e6-e721-4447-a4a5-e6c14e1e0f36</Id>
+      <Database Name="cv" Series="9202" Issue="124311" />
     </Book>
     <Book Series="X-Men: The Hidden Years" Number="13" Volume="1999" Year="2000">
-      <Id>0c779ea0-f1b7-4f9e-9ce4-4e51d820c5e7</Id>
+      <Database Name="cv" Series="9202" Issue="124313" />
     </Book>
     <Book Series="X-Men: The Hidden Years" Number="14" Volume="1999" Year="2001">
-      <Id>79c49eb5-411b-4f1d-8531-7ffd2db5500d</Id>
+      <Database Name="cv" Series="9202" Issue="124315" />
     </Book>
     <Book Series="X-Men: The Hidden Years" Number="15" Volume="1999" Year="2001">
-      <Id>515d1676-8962-418d-94b1-c4dca8151c18</Id>
+      <Database Name="cv" Series="9202" Issue="120844" />
     </Book>
     <Book Series="X-Men: The Hidden Years" Number="16" Volume="1999" Year="2001">
-      <Id>01a6116b-b6aa-45f4-878a-6f0440a7e00a</Id>
+      <Database Name="cv" Series="9202" Issue="124316" />
     </Book>
     <Book Series="X-Men: The Hidden Years" Number="17" Volume="1999" Year="2001">
-      <Id>d95010d1-c041-4f4e-954c-b68b88b40036</Id>
+      <Database Name="cv" Series="9202" Issue="124317" />
     </Book>
     <Book Series="X-Men: The Hidden Years" Number="18" Volume="1999" Year="2001">
-      <Id>16306685-4e6b-4d16-978c-cb294f8e97f5</Id>
+      <Database Name="cv" Series="9202" Issue="124320" />
     </Book>
     <Book Series="X-Men: The Hidden Years" Number="19" Volume="1999" Year="2001">
-      <Id>42d739af-203c-4400-b251-0cc0d9f9f469</Id>
+      <Database Name="cv" Series="9202" Issue="124326" />
     </Book>
     <Book Series="X-Men: The Hidden Years" Number="20" Volume="1999" Year="2001">
-      <Id>51bab489-6006-49b3-9b73-27810afc4e5e</Id>
+      <Database Name="cv" Series="9202" Issue="124321" />
     </Book>
     <Book Series="X-Men: The Hidden Years" Number="21" Volume="1999" Year="2001">
-      <Id>70d72f7f-97d8-4444-93d7-ac92118bbb88</Id>
+      <Database Name="cv" Series="9202" Issue="124319" />
     </Book>
     <Book Series="X-Men: The Hidden Years" Number="22" Volume="1999" Year="2001">
-      <Id>3197c5e4-8727-4f98-b1a9-c68b571b5d96</Id>
+      <Database Name="cv" Series="9202" Issue="70489" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="92" Volume="1963" Year="1971">
-      <Id>38aae8c3-2f41-44c2-8fd9-3a061f69f0c0</Id>
+      <Database Name="cv" Series="2127" Issue="11214" />
     </Book>
     <Book Series="The Incredible Hulk" Number="150" Volume="1968" Year="1972">
-      <Id>52ae7dea-8895-4717-859d-ed57f90aca0f</Id>
+      <Database Name="cv" Series="2406" Issue="12123" />
     </Book>
     <Book Series="Marvel Team-Up" Number="4" Volume="1972" Year="1972">
-      <Id>af10b63a-d907-428f-b1be-bbab73cc97d3</Id>
+      <Database Name="cv" Series="2576" Issue="12489" />
     </Book>
     <Book Series="Amazing Adventures" Number="11" Volume="1970" Year="1972">
-      <Id>7b2bae25-64e7-48c1-8bd2-c6ed3b20f519</Id>
+      <Database Name="cv" Series="2469" Issue="12046" />
     </Book>
     <Book Series="Amazing Adventures" Number="12" Volume="1970" Year="1972">
-      <Id>9aec7a5c-6554-4944-9b34-224aa73c3e95</Id>
+      <Database Name="cv" Series="2469" Issue="12181" />
     </Book>
     <Book Series="Amazing Adventures" Number="13" Volume="1970" Year="1972">
-      <Id>570f4845-0a0a-47e1-a8ad-e31cffdd35a9</Id>
+      <Database Name="cv" Series="2469" Issue="12331" />
     </Book>
     <Book Series="Amazing Adventures" Number="14" Volume="1970" Year="1972">
-      <Id>4458af1c-2c64-4e9c-ad82-c92eaa35ab80</Id>
+      <Database Name="cv" Series="2469" Issue="12472" />
     </Book>
     <Book Series="Amazing Adventures" Number="15" Volume="1970" Year="1972">
-      <Id>eb7e8c2a-ffb2-4e52-b0b6-66912f5791fb</Id>
+      <Database Name="cv" Series="2469" Issue="12639" />
     </Book>
     <Book Series="Amazing Adventures" Number="16" Volume="1970" Year="1973">
-      <Id>28270061-5777-4740-a8c9-832ff40a64dc</Id>
+      <Database Name="cv" Series="2469" Issue="12821" />
     </Book>
     <Book Series="The Incredible Hulk" Number="161" Volume="1968" Year="1973">
-      <Id>b188df38-2275-4309-a3cc-4b8efde11106</Id>
+      <Database Name="cv" Series="2406" Issue="13010" />
     </Book>
     <Book Series="Amazing Adventures" Number="17" Volume="1970" Year="1973">
-      <Id>2c1ab82f-c266-4a1e-b577-9ee1a1ebbaad</Id>
+      <Database Name="cv" Series="2469" Issue="12998" />
     </Book>
     <Book Series="The Avengers" Number="110" Volume="1963" Year="1973">
-      <Id>6b47978f-04cd-4017-9622-4ac98bbc050c</Id>
+      <Database Name="cv" Series="2128" Issue="13098" />
     </Book>
     <Book Series="The Avengers" Number="111" Volume="1963" Year="1973">
-      <Id>899e66f4-0334-4fdc-ae5c-22bc890573b6</Id>
+      <Database Name="cv" Series="2128" Issue="13170" />
     </Book>
     <Book Series="The Incredible Hulk" Number="172" Volume="1968" Year="1974">
-      <Id>12e5801b-3710-4467-8c78-2976a34d2eb0</Id>
+      <Database Name="cv" Series="2406" Issue="14059" />
     </Book>
     <Book Series="Captain America" Number="172" Volume="1968" Year="1974">
-      <Id>89fe30fc-0395-4c97-bbad-a5a568aceaf0</Id>
+      <Database Name="cv" Series="2400" Issue="14190" />
     </Book>
     <Book Series="Captain America" Number="173" Volume="1968" Year="1974">
-      <Id>9083b981-d674-4da8-b57c-61ccc8060690</Id>
+      <Database Name="cv" Series="2400" Issue="14256" />
     </Book>
     <Book Series="Captain America" Number="174" Volume="1968" Year="1974">
-      <Id>6a189d49-747e-416d-b486-eec941fc1d00</Id>
+      <Database Name="cv" Series="2400" Issue="14330" />
     </Book>
     <Book Series="Captain America" Number="175" Volume="1968" Year="1974">
-      <Id>a4b69196-8689-41e8-80ab-3067724d7d6a</Id>
+      <Database Name="cv" Series="2400" Issue="14409" />
     </Book>
     <Book Series="Marvel Team-Up" Number="23" Volume="1972" Year="1974">
-      <Id>089af553-68dc-41e4-8bbe-c4d5f03db97e</Id>
+      <Database Name="cv" Series="2576" Issue="14432" />
     </Book>
     <Book Series="The Defenders" Number="15" Volume="1972" Year="1974">
-      <Id>cdfb5735-d001-4918-ac00-8c8703e483f7</Id>
+      <Database Name="cv" Series="2569" Issue="112435" />
     </Book>
     <Book Series="The Defenders" Number="16" Volume="1972" Year="1974">
-      <Id>a68d7bad-38a7-4449-9fa4-82328cd762c8</Id>
+      <Database Name="cv" Series="2569" Issue="14659" />
     </Book>
     <Book Series="The Incredible Hulk" Number="180" Volume="1968" Year="1974">
-      <Id>d2096154-9573-42ae-8894-dcea6796bc02</Id>
+      <Database Name="cv" Series="2406" Issue="14667" />
     </Book>
     <Book Series="The Incredible Hulk" Number="181" Volume="1968" Year="1974">
-      <Id>2644162f-35dc-4fd1-95a7-9f2ba9284b2f</Id>
+      <Database Name="cv" Series="2406" Issue="14760" />
     </Book>
     <Book Series="The Incredible Hulk" Number="182" Volume="1968" Year="1974">
-      <Id>daebbed4-aeba-485b-ae56-f2c9f56da8df</Id>
+      <Database Name="cv" Series="2406" Issue="14841" />
     </Book>
     <Book Series="Marvel Team-Up" Number="38" Volume="1972" Year="1975">
-      <Id>4979b850-f3da-4c03-b818-f1b3969c506b</Id>
+      <Database Name="cv" Series="2576" Issue="15694" />
     </Book>
     <Book Series="X-Men: First Class Finals" Number="1" Volume="2009" Year="2009">
-      <Id>31787260-577e-49d1-a3e4-0f31150bb1f0</Id>
+      <Database Name="cv" Series="25669" Issue="151276" />
     </Book>
     <Book Series="X-Men: First Class Finals" Number="2" Volume="2009" Year="2009">
-      <Id>42141af0-75e5-46f0-ac31-11147e4549d5</Id>
+      <Database Name="cv" Series="25669" Issue="153877" />
     </Book>
     <Book Series="X-Men: First Class Finals" Number="3" Volume="2009" Year="2009">
-      <Id>9cbc5fa4-6caa-4610-8ee7-6e367138c38e</Id>
+      <Database Name="cv" Series="25669" Issue="154464" />
     </Book>
     <Book Series="X-Men: First Class Finals" Number="4" Volume="2009" Year="2009">
-      <Id>5d40ae3e-7fa7-485e-90ea-9bfc13954fe5</Id>
+      <Database Name="cv" Series="25669" Issue="156642" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 002 (New X-Men).cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 002 (New X-Men).cbl
@@ -1,948 +1,949 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>X-Men - Part 2 (New X-Men)</Name>
+  <Name>X-Men - Part 002 (New X-Men)</Name>
+  <NumIssues>314</NumIssues>
   <Books>
     <Book Series="Giant-Size X-Men" Number="1" Volume="1975" Year="1975">
-      <Id>9dfa58f2-a203-4639-ba6f-86b3378e15fc</Id>
+      <Database Name="cv" Series="2763" Issue="14890" />
     </Book>
     <Book Series="The X-Men" Number="94" Volume="1963" Year="1975">
-      <Id>856ded5d-d0c9-412b-803e-ca18fbe4ec77</Id>
+      <Database Name="cv" Series="2133" Issue="15508" />
     </Book>
     <Book Series="The X-Men" Number="95" Volume="1963" Year="1975">
-      <Id>7c3e2846-f48b-404f-a0fb-3f10e78b7e6d</Id>
+      <Database Name="cv" Series="2133" Issue="15711" />
     </Book>
     <Book Series="The X-Men" Number="96" Volume="1963" Year="1975">
-      <Id>369f686e-35c0-4a11-a4ed-18ff1a678f19</Id>
+      <Database Name="cv" Series="2133" Issue="15889" />
     </Book>
     <Book Series="The X-Men" Number="97" Volume="1963" Year="1976">
-      <Id>d35d4074-9c1b-4259-8038-c42ec2a79518</Id>
+      <Database Name="cv" Series="2133" Issue="16100" />
     </Book>
     <Book Series="The X-Men" Number="98" Volume="1963" Year="1976">
-      <Id>0b4b836e-908c-4fb8-aecd-6746cc78e141</Id>
+      <Database Name="cv" Series="2133" Issue="16278" />
     </Book>
     <Book Series="The X-Men" Number="99" Volume="1963" Year="1976">
-      <Id>8e086810-d2f1-4d56-9f14-dc6f8d6a8940</Id>
+      <Database Name="cv" Series="2133" Issue="16440" />
     </Book>
     <Book Series="The X-Men" Number="100" Volume="1963" Year="1976">
-      <Id>546a811a-b360-41b1-bd9b-481a8811261c</Id>
+      <Database Name="cv" Series="2133" Issue="16618" />
     </Book>
     <Book Series="The X-Men" Number="101" Volume="1963" Year="1976">
-      <Id>c2ff5c1b-a642-4be4-bef7-4b710e3fa7cd</Id>
+      <Database Name="cv" Series="2133" Issue="16800" />
     </Book>
     <Book Series="The X-Men" Number="102" Volume="1963" Year="1976">
-      <Id>bede9f8c-3d22-4495-9c6a-ac6e9cc9c8e6</Id>
+      <Database Name="cv" Series="2133" Issue="16981" />
     </Book>
     <Book Series="The X-Men" Number="103" Volume="1963" Year="1977">
-      <Id>eec93d96-dbec-4c9e-86c4-f4192f41ce36</Id>
+      <Database Name="cv" Series="2133" Issue="17209" />
     </Book>
     <Book Series="The X-Men" Number="104" Volume="1963" Year="1977">
-      <Id>1f97361c-3f1b-4064-9fe4-a63daa414d23</Id>
+      <Database Name="cv" Series="2133" Issue="17371" />
     </Book>
     <Book Series="The X-Men" Number="105" Volume="1963" Year="1977">
-      <Id>403586ae-89b5-48ae-9c83-6f04a8267928</Id>
+      <Database Name="cv" Series="2133" Issue="17526" />
     </Book>
     <Book Series="The X-Men" Number="106" Volume="1963" Year="1977">
-      <Id>89b1cb17-d447-42fd-884b-cdb8ab7adc1e</Id>
+      <Database Name="cv" Series="2133" Issue="17708" />
     </Book>
     <Book Series="The X-Men" Number="107" Volume="1963" Year="1977">
-      <Id>1cd9eac5-5a9c-4aed-9e85-c43c35d47d12</Id>
+      <Database Name="cv" Series="2133" Issue="17894" />
     </Book>
     <Book Series="The X-Men" Number="108" Volume="1963" Year="1977">
-      <Id>e1813269-b69a-4fac-b717-8c5dea792062</Id>
+      <Database Name="cv" Series="2133" Issue="18064" />
     </Book>
     <Book Series="The X-Men" Number="109" Volume="1963" Year="1978">
-      <Id>90c2187b-d4d7-4f30-9838-ddbaada45d1b</Id>
+      <Database Name="cv" Series="2133" Issue="18267" />
     </Book>
     <Book Series="The X-Men" Number="110" Volume="1963" Year="1978">
-      <Id>5111e542-09bc-46fa-937a-d29f60ea6a32</Id>
+      <Database Name="cv" Series="2133" Issue="18435" />
     </Book>
     <Book Series="Uncanny X-Men: First Class" Number="1" Volume="2009" Year="2009">
-      <Id>89671bf3-551c-43da-85c0-686aa4219131</Id>
+      <Database Name="cv" Series="27037" Issue="163641" />
     </Book>
     <Book Series="Uncanny X-Men: First Class" Number="2" Volume="2009" Year="2009">
-      <Id>69052b4b-82a1-4f52-bfcd-8f22b6671ed6</Id>
+      <Database Name="cv" Series="27037" Issue="166810" />
     </Book>
     <Book Series="Uncanny X-Men: First Class" Number="3" Volume="2009" Year="2009">
-      <Id>75129674-c0c1-4d82-b659-0561fc228993</Id>
+      <Database Name="cv" Series="27037" Issue="171556" />
     </Book>
     <Book Series="Uncanny X-Men: First Class" Number="4" Volume="2009" Year="2009">
-      <Id>3db2ecb3-947c-4057-9cb2-bcead6ec8eab</Id>
+      <Database Name="cv" Series="27037" Issue="176137" />
     </Book>
     <Book Series="Uncanny X-Men: First Class" Number="5" Volume="2009" Year="2010">
-      <Id>a29596c4-6b9d-4bb0-9405-b757072d6f47</Id>
+      <Database Name="cv" Series="27037" Issue="182998" />
     </Book>
     <Book Series="Uncanny X-Men: First Class" Number="6" Volume="2009" Year="2010">
-      <Id>0410f4d2-9bb8-48a5-97db-1800de476967</Id>
+      <Database Name="cv" Series="27037" Issue="186932" />
     </Book>
     <Book Series="Uncanny X-Men: First Class" Number="7" Volume="2009" Year="2010">
-      <Id>90a912b2-c484-4042-a765-320e3cad1c7e</Id>
+      <Database Name="cv" Series="27037" Issue="192764" />
     </Book>
     <Book Series="Uncanny X-Men: First Class" Number="8" Volume="2009" Year="2010">
-      <Id>f3841f64-3239-46f8-88f9-f06bc8fc37e5</Id>
+      <Database Name="cv" Series="27037" Issue="196856" />
     </Book>
     <Book Series="The X-Men" Number="111" Volume="1963" Year="1978">
-      <Id>3f9cf222-455c-42cd-91eb-3e6086526e83</Id>
+      <Database Name="cv" Series="2133" Issue="18598" />
     </Book>
     <Book Series="The X-Men" Number="112" Volume="1963" Year="1978">
-      <Id>98360a75-4d4c-4824-88f2-4b2d9e58a997</Id>
+      <Database Name="cv" Series="2133" Issue="18757" />
     </Book>
     <Book Series="The X-Men" Number="113" Volume="1963" Year="1978">
-      <Id>0e9cb546-1482-4fb9-8791-70f8bb26e0f2</Id>
+      <Database Name="cv" Series="2133" Issue="18837" />
     </Book>
     <Book Series="The X-Men" Number="114" Volume="1963" Year="1978">
-      <Id>d3d77c77-cbeb-40d1-abe4-f0ed659b6b44</Id>
+      <Database Name="cv" Series="2133" Issue="18916" />
     </Book>
     <Book Series="The X-Men" Number="115" Volume="1963" Year="1978">
-      <Id>5db497e8-6de8-456c-9a5f-3b09a96b3961</Id>
+      <Database Name="cv" Series="2133" Issue="18985" />
     </Book>
     <Book Series="The X-Men" Number="116" Volume="1963" Year="1978">
-      <Id>d427c6c9-0e19-41d6-a420-9a8d41e52670</Id>
+      <Database Name="cv" Series="2133" Issue="19060" />
     </Book>
     <Book Series="The X-Men" Number="117" Volume="1963" Year="1979">
-      <Id>53d7e0fe-daf3-4ece-bc24-48666576ca10</Id>
+      <Database Name="cv" Series="2133" Issue="19210" />
     </Book>
     <Book Series="The X-Men" Number="118" Volume="1963" Year="1979">
-      <Id>c22c3a64-36c6-419f-a532-0bc291c138ea</Id>
+      <Database Name="cv" Series="2133" Issue="19317" />
     </Book>
     <Book Series="The X-Men" Number="119" Volume="1963" Year="1979">
-      <Id>a4ca27ae-9958-4a5b-9891-1423afb05c33</Id>
+      <Database Name="cv" Series="2133" Issue="19386" />
     </Book>
     <Book Series="The X-Men" Number="120" Volume="1963" Year="1979">
-      <Id>3d1a375f-0e6f-493d-9482-492d13e72c67</Id>
+      <Database Name="cv" Series="2133" Issue="19455" />
     </Book>
     <Book Series="The X-Men" Number="121" Volume="1963" Year="1979">
-      <Id>248ed0fd-7e4e-4e1f-ae28-7fe4e5fcbc24</Id>
+      <Database Name="cv" Series="2133" Issue="19525" />
     </Book>
     <Book Series="The X-Men" Number="122" Volume="1963" Year="1979">
-      <Id>098eb824-cba0-4e03-a56a-a07972b57144</Id>
+      <Database Name="cv" Series="2133" Issue="19592" />
     </Book>
     <Book Series="The X-Men" Number="123" Volume="1963" Year="1979">
-      <Id>2177c9f5-b22c-4420-85db-042775d9ce2f</Id>
+      <Database Name="cv" Series="2133" Issue="123628" />
     </Book>
     <Book Series="The X-Men" Number="124" Volume="1963" Year="1979">
-      <Id>fcb2db82-9747-49cd-897c-cf88edb4dc47</Id>
+      <Database Name="cv" Series="2133" Issue="19726" />
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="3" Volume="1982" Year="1979">
-      <Id>3e40cf38-4f6c-4106-af0e-0fd24cc7ba9a</Id>
+    <Book Series="X-Men Annual" Number="3" Volume="1970" Year="1979">
+      <Database Name="cv" Series="22988" Issue="138857" />
     </Book>
     <Book Series="The X-Men" Number="125" Volume="1963" Year="1979">
-      <Id>8190cb33-1ccd-4a66-8cb9-ae33a2df4be7</Id>
+      <Database Name="cv" Series="2133" Issue="19794" />
     </Book>
     <Book Series="The X-Men" Number="126" Volume="1963" Year="1979">
-      <Id>979dc202-a0df-433e-a56b-34fd0b0da9df</Id>
+      <Database Name="cv" Series="2133" Issue="19865" />
     </Book>
     <Book Series="The X-Men" Number="127" Volume="1963" Year="1979">
-      <Id>40b6d305-9115-4367-8db9-69b856b10c30</Id>
+      <Database Name="cv" Series="2133" Issue="19934" />
     </Book>
     <Book Series="The X-Men" Number="128" Volume="1963" Year="1979">
-      <Id>cda0552b-243b-4790-ac3a-116eca8bbd43</Id>
+      <Database Name="cv" Series="2133" Issue="20006" />
     </Book>
     <Book Series="The X-Men" Number="129" Volume="1963" Year="1980">
-      <Id>cdffd778-1dee-4921-be00-cadb4e85a6e9</Id>
+      <Database Name="cv" Series="2133" Issue="20114" />
     </Book>
     <Book Series="The X-Men" Number="130" Volume="1963" Year="1980">
-      <Id>5a7a7acc-400a-4bb0-af9c-fbb06e544656</Id>
+      <Database Name="cv" Series="2133" Issue="20186" />
     </Book>
     <Book Series="The X-Men" Number="131" Volume="1963" Year="1980">
-      <Id>d95862fc-05d4-428a-8628-93c2758321f8</Id>
+      <Database Name="cv" Series="2133" Issue="20258" />
     </Book>
     <Book Series="The X-Men" Number="132" Volume="1963" Year="1980">
-      <Id>b70fb928-b553-4b7d-b07e-7353d71d7541</Id>
+      <Database Name="cv" Series="2133" Issue="20333" />
     </Book>
     <Book Series="The X-Men" Number="133" Volume="1963" Year="1980">
-      <Id>6382a00d-b89a-41e9-b9f6-a5da02a42c05</Id>
+      <Database Name="cv" Series="2133" Issue="20403" />
     </Book>
     <Book Series="The X-Men" Number="134" Volume="1963" Year="1980">
-      <Id>d4a0c68d-7d0d-4fc6-900f-d4e7197a28f7</Id>
+      <Database Name="cv" Series="2133" Issue="20477" />
     </Book>
     <Book Series="The X-Men" Number="135" Volume="1963" Year="1980">
-      <Id>f41219ee-16c1-4005-a9dd-2f9cd552303b</Id>
+      <Database Name="cv" Series="2133" Issue="20546" />
     </Book>
     <Book Series="The X-Men" Number="136" Volume="1963" Year="1980">
-      <Id>baf1e509-1eb9-4cce-b243-a570b2eacb59</Id>
+      <Database Name="cv" Series="2133" Issue="20613" />
     </Book>
     <Book Series="The X-Men" Number="137" Volume="1963" Year="1980">
-      <Id>faf67fc4-6721-498d-841e-13ebbf6be536</Id>
+      <Database Name="cv" Series="2133" Issue="20681" />
     </Book>
     <Book Series="The X-Men" Number="138" Volume="1963" Year="1980">
-      <Id>7c41b0bc-8fb2-4a99-bebc-1fec9374382b</Id>
+      <Database Name="cv" Series="2133" Issue="20751" />
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="4" Volume="1982" Year="1980">
-      <Id>38168df4-1fcd-462b-81d8-1f9b770557e3</Id>
+    <Book Series="X-Men Annual" Number="4" Volume="1970" Year="1980">
+      <Database Name="cv" Series="22988" Issue="136137" />
     </Book>
     <Book Series="The X-Men" Number="139" Volume="1963" Year="1980">
-      <Id>6a3b363e-4635-49c0-bcc6-86024a6d76d0</Id>
+      <Database Name="cv" Series="2133" Issue="20812" />
     </Book>
     <Book Series="The X-Men" Number="140" Volume="1963" Year="1980">
-      <Id>9b409ab7-44c3-4285-8f58-eed190e08418</Id>
+      <Database Name="cv" Series="2133" Issue="20884" />
     </Book>
     <Book Series="The X-Men" Number="141" Volume="1963" Year="1981">
-      <Id>3ba55d27-b36a-418b-bac5-d793bb4f45c2</Id>
+      <Database Name="cv" Series="2133" Issue="20988" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="142" Volume="1981" Year="1981">
-      <Id>74b01b51-40b7-4eb3-8193-86fac8ada469</Id>
+      <Database Name="cv" Series="3092" Issue="21057" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="143" Volume="1981" Year="1981">
-      <Id>987b7d9f-9732-426f-8415-a304dd7be77c</Id>
+      <Database Name="cv" Series="3092" Issue="21127" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="144" Volume="1981" Year="1981">
-      <Id>8b139b7d-29fc-472e-b31f-01f5a9c38186</Id>
+      <Database Name="cv" Series="3092" Issue="107059" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="145" Volume="1981" Year="1981">
-      <Id>6ed83e4d-96c7-49f1-a5bf-db3e491dfe6c</Id>
+      <Database Name="cv" Series="3092" Issue="21258" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="146" Volume="1981" Year="1981">
-      <Id>7df126d5-02f7-4091-ac21-810b59c231e9</Id>
+      <Database Name="cv" Series="3092" Issue="21320" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="147" Volume="1981" Year="1981">
-      <Id>1e43624d-80b3-4dc0-a05e-6865e1b1c0b9</Id>
+      <Database Name="cv" Series="3092" Issue="21392" />
     </Book>
     <Book Series="Spider-Woman" Number="37" Volume="1978" Year="1981">
-      <Id>e54dab93-c568-43f6-a4ed-ee5f610d2491</Id>
+      <Database Name="cv" Series="2960" Issue="21193" />
     </Book>
     <Book Series="Spider-Woman" Number="38" Volume="1978" Year="1981">
-      <Id>c9743747-f5c2-4791-9c17-c1bdce781875</Id>
+      <Database Name="cv" Series="2960" Issue="21316" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="148" Volume="1981" Year="1981">
-      <Id>a00e8d5f-3db8-4eb8-a263-f37bc8caa6dd</Id>
+      <Database Name="cv" Series="3092" Issue="21461" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="149" Volume="1981" Year="1981">
-      <Id>ba96d22a-3d7d-47a7-9f1b-887cc05b54f7</Id>
+      <Database Name="cv" Series="3092" Issue="21531" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="150" Volume="1981" Year="1981">
-      <Id>594d6801-df46-4285-aa89-56bf91bd809b</Id>
+      <Database Name="cv" Series="3092" Issue="21614" />
     </Book>
     <Book Series="The Avengers Annual" Number="10" Volume="1967" Year="1981">
-      <Id>73e646a5-43a9-41b7-b246-7548d1473d92</Id>
+      <Database Name="cv" Series="2350" Issue="20918" />
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="5" Volume="1982" Year="1981">
-      <Id>b32fdfd9-b4ad-493e-bfec-4a9c41531d15</Id>
+    <Book Series="X-Men Annual" Number="5" Volume="1970" Year="1981">
+      <Database Name="cv" Series="22988" Issue="138854" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="151" Volume="1981" Year="1981">
-      <Id>6665acb1-7230-4229-b0a0-23d8b5d3b490</Id>
+      <Database Name="cv" Series="3092" Issue="21679" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="152" Volume="1981" Year="1981">
-      <Id>77a0d314-be8a-4e25-bc3a-21e68fde37ac</Id>
+      <Database Name="cv" Series="3092" Issue="21752" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="153" Volume="1981" Year="1982">
-      <Id>766ac5f5-67c0-47e0-adbe-4c8d7f674c19</Id>
+      <Database Name="cv" Series="3092" Issue="21875" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="154" Volume="1981" Year="1982">
-      <Id>80bb6b7f-79e3-4d9b-a8a9-9e59e97e5a7d</Id>
+      <Database Name="cv" Series="3092" Issue="21952" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="155" Volume="1981" Year="1982">
-      <Id>1e104096-410e-4fc7-ad5d-ccdc41d8154a</Id>
+      <Database Name="cv" Series="3092" Issue="22027" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="156" Volume="1981" Year="1982">
-      <Id>bc0ad44d-7c2b-4448-adb9-1dbad3dff745</Id>
+      <Database Name="cv" Series="3092" Issue="22100" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="157" Volume="1981" Year="1982">
-      <Id>28de84ac-0e01-4430-aa53-bd7bba8687c8</Id>
+      <Database Name="cv" Series="3092" Issue="22179" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="158" Volume="1981" Year="1982">
-      <Id>813ed328-f83c-4a74-aa75-a7665f2c0c3b</Id>
+      <Database Name="cv" Series="3092" Issue="22248" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="159" Volume="1981" Year="1982">
-      <Id>68f68c89-60d9-43d4-81f2-11e20036b272</Id>
+      <Database Name="cv" Series="3092" Issue="22318" />
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="6" Volume="1982" Year="1982">
-      <Id>de97eb55-3292-4cd8-bae3-fe0b117c883d</Id>
+    <Book Series="X-Men Annual" Number="6" Volume="1970" Year="1982">
+      <Database Name="cv" Series="22988" Issue="135753" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="160" Volume="1981" Year="1982">
-      <Id>6b2b0dee-4899-4a9f-972e-8e49baa132af</Id>
+      <Database Name="cv" Series="3092" Issue="22393" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="161" Volume="1981" Year="1982">
-      <Id>9c038486-707d-4eeb-95e4-a8f37d1a05f5</Id>
+      <Database Name="cv" Series="3092" Issue="22462" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="162" Volume="1981" Year="1982">
-      <Id>317c764f-e444-4928-b6ca-82fd754c5d61</Id>
+      <Database Name="cv" Series="3092" Issue="22537" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="163" Volume="1981" Year="1982">
-      <Id>8d415cf0-68e4-4491-ae0b-5cbda16cb2e7</Id>
+      <Database Name="cv" Series="3092" Issue="22611" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="164" Volume="1981" Year="1982">
-      <Id>413e8400-c470-4d12-ac1e-99b904b0a877</Id>
+      <Database Name="cv" Series="3092" Issue="22687" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="165" Volume="1981" Year="1983">
-      <Id>903ebd0c-b8c6-4aef-832c-291ab0671596</Id>
+      <Database Name="cv" Series="3092" Issue="22808" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="166" Volume="1981" Year="1983">
-      <Id>0241089d-8f73-4af7-aeb1-23905e2662d9</Id>
+      <Database Name="cv" Series="3092" Issue="22882" />
     </Book>
     <Book Series="Marvel Graphic Novel" Number="4" Volume="1982" Year="1982">
-      <Id>3e713f8d-b357-4fa1-a85a-9a77ab5bdcba</Id>
+      <Database Name="cv" Series="3144" Issue="21793" />
     </Book>
     <Book Series="The New Mutants" Number="1" Volume="1983" Year="1983">
-      <Id>311f0ba5-087e-49cb-bfa8-c98cb8b03d8b</Id>
+      <Database Name="cv" Series="3234" Issue="22961" />
     </Book>
     <Book Series="The New Mutants" Number="2" Volume="1983" Year="1983">
-      <Id>849abfba-7bb6-40db-97b5-4d2143b003ef</Id>
+      <Database Name="cv" Series="3234" Issue="23042" />
     </Book>
     <Book Series="The New Mutants" Number="3" Volume="1983" Year="1983">
-      <Id>065397c9-6aa8-46f0-80c6-5d3b2b371a8a</Id>
+      <Database Name="cv" Series="3234" Issue="23131" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="167" Volume="1981" Year="1983">
-      <Id>ff2e760c-d6f2-44fe-859a-25aee4164b72</Id>
+      <Database Name="cv" Series="3092" Issue="22969" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="168" Volume="1981" Year="1983">
-      <Id>03edef4b-b95b-40a4-8f67-0859bd7f7a79</Id>
+      <Database Name="cv" Series="3092" Issue="23051" />
     </Book>
     <Book Series="Magik (Storm and Illyana Limited Series)" Number="1" Volume="1983" Year="1983">
-      <Id>fbb8adfb-3997-4c99-83ab-629844ac2da8</Id>
+      <Database Name="cv" Series="3230" Issue="23731" />
     </Book>
     <Book Series="Magik (Storm and Illyana Limited Series)" Number="2" Volume="1983" Year="1984">
-      <Id>071ade06-dad3-4995-9f32-2db70dbcf3cc</Id>
+      <Database Name="cv" Series="3230" Issue="23879" />
     </Book>
     <Book Series="Magik (Storm and Illyana Limited Series)" Number="3" Volume="1983" Year="1984">
-      <Id>3a26cfbf-d6ad-4513-8e7f-1c513541c9a3</Id>
+      <Database Name="cv" Series="3230" Issue="23984" />
     </Book>
     <Book Series="Magik (Storm and Illyana Limited Series)" Number="4" Volume="1983" Year="1984">
-      <Id>946c0469-3c5d-40fb-bf07-53ae1b7732ed</Id>
+      <Database Name="cv" Series="3230" Issue="24100" />
     </Book>
     <Book Series="Marvel Graphic Novel" Number="5" Volume="1982" Year="1982">
-      <Id>acf56583-db2d-4e27-9c05-14184a66b3b2</Id>
+      <Database Name="cv" Series="3144" Issue="21795" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="169" Volume="1981" Year="1983">
-      <Id>71353ccc-3b07-4bae-9d70-df5c60b07ced</Id>
+      <Database Name="cv" Series="3092" Issue="23139" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="170" Volume="1981" Year="1983">
-      <Id>90f2cbf5-40d1-441b-8f67-aa28cf39dd9a</Id>
+      <Database Name="cv" Series="3092" Issue="23219" />
     </Book>
     <Book Series="The New Mutants" Number="4" Volume="1983" Year="1983">
-      <Id>8391f300-513d-4904-b8b0-a5be47f18cfd</Id>
+      <Database Name="cv" Series="3234" Issue="23212" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="171" Volume="1981" Year="1983">
-      <Id>d081f7ac-4569-4647-821c-876228d549ea</Id>
+      <Database Name="cv" Series="3092" Issue="23307" />
     </Book>
     <Book Series="Wolverine" Number="1" Volume="1982" Year="1982">
-      <Id>3e70a1fe-4021-4122-9e5c-a996122fb79a</Id>
+      <Database Name="cv" Series="3157" Issue="22463" />
     </Book>
     <Book Series="Wolverine" Number="2" Volume="1982" Year="1982">
-      <Id>0a47cd23-f75a-4260-aaba-1fe5d50d78a6</Id>
+      <Database Name="cv" Series="3157" Issue="22539" />
     </Book>
     <Book Series="Wolverine" Number="3" Volume="1982" Year="1982">
-      <Id>b85bd6ba-26aa-4d77-9f5b-2a3ad03a7cd7</Id>
+      <Database Name="cv" Series="3157" Issue="22613" />
     </Book>
     <Book Series="Wolverine" Number="4" Volume="1982" Year="1982">
-      <Id>adfd615c-552e-4c89-a89e-b1330e2cfc8d</Id>
+      <Database Name="cv" Series="3157" Issue="22690" />
     </Book>
     <Book Series="The New Mutants" Number="5" Volume="1983" Year="1983">
-      <Id>89295e6a-ecda-42ba-ae83-95121a38dda3</Id>
+      <Database Name="cv" Series="3234" Issue="23300" />
     </Book>
     <Book Series="The New Mutants" Number="6" Volume="1983" Year="1983">
-      <Id>82f230b0-7ae9-444a-82a6-05dea02c20e2</Id>
+      <Database Name="cv" Series="3234" Issue="23380" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="172" Volume="1981" Year="1983">
-      <Id>45873a60-93ff-4e62-ad51-89905f249470</Id>
+      <Database Name="cv" Series="3092" Issue="23387" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="173" Volume="1981" Year="1983">
-      <Id>a8dc46ac-61d1-4ee8-98d8-5c3c75eb27ab</Id>
+      <Database Name="cv" Series="3092" Issue="23469" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="174" Volume="1981" Year="1983">
-      <Id>661ddff7-3bfe-4d0a-a3d1-dba1e3c3b0b4</Id>
+      <Database Name="cv" Series="3092" Issue="23556" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="175" Volume="1981" Year="1983">
-      <Id>6003bca8-5393-4a9f-b66e-26d1a6f0b106</Id>
+      <Database Name="cv" Series="3092" Issue="23648" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="176" Volume="1981" Year="1983">
-      <Id>92333cb3-003a-4720-8aac-d940f100523e</Id>
+      <Database Name="cv" Series="3092" Issue="23743" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="177" Volume="1981" Year="1984">
-      <Id>de7ac5f0-125c-4aac-9871-4211631bfeab</Id>
+      <Database Name="cv" Series="3092" Issue="23894" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="178" Volume="1981" Year="1984">
-      <Id>86558165-a3ee-4e41-a736-e277905e34fa</Id>
+      <Database Name="cv" Series="3092" Issue="23994" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="179" Volume="1981" Year="1984">
-      <Id>ac878931-b7a5-4824-a6d4-a65104150002</Id>
+      <Database Name="cv" Series="3092" Issue="24112" />
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="7" Volume="1982" Year="1983">
-      <Id>51541e1b-a396-468b-bd80-83bd1db57998</Id>
+    <Book Series="X-Men Annual" Number="7" Volume="1970" Year="1983">
+      <Database Name="cv" Series="22988" Issue="111577" />
     </Book>
     <Book Series="The New Mutants" Number="7" Volume="1983" Year="1983">
-      <Id>e2b63298-e04c-4626-886c-126992a371a1</Id>
+      <Database Name="cv" Series="3234" Issue="23461" />
     </Book>
     <Book Series="The New Mutants" Number="8" Volume="1983" Year="1983">
-      <Id>657a8207-e557-48dd-9fbe-4ac8e422c280</Id>
+      <Database Name="cv" Series="3234" Issue="23549" />
     </Book>
     <Book Series="The New Mutants" Number="9" Volume="1983" Year="1983">
-      <Id>a8056614-f8f1-4d89-a3db-4502a419991f</Id>
+      <Database Name="cv" Series="3234" Issue="23639" />
     </Book>
     <Book Series="The New Mutants" Number="10" Volume="1983" Year="1983">
-      <Id>8c65e815-e666-4711-9c6d-62c061881a94</Id>
+      <Database Name="cv" Series="3234" Issue="23735" />
     </Book>
     <Book Series="The New Mutants" Number="11" Volume="1983" Year="1984">
-      <Id>1c389791-ea05-401e-9b24-1877a107b2d2</Id>
+      <Database Name="cv" Series="3234" Issue="23886" />
     </Book>
     <Book Series="The New Mutants" Number="12" Volume="1983" Year="1984">
-      <Id>03f15814-2028-4e17-920e-9aef5c5314ec</Id>
+      <Database Name="cv" Series="3234" Issue="24011" />
     </Book>
     <Book Series="The New Mutants" Number="13" Volume="1983" Year="1984">
-      <Id>66b31c6d-092b-476c-999f-1d5d43563e1d</Id>
+      <Database Name="cv" Series="3234" Issue="24127" />
     </Book>
     <Book Series="The New Mutants" Number="14" Volume="1983" Year="1984">
-      <Id>5fb678e8-14c3-46a4-8329-d1d6ba1b759b</Id>
+      <Database Name="cv" Series="3234" Issue="24229" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="180" Volume="1981" Year="1984">
-      <Id>4c023075-8ff0-450e-9086-45f9760ec8c8</Id>
+      <Database Name="cv" Series="3092" Issue="24216" />
     </Book>
     <Book Series="The New Mutants" Number="15" Volume="1983" Year="1984">
-      <Id>1074243e-7c42-4875-8759-70e6145149f8</Id>
+      <Database Name="cv" Series="3234" Issue="24330" />
     </Book>
     <Book Series="The New Mutants" Number="16" Volume="1983" Year="1984">
-      <Id>991a574b-c35a-48c4-9e43-a5436dc303fe</Id>
+      <Database Name="cv" Series="3234" Issue="24431" />
     </Book>
     <Book Series="The New Mutants" Number="17" Volume="1983" Year="1984">
-      <Id>21157f41-ff53-4bdc-8286-619eaed7351d</Id>
+      <Database Name="cv" Series="3234" Issue="24525" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="1" Volume="1984" Year="1984">
-      <Id>12503f27-0432-4189-bf4d-9a092c361be5</Id>
+      <Database Name="cv" Series="3352" Issue="57504" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="2" Volume="1984" Year="1984">
-      <Id>0df09638-e7aa-4c19-b3b9-92994d19f00c</Id>
+      <Database Name="cv" Series="3352" Issue="57505" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="3" Volume="1984" Year="1984">
-      <Id>dd4bf6df-05ce-409d-8342-ad408f5001de</Id>
+      <Database Name="cv" Series="3352" Issue="57506" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="4" Volume="1984" Year="1984">
-      <Id>61d4e08c-4ec2-4fb5-9c79-c6da12e143c6</Id>
+      <Database Name="cv" Series="3352" Issue="57507" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="5" Volume="1984" Year="1984">
-      <Id>26d243b1-683b-4584-ad74-9a6b9c73566d</Id>
+      <Database Name="cv" Series="3352" Issue="57508" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="6" Volume="1984" Year="1984">
-      <Id>a089a0c1-e78d-4068-8116-f1deb0dd9c14</Id>
+      <Database Name="cv" Series="3352" Issue="57509" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="7" Volume="1984" Year="1984">
-      <Id>05b79a55-a242-4e11-985b-0466169555da</Id>
+      <Database Name="cv" Series="3352" Issue="57510" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="8" Volume="1984" Year="1984">
-      <Id>111ee946-dd1c-4452-bb71-206092ce3b80</Id>
+      <Database Name="cv" Series="3352" Issue="57511" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="9" Volume="1984" Year="1985">
-      <Id>2de4ebb6-4faf-49f5-be60-08921d7d14d2</Id>
+      <Database Name="cv" Series="3352" Issue="57512" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="10" Volume="1984" Year="1985">
-      <Id>a9133d85-6b2d-4287-98f2-5365a1bf2ab2</Id>
+      <Database Name="cv" Series="3352" Issue="57513" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="11" Volume="1984" Year="1985">
-      <Id>882ae5ee-1c89-48a6-a5ed-5390b175586e</Id>
+      <Database Name="cv" Series="3352" Issue="57514" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="12" Volume="1984" Year="1985">
-      <Id>0c242418-14f2-4115-bd77-b507f0c577a1</Id>
+      <Database Name="cv" Series="3352" Issue="57515" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="181" Volume="1981" Year="1984">
-      <Id>76dc7cb0-75fc-4628-a688-08235fcace76</Id>
+      <Database Name="cv" Series="3092" Issue="24322" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="182" Volume="1981" Year="1984">
-      <Id>a762704e-1282-4524-821a-b23e3a72139f</Id>
+      <Database Name="cv" Series="3092" Issue="24419" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="183" Volume="1981" Year="1984">
-      <Id>3a430de1-16ac-496d-8180-8d6e8fa7b598</Id>
+      <Database Name="cv" Series="3092" Issue="24518" />
     </Book>
     <Book Series="The New Mutants" Number="18" Volume="1983" Year="1984">
-      <Id>bdbaf7de-da00-43e2-bbf2-57855ac58b89</Id>
+      <Database Name="cv" Series="3234" Issue="24627" />
     </Book>
     <Book Series="The New Mutants" Number="19" Volume="1983" Year="1984">
-      <Id>a14a74cf-4a02-4358-89c0-457a72750180</Id>
+      <Database Name="cv" Series="3234" Issue="24717" />
     </Book>
     <Book Series="The New Mutants" Number="20" Volume="1983" Year="1984">
-      <Id>bba7991a-8961-4cd0-bf61-3b2e8752099e</Id>
+      <Database Name="cv" Series="3234" Issue="24818" />
     </Book>
     <Book Series="The New Mutants" Number="21" Volume="1983" Year="1984">
-      <Id>6b685455-3c9c-4ad2-b916-1ea82445694c</Id>
+      <Database Name="cv" Series="3234" Issue="24913" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="184" Volume="1981" Year="1984">
-      <Id>2146538b-bb96-4543-853d-26ed0b3d21b3</Id>
+      <Database Name="cv" Series="3092" Issue="24620" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="185" Volume="1981" Year="1984">
-      <Id>be239f29-2465-4be7-b677-5e4766c85933</Id>
+      <Database Name="cv" Series="3092" Issue="24708" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="186" Volume="1981" Year="1984">
-      <Id>4e20bdf3-2b17-42fe-a318-6b7282ae24b2</Id>
+      <Database Name="cv" Series="3092" Issue="24808" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="187" Volume="1981" Year="1984">
-      <Id>b1b44792-f617-4caf-9898-545d8bc28be8</Id>
+      <Database Name="cv" Series="3092" Issue="24907" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="188" Volume="1981" Year="1984">
-      <Id>70589586-c0e0-481a-8d97-1c79b8b779f5</Id>
+      <Database Name="cv" Series="3092" Issue="25014" />
     </Book>
     <Book Series="Kitty Pryde and Wolverine" Number="1" Volume="1984" Year="1984">
-      <Id>8174ac31-20e7-431f-8eab-18cefb74f8b4</Id>
+      <Database Name="cv" Series="3348" Issue="24893" />
     </Book>
     <Book Series="Kitty Pryde and Wolverine" Number="2" Volume="1984" Year="1984">
-      <Id>9228a06a-5592-46b8-b39c-c2c1d2a9b9d5</Id>
+      <Database Name="cv" Series="3348" Issue="24997" />
     </Book>
     <Book Series="Kitty Pryde and Wolverine" Number="3" Volume="1984" Year="1985">
-      <Id>6ccfb6ca-8d3d-4efb-9c06-b382fc25a8e9</Id>
+      <Database Name="cv" Series="3348" Issue="25166" />
     </Book>
     <Book Series="Kitty Pryde and Wolverine" Number="4" Volume="1984" Year="1985">
-      <Id>08c21cfc-8c66-4090-acc7-ec7f93ede345</Id>
+      <Database Name="cv" Series="3348" Issue="25265" />
     </Book>
     <Book Series="Kitty Pryde and Wolverine" Number="5" Volume="1984" Year="1985">
-      <Id>a5a63142-15c6-4530-870a-465a7a54aed6</Id>
+      <Database Name="cv" Series="3348" Issue="25290" />
     </Book>
     <Book Series="Kitty Pryde and Wolverine" Number="6" Volume="1984" Year="1985">
-      <Id>56c09a79-85cf-40a6-acf6-5a7c47aaea58</Id>
+      <Database Name="cv" Series="3348" Issue="25394" />
     </Book>
     <Book Series="The New Mutants Annual" Number="1" Volume="1984" Year="1984">
-      <Id>3bb835c7-8322-46b5-ace2-b608b855b70a</Id>
+      <Database Name="cv" Series="3356" Issue="23775" />
     </Book>
     <Book Series="Iceman" Number="1" Volume="1984" Year="1984">
-      <Id>1047a0ac-7080-4b38-b647-724fb025faae</Id>
+      <Database Name="cv" Series="3345" Issue="25018" />
     </Book>
     <Book Series="Iceman" Number="2" Volume="1984" Year="1985">
-      <Id>2a28ba3b-8d6b-4c0e-bdf7-58346c89f292</Id>
+      <Database Name="cv" Series="3345" Issue="25280" />
     </Book>
     <Book Series="Iceman" Number="3" Volume="1984" Year="1985">
-      <Id>1a473481-d760-45f5-92d8-f3ebb4853af5</Id>
+      <Database Name="cv" Series="3345" Issue="25410" />
     </Book>
     <Book Series="Iceman" Number="4" Volume="1984" Year="1985">
-      <Id>fe0eb173-a798-47b8-b17f-9b264835003c</Id>
+      <Database Name="cv" Series="3345" Issue="25607" />
     </Book>
     <Book Series="The New Mutants" Number="22" Volume="1983" Year="1984">
-      <Id>a28e1982-8219-4006-a93e-d6fea83663d1</Id>
+      <Database Name="cv" Series="3234" Issue="25024" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="189" Volume="1981" Year="1985">
-      <Id>b3ffd42f-7cf7-48f0-aada-550740283579</Id>
+      <Database Name="cv" Series="3092" Issue="25178" />
     </Book>
     <Book Series="The New Mutants" Number="23" Volume="1983" Year="1985">
-      <Id>0afa9aec-13da-4461-b673-86dca7b2833d</Id>
+      <Database Name="cv" Series="3234" Issue="25182" />
     </Book>
     <Book Series="The New Mutants" Number="24" Volume="1983" Year="1985">
-      <Id>43e64028-0942-44a8-b56f-5394256315d2</Id>
+      <Database Name="cv" Series="3234" Issue="25286" />
     </Book>
     <Book Series="The New Mutants" Number="25" Volume="1983" Year="1985">
-      <Id>74aad6b6-182b-4b05-9fca-a53f680f0d9d</Id>
+      <Database Name="cv" Series="3234" Issue="25311" />
     </Book>
     <Book Series="Marvel Graphic Novel" Number="12" Volume="1982" Year="1984">
-      <Id>6a797284-312c-4a03-aa5a-e82ff17d5654</Id>
+      <Database Name="cv" Series="3144" Issue="108265" />
     </Book>
     <Book Series="Beauty and the Beast" Number="1" Volume="1984" Year="1984">
-      <Id>5d395011-5bc4-40a0-9638-71a1453294f5</Id>
+      <Database Name="cv" Series="3333" Issue="24983" />
     </Book>
     <Book Series="Beauty and the Beast" Number="2" Volume="1984" Year="1985">
-      <Id>d68cd6d3-fc80-48db-b484-d9137f46cd26</Id>
+      <Database Name="cv" Series="3333" Issue="25252" />
     </Book>
     <Book Series="Beauty and the Beast" Number="3" Volume="1984" Year="1985">
-      <Id>883f381a-d63f-4c27-a134-4d77c0d6b6be</Id>
+      <Database Name="cv" Series="3333" Issue="25381" />
     </Book>
     <Book Series="Beauty and the Beast" Number="4" Volume="1984" Year="1985">
-      <Id>1f99b1d5-f651-4bf3-a015-20e92f0606a2</Id>
+      <Database Name="cv" Series="3333" Issue="25576" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="190" Volume="1981" Year="1985">
-      <Id>0de7bfc3-ee48-4783-8856-9772654afa58</Id>
+      <Database Name="cv" Series="3092" Issue="25279" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="191" Volume="1981" Year="1985">
-      <Id>16777a91-1a00-4599-bf8c-850cfdec4880</Id>
+      <Database Name="cv" Series="3092" Issue="25301" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="192" Volume="1981" Year="1985">
-      <Id>0c191262-3c49-43d9-8dd6-284b8212d3f9</Id>
+      <Database Name="cv" Series="3092" Issue="25406" />
     </Book>
     <Book Series="X-Men/Alpha Flight" Number="1" Volume="1985" Year="1985">
-      <Id>44904380-8c48-4806-823d-2a51e6074d49</Id>
+      <Database Name="cv" Series="3522" Issue="57851" />
     </Book>
     <Book Series="X-Men/Alpha Flight" Number="2" Volume="1985" Year="1986">
-      <Id>b3c23538-f933-49fd-b90a-d53d6884bd3e</Id>
+      <Database Name="cv" Series="3522" Issue="57852" />
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="8" Volume="1982" Year="1984">
-      <Id>bdbb4381-28cc-4bac-b806-1cbee1c5b3b4</Id>
+    <Book Series="X-Men Annual" Number="8" Volume="1970" Year="1984">
+      <Database Name="cv" Series="22988" Issue="111578" />
     </Book>
     <Book Series="Firestar" Number="1" Volume="1986" Year="1986">
-      <Id>d3130e1a-d531-4c40-9bc6-c2711c1088d8</Id>
+      <Database Name="cv" Series="3631" Issue="26599" />
     </Book>
     <Book Series="Firestar" Number="2" Volume="1986" Year="1986">
-      <Id>b57715bd-40f2-486d-9515-7c967b6c65d9</Id>
+      <Database Name="cv" Series="3631" Issue="26699" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="193" Volume="1981" Year="1985">
-      <Id>40e2d805-6762-404d-b88b-5de72f290c81</Id>
+      <Database Name="cv" Series="3092" Issue="25500" />
     </Book>
     <Book Series="Firestar" Number="3" Volume="1986" Year="1986">
-      <Id>9946a545-2620-4eaf-80db-83bc3401e621</Id>
+      <Database Name="cv" Series="3631" Issue="26791" />
     </Book>
     <Book Series="Firestar" Number="4" Volume="1986" Year="1986">
-      <Id>f313e558-aaf3-4412-a24b-9f4de10c9aaf</Id>
+      <Database Name="cv" Series="3631" Issue="26890" />
     </Book>
     <Book Series="The New Mutants" Number="26" Volume="1983" Year="1985">
-      <Id>c5285332-c617-436b-bd48-c3917cc2fd69</Id>
+      <Database Name="cv" Series="3234" Issue="25414" />
     </Book>
     <Book Series="The New Mutants" Number="27" Volume="1983" Year="1985">
-      <Id>dc012a77-8651-4356-b729-f6d122ce2915</Id>
+      <Database Name="cv" Series="3234" Issue="25509" />
     </Book>
     <Book Series="The New Mutants" Number="28" Volume="1983" Year="1985">
-      <Id>636a16cb-a7c5-411e-a46d-71fc98964215</Id>
+      <Database Name="cv" Series="3234" Issue="25614" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="194" Volume="1981" Year="1985">
-      <Id>6946b0e3-78f6-417e-bc7f-694155938344</Id>
+      <Database Name="cv" Series="3092" Issue="25602" />
     </Book>
     <Book Series="The New Mutants" Number="29" Volume="1983" Year="1985">
-      <Id>5ee71ab5-1d38-4cac-b698-6a7f60916ef4</Id>
+      <Database Name="cv" Series="3234" Issue="25707" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="195" Volume="1981" Year="1985">
-      <Id>22d59874-f2c4-46a0-938c-a0533290b291</Id>
+      <Database Name="cv" Series="3092" Issue="25701" />
     </Book>
     <Book Series="Secret Wars II" Number="1" Volume="1985" Year="1985">
-      <Id>543f78c6-4f66-4b9e-af48-b03dc17f137b</Id>
+      <Database Name="cv" Series="3506" Issue="57516" />
     </Book>
     <Book Series="The New Mutants" Number="30" Volume="1983" Year="1985">
-      <Id>c5326003-ff7d-4ea4-8a7a-b7a045ca1bf6</Id>
+      <Database Name="cv" Series="3234" Issue="25811" />
     </Book>
     <Book Series="The New Mutants" Number="31" Volume="1983" Year="1985">
-      <Id>8fbb5190-7c1c-4e91-81b4-6da4f0995548</Id>
+      <Database Name="cv" Series="3234" Issue="25904" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="196" Volume="1981" Year="1985">
-      <Id>f5600b74-eaa4-4a1e-affe-c9897c05739b</Id>
+      <Database Name="cv" Series="3092" Issue="25801" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="197" Volume="1981" Year="1985">
-      <Id>dad9ce62-6f81-4d46-8014-3f39f535850a</Id>
+      <Database Name="cv" Series="3092" Issue="25896" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="198" Volume="1981" Year="1985">
-      <Id>8927440e-4028-4750-b206-2869fbdf1227</Id>
+      <Database Name="cv" Series="3092" Issue="25999" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="199" Volume="1981" Year="1985">
-      <Id>80c32fb3-2588-49c2-9003-c3010a533a0c</Id>
+      <Database Name="cv" Series="3092" Issue="26105" />
     </Book>
     <Book Series="The New Mutants" Number="32" Volume="1983" Year="1985">
-      <Id>f7feba42-96fb-4e8b-b63c-aab46b1fef69</Id>
+      <Database Name="cv" Series="3234" Issue="26014" />
     </Book>
     <Book Series="The New Mutants" Number="33" Volume="1983" Year="1985">
-      <Id>8ed5f8d6-eb4d-4d82-96a0-20020cae4ea9</Id>
+      <Database Name="cv" Series="3234" Issue="26090" />
     </Book>
     <Book Series="The New Mutants" Number="34" Volume="1983" Year="1985">
-      <Id>38efbd44-0448-4571-95ab-74b8ac3a2ef8</Id>
+      <Database Name="cv" Series="3234" Issue="26234" />
     </Book>
     <Book Series="The New Mutants Special Edition" Number="1" Volume="1985" Year="1985">
-      <Id>778187da-7849-4af7-a3fc-7c7b86abe177</Id>
+      <Database Name="cv" Series="18380" Issue="110014" />
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="9" Volume="1982" Year="1985">
-      <Id>885beb8e-315b-4487-899e-b082be8e072c</Id>
+    <Book Series="X-Men Annual" Number="9" Volume="1970" Year="1985">
+      <Database Name="cv" Series="22988" Issue="111575" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="200" Volume="1981" Year="1985">
-      <Id>79a98173-d6c6-4f5a-a26b-9ce9f2f7ff56</Id>
+      <Database Name="cv" Series="3092" Issue="26210" />
     </Book>
     <Book Series="The New Mutants" Number="35" Volume="1983" Year="1986">
-      <Id>fe6899d5-d738-4b02-9d7e-436f5c937704</Id>
+      <Database Name="cv" Series="3234" Issue="26428" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="201" Volume="1981" Year="1986">
-      <Id>76017666-c419-4d59-9e85-d7db783818b5</Id>
+      <Database Name="cv" Series="3092" Issue="26413" />
     </Book>
     <Book Series="Heroes for Hope Starring the X-Men" Number="1" Volume="1985" Year="1985">
-      <Id>26d005f0-78cb-42cd-b283-ae055751f202</Id>
+      <Database Name="cv" Series="18450" Issue="108266" />
     </Book>
     <Book Series="Secret Wars II" Number="5" Volume="1985" Year="1985">
-      <Id>e80850ac-88cf-433c-bb02-82f1f7516b3b</Id>
+      <Database Name="cv" Series="3506" Issue="57519" />
     </Book>
     <Book Series="The New Mutants" Number="36" Volume="1983" Year="1986">
-      <Id>8a5afb02-e1a5-47e8-b8ce-bf70050cfb73</Id>
+      <Database Name="cv" Series="3234" Issue="26542" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="202" Volume="1981" Year="1986">
-      <Id>5810cff5-3b6c-483f-b8fc-f3495707dd0e</Id>
+      <Database Name="cv" Series="3092" Issue="26519" />
     </Book>
     <Book Series="Secret Wars II" Number="8" Volume="1985" Year="1986">
-      <Id>86da0eda-eb3b-4191-993e-1cf84f258f12</Id>
+      <Database Name="cv" Series="3506" Issue="57522" />
     </Book>
     <Book Series="The New Mutants" Number="37" Volume="1983" Year="1986">
-      <Id>a8fab391-88f6-4120-a262-fb5874d49fd6</Id>
+      <Database Name="cv" Series="3234" Issue="26631" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="203" Volume="1981" Year="1986">
-      <Id>1516fab2-3d17-4de5-a1ff-bcfbf9399ea3</Id>
+      <Database Name="cv" Series="3092" Issue="26613" />
     </Book>
     <Book Series="Secret Wars II" Number="9" Volume="1985" Year="1986">
-      <Id>5df1cc54-4071-4cda-bbc7-0365b4916394</Id>
+      <Database Name="cv" Series="3506" Issue="57523" />
     </Book>
     <Book Series="The New Mutants" Number="38" Volume="1983" Year="1986">
-      <Id>04950f8e-aa11-4d95-a362-a6c9db4aa802</Id>
+      <Database Name="cv" Series="3234" Issue="26728" />
     </Book>
     <Book Series="The New Mutants" Number="39" Volume="1983" Year="1986">
-      <Id>450263e3-ffae-4427-bfd4-b56e4e3c22a7</Id>
+      <Database Name="cv" Series="3234" Issue="26819" />
     </Book>
     <Book Series="The New Mutants" Number="40" Volume="1983" Year="1986">
-      <Id>3d639b74-ab6c-4268-9f4b-79610fb50917</Id>
+      <Database Name="cv" Series="3234" Issue="26894" />
     </Book>
     <Book Series="Fantastic Four" Number="286" Volume="1961" Year="1986">
-      <Id>4402a50a-b6bc-4509-9d62-6a222ee1b726</Id>
+      <Database Name="cv" Series="2045" Issue="26396" />
     </Book>
     <Book Series="X-Factor" Number="1" Volume="1986" Year="1986">
-      <Id>05aeab43-9e9a-425c-99ef-453894a1f373</Id>
+      <Database Name="cv" Series="3657" Issue="26523" />
     </Book>
     <Book Series="X-Factor" Number="2" Volume="1986" Year="1986">
-      <Id>57feb9d8-d419-439d-8c04-acf59accfa07</Id>
+      <Database Name="cv" Series="3657" Issue="26617" />
     </Book>
     <Book Series="X-Factor" Number="3" Volume="1986" Year="1986">
-      <Id>7fcef109-8351-41f3-8759-e52168e8c813</Id>
+      <Database Name="cv" Series="3657" Issue="26714" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="204" Volume="1981" Year="1986">
-      <Id>4523bdfe-795c-4747-8cd9-1131fe39dab9</Id>
+      <Database Name="cv" Series="3092" Issue="26710" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="205" Volume="1981" Year="1986">
-      <Id>6f0b15d7-59c0-40b0-a9a8-71d4bdc92e8f</Id>
+      <Database Name="cv" Series="3092" Issue="26804" />
     </Book>
     <Book Series="X-Factor Annual" Number="1" Volume="1986" Year="1986">
-      <Id>a3319d60-8c87-4da3-8926-7c366e376a4d</Id>
+      <Database Name="cv" Series="3658" Issue="66333" />
     </Book>
     <Book Series="X-Factor" Number="4" Volume="1986" Year="1986">
-      <Id>65908dbc-f809-41af-aedb-92a760145486</Id>
+      <Database Name="cv" Series="3657" Issue="26808" />
     </Book>
     <Book Series="X-Factor" Number="5" Volume="1986" Year="1986">
-      <Id>f0f9a4b1-71ee-4c58-b1f5-ee312746ef5b</Id>
+      <Database Name="cv" Series="3657" Issue="26906" />
     </Book>
     <Book Series="X-Factor" Number="6" Volume="1986" Year="1986">
-      <Id>60104271-960e-4ed9-84eb-8a113fba94f3</Id>
+      <Database Name="cv" Series="3657" Issue="27001" />
     </Book>
     <Book Series="The New Mutants" Number="41" Volume="1983" Year="1986">
-      <Id>1b7bb8ee-a703-4dc1-9cb9-da51edb77345</Id>
+      <Database Name="cv" Series="3234" Issue="27014" />
     </Book>
     <Book Series="The New Mutants" Number="42" Volume="1983" Year="1986">
-      <Id>f97e4285-f4ce-403b-bc68-803b7c16797c</Id>
+      <Database Name="cv" Series="3234" Issue="27116" />
     </Book>
     <Book Series="The New Mutants" Number="43" Volume="1983" Year="1986">
-      <Id>1a62e6b2-8285-474d-bf1c-fdc8aac536ea</Id>
+      <Database Name="cv" Series="3234" Issue="27207" />
     </Book>
     <Book Series="The New Mutants" Number="44" Volume="1983" Year="1986">
-      <Id>1799ecd2-84dc-4d1c-afc3-380d93884f7f</Id>
+      <Database Name="cv" Series="3234" Issue="27310" />
     </Book>
     <Book Series="The New Mutants" Number="45" Volume="1983" Year="1986">
-      <Id>402f4833-1a8b-4fd6-97a2-f1465ee91ec5</Id>
+      <Database Name="cv" Series="3234" Issue="27414" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="206" Volume="1981" Year="1986">
-      <Id>f82a1b37-4682-461c-97e2-2155d6f68495</Id>
+      <Database Name="cv" Series="3092" Issue="26902" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="207" Volume="1981" Year="1986">
-      <Id>f33fe9c7-6318-48f4-accc-60eb60ea8fd9</Id>
+      <Database Name="cv" Series="3092" Issue="26997" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="208" Volume="1981" Year="1986">
-      <Id>2508bb08-59d8-4731-a331-a56701ca223d</Id>
+      <Database Name="cv" Series="3092" Issue="27093" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="209" Volume="1981" Year="1986">
-      <Id>e4a0eb9a-d78c-415a-9305-a6021187c42d</Id>
+      <Database Name="cv" Series="3092" Issue="27189" />
     </Book>
     <Book Series="Longshot" Number="1" Volume="1985" Year="1985">
-      <Id>419e72d1-c98a-4037-a122-88561e7e4122</Id>
+      <Database Name="cv" Series="3489" Issue="25907" />
     </Book>
     <Book Series="Longshot" Number="2" Volume="1985" Year="1985">
-      <Id>7a3310b6-0499-4180-a5c2-313c2a7feac8</Id>
+      <Database Name="cv" Series="3489" Issue="26013" />
     </Book>
     <Book Series="Longshot" Number="3" Volume="1985" Year="1985">
-      <Id>ea074994-6ed6-4143-a653-38289a812f94</Id>
+      <Database Name="cv" Series="3489" Issue="26117" />
     </Book>
     <Book Series="Longshot" Number="4" Volume="1985" Year="1985">
-      <Id>d3648860-98a5-41e6-8431-11cf6d6ce9bc</Id>
+      <Database Name="cv" Series="3489" Issue="26233" />
     </Book>
     <Book Series="Longshot" Number="5" Volume="1985" Year="1986">
-      <Id>21acb67d-9b18-4ef0-b018-a481a1b09be1</Id>
+      <Database Name="cv" Series="3489" Issue="26427" />
     </Book>
     <Book Series="Longshot" Number="6" Volume="1985" Year="1986">
-      <Id>6c78009e-4098-4c5d-9be9-a8ef93c5b10f</Id>
+      <Database Name="cv" Series="3489" Issue="26541" />
     </Book>
     <Book Series="The New Mutants Annual" Number="2" Volume="1984" Year="1986">
-      <Id>b2296f9b-6dde-42e3-af9f-98303e639bca</Id>
+      <Database Name="cv" Series="3356" Issue="26277" />
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="10" Volume="1982" Year="1986">
-      <Id>4a83cc69-8932-41b3-bd97-cf61e0f54146</Id>
+    <Book Series="X-Men Annual" Number="10" Volume="1970" Year="1986">
+      <Database Name="cv" Series="22988" Issue="111576" />
     </Book>
     <Book Series="X-Factor" Number="7" Volume="1986" Year="1986">
-      <Id>f9ce2cd5-749d-4e1e-9d4f-af827c58d0a7</Id>
+      <Database Name="cv" Series="3657" Issue="27097" />
     </Book>
     <Book Series="X-Factor" Number="8" Volume="1986" Year="1986">
-      <Id>0ccf1912-9e31-45af-b06c-b0013c8ff3a7</Id>
+      <Database Name="cv" Series="3657" Issue="27193" />
     </Book>
     <Book Series="X-Factor" Number="9" Volume="1986" Year="1986">
-      <Id>4838a66f-4df9-41f0-ae94-bcabee948c3e</Id>
+      <Database Name="cv" Series="3657" Issue="27290" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="210" Volume="1981" Year="1986">
-      <Id>4682099d-8b4a-420f-8577-5859b86ef292</Id>
+      <Database Name="cv" Series="3092" Issue="107057" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="211" Volume="1981" Year="1986">
-      <Id>cdde4e60-6f7b-4c22-8b91-e193fe958045</Id>
+      <Database Name="cv" Series="3092" Issue="27396" />
     </Book>
     <Book Series="The New Mutants" Number="46" Volume="1983" Year="1986">
-      <Id>fe8e2dd5-abdf-4344-ab22-64e11aaca873</Id>
+      <Database Name="cv" Series="3234" Issue="27523" />
     </Book>
     <Book Series="X-Factor" Number="10" Volume="1986" Year="1986">
-      <Id>732b1bf5-9b25-4458-a3b0-4b3a04937e54</Id>
+      <Database Name="cv" Series="3657" Issue="27399" />
     </Book>
     <Book Series="Thor" Number="373" Volume="1966" Year="1986">
-      <Id>281d08cc-6918-4300-ba1e-f4cec1ec4890</Id>
+      <Database Name="cv" Series="2294" Issue="27395" />
     </Book>
     <Book Series="Power Pack" Number="27" Volume="1984" Year="1986">
-      <Id>f53ce0fb-4566-4158-b0d1-a3202029520f</Id>
+      <Database Name="cv" Series="3358" Issue="27494" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="212" Volume="1981" Year="1986">
-      <Id>d6c52f83-ec04-485a-b59e-8e0b69de221e</Id>
+      <Database Name="cv" Series="3092" Issue="27501" />
     </Book>
     <Book Series="Thor" Number="374" Volume="1966" Year="1986">
-      <Id>db2f6141-de80-43e5-b843-ef27260fbde3</Id>
+      <Database Name="cv" Series="2294" Issue="27500" />
     </Book>
     <Book Series="X-Factor" Number="11" Volume="1986" Year="1986">
-      <Id>633ad431-3fb8-47ae-b5e4-f37f3e29916f</Id>
+      <Database Name="cv" Series="3657" Issue="27504" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="213" Volume="1981" Year="1987">
-      <Id>628d0a8a-e751-45c1-a74d-844179efbab2</Id>
+      <Database Name="cv" Series="3092" Issue="27691" />
     </Book>
     <Book Series="X-Factor" Number="12" Volume="1986" Year="1987">
-      <Id>384a5060-e132-474a-b80d-6ddef791ad58</Id>
+      <Database Name="cv" Series="3657" Issue="27694" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="214" Volume="1981" Year="1987">
-      <Id>f2900b71-e9b2-47b8-89f8-33b106370d8a</Id>
+      <Database Name="cv" Series="3092" Issue="27803" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="215" Volume="1981" Year="1987">
-      <Id>4bc2c6c0-a5b1-4117-aab2-8d7a8450236f</Id>
+      <Database Name="cv" Series="3092" Issue="27912" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="216" Volume="1981" Year="1987">
-      <Id>660d7b88-26ba-4936-8e56-48cbedd76d4c</Id>
+      <Database Name="cv" Series="3092" Issue="28023" />
     </Book>
     <Book Series="The New Mutants" Number="47" Volume="1983" Year="1987">
-      <Id>41403191-412e-4587-a905-8f2252ca3d75</Id>
+      <Database Name="cv" Series="3234" Issue="27712" />
     </Book>
     <Book Series="The New Mutants" Number="48" Volume="1983" Year="1987">
-      <Id>d33000bc-825a-4f92-a2db-b194bcdc4e46</Id>
+      <Database Name="cv" Series="3234" Issue="27826" />
     </Book>
     <Book Series="The New Mutants" Number="49" Volume="1983" Year="1987">
-      <Id>344b4b90-c537-4eb2-aadb-12a7f987950e</Id>
+      <Database Name="cv" Series="3234" Issue="27930" />
     </Book>
     <Book Series="The New Mutants" Number="50" Volume="1983" Year="1987">
-      <Id>17144108-9bdc-4f24-ab46-a7ea76ea4afa</Id>
+      <Database Name="cv" Series="3234" Issue="28045" />
     </Book>
     <Book Series="The New Mutants" Number="51" Volume="1983" Year="1987">
-      <Id>365aeff0-7ade-493f-a1ce-d44c5820ec84</Id>
+      <Database Name="cv" Series="3234" Issue="28142" />
     </Book>
     <Book Series="The New Mutants Annual" Number="3" Volume="1984" Year="1987">
-      <Id>8255332b-825c-45ed-b3de-db88d8ec1bb9</Id>
+      <Database Name="cv" Series="3356" Issue="27570" />
     </Book>
     <Book Series="The New Mutants" Number="52" Volume="1983" Year="1987">
-      <Id>dc440617-c7e5-4115-b4cf-3803bc8638bc</Id>
+      <Database Name="cv" Series="3234" Issue="28252" />
     </Book>
     <Book Series="Fallen Angels" Number="1" Volume="1987" Year="1987">
-      <Id>f47ddbb1-75ab-4336-bea2-f78669cbf6a1</Id>
+      <Database Name="cv" Series="3842" Issue="94587" />
     </Book>
     <Book Series="Fallen Angels" Number="2" Volume="1987" Year="1987">
-      <Id>d50094ed-42bc-4de2-9873-92ed985fec11</Id>
+      <Database Name="cv" Series="3842" Issue="94588" />
     </Book>
     <Book Series="Fallen Angels" Number="3" Volume="1987" Year="1987">
-      <Id>77a4641e-2af5-4c2d-bba5-31ec02d754f0</Id>
+      <Database Name="cv" Series="3842" Issue="94589" />
     </Book>
     <Book Series="Fallen Angels" Number="4" Volume="1987" Year="1987">
-      <Id>133a59ae-781e-47a8-a30d-9b1b1e8c38f7</Id>
+      <Database Name="cv" Series="3842" Issue="94590" />
     </Book>
     <Book Series="Fallen Angels" Number="5" Volume="1987" Year="1987">
-      <Id>7a380820-ed56-489a-ae96-73d9437f851b</Id>
+      <Database Name="cv" Series="3842" Issue="94591" />
     </Book>
     <Book Series="Fallen Angels" Number="6" Volume="1987" Year="1987">
-      <Id>716c1f90-dc8c-4cf2-b4c4-d2bd7e551af8</Id>
+      <Database Name="cv" Series="3842" Issue="94592" />
     </Book>
     <Book Series="Fallen Angels" Number="7" Volume="1987" Year="1987">
-      <Id>190aae90-d3ec-4519-8989-4562b3d6f0ac</Id>
+      <Database Name="cv" Series="3842" Issue="94593" />
     </Book>
     <Book Series="Fallen Angels" Number="8" Volume="1987" Year="1987">
-      <Id>304a3dac-9d47-43c2-810c-1021fff6c7e9</Id>
+      <Database Name="cv" Series="3842" Issue="94594" />
     </Book>
     <Book Series="X-Factor" Number="13" Volume="1986" Year="1987">
-      <Id>0e9d1b3d-50ad-4fb4-b49d-cb903d24dc0c</Id>
+      <Database Name="cv" Series="3657" Issue="27806" />
     </Book>
     <Book Series="X-Factor" Number="14" Volume="1986" Year="1987">
-      <Id>c17b8d9d-d906-441e-bb01-cbe83bd8a331</Id>
+      <Database Name="cv" Series="3657" Issue="27915" />
     </Book>
     <Book Series="X-Factor" Number="15" Volume="1986" Year="1987">
-      <Id>f7fb176d-e955-4e5e-8bf0-907cae4a4a5c</Id>
+      <Database Name="cv" Series="3657" Issue="28026" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="217" Volume="1981" Year="1987">
-      <Id>5efc1a10-77a9-4c50-8e19-a4c7b800681d</Id>
+      <Database Name="cv" Series="3092" Issue="28124" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="218" Volume="1981" Year="1987">
-      <Id>be949729-8d84-4f29-a631-cba8bb52bdd1</Id>
+      <Database Name="cv" Series="3092" Issue="28234" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="219" Volume="1981" Year="1987">
-      <Id>2cbfd3eb-b935-42be-a2c1-a5304470598f</Id>
+      <Database Name="cv" Series="3092" Issue="28351" />
     </Book>
     <Book Series="X-Factor" Number="16" Volume="1986" Year="1987">
-      <Id>8893de27-7d5c-44c2-ae22-1860f09a28ac</Id>
+      <Database Name="cv" Series="3657" Issue="28127" />
     </Book>
     <Book Series="X-Factor" Number="17" Volume="1986" Year="1987">
-      <Id>837c5293-1204-4700-85a8-969b26a42780</Id>
+      <Database Name="cv" Series="3657" Issue="28237" />
     </Book>
     <Book Series="The New Mutants" Number="53" Volume="1983" Year="1987">
-      <Id>026db128-a77b-472d-8de7-4d5653090281</Id>
+      <Database Name="cv" Series="3234" Issue="28378" />
     </Book>
     <Book Series="The New Mutants" Number="54" Volume="1983" Year="1987">
-      <Id>39b6f2b6-ec08-4433-92e5-4262a14249d8</Id>
+      <Database Name="cv" Series="3234" Issue="28490" />
     </Book>
     <Book Series="X-Factor" Number="18" Volume="1986" Year="1987">
-      <Id>c69ce603-d8a3-47a3-b689-e7195eff0171</Id>
+      <Database Name="cv" Series="3657" Issue="28354" />
     </Book>
     <Book Series="X-Factor Annual" Number="2" Volume="1986" Year="1987">
-      <Id>d5abf05a-1244-42a6-9e7d-2f500c2df397</Id>
+      <Database Name="cv" Series="3658" Issue="66334" />
     </Book>
     <Book Series="The X-Men vs. The Avengers" Number="1" Volume="1987" Year="1987">
-      <Id>6c84b1e0-73a2-4cd0-b272-f6712a954150</Id>
+      <Database Name="cv" Series="3867" Issue="28027" />
     </Book>
     <Book Series="The X-Men vs. The Avengers" Number="2" Volume="1987" Year="1987">
-      <Id>627562a8-b997-4012-a925-d01a105591f3</Id>
+      <Database Name="cv" Series="3867" Issue="28128" />
     </Book>
     <Book Series="The X-Men vs. The Avengers" Number="3" Volume="1987" Year="1987">
-      <Id>1888afb2-38ea-47fb-9f71-ff91884c6e21</Id>
+      <Database Name="cv" Series="3867" Issue="28238" />
     </Book>
     <Book Series="The X-Men vs. The Avengers" Number="4" Volume="1987" Year="1987">
-      <Id>ba32d0e1-e837-461b-9330-e31883264d61</Id>
+      <Database Name="cv" Series="3867" Issue="28355" />
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="11" Volume="1970" Year="1987">
-      <Id>8cf5dc45-8bb2-4acd-8c6e-66415131a693</Id>
+    <Book Series="X-Men Annual" Number="11" Volume="1970" Year="1987">
+      <Database Name="cv" Series="22988" Issue="130494" />
     </Book>
     <Book Series="Fantastic Four vs. X-Men" Number="1" Volume="1987" Year="1987">
-      <Id>6390d0fe-00e7-4cf0-bb6d-0378c1502169</Id>
+      <Database Name="cv" Series="3843" Issue="27791" />
     </Book>
     <Book Series="Fantastic Four vs. X-Men" Number="2" Volume="1987" Year="1987">
-      <Id>a98b3388-b63c-4ac0-8dfd-ef6ecd84b393</Id>
+      <Database Name="cv" Series="3843" Issue="27901" />
     </Book>
     <Book Series="Fantastic Four vs. X-Men" Number="3" Volume="1987" Year="1987">
-      <Id>527c59ea-3b74-4f2c-8493-33fe7d483fa4</Id>
+      <Database Name="cv" Series="3843" Issue="28013" />
     </Book>
     <Book Series="Fantastic Four vs. X-Men" Number="4" Volume="1987" Year="1987">
-      <Id>770ea33f-fad2-4803-b15e-afc51d14eea6</Id>
+      <Database Name="cv" Series="3843" Issue="28224" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="220" Volume="1981" Year="1987">
-      <Id>9665c358-b5ad-4239-8d17-76fa4932fed7</Id>
+      <Database Name="cv" Series="3092" Issue="28470" />
     </Book>
     <Book Series="X-Factor" Number="19" Volume="1986" Year="1987">
-      <Id>c78119c4-1297-4fec-a5d5-7a0c24dc952a</Id>
+      <Database Name="cv" Series="3657" Issue="28473" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="221" Volume="1981" Year="1987">
-      <Id>fa3c9bc1-9824-44c8-9e8e-6bf92162124f</Id>
+      <Database Name="cv" Series="3092" Issue="28577" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="222" Volume="1981" Year="1987">
-      <Id>b5309ad7-6c01-4eb1-a01c-a24e2eacda2d</Id>
+      <Database Name="cv" Series="3092" Issue="28700" />
     </Book>
     <Book Series="X-Factor" Number="20" Volume="1986" Year="1987">
-      <Id>1997af78-f64f-4d66-b6db-a9fb07eb348c</Id>
+      <Database Name="cv" Series="3657" Issue="28582" />
     </Book>
     <Book Series="The Incredible Hulk" Number="336" Volume="1968" Year="1987">
-      <Id>fe2e437d-1b4a-412a-b08c-62db8faee466</Id>
+      <Database Name="cv" Series="2406" Issue="28688" />
     </Book>
     <Book Series="The Incredible Hulk" Number="337" Volume="1968" Year="1987">
-      <Id>a7468067-4f7d-46b0-96cf-4ce45350bc52</Id>
+      <Database Name="cv" Series="2406" Issue="28802" />
     </Book>
     <Book Series="X-Factor" Number="21" Volume="1986" Year="1987">
-      <Id>1ce87f71-0504-4255-bd72-b3a60481baef</Id>
+      <Database Name="cv" Series="3657" Issue="28703" />
     </Book>
     <Book Series="X-Factor" Number="22" Volume="1986" Year="1987">
-      <Id>c7ed5168-1d6a-47ff-ae31-abd42e325211</Id>
+      <Database Name="cv" Series="3657" Issue="28821" />
     </Book>
     <Book Series="X-Factor" Number="23" Volume="1986" Year="1987">
-      <Id>9adc7062-6524-45ef-80a2-c852a06d1cc9</Id>
+      <Database Name="cv" Series="3657" Issue="28938" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="223" Volume="1981" Year="1987">
-      <Id>b2538809-4899-4ce2-a266-1db6326d3e75</Id>
+      <Database Name="cv" Series="3092" Issue="28817" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="224" Volume="1981" Year="1987">
-      <Id>0c974ab0-9fc0-49f5-9edc-db22a1d6ec40</Id>
+      <Database Name="cv" Series="3092" Issue="28935" />
     </Book>
     <Book Series="The New Mutants" Number="55" Volume="1983" Year="1987">
-      <Id>58d449f1-2ea7-45c7-9370-19506953fdf3</Id>
+      <Database Name="cv" Series="3234" Issue="28603" />
     </Book>
     <Book Series="The New Mutants" Number="56" Volume="1983" Year="1987">
-      <Id>5e336fe8-03ee-479a-9be2-d7a5a545c357</Id>
+      <Database Name="cv" Series="3234" Issue="28724" />
     </Book>
     <Book Series="The New Mutants" Number="57" Volume="1983" Year="1987">
-      <Id>0b69423e-950f-4690-801b-a681a65e6b84</Id>
+      <Database Name="cv" Series="3234" Issue="28842" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 002 (New X-Men).cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 002 (New X-Men).cbl
@@ -2,946 +2,946 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>X-Men - Part 2 (New X-Men)</Name>
   <Books>
-    <Book Series="Giant-Size X-Men" Number="1" Volume="1975" Year="1975" Format="Giant Size">
+    <Book Series="Giant-Size X-Men" Number="1" Volume="1975" Year="1975">
       <Id>9dfa58f2-a203-4639-ba6f-86b3378e15fc</Id>
     </Book>
-    <Book Series="The X-Men" Number="94" Volume="1963" Year="1975" Format="Main Series">
+    <Book Series="The X-Men" Number="94" Volume="1963" Year="1975">
       <Id>856ded5d-d0c9-412b-803e-ca18fbe4ec77</Id>
     </Book>
-    <Book Series="The X-Men" Number="95" Volume="1963" Year="1975" Format="Main Series">
+    <Book Series="The X-Men" Number="95" Volume="1963" Year="1975">
       <Id>7c3e2846-f48b-404f-a0fb-3f10e78b7e6d</Id>
     </Book>
-    <Book Series="The X-Men" Number="96" Volume="1963" Year="1975" Format="Main Series">
+    <Book Series="The X-Men" Number="96" Volume="1963" Year="1975">
       <Id>369f686e-35c0-4a11-a4ed-18ff1a678f19</Id>
     </Book>
-    <Book Series="The X-Men" Number="97" Volume="1963" Year="1976" Format="Main Series">
+    <Book Series="The X-Men" Number="97" Volume="1963" Year="1976">
       <Id>d35d4074-9c1b-4259-8038-c42ec2a79518</Id>
     </Book>
-    <Book Series="The X-Men" Number="98" Volume="1963" Year="1976" Format="Main Series">
+    <Book Series="The X-Men" Number="98" Volume="1963" Year="1976">
       <Id>0b4b836e-908c-4fb8-aecd-6746cc78e141</Id>
     </Book>
-    <Book Series="The X-Men" Number="99" Volume="1963" Year="1976" Format="Main Series">
+    <Book Series="The X-Men" Number="99" Volume="1963" Year="1976">
       <Id>8e086810-d2f1-4d56-9f14-dc6f8d6a8940</Id>
     </Book>
-    <Book Series="The X-Men" Number="100" Volume="1963" Year="1976" Format="Main Series">
+    <Book Series="The X-Men" Number="100" Volume="1963" Year="1976">
       <Id>546a811a-b360-41b1-bd9b-481a8811261c</Id>
     </Book>
-    <Book Series="The X-Men" Number="101" Volume="1963" Year="1976" Format="Main Series">
+    <Book Series="The X-Men" Number="101" Volume="1963" Year="1976">
       <Id>c2ff5c1b-a642-4be4-bef7-4b710e3fa7cd</Id>
     </Book>
-    <Book Series="The X-Men" Number="102" Volume="1963" Year="1976" Format="Main Series">
+    <Book Series="The X-Men" Number="102" Volume="1963" Year="1976">
       <Id>bede9f8c-3d22-4495-9c6a-ac6e9cc9c8e6</Id>
     </Book>
-    <Book Series="The X-Men" Number="103" Volume="1963" Year="1977" Format="Main Series">
+    <Book Series="The X-Men" Number="103" Volume="1963" Year="1977">
       <Id>eec93d96-dbec-4c9e-86c4-f4192f41ce36</Id>
     </Book>
-    <Book Series="The X-Men" Number="104" Volume="1963" Year="1977" Format="Main Series">
+    <Book Series="The X-Men" Number="104" Volume="1963" Year="1977">
       <Id>1f97361c-3f1b-4064-9fe4-a63daa414d23</Id>
     </Book>
-    <Book Series="The X-Men" Number="105" Volume="1963" Year="1977" Format="Main Series">
+    <Book Series="The X-Men" Number="105" Volume="1963" Year="1977">
       <Id>403586ae-89b5-48ae-9c83-6f04a8267928</Id>
     </Book>
-    <Book Series="The X-Men" Number="106" Volume="1963" Year="1977" Format="Main Series">
+    <Book Series="The X-Men" Number="106" Volume="1963" Year="1977">
       <Id>89b1cb17-d447-42fd-884b-cdb8ab7adc1e</Id>
     </Book>
-    <Book Series="The X-Men" Number="107" Volume="1963" Year="1977" Format="Main Series">
+    <Book Series="The X-Men" Number="107" Volume="1963" Year="1977">
       <Id>1cd9eac5-5a9c-4aed-9e85-c43c35d47d12</Id>
     </Book>
-    <Book Series="The X-Men" Number="108" Volume="1963" Year="1977" Format="Main Series">
+    <Book Series="The X-Men" Number="108" Volume="1963" Year="1977">
       <Id>e1813269-b69a-4fac-b717-8c5dea792062</Id>
     </Book>
-    <Book Series="The X-Men" Number="109" Volume="1963" Year="1978" Format="Main Series">
+    <Book Series="The X-Men" Number="109" Volume="1963" Year="1978">
       <Id>90c2187b-d4d7-4f30-9838-ddbaada45d1b</Id>
     </Book>
-    <Book Series="The X-Men" Number="110" Volume="1963" Year="1978" Format="Main Series">
+    <Book Series="The X-Men" Number="110" Volume="1963" Year="1978">
       <Id>5111e542-09bc-46fa-937a-d29f60ea6a32</Id>
     </Book>
-    <Book Series="Uncanny X-Men: First Class" Number="1" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Uncanny X-Men: First Class" Number="1" Volume="2009" Year="2009">
       <Id>89671bf3-551c-43da-85c0-686aa4219131</Id>
     </Book>
-    <Book Series="Uncanny X-Men: First Class" Number="2" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Uncanny X-Men: First Class" Number="2" Volume="2009" Year="2009">
       <Id>69052b4b-82a1-4f52-bfcd-8f22b6671ed6</Id>
     </Book>
-    <Book Series="Uncanny X-Men: First Class" Number="3" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Uncanny X-Men: First Class" Number="3" Volume="2009" Year="2009">
       <Id>75129674-c0c1-4d82-b659-0561fc228993</Id>
     </Book>
-    <Book Series="Uncanny X-Men: First Class" Number="4" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Uncanny X-Men: First Class" Number="4" Volume="2009" Year="2009">
       <Id>3db2ecb3-947c-4057-9cb2-bcead6ec8eab</Id>
     </Book>
-    <Book Series="Uncanny X-Men: First Class" Number="5" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Uncanny X-Men: First Class" Number="5" Volume="2009" Year="2010">
       <Id>a29596c4-6b9d-4bb0-9405-b757072d6f47</Id>
     </Book>
-    <Book Series="Uncanny X-Men: First Class" Number="6" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Uncanny X-Men: First Class" Number="6" Volume="2009" Year="2010">
       <Id>0410f4d2-9bb8-48a5-97db-1800de476967</Id>
     </Book>
-    <Book Series="Uncanny X-Men: First Class" Number="7" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Uncanny X-Men: First Class" Number="7" Volume="2009" Year="2010">
       <Id>90a912b2-c484-4042-a765-320e3cad1c7e</Id>
     </Book>
-    <Book Series="Uncanny X-Men: First Class" Number="8" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Uncanny X-Men: First Class" Number="8" Volume="2009" Year="2010">
       <Id>f3841f64-3239-46f8-88f9-f06bc8fc37e5</Id>
     </Book>
-    <Book Series="The X-Men" Number="111" Volume="1963" Year="1978" Format="Main Series">
+    <Book Series="The X-Men" Number="111" Volume="1963" Year="1978">
       <Id>3f9cf222-455c-42cd-91eb-3e6086526e83</Id>
     </Book>
-    <Book Series="The X-Men" Number="112" Volume="1963" Year="1978" Format="Main Series">
+    <Book Series="The X-Men" Number="112" Volume="1963" Year="1978">
       <Id>98360a75-4d4c-4824-88f2-4b2d9e58a997</Id>
     </Book>
-    <Book Series="The X-Men" Number="113" Volume="1963" Year="1978" Format="Main Series">
+    <Book Series="The X-Men" Number="113" Volume="1963" Year="1978">
       <Id>0e9cb546-1482-4fb9-8791-70f8bb26e0f2</Id>
     </Book>
-    <Book Series="The X-Men" Number="114" Volume="1963" Year="1978" Format="Main Series">
+    <Book Series="The X-Men" Number="114" Volume="1963" Year="1978">
       <Id>d3d77c77-cbeb-40d1-abe4-f0ed659b6b44</Id>
     </Book>
-    <Book Series="The X-Men" Number="115" Volume="1963" Year="1978" Format="Main Series">
+    <Book Series="The X-Men" Number="115" Volume="1963" Year="1978">
       <Id>5db497e8-6de8-456c-9a5f-3b09a96b3961</Id>
     </Book>
-    <Book Series="The X-Men" Number="116" Volume="1963" Year="1978" Format="Main Series">
+    <Book Series="The X-Men" Number="116" Volume="1963" Year="1978">
       <Id>d427c6c9-0e19-41d6-a420-9a8d41e52670</Id>
     </Book>
-    <Book Series="The X-Men" Number="117" Volume="1963" Year="1979" Format="Main Series">
+    <Book Series="The X-Men" Number="117" Volume="1963" Year="1979">
       <Id>53d7e0fe-daf3-4ece-bc24-48666576ca10</Id>
     </Book>
-    <Book Series="The X-Men" Number="118" Volume="1963" Year="1979" Format="Main Series">
+    <Book Series="The X-Men" Number="118" Volume="1963" Year="1979">
       <Id>c22c3a64-36c6-419f-a532-0bc291c138ea</Id>
     </Book>
-    <Book Series="The X-Men" Number="119" Volume="1963" Year="1979" Format="Main Series">
+    <Book Series="The X-Men" Number="119" Volume="1963" Year="1979">
       <Id>a4ca27ae-9958-4a5b-9891-1423afb05c33</Id>
     </Book>
-    <Book Series="The X-Men" Number="120" Volume="1963" Year="1979" Format="Main Series">
+    <Book Series="The X-Men" Number="120" Volume="1963" Year="1979">
       <Id>3d1a375f-0e6f-493d-9482-492d13e72c67</Id>
     </Book>
-    <Book Series="The X-Men" Number="121" Volume="1963" Year="1979" Format="Main Series">
+    <Book Series="The X-Men" Number="121" Volume="1963" Year="1979">
       <Id>248ed0fd-7e4e-4e1f-ae28-7fe4e5fcbc24</Id>
     </Book>
-    <Book Series="The X-Men" Number="122" Volume="1963" Year="1979" Format="Main Series">
+    <Book Series="The X-Men" Number="122" Volume="1963" Year="1979">
       <Id>098eb824-cba0-4e03-a56a-a07972b57144</Id>
     </Book>
-    <Book Series="The X-Men" Number="123" Volume="1963" Year="1979" Format="Main Series">
+    <Book Series="The X-Men" Number="123" Volume="1963" Year="1979">
       <Id>2177c9f5-b22c-4420-85db-042775d9ce2f</Id>
     </Book>
-    <Book Series="The X-Men" Number="124" Volume="1963" Year="1979" Format="Main Series">
+    <Book Series="The X-Men" Number="124" Volume="1963" Year="1979">
       <Id>fcb2db82-9747-49cd-897c-cf88edb4dc47</Id>
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="3" Volume="1982" Year="1979" Format="Annual">
+    <Book Series="The Uncanny X-Men Annual" Number="3" Volume="1982" Year="1979">
       <Id>3e40cf38-4f6c-4106-af0e-0fd24cc7ba9a</Id>
     </Book>
-    <Book Series="The X-Men" Number="125" Volume="1963" Year="1979" Format="Main Series">
+    <Book Series="The X-Men" Number="125" Volume="1963" Year="1979">
       <Id>8190cb33-1ccd-4a66-8cb9-ae33a2df4be7</Id>
     </Book>
-    <Book Series="The X-Men" Number="126" Volume="1963" Year="1979" Format="Main Series">
+    <Book Series="The X-Men" Number="126" Volume="1963" Year="1979">
       <Id>979dc202-a0df-433e-a56b-34fd0b0da9df</Id>
     </Book>
-    <Book Series="The X-Men" Number="127" Volume="1963" Year="1979" Format="Main Series">
+    <Book Series="The X-Men" Number="127" Volume="1963" Year="1979">
       <Id>40b6d305-9115-4367-8db9-69b856b10c30</Id>
     </Book>
-    <Book Series="The X-Men" Number="128" Volume="1963" Year="1979" Format="Main Series">
+    <Book Series="The X-Men" Number="128" Volume="1963" Year="1979">
       <Id>cda0552b-243b-4790-ac3a-116eca8bbd43</Id>
     </Book>
-    <Book Series="The X-Men" Number="129" Volume="1963" Year="1980" Format="Main Series">
+    <Book Series="The X-Men" Number="129" Volume="1963" Year="1980">
       <Id>cdffd778-1dee-4921-be00-cadb4e85a6e9</Id>
     </Book>
-    <Book Series="The X-Men" Number="130" Volume="1963" Year="1980" Format="Main Series">
+    <Book Series="The X-Men" Number="130" Volume="1963" Year="1980">
       <Id>5a7a7acc-400a-4bb0-af9c-fbb06e544656</Id>
     </Book>
-    <Book Series="The X-Men" Number="131" Volume="1963" Year="1980" Format="Main Series">
+    <Book Series="The X-Men" Number="131" Volume="1963" Year="1980">
       <Id>d95862fc-05d4-428a-8628-93c2758321f8</Id>
     </Book>
-    <Book Series="The X-Men" Number="132" Volume="1963" Year="1980" Format="Main Series">
+    <Book Series="The X-Men" Number="132" Volume="1963" Year="1980">
       <Id>b70fb928-b553-4b7d-b07e-7353d71d7541</Id>
     </Book>
-    <Book Series="The X-Men" Number="133" Volume="1963" Year="1980" Format="Main Series">
+    <Book Series="The X-Men" Number="133" Volume="1963" Year="1980">
       <Id>6382a00d-b89a-41e9-b9f6-a5da02a42c05</Id>
     </Book>
-    <Book Series="The X-Men" Number="134" Volume="1963" Year="1980" Format="Main Series">
+    <Book Series="The X-Men" Number="134" Volume="1963" Year="1980">
       <Id>d4a0c68d-7d0d-4fc6-900f-d4e7197a28f7</Id>
     </Book>
-    <Book Series="The X-Men" Number="135" Volume="1963" Year="1980" Format="Main Series">
+    <Book Series="The X-Men" Number="135" Volume="1963" Year="1980">
       <Id>f41219ee-16c1-4005-a9dd-2f9cd552303b</Id>
     </Book>
-    <Book Series="The X-Men" Number="136" Volume="1963" Year="1980" Format="Main Series">
+    <Book Series="The X-Men" Number="136" Volume="1963" Year="1980">
       <Id>baf1e509-1eb9-4cce-b243-a570b2eacb59</Id>
     </Book>
-    <Book Series="The X-Men" Number="137" Volume="1963" Year="1980" Format="Main Series">
+    <Book Series="The X-Men" Number="137" Volume="1963" Year="1980">
       <Id>faf67fc4-6721-498d-841e-13ebbf6be536</Id>
     </Book>
-    <Book Series="The X-Men" Number="138" Volume="1963" Year="1980" Format="Main Series">
+    <Book Series="The X-Men" Number="138" Volume="1963" Year="1980">
       <Id>7c41b0bc-8fb2-4a99-bebc-1fec9374382b</Id>
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="4" Volume="1982" Year="1980" Format="Annual">
+    <Book Series="The Uncanny X-Men Annual" Number="4" Volume="1982" Year="1980">
       <Id>38168df4-1fcd-462b-81d8-1f9b770557e3</Id>
     </Book>
-    <Book Series="The X-Men" Number="139" Volume="1963" Year="1980" Format="Main Series">
+    <Book Series="The X-Men" Number="139" Volume="1963" Year="1980">
       <Id>6a3b363e-4635-49c0-bcc6-86024a6d76d0</Id>
     </Book>
-    <Book Series="The X-Men" Number="140" Volume="1963" Year="1980" Format="Main Series">
+    <Book Series="The X-Men" Number="140" Volume="1963" Year="1980">
       <Id>9b409ab7-44c3-4285-8f58-eed190e08418</Id>
     </Book>
-    <Book Series="The X-Men" Number="141" Volume="1963" Year="1981" Format="Main Series">
+    <Book Series="The X-Men" Number="141" Volume="1963" Year="1981">
       <Id>3ba55d27-b36a-418b-bac5-d793bb4f45c2</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="142" Volume="1981" Year="1981" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="142" Volume="1981" Year="1981">
       <Id>74b01b51-40b7-4eb3-8193-86fac8ada469</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="143" Volume="1981" Year="1981" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="143" Volume="1981" Year="1981">
       <Id>987b7d9f-9732-426f-8415-a304dd7be77c</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="144" Volume="1981" Year="1981" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="144" Volume="1981" Year="1981">
       <Id>8b139b7d-29fc-472e-b31f-01f5a9c38186</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="145" Volume="1981" Year="1981" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="145" Volume="1981" Year="1981">
       <Id>6ed83e4d-96c7-49f1-a5bf-db3e491dfe6c</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="146" Volume="1981" Year="1981" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="146" Volume="1981" Year="1981">
       <Id>7df126d5-02f7-4091-ac21-810b59c231e9</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="147" Volume="1981" Year="1981" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="147" Volume="1981" Year="1981">
       <Id>1e43624d-80b3-4dc0-a05e-6865e1b1c0b9</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="37" Volume="1978" Year="1981" Format="Main Series">
+    <Book Series="Spider-Woman" Number="37" Volume="1978" Year="1981">
       <Id>e54dab93-c568-43f6-a4ed-ee5f610d2491</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="38" Volume="1978" Year="1981" Format="Main Series">
+    <Book Series="Spider-Woman" Number="38" Volume="1978" Year="1981">
       <Id>c9743747-f5c2-4791-9c17-c1bdce781875</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="148" Volume="1981" Year="1981" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="148" Volume="1981" Year="1981">
       <Id>a00e8d5f-3db8-4eb8-a263-f37bc8caa6dd</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="149" Volume="1981" Year="1981" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="149" Volume="1981" Year="1981">
       <Id>ba96d22a-3d7d-47a7-9f1b-887cc05b54f7</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="150" Volume="1981" Year="1981" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="150" Volume="1981" Year="1981">
       <Id>594d6801-df46-4285-aa89-56bf91bd809b</Id>
     </Book>
-    <Book Series="The Avengers Annual" Number="10" Volume="1967" Year="1981" Format="Annual">
+    <Book Series="The Avengers Annual" Number="10" Volume="1967" Year="1981">
       <Id>73e646a5-43a9-41b7-b246-7548d1473d92</Id>
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="5" Volume="1982" Year="1981" Format="Annual">
+    <Book Series="The Uncanny X-Men Annual" Number="5" Volume="1982" Year="1981">
       <Id>b32fdfd9-b4ad-493e-bfec-4a9c41531d15</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="151" Volume="1981" Year="1981" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="151" Volume="1981" Year="1981">
       <Id>6665acb1-7230-4229-b0a0-23d8b5d3b490</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="152" Volume="1981" Year="1981" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="152" Volume="1981" Year="1981">
       <Id>77a0d314-be8a-4e25-bc3a-21e68fde37ac</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="153" Volume="1981" Year="1982" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="153" Volume="1981" Year="1982">
       <Id>766ac5f5-67c0-47e0-adbe-4c8d7f674c19</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="154" Volume="1981" Year="1982" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="154" Volume="1981" Year="1982">
       <Id>80bb6b7f-79e3-4d9b-a8a9-9e59e97e5a7d</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="155" Volume="1981" Year="1982" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="155" Volume="1981" Year="1982">
       <Id>1e104096-410e-4fc7-ad5d-ccdc41d8154a</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="156" Volume="1981" Year="1982" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="156" Volume="1981" Year="1982">
       <Id>bc0ad44d-7c2b-4448-adb9-1dbad3dff745</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="157" Volume="1981" Year="1982" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="157" Volume="1981" Year="1982">
       <Id>28de84ac-0e01-4430-aa53-bd7bba8687c8</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="158" Volume="1981" Year="1982" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="158" Volume="1981" Year="1982">
       <Id>813ed328-f83c-4a74-aa75-a7665f2c0c3b</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="159" Volume="1981" Year="1982" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="159" Volume="1981" Year="1982">
       <Id>68f68c89-60d9-43d4-81f2-11e20036b272</Id>
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="6" Volume="1982" Year="1982" Format="Annual">
+    <Book Series="The Uncanny X-Men Annual" Number="6" Volume="1982" Year="1982">
       <Id>de97eb55-3292-4cd8-bae3-fe0b117c883d</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="160" Volume="1981" Year="1982" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="160" Volume="1981" Year="1982">
       <Id>6b2b0dee-4899-4a9f-972e-8e49baa132af</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="161" Volume="1981" Year="1982" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="161" Volume="1981" Year="1982">
       <Id>9c038486-707d-4eeb-95e4-a8f37d1a05f5</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="162" Volume="1981" Year="1982" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="162" Volume="1981" Year="1982">
       <Id>317c764f-e444-4928-b6ca-82fd754c5d61</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="163" Volume="1981" Year="1982" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="163" Volume="1981" Year="1982">
       <Id>8d415cf0-68e4-4491-ae0b-5cbda16cb2e7</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="164" Volume="1981" Year="1982" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="164" Volume="1981" Year="1982">
       <Id>413e8400-c470-4d12-ac1e-99b904b0a877</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="165" Volume="1981" Year="1983" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="165" Volume="1981" Year="1983">
       <Id>903ebd0c-b8c6-4aef-832c-291ab0671596</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="166" Volume="1981" Year="1983" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="166" Volume="1981" Year="1983">
       <Id>0241089d-8f73-4af7-aeb1-23905e2662d9</Id>
     </Book>
-    <Book Series="Marvel Graphic Novel" Number="4" Volume="1982" Year="1982" Format="Graphic Novel">
+    <Book Series="Marvel Graphic Novel" Number="4" Volume="1982" Year="1982">
       <Id>3e713f8d-b357-4fa1-a85a-9a77ab5bdcba</Id>
     </Book>
-    <Book Series="The New Mutants" Number="1" Volume="1983" Year="1983" Format="Main Series">
+    <Book Series="The New Mutants" Number="1" Volume="1983" Year="1983">
       <Id>311f0ba5-087e-49cb-bfa8-c98cb8b03d8b</Id>
     </Book>
-    <Book Series="The New Mutants" Number="2" Volume="1983" Year="1983" Format="Main Series">
+    <Book Series="The New Mutants" Number="2" Volume="1983" Year="1983">
       <Id>849abfba-7bb6-40db-97b5-4d2143b003ef</Id>
     </Book>
-    <Book Series="The New Mutants" Number="3" Volume="1983" Year="1983" Format="Main Series">
+    <Book Series="The New Mutants" Number="3" Volume="1983" Year="1983">
       <Id>065397c9-6aa8-46f0-80c6-5d3b2b371a8a</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="167" Volume="1981" Year="1983" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="167" Volume="1981" Year="1983">
       <Id>ff2e760c-d6f2-44fe-859a-25aee4164b72</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="168" Volume="1981" Year="1983" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="168" Volume="1981" Year="1983">
       <Id>03edef4b-b95b-40a4-8f67-0859bd7f7a79</Id>
     </Book>
-    <Book Series="Magik (Storm and Illyana Limited Series)" Number="1" Volume="1983" Year="1983" Format="Limited Series">
+    <Book Series="Magik (Storm and Illyana Limited Series)" Number="1" Volume="1983" Year="1983">
       <Id>fbb8adfb-3997-4c99-83ab-629844ac2da8</Id>
     </Book>
-    <Book Series="Magik (Storm and Illyana Limited Series)" Number="2" Volume="1983" Year="1984" Format="Limited Series">
+    <Book Series="Magik (Storm and Illyana Limited Series)" Number="2" Volume="1983" Year="1984">
       <Id>071ade06-dad3-4995-9f32-2db70dbcf3cc</Id>
     </Book>
-    <Book Series="Magik (Storm and Illyana Limited Series)" Number="3" Volume="1983" Year="1984" Format="Limited Series">
+    <Book Series="Magik (Storm and Illyana Limited Series)" Number="3" Volume="1983" Year="1984">
       <Id>3a26cfbf-d6ad-4513-8e7f-1c513541c9a3</Id>
     </Book>
-    <Book Series="Magik (Storm and Illyana Limited Series)" Number="4" Volume="1983" Year="1984" Format="Limited Series">
+    <Book Series="Magik (Storm and Illyana Limited Series)" Number="4" Volume="1983" Year="1984">
       <Id>946c0469-3c5d-40fb-bf07-53ae1b7732ed</Id>
     </Book>
-    <Book Series="Marvel Graphic Novel" Number="5" Volume="1982" Year="1982" Format="Graphic Novel">
+    <Book Series="Marvel Graphic Novel" Number="5" Volume="1982" Year="1982">
       <Id>acf56583-db2d-4e27-9c05-14184a66b3b2</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="169" Volume="1981" Year="1983" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="169" Volume="1981" Year="1983">
       <Id>71353ccc-3b07-4bae-9d70-df5c60b07ced</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="170" Volume="1981" Year="1983" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="170" Volume="1981" Year="1983">
       <Id>90f2cbf5-40d1-441b-8f67-aa28cf39dd9a</Id>
     </Book>
-    <Book Series="The New Mutants" Number="4" Volume="1983" Year="1983" Format="Main Series">
+    <Book Series="The New Mutants" Number="4" Volume="1983" Year="1983">
       <Id>8391f300-513d-4904-b8b0-a5be47f18cfd</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="171" Volume="1981" Year="1983" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="171" Volume="1981" Year="1983">
       <Id>d081f7ac-4569-4647-821c-876228d549ea</Id>
     </Book>
-    <Book Series="Wolverine" Number="1" Volume="1982" Year="1982" Format="Limited Series">
+    <Book Series="Wolverine" Number="1" Volume="1982" Year="1982">
       <Id>3e70a1fe-4021-4122-9e5c-a996122fb79a</Id>
     </Book>
-    <Book Series="Wolverine" Number="2" Volume="1982" Year="1982" Format="Limited Series">
+    <Book Series="Wolverine" Number="2" Volume="1982" Year="1982">
       <Id>0a47cd23-f75a-4260-aaba-1fe5d50d78a6</Id>
     </Book>
-    <Book Series="Wolverine" Number="3" Volume="1982" Year="1982" Format="Limited Series">
+    <Book Series="Wolverine" Number="3" Volume="1982" Year="1982">
       <Id>b85bd6ba-26aa-4d77-9f5b-2a3ad03a7cd7</Id>
     </Book>
-    <Book Series="Wolverine" Number="4" Volume="1982" Year="1982" Format="Limited Series">
+    <Book Series="Wolverine" Number="4" Volume="1982" Year="1982">
       <Id>adfd615c-552e-4c89-a89e-b1330e2cfc8d</Id>
     </Book>
-    <Book Series="The New Mutants" Number="5" Volume="1983" Year="1983" Format="Main Series">
+    <Book Series="The New Mutants" Number="5" Volume="1983" Year="1983">
       <Id>89295e6a-ecda-42ba-ae83-95121a38dda3</Id>
     </Book>
-    <Book Series="The New Mutants" Number="6" Volume="1983" Year="1983" Format="Main Series">
+    <Book Series="The New Mutants" Number="6" Volume="1983" Year="1983">
       <Id>82f230b0-7ae9-444a-82a6-05dea02c20e2</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="172" Volume="1981" Year="1983" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="172" Volume="1981" Year="1983">
       <Id>45873a60-93ff-4e62-ad51-89905f249470</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="173" Volume="1981" Year="1983" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="173" Volume="1981" Year="1983">
       <Id>a8dc46ac-61d1-4ee8-98d8-5c3c75eb27ab</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="174" Volume="1981" Year="1983" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="174" Volume="1981" Year="1983">
       <Id>661ddff7-3bfe-4d0a-a3d1-dba1e3c3b0b4</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="175" Volume="1981" Year="1983" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="175" Volume="1981" Year="1983">
       <Id>6003bca8-5393-4a9f-b66e-26d1a6f0b106</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="176" Volume="1981" Year="1983" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="176" Volume="1981" Year="1983">
       <Id>92333cb3-003a-4720-8aac-d940f100523e</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="177" Volume="1981" Year="1984" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="177" Volume="1981" Year="1984">
       <Id>de7ac5f0-125c-4aac-9871-4211631bfeab</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="178" Volume="1981" Year="1984" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="178" Volume="1981" Year="1984">
       <Id>86558165-a3ee-4e41-a736-e277905e34fa</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="179" Volume="1981" Year="1984" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="179" Volume="1981" Year="1984">
       <Id>ac878931-b7a5-4824-a6d4-a65104150002</Id>
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="7" Volume="1982" Year="1983" Format="Annual">
+    <Book Series="The Uncanny X-Men Annual" Number="7" Volume="1982" Year="1983">
       <Id>51541e1b-a396-468b-bd80-83bd1db57998</Id>
     </Book>
-    <Book Series="The New Mutants" Number="7" Volume="1983" Year="1983" Format="Main Series">
+    <Book Series="The New Mutants" Number="7" Volume="1983" Year="1983">
       <Id>e2b63298-e04c-4626-886c-126992a371a1</Id>
     </Book>
-    <Book Series="The New Mutants" Number="8" Volume="1983" Year="1983" Format="Main Series">
+    <Book Series="The New Mutants" Number="8" Volume="1983" Year="1983">
       <Id>657a8207-e557-48dd-9fbe-4ac8e422c280</Id>
     </Book>
-    <Book Series="The New Mutants" Number="9" Volume="1983" Year="1983" Format="Main Series">
+    <Book Series="The New Mutants" Number="9" Volume="1983" Year="1983">
       <Id>a8056614-f8f1-4d89-a3db-4502a419991f</Id>
     </Book>
-    <Book Series="The New Mutants" Number="10" Volume="1983" Year="1983" Format="Main Series">
+    <Book Series="The New Mutants" Number="10" Volume="1983" Year="1983">
       <Id>8c65e815-e666-4711-9c6d-62c061881a94</Id>
     </Book>
-    <Book Series="The New Mutants" Number="11" Volume="1983" Year="1984" Format="Main Series">
+    <Book Series="The New Mutants" Number="11" Volume="1983" Year="1984">
       <Id>1c389791-ea05-401e-9b24-1877a107b2d2</Id>
     </Book>
-    <Book Series="The New Mutants" Number="12" Volume="1983" Year="1984" Format="Main Series">
+    <Book Series="The New Mutants" Number="12" Volume="1983" Year="1984">
       <Id>03f15814-2028-4e17-920e-9aef5c5314ec</Id>
     </Book>
-    <Book Series="The New Mutants" Number="13" Volume="1983" Year="1984" Format="Main Series">
+    <Book Series="The New Mutants" Number="13" Volume="1983" Year="1984">
       <Id>66b31c6d-092b-476c-999f-1d5d43563e1d</Id>
     </Book>
-    <Book Series="The New Mutants" Number="14" Volume="1983" Year="1984" Format="Main Series">
+    <Book Series="The New Mutants" Number="14" Volume="1983" Year="1984">
       <Id>5fb678e8-14c3-46a4-8329-d1d6ba1b759b</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="180" Volume="1981" Year="1984" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="180" Volume="1981" Year="1984">
       <Id>4c023075-8ff0-450e-9086-45f9760ec8c8</Id>
     </Book>
-    <Book Series="The New Mutants" Number="15" Volume="1983" Year="1984" Format="Main Series">
+    <Book Series="The New Mutants" Number="15" Volume="1983" Year="1984">
       <Id>1074243e-7c42-4875-8759-70e6145149f8</Id>
     </Book>
-    <Book Series="The New Mutants" Number="16" Volume="1983" Year="1984" Format="Main Series">
+    <Book Series="The New Mutants" Number="16" Volume="1983" Year="1984">
       <Id>991a574b-c35a-48c4-9e43-a5436dc303fe</Id>
     </Book>
-    <Book Series="The New Mutants" Number="17" Volume="1983" Year="1984" Format="Main Series">
+    <Book Series="The New Mutants" Number="17" Volume="1983" Year="1984">
       <Id>21157f41-ff53-4bdc-8286-619eaed7351d</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="1" Volume="1984" Year="1984" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="1" Volume="1984" Year="1984">
       <Id>12503f27-0432-4189-bf4d-9a092c361be5</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="2" Volume="1984" Year="1984" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="2" Volume="1984" Year="1984">
       <Id>0df09638-e7aa-4c19-b3b9-92994d19f00c</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="3" Volume="1984" Year="1984" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="3" Volume="1984" Year="1984">
       <Id>dd4bf6df-05ce-409d-8342-ad408f5001de</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="4" Volume="1984" Year="1984" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="4" Volume="1984" Year="1984">
       <Id>61d4e08c-4ec2-4fb5-9c79-c6da12e143c6</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="5" Volume="1984" Year="1984" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="5" Volume="1984" Year="1984">
       <Id>26d243b1-683b-4584-ad74-9a6b9c73566d</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="6" Volume="1984" Year="1984" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="6" Volume="1984" Year="1984">
       <Id>a089a0c1-e78d-4068-8116-f1deb0dd9c14</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="7" Volume="1984" Year="1984" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="7" Volume="1984" Year="1984">
       <Id>05b79a55-a242-4e11-985b-0466169555da</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="8" Volume="1984" Year="1984" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="8" Volume="1984" Year="1984">
       <Id>111ee946-dd1c-4452-bb71-206092ce3b80</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="9" Volume="1984" Year="1985" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="9" Volume="1984" Year="1985">
       <Id>2de4ebb6-4faf-49f5-be60-08921d7d14d2</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="10" Volume="1984" Year="1985" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="10" Volume="1984" Year="1985">
       <Id>a9133d85-6b2d-4287-98f2-5365a1bf2ab2</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="11" Volume="1984" Year="1985" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="11" Volume="1984" Year="1985">
       <Id>882ae5ee-1c89-48a6-a5ed-5390b175586e</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="12" Volume="1984" Year="1985" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="12" Volume="1984" Year="1985">
       <Id>0c242418-14f2-4115-bd77-b507f0c577a1</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="181" Volume="1981" Year="1984" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="181" Volume="1981" Year="1984">
       <Id>76dc7cb0-75fc-4628-a688-08235fcace76</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="182" Volume="1981" Year="1984" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="182" Volume="1981" Year="1984">
       <Id>a762704e-1282-4524-821a-b23e3a72139f</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="183" Volume="1981" Year="1984" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="183" Volume="1981" Year="1984">
       <Id>3a430de1-16ac-496d-8180-8d6e8fa7b598</Id>
     </Book>
-    <Book Series="The New Mutants" Number="18" Volume="1983" Year="1984" Format="Main Series">
+    <Book Series="The New Mutants" Number="18" Volume="1983" Year="1984">
       <Id>bdbaf7de-da00-43e2-bbf2-57855ac58b89</Id>
     </Book>
-    <Book Series="The New Mutants" Number="19" Volume="1983" Year="1984" Format="Main Series">
+    <Book Series="The New Mutants" Number="19" Volume="1983" Year="1984">
       <Id>a14a74cf-4a02-4358-89c0-457a72750180</Id>
     </Book>
-    <Book Series="The New Mutants" Number="20" Volume="1983" Year="1984" Format="Main Series">
+    <Book Series="The New Mutants" Number="20" Volume="1983" Year="1984">
       <Id>bba7991a-8961-4cd0-bf61-3b2e8752099e</Id>
     </Book>
-    <Book Series="The New Mutants" Number="21" Volume="1983" Year="1984" Format="Main Series">
+    <Book Series="The New Mutants" Number="21" Volume="1983" Year="1984">
       <Id>6b685455-3c9c-4ad2-b916-1ea82445694c</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="184" Volume="1981" Year="1984" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="184" Volume="1981" Year="1984">
       <Id>2146538b-bb96-4543-853d-26ed0b3d21b3</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="185" Volume="1981" Year="1984" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="185" Volume="1981" Year="1984">
       <Id>be239f29-2465-4be7-b677-5e4766c85933</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="186" Volume="1981" Year="1984" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="186" Volume="1981" Year="1984">
       <Id>4e20bdf3-2b17-42fe-a318-6b7282ae24b2</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="187" Volume="1981" Year="1984" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="187" Volume="1981" Year="1984">
       <Id>b1b44792-f617-4caf-9898-545d8bc28be8</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="188" Volume="1981" Year="1984" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="188" Volume="1981" Year="1984">
       <Id>70589586-c0e0-481a-8d97-1c79b8b779f5</Id>
     </Book>
-    <Book Series="Kitty Pryde and Wolverine" Number="1" Volume="1984" Year="1984" Format="Limited Series">
+    <Book Series="Kitty Pryde and Wolverine" Number="1" Volume="1984" Year="1984">
       <Id>8174ac31-20e7-431f-8eab-18cefb74f8b4</Id>
     </Book>
-    <Book Series="Kitty Pryde and Wolverine" Number="2" Volume="1984" Year="1984" Format="Limited Series">
+    <Book Series="Kitty Pryde and Wolverine" Number="2" Volume="1984" Year="1984">
       <Id>9228a06a-5592-46b8-b39c-c2c1d2a9b9d5</Id>
     </Book>
-    <Book Series="Kitty Pryde and Wolverine" Number="3" Volume="1984" Year="1985" Format="Limited Series">
+    <Book Series="Kitty Pryde and Wolverine" Number="3" Volume="1984" Year="1985">
       <Id>6ccfb6ca-8d3d-4efb-9c06-b382fc25a8e9</Id>
     </Book>
-    <Book Series="Kitty Pryde and Wolverine" Number="4" Volume="1984" Year="1985" Format="Limited Series">
+    <Book Series="Kitty Pryde and Wolverine" Number="4" Volume="1984" Year="1985">
       <Id>08c21cfc-8c66-4090-acc7-ec7f93ede345</Id>
     </Book>
-    <Book Series="Kitty Pryde and Wolverine" Number="5" Volume="1984" Year="1985" Format="Limited Series">
+    <Book Series="Kitty Pryde and Wolverine" Number="5" Volume="1984" Year="1985">
       <Id>a5a63142-15c6-4530-870a-465a7a54aed6</Id>
     </Book>
-    <Book Series="Kitty Pryde and Wolverine" Number="6" Volume="1984" Year="1985" Format="Limited Series">
+    <Book Series="Kitty Pryde and Wolverine" Number="6" Volume="1984" Year="1985">
       <Id>56c09a79-85cf-40a6-acf6-5a7c47aaea58</Id>
     </Book>
-    <Book Series="The New Mutants Annual" Number="1" Volume="1984" Year="1984" Format="Annual">
+    <Book Series="The New Mutants Annual" Number="1" Volume="1984" Year="1984">
       <Id>3bb835c7-8322-46b5-ace2-b608b855b70a</Id>
     </Book>
-    <Book Series="Iceman" Number="1" Volume="1984" Year="1984" Format="Limited Series">
+    <Book Series="Iceman" Number="1" Volume="1984" Year="1984">
       <Id>1047a0ac-7080-4b38-b647-724fb025faae</Id>
     </Book>
-    <Book Series="Iceman" Number="2" Volume="1984" Year="1985" Format="Limited Series">
+    <Book Series="Iceman" Number="2" Volume="1984" Year="1985">
       <Id>2a28ba3b-8d6b-4c0e-bdf7-58346c89f292</Id>
     </Book>
-    <Book Series="Iceman" Number="3" Volume="1984" Year="1985" Format="Limited Series">
+    <Book Series="Iceman" Number="3" Volume="1984" Year="1985">
       <Id>1a473481-d760-45f5-92d8-f3ebb4853af5</Id>
     </Book>
-    <Book Series="Iceman" Number="4" Volume="1984" Year="1985" Format="Limited Series">
+    <Book Series="Iceman" Number="4" Volume="1984" Year="1985">
       <Id>fe0eb173-a798-47b8-b17f-9b264835003c</Id>
     </Book>
-    <Book Series="The New Mutants" Number="22" Volume="1983" Year="1984" Format="Main Series">
+    <Book Series="The New Mutants" Number="22" Volume="1983" Year="1984">
       <Id>a28e1982-8219-4006-a93e-d6fea83663d1</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="189" Volume="1981" Year="1985" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="189" Volume="1981" Year="1985">
       <Id>b3ffd42f-7cf7-48f0-aada-550740283579</Id>
     </Book>
-    <Book Series="The New Mutants" Number="23" Volume="1983" Year="1985" Format="Main Series">
+    <Book Series="The New Mutants" Number="23" Volume="1983" Year="1985">
       <Id>0afa9aec-13da-4461-b673-86dca7b2833d</Id>
     </Book>
-    <Book Series="The New Mutants" Number="24" Volume="1983" Year="1985" Format="Main Series">
+    <Book Series="The New Mutants" Number="24" Volume="1983" Year="1985">
       <Id>43e64028-0942-44a8-b56f-5394256315d2</Id>
     </Book>
-    <Book Series="The New Mutants" Number="25" Volume="1983" Year="1985" Format="Main Series">
+    <Book Series="The New Mutants" Number="25" Volume="1983" Year="1985">
       <Id>74aad6b6-182b-4b05-9fca-a53f680f0d9d</Id>
     </Book>
-    <Book Series="Marvel Graphic Novel" Number="12" Volume="1982" Year="1984" Format="Graphic Novel">
+    <Book Series="Marvel Graphic Novel" Number="12" Volume="1982" Year="1984">
       <Id>6a797284-312c-4a03-aa5a-e82ff17d5654</Id>
     </Book>
-    <Book Series="Beauty and the Beast" Number="1" Volume="1984" Year="1984" Format="Limited Series">
+    <Book Series="Beauty and the Beast" Number="1" Volume="1984" Year="1984">
       <Id>5d395011-5bc4-40a0-9638-71a1453294f5</Id>
     </Book>
-    <Book Series="Beauty and the Beast" Number="2" Volume="1984" Year="1985" Format="Limited Series">
+    <Book Series="Beauty and the Beast" Number="2" Volume="1984" Year="1985">
       <Id>d68cd6d3-fc80-48db-b484-d9137f46cd26</Id>
     </Book>
-    <Book Series="Beauty and the Beast" Number="3" Volume="1984" Year="1985" Format="Limited Series">
+    <Book Series="Beauty and the Beast" Number="3" Volume="1984" Year="1985">
       <Id>883f381a-d63f-4c27-a134-4d77c0d6b6be</Id>
     </Book>
-    <Book Series="Beauty and the Beast" Number="4" Volume="1984" Year="1985" Format="Limited Series">
+    <Book Series="Beauty and the Beast" Number="4" Volume="1984" Year="1985">
       <Id>1f99b1d5-f651-4bf3-a015-20e92f0606a2</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="190" Volume="1981" Year="1985" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="190" Volume="1981" Year="1985">
       <Id>0de7bfc3-ee48-4783-8856-9772654afa58</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="191" Volume="1981" Year="1985" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="191" Volume="1981" Year="1985">
       <Id>16777a91-1a00-4599-bf8c-850cfdec4880</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="192" Volume="1981" Year="1985" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="192" Volume="1981" Year="1985">
       <Id>0c191262-3c49-43d9-8dd6-284b8212d3f9</Id>
     </Book>
-    <Book Series="X-Men/Alpha Flight" Number="1" Volume="1985" Year="1985" Format="Limited Series">
+    <Book Series="X-Men/Alpha Flight" Number="1" Volume="1985" Year="1985">
       <Id>44904380-8c48-4806-823d-2a51e6074d49</Id>
     </Book>
-    <Book Series="X-Men/Alpha Flight" Number="2" Volume="1985" Year="1986" Format="Limited Series">
+    <Book Series="X-Men/Alpha Flight" Number="2" Volume="1985" Year="1986">
       <Id>b3c23538-f933-49fd-b90a-d53d6884bd3e</Id>
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="8" Volume="1982" Year="1984" Format="Annual">
+    <Book Series="The Uncanny X-Men Annual" Number="8" Volume="1982" Year="1984">
       <Id>bdbb4381-28cc-4bac-b806-1cbee1c5b3b4</Id>
     </Book>
-    <Book Series="Firestar" Number="1" Volume="1986" Year="1986" Format="Limited Series">
+    <Book Series="Firestar" Number="1" Volume="1986" Year="1986">
       <Id>d3130e1a-d531-4c40-9bc6-c2711c1088d8</Id>
     </Book>
-    <Book Series="Firestar" Number="2" Volume="1986" Year="1986" Format="Limited Series">
+    <Book Series="Firestar" Number="2" Volume="1986" Year="1986">
       <Id>b57715bd-40f2-486d-9515-7c967b6c65d9</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="193" Volume="1981" Year="1985" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="193" Volume="1981" Year="1985">
       <Id>40e2d805-6762-404d-b88b-5de72f290c81</Id>
     </Book>
-    <Book Series="Firestar" Number="3" Volume="1986" Year="1986" Format="Limited Series">
+    <Book Series="Firestar" Number="3" Volume="1986" Year="1986">
       <Id>9946a545-2620-4eaf-80db-83bc3401e621</Id>
     </Book>
-    <Book Series="Firestar" Number="4" Volume="1986" Year="1986" Format="Limited Series">
+    <Book Series="Firestar" Number="4" Volume="1986" Year="1986">
       <Id>f313e558-aaf3-4412-a24b-9f4de10c9aaf</Id>
     </Book>
-    <Book Series="The New Mutants" Number="26" Volume="1983" Year="1985" Format="Main Series">
+    <Book Series="The New Mutants" Number="26" Volume="1983" Year="1985">
       <Id>c5285332-c617-436b-bd48-c3917cc2fd69</Id>
     </Book>
-    <Book Series="The New Mutants" Number="27" Volume="1983" Year="1985" Format="Main Series">
+    <Book Series="The New Mutants" Number="27" Volume="1983" Year="1985">
       <Id>dc012a77-8651-4356-b729-f6d122ce2915</Id>
     </Book>
-    <Book Series="The New Mutants" Number="28" Volume="1983" Year="1985" Format="Main Series">
+    <Book Series="The New Mutants" Number="28" Volume="1983" Year="1985">
       <Id>636a16cb-a7c5-411e-a46d-71fc98964215</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="194" Volume="1981" Year="1985" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="194" Volume="1981" Year="1985">
       <Id>6946b0e3-78f6-417e-bc7f-694155938344</Id>
     </Book>
-    <Book Series="The New Mutants" Number="29" Volume="1983" Year="1985" Format="Main Series">
+    <Book Series="The New Mutants" Number="29" Volume="1983" Year="1985">
       <Id>5ee71ab5-1d38-4cac-b698-6a7f60916ef4</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="195" Volume="1981" Year="1985" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="195" Volume="1981" Year="1985">
       <Id>22d59874-f2c4-46a0-938c-a0533290b291</Id>
     </Book>
-    <Book Series="Secret Wars II" Number="1" Volume="1985" Year="1985" Format="Crossover">
+    <Book Series="Secret Wars II" Number="1" Volume="1985" Year="1985">
       <Id>543f78c6-4f66-4b9e-af48-b03dc17f137b</Id>
     </Book>
-    <Book Series="The New Mutants" Number="30" Volume="1983" Year="1985" Format="Main Series">
+    <Book Series="The New Mutants" Number="30" Volume="1983" Year="1985">
       <Id>c5326003-ff7d-4ea4-8a7a-b7a045ca1bf6</Id>
     </Book>
-    <Book Series="The New Mutants" Number="31" Volume="1983" Year="1985" Format="Main Series">
+    <Book Series="The New Mutants" Number="31" Volume="1983" Year="1985">
       <Id>8fbb5190-7c1c-4e91-81b4-6da4f0995548</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="196" Volume="1981" Year="1985" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="196" Volume="1981" Year="1985">
       <Id>f5600b74-eaa4-4a1e-affe-c9897c05739b</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="197" Volume="1981" Year="1985" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="197" Volume="1981" Year="1985">
       <Id>dad9ce62-6f81-4d46-8014-3f39f535850a</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="198" Volume="1981" Year="1985" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="198" Volume="1981" Year="1985">
       <Id>8927440e-4028-4750-b206-2869fbdf1227</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="199" Volume="1981" Year="1985" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="199" Volume="1981" Year="1985">
       <Id>80c32fb3-2588-49c2-9003-c3010a533a0c</Id>
     </Book>
-    <Book Series="The New Mutants" Number="32" Volume="1983" Year="1985" Format="Main Series">
+    <Book Series="The New Mutants" Number="32" Volume="1983" Year="1985">
       <Id>f7feba42-96fb-4e8b-b63c-aab46b1fef69</Id>
     </Book>
-    <Book Series="The New Mutants" Number="33" Volume="1983" Year="1985" Format="Main Series">
+    <Book Series="The New Mutants" Number="33" Volume="1983" Year="1985">
       <Id>8ed5f8d6-eb4d-4d82-96a0-20020cae4ea9</Id>
     </Book>
-    <Book Series="The New Mutants" Number="34" Volume="1983" Year="1985" Format="Main Series">
+    <Book Series="The New Mutants" Number="34" Volume="1983" Year="1985">
       <Id>38efbd44-0448-4571-95ab-74b8ac3a2ef8</Id>
     </Book>
-    <Book Series="The New Mutants Special Edition" Number="1" Volume="1985" Year="1985" Format="One-Shot">
+    <Book Series="The New Mutants Special Edition" Number="1" Volume="1985" Year="1985">
       <Id>778187da-7849-4af7-a3fc-7c7b86abe177</Id>
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="9" Volume="1982" Year="1985" Format="Annual">
+    <Book Series="The Uncanny X-Men Annual" Number="9" Volume="1982" Year="1985">
       <Id>885beb8e-315b-4487-899e-b082be8e072c</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="200" Volume="1981" Year="1985" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="200" Volume="1981" Year="1985">
       <Id>79a98173-d6c6-4f5a-a26b-9ce9f2f7ff56</Id>
     </Book>
-    <Book Series="The New Mutants" Number="35" Volume="1983" Year="1986" Format="Main Series">
+    <Book Series="The New Mutants" Number="35" Volume="1983" Year="1986">
       <Id>fe6899d5-d738-4b02-9d7e-436f5c937704</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="201" Volume="1981" Year="1986" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="201" Volume="1981" Year="1986">
       <Id>76017666-c419-4d59-9e85-d7db783818b5</Id>
     </Book>
-    <Book Series="Heroes for Hope Starring the X-Men" Number="1" Volume="1985" Year="1985" Format="One-Shot">
+    <Book Series="Heroes for Hope Starring the X-Men" Number="1" Volume="1985" Year="1985">
       <Id>26d005f0-78cb-42cd-b283-ae055751f202</Id>
     </Book>
-    <Book Series="Secret Wars II" Number="5" Volume="1985" Year="1985" Format="Crossover">
+    <Book Series="Secret Wars II" Number="5" Volume="1985" Year="1985">
       <Id>e80850ac-88cf-433c-bb02-82f1f7516b3b</Id>
     </Book>
-    <Book Series="The New Mutants" Number="36" Volume="1983" Year="1986" Format="Main Series">
+    <Book Series="The New Mutants" Number="36" Volume="1983" Year="1986">
       <Id>8a5afb02-e1a5-47e8-b8ce-bf70050cfb73</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="202" Volume="1981" Year="1986" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="202" Volume="1981" Year="1986">
       <Id>5810cff5-3b6c-483f-b8fc-f3495707dd0e</Id>
     </Book>
-    <Book Series="Secret Wars II" Number="8" Volume="1985" Year="1986" Format="Crossover">
+    <Book Series="Secret Wars II" Number="8" Volume="1985" Year="1986">
       <Id>86da0eda-eb3b-4191-993e-1cf84f258f12</Id>
     </Book>
-    <Book Series="The New Mutants" Number="37" Volume="1983" Year="1986" Format="Main Series">
+    <Book Series="The New Mutants" Number="37" Volume="1983" Year="1986">
       <Id>a8fab391-88f6-4120-a262-fb5874d49fd6</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="203" Volume="1981" Year="1986" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="203" Volume="1981" Year="1986">
       <Id>1516fab2-3d17-4de5-a1ff-bcfbf9399ea3</Id>
     </Book>
-    <Book Series="Secret Wars II" Number="9" Volume="1985" Year="1986" Format="Crossover">
+    <Book Series="Secret Wars II" Number="9" Volume="1985" Year="1986">
       <Id>5df1cc54-4071-4cda-bbc7-0365b4916394</Id>
     </Book>
-    <Book Series="The New Mutants" Number="38" Volume="1983" Year="1986" Format="Main Series">
+    <Book Series="The New Mutants" Number="38" Volume="1983" Year="1986">
       <Id>04950f8e-aa11-4d95-a362-a6c9db4aa802</Id>
     </Book>
-    <Book Series="The New Mutants" Number="39" Volume="1983" Year="1986" Format="Main Series">
+    <Book Series="The New Mutants" Number="39" Volume="1983" Year="1986">
       <Id>450263e3-ffae-4427-bfd4-b56e4e3c22a7</Id>
     </Book>
-    <Book Series="The New Mutants" Number="40" Volume="1983" Year="1986" Format="Main Series">
+    <Book Series="The New Mutants" Number="40" Volume="1983" Year="1986">
       <Id>3d639b74-ab6c-4268-9f4b-79610fb50917</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="286" Volume="1961" Year="1986" Format="Main Series">
+    <Book Series="Fantastic Four" Number="286" Volume="1961" Year="1986">
       <Id>4402a50a-b6bc-4509-9d62-6a222ee1b726</Id>
     </Book>
-    <Book Series="X-Factor" Number="1" Volume="1986" Year="1986" Format="Main Series">
+    <Book Series="X-Factor" Number="1" Volume="1986" Year="1986">
       <Id>05aeab43-9e9a-425c-99ef-453894a1f373</Id>
     </Book>
-    <Book Series="X-Factor" Number="2" Volume="1986" Year="1986" Format="Main Series">
+    <Book Series="X-Factor" Number="2" Volume="1986" Year="1986">
       <Id>57feb9d8-d419-439d-8c04-acf59accfa07</Id>
     </Book>
-    <Book Series="X-Factor" Number="3" Volume="1986" Year="1986" Format="Main Series">
+    <Book Series="X-Factor" Number="3" Volume="1986" Year="1986">
       <Id>7fcef109-8351-41f3-8759-e52168e8c813</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="204" Volume="1981" Year="1986" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="204" Volume="1981" Year="1986">
       <Id>4523bdfe-795c-4747-8cd9-1131fe39dab9</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="205" Volume="1981" Year="1986" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="205" Volume="1981" Year="1986">
       <Id>6f0b15d7-59c0-40b0-a9a8-71d4bdc92e8f</Id>
     </Book>
-    <Book Series="X-Factor Annual" Number="1" Volume="1986" Year="1986" Format="Annual">
+    <Book Series="X-Factor Annual" Number="1" Volume="1986" Year="1986">
       <Id>a3319d60-8c87-4da3-8926-7c366e376a4d</Id>
     </Book>
-    <Book Series="X-Factor" Number="4" Volume="1986" Year="1986" Format="Main Series">
+    <Book Series="X-Factor" Number="4" Volume="1986" Year="1986">
       <Id>65908dbc-f809-41af-aedb-92a760145486</Id>
     </Book>
-    <Book Series="X-Factor" Number="5" Volume="1986" Year="1986" Format="Main Series">
+    <Book Series="X-Factor" Number="5" Volume="1986" Year="1986">
       <Id>f0f9a4b1-71ee-4c58-b1f5-ee312746ef5b</Id>
     </Book>
-    <Book Series="X-Factor" Number="6" Volume="1986" Year="1986" Format="Main Series">
+    <Book Series="X-Factor" Number="6" Volume="1986" Year="1986">
       <Id>60104271-960e-4ed9-84eb-8a113fba94f3</Id>
     </Book>
-    <Book Series="The New Mutants" Number="41" Volume="1983" Year="1986" Format="Main Series">
+    <Book Series="The New Mutants" Number="41" Volume="1983" Year="1986">
       <Id>1b7bb8ee-a703-4dc1-9cb9-da51edb77345</Id>
     </Book>
-    <Book Series="The New Mutants" Number="42" Volume="1983" Year="1986" Format="Main Series">
+    <Book Series="The New Mutants" Number="42" Volume="1983" Year="1986">
       <Id>f97e4285-f4ce-403b-bc68-803b7c16797c</Id>
     </Book>
-    <Book Series="The New Mutants" Number="43" Volume="1983" Year="1986" Format="Main Series">
+    <Book Series="The New Mutants" Number="43" Volume="1983" Year="1986">
       <Id>1a62e6b2-8285-474d-bf1c-fdc8aac536ea</Id>
     </Book>
-    <Book Series="The New Mutants" Number="44" Volume="1983" Year="1986" Format="Main Series">
+    <Book Series="The New Mutants" Number="44" Volume="1983" Year="1986">
       <Id>1799ecd2-84dc-4d1c-afc3-380d93884f7f</Id>
     </Book>
-    <Book Series="The New Mutants" Number="45" Volume="1983" Year="1986" Format="Main Series">
+    <Book Series="The New Mutants" Number="45" Volume="1983" Year="1986">
       <Id>402f4833-1a8b-4fd6-97a2-f1465ee91ec5</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="206" Volume="1981" Year="1986" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="206" Volume="1981" Year="1986">
       <Id>f82a1b37-4682-461c-97e2-2155d6f68495</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="207" Volume="1981" Year="1986" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="207" Volume="1981" Year="1986">
       <Id>f33fe9c7-6318-48f4-accc-60eb60ea8fd9</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="208" Volume="1981" Year="1986" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="208" Volume="1981" Year="1986">
       <Id>2508bb08-59d8-4731-a331-a56701ca223d</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="209" Volume="1981" Year="1986" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="209" Volume="1981" Year="1986">
       <Id>e4a0eb9a-d78c-415a-9305-a6021187c42d</Id>
     </Book>
-    <Book Series="Longshot" Number="1" Volume="1985" Year="1985" Format="Limited Series">
+    <Book Series="Longshot" Number="1" Volume="1985" Year="1985">
       <Id>419e72d1-c98a-4037-a122-88561e7e4122</Id>
     </Book>
-    <Book Series="Longshot" Number="2" Volume="1985" Year="1985" Format="Limited Series">
+    <Book Series="Longshot" Number="2" Volume="1985" Year="1985">
       <Id>7a3310b6-0499-4180-a5c2-313c2a7feac8</Id>
     </Book>
-    <Book Series="Longshot" Number="3" Volume="1985" Year="1985" Format="Limited Series">
+    <Book Series="Longshot" Number="3" Volume="1985" Year="1985">
       <Id>ea074994-6ed6-4143-a653-38289a812f94</Id>
     </Book>
-    <Book Series="Longshot" Number="4" Volume="1985" Year="1985" Format="Limited Series">
+    <Book Series="Longshot" Number="4" Volume="1985" Year="1985">
       <Id>d3648860-98a5-41e6-8431-11cf6d6ce9bc</Id>
     </Book>
-    <Book Series="Longshot" Number="5" Volume="1985" Year="1986" Format="Limited Series">
+    <Book Series="Longshot" Number="5" Volume="1985" Year="1986">
       <Id>21acb67d-9b18-4ef0-b018-a481a1b09be1</Id>
     </Book>
-    <Book Series="Longshot" Number="6" Volume="1985" Year="1986" Format="Limited Series">
+    <Book Series="Longshot" Number="6" Volume="1985" Year="1986">
       <Id>6c78009e-4098-4c5d-9be9-a8ef93c5b10f</Id>
     </Book>
-    <Book Series="The New Mutants Annual" Number="2" Volume="1984" Year="1986" Format="Annual">
+    <Book Series="The New Mutants Annual" Number="2" Volume="1984" Year="1986">
       <Id>b2296f9b-6dde-42e3-af9f-98303e639bca</Id>
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="10" Volume="1982" Year="1986" Format="Annual">
+    <Book Series="The Uncanny X-Men Annual" Number="10" Volume="1982" Year="1986">
       <Id>4a83cc69-8932-41b3-bd97-cf61e0f54146</Id>
     </Book>
-    <Book Series="X-Factor" Number="7" Volume="1986" Year="1986" Format="Main Series">
+    <Book Series="X-Factor" Number="7" Volume="1986" Year="1986">
       <Id>f9ce2cd5-749d-4e1e-9d4f-af827c58d0a7</Id>
     </Book>
-    <Book Series="X-Factor" Number="8" Volume="1986" Year="1986" Format="Main Series">
+    <Book Series="X-Factor" Number="8" Volume="1986" Year="1986">
       <Id>0ccf1912-9e31-45af-b06c-b0013c8ff3a7</Id>
     </Book>
-    <Book Series="X-Factor" Number="9" Volume="1986" Year="1986" Format="Main Series">
+    <Book Series="X-Factor" Number="9" Volume="1986" Year="1986">
       <Id>4838a66f-4df9-41f0-ae94-bcabee948c3e</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="210" Volume="1981" Year="1986" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="210" Volume="1981" Year="1986">
       <Id>4682099d-8b4a-420f-8577-5859b86ef292</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="211" Volume="1981" Year="1986" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="211" Volume="1981" Year="1986">
       <Id>cdde4e60-6f7b-4c22-8b91-e193fe958045</Id>
     </Book>
-    <Book Series="The New Mutants" Number="46" Volume="1983" Year="1986" Format="Main Series">
+    <Book Series="The New Mutants" Number="46" Volume="1983" Year="1986">
       <Id>fe8e2dd5-abdf-4344-ab22-64e11aaca873</Id>
     </Book>
-    <Book Series="X-Factor" Number="10" Volume="1986" Year="1986" Format="Main Series">
+    <Book Series="X-Factor" Number="10" Volume="1986" Year="1986">
       <Id>732b1bf5-9b25-4458-a3b0-4b3a04937e54</Id>
     </Book>
-    <Book Series="Thor" Number="373" Volume="1966" Year="1986" Format="Main Series">
+    <Book Series="Thor" Number="373" Volume="1966" Year="1986">
       <Id>281d08cc-6918-4300-ba1e-f4cec1ec4890</Id>
     </Book>
-    <Book Series="Power Pack" Number="27" Volume="1984" Year="1986" Format="Main Series">
+    <Book Series="Power Pack" Number="27" Volume="1984" Year="1986">
       <Id>f53ce0fb-4566-4158-b0d1-a3202029520f</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="212" Volume="1981" Year="1986" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="212" Volume="1981" Year="1986">
       <Id>d6c52f83-ec04-485a-b59e-8e0b69de221e</Id>
     </Book>
-    <Book Series="Thor" Number="374" Volume="1966" Year="1986" Format="Main Series">
+    <Book Series="Thor" Number="374" Volume="1966" Year="1986">
       <Id>db2f6141-de80-43e5-b843-ef27260fbde3</Id>
     </Book>
-    <Book Series="X-Factor" Number="11" Volume="1986" Year="1986" Format="Main Series">
+    <Book Series="X-Factor" Number="11" Volume="1986" Year="1986">
       <Id>633ad431-3fb8-47ae-b5e4-f37f3e29916f</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="213" Volume="1981" Year="1987" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="213" Volume="1981" Year="1987">
       <Id>628d0a8a-e751-45c1-a74d-844179efbab2</Id>
     </Book>
-    <Book Series="X-Factor" Number="12" Volume="1986" Year="1987" Format="Main Series">
+    <Book Series="X-Factor" Number="12" Volume="1986" Year="1987">
       <Id>384a5060-e132-474a-b80d-6ddef791ad58</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="214" Volume="1981" Year="1987" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="214" Volume="1981" Year="1987">
       <Id>f2900b71-e9b2-47b8-89f8-33b106370d8a</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="215" Volume="1981" Year="1987" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="215" Volume="1981" Year="1987">
       <Id>4bc2c6c0-a5b1-4117-aab2-8d7a8450236f</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="216" Volume="1981" Year="1987" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="216" Volume="1981" Year="1987">
       <Id>660d7b88-26ba-4936-8e56-48cbedd76d4c</Id>
     </Book>
-    <Book Series="The New Mutants" Number="47" Volume="1983" Year="1987" Format="Main Series">
+    <Book Series="The New Mutants" Number="47" Volume="1983" Year="1987">
       <Id>41403191-412e-4587-a905-8f2252ca3d75</Id>
     </Book>
-    <Book Series="The New Mutants" Number="48" Volume="1983" Year="1987" Format="Main Series">
+    <Book Series="The New Mutants" Number="48" Volume="1983" Year="1987">
       <Id>d33000bc-825a-4f92-a2db-b194bcdc4e46</Id>
     </Book>
-    <Book Series="The New Mutants" Number="49" Volume="1983" Year="1987" Format="Main Series">
+    <Book Series="The New Mutants" Number="49" Volume="1983" Year="1987">
       <Id>344b4b90-c537-4eb2-aadb-12a7f987950e</Id>
     </Book>
-    <Book Series="The New Mutants" Number="50" Volume="1983" Year="1987" Format="Main Series">
+    <Book Series="The New Mutants" Number="50" Volume="1983" Year="1987">
       <Id>17144108-9bdc-4f24-ab46-a7ea76ea4afa</Id>
     </Book>
-    <Book Series="The New Mutants" Number="51" Volume="1983" Year="1987" Format="Main Series">
+    <Book Series="The New Mutants" Number="51" Volume="1983" Year="1987">
       <Id>365aeff0-7ade-493f-a1ce-d44c5820ec84</Id>
     </Book>
-    <Book Series="The New Mutants Annual" Number="3" Volume="1984" Year="1987" Format="Annual">
+    <Book Series="The New Mutants Annual" Number="3" Volume="1984" Year="1987">
       <Id>8255332b-825c-45ed-b3de-db88d8ec1bb9</Id>
     </Book>
-    <Book Series="The New Mutants" Number="52" Volume="1983" Year="1987" Format="Main Series">
+    <Book Series="The New Mutants" Number="52" Volume="1983" Year="1987">
       <Id>dc440617-c7e5-4115-b4cf-3803bc8638bc</Id>
     </Book>
-    <Book Series="Fallen Angels" Number="1" Volume="1987" Year="1987" Format="Limited Series">
+    <Book Series="Fallen Angels" Number="1" Volume="1987" Year="1987">
       <Id>f47ddbb1-75ab-4336-bea2-f78669cbf6a1</Id>
     </Book>
-    <Book Series="Fallen Angels" Number="2" Volume="1987" Year="1987" Format="Limited Series">
+    <Book Series="Fallen Angels" Number="2" Volume="1987" Year="1987">
       <Id>d50094ed-42bc-4de2-9873-92ed985fec11</Id>
     </Book>
-    <Book Series="Fallen Angels" Number="3" Volume="1987" Year="1987" Format="Limited Series">
+    <Book Series="Fallen Angels" Number="3" Volume="1987" Year="1987">
       <Id>77a4641e-2af5-4c2d-bba5-31ec02d754f0</Id>
     </Book>
-    <Book Series="Fallen Angels" Number="4" Volume="1987" Year="1987" Format="Limited Series">
+    <Book Series="Fallen Angels" Number="4" Volume="1987" Year="1987">
       <Id>133a59ae-781e-47a8-a30d-9b1b1e8c38f7</Id>
     </Book>
-    <Book Series="Fallen Angels" Number="5" Volume="1987" Year="1987" Format="Limited Series">
+    <Book Series="Fallen Angels" Number="5" Volume="1987" Year="1987">
       <Id>7a380820-ed56-489a-ae96-73d9437f851b</Id>
     </Book>
-    <Book Series="Fallen Angels" Number="6" Volume="1987" Year="1987" Format="Limited Series">
+    <Book Series="Fallen Angels" Number="6" Volume="1987" Year="1987">
       <Id>716c1f90-dc8c-4cf2-b4c4-d2bd7e551af8</Id>
     </Book>
-    <Book Series="Fallen Angels" Number="7" Volume="1987" Year="1987" Format="Limited Series">
+    <Book Series="Fallen Angels" Number="7" Volume="1987" Year="1987">
       <Id>190aae90-d3ec-4519-8989-4562b3d6f0ac</Id>
     </Book>
-    <Book Series="Fallen Angels" Number="8" Volume="1987" Year="1987" Format="Limited Series">
+    <Book Series="Fallen Angels" Number="8" Volume="1987" Year="1987">
       <Id>304a3dac-9d47-43c2-810c-1021fff6c7e9</Id>
     </Book>
-    <Book Series="X-Factor" Number="13" Volume="1986" Year="1987" Format="Main Series">
+    <Book Series="X-Factor" Number="13" Volume="1986" Year="1987">
       <Id>0e9d1b3d-50ad-4fb4-b49d-cb903d24dc0c</Id>
     </Book>
-    <Book Series="X-Factor" Number="14" Volume="1986" Year="1987" Format="Main Series">
+    <Book Series="X-Factor" Number="14" Volume="1986" Year="1987">
       <Id>c17b8d9d-d906-441e-bb01-cbe83bd8a331</Id>
     </Book>
-    <Book Series="X-Factor" Number="15" Volume="1986" Year="1987" Format="Main Series">
+    <Book Series="X-Factor" Number="15" Volume="1986" Year="1987">
       <Id>f7fb176d-e955-4e5e-8bf0-907cae4a4a5c</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="217" Volume="1981" Year="1987" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="217" Volume="1981" Year="1987">
       <Id>5efc1a10-77a9-4c50-8e19-a4c7b800681d</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="218" Volume="1981" Year="1987" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="218" Volume="1981" Year="1987">
       <Id>be949729-8d84-4f29-a631-cba8bb52bdd1</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="219" Volume="1981" Year="1987" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="219" Volume="1981" Year="1987">
       <Id>2cbfd3eb-b935-42be-a2c1-a5304470598f</Id>
     </Book>
-    <Book Series="X-Factor" Number="16" Volume="1986" Year="1987" Format="Main Series">
+    <Book Series="X-Factor" Number="16" Volume="1986" Year="1987">
       <Id>8893de27-7d5c-44c2-ae22-1860f09a28ac</Id>
     </Book>
-    <Book Series="X-Factor" Number="17" Volume="1986" Year="1987" Format="Main Series">
+    <Book Series="X-Factor" Number="17" Volume="1986" Year="1987">
       <Id>837c5293-1204-4700-85a8-969b26a42780</Id>
     </Book>
-    <Book Series="The New Mutants" Number="53" Volume="1983" Year="1987" Format="Main Series">
+    <Book Series="The New Mutants" Number="53" Volume="1983" Year="1987">
       <Id>026db128-a77b-472d-8de7-4d5653090281</Id>
     </Book>
-    <Book Series="The New Mutants" Number="54" Volume="1983" Year="1987" Format="Main Series">
+    <Book Series="The New Mutants" Number="54" Volume="1983" Year="1987">
       <Id>39b6f2b6-ec08-4433-92e5-4262a14249d8</Id>
     </Book>
-    <Book Series="X-Factor" Number="18" Volume="1986" Year="1987" Format="Main Series">
+    <Book Series="X-Factor" Number="18" Volume="1986" Year="1987">
       <Id>c69ce603-d8a3-47a3-b689-e7195eff0171</Id>
     </Book>
-    <Book Series="X-Factor Annual" Number="2" Volume="1986" Year="1987" Format="Annual">
+    <Book Series="X-Factor Annual" Number="2" Volume="1986" Year="1987">
       <Id>d5abf05a-1244-42a6-9e7d-2f500c2df397</Id>
     </Book>
-    <Book Series="The X-Men vs. The Avengers" Number="1" Volume="1987" Year="1987" Format="Limited Series">
+    <Book Series="The X-Men vs. The Avengers" Number="1" Volume="1987" Year="1987">
       <Id>6c84b1e0-73a2-4cd0-b272-f6712a954150</Id>
     </Book>
-    <Book Series="The X-Men vs. The Avengers" Number="2" Volume="1987" Year="1987" Format="Limited Series">
+    <Book Series="The X-Men vs. The Avengers" Number="2" Volume="1987" Year="1987">
       <Id>627562a8-b997-4012-a925-d01a105591f3</Id>
     </Book>
-    <Book Series="The X-Men vs. The Avengers" Number="3" Volume="1987" Year="1987" Format="Limited Series">
+    <Book Series="The X-Men vs. The Avengers" Number="3" Volume="1987" Year="1987">
       <Id>1888afb2-38ea-47fb-9f71-ff91884c6e21</Id>
     </Book>
-    <Book Series="The X-Men vs. The Avengers" Number="4" Volume="1987" Year="1987" Format="Limited Series">
+    <Book Series="The X-Men vs. The Avengers" Number="4" Volume="1987" Year="1987">
       <Id>ba32d0e1-e837-461b-9330-e31883264d61</Id>
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="11" Volume="1970" Year="1987" Format="Annual">
+    <Book Series="The Uncanny X-Men Annual" Number="11" Volume="1970" Year="1987">
       <Id>8cf5dc45-8bb2-4acd-8c6e-66415131a693</Id>
     </Book>
-    <Book Series="Fantastic Four vs. X-Men" Number="1" Volume="1987" Year="1987" Format="Limited Series">
+    <Book Series="Fantastic Four vs. X-Men" Number="1" Volume="1987" Year="1987">
       <Id>6390d0fe-00e7-4cf0-bb6d-0378c1502169</Id>
     </Book>
-    <Book Series="Fantastic Four vs. X-Men" Number="2" Volume="1987" Year="1987" Format="Limited Series">
+    <Book Series="Fantastic Four vs. X-Men" Number="2" Volume="1987" Year="1987">
       <Id>a98b3388-b63c-4ac0-8dfd-ef6ecd84b393</Id>
     </Book>
-    <Book Series="Fantastic Four vs. X-Men" Number="3" Volume="1987" Year="1987" Format="Limited Series">
+    <Book Series="Fantastic Four vs. X-Men" Number="3" Volume="1987" Year="1987">
       <Id>527c59ea-3b74-4f2c-8493-33fe7d483fa4</Id>
     </Book>
-    <Book Series="Fantastic Four vs. X-Men" Number="4" Volume="1987" Year="1987" Format="Limited Series">
+    <Book Series="Fantastic Four vs. X-Men" Number="4" Volume="1987" Year="1987">
       <Id>770ea33f-fad2-4803-b15e-afc51d14eea6</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="220" Volume="1981" Year="1987" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="220" Volume="1981" Year="1987">
       <Id>9665c358-b5ad-4239-8d17-76fa4932fed7</Id>
     </Book>
-    <Book Series="X-Factor" Number="19" Volume="1986" Year="1987" Format="Main Series">
+    <Book Series="X-Factor" Number="19" Volume="1986" Year="1987">
       <Id>c78119c4-1297-4fec-a5d5-7a0c24dc952a</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="221" Volume="1981" Year="1987" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="221" Volume="1981" Year="1987">
       <Id>fa3c9bc1-9824-44c8-9e8e-6bf92162124f</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="222" Volume="1981" Year="1987" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="222" Volume="1981" Year="1987">
       <Id>b5309ad7-6c01-4eb1-a01c-a24e2eacda2d</Id>
     </Book>
-    <Book Series="X-Factor" Number="20" Volume="1986" Year="1987" Format="Main Series">
+    <Book Series="X-Factor" Number="20" Volume="1986" Year="1987">
       <Id>1997af78-f64f-4d66-b6db-a9fb07eb348c</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="336" Volume="1968" Year="1987" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="336" Volume="1968" Year="1987">
       <Id>fe2e437d-1b4a-412a-b08c-62db8faee466</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="337" Volume="1968" Year="1987" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="337" Volume="1968" Year="1987">
       <Id>a7468067-4f7d-46b0-96cf-4ce45350bc52</Id>
     </Book>
-    <Book Series="X-Factor" Number="21" Volume="1986" Year="1987" Format="Main Series">
+    <Book Series="X-Factor" Number="21" Volume="1986" Year="1987">
       <Id>1ce87f71-0504-4255-bd72-b3a60481baef</Id>
     </Book>
-    <Book Series="X-Factor" Number="22" Volume="1986" Year="1987" Format="Main Series">
+    <Book Series="X-Factor" Number="22" Volume="1986" Year="1987">
       <Id>c7ed5168-1d6a-47ff-ae31-abd42e325211</Id>
     </Book>
-    <Book Series="X-Factor" Number="23" Volume="1986" Year="1987" Format="Main Series">
+    <Book Series="X-Factor" Number="23" Volume="1986" Year="1987">
       <Id>9adc7062-6524-45ef-80a2-c852a06d1cc9</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="223" Volume="1981" Year="1987" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="223" Volume="1981" Year="1987">
       <Id>b2538809-4899-4ce2-a266-1db6326d3e75</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="224" Volume="1981" Year="1987" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="224" Volume="1981" Year="1987">
       <Id>0c974ab0-9fc0-49f5-9edc-db22a1d6ec40</Id>
     </Book>
-    <Book Series="The New Mutants" Number="55" Volume="1983" Year="1987" Format="Main Series">
+    <Book Series="The New Mutants" Number="55" Volume="1983" Year="1987">
       <Id>58d449f1-2ea7-45c7-9370-19506953fdf3</Id>
     </Book>
-    <Book Series="The New Mutants" Number="56" Volume="1983" Year="1987" Format="Main Series">
+    <Book Series="The New Mutants" Number="56" Volume="1983" Year="1987">
       <Id>5e336fe8-03ee-479a-9be2-d7a5a545c357</Id>
     </Book>
-    <Book Series="The New Mutants" Number="57" Volume="1983" Year="1987" Format="Main Series">
+    <Book Series="The New Mutants" Number="57" Volume="1983" Year="1987">
       <Id>0b69423e-950f-4690-801b-a681a65e6b84</Id>
     </Book>
   </Books>

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 003.cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 003.cbl
@@ -1,882 +1,883 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>X-Men - Part 3</Name>
+  <Name>X-Men - Part 003</Name>
+  <NumIssues>292</NumIssues>
   <Books>
     <Book Series="X-Factor" Number="24" Volume="1986" Year="1988">
-      <Id>fa779977-dcf6-45d8-ba7f-bd92e6ceffdc</Id>
+      <Database Name="cv" Series="3657" Issue="29161" />
     </Book>
     <Book Series="X-Factor" Number="25" Volume="1986" Year="1988">
-      <Id>bf2b4013-943a-4c0a-aa7c-3e5f8110a9c8</Id>
+      <Database Name="cv" Series="3657" Issue="29276" />
     </Book>
     <Book Series="X-Factor" Number="26" Volume="1986" Year="1988">
-      <Id>ccfa30e6-2be6-42f6-9f9b-7d6b6ae72586</Id>
+      <Database Name="cv" Series="3657" Issue="29387" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="225" Volume="1981" Year="1988">
-      <Id>808250b1-c957-4274-b609-69e65da60572</Id>
+      <Database Name="cv" Series="3092" Issue="29158" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="226" Volume="1981" Year="1988">
-      <Id>c736a3e2-d63c-48be-b939-4b43554e80ae</Id>
+      <Database Name="cv" Series="3092" Issue="29273" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="227" Volume="1981" Year="1988">
-      <Id>ac03a80d-556c-4775-95b6-10c3c2544227</Id>
+      <Database Name="cv" Series="3092" Issue="29383" />
     </Book>
     <Book Series="The New Mutants" Number="58" Volume="1983" Year="1987">
-      <Id>4f18eb1f-0f7a-41cb-872b-988032738210</Id>
+      <Database Name="cv" Series="3234" Issue="28954" />
     </Book>
     <Book Series="The New Mutants" Number="59" Volume="1983" Year="1988">
-      <Id>587b21a5-af41-4ae7-a959-faf153cf0b7a</Id>
+      <Database Name="cv" Series="3234" Issue="29179" />
     </Book>
     <Book Series="The New Mutants" Number="60" Volume="1983" Year="1988">
-      <Id>5ea32912-2c74-49ad-aa47-bb9baba9320b</Id>
+      <Database Name="cv" Series="3234" Issue="29296" />
     </Book>
     <Book Series="The New Mutants" Number="61" Volume="1983" Year="1988">
-      <Id>62bfba72-2d59-4e10-aa42-81d297db0f17</Id>
+      <Database Name="cv" Series="3234" Issue="29405" />
     </Book>
     <Book Series="X-Factor" Number="27" Volume="1986" Year="1988">
-      <Id>6ed3eae6-dd97-499e-8808-66bb52d26970</Id>
+      <Database Name="cv" Series="3657" Issue="29497" />
     </Book>
     <Book Series="The New Mutants" Number="62" Volume="1983" Year="1988">
-      <Id>29978b9c-97ba-4e7d-aad2-2d363a38a737</Id>
+      <Database Name="cv" Series="3234" Issue="29517" />
     </Book>
     <Book Series="The New Mutants" Number="63" Volume="1983" Year="1988">
-      <Id>85b4022c-0a50-4c20-b7e3-724a39b4f640</Id>
+      <Database Name="cv" Series="3234" Issue="29629" />
     </Book>
     <Book Series="The New Mutants" Number="64" Volume="1983" Year="1988">
-      <Id>4bf51d11-79ed-4475-bbc5-2bfc420b89a8</Id>
+      <Database Name="cv" Series="3234" Issue="29739" />
     </Book>
     <Book Series="The New Mutants" Number="65" Volume="1983" Year="1988">
-      <Id>68b403bb-adc9-4f89-9043-b463c32b0918</Id>
+      <Database Name="cv" Series="3234" Issue="29866" />
     </Book>
     <Book Series="The New Mutants" Number="66" Volume="1983" Year="1988">
-      <Id>2221d344-f9e2-41b4-9171-0e06e634d0a7</Id>
+      <Database Name="cv" Series="3234" Issue="29980" />
     </Book>
     <Book Series="X-Factor" Number="28" Volume="1986" Year="1988">
-      <Id>f667c541-1810-48fa-8bb0-9be8bbf02ed1</Id>
+      <Database Name="cv" Series="3657" Issue="29607" />
     </Book>
     <Book Series="Excalibur Special Edition" Number="1" Volume="1987" Year="1987">
-      <Id>8cbdeb03-3d32-409a-a0d3-41a814e05ecf</Id>
+      <Database Name="cv" Series="20173" Issue="120344" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="228" Volume="1981" Year="1988">
-      <Id>da004980-a60a-4856-b782-24337886a535</Id>
+      <Database Name="cv" Series="3092" Issue="29494" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="229" Volume="1981" Year="1988">
-      <Id>3b61a6ea-2868-40e7-8f9a-25f34d309342</Id>
+      <Database Name="cv" Series="3092" Issue="29603" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="230" Volume="1981" Year="1988">
-      <Id>f22d1184-48a0-49e4-a1b3-608d42ef3c77</Id>
+      <Database Name="cv" Series="3092" Issue="29719" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="231" Volume="1981" Year="1988">
-      <Id>7a830c73-467c-4ed4-b06c-8bc8744eee79</Id>
+      <Database Name="cv" Series="3092" Issue="29838" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="232" Volume="1981" Year="1988">
-      <Id>6b4d22b3-1187-462e-8db0-8198adb88b2c</Id>
+      <Database Name="cv" Series="3092" Issue="29954" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="233" Volume="1981" Year="1988">
-      <Id>01b8be0b-582d-4883-ae26-7e4d43e78263</Id>
+      <Database Name="cv" Series="3092" Issue="30070" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="234" Volume="1981" Year="1988">
-      <Id>85e66657-d34e-4b27-b3b1-71873f210deb</Id>
+      <Database Name="cv" Series="3092" Issue="30103" />
     </Book>
     <Book Series="Wolverine" Number="1" Volume="1988" Year="1988">
-      <Id>f40ca0ae-ed1b-4057-ad93-4d298612768d</Id>
+      <Database Name="cv" Series="4250" Issue="64266" />
     </Book>
     <Book Series="Wolverine" Number="2" Volume="1988" Year="1988">
-      <Id>5989e435-58dd-4c81-953f-e483d9ccb10d</Id>
+      <Database Name="cv" Series="4250" Issue="64267" />
     </Book>
     <Book Series="Wolverine" Number="3" Volume="1988" Year="1989">
-      <Id>36039684-ff8d-4b98-a561-cb7412410795</Id>
+      <Database Name="cv" Series="4250" Issue="64268" />
     </Book>
     <Book Series="X-Factor" Number="29" Volume="1986" Year="1988">
-      <Id>530db5e4-f403-467d-9659-ee5c1bf0c5f9</Id>
+      <Database Name="cv" Series="3657" Issue="29723" />
     </Book>
     <Book Series="X-Factor" Number="30" Volume="1986" Year="1988">
-      <Id>815c60b3-c0b8-4dfe-9973-2277ecf9a542</Id>
+      <Database Name="cv" Series="3657" Issue="29842" />
     </Book>
     <Book Series="X-Factor" Number="31" Volume="1986" Year="1988">
-      <Id>1fc93f33-73f8-4bec-91bf-c75a9c55e0d7</Id>
+      <Database Name="cv" Series="3657" Issue="29957" />
     </Book>
     <Book Series="Wolverine" Number="4" Volume="1988" Year="1989">
-      <Id>70516ef9-354b-4513-ad2e-f170ca62f3dc</Id>
+      <Database Name="cv" Series="4250" Issue="64269" />
     </Book>
     <Book Series="Wolverine" Number="5" Volume="1988" Year="1989">
-      <Id>d75cd6ca-f0da-4706-aa94-1c8445390a46</Id>
+      <Database Name="cv" Series="4250" Issue="64270" />
     </Book>
     <Book Series="Wolverine" Number="6" Volume="1988" Year="1989">
-      <Id>cc11d34c-ea68-45e1-a9d5-ad7681bad1da</Id>
+      <Database Name="cv" Series="4250" Issue="64271" />
     </Book>
     <Book Series="Wolverine" Number="7" Volume="1988" Year="1989">
-      <Id>8e47f2af-6183-4034-a525-d1dfd49534c3</Id>
+      <Database Name="cv" Series="4250" Issue="64272" />
     </Book>
     <Book Series="Wolverine" Number="8" Volume="1988" Year="1989">
-      <Id>31129958-eb9f-4eff-8196-287c6faada49</Id>
+      <Database Name="cv" Series="4250" Issue="64273" />
     </Book>
     <Book Series="Excalibur" Number="1" Volume="1988" Year="1988">
-      <Id>9b0d4ce8-24b2-4922-94c3-5ce7949054d0</Id>
+      <Database Name="cv" Series="4052" Issue="30178" />
     </Book>
     <Book Series="Excalibur" Number="2" Volume="1988" Year="1988">
-      <Id>3b3e5c21-2260-40c3-81ad-af455cbb97fc</Id>
+      <Database Name="cv" Series="4052" Issue="30308" />
     </Book>
     <Book Series="Excalibur" Number="3" Volume="1988" Year="1988">
-      <Id>fa77a58c-a9d1-4b64-9b7f-d8ba24793e43</Id>
+      <Database Name="cv" Series="4052" Issue="30429" />
     </Book>
     <Book Series="X-Factor Annual" Number="3" Volume="1986" Year="1988">
-      <Id>af6b1434-4e52-44d9-9791-87ed33249dad</Id>
+      <Database Name="cv" Series="3658" Issue="66335" />
     </Book>
     <Book Series="The New Mutants Annual" Number="4" Volume="1984" Year="1988">
-      <Id>82a6ccca-a6f7-4f52-94bd-6e44e0979a46</Id>
+      <Database Name="cv" Series="3356" Issue="29033" />
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="12" Volume="1970" Year="1988">
-      <Id>0efa6f04-32e6-4e12-80b9-603ccd42e1a8</Id>
+    <Book Series="X-Men Annual" Number="12" Volume="1970" Year="1988">
+      <Database Name="cv" Series="22988" Issue="108152" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="235" Volume="1981" Year="1988">
-      <Id>784050ce-979e-47f3-9dc4-71d58a9a7755</Id>
+      <Database Name="cv" Series="3092" Issue="30194" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="236" Volume="1981" Year="1988">
-      <Id>778fbf7c-c4f3-4736-8779-c5ee78a1e721</Id>
+      <Database Name="cv" Series="3092" Issue="30232" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="237" Volume="1981" Year="1988">
-      <Id>8f8f7b60-bce0-42d7-b884-1f4da5d56d37</Id>
+      <Database Name="cv" Series="3092" Issue="30326" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="238" Volume="1981" Year="1988">
-      <Id>c20eaa0a-706b-4e81-b475-f792aa00523e</Id>
+      <Database Name="cv" Series="3092" Issue="30360" />
     </Book>
     <Book Series="Wolverine" Number="9" Volume="1988" Year="1989">
-      <Id>0388414f-4a80-4ec2-b526-777b2f44b530</Id>
+      <Database Name="cv" Series="4250" Issue="64274" />
     </Book>
     <Book Series="X-Factor" Number="32" Volume="1986" Year="1988">
-      <Id>0e9b615e-9a47-40b3-8793-59f01f7cb53c</Id>
+      <Database Name="cv" Series="3657" Issue="30074" />
     </Book>
     <Book Series="Wolverine" Number="10" Volume="1988" Year="1989">
-      <Id>314d074e-92cc-4bb9-bf6b-f820514a4a89</Id>
+      <Database Name="cv" Series="4250" Issue="64275" />
     </Book>
     <Book Series="X-Factor" Number="33" Volume="1986" Year="1988">
-      <Id>c647bd08-dbf9-47b3-b280-06d35398ba9e</Id>
+      <Database Name="cv" Series="3657" Issue="30198" />
     </Book>
     <Book Series="X-Factor" Number="34" Volume="1986" Year="1988">
-      <Id>9e816134-9a58-4778-bab6-9b996b365a77</Id>
+      <Database Name="cv" Series="3657" Issue="30329" />
     </Book>
     <Book Series="X-Factor" Number="35" Volume="1986" Year="1988">
-      <Id>e394ed56-3b4d-429e-888b-dcd080abc571</Id>
+      <Database Name="cv" Series="3657" Issue="30451" />
     </Book>
     <Book Series="Excalibur" Number="4" Volume="1988" Year="1989">
-      <Id>2e1ec6d9-4948-4a13-8de3-622dbeeec38e</Id>
+      <Database Name="cv" Series="4052" Issue="30779" />
     </Book>
     <Book Series="Excalibur" Number="5" Volume="1988" Year="1989">
-      <Id>1c295916-b8c4-4a80-9b37-794ce03687a0</Id>
+      <Database Name="cv" Series="4052" Issue="113568" />
     </Book>
     <Book Series="The New Mutants" Number="67" Volume="1983" Year="1988">
-      <Id>a49a2e1e-209f-41e9-ad30-23a0b93e99b6</Id>
+      <Database Name="cv" Series="3234" Issue="30096" />
     </Book>
     <Book Series="The New Mutants" Number="68" Volume="1983" Year="1988">
-      <Id>5089954b-6f0e-4cf5-b2b0-06e08f9442f1</Id>
+      <Database Name="cv" Series="3234" Issue="30226" />
     </Book>
     <Book Series="The New Mutants" Number="69" Volume="1983" Year="1988">
-      <Id>01ac7f3a-e0c9-4db1-b229-21eca963f223</Id>
+      <Database Name="cv" Series="3234" Issue="30354" />
     </Book>
     <Book Series="The New Mutants" Number="70" Volume="1983" Year="1988">
-      <Id>a59dd781-84f5-41ab-9860-1c40f8573024</Id>
+      <Database Name="cv" Series="3234" Issue="30472" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="239" Volume="1981" Year="1988">
-      <Id>067856a4-cd8b-41e1-b779-a3ade71939b3</Id>
+      <Database Name="cv" Series="3092" Issue="30448" />
     </Book>
     <Book Series="X-Terminators" Number="1" Volume="1988" Year="1988">
-      <Id>b7e20314-39e2-4ec9-8a09-a55df61da657</Id>
+      <Database Name="cv" Series="4082" Issue="30213" />
     </Book>
     <Book Series="X-Terminators" Number="2" Volume="1988" Year="1988">
-      <Id>cb701d97-dfb2-41a6-aaad-ce590af7a900</Id>
+      <Database Name="cv" Series="4082" Issue="30342" />
     </Book>
     <Book Series="X-Terminators" Number="3" Volume="1988" Year="1988">
-      <Id>397051a0-ae96-4eb4-a43c-48831dd36183</Id>
+      <Database Name="cv" Series="4082" Issue="30460" />
     </Book>
     <Book Series="The New Mutants" Number="71" Volume="1983" Year="1989">
-      <Id>30c564ef-dd8d-40c5-ad27-aa9fc932fb68</Id>
+      <Database Name="cv" Series="3234" Issue="30824" />
     </Book>
     <Book Series="X-Terminators" Number="4" Volume="1988" Year="1989">
-      <Id>37330612-cd27-43fe-b8b5-ad42e180e7f2</Id>
+      <Database Name="cv" Series="4082" Issue="30811" />
     </Book>
     <Book Series="The New Mutants" Number="72" Volume="1983" Year="1989">
-      <Id>03edb927-ebb4-4b1c-a050-27c07670ce46</Id>
+      <Database Name="cv" Series="3234" Issue="30929" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="240" Volume="1981" Year="1989">
-      <Id>672b65e6-665b-4e71-9d53-4237be36e1c3</Id>
+      <Database Name="cv" Series="3092" Issue="30797" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="241" Volume="1981" Year="1989">
-      <Id>e50c8c0f-5253-405e-ba0d-50630bb0a9a0</Id>
+      <Database Name="cv" Series="3092" Issue="30905" />
     </Book>
     <Book Series="X-Factor" Number="36" Volume="1986" Year="1989">
-      <Id>79a47b95-a7ef-4f8a-b049-fd24b85b294e</Id>
+      <Database Name="cv" Series="3657" Issue="30800" />
     </Book>
     <Book Series="X-Factor" Number="37" Volume="1986" Year="1989">
-      <Id>9b5046d2-5ffd-4468-b9c7-3709da1dc9f2</Id>
+      <Database Name="cv" Series="3657" Issue="30908" />
     </Book>
     <Book Series="The New Mutants" Number="73" Volume="1983" Year="1989">
-      <Id>d48c44e6-ea0c-4cb3-9c81-221366ca64f5</Id>
+      <Database Name="cv" Series="3234" Issue="31027" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="242" Volume="1981" Year="1989">
-      <Id>368f32a3-265c-49eb-b2ca-79d931c7d340</Id>
+      <Database Name="cv" Series="3092" Issue="31006" />
     </Book>
     <Book Series="X-Factor" Number="38" Volume="1986" Year="1989">
-      <Id>c667b8d9-49e7-4e92-926a-357cf7e4275e</Id>
+      <Database Name="cv" Series="3657" Issue="31009" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="243" Volume="1981" Year="1989">
-      <Id>566291ee-2a52-4572-a2c9-be0f36cb488b</Id>
+      <Database Name="cv" Series="3092" Issue="31117" />
     </Book>
     <Book Series="X-Factor" Number="39" Volume="1986" Year="1989">
-      <Id>af64f297-8804-49dc-87e7-9e93ab6416d2</Id>
+      <Database Name="cv" Series="3657" Issue="31120" />
     </Book>
     <Book Series="Excalibur" Number="6" Volume="1988" Year="1989">
-      <Id>b0095a88-3ca8-4ea3-b98c-4b7968875a76</Id>
+      <Database Name="cv" Series="4052" Issue="30989" />
     </Book>
     <Book Series="Excalibur" Number="7" Volume="1988" Year="1989">
-      <Id>ec2a4752-5343-4951-a132-584ad1d34b74</Id>
+      <Database Name="cv" Series="4052" Issue="31100" />
     </Book>
     <Book Series="The New Mutants" Number="74" Volume="1983" Year="1989">
-      <Id>2c6fb138-f442-421c-8cb7-b8f134e78f90</Id>
+      <Database Name="cv" Series="3234" Issue="31143" />
     </Book>
     <Book Series="Excalibur" Number="8" Volume="1988" Year="1989">
-      <Id>d1c8ad0a-78b9-4486-b0f3-c0379e147618</Id>
+      <Database Name="cv" Series="4052" Issue="66340" />
     </Book>
     <Book Series="The New Mutants" Number="75" Volume="1983" Year="1989">
-      <Id>373ed4dd-5d26-42cd-ad4d-96d40f8b8141</Id>
+      <Database Name="cv" Series="3234" Issue="31251" />
     </Book>
     <Book Series="The New Mutants" Number="76" Volume="1983" Year="1989">
-      <Id>3e301302-8c09-49b0-a538-770307bbd835</Id>
+      <Database Name="cv" Series="3234" Issue="31363" />
     </Book>
     <Book Series="X-Factor" Number="40" Volume="1986" Year="1989">
-      <Id>3a841f11-310f-4390-96e0-770fd63044f3</Id>
+      <Database Name="cv" Series="3657" Issue="31233" />
     </Book>
     <Book Series="Excalibur" Number="9" Volume="1988" Year="1989">
-      <Id>6e99fa12-91e5-4005-a7ab-71e5f8201ebb</Id>
+      <Database Name="cv" Series="4052" Issue="31323" />
     </Book>
     <Book Series="Excalibur" Number="10" Volume="1988" Year="1989">
-      <Id>8d5bd57f-20df-4c82-bb70-36d99f35a44a</Id>
+      <Database Name="cv" Series="4052" Issue="66341" />
     </Book>
     <Book Series="Excalibur" Number="11" Volume="1988" Year="1989">
-      <Id>db15b923-ba79-4241-9b57-0b50b7bdb0ba</Id>
+      <Database Name="cv" Series="4052" Issue="66342" />
     </Book>
     <Book Series="Excalibur" Number="12" Volume="1988" Year="1989">
-      <Id>6582939d-dab1-40b9-bf3a-a4f87ed97298</Id>
+      <Database Name="cv" Series="4052" Issue="31651" />
     </Book>
     <Book Series="Excalibur" Number="13" Volume="1988" Year="1989">
-      <Id>0b1dc1e5-ad0f-4245-a115-58b24ea77ac9</Id>
+      <Database Name="cv" Series="4052" Issue="31761" />
     </Book>
     <Book Series="Excalibur" Number="14" Volume="1988" Year="1989">
-      <Id>e81e07f3-d0c9-4603-8bd1-56d9cc2fbacd</Id>
+      <Database Name="cv" Series="4052" Issue="31866" />
     </Book>
     <Book Series="Excalibur" Number="15" Volume="1988" Year="1989">
-      <Id>c8d30969-b984-4ed9-838c-6e8c9f313d88</Id>
+      <Database Name="cv" Series="4052" Issue="31921" />
     </Book>
     <Book Series="Excalibur" Number="16" Volume="1988" Year="1989">
-      <Id>5fa40596-1477-4df7-ba67-805143dbd0b4</Id>
+      <Database Name="cv" Series="4052" Issue="31996" />
     </Book>
     <Book Series="Excalibur" Number="17" Volume="1988" Year="1989">
-      <Id>e1f5845c-b4c2-404d-b164-0134e05acc4e</Id>
+      <Database Name="cv" Series="4052" Issue="32058" />
     </Book>
     <Book Series="Excalibur" Number="18" Volume="1988" Year="1990">
-      <Id>fb920468-3b02-4e2d-977f-d2aedeb3c0e1</Id>
+      <Database Name="cv" Series="4052" Issue="66343" />
     </Book>
     <Book Series="Excalibur" Number="19" Volume="1988" Year="1990">
-      <Id>7e7b3363-d590-4b32-bd12-36e66b15ef9d</Id>
+      <Database Name="cv" Series="4052" Issue="32417" />
     </Book>
     <Book Series="Excalibur" Number="20" Volume="1988" Year="1990">
-      <Id>00fe744f-b3f4-4b7c-a62e-2b3b37a78508</Id>
+      <Database Name="cv" Series="4052" Issue="66344" />
     </Book>
     <Book Series="Excalibur" Number="21" Volume="1988" Year="1990">
-      <Id>b3b6b4f4-2a27-4841-8952-04b9755703ea</Id>
+      <Database Name="cv" Series="4052" Issue="66345" />
     </Book>
     <Book Series="Excalibur" Number="22" Volume="1988" Year="1990">
-      <Id>cca9f24c-da5f-4a12-b6c6-ffa92c91097f</Id>
+      <Database Name="cv" Series="4052" Issue="32836" />
     </Book>
     <Book Series="Excalibur" Number="23" Volume="1988" Year="1990">
-      <Id>9d2f54ad-8cf9-437c-8f35-59fcefbdf268</Id>
+      <Database Name="cv" Series="4052" Issue="66346" />
     </Book>
     <Book Series="Excalibur" Number="24" Volume="1988" Year="1990">
-      <Id>f1f89de1-83c9-4d4a-972f-e70f0f50f864</Id>
+      <Database Name="cv" Series="4052" Issue="32962" />
     </Book>
     <Book Series="Wolverine" Number="11" Volume="1988" Year="1989">
-      <Id>df6854d1-a6e5-483d-8003-aba53a801f04</Id>
+      <Database Name="cv" Series="4250" Issue="64276" />
     </Book>
     <Book Series="Wolverine" Number="12" Volume="1988" Year="1989">
-      <Id>3e9d4800-630c-4c87-9776-54de461a09ef</Id>
+      <Database Name="cv" Series="4250" Issue="64277" />
     </Book>
     <Book Series="Wolverine" Number="13" Volume="1988" Year="1989">
-      <Id>f7265a16-ee50-42b3-8393-f45426c98678</Id>
+      <Database Name="cv" Series="4250" Issue="64278" />
     </Book>
     <Book Series="Wolverine" Number="14" Volume="1988" Year="1989">
-      <Id>e914c884-d3b6-4925-9e07-44b72cff8fd3</Id>
+      <Database Name="cv" Series="4250" Issue="64279" />
     </Book>
     <Book Series="Wolverine" Number="15" Volume="1988" Year="1989">
-      <Id>ba31a826-d1a5-4a63-a0ce-fd8a24727396</Id>
+      <Database Name="cv" Series="4250" Issue="64280" />
     </Book>
     <Book Series="Wolverine" Number="16" Volume="1988" Year="1989">
-      <Id>8cdd4465-7004-47e4-8955-60f94997aaa5</Id>
+      <Database Name="cv" Series="4250" Issue="64281" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="51" Volume="1988" Year="1990">
-      <Id>ba596d11-5e90-4684-8a88-5cb1abea415a</Id>
+      <Database Name="cv" Series="4058" Issue="32843" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="52" Volume="1988" Year="1990">
-      <Id>eae784cf-8243-43e5-baf2-1049f3a2636a</Id>
+      <Database Name="cv" Series="4058" Issue="32895" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="53" Volume="1988" Year="1990">
-      <Id>1e7ed635-8f16-4078-b87c-f506b8dc296a</Id>
+      <Database Name="cv" Series="4058" Issue="32968" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="244" Volume="1981" Year="1989">
-      <Id>5863567b-eb86-4737-b27e-f283ecd1b8f3</Id>
+      <Database Name="cv" Series="3092" Issue="31230" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="245" Volume="1981" Year="1989">
-      <Id>70693513-edee-4511-8c9b-499df54fbe66</Id>
+      <Database Name="cv" Series="3092" Issue="31340" />
     </Book>
-    <Book Series="Havok &amp; Wolverine: Meltdown" Number="1" Volume="1989" Year="1989">
-      <Id>851fc0a1-f7aa-4a3e-976f-8d5af31d73d3</Id>
+    <Book Series="Havok &#38; Wolverine: Meltdown" Number="1" Volume="1989" Year="1989">
+      <Database Name="cv" Series="4055" Issue="29050" />
     </Book>
-    <Book Series="Havok &amp; Wolverine: Meltdown" Number="2" Volume="1989" Year="1989">
-      <Id>9992ac42-9617-4dbe-a41f-02bd460b9e70</Id>
+    <Book Series="Havok &#38; Wolverine: Meltdown" Number="2" Volume="1989" Year="1989">
+      <Database Name="cv" Series="4055" Issue="29062" />
     </Book>
-    <Book Series="Havok &amp; Wolverine: Meltdown" Number="3" Volume="1989" Year="1989">
-      <Id>2cf57cef-f814-4f38-a865-5ead1b2792b3</Id>
+    <Book Series="Havok &#38; Wolverine: Meltdown" Number="3" Volume="1989" Year="1989">
+      <Database Name="cv" Series="4055" Issue="30644" />
     </Book>
-    <Book Series="Havok &amp; Wolverine: Meltdown" Number="4" Volume="1989" Year="1989">
-      <Id>9dc17187-1add-4c1d-9fba-abf01902169e</Id>
+    <Book Series="Havok &#38; Wolverine: Meltdown" Number="4" Volume="1989" Year="1989">
+      <Database Name="cv" Series="4055" Issue="30684" />
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="13" Volume="1982" Year="1989">
-      <Id>ec9b23b2-46de-4b27-92f8-00563b3657ab</Id>
+    <Book Series="X-Men Annual" Number="13" Volume="1970" Year="1989">
+      <Database Name="cv" Series="22988" Issue="107609" />
     </Book>
     <Book Series="The New Mutants Annual" Number="5" Volume="1984" Year="1989">
-      <Id>475c3943-61c3-49b4-ae1f-4c6f2e5dc427</Id>
+      <Database Name="cv" Series="3356" Issue="30616" />
     </Book>
     <Book Series="X-Factor Annual" Number="4" Volume="1986" Year="1989">
-      <Id>1e35c411-cf55-4175-8de2-c1df92ea5264</Id>
+      <Database Name="cv" Series="3658" Issue="30609" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="246" Volume="1981" Year="1989">
-      <Id>08913372-1c6d-4bb9-be25-a3679d3382e6</Id>
+      <Database Name="cv" Series="3092" Issue="31451" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="247" Volume="1981" Year="1989">
-      <Id>5c6e562a-bb8e-437d-ba4b-acdb8a98ad02</Id>
+      <Database Name="cv" Series="3092" Issue="31554" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="248" Volume="1981" Year="1989">
-      <Id>6a4ef602-d9bd-460f-8f7c-645eb288cd0a</Id>
+      <Database Name="cv" Series="3092" Issue="31670" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="249" Volume="1981" Year="1989">
-      <Id>4c40f0bd-d948-4aab-a366-97a15a8595f7</Id>
+      <Database Name="cv" Series="3092" Issue="31781" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="250" Volume="1981" Year="1989">
-      <Id>bddbfc66-c2e9-457e-8781-175b2cbc9e60</Id>
+      <Database Name="cv" Series="3092" Issue="31807" />
     </Book>
     <Book Series="X-Factor" Number="41" Volume="1986" Year="1989">
-      <Id>63569bbe-e3d1-4937-9956-4b3e73151290</Id>
+      <Database Name="cv" Series="3657" Issue="31353" />
     </Book>
     <Book Series="X-Factor" Number="42" Volume="1986" Year="1989">
-      <Id>93609a00-f51d-4d71-80a7-f2fdb65dec78</Id>
+      <Database Name="cv" Series="3657" Issue="31463" />
     </Book>
     <Book Series="The New Mutants" Number="77" Volume="1983" Year="1989">
-      <Id>076a899d-5298-434a-a029-5ad5a5950b9f</Id>
+      <Database Name="cv" Series="3234" Issue="31472" />
     </Book>
     <Book Series="The New Mutants" Number="78" Volume="1983" Year="1989">
-      <Id>d04569a3-7078-46d9-a474-abb2eb872807</Id>
+      <Database Name="cv" Series="3234" Issue="31579" />
     </Book>
     <Book Series="The New Mutants" Number="79" Volume="1983" Year="1989">
-      <Id>9ba8cea8-7abd-42b7-8320-5402ccfc1845</Id>
+      <Database Name="cv" Series="3234" Issue="31691" />
     </Book>
     <Book Series="The New Mutants" Number="80" Volume="1983" Year="1989">
-      <Id>a1f07d7c-e6cf-4a1e-8312-0169cbd40e23</Id>
+      <Database Name="cv" Series="3234" Issue="31800" />
     </Book>
     <Book Series="The New Mutants" Number="81" Volume="1983" Year="1989">
-      <Id>59f66b9d-af70-437a-8b9b-bff5821e4643</Id>
+      <Database Name="cv" Series="3234" Issue="31906" />
     </Book>
     <Book Series="The New Mutants" Number="82" Volume="1983" Year="1989">
-      <Id>13f0f495-2d23-42c6-a75a-6170069ad0d0</Id>
+      <Database Name="cv" Series="3234" Issue="31940" />
     </Book>
     <Book Series="The New Mutants" Number="83" Volume="1983" Year="1989">
-      <Id>b40702be-6f17-46f1-8429-f486e8be9cc7</Id>
+      <Database Name="cv" Series="3234" Issue="32044" />
     </Book>
     <Book Series="The New Mutants" Number="84" Volume="1983" Year="1989">
-      <Id>e3c61634-c30f-4e64-86e4-e906d3a2aa3f</Id>
+      <Database Name="cv" Series="3234" Issue="32078" />
     </Book>
     <Book Series="The New Mutants" Number="85" Volume="1983" Year="1990">
-      <Id>2cf5cfa8-00f4-48c1-8e18-74e18649ca4e</Id>
+      <Database Name="cv" Series="3234" Issue="32356" />
     </Book>
     <Book Series="The New Mutants" Number="86" Volume="1983" Year="1990">
-      <Id>b417d492-9bf4-4c6c-993e-28c8d6f19176</Id>
+      <Database Name="cv" Series="3234" Issue="32456" />
     </Book>
     <Book Series="Wolverine: The Jungle Adventure" Number="1" Volume="1990" Year="1990">
-      <Id>3956051e-5043-4577-b8bb-2ab2ce41ba6e</Id>
+      <Database Name="cv" Series="23053" Issue="138923" />
     </Book>
     <Book Series="Wolverine" Number="17" Volume="1988" Year="1989">
-      <Id>141440da-8e18-46f9-95b5-f6670cd6b9d0</Id>
+      <Database Name="cv" Series="4250" Issue="64282" />
     </Book>
     <Book Series="Wolverine" Number="18" Volume="1988" Year="1989">
-      <Id>f2a095dd-9135-4ca9-bb4e-f0b66958c44b</Id>
+      <Database Name="cv" Series="4250" Issue="64283" />
     </Book>
     <Book Series="Wolverine" Number="19" Volume="1988" Year="1989">
-      <Id>ec4ea6e1-20b9-44c9-bd16-0cc01ca0792f</Id>
+      <Database Name="cv" Series="4250" Issue="64284" />
     </Book>
     <Book Series="Wolverine" Number="20" Volume="1988" Year="1990">
-      <Id>7fbd7949-6dd1-4138-be3b-d234ed1291c6</Id>
+      <Database Name="cv" Series="4250" Issue="64285" />
     </Book>
     <Book Series="X-Factor" Number="43" Volume="1986" Year="1989">
-      <Id>56129c26-b21b-4153-8ebd-ffc28fefef25</Id>
+      <Database Name="cv" Series="3657" Issue="31568" />
     </Book>
     <Book Series="X-Factor" Number="44" Volume="1986" Year="1989">
-      <Id>abdb95c6-1ae9-4270-9164-f45157eb6b35</Id>
+      <Database Name="cv" Series="3657" Issue="31681" />
     </Book>
     <Book Series="X-Factor" Number="45" Volume="1986" Year="1989">
-      <Id>42daf7f2-de29-4124-b7e7-ce9471d1de12</Id>
+      <Database Name="cv" Series="3657" Issue="31792" />
     </Book>
     <Book Series="X-Factor" Number="46" Volume="1986" Year="1989">
-      <Id>3f31e714-cbf0-4959-be83-869bdbdb3065</Id>
+      <Database Name="cv" Series="3657" Issue="31899" />
     </Book>
     <Book Series="X-Factor" Number="47" Volume="1986" Year="1989">
-      <Id>8aabe919-638d-400a-9772-0b166d7cbbf6</Id>
+      <Database Name="cv" Series="3657" Issue="31938" />
     </Book>
     <Book Series="X-Factor" Number="48" Volume="1986" Year="1989">
-      <Id>ed8c0580-b08b-4d79-a2f1-1540100edb35</Id>
+      <Database Name="cv" Series="3657" Issue="32035" />
     </Book>
     <Book Series="X-Factor" Number="49" Volume="1986" Year="1989">
-      <Id>7c13115c-b2d6-4452-b86f-8f4e32f28ca5</Id>
+      <Database Name="cv" Series="3657" Issue="32077" />
     </Book>
     <Book Series="X-Factor" Number="50" Volume="1986" Year="1990">
-      <Id>0c5bff26-1945-4a72-9813-ae0ec4baa9e7</Id>
+      <Database Name="cv" Series="3657" Issue="32340" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="251" Volume="1981" Year="1989">
-      <Id>1b25fc57-3deb-45c9-a3be-248237e8b6b2</Id>
+      <Database Name="cv" Series="3092" Issue="31885" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="252" Volume="1981" Year="1989">
-      <Id>4cf05c9c-e0b8-40b7-ac89-237d91fa538b</Id>
+      <Database Name="cv" Series="3092" Issue="31935" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="253" Volume="1981" Year="1989">
-      <Id>3b399d66-cccb-4fce-bb93-23028b77c49e</Id>
+      <Database Name="cv" Series="3092" Issue="31944" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="254" Volume="1981" Year="1989">
-      <Id>227e432b-0e75-4358-acc2-73651cb0a1ac</Id>
+      <Database Name="cv" Series="3092" Issue="32017" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="255" Volume="1981" Year="1989">
-      <Id>edd7bd9f-f2e0-4156-ae80-8c8d0c5ae211</Id>
+      <Database Name="cv" Series="3092" Issue="32074" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="256" Volume="1981" Year="1989">
-      <Id>ed660880-2bdd-4f18-8121-fb6165c7f3f3</Id>
+      <Database Name="cv" Series="3092" Issue="32081" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="257" Volume="1981" Year="1990">
-      <Id>7a1a2332-e9f3-4871-9a83-f619749f9748</Id>
+      <Database Name="cv" Series="3092" Issue="32337" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="258" Volume="1981" Year="1990">
-      <Id>b90f2436-abd5-4889-8f45-73ee148f62d4</Id>
+      <Database Name="cv" Series="3092" Issue="32436" />
     </Book>
     <Book Series="Wolverine" Number="21" Volume="1988" Year="1990">
-      <Id>68712705-6bfc-4ae9-acb6-b3947b83093e</Id>
+      <Database Name="cv" Series="4250" Issue="64286" />
     </Book>
     <Book Series="Wolverine" Number="22" Volume="1988" Year="1990">
-      <Id>af721590-62e2-4ffb-a803-f18bf3448aa6</Id>
+      <Database Name="cv" Series="4250" Issue="114384" />
     </Book>
     <Book Series="Wolverine" Number="23" Volume="1988" Year="1990">
-      <Id>6bc879f7-9e8e-4b75-9a0f-4591c81ea771</Id>
+      <Database Name="cv" Series="4250" Issue="64287" />
     </Book>
     <Book Series="Wolverine" Number="24" Volume="1988" Year="1990">
-      <Id>ffec43e9-f277-4ec9-9e78-08e7024c2a20</Id>
+      <Database Name="cv" Series="4250" Issue="64288" />
     </Book>
     <Book Series="Wolverine" Number="25" Volume="1988" Year="1990">
-      <Id>1b9c806c-9cae-4658-a55b-2bccb97f9a9d</Id>
+      <Database Name="cv" Series="4250" Issue="114385" />
     </Book>
     <Book Series="Wolverine" Number="26" Volume="1988" Year="1990">
-      <Id>78d819da-1201-4853-8a21-c215ae27df71</Id>
+      <Database Name="cv" Series="4250" Issue="64289" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="259" Volume="1981" Year="1990">
-      <Id>fc8ba1a9-b82c-4225-816d-ccc033b6a1bc</Id>
+      <Database Name="cv" Series="3092" Issue="32535" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="260" Volume="1981" Year="1990">
-      <Id>194f4936-b38d-4c28-9ea7-bcb8385f921e</Id>
+      <Database Name="cv" Series="3092" Issue="32647" />
     </Book>
     <Book Series="The New Mutants" Number="87" Volume="1983" Year="1990">
-      <Id>2502b2fa-8b35-4e54-a792-a3e7cdba7ec3</Id>
+      <Database Name="cv" Series="3234" Issue="32559" />
     </Book>
     <Book Series="The New Mutants" Number="88" Volume="1983" Year="1990">
-      <Id>e7b7a98b-ca42-4217-86cd-2eb08c73df6d</Id>
+      <Database Name="cv" Series="3234" Issue="32669" />
     </Book>
     <Book Series="The New Mutants" Number="89" Volume="1983" Year="1990">
-      <Id>16b64c5e-dfd1-4ab1-8d5f-3dc3629738df</Id>
+      <Database Name="cv" Series="3234" Issue="32766" />
     </Book>
     <Book Series="X-Factor" Number="51" Volume="1986" Year="1990">
-      <Id>af38f884-8ac2-47c3-ae16-43e7818d2f81</Id>
+      <Database Name="cv" Series="3657" Issue="32448" />
     </Book>
     <Book Series="X-Factor" Number="52" Volume="1986" Year="1990">
-      <Id>6ffbcc50-f253-4124-8e1b-ae922de3a112</Id>
+      <Database Name="cv" Series="3657" Issue="32539" />
     </Book>
     <Book Series="X-Factor" Number="53" Volume="1986" Year="1990">
-      <Id>3c7e47b4-ed5c-46e3-899a-9dfceb5d9b5b</Id>
+      <Database Name="cv" Series="3657" Issue="32650" />
     </Book>
     <Book Series="The New Mutants" Number="90" Volume="1983" Year="1990">
-      <Id>12c4642d-3627-4b88-9795-ffc5dfc2a0b9</Id>
+      <Database Name="cv" Series="3234" Issue="32887" />
     </Book>
     <Book Series="The New Mutants" Number="91" Volume="1983" Year="1990">
-      <Id>5000032a-cb02-4d87-87aa-42fd6076db19</Id>
+      <Database Name="cv" Series="3234" Issue="33006" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="261" Volume="1981" Year="1990">
-      <Id>998496cb-10e8-4a41-a340-6732ae56c258</Id>
+      <Database Name="cv" Series="3092" Issue="32741" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="262" Volume="1981" Year="1990">
-      <Id>45aecfc9-d9cb-4e4c-882f-3db8e5fae060</Id>
+      <Database Name="cv" Series="3092" Issue="32861" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="263" Volume="1981" Year="1990">
-      <Id>8eed62e8-1488-43a5-a060-16b53d38cb24</Id>
+      <Database Name="cv" Series="3092" Issue="32982" />
     </Book>
     <Book Series="X-Factor" Number="54" Volume="1986" Year="1990">
-      <Id>54008b72-e768-462a-8567-38fcb6c1e532</Id>
+      <Database Name="cv" Series="3657" Issue="32744" />
     </Book>
     <Book Series="X-Factor" Number="55" Volume="1986" Year="1990">
-      <Id>0f4a38e4-f2e1-4459-8f4b-c195d942b457</Id>
+      <Database Name="cv" Series="3657" Issue="32864" />
     </Book>
     <Book Series="The New Mutants" Number="92" Volume="1983" Year="1990">
-      <Id>19b1fdaf-9cd7-41d9-bd37-4949e4fe892e</Id>
+      <Database Name="cv" Series="3234" Issue="33125" />
     </Book>
     <Book Series="Excalibur" Number="25" Volume="1988" Year="1990">
-      <Id>1385ce3b-38e2-4592-9767-9b9340a13d5e</Id>
+      <Database Name="cv" Series="4052" Issue="66347" />
     </Book>
     <Book Series="Excalibur" Number="26" Volume="1988" Year="1990">
-      <Id>28644cae-f079-429f-bce3-9bfac682491e</Id>
+      <Database Name="cv" Series="4052" Issue="66348" />
     </Book>
     <Book Series="Excalibur" Number="27" Volume="1988" Year="1990">
-      <Id>184f9840-1451-40c1-b2f1-baced162d99e</Id>
+      <Database Name="cv" Series="4052" Issue="33076" />
     </Book>
     <Book Series="Excalibur" Number="28" Volume="1988" Year="1990">
-      <Id>8576b938-7bef-4705-a321-5077346d3be2</Id>
+      <Database Name="cv" Series="4052" Issue="66349" />
     </Book>
     <Book Series="Excalibur" Number="29" Volume="1988" Year="1990">
-      <Id>f0d816ce-1725-4357-b8ea-bb8a084f41e1</Id>
+      <Database Name="cv" Series="4052" Issue="66350" />
     </Book>
     <Book Series="Excalibur" Number="30" Volume="1988" Year="1990">
-      <Id>4ffe3dd5-96e5-453a-b109-f1c8276db96d</Id>
+      <Database Name="cv" Series="4052" Issue="113569" />
     </Book>
     <Book Series="Excalibur" Number="31" Volume="1988" Year="1990">
-      <Id>3b8dff12-2e24-4a26-b960-937ba64c9a0d</Id>
+      <Database Name="cv" Series="4052" Issue="66351" />
     </Book>
     <Book Series="New Mutants Summer Special" Number="1" Volume="1990" Year="1990">
-      <Id>06d1a1d1-f3a8-4dc2-9daa-d35af58a4afd</Id>
+      <Database Name="cv" Series="20601" Issue="123502" />
     </Book>
     <Book Series="Wolverine" Number="27" Volume="1988" Year="1990">
-      <Id>dea71988-1a05-429e-a389-2aa41a256e7a</Id>
+      <Database Name="cv" Series="4250" Issue="64290" />
     </Book>
     <Book Series="Wolverine" Number="28" Volume="1988" Year="1990">
-      <Id>9808ac43-0168-408b-935b-822278350640</Id>
+      <Database Name="cv" Series="4250" Issue="64291" />
     </Book>
     <Book Series="Wolverine" Number="29" Volume="1988" Year="1990">
-      <Id>9494b40f-be07-43fc-8f56-98288c22dbe8</Id>
+      <Database Name="cv" Series="4250" Issue="64292" />
     </Book>
     <Book Series="Wolverine" Number="30" Volume="1988" Year="1990">
-      <Id>daa14271-7640-4017-a793-36810fa8a69f</Id>
+      <Database Name="cv" Series="4250" Issue="64293" />
     </Book>
     <Book Series="Wolverine and the Punisher: Damaging Evidence" Number="1" Volume="1993" Year="1993">
-      <Id>eee3ea60-4127-4082-ab1d-c179a7d716f2</Id>
+      <Database Name="cv" Series="7183" Issue="51311" />
     </Book>
     <Book Series="Wolverine and the Punisher: Damaging Evidence" Number="2" Volume="1993" Year="1993">
-      <Id>9ff2aa33-75e7-46b4-aceb-c52583346985</Id>
+      <Database Name="cv" Series="7183" Issue="51312" />
     </Book>
     <Book Series="Wolverine and the Punisher: Damaging Evidence" Number="3" Volume="1993" Year="1993">
-      <Id>ddb0496a-71c0-41b7-be6d-93b6844d5f11</Id>
+      <Database Name="cv" Series="7183" Issue="51313" />
     </Book>
     <Book Series="X-Factor" Number="56" Volume="1986" Year="1990">
-      <Id>41c36a4a-0d97-44b3-8caa-69716e98dbea</Id>
+      <Database Name="cv" Series="3657" Issue="32985" />
     </Book>
     <Book Series="X-Factor" Number="57" Volume="1986" Year="1990">
-      <Id>36a1fc6e-97fa-44df-aaad-e69273439514</Id>
+      <Database Name="cv" Series="3657" Issue="33102" />
     </Book>
     <Book Series="X-Factor" Number="58" Volume="1986" Year="1990">
-      <Id>91088964-370c-40f3-a00c-412ef7aae2d5</Id>
+      <Database Name="cv" Series="3657" Issue="33232" />
     </Book>
     <Book Series="X-Men Spotlight on... Starjammers" Number="1" Volume="1990" Year="1990">
-      <Id>13a27d5d-d9fa-4469-8297-29f9acd8fd78</Id>
+      <Database Name="cv" Series="4428" Issue="33604" />
     </Book>
     <Book Series="X-Men Spotlight on... Starjammers" Number="2" Volume="1990" Year="1990">
-      <Id>483dd7f7-5495-43f6-b4cd-ecafab1cf91c</Id>
+      <Database Name="cv" Series="4428" Issue="33611" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="264" Volume="1981" Year="1990">
-      <Id>fe26e2a7-d186-42b1-b8c6-cdd6dc50056d</Id>
+      <Database Name="cv" Series="3092" Issue="33015" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="265" Volume="1981" Year="1990">
-      <Id>a007b092-310d-4172-a9d7-d5b8b08b6a0c</Id>
+      <Database Name="cv" Series="3092" Issue="33099" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="266" Volume="1981" Year="1990">
-      <Id>db307869-4d0f-4d42-be4e-0110cf4ad2fb</Id>
+      <Database Name="cv" Series="3092" Issue="33137" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="267" Volume="1981" Year="1990">
-      <Id>aaed4e34-b63a-49de-91b1-59ff265f62be</Id>
+      <Database Name="cv" Series="3092" Issue="106308" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="268" Volume="1981" Year="1990">
-      <Id>bf75bc06-3c4a-47cb-ac02-ef30ec52e443</Id>
+      <Database Name="cv" Series="3092" Issue="33256" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="269" Volume="1981" Year="1990">
-      <Id>2ea83b2e-5b3d-43b0-a703-1e6ba5649ee3</Id>
+      <Database Name="cv" Series="3092" Issue="33334" />
     </Book>
     <Book Series="Excalibur" Number="32" Volume="1988" Year="1990">
-      <Id>3684e303-40c8-4a9b-9059-8f2b6b04df38</Id>
+      <Database Name="cv" Series="4052" Issue="120771" />
     </Book>
     <Book Series="Excalibur" Number="33" Volume="1988" Year="1991">
-      <Id>150a7da5-e498-4396-9193-fa468913fbdc</Id>
+      <Database Name="cv" Series="4052" Issue="120772" />
     </Book>
     <Book Series="Excalibur" Number="34" Volume="1988" Year="1991">
-      <Id>39141336-39f0-48ef-8941-2a76b374c1f7</Id>
+      <Database Name="cv" Series="4052" Issue="120773" />
     </Book>
     <Book Series="Fantastic Four Annual" Number="23" Volume="1963" Year="1990">
-      <Id>7ba1b3a2-b9c5-45b0-9975-956f22003d29</Id>
+      <Database Name="cv" Series="2129" Issue="32252" />
     </Book>
     <Book Series="X-Factor Annual" Number="5" Volume="1986" Year="1990">
-      <Id>df41e93f-e783-4987-8ba0-9693cb2ce13e</Id>
+      <Database Name="cv" Series="3658" Issue="66336" />
     </Book>
     <Book Series="The New Mutants Annual" Number="6" Volume="1984" Year="1990">
-      <Id>c705814c-8ea3-474b-a7fb-66bf9900dfd2</Id>
+      <Database Name="cv" Series="3356" Issue="32179" />
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="14" Volume="1982" Year="1990">
-      <Id>39834abe-9729-466d-b054-44afd6118cd6</Id>
+    <Book Series="X-Men Annual" Number="14" Volume="1970" Year="1990">
+      <Database Name="cv" Series="22988" Issue="107610" />
     </Book>
     <Book Series="Wolverine: Rahne of Terra" Number="1" Volume="1991" Year="1991">
-      <Id>268fae99-cfc4-4800-b21d-57eec7548887</Id>
+      <Database Name="cv" Series="20603" Issue="123519" />
     </Book>
     <Book Series="The New Mutants" Number="93" Volume="1983" Year="1990">
-      <Id>2cf4a82a-da80-4f42-be1c-1cdbe58ece5a</Id>
+      <Database Name="cv" Series="3234" Issue="33243" />
     </Book>
     <Book Series="The New Mutants" Number="94" Volume="1983" Year="1990">
-      <Id>7d6b07fb-fd99-4636-9794-717011dd7e4d</Id>
+      <Database Name="cv" Series="3234" Issue="33358" />
     </Book>
     <Book Series="Wolverine" Number="31" Volume="1988" Year="1990">
-      <Id>d46623fa-7b49-444f-a67a-3e472d5258ae</Id>
+      <Database Name="cv" Series="4250" Issue="64294" />
     </Book>
     <Book Series="Wolverine" Number="32" Volume="1988" Year="1990">
-      <Id>493169d7-d741-4c69-bc4a-58283ab3e57a</Id>
+      <Database Name="cv" Series="4250" Issue="64295" />
     </Book>
     <Book Series="Wolverine" Number="33" Volume="1988" Year="1990">
-      <Id>b0ac3761-cb96-4d17-b159-c9a399ba932b</Id>
+      <Database Name="cv" Series="4250" Issue="64296" />
     </Book>
     <Book Series="X-Factor" Number="59" Volume="1986" Year="1990">
-      <Id>cbabf480-6049-43d9-9ffc-ffa7e5393899</Id>
+      <Database Name="cv" Series="3657" Issue="33338" />
     </Book>
-    <Book Series="X-Factor Special" Number="1" Volume="1990" Year="1990">
-      <Id>3e2f8361-e660-46ba-bbbc-6a5508bc458e</Id>
+    <Book Series="X-Factor - Prisoner of Love" Number="1" Volume="1990" Year="1990">
+      <Database Name="cv" Series="24240" Issue="144023" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="270" Volume="1981" Year="1990">
-      <Id>2fe1ff11-29e8-4bb2-86e0-aa83f254104d</Id>
+      <Database Name="cv" Series="3092" Issue="33443" />
     </Book>
     <Book Series="The New Mutants" Number="95" Volume="1983" Year="1990">
-      <Id>24018547-17af-420c-9f90-88987ccc6bc6</Id>
+      <Database Name="cv" Series="3234" Issue="33468" />
     </Book>
     <Book Series="X-Factor" Number="60" Volume="1986" Year="1990">
-      <Id>33823876-77d6-4e61-9713-3191dc9244f7</Id>
+      <Database Name="cv" Series="3657" Issue="33446" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="271" Volume="1981" Year="1990">
-      <Id>cf7c2c94-4069-488c-beaf-5eca40a8c323</Id>
+      <Database Name="cv" Series="3092" Issue="33551" />
     </Book>
     <Book Series="The New Mutants" Number="96" Volume="1983" Year="1990">
-      <Id>107ece0e-f39f-4563-bec0-5f71b366cf43</Id>
+      <Database Name="cv" Series="3234" Issue="106559" />
     </Book>
     <Book Series="X-Factor" Number="61" Volume="1986" Year="1990">
-      <Id>c07abbc7-cda3-4627-97d9-b06c69a5bef2</Id>
+      <Database Name="cv" Series="3657" Issue="33554" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="272" Volume="1981" Year="1991">
-      <Id>62b15bff-7e55-4a9e-b424-15f428e08922</Id>
+      <Database Name="cv" Series="3092" Issue="33793" />
     </Book>
     <Book Series="The New Mutants" Number="97" Volume="1983" Year="1991">
-      <Id>060ed684-90af-4df2-a961-550f048a1dfc</Id>
+      <Database Name="cv" Series="3234" Issue="33816" />
     </Book>
     <Book Series="X-Factor" Number="62" Volume="1986" Year="1991">
-      <Id>d8895972-bf5d-4fe3-bcc4-cd0abe1afe19</Id>
+      <Database Name="cv" Series="3657" Issue="33807" />
     </Book>
     <Book Series="Excalibur" Number="35" Volume="1988" Year="1991">
-      <Id>1e16bf17-f784-461f-a6b3-0ed9453ab2bc</Id>
+      <Database Name="cv" Series="4052" Issue="66352" />
     </Book>
     <Book Series="X-Men: True Friends" Number="1" Volume="1999" Year="1999">
-      <Id>c22e954f-1bf2-4118-8496-b3e8c54d17ad</Id>
+      <Database Name="cv" Series="6361" Issue="46025" />
     </Book>
     <Book Series="X-Men: True Friends" Number="2" Volume="1999" Year="1999">
-      <Id>37d05483-d59e-4ff8-b114-5a511ec1c7a7</Id>
+      <Database Name="cv" Series="6361" Issue="46072" />
     </Book>
     <Book Series="X-Men: True Friends" Number="3" Volume="1999" Year="1999">
-      <Id>d8a55c95-a663-4872-b961-301aa02b895a</Id>
+      <Database Name="cv" Series="6361" Issue="46118" />
     </Book>
     <Book Series="Excalibur" Number="36" Volume="1988" Year="1991">
-      <Id>e84a6d29-5508-4684-84d2-19c338f4428c</Id>
+      <Database Name="cv" Series="4052" Issue="66353" />
     </Book>
     <Book Series="Wolverine" Number="34" Volume="1988" Year="1990">
-      <Id>e52c30a1-9fc6-4981-8dbc-d14da2727151</Id>
+      <Database Name="cv" Series="4250" Issue="64297" />
     </Book>
-    <Book Series="Wolverine Annual  2 - Bloodlust" Number="1" Volume="1990" Year="1990">
-      <Id>84ffb69a-020f-47cf-9209-af63a41b6338</Id>
+    <Book Series="Wolverine: Bloodlust" Number="1" Volume="1990" Year="1990">
+      <Database Name="cv" Series="23816" Issue="142318" />
     </Book>
     <Book Series="Wolverine" Number="35" Volume="1988" Year="1991">
-      <Id>70117de5-7f5d-4905-8aea-1751957ae78f</Id>
+      <Database Name="cv" Series="4250" Issue="64298" />
     </Book>
     <Book Series="Wolverine" Number="36" Volume="1988" Year="1991">
-      <Id>c6a1a1e0-74ed-440d-8bb1-715323da8924</Id>
+      <Database Name="cv" Series="4250" Issue="64299" />
     </Book>
     <Book Series="Wolverine" Number="37" Volume="1988" Year="1991">
-      <Id>3b3f64fb-f964-486e-af54-bd43a397dd42</Id>
+      <Database Name="cv" Series="4250" Issue="64300" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="72" Volume="1988" Year="1991">
-      <Id>c1a8ad40-a1f7-45d5-b6e2-0962dceb98b6</Id>
+      <Database Name="cv" Series="4058" Issue="34032" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="73" Volume="1988" Year="1991">
-      <Id>9d462553-cd18-4865-9b1a-5f3dd989af72</Id>
+      <Database Name="cv" Series="4058" Issue="34033" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="74" Volume="1988" Year="1991">
-      <Id>72c161ad-c41f-4ce4-8e70-e24d2f55fe75</Id>
+      <Database Name="cv" Series="4058" Issue="34099" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="75" Volume="1988" Year="1991">
-      <Id>57e9df72-220a-44d4-a229-48b9e6a6ff06</Id>
+      <Database Name="cv" Series="4058" Issue="34145" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="76" Volume="1988" Year="1991">
-      <Id>732b1231-aa94-4e8f-9577-3ad94ad0fe32</Id>
+      <Database Name="cv" Series="4058" Issue="34203" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="77" Volume="1988" Year="1991">
-      <Id>395a0408-1af3-4791-a5e8-739f257396a1</Id>
+      <Database Name="cv" Series="4058" Issue="34244" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="78" Volume="1988" Year="1991">
-      <Id>125cff93-817a-4276-bee9-64da8a0defe6</Id>
+      <Database Name="cv" Series="4058" Issue="34301" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="79" Volume="1988" Year="1991">
-      <Id>af5a0bf1-de02-43ba-b4d6-2b2fbf2c92d4</Id>
+      <Database Name="cv" Series="4058" Issue="34344" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="80" Volume="1988" Year="1991">
-      <Id>47ef1007-a925-477a-aa7f-4511a88f6a69</Id>
+      <Database Name="cv" Series="4058" Issue="34418" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="81" Volume="1988" Year="1991">
-      <Id>33674b93-676b-4b07-aa7e-2dd6c6df4fac</Id>
+      <Database Name="cv" Series="4058" Issue="34465" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="82" Volume="1988" Year="1991">
-      <Id>19929ddc-3ce2-4f95-a69f-246415196470</Id>
+      <Database Name="cv" Series="4058" Issue="34532" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="83" Volume="1988" Year="1991">
-      <Id>9bdef651-872a-4df8-9f6f-7944fe21c231</Id>
+      <Database Name="cv" Series="4058" Issue="34577" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="84" Volume="1988" Year="1991">
-      <Id>0e306ad2-290c-42c6-bb8c-9c3c3639cea0</Id>
+      <Database Name="cv" Series="4058" Issue="34651" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="273" Volume="1981" Year="1991">
-      <Id>6322239e-f919-4079-88a1-fdbf769342a8</Id>
+      <Database Name="cv" Series="3092" Issue="33893" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="274" Volume="1981" Year="1991">
-      <Id>e1fd9dce-82d1-4a2e-803d-be04e5fba213</Id>
+      <Database Name="cv" Series="3092" Issue="34007" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="275" Volume="1981" Year="1991">
-      <Id>8ef12ec9-5be7-465a-ba76-8eaf443d91e4</Id>
+      <Database Name="cv" Series="3092" Issue="34111" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="276" Volume="1981" Year="1991">
-      <Id>f24b4495-5692-43fe-bfa6-defa6c690961</Id>
+      <Database Name="cv" Series="3092" Issue="34214" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="277" Volume="1981" Year="1991">
-      <Id>99c7be7e-854c-4880-ad24-4873f2899b40</Id>
+      <Database Name="cv" Series="3092" Issue="34313" />
     </Book>
     <Book Series="X-Factor" Number="63" Volume="1986" Year="1991">
-      <Id>8ecaaac8-6339-4e7f-9961-e653515464eb</Id>
+      <Database Name="cv" Series="3657" Issue="33907" />
     </Book>
     <Book Series="X-Factor" Number="64" Volume="1986" Year="1991">
-      <Id>05f9bdc1-3b9a-4d56-b7d1-2aa9b1dcc34c</Id>
+      <Database Name="cv" Series="3657" Issue="129887" />
     </Book>
     <Book Series="The New Mutants" Number="98" Volume="1983" Year="1991">
-      <Id>59b3aa79-d229-4faa-8209-6046ec378cd2</Id>
+      <Database Name="cv" Series="3234" Issue="33921" />
     </Book>
     <Book Series="The New Mutants" Number="99" Volume="1983" Year="1991">
-      <Id>cba47471-d0d4-4652-83e0-cca0b8f9ca9f</Id>
+      <Database Name="cv" Series="3234" Issue="34025" />
     </Book>
     <Book Series="The New Mutants" Number="100" Volume="1983" Year="1991">
-      <Id>04b37f78-a2a3-446c-8766-3f4f13957811</Id>
+      <Database Name="cv" Series="3234" Issue="34134" />
     </Book>
     <Book Series="The New Mutants Annual" Number="7" Volume="1984" Year="1991">
-      <Id>77083e80-dded-49ca-97fd-570c0624f738</Id>
+      <Database Name="cv" Series="3356" Issue="33658" />
     </Book>
     <Book Series="The New Warriors Annual" Number="1" Volume="1991" Year="1991">
-      <Id>064446d1-a774-4315-8103-801760b50f8a</Id>
+      <Database Name="cv" Series="11874" Issue="103923" />
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="15" Volume="1982" Year="1991">
-      <Id>b1ba4687-e622-4eab-a287-52e13e92e05b</Id>
+    <Book Series="X-Men Annual" Number="15" Volume="1970" Year="1991">
+      <Database Name="cv" Series="22988" Issue="108825" />
     </Book>
     <Book Series="X-Factor Annual" Number="6" Volume="1986" Year="1991">
-      <Id>43e974f0-7afa-4e7f-b407-6208688b2512</Id>
+      <Database Name="cv" Series="3658" Issue="66337" />
     </Book>
     <Book Series="Excalibur" Number="37" Volume="1988" Year="1991">
-      <Id>19f2da3d-e486-41ae-b254-32dd2a1f3c13</Id>
+      <Database Name="cv" Series="4052" Issue="34196" />
     </Book>
     <Book Series="Excalibur" Number="38" Volume="1988" Year="1991">
-      <Id>63a634ac-2bb2-41b7-8be3-6be048631561</Id>
+      <Database Name="cv" Series="4052" Issue="34295" />
     </Book>
     <Book Series="Excalibur" Number="39" Volume="1988" Year="1991">
-      <Id>342949f9-db7e-4701-abc0-8fa6c31e902a</Id>
+      <Database Name="cv" Series="4052" Issue="34410" />
     </Book>
     <Book Series="Excalibur" Number="40" Volume="1988" Year="1991">
-      <Id>c08dea99-91af-4ccd-8a30-23b5e4a217cb</Id>
+      <Database Name="cv" Series="4052" Issue="66354" />
     </Book>
     <Book Series="Excalibur" Number="41" Volume="1988" Year="1991">
-      <Id>d702c258-49e8-4e21-8c70-0848a179dac3</Id>
+      <Database Name="cv" Series="4052" Issue="66355" />
     </Book>
     <Book Series="Wolverine" Number="38" Volume="1988" Year="1991">
-      <Id>0cddd7ea-9056-406d-bff6-7b1e7b284d68</Id>
+      <Database Name="cv" Series="4250" Issue="64301" />
     </Book>
     <Book Series="Wolverine" Number="39" Volume="1988" Year="1991">
-      <Id>d6763c37-3871-4796-8cd5-38177a3644e8</Id>
+      <Database Name="cv" Series="4250" Issue="64302" />
     </Book>
     <Book Series="Wolverine" Number="40" Volume="1988" Year="1991">
-      <Id>ddfc85db-217e-4944-8aca-b6c77e53d05b</Id>
+      <Database Name="cv" Series="4250" Issue="64303" />
     </Book>
     <Book Series="Wolverine" Number="41" Volume="1988" Year="1991">
-      <Id>03a6ef5c-abee-4be1-9252-c597f7a3518a</Id>
+      <Database Name="cv" Series="4250" Issue="64304" />
     </Book>
     <Book Series="Wolverine" Number="42" Volume="1988" Year="1991">
-      <Id>753a1108-3e4b-4717-b226-09ff88202010</Id>
+      <Database Name="cv" Series="4250" Issue="64305" />
     </Book>
     <Book Series="Wolverine" Number="43" Volume="1988" Year="1991">
-      <Id>995f4a9d-c93b-4a46-9568-e6359ec420b7</Id>
+      <Database Name="cv" Series="4250" Issue="64306" />
     </Book>
     <Book Series="Wolverine" Number="44" Volume="1988" Year="1991">
-      <Id>a0a1dbc9-ff8b-4fff-9173-cd04f09794e6</Id>
+      <Database Name="cv" Series="4250" Issue="64307" />
     </Book>
     <Book Series="Wolverine" Number="45" Volume="1988" Year="1991">
-      <Id>878a6154-7e64-4a93-9b3e-b474d63b35cc</Id>
+      <Database Name="cv" Series="4250" Issue="64308" />
     </Book>
     <Book Series="Wolverine" Number="46" Volume="1988" Year="1991">
-      <Id>3986897a-4af1-4543-8009-7da10d0bbe9c</Id>
+      <Database Name="cv" Series="4250" Issue="64309" />
     </Book>
     <Book Series="X-Factor" Number="65" Volume="1986" Year="1991">
-      <Id>322006f6-866b-4cf0-bac1-9cfe4c6b00be</Id>
+      <Database Name="cv" Series="3657" Issue="34123" />
     </Book>
     <Book Series="X-Factor" Number="66" Volume="1986" Year="1991">
-      <Id>772cc388-232c-4367-b91d-bd155814ac2b</Id>
+      <Database Name="cv" Series="3657" Issue="34217" />
     </Book>
     <Book Series="X-Factor" Number="67" Volume="1986" Year="1991">
-      <Id>37a53372-5535-452f-8de0-433fed99db5c</Id>
+      <Database Name="cv" Series="3657" Issue="34316" />
     </Book>
     <Book Series="X-Factor" Number="68" Volume="1986" Year="1991">
-      <Id>e369d0e3-f201-4764-b795-3f85b288b53e</Id>
+      <Database Name="cv" Series="3657" Issue="34433" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="278" Volume="1981" Year="1991">
-      <Id>39645eea-536d-4082-81cf-e3f108f68b26</Id>
+      <Database Name="cv" Series="3092" Issue="34430" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="279" Volume="1981" Year="1991">
-      <Id>0459264b-7c01-4bf4-bf94-9b3bb6ac901f</Id>
+      <Database Name="cv" Series="3092" Issue="34545" />
     </Book>
     <Book Series="X-Factor" Number="69" Volume="1986" Year="1991">
-      <Id>d722a121-8f6a-4be7-a112-beb1614a03d4</Id>
+      <Database Name="cv" Series="3657" Issue="34548" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="280" Volume="1981" Year="1991">
-      <Id>5c195442-1dbb-436e-a884-f8ebed7cab2f</Id>
+      <Database Name="cv" Series="3092" Issue="34661" />
     </Book>
     <Book Series="X-Factor" Number="70" Volume="1986" Year="1991">
-      <Id>f60abf20-622f-4d4d-abe2-a90898745ef3</Id>
+      <Database Name="cv" Series="3657" Issue="34665" />
     </Book>
     <Book Series="Excalibur" Number="42" Volume="1988" Year="1991">
-      <Id>dd135cba-5ebc-47a2-8190-0af942dd8c3f</Id>
+      <Database Name="cv" Series="4052" Issue="34760" />
     </Book>
     <Book Series="Excalibur" Number="43" Volume="1988" Year="1991">
-      <Id>f9beb002-f30b-4b10-af77-66089a9b01d9</Id>
+      <Database Name="cv" Series="4052" Issue="34877" />
     </Book>
     <Book Series="Excalibur" Number="44" Volume="1988" Year="1991">
-      <Id>7691bf4e-7509-4413-a70c-08a9c802d01a</Id>
+      <Database Name="cv" Series="4052" Issue="34931" />
     </Book>
     <Book Series="Excalibur" Number="45" Volume="1988" Year="1991">
-      <Id>da6c131c-9e64-4194-8f55-8fdd2fa27775</Id>
+      <Database Name="cv" Series="4052" Issue="120774" />
     </Book>
     <Book Series="Excalibur" Number="46" Volume="1988" Year="1992">
-      <Id>d4b109e2-b520-45eb-8954-9815c74de0ce</Id>
+      <Database Name="cv" Series="4052" Issue="35257" />
     </Book>
     <Book Series="Excalibur" Number="47" Volume="1988" Year="1992">
-      <Id>143c482f-42bd-4d86-b47c-e6c7a76bb845</Id>
+      <Database Name="cv" Series="4052" Issue="35364" />
     </Book>
     <Book Series="Wolverine" Number="47" Volume="1988" Year="1991">
-      <Id>f9fef829-005f-4582-8f2d-caf2d8a4cb0d</Id>
+      <Database Name="cv" Series="4250" Issue="64310" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 003.cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 003.cbl
@@ -2,880 +2,880 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>X-Men - Part 3</Name>
   <Books>
-    <Book Series="X-Factor" Number="24" Volume="1986" Year="1988" Format="Main Series">
+    <Book Series="X-Factor" Number="24" Volume="1986" Year="1988">
       <Id>fa779977-dcf6-45d8-ba7f-bd92e6ceffdc</Id>
     </Book>
-    <Book Series="X-Factor" Number="25" Volume="1986" Year="1988" Format="Main Series">
+    <Book Series="X-Factor" Number="25" Volume="1986" Year="1988">
       <Id>bf2b4013-943a-4c0a-aa7c-3e5f8110a9c8</Id>
     </Book>
-    <Book Series="X-Factor" Number="26" Volume="1986" Year="1988" Format="Main Series">
+    <Book Series="X-Factor" Number="26" Volume="1986" Year="1988">
       <Id>ccfa30e6-2be6-42f6-9f9b-7d6b6ae72586</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="225" Volume="1981" Year="1988" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="225" Volume="1981" Year="1988">
       <Id>808250b1-c957-4274-b609-69e65da60572</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="226" Volume="1981" Year="1988" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="226" Volume="1981" Year="1988">
       <Id>c736a3e2-d63c-48be-b939-4b43554e80ae</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="227" Volume="1981" Year="1988" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="227" Volume="1981" Year="1988">
       <Id>ac03a80d-556c-4775-95b6-10c3c2544227</Id>
     </Book>
-    <Book Series="The New Mutants" Number="58" Volume="1983" Year="1987" Format="Main Series">
+    <Book Series="The New Mutants" Number="58" Volume="1983" Year="1987">
       <Id>4f18eb1f-0f7a-41cb-872b-988032738210</Id>
     </Book>
-    <Book Series="The New Mutants" Number="59" Volume="1983" Year="1988" Format="Main Series">
+    <Book Series="The New Mutants" Number="59" Volume="1983" Year="1988">
       <Id>587b21a5-af41-4ae7-a959-faf153cf0b7a</Id>
     </Book>
-    <Book Series="The New Mutants" Number="60" Volume="1983" Year="1988" Format="Main Series">
+    <Book Series="The New Mutants" Number="60" Volume="1983" Year="1988">
       <Id>5ea32912-2c74-49ad-aa47-bb9baba9320b</Id>
     </Book>
-    <Book Series="The New Mutants" Number="61" Volume="1983" Year="1988" Format="Main Series">
+    <Book Series="The New Mutants" Number="61" Volume="1983" Year="1988">
       <Id>62bfba72-2d59-4e10-aa42-81d297db0f17</Id>
     </Book>
-    <Book Series="X-Factor" Number="27" Volume="1986" Year="1988" Format="Main Series">
+    <Book Series="X-Factor" Number="27" Volume="1986" Year="1988">
       <Id>6ed3eae6-dd97-499e-8808-66bb52d26970</Id>
     </Book>
-    <Book Series="The New Mutants" Number="62" Volume="1983" Year="1988" Format="Main Series">
+    <Book Series="The New Mutants" Number="62" Volume="1983" Year="1988">
       <Id>29978b9c-97ba-4e7d-aad2-2d363a38a737</Id>
     </Book>
-    <Book Series="The New Mutants" Number="63" Volume="1983" Year="1988" Format="Main Series">
+    <Book Series="The New Mutants" Number="63" Volume="1983" Year="1988">
       <Id>85b4022c-0a50-4c20-b7e3-724a39b4f640</Id>
     </Book>
-    <Book Series="The New Mutants" Number="64" Volume="1983" Year="1988" Format="Main Series">
+    <Book Series="The New Mutants" Number="64" Volume="1983" Year="1988">
       <Id>4bf51d11-79ed-4475-bbc5-2bfc420b89a8</Id>
     </Book>
-    <Book Series="The New Mutants" Number="65" Volume="1983" Year="1988" Format="Main Series">
+    <Book Series="The New Mutants" Number="65" Volume="1983" Year="1988">
       <Id>68b403bb-adc9-4f89-9043-b463c32b0918</Id>
     </Book>
-    <Book Series="The New Mutants" Number="66" Volume="1983" Year="1988" Format="Main Series">
+    <Book Series="The New Mutants" Number="66" Volume="1983" Year="1988">
       <Id>2221d344-f9e2-41b4-9171-0e06e634d0a7</Id>
     </Book>
-    <Book Series="X-Factor" Number="28" Volume="1986" Year="1988" Format="Main Series">
+    <Book Series="X-Factor" Number="28" Volume="1986" Year="1988">
       <Id>f667c541-1810-48fa-8bb0-9be8bbf02ed1</Id>
     </Book>
-    <Book Series="Excalibur Special Edition" Number="1" Volume="1987" Year="1987" Format="One-Shot">
+    <Book Series="Excalibur Special Edition" Number="1" Volume="1987" Year="1987">
       <Id>8cbdeb03-3d32-409a-a0d3-41a814e05ecf</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="228" Volume="1981" Year="1988" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="228" Volume="1981" Year="1988">
       <Id>da004980-a60a-4856-b782-24337886a535</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="229" Volume="1981" Year="1988" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="229" Volume="1981" Year="1988">
       <Id>3b61a6ea-2868-40e7-8f9a-25f34d309342</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="230" Volume="1981" Year="1988" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="230" Volume="1981" Year="1988">
       <Id>f22d1184-48a0-49e4-a1b3-608d42ef3c77</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="231" Volume="1981" Year="1988" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="231" Volume="1981" Year="1988">
       <Id>7a830c73-467c-4ed4-b06c-8bc8744eee79</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="232" Volume="1981" Year="1988" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="232" Volume="1981" Year="1988">
       <Id>6b4d22b3-1187-462e-8db0-8198adb88b2c</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="233" Volume="1981" Year="1988" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="233" Volume="1981" Year="1988">
       <Id>01b8be0b-582d-4883-ae26-7e4d43e78263</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="234" Volume="1981" Year="1988" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="234" Volume="1981" Year="1988">
       <Id>85e66657-d34e-4b27-b3b1-71873f210deb</Id>
     </Book>
-    <Book Series="Wolverine" Number="1" Volume="1988" Year="1988" Format="Main Series">
+    <Book Series="Wolverine" Number="1" Volume="1988" Year="1988">
       <Id>f40ca0ae-ed1b-4057-ad93-4d298612768d</Id>
     </Book>
-    <Book Series="Wolverine" Number="2" Volume="1988" Year="1988" Format="Main Series">
+    <Book Series="Wolverine" Number="2" Volume="1988" Year="1988">
       <Id>5989e435-58dd-4c81-953f-e483d9ccb10d</Id>
     </Book>
-    <Book Series="Wolverine" Number="3" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Wolverine" Number="3" Volume="1988" Year="1989">
       <Id>36039684-ff8d-4b98-a561-cb7412410795</Id>
     </Book>
-    <Book Series="X-Factor" Number="29" Volume="1986" Year="1988" Format="Main Series">
+    <Book Series="X-Factor" Number="29" Volume="1986" Year="1988">
       <Id>530db5e4-f403-467d-9659-ee5c1bf0c5f9</Id>
     </Book>
-    <Book Series="X-Factor" Number="30" Volume="1986" Year="1988" Format="Main Series">
+    <Book Series="X-Factor" Number="30" Volume="1986" Year="1988">
       <Id>815c60b3-c0b8-4dfe-9973-2277ecf9a542</Id>
     </Book>
-    <Book Series="X-Factor" Number="31" Volume="1986" Year="1988" Format="Main Series">
+    <Book Series="X-Factor" Number="31" Volume="1986" Year="1988">
       <Id>1fc93f33-73f8-4bec-91bf-c75a9c55e0d7</Id>
     </Book>
-    <Book Series="Wolverine" Number="4" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Wolverine" Number="4" Volume="1988" Year="1989">
       <Id>70516ef9-354b-4513-ad2e-f170ca62f3dc</Id>
     </Book>
-    <Book Series="Wolverine" Number="5" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Wolverine" Number="5" Volume="1988" Year="1989">
       <Id>d75cd6ca-f0da-4706-aa94-1c8445390a46</Id>
     </Book>
-    <Book Series="Wolverine" Number="6" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Wolverine" Number="6" Volume="1988" Year="1989">
       <Id>cc11d34c-ea68-45e1-a9d5-ad7681bad1da</Id>
     </Book>
-    <Book Series="Wolverine" Number="7" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Wolverine" Number="7" Volume="1988" Year="1989">
       <Id>8e47f2af-6183-4034-a525-d1dfd49534c3</Id>
     </Book>
-    <Book Series="Wolverine" Number="8" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Wolverine" Number="8" Volume="1988" Year="1989">
       <Id>31129958-eb9f-4eff-8196-287c6faada49</Id>
     </Book>
-    <Book Series="Excalibur" Number="1" Volume="1988" Year="1988" Format="Main Series">
+    <Book Series="Excalibur" Number="1" Volume="1988" Year="1988">
       <Id>9b0d4ce8-24b2-4922-94c3-5ce7949054d0</Id>
     </Book>
-    <Book Series="Excalibur" Number="2" Volume="1988" Year="1988" Format="Main Series">
+    <Book Series="Excalibur" Number="2" Volume="1988" Year="1988">
       <Id>3b3e5c21-2260-40c3-81ad-af455cbb97fc</Id>
     </Book>
-    <Book Series="Excalibur" Number="3" Volume="1988" Year="1988" Format="Main Series">
+    <Book Series="Excalibur" Number="3" Volume="1988" Year="1988">
       <Id>fa77a58c-a9d1-4b64-9b7f-d8ba24793e43</Id>
     </Book>
-    <Book Series="X-Factor Annual" Number="3" Volume="1986" Year="1988" Format="Annual">
+    <Book Series="X-Factor Annual" Number="3" Volume="1986" Year="1988">
       <Id>af6b1434-4e52-44d9-9791-87ed33249dad</Id>
     </Book>
-    <Book Series="The New Mutants Annual" Number="4" Volume="1984" Year="1988" Format="Annual">
+    <Book Series="The New Mutants Annual" Number="4" Volume="1984" Year="1988">
       <Id>82a6ccca-a6f7-4f52-94bd-6e44e0979a46</Id>
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="12" Volume="1970" Year="1988" Format="Annual">
+    <Book Series="The Uncanny X-Men Annual" Number="12" Volume="1970" Year="1988">
       <Id>0efa6f04-32e6-4e12-80b9-603ccd42e1a8</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="235" Volume="1981" Year="1988" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="235" Volume="1981" Year="1988">
       <Id>784050ce-979e-47f3-9dc4-71d58a9a7755</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="236" Volume="1981" Year="1988" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="236" Volume="1981" Year="1988">
       <Id>778fbf7c-c4f3-4736-8779-c5ee78a1e721</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="237" Volume="1981" Year="1988" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="237" Volume="1981" Year="1988">
       <Id>8f8f7b60-bce0-42d7-b884-1f4da5d56d37</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="238" Volume="1981" Year="1988" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="238" Volume="1981" Year="1988">
       <Id>c20eaa0a-706b-4e81-b475-f792aa00523e</Id>
     </Book>
-    <Book Series="Wolverine" Number="9" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Wolverine" Number="9" Volume="1988" Year="1989">
       <Id>0388414f-4a80-4ec2-b526-777b2f44b530</Id>
     </Book>
-    <Book Series="X-Factor" Number="32" Volume="1986" Year="1988" Format="Main Series">
+    <Book Series="X-Factor" Number="32" Volume="1986" Year="1988">
       <Id>0e9b615e-9a47-40b3-8793-59f01f7cb53c</Id>
     </Book>
-    <Book Series="Wolverine" Number="10" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Wolverine" Number="10" Volume="1988" Year="1989">
       <Id>314d074e-92cc-4bb9-bf6b-f820514a4a89</Id>
     </Book>
-    <Book Series="X-Factor" Number="33" Volume="1986" Year="1988" Format="Main Series">
+    <Book Series="X-Factor" Number="33" Volume="1986" Year="1988">
       <Id>c647bd08-dbf9-47b3-b280-06d35398ba9e</Id>
     </Book>
-    <Book Series="X-Factor" Number="34" Volume="1986" Year="1988" Format="Main Series">
+    <Book Series="X-Factor" Number="34" Volume="1986" Year="1988">
       <Id>9e816134-9a58-4778-bab6-9b996b365a77</Id>
     </Book>
-    <Book Series="X-Factor" Number="35" Volume="1986" Year="1988" Format="Main Series">
+    <Book Series="X-Factor" Number="35" Volume="1986" Year="1988">
       <Id>e394ed56-3b4d-429e-888b-dcd080abc571</Id>
     </Book>
-    <Book Series="Excalibur" Number="4" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Excalibur" Number="4" Volume="1988" Year="1989">
       <Id>2e1ec6d9-4948-4a13-8de3-622dbeeec38e</Id>
     </Book>
-    <Book Series="Excalibur" Number="5" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Excalibur" Number="5" Volume="1988" Year="1989">
       <Id>1c295916-b8c4-4a80-9b37-794ce03687a0</Id>
     </Book>
-    <Book Series="The New Mutants" Number="67" Volume="1983" Year="1988" Format="Main Series">
+    <Book Series="The New Mutants" Number="67" Volume="1983" Year="1988">
       <Id>a49a2e1e-209f-41e9-ad30-23a0b93e99b6</Id>
     </Book>
-    <Book Series="The New Mutants" Number="68" Volume="1983" Year="1988" Format="Main Series">
+    <Book Series="The New Mutants" Number="68" Volume="1983" Year="1988">
       <Id>5089954b-6f0e-4cf5-b2b0-06e08f9442f1</Id>
     </Book>
-    <Book Series="The New Mutants" Number="69" Volume="1983" Year="1988" Format="Main Series">
+    <Book Series="The New Mutants" Number="69" Volume="1983" Year="1988">
       <Id>01ac7f3a-e0c9-4db1-b229-21eca963f223</Id>
     </Book>
-    <Book Series="The New Mutants" Number="70" Volume="1983" Year="1988" Format="Main Series">
+    <Book Series="The New Mutants" Number="70" Volume="1983" Year="1988">
       <Id>a59dd781-84f5-41ab-9860-1c40f8573024</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="239" Volume="1981" Year="1988" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="239" Volume="1981" Year="1988">
       <Id>067856a4-cd8b-41e1-b779-a3ade71939b3</Id>
     </Book>
-    <Book Series="X-Terminators" Number="1" Volume="1988" Year="1988" Format="Limited Series">
+    <Book Series="X-Terminators" Number="1" Volume="1988" Year="1988">
       <Id>b7e20314-39e2-4ec9-8a09-a55df61da657</Id>
     </Book>
-    <Book Series="X-Terminators" Number="2" Volume="1988" Year="1988" Format="Limited Series">
+    <Book Series="X-Terminators" Number="2" Volume="1988" Year="1988">
       <Id>cb701d97-dfb2-41a6-aaad-ce590af7a900</Id>
     </Book>
-    <Book Series="X-Terminators" Number="3" Volume="1988" Year="1988" Format="Limited Series">
+    <Book Series="X-Terminators" Number="3" Volume="1988" Year="1988">
       <Id>397051a0-ae96-4eb4-a43c-48831dd36183</Id>
     </Book>
-    <Book Series="The New Mutants" Number="71" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="The New Mutants" Number="71" Volume="1983" Year="1989">
       <Id>30c564ef-dd8d-40c5-ad27-aa9fc932fb68</Id>
     </Book>
-    <Book Series="X-Terminators" Number="4" Volume="1988" Year="1989" Format="Limited Series">
+    <Book Series="X-Terminators" Number="4" Volume="1988" Year="1989">
       <Id>37330612-cd27-43fe-b8b5-ad42e180e7f2</Id>
     </Book>
-    <Book Series="The New Mutants" Number="72" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="The New Mutants" Number="72" Volume="1983" Year="1989">
       <Id>03edb927-ebb4-4b1c-a050-27c07670ce46</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="240" Volume="1981" Year="1989" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="240" Volume="1981" Year="1989">
       <Id>672b65e6-665b-4e71-9d53-4237be36e1c3</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="241" Volume="1981" Year="1989" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="241" Volume="1981" Year="1989">
       <Id>e50c8c0f-5253-405e-ba0d-50630bb0a9a0</Id>
     </Book>
-    <Book Series="X-Factor" Number="36" Volume="1986" Year="1989" Format="Main Series">
+    <Book Series="X-Factor" Number="36" Volume="1986" Year="1989">
       <Id>79a47b95-a7ef-4f8a-b049-fd24b85b294e</Id>
     </Book>
-    <Book Series="X-Factor" Number="37" Volume="1986" Year="1989" Format="Main Series">
+    <Book Series="X-Factor" Number="37" Volume="1986" Year="1989">
       <Id>9b5046d2-5ffd-4468-b9c7-3709da1dc9f2</Id>
     </Book>
-    <Book Series="The New Mutants" Number="73" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="The New Mutants" Number="73" Volume="1983" Year="1989">
       <Id>d48c44e6-ea0c-4cb3-9c81-221366ca64f5</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="242" Volume="1981" Year="1989" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="242" Volume="1981" Year="1989">
       <Id>368f32a3-265c-49eb-b2ca-79d931c7d340</Id>
     </Book>
-    <Book Series="X-Factor" Number="38" Volume="1986" Year="1989" Format="Main Series">
+    <Book Series="X-Factor" Number="38" Volume="1986" Year="1989">
       <Id>c667b8d9-49e7-4e92-926a-357cf7e4275e</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="243" Volume="1981" Year="1989" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="243" Volume="1981" Year="1989">
       <Id>566291ee-2a52-4572-a2c9-be0f36cb488b</Id>
     </Book>
-    <Book Series="X-Factor" Number="39" Volume="1986" Year="1989" Format="Main Series">
+    <Book Series="X-Factor" Number="39" Volume="1986" Year="1989">
       <Id>af64f297-8804-49dc-87e7-9e93ab6416d2</Id>
     </Book>
-    <Book Series="Excalibur" Number="6" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Excalibur" Number="6" Volume="1988" Year="1989">
       <Id>b0095a88-3ca8-4ea3-b98c-4b7968875a76</Id>
     </Book>
-    <Book Series="Excalibur" Number="7" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Excalibur" Number="7" Volume="1988" Year="1989">
       <Id>ec2a4752-5343-4951-a132-584ad1d34b74</Id>
     </Book>
-    <Book Series="The New Mutants" Number="74" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="The New Mutants" Number="74" Volume="1983" Year="1989">
       <Id>2c6fb138-f442-421c-8cb7-b8f134e78f90</Id>
     </Book>
-    <Book Series="Excalibur" Number="8" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Excalibur" Number="8" Volume="1988" Year="1989">
       <Id>d1c8ad0a-78b9-4486-b0f3-c0379e147618</Id>
     </Book>
-    <Book Series="The New Mutants" Number="75" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="The New Mutants" Number="75" Volume="1983" Year="1989">
       <Id>373ed4dd-5d26-42cd-ad4d-96d40f8b8141</Id>
     </Book>
-    <Book Series="The New Mutants" Number="76" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="The New Mutants" Number="76" Volume="1983" Year="1989">
       <Id>3e301302-8c09-49b0-a538-770307bbd835</Id>
     </Book>
-    <Book Series="X-Factor" Number="40" Volume="1986" Year="1989" Format="Main Series">
+    <Book Series="X-Factor" Number="40" Volume="1986" Year="1989">
       <Id>3a841f11-310f-4390-96e0-770fd63044f3</Id>
     </Book>
-    <Book Series="Excalibur" Number="9" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Excalibur" Number="9" Volume="1988" Year="1989">
       <Id>6e99fa12-91e5-4005-a7ab-71e5f8201ebb</Id>
     </Book>
-    <Book Series="Excalibur" Number="10" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Excalibur" Number="10" Volume="1988" Year="1989">
       <Id>8d5bd57f-20df-4c82-bb70-36d99f35a44a</Id>
     </Book>
-    <Book Series="Excalibur" Number="11" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Excalibur" Number="11" Volume="1988" Year="1989">
       <Id>db15b923-ba79-4241-9b57-0b50b7bdb0ba</Id>
     </Book>
-    <Book Series="Excalibur" Number="12" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Excalibur" Number="12" Volume="1988" Year="1989">
       <Id>6582939d-dab1-40b9-bf3a-a4f87ed97298</Id>
     </Book>
-    <Book Series="Excalibur" Number="13" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Excalibur" Number="13" Volume="1988" Year="1989">
       <Id>0b1dc1e5-ad0f-4245-a115-58b24ea77ac9</Id>
     </Book>
-    <Book Series="Excalibur" Number="14" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Excalibur" Number="14" Volume="1988" Year="1989">
       <Id>e81e07f3-d0c9-4603-8bd1-56d9cc2fbacd</Id>
     </Book>
-    <Book Series="Excalibur" Number="15" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Excalibur" Number="15" Volume="1988" Year="1989">
       <Id>c8d30969-b984-4ed9-838c-6e8c9f313d88</Id>
     </Book>
-    <Book Series="Excalibur" Number="16" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Excalibur" Number="16" Volume="1988" Year="1989">
       <Id>5fa40596-1477-4df7-ba67-805143dbd0b4</Id>
     </Book>
-    <Book Series="Excalibur" Number="17" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Excalibur" Number="17" Volume="1988" Year="1989">
       <Id>e1f5845c-b4c2-404d-b164-0134e05acc4e</Id>
     </Book>
-    <Book Series="Excalibur" Number="18" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Excalibur" Number="18" Volume="1988" Year="1990">
       <Id>fb920468-3b02-4e2d-977f-d2aedeb3c0e1</Id>
     </Book>
-    <Book Series="Excalibur" Number="19" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Excalibur" Number="19" Volume="1988" Year="1990">
       <Id>7e7b3363-d590-4b32-bd12-36e66b15ef9d</Id>
     </Book>
-    <Book Series="Excalibur" Number="20" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Excalibur" Number="20" Volume="1988" Year="1990">
       <Id>00fe744f-b3f4-4b7c-a62e-2b3b37a78508</Id>
     </Book>
-    <Book Series="Excalibur" Number="21" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Excalibur" Number="21" Volume="1988" Year="1990">
       <Id>b3b6b4f4-2a27-4841-8952-04b9755703ea</Id>
     </Book>
-    <Book Series="Excalibur" Number="22" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Excalibur" Number="22" Volume="1988" Year="1990">
       <Id>cca9f24c-da5f-4a12-b6c6-ffa92c91097f</Id>
     </Book>
-    <Book Series="Excalibur" Number="23" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Excalibur" Number="23" Volume="1988" Year="1990">
       <Id>9d2f54ad-8cf9-437c-8f35-59fcefbdf268</Id>
     </Book>
-    <Book Series="Excalibur" Number="24" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Excalibur" Number="24" Volume="1988" Year="1990">
       <Id>f1f89de1-83c9-4d4a-972f-e70f0f50f864</Id>
     </Book>
-    <Book Series="Wolverine" Number="11" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Wolverine" Number="11" Volume="1988" Year="1989">
       <Id>df6854d1-a6e5-483d-8003-aba53a801f04</Id>
     </Book>
-    <Book Series="Wolverine" Number="12" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Wolverine" Number="12" Volume="1988" Year="1989">
       <Id>3e9d4800-630c-4c87-9776-54de461a09ef</Id>
     </Book>
-    <Book Series="Wolverine" Number="13" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Wolverine" Number="13" Volume="1988" Year="1989">
       <Id>f7265a16-ee50-42b3-8393-f45426c98678</Id>
     </Book>
-    <Book Series="Wolverine" Number="14" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Wolverine" Number="14" Volume="1988" Year="1989">
       <Id>e914c884-d3b6-4925-9e07-44b72cff8fd3</Id>
     </Book>
-    <Book Series="Wolverine" Number="15" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Wolverine" Number="15" Volume="1988" Year="1989">
       <Id>ba31a826-d1a5-4a63-a0ce-fd8a24727396</Id>
     </Book>
-    <Book Series="Wolverine" Number="16" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Wolverine" Number="16" Volume="1988" Year="1989">
       <Id>8cdd4465-7004-47e4-8955-60f94997aaa5</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="51" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="51" Volume="1988" Year="1990">
       <Id>ba596d11-5e90-4684-8a88-5cb1abea415a</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="52" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="52" Volume="1988" Year="1990">
       <Id>eae784cf-8243-43e5-baf2-1049f3a2636a</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="53" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="53" Volume="1988" Year="1990">
       <Id>1e7ed635-8f16-4078-b87c-f506b8dc296a</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="244" Volume="1981" Year="1989" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="244" Volume="1981" Year="1989">
       <Id>5863567b-eb86-4737-b27e-f283ecd1b8f3</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="245" Volume="1981" Year="1989" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="245" Volume="1981" Year="1989">
       <Id>70693513-edee-4511-8c9b-499df54fbe66</Id>
     </Book>
-    <Book Series="Havok &amp; Wolverine: Meltdown" Number="1" Volume="1989" Year="1989" Format="Limited Series">
+    <Book Series="Havok &amp; Wolverine: Meltdown" Number="1" Volume="1989" Year="1989">
       <Id>851fc0a1-f7aa-4a3e-976f-8d5af31d73d3</Id>
     </Book>
-    <Book Series="Havok &amp; Wolverine: Meltdown" Number="2" Volume="1989" Year="1989" Format="Limited Series">
+    <Book Series="Havok &amp; Wolverine: Meltdown" Number="2" Volume="1989" Year="1989">
       <Id>9992ac42-9617-4dbe-a41f-02bd460b9e70</Id>
     </Book>
-    <Book Series="Havok &amp; Wolverine: Meltdown" Number="3" Volume="1989" Year="1989" Format="Limited Series">
+    <Book Series="Havok &amp; Wolverine: Meltdown" Number="3" Volume="1989" Year="1989">
       <Id>2cf57cef-f814-4f38-a865-5ead1b2792b3</Id>
     </Book>
-    <Book Series="Havok &amp; Wolverine: Meltdown" Number="4" Volume="1989" Year="1989" Format="Limited Series">
+    <Book Series="Havok &amp; Wolverine: Meltdown" Number="4" Volume="1989" Year="1989">
       <Id>9dc17187-1add-4c1d-9fba-abf01902169e</Id>
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="13" Volume="1982" Year="1989" Format="Annual">
+    <Book Series="The Uncanny X-Men Annual" Number="13" Volume="1982" Year="1989">
       <Id>ec9b23b2-46de-4b27-92f8-00563b3657ab</Id>
     </Book>
-    <Book Series="The New Mutants Annual" Number="5" Volume="1984" Year="1989" Format="Annual">
+    <Book Series="The New Mutants Annual" Number="5" Volume="1984" Year="1989">
       <Id>475c3943-61c3-49b4-ae1f-4c6f2e5dc427</Id>
     </Book>
-    <Book Series="X-Factor Annual" Number="4" Volume="1986" Year="1989" Format="Annual">
+    <Book Series="X-Factor Annual" Number="4" Volume="1986" Year="1989">
       <Id>1e35c411-cf55-4175-8de2-c1df92ea5264</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="246" Volume="1981" Year="1989" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="246" Volume="1981" Year="1989">
       <Id>08913372-1c6d-4bb9-be25-a3679d3382e6</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="247" Volume="1981" Year="1989" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="247" Volume="1981" Year="1989">
       <Id>5c6e562a-bb8e-437d-ba4b-acdb8a98ad02</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="248" Volume="1981" Year="1989" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="248" Volume="1981" Year="1989">
       <Id>6a4ef602-d9bd-460f-8f7c-645eb288cd0a</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="249" Volume="1981" Year="1989" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="249" Volume="1981" Year="1989">
       <Id>4c40f0bd-d948-4aab-a366-97a15a8595f7</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="250" Volume="1981" Year="1989" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="250" Volume="1981" Year="1989">
       <Id>bddbfc66-c2e9-457e-8781-175b2cbc9e60</Id>
     </Book>
-    <Book Series="X-Factor" Number="41" Volume="1986" Year="1989" Format="Main Series">
+    <Book Series="X-Factor" Number="41" Volume="1986" Year="1989">
       <Id>63569bbe-e3d1-4937-9956-4b3e73151290</Id>
     </Book>
-    <Book Series="X-Factor" Number="42" Volume="1986" Year="1989" Format="Main Series">
+    <Book Series="X-Factor" Number="42" Volume="1986" Year="1989">
       <Id>93609a00-f51d-4d71-80a7-f2fdb65dec78</Id>
     </Book>
-    <Book Series="The New Mutants" Number="77" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="The New Mutants" Number="77" Volume="1983" Year="1989">
       <Id>076a899d-5298-434a-a029-5ad5a5950b9f</Id>
     </Book>
-    <Book Series="The New Mutants" Number="78" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="The New Mutants" Number="78" Volume="1983" Year="1989">
       <Id>d04569a3-7078-46d9-a474-abb2eb872807</Id>
     </Book>
-    <Book Series="The New Mutants" Number="79" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="The New Mutants" Number="79" Volume="1983" Year="1989">
       <Id>9ba8cea8-7abd-42b7-8320-5402ccfc1845</Id>
     </Book>
-    <Book Series="The New Mutants" Number="80" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="The New Mutants" Number="80" Volume="1983" Year="1989">
       <Id>a1f07d7c-e6cf-4a1e-8312-0169cbd40e23</Id>
     </Book>
-    <Book Series="The New Mutants" Number="81" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="The New Mutants" Number="81" Volume="1983" Year="1989">
       <Id>59f66b9d-af70-437a-8b9b-bff5821e4643</Id>
     </Book>
-    <Book Series="The New Mutants" Number="82" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="The New Mutants" Number="82" Volume="1983" Year="1989">
       <Id>13f0f495-2d23-42c6-a75a-6170069ad0d0</Id>
     </Book>
-    <Book Series="The New Mutants" Number="83" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="The New Mutants" Number="83" Volume="1983" Year="1989">
       <Id>b40702be-6f17-46f1-8429-f486e8be9cc7</Id>
     </Book>
-    <Book Series="The New Mutants" Number="84" Volume="1983" Year="1989" Format="Main Series">
+    <Book Series="The New Mutants" Number="84" Volume="1983" Year="1989">
       <Id>e3c61634-c30f-4e64-86e4-e906d3a2aa3f</Id>
     </Book>
-    <Book Series="The New Mutants" Number="85" Volume="1983" Year="1990" Format="Main Series">
+    <Book Series="The New Mutants" Number="85" Volume="1983" Year="1990">
       <Id>2cf5cfa8-00f4-48c1-8e18-74e18649ca4e</Id>
     </Book>
-    <Book Series="The New Mutants" Number="86" Volume="1983" Year="1990" Format="Main Series">
+    <Book Series="The New Mutants" Number="86" Volume="1983" Year="1990">
       <Id>b417d492-9bf4-4c6c-993e-28c8d6f19176</Id>
     </Book>
-    <Book Series="Wolverine: The Jungle Adventure" Number="1" Volume="1990" Year="1990" Format="One-Shot">
+    <Book Series="Wolverine: The Jungle Adventure" Number="1" Volume="1990" Year="1990">
       <Id>3956051e-5043-4577-b8bb-2ab2ce41ba6e</Id>
     </Book>
-    <Book Series="Wolverine" Number="17" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Wolverine" Number="17" Volume="1988" Year="1989">
       <Id>141440da-8e18-46f9-95b5-f6670cd6b9d0</Id>
     </Book>
-    <Book Series="Wolverine" Number="18" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Wolverine" Number="18" Volume="1988" Year="1989">
       <Id>f2a095dd-9135-4ca9-bb4e-f0b66958c44b</Id>
     </Book>
-    <Book Series="Wolverine" Number="19" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Wolverine" Number="19" Volume="1988" Year="1989">
       <Id>ec4ea6e1-20b9-44c9-bd16-0cc01ca0792f</Id>
     </Book>
-    <Book Series="Wolverine" Number="20" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Wolverine" Number="20" Volume="1988" Year="1990">
       <Id>7fbd7949-6dd1-4138-be3b-d234ed1291c6</Id>
     </Book>
-    <Book Series="X-Factor" Number="43" Volume="1986" Year="1989" Format="Main Series">
+    <Book Series="X-Factor" Number="43" Volume="1986" Year="1989">
       <Id>56129c26-b21b-4153-8ebd-ffc28fefef25</Id>
     </Book>
-    <Book Series="X-Factor" Number="44" Volume="1986" Year="1989" Format="Main Series">
+    <Book Series="X-Factor" Number="44" Volume="1986" Year="1989">
       <Id>abdb95c6-1ae9-4270-9164-f45157eb6b35</Id>
     </Book>
-    <Book Series="X-Factor" Number="45" Volume="1986" Year="1989" Format="Main Series">
+    <Book Series="X-Factor" Number="45" Volume="1986" Year="1989">
       <Id>42daf7f2-de29-4124-b7e7-ce9471d1de12</Id>
     </Book>
-    <Book Series="X-Factor" Number="46" Volume="1986" Year="1989" Format="Main Series">
+    <Book Series="X-Factor" Number="46" Volume="1986" Year="1989">
       <Id>3f31e714-cbf0-4959-be83-869bdbdb3065</Id>
     </Book>
-    <Book Series="X-Factor" Number="47" Volume="1986" Year="1989" Format="Main Series">
+    <Book Series="X-Factor" Number="47" Volume="1986" Year="1989">
       <Id>8aabe919-638d-400a-9772-0b166d7cbbf6</Id>
     </Book>
-    <Book Series="X-Factor" Number="48" Volume="1986" Year="1989" Format="Main Series">
+    <Book Series="X-Factor" Number="48" Volume="1986" Year="1989">
       <Id>ed8c0580-b08b-4d79-a2f1-1540100edb35</Id>
     </Book>
-    <Book Series="X-Factor" Number="49" Volume="1986" Year="1989" Format="Main Series">
+    <Book Series="X-Factor" Number="49" Volume="1986" Year="1989">
       <Id>7c13115c-b2d6-4452-b86f-8f4e32f28ca5</Id>
     </Book>
-    <Book Series="X-Factor" Number="50" Volume="1986" Year="1990" Format="Main Series">
+    <Book Series="X-Factor" Number="50" Volume="1986" Year="1990">
       <Id>0c5bff26-1945-4a72-9813-ae0ec4baa9e7</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="251" Volume="1981" Year="1989" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="251" Volume="1981" Year="1989">
       <Id>1b25fc57-3deb-45c9-a3be-248237e8b6b2</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="252" Volume="1981" Year="1989" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="252" Volume="1981" Year="1989">
       <Id>4cf05c9c-e0b8-40b7-ac89-237d91fa538b</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="253" Volume="1981" Year="1989" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="253" Volume="1981" Year="1989">
       <Id>3b399d66-cccb-4fce-bb93-23028b77c49e</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="254" Volume="1981" Year="1989" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="254" Volume="1981" Year="1989">
       <Id>227e432b-0e75-4358-acc2-73651cb0a1ac</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="255" Volume="1981" Year="1989" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="255" Volume="1981" Year="1989">
       <Id>edd7bd9f-f2e0-4156-ae80-8c8d0c5ae211</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="256" Volume="1981" Year="1989" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="256" Volume="1981" Year="1989">
       <Id>ed660880-2bdd-4f18-8121-fb6165c7f3f3</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="257" Volume="1981" Year="1990" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="257" Volume="1981" Year="1990">
       <Id>7a1a2332-e9f3-4871-9a83-f619749f9748</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="258" Volume="1981" Year="1990" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="258" Volume="1981" Year="1990">
       <Id>b90f2436-abd5-4889-8f45-73ee148f62d4</Id>
     </Book>
-    <Book Series="Wolverine" Number="21" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Wolverine" Number="21" Volume="1988" Year="1990">
       <Id>68712705-6bfc-4ae9-acb6-b3947b83093e</Id>
     </Book>
-    <Book Series="Wolverine" Number="22" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Wolverine" Number="22" Volume="1988" Year="1990">
       <Id>af721590-62e2-4ffb-a803-f18bf3448aa6</Id>
     </Book>
-    <Book Series="Wolverine" Number="23" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Wolverine" Number="23" Volume="1988" Year="1990">
       <Id>6bc879f7-9e8e-4b75-9a0f-4591c81ea771</Id>
     </Book>
-    <Book Series="Wolverine" Number="24" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Wolverine" Number="24" Volume="1988" Year="1990">
       <Id>ffec43e9-f277-4ec9-9e78-08e7024c2a20</Id>
     </Book>
-    <Book Series="Wolverine" Number="25" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Wolverine" Number="25" Volume="1988" Year="1990">
       <Id>1b9c806c-9cae-4658-a55b-2bccb97f9a9d</Id>
     </Book>
-    <Book Series="Wolverine" Number="26" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Wolverine" Number="26" Volume="1988" Year="1990">
       <Id>78d819da-1201-4853-8a21-c215ae27df71</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="259" Volume="1981" Year="1990" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="259" Volume="1981" Year="1990">
       <Id>fc8ba1a9-b82c-4225-816d-ccc033b6a1bc</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="260" Volume="1981" Year="1990" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="260" Volume="1981" Year="1990">
       <Id>194f4936-b38d-4c28-9ea7-bcb8385f921e</Id>
     </Book>
-    <Book Series="The New Mutants" Number="87" Volume="1983" Year="1990" Format="Main Series">
+    <Book Series="The New Mutants" Number="87" Volume="1983" Year="1990">
       <Id>2502b2fa-8b35-4e54-a792-a3e7cdba7ec3</Id>
     </Book>
-    <Book Series="The New Mutants" Number="88" Volume="1983" Year="1990" Format="Main Series">
+    <Book Series="The New Mutants" Number="88" Volume="1983" Year="1990">
       <Id>e7b7a98b-ca42-4217-86cd-2eb08c73df6d</Id>
     </Book>
-    <Book Series="The New Mutants" Number="89" Volume="1983" Year="1990" Format="Main Series">
+    <Book Series="The New Mutants" Number="89" Volume="1983" Year="1990">
       <Id>16b64c5e-dfd1-4ab1-8d5f-3dc3629738df</Id>
     </Book>
-    <Book Series="X-Factor" Number="51" Volume="1986" Year="1990" Format="Main Series">
+    <Book Series="X-Factor" Number="51" Volume="1986" Year="1990">
       <Id>af38f884-8ac2-47c3-ae16-43e7818d2f81</Id>
     </Book>
-    <Book Series="X-Factor" Number="52" Volume="1986" Year="1990" Format="Main Series">
+    <Book Series="X-Factor" Number="52" Volume="1986" Year="1990">
       <Id>6ffbcc50-f253-4124-8e1b-ae922de3a112</Id>
     </Book>
-    <Book Series="X-Factor" Number="53" Volume="1986" Year="1990" Format="Main Series">
+    <Book Series="X-Factor" Number="53" Volume="1986" Year="1990">
       <Id>3c7e47b4-ed5c-46e3-899a-9dfceb5d9b5b</Id>
     </Book>
-    <Book Series="The New Mutants" Number="90" Volume="1983" Year="1990" Format="Main Series">
+    <Book Series="The New Mutants" Number="90" Volume="1983" Year="1990">
       <Id>12c4642d-3627-4b88-9795-ffc5dfc2a0b9</Id>
     </Book>
-    <Book Series="The New Mutants" Number="91" Volume="1983" Year="1990" Format="Main Series">
+    <Book Series="The New Mutants" Number="91" Volume="1983" Year="1990">
       <Id>5000032a-cb02-4d87-87aa-42fd6076db19</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="261" Volume="1981" Year="1990" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="261" Volume="1981" Year="1990">
       <Id>998496cb-10e8-4a41-a340-6732ae56c258</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="262" Volume="1981" Year="1990" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="262" Volume="1981" Year="1990">
       <Id>45aecfc9-d9cb-4e4c-882f-3db8e5fae060</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="263" Volume="1981" Year="1990" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="263" Volume="1981" Year="1990">
       <Id>8eed62e8-1488-43a5-a060-16b53d38cb24</Id>
     </Book>
-    <Book Series="X-Factor" Number="54" Volume="1986" Year="1990" Format="Main Series">
+    <Book Series="X-Factor" Number="54" Volume="1986" Year="1990">
       <Id>54008b72-e768-462a-8567-38fcb6c1e532</Id>
     </Book>
-    <Book Series="X-Factor" Number="55" Volume="1986" Year="1990" Format="Main Series">
+    <Book Series="X-Factor" Number="55" Volume="1986" Year="1990">
       <Id>0f4a38e4-f2e1-4459-8f4b-c195d942b457</Id>
     </Book>
-    <Book Series="The New Mutants" Number="92" Volume="1983" Year="1990" Format="Main Series">
+    <Book Series="The New Mutants" Number="92" Volume="1983" Year="1990">
       <Id>19b1fdaf-9cd7-41d9-bd37-4949e4fe892e</Id>
     </Book>
-    <Book Series="Excalibur" Number="25" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Excalibur" Number="25" Volume="1988" Year="1990">
       <Id>1385ce3b-38e2-4592-9767-9b9340a13d5e</Id>
     </Book>
-    <Book Series="Excalibur" Number="26" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Excalibur" Number="26" Volume="1988" Year="1990">
       <Id>28644cae-f079-429f-bce3-9bfac682491e</Id>
     </Book>
-    <Book Series="Excalibur" Number="27" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Excalibur" Number="27" Volume="1988" Year="1990">
       <Id>184f9840-1451-40c1-b2f1-baced162d99e</Id>
     </Book>
-    <Book Series="Excalibur" Number="28" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Excalibur" Number="28" Volume="1988" Year="1990">
       <Id>8576b938-7bef-4705-a321-5077346d3be2</Id>
     </Book>
-    <Book Series="Excalibur" Number="29" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Excalibur" Number="29" Volume="1988" Year="1990">
       <Id>f0d816ce-1725-4357-b8ea-bb8a084f41e1</Id>
     </Book>
-    <Book Series="Excalibur" Number="30" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Excalibur" Number="30" Volume="1988" Year="1990">
       <Id>4ffe3dd5-96e5-453a-b109-f1c8276db96d</Id>
     </Book>
-    <Book Series="Excalibur" Number="31" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Excalibur" Number="31" Volume="1988" Year="1990">
       <Id>3b8dff12-2e24-4a26-b960-937ba64c9a0d</Id>
     </Book>
-    <Book Series="New Mutants Summer Special" Number="1" Volume="1990" Year="1990" Format="One-Shot">
+    <Book Series="New Mutants Summer Special" Number="1" Volume="1990" Year="1990">
       <Id>06d1a1d1-f3a8-4dc2-9daa-d35af58a4afd</Id>
     </Book>
-    <Book Series="Wolverine" Number="27" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Wolverine" Number="27" Volume="1988" Year="1990">
       <Id>dea71988-1a05-429e-a389-2aa41a256e7a</Id>
     </Book>
-    <Book Series="Wolverine" Number="28" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Wolverine" Number="28" Volume="1988" Year="1990">
       <Id>9808ac43-0168-408b-935b-822278350640</Id>
     </Book>
-    <Book Series="Wolverine" Number="29" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Wolverine" Number="29" Volume="1988" Year="1990">
       <Id>9494b40f-be07-43fc-8f56-98288c22dbe8</Id>
     </Book>
-    <Book Series="Wolverine" Number="30" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Wolverine" Number="30" Volume="1988" Year="1990">
       <Id>daa14271-7640-4017-a793-36810fa8a69f</Id>
     </Book>
-    <Book Series="Wolverine and the Punisher: Damaging Evidence" Number="1" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="Wolverine and the Punisher: Damaging Evidence" Number="1" Volume="1993" Year="1993">
       <Id>eee3ea60-4127-4082-ab1d-c179a7d716f2</Id>
     </Book>
-    <Book Series="Wolverine and the Punisher: Damaging Evidence" Number="2" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="Wolverine and the Punisher: Damaging Evidence" Number="2" Volume="1993" Year="1993">
       <Id>9ff2aa33-75e7-46b4-aceb-c52583346985</Id>
     </Book>
-    <Book Series="Wolverine and the Punisher: Damaging Evidence" Number="3" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="Wolverine and the Punisher: Damaging Evidence" Number="3" Volume="1993" Year="1993">
       <Id>ddb0496a-71c0-41b7-be6d-93b6844d5f11</Id>
     </Book>
-    <Book Series="X-Factor" Number="56" Volume="1986" Year="1990" Format="Main Series">
+    <Book Series="X-Factor" Number="56" Volume="1986" Year="1990">
       <Id>41c36a4a-0d97-44b3-8caa-69716e98dbea</Id>
     </Book>
-    <Book Series="X-Factor" Number="57" Volume="1986" Year="1990" Format="Main Series">
+    <Book Series="X-Factor" Number="57" Volume="1986" Year="1990">
       <Id>36a1fc6e-97fa-44df-aaad-e69273439514</Id>
     </Book>
-    <Book Series="X-Factor" Number="58" Volume="1986" Year="1990" Format="Main Series">
+    <Book Series="X-Factor" Number="58" Volume="1986" Year="1990">
       <Id>91088964-370c-40f3-a00c-412ef7aae2d5</Id>
     </Book>
-    <Book Series="X-Men Spotlight on... Starjammers" Number="1" Volume="1990" Year="1990" Format="Limited Series">
+    <Book Series="X-Men Spotlight on... Starjammers" Number="1" Volume="1990" Year="1990">
       <Id>13a27d5d-d9fa-4469-8297-29f9acd8fd78</Id>
     </Book>
-    <Book Series="X-Men Spotlight on... Starjammers" Number="2" Volume="1990" Year="1990" Format="Limited Series">
+    <Book Series="X-Men Spotlight on... Starjammers" Number="2" Volume="1990" Year="1990">
       <Id>483dd7f7-5495-43f6-b4cd-ecafab1cf91c</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="264" Volume="1981" Year="1990" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="264" Volume="1981" Year="1990">
       <Id>fe26e2a7-d186-42b1-b8c6-cdd6dc50056d</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="265" Volume="1981" Year="1990" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="265" Volume="1981" Year="1990">
       <Id>a007b092-310d-4172-a9d7-d5b8b08b6a0c</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="266" Volume="1981" Year="1990" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="266" Volume="1981" Year="1990">
       <Id>db307869-4d0f-4d42-be4e-0110cf4ad2fb</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="267" Volume="1981" Year="1990" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="267" Volume="1981" Year="1990">
       <Id>aaed4e34-b63a-49de-91b1-59ff265f62be</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="268" Volume="1981" Year="1990" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="268" Volume="1981" Year="1990">
       <Id>bf75bc06-3c4a-47cb-ac02-ef30ec52e443</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="269" Volume="1981" Year="1990" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="269" Volume="1981" Year="1990">
       <Id>2ea83b2e-5b3d-43b0-a703-1e6ba5649ee3</Id>
     </Book>
-    <Book Series="Excalibur" Number="32" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Excalibur" Number="32" Volume="1988" Year="1990">
       <Id>3684e303-40c8-4a9b-9059-8f2b6b04df38</Id>
     </Book>
-    <Book Series="Excalibur" Number="33" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Excalibur" Number="33" Volume="1988" Year="1991">
       <Id>150a7da5-e498-4396-9193-fa468913fbdc</Id>
     </Book>
-    <Book Series="Excalibur" Number="34" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Excalibur" Number="34" Volume="1988" Year="1991">
       <Id>39141336-39f0-48ef-8941-2a76b374c1f7</Id>
     </Book>
-    <Book Series="Fantastic Four Annual" Number="23" Volume="1963" Year="1990" Format="Annual">
+    <Book Series="Fantastic Four Annual" Number="23" Volume="1963" Year="1990">
       <Id>7ba1b3a2-b9c5-45b0-9975-956f22003d29</Id>
     </Book>
-    <Book Series="X-Factor Annual" Number="5" Volume="1986" Year="1990" Format="Annual">
+    <Book Series="X-Factor Annual" Number="5" Volume="1986" Year="1990">
       <Id>df41e93f-e783-4987-8ba0-9693cb2ce13e</Id>
     </Book>
-    <Book Series="The New Mutants Annual" Number="6" Volume="1984" Year="1990" Format="Annual">
+    <Book Series="The New Mutants Annual" Number="6" Volume="1984" Year="1990">
       <Id>c705814c-8ea3-474b-a7fb-66bf9900dfd2</Id>
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="14" Volume="1982" Year="1990" Format="Annual">
+    <Book Series="The Uncanny X-Men Annual" Number="14" Volume="1982" Year="1990">
       <Id>39834abe-9729-466d-b054-44afd6118cd6</Id>
     </Book>
-    <Book Series="Wolverine: Rahne of Terra" Number="1" Volume="1991" Year="1991" Format="One-Shot">
+    <Book Series="Wolverine: Rahne of Terra" Number="1" Volume="1991" Year="1991">
       <Id>268fae99-cfc4-4800-b21d-57eec7548887</Id>
     </Book>
-    <Book Series="The New Mutants" Number="93" Volume="1983" Year="1990" Format="Main Series">
+    <Book Series="The New Mutants" Number="93" Volume="1983" Year="1990">
       <Id>2cf4a82a-da80-4f42-be1c-1cdbe58ece5a</Id>
     </Book>
-    <Book Series="The New Mutants" Number="94" Volume="1983" Year="1990" Format="Main Series">
+    <Book Series="The New Mutants" Number="94" Volume="1983" Year="1990">
       <Id>7d6b07fb-fd99-4636-9794-717011dd7e4d</Id>
     </Book>
-    <Book Series="Wolverine" Number="31" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Wolverine" Number="31" Volume="1988" Year="1990">
       <Id>d46623fa-7b49-444f-a67a-3e472d5258ae</Id>
     </Book>
-    <Book Series="Wolverine" Number="32" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Wolverine" Number="32" Volume="1988" Year="1990">
       <Id>493169d7-d741-4c69-bc4a-58283ab3e57a</Id>
     </Book>
-    <Book Series="Wolverine" Number="33" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Wolverine" Number="33" Volume="1988" Year="1990">
       <Id>b0ac3761-cb96-4d17-b159-c9a399ba932b</Id>
     </Book>
-    <Book Series="X-Factor" Number="59" Volume="1986" Year="1990" Format="Main Series">
+    <Book Series="X-Factor" Number="59" Volume="1986" Year="1990">
       <Id>cbabf480-6049-43d9-9ffc-ffa7e5393899</Id>
     </Book>
-    <Book Series="X-Factor Special" Number="1" Volume="1990" Year="1990" Format="One-Shot">
+    <Book Series="X-Factor Special" Number="1" Volume="1990" Year="1990">
       <Id>3e2f8361-e660-46ba-bbbc-6a5508bc458e</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="270" Volume="1981" Year="1990" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="270" Volume="1981" Year="1990">
       <Id>2fe1ff11-29e8-4bb2-86e0-aa83f254104d</Id>
     </Book>
-    <Book Series="The New Mutants" Number="95" Volume="1983" Year="1990" Format="Main Series">
+    <Book Series="The New Mutants" Number="95" Volume="1983" Year="1990">
       <Id>24018547-17af-420c-9f90-88987ccc6bc6</Id>
     </Book>
-    <Book Series="X-Factor" Number="60" Volume="1986" Year="1990" Format="Main Series">
+    <Book Series="X-Factor" Number="60" Volume="1986" Year="1990">
       <Id>33823876-77d6-4e61-9713-3191dc9244f7</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="271" Volume="1981" Year="1990" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="271" Volume="1981" Year="1990">
       <Id>cf7c2c94-4069-488c-beaf-5eca40a8c323</Id>
     </Book>
-    <Book Series="The New Mutants" Number="96" Volume="1983" Year="1990" Format="Main Series">
+    <Book Series="The New Mutants" Number="96" Volume="1983" Year="1990">
       <Id>107ece0e-f39f-4563-bec0-5f71b366cf43</Id>
     </Book>
-    <Book Series="X-Factor" Number="61" Volume="1986" Year="1990" Format="Main Series">
+    <Book Series="X-Factor" Number="61" Volume="1986" Year="1990">
       <Id>c07abbc7-cda3-4627-97d9-b06c69a5bef2</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="272" Volume="1981" Year="1991" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="272" Volume="1981" Year="1991">
       <Id>62b15bff-7e55-4a9e-b424-15f428e08922</Id>
     </Book>
-    <Book Series="The New Mutants" Number="97" Volume="1983" Year="1991" Format="Main Series">
+    <Book Series="The New Mutants" Number="97" Volume="1983" Year="1991">
       <Id>060ed684-90af-4df2-a961-550f048a1dfc</Id>
     </Book>
-    <Book Series="X-Factor" Number="62" Volume="1986" Year="1991" Format="Main Series">
+    <Book Series="X-Factor" Number="62" Volume="1986" Year="1991">
       <Id>d8895972-bf5d-4fe3-bcc4-cd0abe1afe19</Id>
     </Book>
-    <Book Series="Excalibur" Number="35" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Excalibur" Number="35" Volume="1988" Year="1991">
       <Id>1e16bf17-f784-461f-a6b3-0ed9453ab2bc</Id>
     </Book>
-    <Book Series="X-Men: True Friends" Number="1" Volume="1999" Year="1999" Format="Limited Series">
+    <Book Series="X-Men: True Friends" Number="1" Volume="1999" Year="1999">
       <Id>c22e954f-1bf2-4118-8496-b3e8c54d17ad</Id>
     </Book>
-    <Book Series="X-Men: True Friends" Number="2" Volume="1999" Year="1999" Format="Limited Series">
+    <Book Series="X-Men: True Friends" Number="2" Volume="1999" Year="1999">
       <Id>37d05483-d59e-4ff8-b114-5a511ec1c7a7</Id>
     </Book>
-    <Book Series="X-Men: True Friends" Number="3" Volume="1999" Year="1999" Format="Limited Series">
+    <Book Series="X-Men: True Friends" Number="3" Volume="1999" Year="1999">
       <Id>d8a55c95-a663-4872-b961-301aa02b895a</Id>
     </Book>
-    <Book Series="Excalibur" Number="36" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Excalibur" Number="36" Volume="1988" Year="1991">
       <Id>e84a6d29-5508-4684-84d2-19c338f4428c</Id>
     </Book>
-    <Book Series="Wolverine" Number="34" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Wolverine" Number="34" Volume="1988" Year="1990">
       <Id>e52c30a1-9fc6-4981-8dbc-d14da2727151</Id>
     </Book>
-    <Book Series="Wolverine Annual  2 - Bloodlust" Number="1" Volume="1990" Year="1990" Format="Annual">
+    <Book Series="Wolverine Annual  2 - Bloodlust" Number="1" Volume="1990" Year="1990">
       <Id>84ffb69a-020f-47cf-9209-af63a41b6338</Id>
     </Book>
-    <Book Series="Wolverine" Number="35" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Wolverine" Number="35" Volume="1988" Year="1991">
       <Id>70117de5-7f5d-4905-8aea-1751957ae78f</Id>
     </Book>
-    <Book Series="Wolverine" Number="36" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Wolverine" Number="36" Volume="1988" Year="1991">
       <Id>c6a1a1e0-74ed-440d-8bb1-715323da8924</Id>
     </Book>
-    <Book Series="Wolverine" Number="37" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Wolverine" Number="37" Volume="1988" Year="1991">
       <Id>3b3f64fb-f964-486e-af54-bd43a397dd42</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="72" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="72" Volume="1988" Year="1991">
       <Id>c1a8ad40-a1f7-45d5-b6e2-0962dceb98b6</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="73" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="73" Volume="1988" Year="1991">
       <Id>9d462553-cd18-4865-9b1a-5f3dd989af72</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="74" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="74" Volume="1988" Year="1991">
       <Id>72c161ad-c41f-4ce4-8e70-e24d2f55fe75</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="75" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="75" Volume="1988" Year="1991">
       <Id>57e9df72-220a-44d4-a229-48b9e6a6ff06</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="76" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="76" Volume="1988" Year="1991">
       <Id>732b1231-aa94-4e8f-9577-3ad94ad0fe32</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="77" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="77" Volume="1988" Year="1991">
       <Id>395a0408-1af3-4791-a5e8-739f257396a1</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="78" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="78" Volume="1988" Year="1991">
       <Id>125cff93-817a-4276-bee9-64da8a0defe6</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="79" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="79" Volume="1988" Year="1991">
       <Id>af5a0bf1-de02-43ba-b4d6-2b2fbf2c92d4</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="80" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="80" Volume="1988" Year="1991">
       <Id>47ef1007-a925-477a-aa7f-4511a88f6a69</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="81" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="81" Volume="1988" Year="1991">
       <Id>33674b93-676b-4b07-aa7e-2dd6c6df4fac</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="82" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="82" Volume="1988" Year="1991">
       <Id>19929ddc-3ce2-4f95-a69f-246415196470</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="83" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="83" Volume="1988" Year="1991">
       <Id>9bdef651-872a-4df8-9f6f-7944fe21c231</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="84" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="84" Volume="1988" Year="1991">
       <Id>0e306ad2-290c-42c6-bb8c-9c3c3639cea0</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="273" Volume="1981" Year="1991" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="273" Volume="1981" Year="1991">
       <Id>6322239e-f919-4079-88a1-fdbf769342a8</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="274" Volume="1981" Year="1991" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="274" Volume="1981" Year="1991">
       <Id>e1fd9dce-82d1-4a2e-803d-be04e5fba213</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="275" Volume="1981" Year="1991" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="275" Volume="1981" Year="1991">
       <Id>8ef12ec9-5be7-465a-ba76-8eaf443d91e4</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="276" Volume="1981" Year="1991" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="276" Volume="1981" Year="1991">
       <Id>f24b4495-5692-43fe-bfa6-defa6c690961</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="277" Volume="1981" Year="1991" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="277" Volume="1981" Year="1991">
       <Id>99c7be7e-854c-4880-ad24-4873f2899b40</Id>
     </Book>
-    <Book Series="X-Factor" Number="63" Volume="1986" Year="1991" Format="Main Series">
+    <Book Series="X-Factor" Number="63" Volume="1986" Year="1991">
       <Id>8ecaaac8-6339-4e7f-9961-e653515464eb</Id>
     </Book>
-    <Book Series="X-Factor" Number="64" Volume="1986" Year="1991" Format="Main Series">
+    <Book Series="X-Factor" Number="64" Volume="1986" Year="1991">
       <Id>05f9bdc1-3b9a-4d56-b7d1-2aa9b1dcc34c</Id>
     </Book>
-    <Book Series="The New Mutants" Number="98" Volume="1983" Year="1991" Format="Main Series">
+    <Book Series="The New Mutants" Number="98" Volume="1983" Year="1991">
       <Id>59b3aa79-d229-4faa-8209-6046ec378cd2</Id>
     </Book>
-    <Book Series="The New Mutants" Number="99" Volume="1983" Year="1991" Format="Main Series">
+    <Book Series="The New Mutants" Number="99" Volume="1983" Year="1991">
       <Id>cba47471-d0d4-4652-83e0-cca0b8f9ca9f</Id>
     </Book>
-    <Book Series="The New Mutants" Number="100" Volume="1983" Year="1991" Format="Main Series">
+    <Book Series="The New Mutants" Number="100" Volume="1983" Year="1991">
       <Id>04b37f78-a2a3-446c-8766-3f4f13957811</Id>
     </Book>
-    <Book Series="The New Mutants Annual" Number="7" Volume="1984" Year="1991" Format="Annual">
+    <Book Series="The New Mutants Annual" Number="7" Volume="1984" Year="1991">
       <Id>77083e80-dded-49ca-97fd-570c0624f738</Id>
     </Book>
-    <Book Series="The New Warriors Annual" Number="1" Volume="1991" Year="1991" Format="Annual">
+    <Book Series="The New Warriors Annual" Number="1" Volume="1991" Year="1991">
       <Id>064446d1-a774-4315-8103-801760b50f8a</Id>
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="15" Volume="1982" Year="1991" Format="Annual">
+    <Book Series="The Uncanny X-Men Annual" Number="15" Volume="1982" Year="1991">
       <Id>b1ba4687-e622-4eab-a287-52e13e92e05b</Id>
     </Book>
-    <Book Series="X-Factor Annual" Number="6" Volume="1986" Year="1991" Format="Annual">
+    <Book Series="X-Factor Annual" Number="6" Volume="1986" Year="1991">
       <Id>43e974f0-7afa-4e7f-b407-6208688b2512</Id>
     </Book>
-    <Book Series="Excalibur" Number="37" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Excalibur" Number="37" Volume="1988" Year="1991">
       <Id>19f2da3d-e486-41ae-b254-32dd2a1f3c13</Id>
     </Book>
-    <Book Series="Excalibur" Number="38" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Excalibur" Number="38" Volume="1988" Year="1991">
       <Id>63a634ac-2bb2-41b7-8be3-6be048631561</Id>
     </Book>
-    <Book Series="Excalibur" Number="39" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Excalibur" Number="39" Volume="1988" Year="1991">
       <Id>342949f9-db7e-4701-abc0-8fa6c31e902a</Id>
     </Book>
-    <Book Series="Excalibur" Number="40" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Excalibur" Number="40" Volume="1988" Year="1991">
       <Id>c08dea99-91af-4ccd-8a30-23b5e4a217cb</Id>
     </Book>
-    <Book Series="Excalibur" Number="41" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Excalibur" Number="41" Volume="1988" Year="1991">
       <Id>d702c258-49e8-4e21-8c70-0848a179dac3</Id>
     </Book>
-    <Book Series="Wolverine" Number="38" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Wolverine" Number="38" Volume="1988" Year="1991">
       <Id>0cddd7ea-9056-406d-bff6-7b1e7b284d68</Id>
     </Book>
-    <Book Series="Wolverine" Number="39" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Wolverine" Number="39" Volume="1988" Year="1991">
       <Id>d6763c37-3871-4796-8cd5-38177a3644e8</Id>
     </Book>
-    <Book Series="Wolverine" Number="40" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Wolverine" Number="40" Volume="1988" Year="1991">
       <Id>ddfc85db-217e-4944-8aca-b6c77e53d05b</Id>
     </Book>
-    <Book Series="Wolverine" Number="41" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Wolverine" Number="41" Volume="1988" Year="1991">
       <Id>03a6ef5c-abee-4be1-9252-c597f7a3518a</Id>
     </Book>
-    <Book Series="Wolverine" Number="42" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Wolverine" Number="42" Volume="1988" Year="1991">
       <Id>753a1108-3e4b-4717-b226-09ff88202010</Id>
     </Book>
-    <Book Series="Wolverine" Number="43" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Wolverine" Number="43" Volume="1988" Year="1991">
       <Id>995f4a9d-c93b-4a46-9568-e6359ec420b7</Id>
     </Book>
-    <Book Series="Wolverine" Number="44" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Wolverine" Number="44" Volume="1988" Year="1991">
       <Id>a0a1dbc9-ff8b-4fff-9173-cd04f09794e6</Id>
     </Book>
-    <Book Series="Wolverine" Number="45" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Wolverine" Number="45" Volume="1988" Year="1991">
       <Id>878a6154-7e64-4a93-9b3e-b474d63b35cc</Id>
     </Book>
-    <Book Series="Wolverine" Number="46" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Wolverine" Number="46" Volume="1988" Year="1991">
       <Id>3986897a-4af1-4543-8009-7da10d0bbe9c</Id>
     </Book>
-    <Book Series="X-Factor" Number="65" Volume="1986" Year="1991" Format="Main Series">
+    <Book Series="X-Factor" Number="65" Volume="1986" Year="1991">
       <Id>322006f6-866b-4cf0-bac1-9cfe4c6b00be</Id>
     </Book>
-    <Book Series="X-Factor" Number="66" Volume="1986" Year="1991" Format="Main Series">
+    <Book Series="X-Factor" Number="66" Volume="1986" Year="1991">
       <Id>772cc388-232c-4367-b91d-bd155814ac2b</Id>
     </Book>
-    <Book Series="X-Factor" Number="67" Volume="1986" Year="1991" Format="Main Series">
+    <Book Series="X-Factor" Number="67" Volume="1986" Year="1991">
       <Id>37a53372-5535-452f-8de0-433fed99db5c</Id>
     </Book>
-    <Book Series="X-Factor" Number="68" Volume="1986" Year="1991" Format="Main Series">
+    <Book Series="X-Factor" Number="68" Volume="1986" Year="1991">
       <Id>e369d0e3-f201-4764-b795-3f85b288b53e</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="278" Volume="1981" Year="1991" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="278" Volume="1981" Year="1991">
       <Id>39645eea-536d-4082-81cf-e3f108f68b26</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="279" Volume="1981" Year="1991" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="279" Volume="1981" Year="1991">
       <Id>0459264b-7c01-4bf4-bf94-9b3bb6ac901f</Id>
     </Book>
-    <Book Series="X-Factor" Number="69" Volume="1986" Year="1991" Format="Main Series">
+    <Book Series="X-Factor" Number="69" Volume="1986" Year="1991">
       <Id>d722a121-8f6a-4be7-a112-beb1614a03d4</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="280" Volume="1981" Year="1991" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="280" Volume="1981" Year="1991">
       <Id>5c195442-1dbb-436e-a884-f8ebed7cab2f</Id>
     </Book>
-    <Book Series="X-Factor" Number="70" Volume="1986" Year="1991" Format="Main Series">
+    <Book Series="X-Factor" Number="70" Volume="1986" Year="1991">
       <Id>f60abf20-622f-4d4d-abe2-a90898745ef3</Id>
     </Book>
-    <Book Series="Excalibur" Number="42" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Excalibur" Number="42" Volume="1988" Year="1991">
       <Id>dd135cba-5ebc-47a2-8190-0af942dd8c3f</Id>
     </Book>
-    <Book Series="Excalibur" Number="43" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Excalibur" Number="43" Volume="1988" Year="1991">
       <Id>f9beb002-f30b-4b10-af77-66089a9b01d9</Id>
     </Book>
-    <Book Series="Excalibur" Number="44" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Excalibur" Number="44" Volume="1988" Year="1991">
       <Id>7691bf4e-7509-4413-a70c-08a9c802d01a</Id>
     </Book>
-    <Book Series="Excalibur" Number="45" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Excalibur" Number="45" Volume="1988" Year="1991">
       <Id>da6c131c-9e64-4194-8f55-8fdd2fa27775</Id>
     </Book>
-    <Book Series="Excalibur" Number="46" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Excalibur" Number="46" Volume="1988" Year="1992">
       <Id>d4b109e2-b520-45eb-8954-9815c74de0ce</Id>
     </Book>
-    <Book Series="Excalibur" Number="47" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Excalibur" Number="47" Volume="1988" Year="1992">
       <Id>143c482f-42bd-4d86-b47c-e6c7a76bb845</Id>
     </Book>
-    <Book Series="Wolverine" Number="47" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Wolverine" Number="47" Volume="1988" Year="1991">
       <Id>f9fef829-005f-4582-8f2d-caf2d8a4cb0d</Id>
     </Book>
   </Books>

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 004 (Blue - Gold).cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 004 (Blue - Gold).cbl
@@ -1,921 +1,922 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>X-Men - Part 4 (Blue &amp; Gold)</Name>
+  <Name>X-Men - Part 004 (Blue - Gold)</Name>
+  <NumIssues>305</NumIssues>
   <Books>
     <Book Series="X-Force" Number="1" Volume="1991" Year="1991">
-      <Id>2fea3f60-b356-4df8-904c-249fd5142675</Id>
+      <Database Name="cv" Series="4604" Issue="34549" />
     </Book>
     <Book Series="X-Factor" Number="71" Volume="1986" Year="1991">
-      <Id>2d4fa258-1e00-4531-9d1f-81a4996128b6</Id>
+      <Database Name="cv" Series="3657" Issue="34782" />
     </Book>
     <Book Series="X-Factor" Number="72" Volume="1986" Year="1991">
-      <Id>01130b8a-e426-4b01-a7b4-d3ea344b8c62</Id>
+      <Database Name="cv" Series="3657" Issue="34898" />
     </Book>
     <Book Series="X-Factor" Number="73" Volume="1986" Year="1991">
-      <Id>3dcb965a-78f2-4c2a-83af-1d771430fe43</Id>
+      <Database Name="cv" Series="3657" Issue="35017" />
     </Book>
     <Book Series="X-Factor" Number="74" Volume="1986" Year="1992">
-      <Id>7999ae32-5525-41bd-ba53-548f767116d2</Id>
+      <Database Name="cv" Series="3657" Issue="35274" />
     </Book>
     <Book Series="X-Factor" Number="75" Volume="1986" Year="1992">
-      <Id>4ea335c1-be12-4418-9b4c-0ff8709381ff</Id>
+      <Database Name="cv" Series="3657" Issue="35377" />
     </Book>
     <Book Series="X-Men" Number="1" Volume="1991" Year="1991">
-      <Id>355e5079-33e8-40dd-bbbc-1a048e0d868a</Id>
+      <Database Name="cv" Series="4605" Issue="34784" />
     </Book>
     <Book Series="X-Men" Number="2" Volume="1991" Year="1991">
-      <Id>bc1d283a-dd5c-43fb-b60b-7937dadb14a2</Id>
+      <Database Name="cv" Series="4605" Issue="34900" />
     </Book>
     <Book Series="X-Men" Number="3" Volume="1991" Year="1991">
-      <Id>6e6580a6-0172-4821-9258-e92b4799b92e</Id>
+      <Database Name="cv" Series="4605" Issue="35019" />
     </Book>
     <Book Series="X-Force" Number="2" Volume="1991" Year="1991">
-      <Id>01698506-da89-431f-b503-5a12987e9e5b</Id>
+      <Database Name="cv" Series="4604" Issue="34666" />
     </Book>
     <Book Series="X-Force" Number="3" Volume="1991" Year="1991">
-      <Id>464d8281-c0a5-4589-b187-3dc4756ffddc</Id>
+      <Database Name="cv" Series="4604" Issue="34783" />
     </Book>
     <Book Series="Spider-Man" Number="16" Volume="1990" Year="1991">
-      <Id>86dbb27b-74fc-4055-9d3f-94e23e550341</Id>
+      <Database Name="cv" Series="4421" Issue="64618" />
     </Book>
     <Book Series="X-Force" Number="4" Volume="1991" Year="1991">
-      <Id>4969a184-69a0-4604-8d39-481d748b9cbb</Id>
+      <Database Name="cv" Series="4604" Issue="34899" />
     </Book>
     <Book Series="Wolverine" Number="48" Volume="1988" Year="1991">
-      <Id>ce20faff-0562-4bd5-9e6e-abb021ec2b9c</Id>
+      <Database Name="cv" Series="4250" Issue="64311" />
     </Book>
     <Book Series="Wolverine" Number="49" Volume="1988" Year="1991">
-      <Id>2fd862ab-8c97-4822-b625-16f8fea454c5</Id>
+      <Database Name="cv" Series="4250" Issue="64312" />
     </Book>
     <Book Series="Wolverine" Number="50" Volume="1988" Year="1992">
-      <Id>7babef8b-41bd-4940-b55a-3e7c31225671</Id>
+      <Database Name="cv" Series="4250" Issue="64313" />
     </Book>
     <Book Series="X-Men" Number="4" Volume="1991" Year="1992">
-      <Id>cf0a82bc-11f4-49db-8d81-9c84a5194f0b</Id>
+      <Database Name="cv" Series="4605" Issue="35276" />
     </Book>
     <Book Series="X-Men" Number="5" Volume="1991" Year="1992">
-      <Id>49202154-8929-4a6f-8b1f-4e74ca0feb8e</Id>
+      <Database Name="cv" Series="4605" Issue="35379" />
     </Book>
     <Book Series="X-Men" Number="6" Volume="1991" Year="1992">
-      <Id>80f233bd-e1c8-43bd-a6f3-2e701ffc233e</Id>
+      <Database Name="cv" Series="4605" Issue="35485" />
     </Book>
     <Book Series="X-Men" Number="7" Volume="1991" Year="1992">
-      <Id>8433d6b0-7d0d-4fb0-87f0-a5bbc0fdac1a</Id>
+      <Database Name="cv" Series="4605" Issue="35588" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="281" Volume="1981" Year="1991">
-      <Id>59e2d021-d852-4e4f-bdab-32079d8a163e</Id>
+      <Database Name="cv" Series="3092" Issue="34779" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="282" Volume="1981" Year="1991">
-      <Id>eec5c12a-fafb-4ff1-a9e4-707d63e5520f</Id>
+      <Database Name="cv" Series="3092" Issue="34895" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="283" Volume="1981" Year="1991">
-      <Id>b2e4527f-ddf2-46eb-ac20-d25219003bbb</Id>
+      <Database Name="cv" Series="3092" Issue="107061" />
     </Book>
     <Book Series="The Incredible Hulk" Number="390" Volume="1968" Year="1992">
-      <Id>50084f5d-7118-418a-9571-b0b63cc52f6c</Id>
+      <Database Name="cv" Series="2406" Issue="35366" />
     </Book>
     <Book Series="The Incredible Hulk" Number="391" Volume="1968" Year="1992">
-      <Id>4902c649-78c5-4ab7-bd4e-69abcce7481f</Id>
+      <Database Name="cv" Series="2406" Issue="35471" />
     </Book>
     <Book Series="X-Factor" Number="76" Volume="1986" Year="1992">
-      <Id>900fcfe1-9741-4c23-afec-f6b88cbcba26</Id>
+      <Database Name="cv" Series="3657" Issue="35483" />
     </Book>
     <Book Series="The Incredible Hulk" Number="392" Volume="1968" Year="1992">
-      <Id>a39519f6-7b80-4fc6-851f-c6d367fac198</Id>
+      <Database Name="cv" Series="2406" Issue="35575" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="284" Volume="1981" Year="1992">
-      <Id>58dcd61c-b927-4a17-8eb7-9952ad178593</Id>
+      <Database Name="cv" Series="3092" Issue="35271" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="285" Volume="1981" Year="1992">
-      <Id>55096403-f4ad-4c53-ac65-bfb39a48f6a1</Id>
+      <Database Name="cv" Series="3092" Issue="107062" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="286" Volume="1981" Year="1992">
-      <Id>d2d07ece-7cea-45a7-8c92-bc29f8c166f0</Id>
+      <Database Name="cv" Series="3092" Issue="35480" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="287" Volume="1981" Year="1992">
-      <Id>4375d392-7659-4c88-8dd1-82cf835c831a</Id>
+      <Database Name="cv" Series="3092" Issue="35583" />
     </Book>
     <Book Series="X-Men" Number="8" Volume="1991" Year="1992">
-      <Id>0df73930-e8e0-4c06-bab7-836a9a20bea8</Id>
+      <Database Name="cv" Series="4605" Issue="35692" />
     </Book>
     <Book Series="Ghost Rider" Number="26" Volume="1990" Year="1992">
-      <Id>fb415ab9-e5e0-4d18-a9fa-a33f3b83766d</Id>
+      <Database Name="cv" Series="4397" Issue="66441" />
     </Book>
     <Book Series="X-Men" Number="9" Volume="1991" Year="1992">
-      <Id>dca0a99e-3dc9-4150-a119-bcd4f1e75e8f</Id>
+      <Database Name="cv" Series="4605" Issue="106565" />
     </Book>
     <Book Series="Ghost Rider" Number="27" Volume="1990" Year="1992">
-      <Id>8cb528ce-300e-49f6-b00a-5004d9f6a7f4</Id>
+      <Database Name="cv" Series="4397" Issue="66442" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="288" Volume="1981" Year="1992">
-      <Id>a1976f6e-58b9-4669-9d71-61af9dbf34e0</Id>
+      <Database Name="cv" Series="3092" Issue="35686" />
     </Book>
     <Book Series="Wolverine" Number="51" Volume="1988" Year="1992">
-      <Id>b161f477-9a33-4a3c-b63f-686cb3429be2</Id>
+      <Database Name="cv" Series="4250" Issue="64314" />
     </Book>
     <Book Series="Wolverine" Number="52" Volume="1988" Year="1992">
-      <Id>66d6539c-54c6-4b21-abde-4f32c61a02e1</Id>
+      <Database Name="cv" Series="4250" Issue="64315" />
     </Book>
     <Book Series="Wolverine" Number="53" Volume="1988" Year="1992">
-      <Id>9ae64411-3eca-48d4-89eb-cd2259139b9d</Id>
+      <Database Name="cv" Series="4250" Issue="64316" />
     </Book>
     <Book Series="Wolverine" Number="54" Volume="1988" Year="1992">
-      <Id>8f9099f1-58b2-4b2c-8215-31e31f8a1159</Id>
+      <Database Name="cv" Series="4250" Issue="35695" />
     </Book>
     <Book Series="Excalibur" Number="48" Volume="1988" Year="1992">
-      <Id>e52f38fc-9e0d-42bd-892f-dd8243666237</Id>
+      <Database Name="cv" Series="4052" Issue="35469" />
     </Book>
     <Book Series="Excalibur" Number="49" Volume="1988" Year="1992">
-      <Id>992fd26a-6a23-46db-b92a-2b6ec8de0ca6</Id>
+      <Database Name="cv" Series="4052" Issue="35573" />
     </Book>
     <Book Series="Excalibur" Number="50" Volume="1988" Year="1992">
-      <Id>2473ffda-84dd-43f2-a180-aded7bd35d1e</Id>
+      <Database Name="cv" Series="4052" Issue="35676" />
     </Book>
     <Book Series="Excalibur: XX Crossing" Number="1" Volume="1992" Year="1992">
-      <Id>1721618e-bbe7-4d40-9e03-726424bf160b</Id>
+      <Database Name="cv" Series="22615" Issue="135750" />
     </Book>
     <Book Series="Excalibur" Number="51" Volume="1988" Year="1992">
-      <Id>717620b7-7eac-47d5-90cf-a85ffd6c0d37</Id>
+      <Database Name="cv" Series="4052" Issue="118524" />
     </Book>
     <Book Series="Excalibur" Number="52" Volume="1988" Year="1992">
-      <Id>ace56cf0-d66b-4b13-9041-0c7d0f65f385</Id>
+      <Database Name="cv" Series="4052" Issue="35904" />
     </Book>
     <Book Series="Excalibur" Number="53" Volume="1988" Year="1992">
-      <Id>96b32ed6-3f71-411b-b2e4-5d4484665758</Id>
+      <Database Name="cv" Series="4052" Issue="36022" />
     </Book>
     <Book Series="Excalibur" Number="54" Volume="1988" Year="1992">
-      <Id>61041930-07dd-4276-ae2f-2a16f409db0f</Id>
+      <Database Name="cv" Series="4052" Issue="36149" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="289" Volume="1981" Year="1992">
-      <Id>4ba0b732-96b3-4e21-8a0f-609a112a77c1</Id>
+      <Database Name="cv" Series="3092" Issue="35791" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="290" Volume="1981" Year="1992">
-      <Id>fad69fc5-c5dc-417a-9f72-c36eb3b9d7cf</Id>
+      <Database Name="cv" Series="3092" Issue="35915" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="101" Volume="1988" Year="1992">
-      <Id>d5c5c8e5-87d9-4b6e-859e-4c8af3d7abf0</Id>
+      <Database Name="cv" Series="4058" Issue="35473" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="102" Volume="1988" Year="1992">
-      <Id>b16a9e5c-db7b-4914-810d-d8893b983e35</Id>
+      <Database Name="cv" Series="4058" Issue="35511" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="103" Volume="1988" Year="1992">
-      <Id>5dddd0c1-58ba-4746-9052-1c8250a6a506</Id>
+      <Database Name="cv" Series="4058" Issue="109573" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="104" Volume="1988" Year="1992">
-      <Id>e2674bc4-9203-4e89-aa56-85d60375ee4c</Id>
+      <Database Name="cv" Series="4058" Issue="35618" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="105" Volume="1988" Year="1992">
-      <Id>658bdfa5-253b-4310-a547-d7e4ee7ff94e</Id>
+      <Database Name="cv" Series="4058" Issue="35680" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="106" Volume="1988" Year="1992">
-      <Id>bc2318d7-6741-4035-baa0-8b32d1ef1a01</Id>
+      <Database Name="cv" Series="4058" Issue="35721" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="107" Volume="1988" Year="1992">
-      <Id>827d81c6-63cb-482b-a19c-fa5b5d609b3b</Id>
+      <Database Name="cv" Series="4058" Issue="35785" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="108" Volume="1988" Year="1992">
-      <Id>d55d9620-e195-4211-bfd6-636f20bd33e7</Id>
+      <Database Name="cv" Series="4058" Issue="35835" />
     </Book>
     <Book Series="X-Force" Number="5" Volume="1991" Year="1991">
-      <Id>c824c994-1e7e-4f1c-9287-50df4ad9d00d</Id>
+      <Database Name="cv" Series="4604" Issue="35018" />
     </Book>
     <Book Series="X-Force" Number="6" Volume="1991" Year="1992">
-      <Id>1f04da08-8bfa-4f93-a451-65385af068b8</Id>
+      <Database Name="cv" Series="4604" Issue="35275" />
     </Book>
     <Book Series="X-Force" Number="7" Volume="1991" Year="1992">
-      <Id>146d8d66-e051-43a7-af0e-6a735cdbf76a</Id>
+      <Database Name="cv" Series="4604" Issue="35378" />
     </Book>
     <Book Series="X-Force" Number="8" Volume="1991" Year="1992">
-      <Id>1772bb34-62e1-4f54-9bf7-78a90145de13</Id>
+      <Database Name="cv" Series="4604" Issue="35484" />
     </Book>
     <Book Series="X-Force" Number="9" Volume="1991" Year="1992">
-      <Id>a3e51a7f-db2d-41ff-b024-8d7e953b8ccd</Id>
+      <Database Name="cv" Series="4604" Issue="35587" />
     </Book>
     <Book Series="X-Force" Number="10" Volume="1991" Year="1992">
-      <Id>714fafe7-7749-4026-84e9-e2011af75aa7</Id>
+      <Database Name="cv" Series="4604" Issue="35691" />
     </Book>
     <Book Series="X-Factor" Number="77" Volume="1986" Year="1992">
-      <Id>171d600e-4ee4-4376-9b1b-56c655e03626</Id>
+      <Database Name="cv" Series="3657" Issue="35586" />
     </Book>
     <Book Series="X-Factor" Number="78" Volume="1986" Year="1992">
-      <Id>28953608-9bf5-4421-a65e-7db1ffc59ad7</Id>
+      <Database Name="cv" Series="3657" Issue="35690" />
     </Book>
     <Book Series="Wolverine" Number="55" Volume="1988" Year="1992">
-      <Id>52440d49-0ceb-41be-8fdd-06849d184716</Id>
+      <Database Name="cv" Series="4250" Issue="35799" />
     </Book>
     <Book Series="Wolverine" Number="56" Volume="1988" Year="1992">
-      <Id>b867ff90-5372-41ab-8a57-284106bef1ba</Id>
+      <Database Name="cv" Series="4250" Issue="35924" />
     </Book>
     <Book Series="Wolverine" Number="57" Volume="1988" Year="1992">
-      <Id>820c1657-46a5-4f0f-bf5f-4ddfe1a0afa6</Id>
+      <Database Name="cv" Series="4250" Issue="35958" />
     </Book>
     <Book Series="Wolverine" Number="58" Volume="1988" Year="1992">
-      <Id>e8f320a1-2885-46c4-9f05-3368f657174c</Id>
+      <Database Name="cv" Series="4250" Issue="36045" />
     </Book>
     <Book Series="Wolverine" Number="59" Volume="1988" Year="1992">
-      <Id>75b66903-7a24-459b-a84d-7271ecb8fc38</Id>
+      <Database Name="cv" Series="4250" Issue="36080" />
     </Book>
     <Book Series="Wolverine" Number="60" Volume="1988" Year="1992">
-      <Id>c1f90d73-5719-4c8b-8b11-b1a756af9487</Id>
+      <Database Name="cv" Series="4250" Issue="36167" />
     </Book>
     <Book Series="X-Men Annual" Number="1" Volume="1992" Year="1992">
-      <Id>3440b5e2-78b5-4a60-8912-8b129b71de20</Id>
+      <Database Name="cv" Series="10748" Issue="90584" />
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="16" Volume="1982" Year="1992">
-      <Id>e025cf31-01c6-4cf3-bb95-7e3a719ae900</Id>
+    <Book Series="The Uncanny X-Men Annual" Number="16" Volume="1992" Year="1992">
+      <Database Name="cv" Series="10757" Issue="91313" />
     </Book>
     <Book Series="X-Factor Annual" Number="7" Volume="1986" Year="1992">
-      <Id>ea4454a5-4ba8-4041-9156-90bd9c8e0ee8</Id>
+      <Database Name="cv" Series="3658" Issue="66338" />
     </Book>
     <Book Series="X-Force Annual" Number="1" Volume="1992" Year="1992">
-      <Id>8a497a9f-7bba-4d89-b9fc-b590921557ee</Id>
+      <Database Name="cv" Series="4822" Issue="35112" />
     </Book>
     <Book Series="X-Men" Number="10" Volume="1991" Year="1992">
-      <Id>5b31352f-7ca1-4812-8621-9f50368a99d2</Id>
+      <Database Name="cv" Series="4605" Issue="35920" />
     </Book>
     <Book Series="X-Men" Number="11" Volume="1991" Year="1992">
-      <Id>093a17b6-3cc6-4618-9fa3-faed9727f474</Id>
+      <Database Name="cv" Series="4605" Issue="36037" />
     </Book>
     <Book Series="X-Factor" Number="79" Volume="1986" Year="1992">
-      <Id>8aaa0f67-3f78-44b4-bd07-25d9d280c7e3</Id>
+      <Database Name="cv" Series="3657" Issue="35794" />
     </Book>
     <Book Series="X-Factor" Number="80" Volume="1986" Year="1992">
-      <Id>7bee7cd3-c66f-45c6-989f-d29b0dde5b5d</Id>
+      <Database Name="cv" Series="3657" Issue="35918" />
     </Book>
     <Book Series="X-Factor" Number="81" Volume="1986" Year="1992">
-      <Id>3b9718b7-191d-44cf-87f6-b92c4641766a</Id>
+      <Database Name="cv" Series="3657" Issue="36035" />
     </Book>
     <Book Series="X-Force" Number="11" Volume="1991" Year="1992">
-      <Id>d769d966-710f-40e1-8aa5-4e96b61c9a33</Id>
+      <Database Name="cv" Series="4604" Issue="35795" />
     </Book>
     <Book Series="X-Force" Number="12" Volume="1991" Year="1992">
-      <Id>b2b991d2-8dda-4bb9-8002-3dad4e74d266</Id>
+      <Database Name="cv" Series="4604" Issue="35919" />
     </Book>
     <Book Series="X-Force" Number="13" Volume="1991" Year="1992">
-      <Id>0e7579bb-311b-4e35-996b-99a0fa22b70a</Id>
+      <Database Name="cv" Series="4604" Issue="36036" />
     </Book>
     <Book Series="X-Force" Number="14" Volume="1991" Year="1992">
-      <Id>3dfc722e-fbef-4d5c-9c55-6fa336dd33b7</Id>
+      <Database Name="cv" Series="4604" Issue="36164" />
     </Book>
     <Book Series="X-Force" Number="15" Volume="1991" Year="1992">
-      <Id>bad78d3d-2e07-449c-aff0-d06fa67d1422</Id>
+      <Database Name="cv" Series="4604" Issue="64587" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="291" Volume="1981" Year="1992">
-      <Id>c09cbe3a-893e-4c38-8802-b75796e0f38a</Id>
+      <Database Name="cv" Series="3092" Issue="36032" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="292" Volume="1981" Year="1992">
-      <Id>9b51c074-d90d-4846-a46d-30d3e6b94223</Id>
+      <Database Name="cv" Series="3092" Issue="36160" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="293" Volume="1981" Year="1992">
-      <Id>413fc650-b261-4d3d-900c-2450c236bf96</Id>
+      <Database Name="cv" Series="3092" Issue="36286" />
     </Book>
     <Book Series="Wolverine" Number="61" Volume="1988" Year="1992">
-      <Id>4a964c2d-b8dc-4574-af86-b83b402233cc</Id>
+      <Database Name="cv" Series="4250" Issue="36202" />
     </Book>
     <Book Series="Wolverine" Number="62" Volume="1988" Year="1992">
-      <Id>e4ac0624-835b-49c8-9240-a58ec8d21127</Id>
+      <Database Name="cv" Series="4250" Issue="36297" />
     </Book>
     <Book Series="Wolverine" Number="63" Volume="1988" Year="1992">
-      <Id>d720a3b0-6be5-434a-b577-d32c279cad67</Id>
+      <Database Name="cv" Series="4250" Issue="36417" />
     </Book>
     <Book Series="Wolverine" Number="64" Volume="1988" Year="1992">
-      <Id>bb4c02b9-4246-4dd5-bc24-c3cb37a47fd2</Id>
+      <Database Name="cv" Series="4250" Issue="36532" />
     </Book>
     <Book Series="Wolverine" Number="65" Volume="1988" Year="1993">
-      <Id>b54a6f25-c6de-4c09-8624-c68ca73a8fca</Id>
+      <Database Name="cv" Series="4250" Issue="36773" />
     </Book>
     <Book Series="X-Factor" Number="82" Volume="1986" Year="1992">
-      <Id>61744252-b2eb-4421-98e5-ca611004c9a3</Id>
+      <Database Name="cv" Series="3657" Issue="36163" />
     </Book>
     <Book Series="X-Factor" Number="83" Volume="1986" Year="1992">
-      <Id>26893b07-c9b4-4387-8ac1-f59e7d9a35ec</Id>
+      <Database Name="cv" Series="3657" Issue="36289" />
     </Book>
     <Book Series="X-Men" Number="12" Volume="1991" Year="1992">
-      <Id>e3cc89a2-bd01-49cf-a989-71f1c9e98c30</Id>
+      <Database Name="cv" Series="4605" Issue="36165" />
     </Book>
     <Book Series="X-Men" Number="13" Volume="1991" Year="1992">
-      <Id>b2f673bd-9aaf-4c35-b546-f18162382a1a</Id>
+      <Database Name="cv" Series="4605" Issue="36290" />
     </Book>
     <Book Series="Excalibur" Number="55" Volume="1988" Year="1992">
-      <Id>44b80cc0-d4eb-49c9-a9f3-609b2fb78248</Id>
+      <Database Name="cv" Series="4052" Issue="36272" />
     </Book>
     <Book Series="Excalibur" Number="56" Volume="1988" Year="1992">
-      <Id>4182896f-43e1-4c6a-810f-3070217d16ce</Id>
+      <Database Name="cv" Series="4052" Issue="36397" />
     </Book>
     <Book Series="Excalibur" Number="57" Volume="1988" Year="1992">
-      <Id>0eab5923-534b-4815-9167-faf61088c40a</Id>
+      <Database Name="cv" Series="4052" Issue="36447" />
     </Book>
     <Book Series="Excalibur" Number="58" Volume="1988" Year="1992">
-      <Id>8ad1aac3-2c79-4b1d-b4e7-d898cda02ba0</Id>
+      <Database Name="cv" Series="4052" Issue="36512" />
     </Book>
     <Book Series="Excalibur" Number="59" Volume="1988" Year="1992">
-      <Id>3040c66f-b424-4874-b435-05bdb2235b8e</Id>
+      <Database Name="cv" Series="4052" Issue="36557" />
     </Book>
     <Book Series="Excalibur" Number="60" Volume="1988" Year="1993">
-      <Id>4cf01a13-1e1f-4f21-a235-e6d52db6385b</Id>
+      <Database Name="cv" Series="4052" Issue="66356" />
     </Book>
     <Book Series="Wolverine: Inner Fury" Number="1" Volume="1992" Year="1992">
-      <Id>0b6f794f-b214-4efc-8abc-6dd23838f5ff</Id>
+      <Database Name="cv" Series="23052" Issue="138921" />
     </Book>
     <Book Series="Cable" Number="1" Volume="1992" Year="1992">
-      <Id>77336113-bdc9-4fb6-8aaf-7177ad9e9df0</Id>
+      <Database Name="cv" Series="4778" Issue="36296" />
     </Book>
     <Book Series="Cable" Number="2" Volume="1992" Year="1992">
-      <Id>205a7023-08b7-41e1-87ae-495e15226250</Id>
+      <Database Name="cv" Series="4778" Issue="36416" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="294" Volume="1981" Year="1992">
-      <Id>b1d89311-5272-4a4d-aefd-071f4eed15e3</Id>
+      <Database Name="cv" Series="3092" Issue="107063" />
     </Book>
     <Book Series="X-Factor" Number="84" Volume="1986" Year="1992">
-      <Id>e64546d6-31fd-424c-8df6-b07aa7b24012</Id>
+      <Database Name="cv" Series="3657" Issue="107134" />
     </Book>
     <Book Series="X-Men" Number="14" Volume="1991" Year="1992">
-      <Id>03c06442-3461-46e8-a44e-6604fb306187</Id>
+      <Database Name="cv" Series="4605" Issue="106566" />
     </Book>
     <Book Series="X-Force" Number="16" Volume="1991" Year="1992">
-      <Id>34861708-243b-4c17-aa3b-2631a0b57262</Id>
+      <Database Name="cv" Series="4604" Issue="107129" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="295" Volume="1981" Year="1992">
-      <Id>ddff2a0d-8990-44f2-9258-9c169a96fd07</Id>
+      <Database Name="cv" Series="3092" Issue="107067" />
     </Book>
     <Book Series="X-Factor" Number="85" Volume="1986" Year="1992">
-      <Id>229ecbfa-64f1-4618-979b-68b0979c991c</Id>
+      <Database Name="cv" Series="3657" Issue="107135" />
     </Book>
     <Book Series="X-Men" Number="15" Volume="1991" Year="1992">
-      <Id>1bb9d4b7-31f5-41b3-a4b2-103d9ed1efa1</Id>
+      <Database Name="cv" Series="4605" Issue="106567" />
     </Book>
     <Book Series="X-Force" Number="17" Volume="1991" Year="1992">
-      <Id>627137ca-4be4-4412-82d5-ba8ec43d9c91</Id>
+      <Database Name="cv" Series="4604" Issue="107130" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="296" Volume="1981" Year="1993">
-      <Id>1f71ab86-fe31-4a68-bafb-b6a36c32781f</Id>
+      <Database Name="cv" Series="3092" Issue="107087" />
     </Book>
     <Book Series="X-Factor" Number="86" Volume="1986" Year="1993">
-      <Id>00b13639-8f33-4ea8-a446-88a2217fa0fc</Id>
+      <Database Name="cv" Series="3657" Issue="107136" />
     </Book>
     <Book Series="X-Men" Number="16" Volume="1991" Year="1993">
-      <Id>1f148072-aac2-4370-a980-e5e2ba1cf200</Id>
+      <Database Name="cv" Series="4605" Issue="106568" />
     </Book>
     <Book Series="X-Force" Number="18" Volume="1991" Year="1993">
-      <Id>c5c67a72-56ee-441e-97a5-144de71a327f</Id>
+      <Database Name="cv" Series="4604" Issue="107133" />
     </Book>
     <Book Series="Stryfe's Strike File" Number="1" Volume="1993" Year="1993">
-      <Id>ed3889d7-e5ab-43ef-9713-5a73d5c93c5f</Id>
+      <Database Name="cv" Series="18149" Issue="106316" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="297" Volume="1981" Year="1993">
-      <Id>bfef0c67-cdf0-4644-8182-ee07cce2e755</Id>
+      <Database Name="cv" Series="3092" Issue="107105" />
     </Book>
     <Book Series="X-Factor" Number="87" Volume="1986" Year="1993">
-      <Id>a9ce13dc-386a-40a4-a92e-47d0eba4f7a2</Id>
+      <Database Name="cv" Series="3657" Issue="36873" />
     </Book>
     <Book Series="Wolverine" Number="66" Volume="1988" Year="1993">
-      <Id>40276c1a-9532-46cc-a396-7f9b97c4ce31</Id>
+      <Database Name="cv" Series="4250" Issue="36881" />
     </Book>
     <Book Series="Wolverine" Number="67" Volume="1988" Year="1993">
-      <Id>20ac1989-0faf-4834-8d3f-787c314e541a</Id>
+      <Database Name="cv" Series="4250" Issue="36996" />
     </Book>
     <Book Series="Wolverine" Number="68" Volume="1988" Year="1993">
-      <Id>d868dda3-f42e-46ae-b7e6-d19c8d61b264</Id>
+      <Database Name="cv" Series="4250" Issue="37118" />
     </Book>
     <Book Series="X-Men" Number="17" Volume="1991" Year="1993">
-      <Id>5a18728f-e713-44fb-9246-3f9d84e97dcd</Id>
+      <Database Name="cv" Series="4605" Issue="36875" />
     </Book>
     <Book Series="X-Men" Number="18" Volume="1991" Year="1993">
-      <Id>a399e595-37d7-442b-a607-afa720bf8f86</Id>
+      <Database Name="cv" Series="4605" Issue="36988" />
     </Book>
     <Book Series="X-Men" Number="19" Volume="1991" Year="1993">
-      <Id>fad551c1-5818-4975-b454-93e64372d3cf</Id>
+      <Database Name="cv" Series="4605" Issue="37107" />
     </Book>
     <Book Series="X-Factor" Number="88" Volume="1986" Year="1993">
-      <Id>665f2272-affc-4d6f-b523-de0816053edb</Id>
+      <Database Name="cv" Series="3657" Issue="36986" />
     </Book>
     <Book Series="X-Force" Number="19" Volume="1991" Year="1993">
-      <Id>e251ccc4-1389-49bb-ac97-37a959a1bacf</Id>
+      <Database Name="cv" Series="4604" Issue="36874" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="298" Volume="1981" Year="1993">
-      <Id>2f283a53-1324-457f-b0f7-d88dd3176754</Id>
+      <Database Name="cv" Series="3092" Issue="36983" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="299" Volume="1981" Year="1993">
-      <Id>375979fd-6bac-47c6-93e6-b853315c7b4f</Id>
+      <Database Name="cv" Series="3092" Issue="37102" />
     </Book>
     <Book Series="X-Factor" Number="89" Volume="1986" Year="1993">
-      <Id>3b49882b-d9dc-40cc-9bcc-de3ec6f1da17</Id>
+      <Database Name="cv" Series="3657" Issue="37105" />
     </Book>
     <Book Series="X-Factor" Number="90" Volume="1986" Year="1993">
-      <Id>7c75b35d-44a3-43f2-8edf-cc8041d6da30</Id>
+      <Database Name="cv" Series="3657" Issue="107196" />
     </Book>
     <Book Series="X-Factor" Number="91" Volume="1986" Year="1993">
-      <Id>19a4008c-0ebb-4f21-a100-c6abdd4e54e1</Id>
+      <Database Name="cv" Series="3657" Issue="37380" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="300" Volume="1981" Year="1993">
-      <Id>3c036d3e-ac07-4363-869e-ace467fe12d6</Id>
+      <Database Name="cv" Series="3092" Issue="37240" />
     </Book>
     <Book Series="X-Force" Number="20" Volume="1991" Year="1993">
-      <Id>4e949605-4e59-4b0e-8379-cd9575f70da1</Id>
+      <Database Name="cv" Series="4604" Issue="36987" />
     </Book>
     <Book Series="X-Force" Number="21" Volume="1991" Year="1993">
-      <Id>e67679e5-a91b-4395-b777-aa0fe10655c3</Id>
+      <Database Name="cv" Series="4604" Issue="37106" />
     </Book>
     <Book Series="X-Force" Number="22" Volume="1991" Year="1993">
-      <Id>4a84d01a-b552-4f69-838d-d4ee81a71c9a</Id>
+      <Database Name="cv" Series="4604" Issue="64499" />
     </Book>
     <Book Series="X-Force" Number="23" Volume="1991" Year="1993">
-      <Id>d8d52215-de0d-40d5-9b61-5d1668af68d6</Id>
+      <Database Name="cv" Series="4604" Issue="64500" />
     </Book>
     <Book Series="Wolverine" Number="69" Volume="1988" Year="1993">
-      <Id>ae058a1d-ab65-4ef3-a4bf-609b914fd559</Id>
+      <Database Name="cv" Series="4250" Issue="37260" />
     </Book>
     <Book Series="Wolverine" Number="70" Volume="1988" Year="1993">
-      <Id>9b25976a-2b7b-446c-b301-e12f019558e8</Id>
+      <Database Name="cv" Series="4250" Issue="37403" />
     </Book>
     <Book Series="Wolverine" Number="71" Volume="1988" Year="1993">
-      <Id>540ac15f-2a5b-4838-be52-44eaa60df80a</Id>
+      <Database Name="cv" Series="4250" Issue="37553" />
     </Book>
     <Book Series="X-Men: Odd Men Out" Number="1" Volume="2008" Year="2008">
-      <Id>23019dca-88a8-4f0d-88ff-0da4f9dd5a28</Id>
+      <Database Name="cv" Series="22414" Issue="134653" />
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="17" Volume="1982" Year="1993">
-      <Id>0d56b548-f065-4fa9-b94c-cda7ecf58dc3</Id>
+    <Book Series="The Uncanny X-Men Annual" Number="17" Volume="1992" Year="1993">
+      <Database Name="cv" Series="10757" Issue="91314" />
     </Book>
     <Book Series="X-Factor Annual" Number="8" Volume="1986" Year="1993">
-      <Id>2431c71a-3813-4b18-885f-389119a4f569</Id>
+      <Database Name="cv" Series="3658" Issue="66339" />
     </Book>
     <Book Series="X-Men Unlimited" Number="1" Volume="1993" Year="1993">
-      <Id>450e2b59-fd07-4458-aec6-13e61ca4fa76</Id>
+      <Database Name="cv" Series="5066" Issue="37382" />
     </Book>
     <Book Series="Excalibur" Number="61" Volume="1988" Year="1993">
-      <Id>68ce5272-995a-41e7-9bf3-81d2bd28a978</Id>
+      <Database Name="cv" Series="4052" Issue="36754" />
     </Book>
     <Book Series="Excalibur" Number="62" Volume="1988" Year="1993">
-      <Id>00a752f6-e29d-4236-a598-053585f0f51b</Id>
+      <Database Name="cv" Series="4052" Issue="36859" />
     </Book>
     <Book Series="Excalibur" Number="63" Volume="1988" Year="1993">
-      <Id>356c0dc4-ba0e-439d-81ce-8310ffe4975a</Id>
+      <Database Name="cv" Series="4052" Issue="36970" />
     </Book>
     <Book Series="Excalibur" Number="64" Volume="1988" Year="1993">
-      <Id>4cc728b4-0df4-469d-8649-e184a1699137</Id>
+      <Database Name="cv" Series="4052" Issue="37089" />
     </Book>
     <Book Series="Excalibur" Number="65" Volume="1988" Year="1993">
-      <Id>4161d56b-6e06-4b43-8d91-f8f93ac8ad46</Id>
+      <Database Name="cv" Series="4052" Issue="37225" />
     </Book>
     <Book Series="Cable" Number="1" Volume="1993" Year="1993">
-      <Id>0d29fe32-effe-460d-b6de-bbf61b28194e</Id>
+      <Database Name="cv" Series="4993" Issue="37254" />
     </Book>
     <Book Series="Cable" Number="2" Volume="1993" Year="1993">
-      <Id>81db4399-a74b-455c-a6df-57647f0b24c4</Id>
+      <Database Name="cv" Series="4993" Issue="37392" />
     </Book>
     <Book Series="Cable" Number="3" Volume="1993" Year="1993">
-      <Id>74d2d414-b7e0-48cb-80a6-c030d96239ed</Id>
+      <Database Name="cv" Series="4993" Issue="37547" />
     </Book>
     <Book Series="Cable" Number="4" Volume="1993" Year="1993">
-      <Id>9880deb5-55be-40d2-9d89-df8dfa60ab41</Id>
+      <Database Name="cv" Series="4993" Issue="37684" />
     </Book>
     <Book Series="X-Men" Number="20" Volume="1991" Year="1993">
-      <Id>22d8c555-3cd7-4b4d-89b9-89c46df1e1f0</Id>
+      <Database Name="cv" Series="4605" Issue="37243" />
     </Book>
     <Book Series="X-Men" Number="21" Volume="1991" Year="1993">
-      <Id>af8abe75-3043-466d-9d1e-6bcc91f2b35c</Id>
+      <Database Name="cv" Series="4605" Issue="37381" />
     </Book>
     <Book Series="X-Men" Number="22" Volume="1991" Year="1993">
-      <Id>d5369f48-5ffe-442f-b159-3b4eea4f2dcb</Id>
+      <Database Name="cv" Series="4605" Issue="37533" />
     </Book>
     <Book Series="X-Men" Number="23" Volume="1991" Year="1993">
-      <Id>03e48a27-cfdd-4b07-93dd-e6127fb75403</Id>
+      <Database Name="cv" Series="4605" Issue="37675" />
     </Book>
     <Book Series="Excalibur Annual" Number="1" Volume="1993" Year="1993">
-      <Id>4a953dcf-63f3-4996-89a6-8b56b6781359</Id>
+      <Database Name="cv" Series="9101" Issue="66561" />
     </Book>
     <Book Series="Excalibur" Number="66" Volume="1988" Year="1993">
-      <Id>9d5349cf-9c81-4e46-b082-6c538371755a</Id>
+      <Database Name="cv" Series="4052" Issue="37360" />
     </Book>
     <Book Series="Excalibur" Number="67" Volume="1988" Year="1993">
-      <Id>8d7efd8c-ecdf-4442-8279-e5d98c9e320f</Id>
+      <Database Name="cv" Series="4052" Issue="37514" />
     </Book>
     <Book Series="Excalibur" Number="68" Volume="1988" Year="1993">
-      <Id>50b070aa-149a-4c67-a243-c73baa7822dd</Id>
+      <Database Name="cv" Series="4052" Issue="66357" />
     </Book>
     <Book Series="Excalibur" Number="69" Volume="1988" Year="1993">
-      <Id>52ebce19-111f-4934-be8d-3ae1c1e2e06c</Id>
+      <Database Name="cv" Series="4052" Issue="66358" />
     </Book>
     <Book Series="Excalibur" Number="70" Volume="1988" Year="1993">
-      <Id>7308bd62-6aa6-4467-b041-68790ca6b70b</Id>
+      <Database Name="cv" Series="4052" Issue="66359" />
     </Book>
     <Book Series="X-Factor" Number="92" Volume="1986" Year="1993">
-      <Id>954fe5a7-75f8-4512-8912-5b32df3e6ec8</Id>
+      <Database Name="cv" Series="3657" Issue="37532" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="301" Volume="1981" Year="1993">
-      <Id>e958d62a-53af-4786-9f4a-a3ba08a0802b</Id>
+      <Database Name="cv" Series="3092" Issue="37402" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="302" Volume="1981" Year="1993">
-      <Id>0d1a85fe-6c4a-4a92-b37e-f89b2836e3f7</Id>
+      <Database Name="cv" Series="3092" Issue="37552" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="303" Volume="1981" Year="1993">
-      <Id>f40a030e-1a7e-4441-8419-faf7a1bbe90d</Id>
+      <Database Name="cv" Series="3092" Issue="37689" />
     </Book>
     <Book Series="Wolverine" Number="72" Volume="1988" Year="1993">
-      <Id>3546124c-d88f-4cbe-9992-1aad66d9bdf6</Id>
+      <Database Name="cv" Series="4250" Issue="37690" />
     </Book>
     <Book Series="Wolverine" Number="73" Volume="1988" Year="1993">
-      <Id>c55dce99-e567-4335-a55f-4cdb3047fddf</Id>
+      <Database Name="cv" Series="4250" Issue="37832" />
     </Book>
     <Book Series="Wolverine" Number="74" Volume="1988" Year="1993">
-      <Id>16c3c21e-4e0a-4357-aaf9-86266b3a1164</Id>
+      <Database Name="cv" Series="4250" Issue="37977" />
     </Book>
     <Book Series="X-Force" Number="24" Volume="1991" Year="1993">
-      <Id>81a758f7-211c-4f33-bacc-253ff793b7a2</Id>
+      <Database Name="cv" Series="4604" Issue="64501" />
     </Book>
     <Book Series="X-Force" Number="25" Volume="1991" Year="1993">
-      <Id>1128cd02-92b1-4179-aa35-b5b16c208580</Id>
+      <Database Name="cv" Series="4604" Issue="64502" />
     </Book>
     <Book Series="X-Factor" Number="93" Volume="1986" Year="1993">
-      <Id>821b7090-edb9-4f33-b1d2-8b04458d3bd3</Id>
+      <Database Name="cv" Series="3657" Issue="37674" />
     </Book>
     <Book Series="Wolverine: Killing" Number="1" Volume="1993" Year="1993">
-      <Id>af380844-0fd4-46ae-b383-4574ced30683</Id>
+      <Database Name="cv" Series="23051" Issue="138920" />
     </Book>
     <Book Series="X-Men" Number="24" Volume="1991" Year="1993">
-      <Id>4f8db239-327b-430d-bf76-119298cfa151</Id>
+      <Database Name="cv" Series="4605" Issue="37813" />
     </Book>
     <Book Series="X-Men Unlimited" Number="2" Volume="1993" Year="1993">
-      <Id>f6dc6ec1-9027-451e-bd0e-54a843748d8d</Id>
+      <Database Name="cv" Series="5066" Issue="37814" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="304" Volume="1981" Year="1993">
-      <Id>380db608-6f86-42b6-9de8-0afce606fe48</Id>
+      <Database Name="cv" Series="3092" Issue="37831" />
     </Book>
     <Book Series="X-Factor" Number="94" Volume="1986" Year="1993">
-      <Id>79ef027f-aeae-43c6-8ce6-c56bba0cc666</Id>
+      <Database Name="cv" Series="3657" Issue="63512" />
     </Book>
     <Book Series="X-Factor" Number="95" Volume="1986" Year="1993">
-      <Id>92d62862-81b5-4793-9da6-240a5cc811f3</Id>
+      <Database Name="cv" Series="3657" Issue="37961" />
     </Book>
     <Book Series="Wolverine: Doombringer" Number="1" Volume="1997" Year="1997">
-      <Id>23d90140-ffd7-4a91-8a13-4217980744aa</Id>
+      <Database Name="cv" Series="27149" Issue="164989" />
     </Book>
     <Book Series="X-Force" Number="26" Volume="1991" Year="1993">
-      <Id>0f3acf34-f252-4b09-8202-512dd37390ae</Id>
+      <Database Name="cv" Series="4604" Issue="64503" />
     </Book>
     <Book Series="Sabretooth" Number="1" Volume="1993" Year="1993">
-      <Id>be2dfd49-1927-4eb0-a7c6-5e3c48d2018d</Id>
+      <Database Name="cv" Series="5041" Issue="37685" />
     </Book>
     <Book Series="Sabretooth" Number="2" Volume="1993" Year="1993">
-      <Id>2e949967-f4da-4084-9091-6662c4a05592</Id>
+      <Database Name="cv" Series="5041" Issue="37827" />
     </Book>
     <Book Series="Sabretooth" Number="3" Volume="1993" Year="1993">
-      <Id>668fbe62-c74b-45a2-a719-0b74610df779</Id>
+      <Database Name="cv" Series="5041" Issue="106319" />
     </Book>
     <Book Series="Sabretooth" Number="4" Volume="1993" Year="1993">
-      <Id>bf168d2d-8989-4fdf-a1dc-b1fc3d8ed0a3</Id>
+      <Database Name="cv" Series="5041" Issue="38283" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="305" Volume="1981" Year="1993">
-      <Id>8228acdd-3107-47df-8d6f-ee0004cf47df</Id>
+      <Database Name="cv" Series="3092" Issue="37976" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="306" Volume="1981" Year="1993">
-      <Id>b896942b-bd4a-43ed-a889-58e6dcfc584c</Id>
+      <Database Name="cv" Series="3092" Issue="38133" />
     </Book>
     <Book Series="Gambit" Number="1" Volume="1993" Year="1993">
-      <Id>3699b3e2-8e3e-48a2-911d-da0fda7432a9</Id>
+      <Database Name="cv" Series="5011" Issue="94616" />
     </Book>
     <Book Series="Gambit" Number="2" Volume="1993" Year="1994">
-      <Id>e9d592b8-4f30-4871-8f5b-2de2b2f80e4e</Id>
+      <Database Name="cv" Series="5011" Issue="94617" />
     </Book>
     <Book Series="Gambit" Number="3" Volume="1993" Year="1994">
-      <Id>73c37fa3-9a3e-4e1e-a62a-83b1cb1e6a8f</Id>
+      <Database Name="cv" Series="5011" Issue="94618" />
     </Book>
     <Book Series="Gambit" Number="4" Volume="1993" Year="1994">
-      <Id>b7010b03-9421-431c-8de2-436f9e7d40ae</Id>
+      <Database Name="cv" Series="5011" Issue="94619" />
     </Book>
     <Book Series="Cable" Number="5" Volume="1993" Year="1993">
-      <Id>e3a5d09c-913f-4a45-b209-9fc651d21b11</Id>
+      <Database Name="cv" Series="4993" Issue="106737" />
     </Book>
     <Book Series="X-Men" Number="25" Volume="1991" Year="1993">
-      <Id>768c6728-f5e6-4635-955c-af8621c1f7fa</Id>
+      <Database Name="cv" Series="4605" Issue="65726" />
     </Book>
     <Book Series="Wolverine" Number="75" Volume="1988" Year="1993">
-      <Id>95b7501d-b382-494d-86ff-4e756139052a</Id>
+      <Database Name="cv" Series="4250" Issue="38134" />
     </Book>
     <Book Series="Excalibur" Number="71" Volume="1988" Year="1993">
-      <Id>4355283a-08f0-4b57-8a61-9b6f53917715</Id>
+      <Database Name="cv" Series="4052" Issue="66360" />
     </Book>
     <Book Series="X-Force Annual" Number="2" Volume="1992" Year="1993">
-      <Id>4fbcb03c-a223-40d5-b7c0-e592b940b9b3</Id>
+      <Database Name="cv" Series="4822" Issue="64589" />
     </Book>
     <Book Series="X-Men Annual" Number="2" Volume="1992" Year="1993">
-      <Id>9a8e7207-9011-4dd2-aaa1-b923027c1dc3</Id>
+      <Database Name="cv" Series="10748" Issue="90585" />
     </Book>
     <Book Series="Wolverine" Number="76" Volume="1988" Year="1993">
-      <Id>f5d56487-4eaf-4206-849a-896d4b9c27d4</Id>
+      <Database Name="cv" Series="4250" Issue="38292" />
     </Book>
     <Book Series="Wolverine" Number="77" Volume="1988" Year="1994">
-      <Id>95456fa1-e8a7-43ab-b57e-dcdf0fcfa358</Id>
+      <Database Name="cv" Series="4250" Issue="38547" />
     </Book>
     <Book Series="Spider-Man and X-Factor: Shadowgames" Number="1" Volume="1994" Year="1994">
-      <Id>f0233bba-1964-40cc-8930-1fed2327c4b1</Id>
+      <Database Name="cv" Series="5330" Issue="57132" />
     </Book>
     <Book Series="Spider-Man and X-Factor: Shadowgames" Number="2" Volume="1994" Year="1994">
-      <Id>940ea147-f6f9-428b-85e5-0d437ac218ff</Id>
+      <Database Name="cv" Series="5330" Issue="57133" />
     </Book>
     <Book Series="Spider-Man and X-Factor: Shadowgames" Number="3" Volume="1994" Year="1994">
-      <Id>2c5ca89e-8aea-4787-89f0-f0674b1d7450</Id>
+      <Database Name="cv" Series="5330" Issue="57134" />
     </Book>
     <Book Series="Excalibur" Number="72" Volume="1988" Year="1993">
-      <Id>16efbbd9-692e-44a5-a31e-c96955e1cd20</Id>
+      <Database Name="cv" Series="4052" Issue="66361" />
     </Book>
     <Book Series="Excalibur" Number="73" Volume="1988" Year="1994">
-      <Id>61949c90-0a90-4079-957c-540f1ed65125</Id>
+      <Database Name="cv" Series="4052" Issue="66362" />
     </Book>
     <Book Series="The Avengers" Number="368" Volume="1963" Year="1993">
-      <Id>f37e0fac-85e5-4de4-b53b-477b82b93b73</Id>
+      <Database Name="cv" Series="2128" Issue="38090" />
     </Book>
     <Book Series="X-Men" Number="26" Volume="1991" Year="1993">
-      <Id>6ee384d0-2229-469a-bd13-6d78114f2642</Id>
+      <Database Name="cv" Series="4605" Issue="65727" />
     </Book>
     <Book Series="Avengers West Coast" Number="101" Volume="1989" Year="1993">
-      <Id>c3e23c28-cb4c-437b-9b63-04afb286b3b6</Id>
+      <Database Name="cv" Series="18494" Issue="114163" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="307" Volume="1981" Year="1993">
-      <Id>0a30017b-d835-4a7b-8dbc-2fc028df2463</Id>
+      <Database Name="cv" Series="3092" Issue="38290" />
     </Book>
     <Book Series="The Avengers" Number="369" Volume="1963" Year="1993">
-      <Id>9f5ed110-da2c-4167-8bc6-abb5e0a9feee</Id>
+      <Database Name="cv" Series="2128" Issue="38246" />
     </Book>
     <Book Series="X-Factor" Number="96" Volume="1986" Year="1993">
-      <Id>3bb90e32-3272-4bb7-85d3-ec08cec275e1</Id>
+      <Database Name="cv" Series="3657" Issue="38111" />
     </Book>
     <Book Series="X-Factor" Number="97" Volume="1986" Year="1993">
-      <Id>cf389442-4e7b-47a6-8f94-00e99bd3a148</Id>
+      <Database Name="cv" Series="3657" Issue="38269" />
     </Book>
     <Book Series="X-Factor" Number="98" Volume="1986" Year="1994">
-      <Id>d426fc40-bfc9-4b5c-8854-eb3c1889ab32</Id>
+      <Database Name="cv" Series="3657" Issue="38518" />
     </Book>
     <Book Series="X-Factor" Number="99" Volume="1986" Year="1994">
-      <Id>802ea250-2d19-4657-bdc5-be58a5118260</Id>
+      <Database Name="cv" Series="3657" Issue="38666" />
     </Book>
     <Book Series="X-Factor" Number="100" Volume="1986" Year="1994">
-      <Id>080b08f8-dec1-4fc2-b396-ef9af292a2cc</Id>
+      <Database Name="cv" Series="3657" Issue="38811" />
     </Book>
     <Book Series="X-Force" Number="27" Volume="1991" Year="1993">
-      <Id>f79acfc8-80b4-4859-91f2-945249921c0c</Id>
+      <Database Name="cv" Series="4604" Issue="64504" />
     </Book>
     <Book Series="X-Force" Number="28" Volume="1991" Year="1993">
-      <Id>1edd5529-0749-4a83-8292-9f8660be525b</Id>
+      <Database Name="cv" Series="4604" Issue="64505" />
     </Book>
     <Book Series="X-Men" Number="27" Volume="1991" Year="1993">
-      <Id>826bb020-83c4-49da-a036-900348711674</Id>
+      <Database Name="cv" Series="4605" Issue="65728" />
     </Book>
     <Book Series="X-Men Unlimited" Number="3" Volume="1993" Year="1993">
-      <Id>500a01a7-faa9-448e-a633-fe7aa2fb2904</Id>
+      <Database Name="cv" Series="5066" Issue="38270" />
     </Book>
     <Book Series="X-Force" Number="29" Volume="1991" Year="1993">
-      <Id>3db3e50b-0d5d-435b-8b69-f528846491cc</Id>
+      <Database Name="cv" Series="4604" Issue="64506" />
     </Book>
     <Book Series="X-Force" Number="30" Volume="1991" Year="1994">
-      <Id>73ed4c81-be28-4a62-a791-061d67fc7a37</Id>
+      <Database Name="cv" Series="4604" Issue="64507" />
     </Book>
     <Book Series="Cable" Number="6" Volume="1993" Year="1993">
-      <Id>ed30bf57-66d9-4b05-8a2e-45b7255bad4a</Id>
+      <Database Name="cv" Series="4993" Issue="38280" />
     </Book>
     <Book Series="Cable" Number="7" Volume="1993" Year="1994">
-      <Id>21535f16-99b3-4d1d-b255-011819f95ed7</Id>
+      <Database Name="cv" Series="4993" Issue="38536" />
     </Book>
     <Book Series="Cable" Number="8" Volume="1993" Year="1994">
-      <Id>9b16ab12-c9f3-48b2-9848-34ead51662e1</Id>
+      <Database Name="cv" Series="4993" Issue="38676" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="308" Volume="1981" Year="1994">
-      <Id>31b4d523-d0cb-4683-a71e-f5ea00802f03</Id>
+      <Database Name="cv" Series="3092" Issue="38545" />
     </Book>
     <Book Series="X-Men" Number="28" Volume="1991" Year="1994">
-      <Id>06d4e34d-95a1-4291-8b39-d2fa81b801ff</Id>
+      <Database Name="cv" Series="4605" Issue="65729" />
     </Book>
     <Book Series="X-Force" Number="31" Volume="1991" Year="1994">
-      <Id>86587a5f-1c16-4c88-bef0-8fa203282f71</Id>
+      <Database Name="cv" Series="4604" Issue="64508" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="309" Volume="1981" Year="1994">
-      <Id>0f970e11-51d7-4419-bf56-e8b472e4e953</Id>
+      <Database Name="cv" Series="3092" Issue="38683" />
     </Book>
     <Book Series="Wolverine" Number="78" Volume="1988" Year="1994">
-      <Id>0fb21942-94fe-44e6-a88b-79745f5bf422</Id>
+      <Database Name="cv" Series="4250" Issue="38685" />
     </Book>
     <Book Series="X-Men" Number="29" Volume="1991" Year="1994">
-      <Id>54a297b2-6125-40d2-b981-003c3491f1a6</Id>
+      <Database Name="cv" Series="4605" Issue="65730" />
     </Book>
     <Book Series="X-Force" Number="32" Volume="1991" Year="1994">
-      <Id>14a74ff2-bcf8-487a-b23b-179814ec5551</Id>
+      <Database Name="cv" Series="4604" Issue="107190" />
     </Book>
     <Book Series="The New Warriors" Number="45" Volume="1990" Year="1994">
-      <Id>cd9b4f9a-bc5a-4925-bd46-e526e98c7689</Id>
+      <Database Name="cv" Series="4407" Issue="105463" />
     </Book>
     <Book Series="X-Force" Number="33" Volume="1991" Year="1994">
-      <Id>b76edf26-c325-433d-bd57-bcfc6e6eb943</Id>
+      <Database Name="cv" Series="4604" Issue="107191" />
     </Book>
     <Book Series="The New Warriors" Number="46" Volume="1990" Year="1994">
-      <Id>ea657ddc-6b4d-4f98-b165-d6e183498c12</Id>
+      <Database Name="cv" Series="4407" Issue="105464" />
     </Book>
     <Book Series="X-Force" Number="34" Volume="1991" Year="1994">
-      <Id>f4181c4c-409c-4421-a5db-5d88e722a3f9</Id>
+      <Database Name="cv" Series="4604" Issue="64509" />
     </Book>
     <Book Series="Cable" Number="9" Volume="1993" Year="1994">
-      <Id>49f7622a-d26e-4fa9-a94f-78b902164b8d</Id>
+      <Database Name="cv" Series="4993" Issue="38825" />
     </Book>
     <Book Series="Cable" Number="10" Volume="1993" Year="1994">
-      <Id>0e7f91d1-8f5b-4192-87b7-9e18cf8f9ab3</Id>
+      <Database Name="cv" Series="4993" Issue="38965" />
     </Book>
     <Book Series="Cable" Number="11" Volume="1993" Year="1994">
-      <Id>b50074e9-b1e7-43b0-82f3-e29c31783be2</Id>
+      <Database Name="cv" Series="4993" Issue="39105" />
     </Book>
     <Book Series="Excalibur" Number="74" Volume="1988" Year="1994">
-      <Id>7f611903-1bd3-44c9-9988-84f27d9bdf6e</Id>
+      <Database Name="cv" Series="4052" Issue="66363" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="310" Volume="1981" Year="1994">
-      <Id>d89fc131-1c34-437b-b1aa-814f2e04590b</Id>
+      <Database Name="cv" Series="3092" Issue="38833" />
     </Book>
     <Book Series="X-Men" Number="30" Volume="1991" Year="1994">
-      <Id>ff94d221-2afa-41b3-919b-207036765223</Id>
+      <Database Name="cv" Series="4605" Issue="65731" />
     </Book>
     <Book Series="Excalibur" Number="75" Volume="1988" Year="1994">
-      <Id>3000f65b-3303-4aeb-a7aa-60c5c3d273f1</Id>
+      <Database Name="cv" Series="4052" Issue="66364" />
     </Book>
     <Book Series="X-Factor" Number="101" Volume="1986" Year="1994">
-      <Id>28e758f6-c38f-43b6-93c1-5a276d741121</Id>
+      <Database Name="cv" Series="3657" Issue="65682" />
     </Book>
     <Book Series="X-Factor Annual" Number="9" Volume="1986" Year="1994">
-      <Id>2d4e269a-ff29-472d-84c1-546a2f2eb4be</Id>
+      <Database Name="cv" Series="3658" Issue="107563" />
     </Book>
     <Book Series="X-Factor" Number="102" Volume="1986" Year="1994">
-      <Id>658151e7-5c7f-4e02-ac06-ba849f46f0a0</Id>
+      <Database Name="cv" Series="3657" Issue="65683" />
     </Book>
     <Book Series="Wolverine" Number="79" Volume="1988" Year="1994">
-      <Id>6d7c1da4-c9cc-4d10-9ba9-97e70e7e3eeb</Id>
+      <Database Name="cv" Series="4250" Issue="38835" />
     </Book>
     <Book Series="Wolverine" Number="80" Volume="1988" Year="1994">
-      <Id>d660e24c-1956-4486-a25d-96045fafa076</Id>
+      <Database Name="cv" Series="4250" Issue="38973" />
     </Book>
     <Book Series="Wolverine" Number="81" Volume="1988" Year="1994">
-      <Id>537f3681-f88d-413d-a402-3288eabb910b</Id>
+      <Database Name="cv" Series="4250" Issue="39113" />
     </Book>
     <Book Series="X-Men" Number="31" Volume="1991" Year="1994">
-      <Id>8f10c4bb-2fe9-4a75-819b-f373e1aa60ed</Id>
+      <Database Name="cv" Series="4605" Issue="65732" />
     </Book>
     <Book Series="X-Men" Number="32" Volume="1991" Year="1994">
-      <Id>0f5bdd97-fff9-4756-85ec-f0142c2d9485</Id>
+      <Database Name="cv" Series="4605" Issue="65733" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="311" Volume="1981" Year="1994">
-      <Id>08471da1-a8e9-479d-b305-2d4b3008ed4b</Id>
+      <Database Name="cv" Series="3092" Issue="38972" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="312" Volume="1981" Year="1994">
-      <Id>3a388548-3585-49d4-a383-1fb03129c639</Id>
+      <Database Name="cv" Series="3092" Issue="39112" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="313" Volume="1981" Year="1994">
-      <Id>b8ff9cb5-db11-46ae-80aa-3369a21ccd6c</Id>
+      <Database Name="cv" Series="3092" Issue="39262" />
     </Book>
     <Book Series="Wolverine" Number="82" Volume="1988" Year="1994">
-      <Id>f85a8ec8-22cf-4df1-817c-55ded47fd75e</Id>
+      <Database Name="cv" Series="4250" Issue="39263" />
     </Book>
     <Book Series="X-Factor" Number="103" Volume="1986" Year="1994">
-      <Id>58140226-be47-4a2d-b0ca-83b9ca75e19c</Id>
+      <Database Name="cv" Series="3657" Issue="65684" />
     </Book>
     <Book Series="X-Factor" Number="104" Volume="1986" Year="1994">
-      <Id>1215f864-6ca5-4cc1-a31b-86dfedcdf4d5</Id>
+      <Database Name="cv" Series="3657" Issue="65685" />
     </Book>
     <Book Series="X-Factor" Number="105" Volume="1986" Year="1994">
-      <Id>71743b5f-7609-47ed-8a66-19cb8d8383b3</Id>
+      <Database Name="cv" Series="3657" Issue="65686" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="314" Volume="1981" Year="1994">
-      <Id>b62d721e-39e2-474f-a219-4933a805fa66</Id>
+      <Database Name="cv" Series="3092" Issue="39405" />
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="18" Volume="1982" Year="1994">
-      <Id>9e9d0be0-06f0-4eda-9a1d-f6470d88ca8e</Id>
+    <Book Series="The Uncanny X-Men Annual" Number="18" Volume="1992" Year="1994">
+      <Database Name="cv" Series="10757" Issue="91315" />
     </Book>
     <Book Series="X-Men Unlimited" Number="4" Volume="1993" Year="1994">
-      <Id>9835675b-e906-495e-bfc7-cbe59cec6857</Id>
+      <Database Name="cv" Series="5066" Issue="38812" />
     </Book>
     <Book Series="Excalibur" Number="76" Volume="1988" Year="1994">
-      <Id>f41ed8cb-3b01-41d9-ad9f-fda4aeb68c90</Id>
+      <Database Name="cv" Series="4052" Issue="66365" />
     </Book>
     <Book Series="Excalibur" Number="77" Volume="1988" Year="1994">
-      <Id>a66950e5-b292-4edf-9cc6-049047727f24</Id>
+      <Database Name="cv" Series="4052" Issue="66366" />
     </Book>
     <Book Series="X-Men Unlimited" Number="5" Volume="1993" Year="1994">
-      <Id>302d05eb-a450-452f-85b1-50d624d57499</Id>
+      <Database Name="cv" Series="5066" Issue="39236" />
     </Book>
     <Book Series="X-Men" Number="33" Volume="1991" Year="1994">
-      <Id>fc66d17a-cf6e-45b5-8b9a-3d91184e6ca0</Id>
+      <Database Name="cv" Series="4605" Issue="65734" />
     </Book>
     <Book Series="Cable" Number="12" Volume="1993" Year="1994">
-      <Id>2265af61-2435-4272-a54c-71d483a6c114</Id>
+      <Database Name="cv" Series="4993" Issue="39266" />
     </Book>
     <Book Series="Cable" Number="13" Volume="1993" Year="1994">
-      <Id>fea1f82c-95d0-4515-99e7-6d8fd5ec46fb</Id>
+      <Database Name="cv" Series="4993" Issue="39409" />
     </Book>
     <Book Series="Cable" Number="14" Volume="1993" Year="1994">
-      <Id>98f6fb76-09a6-4e0a-bc47-222eecc73fa0</Id>
+      <Database Name="cv" Series="4993" Issue="39538" />
     </Book>
     <Book Series="Excalibur" Number="78" Volume="1988" Year="1994">
-      <Id>c817bbbe-2b4c-4d4a-a271-14baefdecdf7</Id>
+      <Database Name="cv" Series="4052" Issue="66367" />
     </Book>
     <Book Series="Excalibur" Number="79" Volume="1988" Year="1994">
-      <Id>35bc67d7-9e99-4c2b-a5dd-de3dc1ce548a</Id>
+      <Database Name="cv" Series="4052" Issue="66368" />
     </Book>
     <Book Series="Excalibur" Number="80" Volume="1988" Year="1994">
-      <Id>e77b3a63-c9b7-41a5-b846-5744a024851a</Id>
+      <Database Name="cv" Series="4052" Issue="66369" />
     </Book>
     <Book Series="X-Men" Number="34" Volume="1991" Year="1994">
-      <Id>5bd64103-274a-47bf-a633-abcf1b082e0a</Id>
+      <Database Name="cv" Series="4605" Issue="65735" />
     </Book>
     <Book Series="X-Force" Number="35" Volume="1991" Year="1994">
-      <Id>c48cbbd1-1b5f-4c22-bf9d-ae7f353c6de8</Id>
+      <Database Name="cv" Series="4604" Issue="107194" />
     </Book>
     <Book Series="X-Force" Number="36" Volume="1991" Year="1994">
-      <Id>2702fded-563f-4fc4-9c73-13499699b9e3</Id>
+      <Database Name="cv" Series="4604" Issue="64510" />
     </Book>
     <Book Series="X-Force" Number="37" Volume="1991" Year="1994">
-      <Id>d3f1b325-95fc-49f8-b6b4-4c438d9a8231</Id>
+      <Database Name="cv" Series="4604" Issue="64511" />
     </Book>
     <Book Series="Wolverine" Number="83" Volume="1988" Year="1994">
-      <Id>62036cff-4cf9-4e79-8821-8f15ab7a3802</Id>
+      <Database Name="cv" Series="4250" Issue="39406" />
     </Book>
     <Book Series="Wolverine" Number="84" Volume="1988" Year="1994">
-      <Id>93e54506-6411-4d0a-ba93-601e27367fed</Id>
+      <Database Name="cv" Series="4250" Issue="39549" />
     </Book>
     <Book Series="Excalibur" Number="81" Volume="1988" Year="1994">
-      <Id>e9ab945a-93b6-4862-8226-8cb0d20990a0</Id>
+      <Database Name="cv" Series="4052" Issue="66370" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="315" Volume="1981" Year="1994">
-      <Id>ec57ce13-abeb-4914-8301-04005a7db878</Id>
+      <Database Name="cv" Series="3092" Issue="39547" />
     </Book>
     <Book Series="Excalibur Annual" Number="2" Volume="1993" Year="1994">
-      <Id>74f69422-7919-43bf-8d4e-878dd6a5e435</Id>
+      <Database Name="cv" Series="9101" Issue="66562" />
     </Book>
     <Book Series="Cable" Number="15" Volume="1993" Year="1994">
-      <Id>5033b82d-7352-433c-b4b0-251405f4ca34</Id>
+      <Database Name="cv" Series="4993" Issue="39674" />
     </Book>
-    <Book Series="Adventures of Cyclops and Phoenix" Number="1" Volume="1994" Year="1994">
-      <Id>d5d9b025-5a72-4079-b0c8-ea76209908b6</Id>
+    <Book Series="The Adventures of Cyclops and Phoenix" Number="1" Volume="1994" Year="1994">
+      <Database Name="cv" Series="5272" Issue="39115" />
     </Book>
-    <Book Series="Adventures of Cyclops and Phoenix" Number="2" Volume="1994" Year="1994">
-      <Id>82239610-f1f1-4df5-8ca4-293fe0cbafb3</Id>
+    <Book Series="The Adventures of Cyclops and Phoenix" Number="2" Volume="1994" Year="1994">
+      <Database Name="cv" Series="5272" Issue="39265" />
     </Book>
-    <Book Series="Adventures of Cyclops and Phoenix" Number="3" Volume="1994" Year="1994">
-      <Id>e2923942-6dc5-48ec-8acc-69192c7de2b2</Id>
+    <Book Series="The Adventures of Cyclops and Phoenix" Number="3" Volume="1994" Year="1994">
+      <Database Name="cv" Series="5272" Issue="39408" />
     </Book>
-    <Book Series="Adventures of Cyclops and Phoenix" Number="4" Volume="1994" Year="1994">
-      <Id>f5c2d118-395c-4dd1-9ac4-aae7859965e4</Id>
+    <Book Series="The Adventures of Cyclops and Phoenix" Number="4" Volume="1994" Year="1994">
+      <Database Name="cv" Series="5272" Issue="39551" />
     </Book>
     <Book Series="X-Men" Number="35" Volume="1991" Year="1994">
-      <Id>a2e9613f-4995-4f24-b882-acac72209fb5</Id>
+      <Database Name="cv" Series="4605" Issue="65736" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="316" Volume="1981" Year="1994">
-      <Id>08acde4b-68fa-4741-9e64-e1ef4c49faa3</Id>
+      <Database Name="cv" Series="3092" Issue="39680" />
     </Book>
     <Book Series="X-Men" Number="36" Volume="1991" Year="1994">
-      <Id>2b488b6a-3dc7-4a86-9169-312821038dee</Id>
+      <Database Name="cv" Series="4605" Issue="65737" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="317" Volume="1981" Year="1994">
-      <Id>0b18e7a6-582f-4190-befc-fa96fab434b5</Id>
+      <Database Name="cv" Series="3092" Issue="39830" />
     </Book>
     <Book Series="X-Men" Number="37" Volume="1991" Year="1994">
-      <Id>4088d591-aca4-470e-a1eb-4acf97416cb5</Id>
+      <Database Name="cv" Series="4605" Issue="65738" />
     </Book>
     <Book Series="X-Factor" Number="106" Volume="1986" Year="1994">
-      <Id>68f8ffee-dd57-40cb-b4f2-dc9a80883c15</Id>
+      <Database Name="cv" Series="3657" Issue="65687" />
     </Book>
     <Book Series="X-Force" Number="38" Volume="1991" Year="1994">
-      <Id>d03bf295-c4c4-4c66-b0b0-ae777e3c20bd</Id>
+      <Database Name="cv" Series="4604" Issue="64512" />
     </Book>
     <Book Series="Excalibur" Number="82" Volume="1988" Year="1994">
-      <Id>48c92a46-c41e-4477-9da7-eff4124b281a</Id>
+      <Database Name="cv" Series="4052" Issue="39791" />
     </Book>
     <Book Series="Wolverine" Number="85" Volume="1988" Year="1994">
-      <Id>e8a8ab3d-5a29-484f-833c-6cba496c2c09</Id>
+      <Database Name="cv" Series="4250" Issue="39683" />
     </Book>
     <Book Series="Cable" Number="16" Volume="1993" Year="1994">
-      <Id>a859acd2-dc93-4bce-b6f8-ee489446d198</Id>
+      <Database Name="cv" Series="4993" Issue="39824" />
     </Book>
     <Book Series="Wolverine" Number="86" Volume="1988" Year="1994">
-      <Id>b64d3a50-8aa2-490b-a112-651fc6a009eb</Id>
+      <Database Name="cv" Series="4250" Issue="39833" />
     </Book>
     <Book Series="Wolverine" Number="87" Volume="1988" Year="1994">
-      <Id>fa00fd7d-1875-442f-8d8b-cbea35cae322</Id>
+      <Database Name="cv" Series="4250" Issue="39977" />
     </Book>
     <Book Series="X-Force" Number="39" Volume="1991" Year="1994">
-      <Id>010fc8b4-67e0-45ce-9733-12e18556b6c3</Id>
+      <Database Name="cv" Series="4604" Issue="64513" />
     </Book>
     <Book Series="X-Force Annual" Number="3" Volume="1992" Year="1994">
-      <Id>525b6a5e-9a8f-4f2d-b60d-8d28321ed771</Id>
+      <Database Name="cv" Series="4822" Issue="64590" />
     </Book>
     <Book Series="X-Men Annual" Number="3" Volume="1992" Year="1994">
-      <Id>193e84b5-99bc-42ec-9639-72735e8054d9</Id>
+      <Database Name="cv" Series="10748" Issue="90586" />
     </Book>
     <Book Series="X-Men Unlimited" Number="6" Volume="1993" Year="1994">
-      <Id>f5aaaa2a-24ef-49e8-beb8-941a3541bcc3</Id>
+      <Database Name="cv" Series="5066" Issue="39657" />
     </Book>
     <Book Series="Excalibur" Number="83" Volume="1988" Year="1994">
-      <Id>87bd4b41-fe99-4864-8d44-5b50c6fe57a4</Id>
+      <Database Name="cv" Series="4052" Issue="39934" />
     </Book>
     <Book Series="Excalibur" Number="84" Volume="1988" Year="1994">
-      <Id>3c3c6cbe-d691-4850-ab6d-0c80a9797e77</Id>
+      <Database Name="cv" Series="4052" Issue="40076" />
     </Book>
     <Book Series="Excalibur" Number="85" Volume="1988" Year="1995">
-      <Id>6c3d84fd-f777-4b5b-b13f-84e677c0ff14</Id>
+      <Database Name="cv" Series="4052" Issue="40317" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 004 (Blue - Gold).cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 004 (Blue - Gold).cbl
@@ -2,919 +2,919 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>X-Men - Part 4 (Blue &amp; Gold)</Name>
   <Books>
-    <Book Series="X-Force" Number="1" Volume="1991" Year="1991" Format="Main Series">
+    <Book Series="X-Force" Number="1" Volume="1991" Year="1991">
       <Id>2fea3f60-b356-4df8-904c-249fd5142675</Id>
     </Book>
-    <Book Series="X-Factor" Number="71" Volume="1986" Year="1991" Format="Main Series">
+    <Book Series="X-Factor" Number="71" Volume="1986" Year="1991">
       <Id>2d4fa258-1e00-4531-9d1f-81a4996128b6</Id>
     </Book>
-    <Book Series="X-Factor" Number="72" Volume="1986" Year="1991" Format="Main Series">
+    <Book Series="X-Factor" Number="72" Volume="1986" Year="1991">
       <Id>01130b8a-e426-4b01-a7b4-d3ea344b8c62</Id>
     </Book>
-    <Book Series="X-Factor" Number="73" Volume="1986" Year="1991" Format="Main Series">
+    <Book Series="X-Factor" Number="73" Volume="1986" Year="1991">
       <Id>3dcb965a-78f2-4c2a-83af-1d771430fe43</Id>
     </Book>
-    <Book Series="X-Factor" Number="74" Volume="1986" Year="1992" Format="Main Series">
+    <Book Series="X-Factor" Number="74" Volume="1986" Year="1992">
       <Id>7999ae32-5525-41bd-ba53-548f767116d2</Id>
     </Book>
-    <Book Series="X-Factor" Number="75" Volume="1986" Year="1992" Format="Main Series">
+    <Book Series="X-Factor" Number="75" Volume="1986" Year="1992">
       <Id>4ea335c1-be12-4418-9b4c-0ff8709381ff</Id>
     </Book>
-    <Book Series="X-Men" Number="1" Volume="1991" Year="1991" Format="Main Series">
+    <Book Series="X-Men" Number="1" Volume="1991" Year="1991">
       <Id>355e5079-33e8-40dd-bbbc-1a048e0d868a</Id>
     </Book>
-    <Book Series="X-Men" Number="2" Volume="1991" Year="1991" Format="Main Series">
+    <Book Series="X-Men" Number="2" Volume="1991" Year="1991">
       <Id>bc1d283a-dd5c-43fb-b60b-7937dadb14a2</Id>
     </Book>
-    <Book Series="X-Men" Number="3" Volume="1991" Year="1991" Format="Main Series">
+    <Book Series="X-Men" Number="3" Volume="1991" Year="1991">
       <Id>6e6580a6-0172-4821-9258-e92b4799b92e</Id>
     </Book>
-    <Book Series="X-Force" Number="2" Volume="1991" Year="1991" Format="Main Series">
+    <Book Series="X-Force" Number="2" Volume="1991" Year="1991">
       <Id>01698506-da89-431f-b503-5a12987e9e5b</Id>
     </Book>
-    <Book Series="X-Force" Number="3" Volume="1991" Year="1991" Format="Main Series">
+    <Book Series="X-Force" Number="3" Volume="1991" Year="1991">
       <Id>464d8281-c0a5-4589-b187-3dc4756ffddc</Id>
     </Book>
-    <Book Series="Spider-Man" Number="16" Volume="1990" Year="1991" Format="Main Series">
+    <Book Series="Spider-Man" Number="16" Volume="1990" Year="1991">
       <Id>86dbb27b-74fc-4055-9d3f-94e23e550341</Id>
     </Book>
-    <Book Series="X-Force" Number="4" Volume="1991" Year="1991" Format="Main Series">
+    <Book Series="X-Force" Number="4" Volume="1991" Year="1991">
       <Id>4969a184-69a0-4604-8d39-481d748b9cbb</Id>
     </Book>
-    <Book Series="Wolverine" Number="48" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Wolverine" Number="48" Volume="1988" Year="1991">
       <Id>ce20faff-0562-4bd5-9e6e-abb021ec2b9c</Id>
     </Book>
-    <Book Series="Wolverine" Number="49" Volume="1988" Year="1991" Format="Main Series">
+    <Book Series="Wolverine" Number="49" Volume="1988" Year="1991">
       <Id>2fd862ab-8c97-4822-b625-16f8fea454c5</Id>
     </Book>
-    <Book Series="Wolverine" Number="50" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Wolverine" Number="50" Volume="1988" Year="1992">
       <Id>7babef8b-41bd-4940-b55a-3e7c31225671</Id>
     </Book>
-    <Book Series="X-Men" Number="4" Volume="1991" Year="1992" Format="Main Series">
+    <Book Series="X-Men" Number="4" Volume="1991" Year="1992">
       <Id>cf0a82bc-11f4-49db-8d81-9c84a5194f0b</Id>
     </Book>
-    <Book Series="X-Men" Number="5" Volume="1991" Year="1992" Format="Main Series">
+    <Book Series="X-Men" Number="5" Volume="1991" Year="1992">
       <Id>49202154-8929-4a6f-8b1f-4e74ca0feb8e</Id>
     </Book>
-    <Book Series="X-Men" Number="6" Volume="1991" Year="1992" Format="Main Series">
+    <Book Series="X-Men" Number="6" Volume="1991" Year="1992">
       <Id>80f233bd-e1c8-43bd-a6f3-2e701ffc233e</Id>
     </Book>
-    <Book Series="X-Men" Number="7" Volume="1991" Year="1992" Format="Main Series">
+    <Book Series="X-Men" Number="7" Volume="1991" Year="1992">
       <Id>8433d6b0-7d0d-4fb0-87f0-a5bbc0fdac1a</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="281" Volume="1981" Year="1991" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="281" Volume="1981" Year="1991">
       <Id>59e2d021-d852-4e4f-bdab-32079d8a163e</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="282" Volume="1981" Year="1991" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="282" Volume="1981" Year="1991">
       <Id>eec5c12a-fafb-4ff1-a9e4-707d63e5520f</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="283" Volume="1981" Year="1991" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="283" Volume="1981" Year="1991">
       <Id>b2e4527f-ddf2-46eb-ac20-d25219003bbb</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="390" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="390" Volume="1968" Year="1992">
       <Id>50084f5d-7118-418a-9571-b0b63cc52f6c</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="391" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="391" Volume="1968" Year="1992">
       <Id>4902c649-78c5-4ab7-bd4e-69abcce7481f</Id>
     </Book>
-    <Book Series="X-Factor" Number="76" Volume="1986" Year="1992" Format="Main Series">
+    <Book Series="X-Factor" Number="76" Volume="1986" Year="1992">
       <Id>900fcfe1-9741-4c23-afec-f6b88cbcba26</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="392" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="392" Volume="1968" Year="1992">
       <Id>a39519f6-7b80-4fc6-851f-c6d367fac198</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="284" Volume="1981" Year="1992" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="284" Volume="1981" Year="1992">
       <Id>58dcd61c-b927-4a17-8eb7-9952ad178593</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="285" Volume="1981" Year="1992" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="285" Volume="1981" Year="1992">
       <Id>55096403-f4ad-4c53-ac65-bfb39a48f6a1</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="286" Volume="1981" Year="1992" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="286" Volume="1981" Year="1992">
       <Id>d2d07ece-7cea-45a7-8c92-bc29f8c166f0</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="287" Volume="1981" Year="1992" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="287" Volume="1981" Year="1992">
       <Id>4375d392-7659-4c88-8dd1-82cf835c831a</Id>
     </Book>
-    <Book Series="X-Men" Number="8" Volume="1991" Year="1992" Format="Main Series">
+    <Book Series="X-Men" Number="8" Volume="1991" Year="1992">
       <Id>0df73930-e8e0-4c06-bab7-836a9a20bea8</Id>
     </Book>
-    <Book Series="Ghost Rider" Number="26" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Ghost Rider" Number="26" Volume="1990" Year="1992">
       <Id>fb415ab9-e5e0-4d18-a9fa-a33f3b83766d</Id>
     </Book>
-    <Book Series="X-Men" Number="9" Volume="1991" Year="1992" Format="Main Series">
+    <Book Series="X-Men" Number="9" Volume="1991" Year="1992">
       <Id>dca0a99e-3dc9-4150-a119-bcd4f1e75e8f</Id>
     </Book>
-    <Book Series="Ghost Rider" Number="27" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Ghost Rider" Number="27" Volume="1990" Year="1992">
       <Id>8cb528ce-300e-49f6-b00a-5004d9f6a7f4</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="288" Volume="1981" Year="1992" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="288" Volume="1981" Year="1992">
       <Id>a1976f6e-58b9-4669-9d71-61af9dbf34e0</Id>
     </Book>
-    <Book Series="Wolverine" Number="51" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Wolverine" Number="51" Volume="1988" Year="1992">
       <Id>b161f477-9a33-4a3c-b63f-686cb3429be2</Id>
     </Book>
-    <Book Series="Wolverine" Number="52" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Wolverine" Number="52" Volume="1988" Year="1992">
       <Id>66d6539c-54c6-4b21-abde-4f32c61a02e1</Id>
     </Book>
-    <Book Series="Wolverine" Number="53" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Wolverine" Number="53" Volume="1988" Year="1992">
       <Id>9ae64411-3eca-48d4-89eb-cd2259139b9d</Id>
     </Book>
-    <Book Series="Wolverine" Number="54" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Wolverine" Number="54" Volume="1988" Year="1992">
       <Id>8f9099f1-58b2-4b2c-8215-31e31f8a1159</Id>
     </Book>
-    <Book Series="Excalibur" Number="48" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Excalibur" Number="48" Volume="1988" Year="1992">
       <Id>e52f38fc-9e0d-42bd-892f-dd8243666237</Id>
     </Book>
-    <Book Series="Excalibur" Number="49" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Excalibur" Number="49" Volume="1988" Year="1992">
       <Id>992fd26a-6a23-46db-b92a-2b6ec8de0ca6</Id>
     </Book>
-    <Book Series="Excalibur" Number="50" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Excalibur" Number="50" Volume="1988" Year="1992">
       <Id>2473ffda-84dd-43f2-a180-aded7bd35d1e</Id>
     </Book>
-    <Book Series="Excalibur: XX Crossing" Number="1" Volume="1992" Year="1992" Format="One-Shot">
+    <Book Series="Excalibur: XX Crossing" Number="1" Volume="1992" Year="1992">
       <Id>1721618e-bbe7-4d40-9e03-726424bf160b</Id>
     </Book>
-    <Book Series="Excalibur" Number="51" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Excalibur" Number="51" Volume="1988" Year="1992">
       <Id>717620b7-7eac-47d5-90cf-a85ffd6c0d37</Id>
     </Book>
-    <Book Series="Excalibur" Number="52" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Excalibur" Number="52" Volume="1988" Year="1992">
       <Id>ace56cf0-d66b-4b13-9041-0c7d0f65f385</Id>
     </Book>
-    <Book Series="Excalibur" Number="53" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Excalibur" Number="53" Volume="1988" Year="1992">
       <Id>96b32ed6-3f71-411b-b2e4-5d4484665758</Id>
     </Book>
-    <Book Series="Excalibur" Number="54" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Excalibur" Number="54" Volume="1988" Year="1992">
       <Id>61041930-07dd-4276-ae2f-2a16f409db0f</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="289" Volume="1981" Year="1992" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="289" Volume="1981" Year="1992">
       <Id>4ba0b732-96b3-4e21-8a0f-609a112a77c1</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="290" Volume="1981" Year="1992" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="290" Volume="1981" Year="1992">
       <Id>fad69fc5-c5dc-417a-9f72-c36eb3b9d7cf</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="101" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="101" Volume="1988" Year="1992">
       <Id>d5c5c8e5-87d9-4b6e-859e-4c8af3d7abf0</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="102" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="102" Volume="1988" Year="1992">
       <Id>b16a9e5c-db7b-4914-810d-d8893b983e35</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="103" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="103" Volume="1988" Year="1992">
       <Id>5dddd0c1-58ba-4746-9052-1c8250a6a506</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="104" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="104" Volume="1988" Year="1992">
       <Id>e2674bc4-9203-4e89-aa56-85d60375ee4c</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="105" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="105" Volume="1988" Year="1992">
       <Id>658bdfa5-253b-4310-a547-d7e4ee7ff94e</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="106" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="106" Volume="1988" Year="1992">
       <Id>bc2318d7-6741-4035-baa0-8b32d1ef1a01</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="107" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="107" Volume="1988" Year="1992">
       <Id>827d81c6-63cb-482b-a19c-fa5b5d609b3b</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="108" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="108" Volume="1988" Year="1992">
       <Id>d55d9620-e195-4211-bfd6-636f20bd33e7</Id>
     </Book>
-    <Book Series="X-Force" Number="5" Volume="1991" Year="1991" Format="Main Series">
+    <Book Series="X-Force" Number="5" Volume="1991" Year="1991">
       <Id>c824c994-1e7e-4f1c-9287-50df4ad9d00d</Id>
     </Book>
-    <Book Series="X-Force" Number="6" Volume="1991" Year="1992" Format="Main Series">
+    <Book Series="X-Force" Number="6" Volume="1991" Year="1992">
       <Id>1f04da08-8bfa-4f93-a451-65385af068b8</Id>
     </Book>
-    <Book Series="X-Force" Number="7" Volume="1991" Year="1992" Format="Main Series">
+    <Book Series="X-Force" Number="7" Volume="1991" Year="1992">
       <Id>146d8d66-e051-43a7-af0e-6a735cdbf76a</Id>
     </Book>
-    <Book Series="X-Force" Number="8" Volume="1991" Year="1992" Format="Main Series">
+    <Book Series="X-Force" Number="8" Volume="1991" Year="1992">
       <Id>1772bb34-62e1-4f54-9bf7-78a90145de13</Id>
     </Book>
-    <Book Series="X-Force" Number="9" Volume="1991" Year="1992" Format="Main Series">
+    <Book Series="X-Force" Number="9" Volume="1991" Year="1992">
       <Id>a3e51a7f-db2d-41ff-b024-8d7e953b8ccd</Id>
     </Book>
-    <Book Series="X-Force" Number="10" Volume="1991" Year="1992" Format="Main Series">
+    <Book Series="X-Force" Number="10" Volume="1991" Year="1992">
       <Id>714fafe7-7749-4026-84e9-e2011af75aa7</Id>
     </Book>
-    <Book Series="X-Factor" Number="77" Volume="1986" Year="1992" Format="Main Series">
+    <Book Series="X-Factor" Number="77" Volume="1986" Year="1992">
       <Id>171d600e-4ee4-4376-9b1b-56c655e03626</Id>
     </Book>
-    <Book Series="X-Factor" Number="78" Volume="1986" Year="1992" Format="Main Series">
+    <Book Series="X-Factor" Number="78" Volume="1986" Year="1992">
       <Id>28953608-9bf5-4421-a65e-7db1ffc59ad7</Id>
     </Book>
-    <Book Series="Wolverine" Number="55" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Wolverine" Number="55" Volume="1988" Year="1992">
       <Id>52440d49-0ceb-41be-8fdd-06849d184716</Id>
     </Book>
-    <Book Series="Wolverine" Number="56" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Wolverine" Number="56" Volume="1988" Year="1992">
       <Id>b867ff90-5372-41ab-8a57-284106bef1ba</Id>
     </Book>
-    <Book Series="Wolverine" Number="57" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Wolverine" Number="57" Volume="1988" Year="1992">
       <Id>820c1657-46a5-4f0f-bf5f-4ddfe1a0afa6</Id>
     </Book>
-    <Book Series="Wolverine" Number="58" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Wolverine" Number="58" Volume="1988" Year="1992">
       <Id>e8f320a1-2885-46c4-9f05-3368f657174c</Id>
     </Book>
-    <Book Series="Wolverine" Number="59" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Wolverine" Number="59" Volume="1988" Year="1992">
       <Id>75b66903-7a24-459b-a84d-7271ecb8fc38</Id>
     </Book>
-    <Book Series="Wolverine" Number="60" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Wolverine" Number="60" Volume="1988" Year="1992">
       <Id>c1f90d73-5719-4c8b-8b11-b1a756af9487</Id>
     </Book>
-    <Book Series="X-Men Annual" Number="1" Volume="1992" Year="1992" Format="Annual">
+    <Book Series="X-Men Annual" Number="1" Volume="1992" Year="1992">
       <Id>3440b5e2-78b5-4a60-8912-8b129b71de20</Id>
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="16" Volume="1982" Year="1992" Format="Annual">
+    <Book Series="The Uncanny X-Men Annual" Number="16" Volume="1982" Year="1992">
       <Id>e025cf31-01c6-4cf3-bb95-7e3a719ae900</Id>
     </Book>
-    <Book Series="X-Factor Annual" Number="7" Volume="1986" Year="1992" Format="Annual">
+    <Book Series="X-Factor Annual" Number="7" Volume="1986" Year="1992">
       <Id>ea4454a5-4ba8-4041-9156-90bd9c8e0ee8</Id>
     </Book>
-    <Book Series="X-Force Annual" Number="1" Volume="1992" Year="1992" Format="Annual">
+    <Book Series="X-Force Annual" Number="1" Volume="1992" Year="1992">
       <Id>8a497a9f-7bba-4d89-b9fc-b590921557ee</Id>
     </Book>
-    <Book Series="X-Men" Number="10" Volume="1991" Year="1992" Format="Main Series">
+    <Book Series="X-Men" Number="10" Volume="1991" Year="1992">
       <Id>5b31352f-7ca1-4812-8621-9f50368a99d2</Id>
     </Book>
-    <Book Series="X-Men" Number="11" Volume="1991" Year="1992" Format="Main Series">
+    <Book Series="X-Men" Number="11" Volume="1991" Year="1992">
       <Id>093a17b6-3cc6-4618-9fa3-faed9727f474</Id>
     </Book>
-    <Book Series="X-Factor" Number="79" Volume="1986" Year="1992" Format="Main Series">
+    <Book Series="X-Factor" Number="79" Volume="1986" Year="1992">
       <Id>8aaa0f67-3f78-44b4-bd07-25d9d280c7e3</Id>
     </Book>
-    <Book Series="X-Factor" Number="80" Volume="1986" Year="1992" Format="Main Series">
+    <Book Series="X-Factor" Number="80" Volume="1986" Year="1992">
       <Id>7bee7cd3-c66f-45c6-989f-d29b0dde5b5d</Id>
     </Book>
-    <Book Series="X-Factor" Number="81" Volume="1986" Year="1992" Format="Main Series">
+    <Book Series="X-Factor" Number="81" Volume="1986" Year="1992">
       <Id>3b9718b7-191d-44cf-87f6-b92c4641766a</Id>
     </Book>
-    <Book Series="X-Force" Number="11" Volume="1991" Year="1992" Format="Main Series">
+    <Book Series="X-Force" Number="11" Volume="1991" Year="1992">
       <Id>d769d966-710f-40e1-8aa5-4e96b61c9a33</Id>
     </Book>
-    <Book Series="X-Force" Number="12" Volume="1991" Year="1992" Format="Main Series">
+    <Book Series="X-Force" Number="12" Volume="1991" Year="1992">
       <Id>b2b991d2-8dda-4bb9-8002-3dad4e74d266</Id>
     </Book>
-    <Book Series="X-Force" Number="13" Volume="1991" Year="1992" Format="Main Series">
+    <Book Series="X-Force" Number="13" Volume="1991" Year="1992">
       <Id>0e7579bb-311b-4e35-996b-99a0fa22b70a</Id>
     </Book>
-    <Book Series="X-Force" Number="14" Volume="1991" Year="1992" Format="Main Series">
+    <Book Series="X-Force" Number="14" Volume="1991" Year="1992">
       <Id>3dfc722e-fbef-4d5c-9c55-6fa336dd33b7</Id>
     </Book>
-    <Book Series="X-Force" Number="15" Volume="1991" Year="1992" Format="Main Series">
+    <Book Series="X-Force" Number="15" Volume="1991" Year="1992">
       <Id>bad78d3d-2e07-449c-aff0-d06fa67d1422</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="291" Volume="1981" Year="1992" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="291" Volume="1981" Year="1992">
       <Id>c09cbe3a-893e-4c38-8802-b75796e0f38a</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="292" Volume="1981" Year="1992" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="292" Volume="1981" Year="1992">
       <Id>9b51c074-d90d-4846-a46d-30d3e6b94223</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="293" Volume="1981" Year="1992" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="293" Volume="1981" Year="1992">
       <Id>413fc650-b261-4d3d-900c-2450c236bf96</Id>
     </Book>
-    <Book Series="Wolverine" Number="61" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Wolverine" Number="61" Volume="1988" Year="1992">
       <Id>4a964c2d-b8dc-4574-af86-b83b402233cc</Id>
     </Book>
-    <Book Series="Wolverine" Number="62" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Wolverine" Number="62" Volume="1988" Year="1992">
       <Id>e4ac0624-835b-49c8-9240-a58ec8d21127</Id>
     </Book>
-    <Book Series="Wolverine" Number="63" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Wolverine" Number="63" Volume="1988" Year="1992">
       <Id>d720a3b0-6be5-434a-b577-d32c279cad67</Id>
     </Book>
-    <Book Series="Wolverine" Number="64" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Wolverine" Number="64" Volume="1988" Year="1992">
       <Id>bb4c02b9-4246-4dd5-bc24-c3cb37a47fd2</Id>
     </Book>
-    <Book Series="Wolverine" Number="65" Volume="1988" Year="1993" Format="Main Series">
+    <Book Series="Wolverine" Number="65" Volume="1988" Year="1993">
       <Id>b54a6f25-c6de-4c09-8624-c68ca73a8fca</Id>
     </Book>
-    <Book Series="X-Factor" Number="82" Volume="1986" Year="1992" Format="Main Series">
+    <Book Series="X-Factor" Number="82" Volume="1986" Year="1992">
       <Id>61744252-b2eb-4421-98e5-ca611004c9a3</Id>
     </Book>
-    <Book Series="X-Factor" Number="83" Volume="1986" Year="1992" Format="Main Series">
+    <Book Series="X-Factor" Number="83" Volume="1986" Year="1992">
       <Id>26893b07-c9b4-4387-8ac1-f59e7d9a35ec</Id>
     </Book>
-    <Book Series="X-Men" Number="12" Volume="1991" Year="1992" Format="Main Series">
+    <Book Series="X-Men" Number="12" Volume="1991" Year="1992">
       <Id>e3cc89a2-bd01-49cf-a989-71f1c9e98c30</Id>
     </Book>
-    <Book Series="X-Men" Number="13" Volume="1991" Year="1992" Format="Main Series">
+    <Book Series="X-Men" Number="13" Volume="1991" Year="1992">
       <Id>b2f673bd-9aaf-4c35-b546-f18162382a1a</Id>
     </Book>
-    <Book Series="Excalibur" Number="55" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Excalibur" Number="55" Volume="1988" Year="1992">
       <Id>44b80cc0-d4eb-49c9-a9f3-609b2fb78248</Id>
     </Book>
-    <Book Series="Excalibur" Number="56" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Excalibur" Number="56" Volume="1988" Year="1992">
       <Id>4182896f-43e1-4c6a-810f-3070217d16ce</Id>
     </Book>
-    <Book Series="Excalibur" Number="57" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Excalibur" Number="57" Volume="1988" Year="1992">
       <Id>0eab5923-534b-4815-9167-faf61088c40a</Id>
     </Book>
-    <Book Series="Excalibur" Number="58" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Excalibur" Number="58" Volume="1988" Year="1992">
       <Id>8ad1aac3-2c79-4b1d-b4e7-d898cda02ba0</Id>
     </Book>
-    <Book Series="Excalibur" Number="59" Volume="1988" Year="1992" Format="Main Series">
+    <Book Series="Excalibur" Number="59" Volume="1988" Year="1992">
       <Id>3040c66f-b424-4874-b435-05bdb2235b8e</Id>
     </Book>
-    <Book Series="Excalibur" Number="60" Volume="1988" Year="1993" Format="Main Series">
+    <Book Series="Excalibur" Number="60" Volume="1988" Year="1993">
       <Id>4cf01a13-1e1f-4f21-a235-e6d52db6385b</Id>
     </Book>
-    <Book Series="Wolverine: Inner Fury" Number="1" Volume="1992" Year="1992" Format="One-Shot">
+    <Book Series="Wolverine: Inner Fury" Number="1" Volume="1992" Year="1992">
       <Id>0b6f794f-b214-4efc-8abc-6dd23838f5ff</Id>
     </Book>
-    <Book Series="Cable" Number="1" Volume="1992" Year="1992" Format="Limited Series">
+    <Book Series="Cable" Number="1" Volume="1992" Year="1992">
       <Id>77336113-bdc9-4fb6-8aaf-7177ad9e9df0</Id>
     </Book>
-    <Book Series="Cable" Number="2" Volume="1992" Year="1992" Format="Limited Series">
+    <Book Series="Cable" Number="2" Volume="1992" Year="1992">
       <Id>205a7023-08b7-41e1-87ae-495e15226250</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="294" Volume="1981" Year="1992" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="294" Volume="1981" Year="1992">
       <Id>b1d89311-5272-4a4d-aefd-071f4eed15e3</Id>
     </Book>
-    <Book Series="X-Factor" Number="84" Volume="1986" Year="1992" Format="Main Series">
+    <Book Series="X-Factor" Number="84" Volume="1986" Year="1992">
       <Id>e64546d6-31fd-424c-8df6-b07aa7b24012</Id>
     </Book>
-    <Book Series="X-Men" Number="14" Volume="1991" Year="1992" Format="Main Series">
+    <Book Series="X-Men" Number="14" Volume="1991" Year="1992">
       <Id>03c06442-3461-46e8-a44e-6604fb306187</Id>
     </Book>
-    <Book Series="X-Force" Number="16" Volume="1991" Year="1992" Format="Main Series">
+    <Book Series="X-Force" Number="16" Volume="1991" Year="1992">
       <Id>34861708-243b-4c17-aa3b-2631a0b57262</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="295" Volume="1981" Year="1992" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="295" Volume="1981" Year="1992">
       <Id>ddff2a0d-8990-44f2-9258-9c169a96fd07</Id>
     </Book>
-    <Book Series="X-Factor" Number="85" Volume="1986" Year="1992" Format="Main Series">
+    <Book Series="X-Factor" Number="85" Volume="1986" Year="1992">
       <Id>229ecbfa-64f1-4618-979b-68b0979c991c</Id>
     </Book>
-    <Book Series="X-Men" Number="15" Volume="1991" Year="1992" Format="Main Series">
+    <Book Series="X-Men" Number="15" Volume="1991" Year="1992">
       <Id>1bb9d4b7-31f5-41b3-a4b2-103d9ed1efa1</Id>
     </Book>
-    <Book Series="X-Force" Number="17" Volume="1991" Year="1992" Format="Main Series">
+    <Book Series="X-Force" Number="17" Volume="1991" Year="1992">
       <Id>627137ca-4be4-4412-82d5-ba8ec43d9c91</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="296" Volume="1981" Year="1993" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="296" Volume="1981" Year="1993">
       <Id>1f71ab86-fe31-4a68-bafb-b6a36c32781f</Id>
     </Book>
-    <Book Series="X-Factor" Number="86" Volume="1986" Year="1993" Format="Main Series">
+    <Book Series="X-Factor" Number="86" Volume="1986" Year="1993">
       <Id>00b13639-8f33-4ea8-a446-88a2217fa0fc</Id>
     </Book>
-    <Book Series="X-Men" Number="16" Volume="1991" Year="1993" Format="Main Series">
+    <Book Series="X-Men" Number="16" Volume="1991" Year="1993">
       <Id>1f148072-aac2-4370-a980-e5e2ba1cf200</Id>
     </Book>
-    <Book Series="X-Force" Number="18" Volume="1991" Year="1993" Format="Main Series">
+    <Book Series="X-Force" Number="18" Volume="1991" Year="1993">
       <Id>c5c67a72-56ee-441e-97a5-144de71a327f</Id>
     </Book>
-    <Book Series="Stryfe's Strike File" Number="1" Volume="1993" Year="1993" Format="One-Shot">
+    <Book Series="Stryfe's Strike File" Number="1" Volume="1993" Year="1993">
       <Id>ed3889d7-e5ab-43ef-9713-5a73d5c93c5f</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="297" Volume="1981" Year="1993" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="297" Volume="1981" Year="1993">
       <Id>bfef0c67-cdf0-4644-8182-ee07cce2e755</Id>
     </Book>
-    <Book Series="X-Factor" Number="87" Volume="1986" Year="1993" Format="Main Series">
+    <Book Series="X-Factor" Number="87" Volume="1986" Year="1993">
       <Id>a9ce13dc-386a-40a4-a92e-47d0eba4f7a2</Id>
     </Book>
-    <Book Series="Wolverine" Number="66" Volume="1988" Year="1993" Format="Main Series">
+    <Book Series="Wolverine" Number="66" Volume="1988" Year="1993">
       <Id>40276c1a-9532-46cc-a396-7f9b97c4ce31</Id>
     </Book>
-    <Book Series="Wolverine" Number="67" Volume="1988" Year="1993" Format="Main Series">
+    <Book Series="Wolverine" Number="67" Volume="1988" Year="1993">
       <Id>20ac1989-0faf-4834-8d3f-787c314e541a</Id>
     </Book>
-    <Book Series="Wolverine" Number="68" Volume="1988" Year="1993" Format="Main Series">
+    <Book Series="Wolverine" Number="68" Volume="1988" Year="1993">
       <Id>d868dda3-f42e-46ae-b7e6-d19c8d61b264</Id>
     </Book>
-    <Book Series="X-Men" Number="17" Volume="1991" Year="1993" Format="Main Series">
+    <Book Series="X-Men" Number="17" Volume="1991" Year="1993">
       <Id>5a18728f-e713-44fb-9246-3f9d84e97dcd</Id>
     </Book>
-    <Book Series="X-Men" Number="18" Volume="1991" Year="1993" Format="Main Series">
+    <Book Series="X-Men" Number="18" Volume="1991" Year="1993">
       <Id>a399e595-37d7-442b-a607-afa720bf8f86</Id>
     </Book>
-    <Book Series="X-Men" Number="19" Volume="1991" Year="1993" Format="Main Series">
+    <Book Series="X-Men" Number="19" Volume="1991" Year="1993">
       <Id>fad551c1-5818-4975-b454-93e64372d3cf</Id>
     </Book>
-    <Book Series="X-Factor" Number="88" Volume="1986" Year="1993" Format="Main Series">
+    <Book Series="X-Factor" Number="88" Volume="1986" Year="1993">
       <Id>665f2272-affc-4d6f-b523-de0816053edb</Id>
     </Book>
-    <Book Series="X-Force" Number="19" Volume="1991" Year="1993" Format="Main Series">
+    <Book Series="X-Force" Number="19" Volume="1991" Year="1993">
       <Id>e251ccc4-1389-49bb-ac97-37a959a1bacf</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="298" Volume="1981" Year="1993" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="298" Volume="1981" Year="1993">
       <Id>2f283a53-1324-457f-b0f7-d88dd3176754</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="299" Volume="1981" Year="1993" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="299" Volume="1981" Year="1993">
       <Id>375979fd-6bac-47c6-93e6-b853315c7b4f</Id>
     </Book>
-    <Book Series="X-Factor" Number="89" Volume="1986" Year="1993" Format="Main Series">
+    <Book Series="X-Factor" Number="89" Volume="1986" Year="1993">
       <Id>3b49882b-d9dc-40cc-9bcc-de3ec6f1da17</Id>
     </Book>
-    <Book Series="X-Factor" Number="90" Volume="1986" Year="1993" Format="Main Series">
+    <Book Series="X-Factor" Number="90" Volume="1986" Year="1993">
       <Id>7c75b35d-44a3-43f2-8edf-cc8041d6da30</Id>
     </Book>
-    <Book Series="X-Factor" Number="91" Volume="1986" Year="1993" Format="Main Series">
+    <Book Series="X-Factor" Number="91" Volume="1986" Year="1993">
       <Id>19a4008c-0ebb-4f21-a100-c6abdd4e54e1</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="300" Volume="1981" Year="1993" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="300" Volume="1981" Year="1993">
       <Id>3c036d3e-ac07-4363-869e-ace467fe12d6</Id>
     </Book>
-    <Book Series="X-Force" Number="20" Volume="1991" Year="1993" Format="Main Series">
+    <Book Series="X-Force" Number="20" Volume="1991" Year="1993">
       <Id>4e949605-4e59-4b0e-8379-cd9575f70da1</Id>
     </Book>
-    <Book Series="X-Force" Number="21" Volume="1991" Year="1993" Format="Main Series">
+    <Book Series="X-Force" Number="21" Volume="1991" Year="1993">
       <Id>e67679e5-a91b-4395-b777-aa0fe10655c3</Id>
     </Book>
-    <Book Series="X-Force" Number="22" Volume="1991" Year="1993" Format="Main Series">
+    <Book Series="X-Force" Number="22" Volume="1991" Year="1993">
       <Id>4a84d01a-b552-4f69-838d-d4ee81a71c9a</Id>
     </Book>
-    <Book Series="X-Force" Number="23" Volume="1991" Year="1993" Format="Main Series">
+    <Book Series="X-Force" Number="23" Volume="1991" Year="1993">
       <Id>d8d52215-de0d-40d5-9b61-5d1668af68d6</Id>
     </Book>
-    <Book Series="Wolverine" Number="69" Volume="1988" Year="1993" Format="Main Series">
+    <Book Series="Wolverine" Number="69" Volume="1988" Year="1993">
       <Id>ae058a1d-ab65-4ef3-a4bf-609b914fd559</Id>
     </Book>
-    <Book Series="Wolverine" Number="70" Volume="1988" Year="1993" Format="Main Series">
+    <Book Series="Wolverine" Number="70" Volume="1988" Year="1993">
       <Id>9b25976a-2b7b-446c-b301-e12f019558e8</Id>
     </Book>
-    <Book Series="Wolverine" Number="71" Volume="1988" Year="1993" Format="Main Series">
+    <Book Series="Wolverine" Number="71" Volume="1988" Year="1993">
       <Id>540ac15f-2a5b-4838-be52-44eaa60df80a</Id>
     </Book>
-    <Book Series="X-Men: Odd Men Out" Number="1" Volume="2008" Year="2008" Format="One-Shot">
+    <Book Series="X-Men: Odd Men Out" Number="1" Volume="2008" Year="2008">
       <Id>23019dca-88a8-4f0d-88ff-0da4f9dd5a28</Id>
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="17" Volume="1982" Year="1993" Format="Annual">
+    <Book Series="The Uncanny X-Men Annual" Number="17" Volume="1982" Year="1993">
       <Id>0d56b548-f065-4fa9-b94c-cda7ecf58dc3</Id>
     </Book>
-    <Book Series="X-Factor Annual" Number="8" Volume="1986" Year="1993" Format="Annual">
+    <Book Series="X-Factor Annual" Number="8" Volume="1986" Year="1993">
       <Id>2431c71a-3813-4b18-885f-389119a4f569</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="1" Volume="1993" Year="1993" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="1" Volume="1993" Year="1993">
       <Id>450e2b59-fd07-4458-aec6-13e61ca4fa76</Id>
     </Book>
-    <Book Series="Excalibur" Number="61" Volume="1988" Year="1993" Format="Main Series">
+    <Book Series="Excalibur" Number="61" Volume="1988" Year="1993">
       <Id>68ce5272-995a-41e7-9bf3-81d2bd28a978</Id>
     </Book>
-    <Book Series="Excalibur" Number="62" Volume="1988" Year="1993" Format="Main Series">
+    <Book Series="Excalibur" Number="62" Volume="1988" Year="1993">
       <Id>00a752f6-e29d-4236-a598-053585f0f51b</Id>
     </Book>
-    <Book Series="Excalibur" Number="63" Volume="1988" Year="1993" Format="Main Series">
+    <Book Series="Excalibur" Number="63" Volume="1988" Year="1993">
       <Id>356c0dc4-ba0e-439d-81ce-8310ffe4975a</Id>
     </Book>
-    <Book Series="Excalibur" Number="64" Volume="1988" Year="1993" Format="Main Series">
+    <Book Series="Excalibur" Number="64" Volume="1988" Year="1993">
       <Id>4cc728b4-0df4-469d-8649-e184a1699137</Id>
     </Book>
-    <Book Series="Excalibur" Number="65" Volume="1988" Year="1993" Format="Main Series">
+    <Book Series="Excalibur" Number="65" Volume="1988" Year="1993">
       <Id>4161d56b-6e06-4b43-8d91-f8f93ac8ad46</Id>
     </Book>
-    <Book Series="Cable" Number="1" Volume="1993" Year="1993" Format="Main Series">
+    <Book Series="Cable" Number="1" Volume="1993" Year="1993">
       <Id>0d29fe32-effe-460d-b6de-bbf61b28194e</Id>
     </Book>
-    <Book Series="Cable" Number="2" Volume="1993" Year="1993" Format="Main Series">
+    <Book Series="Cable" Number="2" Volume="1993" Year="1993">
       <Id>81db4399-a74b-455c-a6df-57647f0b24c4</Id>
     </Book>
-    <Book Series="Cable" Number="3" Volume="1993" Year="1993" Format="Main Series">
+    <Book Series="Cable" Number="3" Volume="1993" Year="1993">
       <Id>74d2d414-b7e0-48cb-80a6-c030d96239ed</Id>
     </Book>
-    <Book Series="Cable" Number="4" Volume="1993" Year="1993" Format="Main Series">
+    <Book Series="Cable" Number="4" Volume="1993" Year="1993">
       <Id>9880deb5-55be-40d2-9d89-df8dfa60ab41</Id>
     </Book>
-    <Book Series="X-Men" Number="20" Volume="1991" Year="1993" Format="Main Series">
+    <Book Series="X-Men" Number="20" Volume="1991" Year="1993">
       <Id>22d8c555-3cd7-4b4d-89b9-89c46df1e1f0</Id>
     </Book>
-    <Book Series="X-Men" Number="21" Volume="1991" Year="1993" Format="Main Series">
+    <Book Series="X-Men" Number="21" Volume="1991" Year="1993">
       <Id>af8abe75-3043-466d-9d1e-6bcc91f2b35c</Id>
     </Book>
-    <Book Series="X-Men" Number="22" Volume="1991" Year="1993" Format="Main Series">
+    <Book Series="X-Men" Number="22" Volume="1991" Year="1993">
       <Id>d5369f48-5ffe-442f-b159-3b4eea4f2dcb</Id>
     </Book>
-    <Book Series="X-Men" Number="23" Volume="1991" Year="1993" Format="Main Series">
+    <Book Series="X-Men" Number="23" Volume="1991" Year="1993">
       <Id>03e48a27-cfdd-4b07-93dd-e6127fb75403</Id>
     </Book>
-    <Book Series="Excalibur Annual" Number="1" Volume="1993" Year="1993" Format="Annual">
+    <Book Series="Excalibur Annual" Number="1" Volume="1993" Year="1993">
       <Id>4a953dcf-63f3-4996-89a6-8b56b6781359</Id>
     </Book>
-    <Book Series="Excalibur" Number="66" Volume="1988" Year="1993" Format="Main Series">
+    <Book Series="Excalibur" Number="66" Volume="1988" Year="1993">
       <Id>9d5349cf-9c81-4e46-b082-6c538371755a</Id>
     </Book>
-    <Book Series="Excalibur" Number="67" Volume="1988" Year="1993" Format="Main Series">
+    <Book Series="Excalibur" Number="67" Volume="1988" Year="1993">
       <Id>8d7efd8c-ecdf-4442-8279-e5d98c9e320f</Id>
     </Book>
-    <Book Series="Excalibur" Number="68" Volume="1988" Year="1993" Format="Main Series">
+    <Book Series="Excalibur" Number="68" Volume="1988" Year="1993">
       <Id>50b070aa-149a-4c67-a243-c73baa7822dd</Id>
     </Book>
-    <Book Series="Excalibur" Number="69" Volume="1988" Year="1993" Format="Main Series">
+    <Book Series="Excalibur" Number="69" Volume="1988" Year="1993">
       <Id>52ebce19-111f-4934-be8d-3ae1c1e2e06c</Id>
     </Book>
-    <Book Series="Excalibur" Number="70" Volume="1988" Year="1993" Format="Main Series">
+    <Book Series="Excalibur" Number="70" Volume="1988" Year="1993">
       <Id>7308bd62-6aa6-4467-b041-68790ca6b70b</Id>
     </Book>
-    <Book Series="X-Factor" Number="92" Volume="1986" Year="1993" Format="Main Series">
+    <Book Series="X-Factor" Number="92" Volume="1986" Year="1993">
       <Id>954fe5a7-75f8-4512-8912-5b32df3e6ec8</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="301" Volume="1981" Year="1993" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="301" Volume="1981" Year="1993">
       <Id>e958d62a-53af-4786-9f4a-a3ba08a0802b</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="302" Volume="1981" Year="1993" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="302" Volume="1981" Year="1993">
       <Id>0d1a85fe-6c4a-4a92-b37e-f89b2836e3f7</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="303" Volume="1981" Year="1993" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="303" Volume="1981" Year="1993">
       <Id>f40a030e-1a7e-4441-8419-faf7a1bbe90d</Id>
     </Book>
-    <Book Series="Wolverine" Number="72" Volume="1988" Year="1993" Format="Main Series">
+    <Book Series="Wolverine" Number="72" Volume="1988" Year="1993">
       <Id>3546124c-d88f-4cbe-9992-1aad66d9bdf6</Id>
     </Book>
-    <Book Series="Wolverine" Number="73" Volume="1988" Year="1993" Format="Main Series">
+    <Book Series="Wolverine" Number="73" Volume="1988" Year="1993">
       <Id>c55dce99-e567-4335-a55f-4cdb3047fddf</Id>
     </Book>
-    <Book Series="Wolverine" Number="74" Volume="1988" Year="1993" Format="Main Series">
+    <Book Series="Wolverine" Number="74" Volume="1988" Year="1993">
       <Id>16c3c21e-4e0a-4357-aaf9-86266b3a1164</Id>
     </Book>
-    <Book Series="X-Force" Number="24" Volume="1991" Year="1993" Format="Main Series">
+    <Book Series="X-Force" Number="24" Volume="1991" Year="1993">
       <Id>81a758f7-211c-4f33-bacc-253ff793b7a2</Id>
     </Book>
-    <Book Series="X-Force" Number="25" Volume="1991" Year="1993" Format="Main Series">
+    <Book Series="X-Force" Number="25" Volume="1991" Year="1993">
       <Id>1128cd02-92b1-4179-aa35-b5b16c208580</Id>
     </Book>
-    <Book Series="X-Factor" Number="93" Volume="1986" Year="1993" Format="Main Series">
+    <Book Series="X-Factor" Number="93" Volume="1986" Year="1993">
       <Id>821b7090-edb9-4f33-b1d2-8b04458d3bd3</Id>
     </Book>
-    <Book Series="Wolverine: Killing" Number="1" Volume="1993" Year="1993" Format="One-Shot">
+    <Book Series="Wolverine: Killing" Number="1" Volume="1993" Year="1993">
       <Id>af380844-0fd4-46ae-b383-4574ced30683</Id>
     </Book>
-    <Book Series="X-Men" Number="24" Volume="1991" Year="1993" Format="Main Series">
+    <Book Series="X-Men" Number="24" Volume="1991" Year="1993">
       <Id>4f8db239-327b-430d-bf76-119298cfa151</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="2" Volume="1993" Year="1993" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="2" Volume="1993" Year="1993">
       <Id>f6dc6ec1-9027-451e-bd0e-54a843748d8d</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="304" Volume="1981" Year="1993" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="304" Volume="1981" Year="1993">
       <Id>380db608-6f86-42b6-9de8-0afce606fe48</Id>
     </Book>
-    <Book Series="X-Factor" Number="94" Volume="1986" Year="1993" Format="Main Series">
+    <Book Series="X-Factor" Number="94" Volume="1986" Year="1993">
       <Id>79ef027f-aeae-43c6-8ce6-c56bba0cc666</Id>
     </Book>
-    <Book Series="X-Factor" Number="95" Volume="1986" Year="1993" Format="Main Series">
+    <Book Series="X-Factor" Number="95" Volume="1986" Year="1993">
       <Id>92d62862-81b5-4793-9da6-240a5cc811f3</Id>
     </Book>
-    <Book Series="Wolverine: Doombringer" Number="1" Volume="1997" Year="1997" Format="One-Shot">
+    <Book Series="Wolverine: Doombringer" Number="1" Volume="1997" Year="1997">
       <Id>23d90140-ffd7-4a91-8a13-4217980744aa</Id>
     </Book>
-    <Book Series="X-Force" Number="26" Volume="1991" Year="1993" Format="Main Series">
+    <Book Series="X-Force" Number="26" Volume="1991" Year="1993">
       <Id>0f3acf34-f252-4b09-8202-512dd37390ae</Id>
     </Book>
-    <Book Series="Sabretooth" Number="1" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="Sabretooth" Number="1" Volume="1993" Year="1993">
       <Id>be2dfd49-1927-4eb0-a7c6-5e3c48d2018d</Id>
     </Book>
-    <Book Series="Sabretooth" Number="2" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="Sabretooth" Number="2" Volume="1993" Year="1993">
       <Id>2e949967-f4da-4084-9091-6662c4a05592</Id>
     </Book>
-    <Book Series="Sabretooth" Number="3" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="Sabretooth" Number="3" Volume="1993" Year="1993">
       <Id>668fbe62-c74b-45a2-a719-0b74610df779</Id>
     </Book>
-    <Book Series="Sabretooth" Number="4" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="Sabretooth" Number="4" Volume="1993" Year="1993">
       <Id>bf168d2d-8989-4fdf-a1dc-b1fc3d8ed0a3</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="305" Volume="1981" Year="1993" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="305" Volume="1981" Year="1993">
       <Id>8228acdd-3107-47df-8d6f-ee0004cf47df</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="306" Volume="1981" Year="1993" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="306" Volume="1981" Year="1993">
       <Id>b896942b-bd4a-43ed-a889-58e6dcfc584c</Id>
     </Book>
-    <Book Series="Gambit" Number="1" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="Gambit" Number="1" Volume="1993" Year="1993">
       <Id>3699b3e2-8e3e-48a2-911d-da0fda7432a9</Id>
     </Book>
-    <Book Series="Gambit" Number="2" Volume="1993" Year="1994" Format="Limited Series">
+    <Book Series="Gambit" Number="2" Volume="1993" Year="1994">
       <Id>e9d592b8-4f30-4871-8f5b-2de2b2f80e4e</Id>
     </Book>
-    <Book Series="Gambit" Number="3" Volume="1993" Year="1994" Format="Limited Series">
+    <Book Series="Gambit" Number="3" Volume="1993" Year="1994">
       <Id>73c37fa3-9a3e-4e1e-a62a-83b1cb1e6a8f</Id>
     </Book>
-    <Book Series="Gambit" Number="4" Volume="1993" Year="1994" Format="Limited Series">
+    <Book Series="Gambit" Number="4" Volume="1993" Year="1994">
       <Id>b7010b03-9421-431c-8de2-436f9e7d40ae</Id>
     </Book>
-    <Book Series="Cable" Number="5" Volume="1993" Year="1993" Format="Main Series">
+    <Book Series="Cable" Number="5" Volume="1993" Year="1993">
       <Id>e3a5d09c-913f-4a45-b209-9fc651d21b11</Id>
     </Book>
-    <Book Series="X-Men" Number="25" Volume="1991" Year="1993" Format="Main Series">
+    <Book Series="X-Men" Number="25" Volume="1991" Year="1993">
       <Id>768c6728-f5e6-4635-955c-af8621c1f7fa</Id>
     </Book>
-    <Book Series="Wolverine" Number="75" Volume="1988" Year="1993" Format="Main Series">
+    <Book Series="Wolverine" Number="75" Volume="1988" Year="1993">
       <Id>95b7501d-b382-494d-86ff-4e756139052a</Id>
     </Book>
-    <Book Series="Excalibur" Number="71" Volume="1988" Year="1993" Format="Main Series">
+    <Book Series="Excalibur" Number="71" Volume="1988" Year="1993">
       <Id>4355283a-08f0-4b57-8a61-9b6f53917715</Id>
     </Book>
-    <Book Series="X-Force Annual" Number="2" Volume="1992" Year="1993" Format="Annual">
+    <Book Series="X-Force Annual" Number="2" Volume="1992" Year="1993">
       <Id>4fbcb03c-a223-40d5-b7c0-e592b940b9b3</Id>
     </Book>
-    <Book Series="X-Men Annual" Number="2" Volume="1992" Year="1993" Format="Annual">
+    <Book Series="X-Men Annual" Number="2" Volume="1992" Year="1993">
       <Id>9a8e7207-9011-4dd2-aaa1-b923027c1dc3</Id>
     </Book>
-    <Book Series="Wolverine" Number="76" Volume="1988" Year="1993" Format="Main Series">
+    <Book Series="Wolverine" Number="76" Volume="1988" Year="1993">
       <Id>f5d56487-4eaf-4206-849a-896d4b9c27d4</Id>
     </Book>
-    <Book Series="Wolverine" Number="77" Volume="1988" Year="1994" Format="Main Series">
+    <Book Series="Wolverine" Number="77" Volume="1988" Year="1994">
       <Id>95456fa1-e8a7-43ab-b57e-dcdf0fcfa358</Id>
     </Book>
-    <Book Series="Spider-Man and X-Factor: Shadowgames" Number="1" Volume="1994" Year="1994" Format="Limited Series">
+    <Book Series="Spider-Man and X-Factor: Shadowgames" Number="1" Volume="1994" Year="1994">
       <Id>f0233bba-1964-40cc-8930-1fed2327c4b1</Id>
     </Book>
-    <Book Series="Spider-Man and X-Factor: Shadowgames" Number="2" Volume="1994" Year="1994" Format="Limited Series">
+    <Book Series="Spider-Man and X-Factor: Shadowgames" Number="2" Volume="1994" Year="1994">
       <Id>940ea147-f6f9-428b-85e5-0d437ac218ff</Id>
     </Book>
-    <Book Series="Spider-Man and X-Factor: Shadowgames" Number="3" Volume="1994" Year="1994" Format="Limited Series">
+    <Book Series="Spider-Man and X-Factor: Shadowgames" Number="3" Volume="1994" Year="1994">
       <Id>2c5ca89e-8aea-4787-89f0-f0674b1d7450</Id>
     </Book>
-    <Book Series="Excalibur" Number="72" Volume="1988" Year="1993" Format="Main Series">
+    <Book Series="Excalibur" Number="72" Volume="1988" Year="1993">
       <Id>16efbbd9-692e-44a5-a31e-c96955e1cd20</Id>
     </Book>
-    <Book Series="Excalibur" Number="73" Volume="1988" Year="1994" Format="Main Series">
+    <Book Series="Excalibur" Number="73" Volume="1988" Year="1994">
       <Id>61949c90-0a90-4079-957c-540f1ed65125</Id>
     </Book>
-    <Book Series="The Avengers" Number="368" Volume="1963" Year="1993" Format="Main Series">
+    <Book Series="The Avengers" Number="368" Volume="1963" Year="1993">
       <Id>f37e0fac-85e5-4de4-b53b-477b82b93b73</Id>
     </Book>
-    <Book Series="X-Men" Number="26" Volume="1991" Year="1993" Format="Main Series">
+    <Book Series="X-Men" Number="26" Volume="1991" Year="1993">
       <Id>6ee384d0-2229-469a-bd13-6d78114f2642</Id>
     </Book>
-    <Book Series="Avengers West Coast" Number="101" Volume="1989" Year="1993" Format="Main Series">
+    <Book Series="Avengers West Coast" Number="101" Volume="1989" Year="1993">
       <Id>c3e23c28-cb4c-437b-9b63-04afb286b3b6</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="307" Volume="1981" Year="1993" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="307" Volume="1981" Year="1993">
       <Id>0a30017b-d835-4a7b-8dbc-2fc028df2463</Id>
     </Book>
-    <Book Series="The Avengers" Number="369" Volume="1963" Year="1993" Format="Main Series">
+    <Book Series="The Avengers" Number="369" Volume="1963" Year="1993">
       <Id>9f5ed110-da2c-4167-8bc6-abb5e0a9feee</Id>
     </Book>
-    <Book Series="X-Factor" Number="96" Volume="1986" Year="1993" Format="Main Series">
+    <Book Series="X-Factor" Number="96" Volume="1986" Year="1993">
       <Id>3bb90e32-3272-4bb7-85d3-ec08cec275e1</Id>
     </Book>
-    <Book Series="X-Factor" Number="97" Volume="1986" Year="1993" Format="Main Series">
+    <Book Series="X-Factor" Number="97" Volume="1986" Year="1993">
       <Id>cf389442-4e7b-47a6-8f94-00e99bd3a148</Id>
     </Book>
-    <Book Series="X-Factor" Number="98" Volume="1986" Year="1994" Format="Main Series">
+    <Book Series="X-Factor" Number="98" Volume="1986" Year="1994">
       <Id>d426fc40-bfc9-4b5c-8854-eb3c1889ab32</Id>
     </Book>
-    <Book Series="X-Factor" Number="99" Volume="1986" Year="1994" Format="Main Series">
+    <Book Series="X-Factor" Number="99" Volume="1986" Year="1994">
       <Id>802ea250-2d19-4657-bdc5-be58a5118260</Id>
     </Book>
-    <Book Series="X-Factor" Number="100" Volume="1986" Year="1994" Format="Main Series">
+    <Book Series="X-Factor" Number="100" Volume="1986" Year="1994">
       <Id>080b08f8-dec1-4fc2-b396-ef9af292a2cc</Id>
     </Book>
-    <Book Series="X-Force" Number="27" Volume="1991" Year="1993" Format="Main Series">
+    <Book Series="X-Force" Number="27" Volume="1991" Year="1993">
       <Id>f79acfc8-80b4-4859-91f2-945249921c0c</Id>
     </Book>
-    <Book Series="X-Force" Number="28" Volume="1991" Year="1993" Format="Main Series">
+    <Book Series="X-Force" Number="28" Volume="1991" Year="1993">
       <Id>1edd5529-0749-4a83-8292-9f8660be525b</Id>
     </Book>
-    <Book Series="X-Men" Number="27" Volume="1991" Year="1993" Format="Main Series">
+    <Book Series="X-Men" Number="27" Volume="1991" Year="1993">
       <Id>826bb020-83c4-49da-a036-900348711674</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="3" Volume="1993" Year="1993" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="3" Volume="1993" Year="1993">
       <Id>500a01a7-faa9-448e-a633-fe7aa2fb2904</Id>
     </Book>
-    <Book Series="X-Force" Number="29" Volume="1991" Year="1993" Format="Main Series">
+    <Book Series="X-Force" Number="29" Volume="1991" Year="1993">
       <Id>3db3e50b-0d5d-435b-8b69-f528846491cc</Id>
     </Book>
-    <Book Series="X-Force" Number="30" Volume="1991" Year="1994" Format="Main Series">
+    <Book Series="X-Force" Number="30" Volume="1991" Year="1994">
       <Id>73ed4c81-be28-4a62-a791-061d67fc7a37</Id>
     </Book>
-    <Book Series="Cable" Number="6" Volume="1993" Year="1993" Format="Main Series">
+    <Book Series="Cable" Number="6" Volume="1993" Year="1993">
       <Id>ed30bf57-66d9-4b05-8a2e-45b7255bad4a</Id>
     </Book>
-    <Book Series="Cable" Number="7" Volume="1993" Year="1994" Format="Main Series">
+    <Book Series="Cable" Number="7" Volume="1993" Year="1994">
       <Id>21535f16-99b3-4d1d-b255-011819f95ed7</Id>
     </Book>
-    <Book Series="Cable" Number="8" Volume="1993" Year="1994" Format="Main Series">
+    <Book Series="Cable" Number="8" Volume="1993" Year="1994">
       <Id>9b16ab12-c9f3-48b2-9848-34ead51662e1</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="308" Volume="1981" Year="1994" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="308" Volume="1981" Year="1994">
       <Id>31b4d523-d0cb-4683-a71e-f5ea00802f03</Id>
     </Book>
-    <Book Series="X-Men" Number="28" Volume="1991" Year="1994" Format="Main Series">
+    <Book Series="X-Men" Number="28" Volume="1991" Year="1994">
       <Id>06d4e34d-95a1-4291-8b39-d2fa81b801ff</Id>
     </Book>
-    <Book Series="X-Force" Number="31" Volume="1991" Year="1994" Format="Main Series">
+    <Book Series="X-Force" Number="31" Volume="1991" Year="1994">
       <Id>86587a5f-1c16-4c88-bef0-8fa203282f71</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="309" Volume="1981" Year="1994" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="309" Volume="1981" Year="1994">
       <Id>0f970e11-51d7-4419-bf56-e8b472e4e953</Id>
     </Book>
-    <Book Series="Wolverine" Number="78" Volume="1988" Year="1994" Format="Main Series">
+    <Book Series="Wolverine" Number="78" Volume="1988" Year="1994">
       <Id>0fb21942-94fe-44e6-a88b-79745f5bf422</Id>
     </Book>
-    <Book Series="X-Men" Number="29" Volume="1991" Year="1994" Format="Main Series">
+    <Book Series="X-Men" Number="29" Volume="1991" Year="1994">
       <Id>54a297b2-6125-40d2-b981-003c3491f1a6</Id>
     </Book>
-    <Book Series="X-Force" Number="32" Volume="1991" Year="1994" Format="Main Series">
+    <Book Series="X-Force" Number="32" Volume="1991" Year="1994">
       <Id>14a74ff2-bcf8-487a-b23b-179814ec5551</Id>
     </Book>
-    <Book Series="The New Warriors" Number="45" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="The New Warriors" Number="45" Volume="1990" Year="1994">
       <Id>cd9b4f9a-bc5a-4925-bd46-e526e98c7689</Id>
     </Book>
-    <Book Series="X-Force" Number="33" Volume="1991" Year="1994" Format="Main Series">
+    <Book Series="X-Force" Number="33" Volume="1991" Year="1994">
       <Id>b76edf26-c325-433d-bd57-bcfc6e6eb943</Id>
     </Book>
-    <Book Series="The New Warriors" Number="46" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="The New Warriors" Number="46" Volume="1990" Year="1994">
       <Id>ea657ddc-6b4d-4f98-b165-d6e183498c12</Id>
     </Book>
-    <Book Series="X-Force" Number="34" Volume="1991" Year="1994" Format="Main Series">
+    <Book Series="X-Force" Number="34" Volume="1991" Year="1994">
       <Id>f4181c4c-409c-4421-a5db-5d88e722a3f9</Id>
     </Book>
-    <Book Series="Cable" Number="9" Volume="1993" Year="1994" Format="Main Series">
+    <Book Series="Cable" Number="9" Volume="1993" Year="1994">
       <Id>49f7622a-d26e-4fa9-a94f-78b902164b8d</Id>
     </Book>
-    <Book Series="Cable" Number="10" Volume="1993" Year="1994" Format="Main Series">
+    <Book Series="Cable" Number="10" Volume="1993" Year="1994">
       <Id>0e7f91d1-8f5b-4192-87b7-9e18cf8f9ab3</Id>
     </Book>
-    <Book Series="Cable" Number="11" Volume="1993" Year="1994" Format="Main Series">
+    <Book Series="Cable" Number="11" Volume="1993" Year="1994">
       <Id>b50074e9-b1e7-43b0-82f3-e29c31783be2</Id>
     </Book>
-    <Book Series="Excalibur" Number="74" Volume="1988" Year="1994" Format="Main Series">
+    <Book Series="Excalibur" Number="74" Volume="1988" Year="1994">
       <Id>7f611903-1bd3-44c9-9988-84f27d9bdf6e</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="310" Volume="1981" Year="1994" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="310" Volume="1981" Year="1994">
       <Id>d89fc131-1c34-437b-b1aa-814f2e04590b</Id>
     </Book>
-    <Book Series="X-Men" Number="30" Volume="1991" Year="1994" Format="Main Series">
+    <Book Series="X-Men" Number="30" Volume="1991" Year="1994">
       <Id>ff94d221-2afa-41b3-919b-207036765223</Id>
     </Book>
-    <Book Series="Excalibur" Number="75" Volume="1988" Year="1994" Format="Main Series">
+    <Book Series="Excalibur" Number="75" Volume="1988" Year="1994">
       <Id>3000f65b-3303-4aeb-a7aa-60c5c3d273f1</Id>
     </Book>
-    <Book Series="X-Factor" Number="101" Volume="1986" Year="1994" Format="Main Series">
+    <Book Series="X-Factor" Number="101" Volume="1986" Year="1994">
       <Id>28e758f6-c38f-43b6-93c1-5a276d741121</Id>
     </Book>
-    <Book Series="X-Factor Annual" Number="9" Volume="1986" Year="1994" Format="Annual">
+    <Book Series="X-Factor Annual" Number="9" Volume="1986" Year="1994">
       <Id>2d4e269a-ff29-472d-84c1-546a2f2eb4be</Id>
     </Book>
-    <Book Series="X-Factor" Number="102" Volume="1986" Year="1994" Format="Main Series">
+    <Book Series="X-Factor" Number="102" Volume="1986" Year="1994">
       <Id>658151e7-5c7f-4e02-ac06-ba849f46f0a0</Id>
     </Book>
-    <Book Series="Wolverine" Number="79" Volume="1988" Year="1994" Format="Main Series">
+    <Book Series="Wolverine" Number="79" Volume="1988" Year="1994">
       <Id>6d7c1da4-c9cc-4d10-9ba9-97e70e7e3eeb</Id>
     </Book>
-    <Book Series="Wolverine" Number="80" Volume="1988" Year="1994" Format="Main Series">
+    <Book Series="Wolverine" Number="80" Volume="1988" Year="1994">
       <Id>d660e24c-1956-4486-a25d-96045fafa076</Id>
     </Book>
-    <Book Series="Wolverine" Number="81" Volume="1988" Year="1994" Format="Main Series">
+    <Book Series="Wolverine" Number="81" Volume="1988" Year="1994">
       <Id>537f3681-f88d-413d-a402-3288eabb910b</Id>
     </Book>
-    <Book Series="X-Men" Number="31" Volume="1991" Year="1994" Format="Main Series">
+    <Book Series="X-Men" Number="31" Volume="1991" Year="1994">
       <Id>8f10c4bb-2fe9-4a75-819b-f373e1aa60ed</Id>
     </Book>
-    <Book Series="X-Men" Number="32" Volume="1991" Year="1994" Format="Main Series">
+    <Book Series="X-Men" Number="32" Volume="1991" Year="1994">
       <Id>0f5bdd97-fff9-4756-85ec-f0142c2d9485</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="311" Volume="1981" Year="1994" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="311" Volume="1981" Year="1994">
       <Id>08471da1-a8e9-479d-b305-2d4b3008ed4b</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="312" Volume="1981" Year="1994" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="312" Volume="1981" Year="1994">
       <Id>3a388548-3585-49d4-a383-1fb03129c639</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="313" Volume="1981" Year="1994" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="313" Volume="1981" Year="1994">
       <Id>b8ff9cb5-db11-46ae-80aa-3369a21ccd6c</Id>
     </Book>
-    <Book Series="Wolverine" Number="82" Volume="1988" Year="1994" Format="Main Series">
+    <Book Series="Wolverine" Number="82" Volume="1988" Year="1994">
       <Id>f85a8ec8-22cf-4df1-817c-55ded47fd75e</Id>
     </Book>
-    <Book Series="X-Factor" Number="103" Volume="1986" Year="1994" Format="Main Series">
+    <Book Series="X-Factor" Number="103" Volume="1986" Year="1994">
       <Id>58140226-be47-4a2d-b0ca-83b9ca75e19c</Id>
     </Book>
-    <Book Series="X-Factor" Number="104" Volume="1986" Year="1994" Format="Main Series">
+    <Book Series="X-Factor" Number="104" Volume="1986" Year="1994">
       <Id>1215f864-6ca5-4cc1-a31b-86dfedcdf4d5</Id>
     </Book>
-    <Book Series="X-Factor" Number="105" Volume="1986" Year="1994" Format="Main Series">
+    <Book Series="X-Factor" Number="105" Volume="1986" Year="1994">
       <Id>71743b5f-7609-47ed-8a66-19cb8d8383b3</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="314" Volume="1981" Year="1994" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="314" Volume="1981" Year="1994">
       <Id>b62d721e-39e2-474f-a219-4933a805fa66</Id>
     </Book>
-    <Book Series="The Uncanny X-Men Annual" Number="18" Volume="1982" Year="1994" Format="Annual">
+    <Book Series="The Uncanny X-Men Annual" Number="18" Volume="1982" Year="1994">
       <Id>9e9d0be0-06f0-4eda-9a1d-f6470d88ca8e</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="4" Volume="1993" Year="1994" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="4" Volume="1993" Year="1994">
       <Id>9835675b-e906-495e-bfc7-cbe59cec6857</Id>
     </Book>
-    <Book Series="Excalibur" Number="76" Volume="1988" Year="1994" Format="Main Series">
+    <Book Series="Excalibur" Number="76" Volume="1988" Year="1994">
       <Id>f41ed8cb-3b01-41d9-ad9f-fda4aeb68c90</Id>
     </Book>
-    <Book Series="Excalibur" Number="77" Volume="1988" Year="1994" Format="Main Series">
+    <Book Series="Excalibur" Number="77" Volume="1988" Year="1994">
       <Id>a66950e5-b292-4edf-9cc6-049047727f24</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="5" Volume="1993" Year="1994" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="5" Volume="1993" Year="1994">
       <Id>302d05eb-a450-452f-85b1-50d624d57499</Id>
     </Book>
-    <Book Series="X-Men" Number="33" Volume="1991" Year="1994" Format="Main Series">
+    <Book Series="X-Men" Number="33" Volume="1991" Year="1994">
       <Id>fc66d17a-cf6e-45b5-8b9a-3d91184e6ca0</Id>
     </Book>
-    <Book Series="Cable" Number="12" Volume="1993" Year="1994" Format="Main Series">
+    <Book Series="Cable" Number="12" Volume="1993" Year="1994">
       <Id>2265af61-2435-4272-a54c-71d483a6c114</Id>
     </Book>
-    <Book Series="Cable" Number="13" Volume="1993" Year="1994" Format="Main Series">
+    <Book Series="Cable" Number="13" Volume="1993" Year="1994">
       <Id>fea1f82c-95d0-4515-99e7-6d8fd5ec46fb</Id>
     </Book>
-    <Book Series="Cable" Number="14" Volume="1993" Year="1994" Format="Main Series">
+    <Book Series="Cable" Number="14" Volume="1993" Year="1994">
       <Id>98f6fb76-09a6-4e0a-bc47-222eecc73fa0</Id>
     </Book>
-    <Book Series="Excalibur" Number="78" Volume="1988" Year="1994" Format="Main Series">
+    <Book Series="Excalibur" Number="78" Volume="1988" Year="1994">
       <Id>c817bbbe-2b4c-4d4a-a271-14baefdecdf7</Id>
     </Book>
-    <Book Series="Excalibur" Number="79" Volume="1988" Year="1994" Format="Main Series">
+    <Book Series="Excalibur" Number="79" Volume="1988" Year="1994">
       <Id>35bc67d7-9e99-4c2b-a5dd-de3dc1ce548a</Id>
     </Book>
-    <Book Series="Excalibur" Number="80" Volume="1988" Year="1994" Format="Main Series">
+    <Book Series="Excalibur" Number="80" Volume="1988" Year="1994">
       <Id>e77b3a63-c9b7-41a5-b846-5744a024851a</Id>
     </Book>
-    <Book Series="X-Men" Number="34" Volume="1991" Year="1994" Format="Main Series">
+    <Book Series="X-Men" Number="34" Volume="1991" Year="1994">
       <Id>5bd64103-274a-47bf-a633-abcf1b082e0a</Id>
     </Book>
-    <Book Series="X-Force" Number="35" Volume="1991" Year="1994" Format="Main Series">
+    <Book Series="X-Force" Number="35" Volume="1991" Year="1994">
       <Id>c48cbbd1-1b5f-4c22-bf9d-ae7f353c6de8</Id>
     </Book>
-    <Book Series="X-Force" Number="36" Volume="1991" Year="1994" Format="Main Series">
+    <Book Series="X-Force" Number="36" Volume="1991" Year="1994">
       <Id>2702fded-563f-4fc4-9c73-13499699b9e3</Id>
     </Book>
-    <Book Series="X-Force" Number="37" Volume="1991" Year="1994" Format="Main Series">
+    <Book Series="X-Force" Number="37" Volume="1991" Year="1994">
       <Id>d3f1b325-95fc-49f8-b6b4-4c438d9a8231</Id>
     </Book>
-    <Book Series="Wolverine" Number="83" Volume="1988" Year="1994" Format="Main Series">
+    <Book Series="Wolverine" Number="83" Volume="1988" Year="1994">
       <Id>62036cff-4cf9-4e79-8821-8f15ab7a3802</Id>
     </Book>
-    <Book Series="Wolverine" Number="84" Volume="1988" Year="1994" Format="Main Series">
+    <Book Series="Wolverine" Number="84" Volume="1988" Year="1994">
       <Id>93e54506-6411-4d0a-ba93-601e27367fed</Id>
     </Book>
-    <Book Series="Excalibur" Number="81" Volume="1988" Year="1994" Format="Main Series">
+    <Book Series="Excalibur" Number="81" Volume="1988" Year="1994">
       <Id>e9ab945a-93b6-4862-8226-8cb0d20990a0</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="315" Volume="1981" Year="1994" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="315" Volume="1981" Year="1994">
       <Id>ec57ce13-abeb-4914-8301-04005a7db878</Id>
     </Book>
-    <Book Series="Excalibur Annual" Number="2" Volume="1993" Year="1994" Format="Annual">
+    <Book Series="Excalibur Annual" Number="2" Volume="1993" Year="1994">
       <Id>74f69422-7919-43bf-8d4e-878dd6a5e435</Id>
     </Book>
-    <Book Series="Cable" Number="15" Volume="1993" Year="1994" Format="Main Series">
+    <Book Series="Cable" Number="15" Volume="1993" Year="1994">
       <Id>5033b82d-7352-433c-b4b0-251405f4ca34</Id>
     </Book>
-    <Book Series="Adventures of Cyclops and Phoenix" Number="1" Volume="1994" Year="1994" Format="Limited Series">
+    <Book Series="Adventures of Cyclops and Phoenix" Number="1" Volume="1994" Year="1994">
       <Id>d5d9b025-5a72-4079-b0c8-ea76209908b6</Id>
     </Book>
-    <Book Series="Adventures of Cyclops and Phoenix" Number="2" Volume="1994" Year="1994" Format="Limited Series">
+    <Book Series="Adventures of Cyclops and Phoenix" Number="2" Volume="1994" Year="1994">
       <Id>82239610-f1f1-4df5-8ca4-293fe0cbafb3</Id>
     </Book>
-    <Book Series="Adventures of Cyclops and Phoenix" Number="3" Volume="1994" Year="1994" Format="Limited Series">
+    <Book Series="Adventures of Cyclops and Phoenix" Number="3" Volume="1994" Year="1994">
       <Id>e2923942-6dc5-48ec-8acc-69192c7de2b2</Id>
     </Book>
-    <Book Series="Adventures of Cyclops and Phoenix" Number="4" Volume="1994" Year="1994" Format="Limited Series">
+    <Book Series="Adventures of Cyclops and Phoenix" Number="4" Volume="1994" Year="1994">
       <Id>f5c2d118-395c-4dd1-9ac4-aae7859965e4</Id>
     </Book>
-    <Book Series="X-Men" Number="35" Volume="1991" Year="1994" Format="Main Series">
+    <Book Series="X-Men" Number="35" Volume="1991" Year="1994">
       <Id>a2e9613f-4995-4f24-b882-acac72209fb5</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="316" Volume="1981" Year="1994" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="316" Volume="1981" Year="1994">
       <Id>08acde4b-68fa-4741-9e64-e1ef4c49faa3</Id>
     </Book>
-    <Book Series="X-Men" Number="36" Volume="1991" Year="1994" Format="Main Series">
+    <Book Series="X-Men" Number="36" Volume="1991" Year="1994">
       <Id>2b488b6a-3dc7-4a86-9169-312821038dee</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="317" Volume="1981" Year="1994" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="317" Volume="1981" Year="1994">
       <Id>0b18e7a6-582f-4190-befc-fa96fab434b5</Id>
     </Book>
-    <Book Series="X-Men" Number="37" Volume="1991" Year="1994" Format="Main Series">
+    <Book Series="X-Men" Number="37" Volume="1991" Year="1994">
       <Id>4088d591-aca4-470e-a1eb-4acf97416cb5</Id>
     </Book>
-    <Book Series="X-Factor" Number="106" Volume="1986" Year="1994" Format="Main Series">
+    <Book Series="X-Factor" Number="106" Volume="1986" Year="1994">
       <Id>68f8ffee-dd57-40cb-b4f2-dc9a80883c15</Id>
     </Book>
-    <Book Series="X-Force" Number="38" Volume="1991" Year="1994" Format="Main Series">
+    <Book Series="X-Force" Number="38" Volume="1991" Year="1994">
       <Id>d03bf295-c4c4-4c66-b0b0-ae777e3c20bd</Id>
     </Book>
-    <Book Series="Excalibur" Number="82" Volume="1988" Year="1994" Format="Main Series">
+    <Book Series="Excalibur" Number="82" Volume="1988" Year="1994">
       <Id>48c92a46-c41e-4477-9da7-eff4124b281a</Id>
     </Book>
-    <Book Series="Wolverine" Number="85" Volume="1988" Year="1994" Format="Main Series">
+    <Book Series="Wolverine" Number="85" Volume="1988" Year="1994">
       <Id>e8a8ab3d-5a29-484f-833c-6cba496c2c09</Id>
     </Book>
-    <Book Series="Cable" Number="16" Volume="1993" Year="1994" Format="Main Series">
+    <Book Series="Cable" Number="16" Volume="1993" Year="1994">
       <Id>a859acd2-dc93-4bce-b6f8-ee489446d198</Id>
     </Book>
-    <Book Series="Wolverine" Number="86" Volume="1988" Year="1994" Format="Main Series">
+    <Book Series="Wolverine" Number="86" Volume="1988" Year="1994">
       <Id>b64d3a50-8aa2-490b-a112-651fc6a009eb</Id>
     </Book>
-    <Book Series="Wolverine" Number="87" Volume="1988" Year="1994" Format="Main Series">
+    <Book Series="Wolverine" Number="87" Volume="1988" Year="1994">
       <Id>fa00fd7d-1875-442f-8d8b-cbea35cae322</Id>
     </Book>
-    <Book Series="X-Force" Number="39" Volume="1991" Year="1994" Format="Main Series">
+    <Book Series="X-Force" Number="39" Volume="1991" Year="1994">
       <Id>010fc8b4-67e0-45ce-9733-12e18556b6c3</Id>
     </Book>
-    <Book Series="X-Force Annual" Number="3" Volume="1992" Year="1994" Format="Annual">
+    <Book Series="X-Force Annual" Number="3" Volume="1992" Year="1994">
       <Id>525b6a5e-9a8f-4f2d-b60d-8d28321ed771</Id>
     </Book>
-    <Book Series="X-Men Annual" Number="3" Volume="1992" Year="1994" Format="Annual">
+    <Book Series="X-Men Annual" Number="3" Volume="1992" Year="1994">
       <Id>193e84b5-99bc-42ec-9639-72735e8054d9</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="6" Volume="1993" Year="1994" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="6" Volume="1993" Year="1994">
       <Id>f5aaaa2a-24ef-49e8-beb8-941a3541bcc3</Id>
     </Book>
-    <Book Series="Excalibur" Number="83" Volume="1988" Year="1994" Format="Main Series">
+    <Book Series="Excalibur" Number="83" Volume="1988" Year="1994">
       <Id>87bd4b41-fe99-4864-8d44-5b50c6fe57a4</Id>
     </Book>
-    <Book Series="Excalibur" Number="84" Volume="1988" Year="1994" Format="Main Series">
+    <Book Series="Excalibur" Number="84" Volume="1988" Year="1994">
       <Id>3c3c6cbe-d691-4850-ab6d-0c80a9797e77</Id>
     </Book>
-    <Book Series="Excalibur" Number="85" Volume="1988" Year="1995" Format="Main Series">
+    <Book Series="Excalibur" Number="85" Volume="1988" Year="1995">
       <Id>6c3d84fd-f777-4b5b-b13f-84e677c0ff14</Id>
     </Book>
   </Books>

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 005.cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 005.cbl
@@ -2,928 +2,928 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>X-Men - Part 5</Name>
   <Books>
-    <Book Series="Bishop" Number="1" Volume="1994" Year="1994" Format="Limited Series">
+    <Book Series="Bishop" Number="1" Volume="1994" Year="1994">
       <Id>0f879a9c-a0d4-4666-8451-d8bf23b19cf8</Id>
     </Book>
-    <Book Series="Bishop" Number="2" Volume="1994" Year="1995" Format="Limited Series">
+    <Book Series="Bishop" Number="2" Volume="1994" Year="1995">
       <Id>30a01bb0-4874-441a-95ac-0ac5aada043c</Id>
     </Book>
-    <Book Series="Bishop" Number="3" Volume="1994" Year="1995" Format="Limited Series">
+    <Book Series="Bishop" Number="3" Volume="1994" Year="1995">
       <Id>aa9477be-271b-491b-b66a-c224f70d30b6</Id>
     </Book>
-    <Book Series="Bishop" Number="4" Volume="1994" Year="1995" Format="Limited Series">
+    <Book Series="Bishop" Number="4" Volume="1994" Year="1995">
       <Id>dfe515ea-9122-4339-aee0-079d3d472077</Id>
     </Book>
-    <Book Series="X-Factor" Number="107" Volume="1986" Year="1994" Format="Main Series">
+    <Book Series="X-Factor" Number="107" Volume="1986" Year="1994">
       <Id>6a53b8a3-247a-4c1f-9bc7-fc38bbd082e3</Id>
     </Book>
-    <Book Series="X-Force" Number="40" Volume="1991" Year="1994" Format="Main Series">
+    <Book Series="X-Force" Number="40" Volume="1991" Year="1994">
       <Id>8c3de41d-8722-4016-9efd-537b124974cd</Id>
     </Book>
-    <Book Series="X-Force" Number="41" Volume="1991" Year="1994" Format="Main Series">
+    <Book Series="X-Force" Number="41" Volume="1991" Year="1994">
       <Id>a3865772-9827-4bb2-9916-6c048c89db80</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="7" Volume="1993" Year="1994" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="7" Volume="1993" Year="1994">
       <Id>b555ef66-26de-43ce-97a7-6fb6bbbdf060</Id>
     </Book>
-    <Book Series="Wolverine" Number="88" Volume="1988" Year="1994" Format="Main Series">
+    <Book Series="Wolverine" Number="88" Volume="1988" Year="1994">
       <Id>9bba1d96-8be8-4863-ab58-dd2d3b7ed9e8</Id>
     </Book>
-    <Book Series="Cable" Number="17" Volume="1993" Year="1994" Format="Main Series">
+    <Book Series="Cable" Number="17" Volume="1993" Year="1994">
       <Id>e65335e2-2fb9-4bfc-8841-5ee5f0820d8b</Id>
     </Book>
-    <Book Series="Cable" Number="18" Volume="1993" Year="1994" Format="Main Series">
+    <Book Series="Cable" Number="18" Volume="1993" Year="1994">
       <Id>492d39bb-a6ba-4151-b9bd-2f834663df1a</Id>
     </Book>
-    <Book Series="Cable" Number="19" Volume="1993" Year="1995" Format="Main Series">
+    <Book Series="Cable" Number="19" Volume="1993" Year="1995">
       <Id>3daeecad-4e19-402a-8c13-182bf64f7c63</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="318" Volume="1981" Year="1994" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="318" Volume="1981" Year="1994">
       <Id>3b6ae773-7ed7-4bc3-a9d7-8e99e4209a77</Id>
     </Book>
-    <Book Series="X-Men" Number="38" Volume="1991" Year="1994" Format="Main Series">
+    <Book Series="X-Men" Number="38" Volume="1991" Year="1994">
       <Id>3a3aae83-35db-4083-9752-e8b44579335c</Id>
     </Book>
-    <Book Series="Generation X" Number="1" Volume="1994" Year="1994" Format="Main Series">
+    <Book Series="Generation X" Number="1" Volume="1994" Year="1994">
       <Id>58697acc-e7f9-40fc-a55f-459830218f5e</Id>
     </Book>
-    <Book Series="Generation X" Number="2" Volume="1994" Year="1994" Format="Main Series">
+    <Book Series="Generation X" Number="2" Volume="1994" Year="1994">
       <Id>ec3a8cdd-40b4-4d6b-bc8c-4ba15a02777d</Id>
     </Book>
-    <Book Series="Generation X" Number="3" Volume="1994" Year="1995" Format="Main Series">
+    <Book Series="Generation X" Number="3" Volume="1994" Year="1995">
       <Id>6fb4727e-ea5a-46ee-bc34-260aa24204a3</Id>
     </Book>
-    <Book Series="X-Men" Number="39" Volume="1991" Year="1994" Format="Main Series">
+    <Book Series="X-Men" Number="39" Volume="1991" Year="1994">
       <Id>318193c1-2c2d-47a8-b10b-87b4336133fe</Id>
     </Book>
-    <Book Series="Rogue" Number="1" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Rogue" Number="1" Volume="1995" Year="1995">
       <Id>25a8854c-6c90-4a0e-8cb7-7e25e2fefa20</Id>
     </Book>
-    <Book Series="Rogue" Number="2" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Rogue" Number="2" Volume="1995" Year="1995">
       <Id>2fd1b5bb-c0ff-408e-a3f4-92f1e3a11567</Id>
     </Book>
-    <Book Series="Rogue" Number="3" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Rogue" Number="3" Volume="1995" Year="1995">
       <Id>e6106078-95c0-40d6-985a-9520c0d4f8ce</Id>
     </Book>
-    <Book Series="Rogue" Number="4" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Rogue" Number="4" Volume="1995" Year="1995">
       <Id>fae973ac-3abe-4406-aa0a-324cfebff6db</Id>
     </Book>
-    <Book Series="Wolverine" Number="89" Volume="1988" Year="1995" Format="Main Series">
+    <Book Series="Wolverine" Number="89" Volume="1988" Year="1995">
       <Id>2ad2f317-6af9-4eb6-90ff-36922ff47666</Id>
     </Book>
-    <Book Series="X-Force" Number="42" Volume="1991" Year="1995" Format="Main Series">
+    <Book Series="X-Force" Number="42" Volume="1991" Year="1995">
       <Id>41282380-b429-44c5-b977-3bb61ad5beed</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="319" Volume="1981" Year="1994" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="319" Volume="1981" Year="1994">
       <Id>85e0d238-f207-493a-9f41-a0ebab1b116c</Id>
     </Book>
-    <Book Series="X-Factor" Number="108" Volume="1986" Year="1994" Format="Main Series">
+    <Book Series="X-Factor" Number="108" Volume="1986" Year="1994">
       <Id>5493b918-fd31-4a49-ba67-08e960dd0e2f</Id>
     </Book>
-    <Book Series="X-Factor" Number="109" Volume="1986" Year="1994" Format="Main Series">
+    <Book Series="X-Factor" Number="109" Volume="1986" Year="1994">
       <Id>298e7d0f-a07d-4187-9176-20bbcf4cd96a</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="320" Volume="1981" Year="1995" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="320" Volume="1981" Year="1995">
       <Id>b33a3ba7-36ae-4783-9244-4c44b1fa4600</Id>
     </Book>
-    <Book Series="X-Men" Number="40" Volume="1991" Year="1995" Format="Main Series">
+    <Book Series="X-Men" Number="40" Volume="1991" Year="1995">
       <Id>4d9ba072-66e6-46dc-ba83-4eb343e3b72b</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="321" Volume="1981" Year="1995" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="321" Volume="1981" Year="1995">
       <Id>91cc9375-1de9-402e-82ab-d853f3bb2d28</Id>
     </Book>
-    <Book Series="Cable" Number="20" Volume="1993" Year="1995" Format="Main Series">
+    <Book Series="Cable" Number="20" Volume="1993" Year="1995">
       <Id>7d7afb0d-89df-4298-a8e8-10fffa77a0c9</Id>
     </Book>
-    <Book Series="X-Men" Number="41" Volume="1991" Year="1995" Format="Main Series">
+    <Book Series="X-Men" Number="41" Volume="1991" Year="1995">
       <Id>886f7e57-49c8-4629-b3b8-a7864e222fb5</Id>
     </Book>
-    <Book Series="X-Factor" Number="110" Volume="1986" Year="1995" Format="Main Series">
+    <Book Series="X-Factor" Number="110" Volume="1986" Year="1995">
       <Id>cea71b92-39d1-4056-a035-e8375eefe5d0</Id>
     </Book>
-    <Book Series="X-Factor" Number="111" Volume="1986" Year="1995" Format="Main Series">
+    <Book Series="X-Factor" Number="111" Volume="1986" Year="1995">
       <Id>5b27e0a0-1b08-4cfe-a1a2-cae6fcc58378</Id>
     </Book>
-    <Book Series="Wolverine" Number="90" Volume="1988" Year="1995" Format="Main Series">
+    <Book Series="Wolverine" Number="90" Volume="1988" Year="1995">
       <Id>8e63517a-d3bb-44be-83e7-4718d484c761</Id>
     </Book>
-    <Book Series="Generation X" Number="4" Volume="1994" Year="1995" Format="Main Series">
+    <Book Series="Generation X" Number="4" Volume="1994" Year="1995">
       <Id>2fc597df-232a-45df-8ece-713c3b442fcd</Id>
     </Book>
-    <Book Series="Excalibur" Number="86" Volume="1988" Year="1995" Format="Main Series">
+    <Book Series="Excalibur" Number="86" Volume="1988" Year="1995">
       <Id>9ae5dc98-f5e6-43ce-9f6e-77f6a900aca1</Id>
     </Book>
-    <Book Series="X-Force" Number="43" Volume="1991" Year="1995" Format="Main Series">
+    <Book Series="X-Force" Number="43" Volume="1991" Year="1995">
       <Id>046584cb-7862-488b-9e5f-ae1f406091ab</Id>
     </Book>
-    <Book Series="X-Men Chronicles" Number="1" Volume="1995" Year="1995" Format="Crossover">
+    <Book Series="X-Men Chronicles" Number="1" Volume="1995" Year="1995">
       <Id>c0738a6b-82ea-4c1c-aa27-4ff33d68a734</Id>
     </Book>
-    <Book Series="X-Man" Number="-1" Volume="1995" Year="1997" Format="Main Series">
+    <Book Series="X-Man" Number="-1" Volume="1995" Year="1997">
       <Id>fe990795-c474-48be-8257-aebca9b2587e</Id>
     </Book>
-    <Book Series="X-Men Chronicles" Number="2" Volume="1995" Year="1995" Format="Crossover">
+    <Book Series="X-Men Chronicles" Number="2" Volume="1995" Year="1995">
       <Id>e41065cb-2145-4679-9356-3eeb043e9272</Id>
     </Book>
-    <Book Series="Tales from the Age of Apocalypse" Number="1" Volume="1996" Year="1996" Format="One-Shot">
+    <Book Series="Tales from the Age of Apocalypse" Number="1" Volume="1996" Year="1996">
       <Id>2a290e06-187b-41c2-9814-f29a6b689e67</Id>
     </Book>
-    <Book Series="Blink" Number="1" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Blink" Number="1" Volume="2001" Year="2001">
       <Id>871dc3c2-9485-4f31-b010-485fa53d1f2a</Id>
     </Book>
-    <Book Series="Blink" Number="2" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Blink" Number="2" Volume="2001" Year="2001">
       <Id>b940d7ba-4fbe-4ed4-8c4b-91f33d285541</Id>
     </Book>
-    <Book Series="Blink" Number="3" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Blink" Number="3" Volume="2001" Year="2001">
       <Id>09b40643-1c2c-443b-ae8b-45805eea2cb7</Id>
     </Book>
-    <Book Series="Blink" Number="4" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Blink" Number="4" Volume="2001" Year="2001">
       <Id>78964e7b-d10a-45d2-b015-f6d1aff6497f</Id>
     </Book>
-    <Book Series="X-Men Alpha" Number="1" Volume="1995" Year="1995" Format="One-Shot">
+    <Book Series="X-Men Alpha" Number="1" Volume="1995" Year="1995">
       <Id>c7bdbc33-48f3-4eac-8db9-2d30091cfa69</Id>
     </Book>
-    <Book Series="Generation Next" Number="1" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Generation Next" Number="1" Volume="1995" Year="1995">
       <Id>aacafac8-86e4-47c8-9d8d-9613767e2807</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="1" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Astonishing X-Men" Number="1" Volume="1995" Year="1995">
       <Id>8cced9a9-8628-4ff6-af10-5bcae9edd8f0</Id>
     </Book>
-    <Book Series="X-Calibre" Number="1" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="X-Calibre" Number="1" Volume="1995" Year="1995">
       <Id>6299f31f-5a84-44c7-a1d0-6e5a58a96f73</Id>
     </Book>
-    <Book Series="Gambit &amp; The X-Ternals" Number="1" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Gambit &amp; The X-Ternals" Number="1" Volume="1995" Year="1995">
       <Id>cf57b814-d417-4db2-ba86-3ef75cc82595</Id>
     </Book>
-    <Book Series="Weapon X" Number="1" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Weapon X" Number="1" Volume="1995" Year="1995">
       <Id>d2548111-5a82-4523-8332-d474ac2d59fd</Id>
     </Book>
-    <Book Series="Amazing X-Men" Number="1" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Amazing X-Men" Number="1" Volume="1995" Year="1995">
       <Id>c8ced0cf-bd4e-4062-86c5-4e79cb528f53</Id>
     </Book>
-    <Book Series="Factor X" Number="1" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Factor X" Number="1" Volume="1995" Year="1995">
       <Id>2399f53e-b799-43e0-8cbb-2f73afaed13b</Id>
     </Book>
-    <Book Series="X-Man" Number="1" Volume="1995" Year="1995" Format="Main Series">
+    <Book Series="X-Man" Number="1" Volume="1995" Year="1995">
       <Id>b6798426-9d74-40ef-99c8-1f93f433796c</Id>
     </Book>
-    <Book Series="Amazing X-Men" Number="2" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Amazing X-Men" Number="2" Volume="1995" Year="1995">
       <Id>b983bd3a-e086-4c54-b033-e8bc49629fa0</Id>
     </Book>
-    <Book Series="Factor X" Number="2" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Factor X" Number="2" Volume="1995" Year="1995">
       <Id>b9b9391f-5041-4fdc-a3be-14dd72a37819</Id>
     </Book>
-    <Book Series="Generation Next" Number="2" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Generation Next" Number="2" Volume="1995" Year="1995">
       <Id>c2e391e5-50c5-4b65-8f9d-28c2bb42caa9</Id>
     </Book>
-    <Book Series="Weapon X" Number="2" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Weapon X" Number="2" Volume="1995" Year="1995">
       <Id>bb034f44-dbb6-4e7a-831e-d03efdc07263</Id>
     </Book>
-    <Book Series="Gambit &amp; The X-Ternals" Number="2" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Gambit &amp; The X-Ternals" Number="2" Volume="1995" Year="1995">
       <Id>7573426b-cadb-4615-b593-61ad8849edff</Id>
     </Book>
-    <Book Series="X-Calibre" Number="2" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="X-Calibre" Number="2" Volume="1995" Year="1995">
       <Id>153b9675-efcd-4e56-a3e9-6c6bbdd2e724</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="2" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Astonishing X-Men" Number="2" Volume="1995" Year="1995">
       <Id>075ce8e4-8193-4380-9a5d-6311691c436b</Id>
     </Book>
-    <Book Series="X-Man" Number="2" Volume="1995" Year="1995" Format="Main Series">
+    <Book Series="X-Man" Number="2" Volume="1995" Year="1995">
       <Id>6069ba8f-3bd2-43a7-94be-449eefd17bd1</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="3" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Astonishing X-Men" Number="3" Volume="1995" Year="1995">
       <Id>ff18452d-55fd-475e-8884-38b3ccb64d9b</Id>
     </Book>
-    <Book Series="Factor X" Number="3" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Factor X" Number="3" Volume="1995" Year="1995">
       <Id>c1abb1ec-152c-4f7c-9634-2eb001ea6ded</Id>
     </Book>
-    <Book Series="X-Universe" Number="1" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="X-Universe" Number="1" Volume="1995" Year="1995">
       <Id>f1f9d17a-e52d-4fa4-aa3b-b053a338209a</Id>
     </Book>
-    <Book Series="Amazing X-Men" Number="3" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Amazing X-Men" Number="3" Volume="1995" Year="1995">
       <Id>9cb82af3-5376-4dcb-8c72-e3ffa4876135</Id>
     </Book>
-    <Book Series="X-Calibre" Number="3" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="X-Calibre" Number="3" Volume="1995" Year="1995">
       <Id>c4179eed-a589-40cf-a237-2da2723aefae</Id>
     </Book>
-    <Book Series="Weapon X" Number="3" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Weapon X" Number="3" Volume="1995" Year="1995">
       <Id>cf185a36-1858-4e28-a1c2-eca13a3a1142</Id>
     </Book>
-    <Book Series="Gambit &amp; The X-Ternals" Number="3" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Gambit &amp; The X-Ternals" Number="3" Volume="1995" Year="1995">
       <Id>0dc276ae-c375-4bab-a079-df7f9df22124</Id>
     </Book>
-    <Book Series="Generation Next" Number="3" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Generation Next" Number="3" Volume="1995" Year="1995">
       <Id>8d8901a0-c27d-41f9-853b-ba067cb40b01</Id>
     </Book>
-    <Book Series="X-Man" Number="3" Volume="1995" Year="1995" Format="Main Series">
+    <Book Series="X-Man" Number="3" Volume="1995" Year="1995">
       <Id>3025bf4f-d549-4574-8cf9-3007cb4c45ec</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="4" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Astonishing X-Men" Number="4" Volume="1995" Year="1995">
       <Id>0dd9b1f0-860e-4235-b813-3fd480a781dc</Id>
     </Book>
-    <Book Series="Generation Next" Number="4" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Generation Next" Number="4" Volume="1995" Year="1995">
       <Id>591ba345-2564-4380-911c-4f0025c3cf25</Id>
     </Book>
-    <Book Series="X-Calibre" Number="4" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="X-Calibre" Number="4" Volume="1995" Year="1995">
       <Id>ac85a233-7c1f-476e-97bc-2a9484ed64eb</Id>
     </Book>
-    <Book Series="X-Man" Number="4" Volume="1995" Year="1995" Format="Main Series">
+    <Book Series="X-Man" Number="4" Volume="1995" Year="1995">
       <Id>934d12ae-ef45-4635-aeb2-7acfbb76db24</Id>
     </Book>
-    <Book Series="Factor X" Number="4" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Factor X" Number="4" Volume="1995" Year="1995">
       <Id>a8136807-4d04-4967-a17b-1e2560be1928</Id>
     </Book>
-    <Book Series="Gambit &amp; The X-Ternals" Number="4" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Gambit &amp; The X-Ternals" Number="4" Volume="1995" Year="1995">
       <Id>5f5ae3cd-921b-4236-ba9d-46c3b20b7552</Id>
     </Book>
-    <Book Series="Amazing X-Men" Number="4" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Amazing X-Men" Number="4" Volume="1995" Year="1995">
       <Id>8219d545-3edc-4b1f-826a-563e3ea33423</Id>
     </Book>
-    <Book Series="Weapon X" Number="4" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Weapon X" Number="4" Volume="1995" Year="1995">
       <Id>67215d65-d31f-467b-8a9c-9357a25d8b13</Id>
     </Book>
-    <Book Series="X-Universe" Number="2" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="X-Universe" Number="2" Volume="1995" Year="1995">
       <Id>b2e98eef-9857-4637-8209-c7d9bdea3745</Id>
     </Book>
-    <Book Series="X-Men Omega" Number="1" Volume="1995" Year="1995" Format="One-Shot">
+    <Book Series="X-Men Omega" Number="1" Volume="1995" Year="1995">
       <Id>b2cd265a-e64e-47a8-a683-fdd55a4a270e</Id>
     </Book>
-    <Book Series="X-Men: Age of Apocalypse" Number="1" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="X-Men: Age of Apocalypse" Number="1" Volume="2005" Year="2005">
       <Id>ef9e8c8d-00df-435b-b572-afa7bb4025e7</Id>
     </Book>
-    <Book Series="X-Men: Age of Apocalypse" Number="2" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="X-Men: Age of Apocalypse" Number="2" Volume="2005" Year="2005">
       <Id>ef4d2110-e409-4ad3-adb1-0ee287eecc1d</Id>
     </Book>
-    <Book Series="X-Men: Age of Apocalypse" Number="3" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="X-Men: Age of Apocalypse" Number="3" Volume="2005" Year="2005">
       <Id>9a7e2e0c-e5fb-424d-bae3-eed9948d93b5</Id>
     </Book>
-    <Book Series="X-Men: Age of Apocalypse" Number="4" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="X-Men: Age of Apocalypse" Number="4" Volume="2005" Year="2005">
       <Id>6bcea370-3a0e-4213-9f5f-a444420ffba7</Id>
     </Book>
-    <Book Series="X-Men: Age of Apocalypse" Number="5" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="X-Men: Age of Apocalypse" Number="5" Volume="2005" Year="2005">
       <Id>6d31c2be-c614-4c9e-a8f1-77742b4b1cd8</Id>
     </Book>
-    <Book Series="X-Men: Age of Apocalypse" Number="6" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="X-Men: Age of Apocalypse" Number="6" Volume="2005" Year="2005">
       <Id>b288d53e-ec3a-4390-867e-d222325707de</Id>
     </Book>
-    <Book Series="X-Men: Prime" Number="1" Volume="1995" Year="1995" Format="One-Shot">
+    <Book Series="X-Men: Prime" Number="1" Volume="1995" Year="1995">
       <Id>a114cd8a-400e-4cd2-93bf-2c129210f7e8</Id>
     </Book>
-    <Book Series="X-Man" Number="5" Volume="1995" Year="1995" Format="Main Series">
+    <Book Series="X-Man" Number="5" Volume="1995" Year="1995">
       <Id>1003af90-c7b1-4d6c-bd20-aff110ae2009</Id>
     </Book>
-    <Book Series="Excalibur" Number="87" Volume="1988" Year="1995" Format="Main Series">
+    <Book Series="Excalibur" Number="87" Volume="1988" Year="1995">
       <Id>fafbe7bf-7fd7-4d1b-815f-275c3b7a4907</Id>
     </Book>
-    <Book Series="Wolverine" Number="91" Volume="1988" Year="1995" Format="Main Series">
+    <Book Series="Wolverine" Number="91" Volume="1988" Year="1995">
       <Id>17f903d7-3dfe-414d-bcb4-1f3bc7e6f687</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="322" Volume="1981" Year="1995" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="322" Volume="1981" Year="1995">
       <Id>57e39fd6-667f-4987-abe3-041338aa55a1</Id>
     </Book>
-    <Book Series="X-Men" Number="42" Volume="1991" Year="1995" Format="Main Series">
+    <Book Series="X-Men" Number="42" Volume="1991" Year="1995">
       <Id>b0a2793f-58d1-49d9-8cfc-368e8062a73e</Id>
     </Book>
-    <Book Series="X-Men" Number="43" Volume="1991" Year="1995" Format="Main Series">
+    <Book Series="X-Men" Number="43" Volume="1991" Year="1995">
       <Id>fe0ce201-c9b5-4e4a-bb69-3d8c9b9e41e5</Id>
     </Book>
-    <Book Series="X-Men" Number="44" Volume="1991" Year="1995" Format="Main Series">
+    <Book Series="X-Men" Number="44" Volume="1991" Year="1995">
       <Id>011b70b2-1f6a-422e-923d-8abafab7b82f</Id>
     </Book>
-    <Book Series="Cable" Number="21" Volume="1993" Year="1995" Format="Main Series">
+    <Book Series="Cable" Number="21" Volume="1993" Year="1995">
       <Id>b671cdd0-5db7-4b9e-ae40-014c140dc5c2</Id>
     </Book>
-    <Book Series="X-Force" Number="44" Volume="1991" Year="1995" Format="Main Series">
+    <Book Series="X-Force" Number="44" Volume="1991" Year="1995">
       <Id>f39b5fce-4e17-4a08-a19a-0936ca6cb959</Id>
     </Book>
-    <Book Series="X-Man" Number="6" Volume="1995" Year="1995" Format="Main Series">
+    <Book Series="X-Man" Number="6" Volume="1995" Year="1995">
       <Id>7800b521-a12a-4ba9-af7e-f25e0159d6f6</Id>
     </Book>
-    <Book Series="X-Factor" Number="112" Volume="1986" Year="1995" Format="Main Series">
+    <Book Series="X-Factor" Number="112" Volume="1986" Year="1995">
       <Id>6ddf0e3b-4312-495f-8d92-4d1f5761bc9e</Id>
     </Book>
-    <Book Series="X-Factor" Number="113" Volume="1986" Year="1995" Format="Main Series">
+    <Book Series="X-Factor" Number="113" Volume="1986" Year="1995">
       <Id>c54e89f8-ed76-4013-b70c-e2eaad818cbf</Id>
     </Book>
-    <Book Series="Cable" Number="22" Volume="1993" Year="1995" Format="Main Series">
+    <Book Series="Cable" Number="22" Volume="1993" Year="1995">
       <Id>8da2ba37-c48d-42c3-aef2-1f2e3c291e93</Id>
     </Book>
-    <Book Series="Wolverine Annual '95" Number="1" Volume="1995" Year="1995" Format="Annual">
+    <Book Series="Wolverine Annual '95" Number="1" Volume="1995" Year="1995">
       <Id>438984c9-5f47-4ecb-ad51-1eb07f9fbb4f</Id>
     </Book>
-    <Book Series="X-Force" Number="45" Volume="1991" Year="1995" Format="Main Series">
+    <Book Series="X-Force" Number="45" Volume="1991" Year="1995">
       <Id>1d6025fb-1083-495e-9a26-c1170af25ca0</Id>
     </Book>
-    <Book Series="X-Force" Number="46" Volume="1991" Year="1995" Format="Main Series">
+    <Book Series="X-Force" Number="46" Volume="1991" Year="1995">
       <Id>95ce1c52-9385-40eb-9852-1439930432fa</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="323" Volume="1981" Year="1995" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="323" Volume="1981" Year="1995">
       <Id>89734e82-e0df-43ad-9f56-44dca0c7304b</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="324" Volume="1981" Year="1995" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="324" Volume="1981" Year="1995">
       <Id>711d13b8-bcd5-472d-894e-446da1539001</Id>
     </Book>
-    <Book Series="Wolverine" Number="92" Volume="1988" Year="1995" Format="Main Series">
+    <Book Series="Wolverine" Number="92" Volume="1988" Year="1995">
       <Id>8c1596fa-be54-4f47-9ebf-3f441a1d557d</Id>
     </Book>
-    <Book Series="Generation X" Number="5" Volume="1994" Year="1995" Format="Main Series">
+    <Book Series="Generation X" Number="5" Volume="1994" Year="1995">
       <Id>3ec80e3d-6bfe-43e7-8e57-58b0dae96e15</Id>
     </Book>
-    <Book Series="Generation X" Number="6" Volume="1994" Year="1995" Format="Main Series">
+    <Book Series="Generation X" Number="6" Volume="1994" Year="1995">
       <Id>6f4714a4-73a1-4a10-9dec-833f3386c9c0</Id>
     </Book>
-    <Book Series="X-Force" Number="47" Volume="1991" Year="1995" Format="Main Series">
+    <Book Series="X-Force" Number="47" Volume="1991" Year="1995">
       <Id>fcd426ea-1257-4e9f-a38c-bf2c4bb8cc59</Id>
     </Book>
-    <Book Series="X-Factor" Number="114" Volume="1986" Year="1995" Format="Main Series">
+    <Book Series="X-Factor" Number="114" Volume="1986" Year="1995">
       <Id>5210d24b-3594-427e-9675-baeaa62bae63</Id>
     </Book>
-    <Book Series="Excalibur" Number="88" Volume="1988" Year="1995" Format="Main Series">
+    <Book Series="Excalibur" Number="88" Volume="1988" Year="1995">
       <Id>4aeb2502-2144-46fe-9375-cea24eaa0a1d</Id>
     </Book>
-    <Book Series="Excalibur" Number="89" Volume="1988" Year="1995" Format="Main Series">
+    <Book Series="Excalibur" Number="89" Volume="1988" Year="1995">
       <Id>059f243d-9d8b-48f9-bdfa-d636b06d98ea</Id>
     </Book>
-    <Book Series="Excalibur" Number="90" Volume="1988" Year="1995" Format="Main Series">
+    <Book Series="Excalibur" Number="90" Volume="1988" Year="1995">
       <Id>23e684ff-aaa7-4e28-a1de-4564bd0c883e</Id>
     </Book>
-    <Book Series="Wolverine: Knight of Terra" Number="1" Volume="1995" Year="1995" Format="One-Shot">
+    <Book Series="Wolverine: Knight of Terra" Number="1" Volume="1995" Year="1995">
       <Id>5ea9aa1e-b0e6-4f94-aabc-e2b2a55c8682</Id>
     </Book>
-    <Book Series="Starjammers" Number="1" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Starjammers" Number="1" Volume="1995" Year="1995">
       <Id>3c6ade65-6154-4b14-b3ff-8e1eb8b884bd</Id>
     </Book>
-    <Book Series="Starjammers" Number="2" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Starjammers" Number="2" Volume="1995" Year="1995">
       <Id>cfe6940d-94a2-4a0d-839c-14916aba6d24</Id>
     </Book>
-    <Book Series="Starjammers" Number="3" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Starjammers" Number="3" Volume="1995" Year="1995">
       <Id>82030bac-f667-4f65-8123-c989c813c708</Id>
     </Book>
-    <Book Series="Starjammers" Number="4" Volume="1995" Year="1996" Format="Limited Series">
+    <Book Series="Starjammers" Number="4" Volume="1995" Year="1996">
       <Id>e65e5c9f-4c1a-41ab-8e64-e51e19fd8166</Id>
     </Book>
-    <Book Series="X-Man" Number="7" Volume="1995" Year="1995" Format="Main Series">
+    <Book Series="X-Man" Number="7" Volume="1995" Year="1995">
       <Id>6d2d39aa-f3b1-4c5e-a4b8-60c4beb3f0e6</Id>
     </Book>
-    <Book Series="X-Men Annual '95" Number="1" Volume="1995" Year="1995" Format="Annual">
+    <Book Series="X-Men Annual '95" Number="1" Volume="1995" Year="1995">
       <Id>3ccf9a99-696e-4ef1-a35f-88d162ccaa14</Id>
     </Book>
-    <Book Series="Wolverine" Number="93" Volume="1988" Year="1995" Format="Main Series">
+    <Book Series="Wolverine" Number="93" Volume="1988" Year="1995">
       <Id>c3d31580-96d4-4ac9-8624-1bf7a8127805</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="325" Volume="1981" Year="1995" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="325" Volume="1981" Year="1995">
       <Id>443b3a50-0847-42fe-bd5c-f405696b4214</Id>
     </Book>
-    <Book Series="X-Men" Number="45" Volume="1991" Year="1995" Format="Main Series">
+    <Book Series="X-Men" Number="45" Volume="1991" Year="1995">
       <Id>ca3e2367-0dec-4e4b-b4c0-6b46915a0d96</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="326" Volume="1981" Year="1995" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="326" Volume="1981" Year="1995">
       <Id>ee2119dc-1039-4c8e-b8ac-662e46fce4e8</Id>
     </Book>
-    <Book Series="X-Factor" Number="115" Volume="1986" Year="1995" Format="Main Series">
+    <Book Series="X-Factor" Number="115" Volume="1986" Year="1995">
       <Id>f67f07fd-a4a6-40f6-8500-36b0cc32d5ce</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="8" Volume="1993" Year="1995" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="8" Volume="1993" Year="1995">
       <Id>c6d52d78-9460-4027-a473-03387cd6babf</Id>
     </Book>
-    <Book Series="Wolverine" Number="94" Volume="1988" Year="1995" Format="Main Series">
+    <Book Series="Wolverine" Number="94" Volume="1988" Year="1995">
       <Id>790d2a70-d212-4b5f-be54-c15a816ecb7f</Id>
     </Book>
-    <Book Series="Storm" Number="1" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Storm" Number="1" Volume="1996" Year="1996">
       <Id>e0b98444-7861-420b-bfc5-80090bcc8061</Id>
     </Book>
-    <Book Series="Storm" Number="2" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Storm" Number="2" Volume="1996" Year="1996">
       <Id>c71f542e-c0ea-476a-b860-96aa25d91a98</Id>
     </Book>
-    <Book Series="Storm" Number="3" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Storm" Number="3" Volume="1996" Year="1996">
       <Id>f9c44871-9aa8-48e9-9b36-2f8b2d15a003</Id>
     </Book>
-    <Book Series="Storm" Number="4" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Storm" Number="4" Volume="1996" Year="1996">
       <Id>0f9a76cd-58f7-4107-b2e7-cde7ce54169f</Id>
     </Book>
-    <Book Series="X-Men: Books of Askani" Number="1" Volume="1995" Year="1995" Format="One-Shot">
+    <Book Series="X-Men: Books of Askani" Number="1" Volume="1995" Year="1995">
       <Id>68a8b1c9-8c94-40a4-aac5-182fac374aa4</Id>
     </Book>
-    <Book Series="Askani'Son" Number="1" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Askani'Son" Number="1" Volume="1996" Year="1996">
       <Id>1afac113-9b8f-4142-b3b2-763c2b21d04a</Id>
     </Book>
-    <Book Series="Askani'Son" Number="2" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Askani'Son" Number="2" Volume="1996" Year="1996">
       <Id>77a9fad8-b4b0-4af3-9777-da2aa983da40</Id>
     </Book>
-    <Book Series="Askani'Son" Number="3" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Askani'Son" Number="3" Volume="1996" Year="1996">
       <Id>a23a637d-b0e4-4fa7-8525-4c652f4a6c99</Id>
     </Book>
-    <Book Series="Askani'Son" Number="4" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Askani'Son" Number="4" Volume="1996" Year="1996">
       <Id>841a47e8-4abe-45ca-b8f2-4ca340c589f7</Id>
     </Book>
-    <Book Series="Cable" Number="23" Volume="1993" Year="1995" Format="Main Series">
+    <Book Series="Cable" Number="23" Volume="1993" Year="1995">
       <Id>03b7465d-a50d-4ceb-90ed-ae3b8f076712</Id>
     </Book>
-    <Book Series="Cable" Number="24" Volume="1993" Year="1995" Format="Main Series">
+    <Book Series="Cable" Number="24" Volume="1993" Year="1995">
       <Id>3bbf784d-fa9b-4b5e-86a4-d8fefb0ad088</Id>
     </Book>
-    <Book Series="Cable" Number="25" Volume="1993" Year="1995" Format="Main Series">
+    <Book Series="Cable" Number="25" Volume="1993" Year="1995">
       <Id>4a0dc050-56cd-48ae-b871-35bddb8e55ec</Id>
     </Book>
-    <Book Series="X-Man" Number="8" Volume="1995" Year="1995" Format="Main Series">
+    <Book Series="X-Man" Number="8" Volume="1995" Year="1995">
       <Id>e962d7d6-60e4-489b-9ed1-9424db55ad53</Id>
     </Book>
-    <Book Series="X-Man" Number="9" Volume="1995" Year="1995" Format="Main Series">
+    <Book Series="X-Man" Number="9" Volume="1995" Year="1995">
       <Id>e092f9d1-5419-4c88-a095-cf29f3ba47f6</Id>
     </Book>
-    <Book Series="X-Man" Number="10" Volume="1995" Year="1995" Format="Main Series">
+    <Book Series="X-Man" Number="10" Volume="1995" Year="1995">
       <Id>c34f2a7e-502a-49a0-8bdb-232e3654825d</Id>
     </Book>
-    <Book Series="Wolverine/Gambit: Victims" Number="1" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Wolverine/Gambit: Victims" Number="1" Volume="1995" Year="1995">
       <Id>2c3adfaf-79fc-4030-bc45-735d17fb4398</Id>
     </Book>
-    <Book Series="Wolverine/Gambit: Victims" Number="2" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Wolverine/Gambit: Victims" Number="2" Volume="1995" Year="1995">
       <Id>bfce13cb-19ca-4fbf-a1c6-eb9aa5463c85</Id>
     </Book>
-    <Book Series="Wolverine/Gambit: Victims" Number="3" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Wolverine/Gambit: Victims" Number="3" Volume="1995" Year="1995">
       <Id>419108f9-bfd2-4028-bd38-bc2457b5abbc</Id>
     </Book>
-    <Book Series="Wolverine/Gambit: Victims" Number="4" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Wolverine/Gambit: Victims" Number="4" Volume="1995" Year="1995">
       <Id>e66b724e-e1e1-48eb-96bb-5459f5a25632</Id>
     </Book>
-    <Book Series="Excalibur" Number="91" Volume="1988" Year="1995" Format="Main Series">
+    <Book Series="Excalibur" Number="91" Volume="1988" Year="1995">
       <Id>ade33538-5792-4918-a042-d05bac4b95e5</Id>
     </Book>
-    <Book Series="Excalibur" Number="92" Volume="1988" Year="1995" Format="Main Series">
+    <Book Series="Excalibur" Number="92" Volume="1988" Year="1995">
       <Id>089a0f50-32ce-40b1-89a4-78f7eb775a62</Id>
     </Book>
-    <Book Series="Generation X" Number="7" Volume="1994" Year="1995" Format="Main Series">
+    <Book Series="Generation X" Number="7" Volume="1994" Year="1995">
       <Id>1d0a1e65-2386-4b37-89ad-6e1bbccb953d</Id>
     </Book>
-    <Book Series="Generation X" Number="8" Volume="1994" Year="1995" Format="Main Series">
+    <Book Series="Generation X" Number="8" Volume="1994" Year="1995">
       <Id>4bd6814c-dc27-4d37-b14a-2842241b78d6</Id>
     </Book>
-    <Book Series="Generation X" Number="9" Volume="1994" Year="1995" Format="Main Series">
+    <Book Series="Generation X" Number="9" Volume="1994" Year="1995">
       <Id>8a45cfa0-adf7-48b2-baaf-f5ff58da82d2</Id>
     </Book>
-    <Book Series="X-Force" Number="48" Volume="1991" Year="1995" Format="Main Series">
+    <Book Series="X-Force" Number="48" Volume="1991" Year="1995">
       <Id>f2870d7f-5f9d-4c6d-9ec7-91080ea08f26</Id>
     </Book>
-    <Book Series="Uncanny X-Men Annual '95" Number="1" Volume="1995" Year="1995" Format="Annual">
+    <Book Series="Uncanny X-Men Annual '95" Number="1" Volume="1995" Year="1995">
       <Id>765f9510-94b2-4758-a703-e62e96a2d0a1</Id>
     </Book>
-    <Book Series="Excalibur" Number="93" Volume="1988" Year="1996" Format="Main Series">
+    <Book Series="Excalibur" Number="93" Volume="1988" Year="1996">
       <Id>c92790af-aedf-4e9f-97c6-de660ac2cb0e</Id>
     </Book>
-    <Book Series="Wolverine" Number="95" Volume="1988" Year="1995" Format="Main Series">
+    <Book Series="Wolverine" Number="95" Volume="1988" Year="1995">
       <Id>0016f1bd-a03e-444d-bf88-b3c617bebcfe</Id>
     </Book>
-    <Book Series="X-Factor" Number="116" Volume="1986" Year="1995" Format="Main Series">
+    <Book Series="X-Factor" Number="116" Volume="1986" Year="1995">
       <Id>e8407bb9-bfc6-4e53-a28a-b08547d36424</Id>
     </Book>
-    <Book Series="Generation X Annual '95" Number="1" Volume="1995" Year="1995" Format="Annual">
+    <Book Series="Generation X Annual '95" Number="1" Volume="1995" Year="1995">
       <Id>b8e07ecf-a6ab-4e66-87bc-5d199206eaae</Id>
     </Book>
-    <Book Series="Generation X" Number="10" Volume="1994" Year="1995" Format="Main Series">
+    <Book Series="Generation X" Number="10" Volume="1994" Year="1995">
       <Id>57bae7bc-f40a-41dd-a62f-b3cce6be3432</Id>
     </Book>
-    <Book Series="Generation X" Number="11" Volume="1994" Year="1996" Format="Main Series">
+    <Book Series="Generation X" Number="11" Volume="1994" Year="1996">
       <Id>4e42796b-7b8c-4ec0-a0f5-4b367e4a24d2</Id>
     </Book>
-    <Book Series="Excalibur" Number="94" Volume="1988" Year="1996" Format="Main Series">
+    <Book Series="Excalibur" Number="94" Volume="1988" Year="1996">
       <Id>feab2a74-3a10-4115-be0f-71c39452ec4b</Id>
     </Book>
-    <Book Series="X-Men" Number="46" Volume="1991" Year="1995" Format="Main Series">
+    <Book Series="X-Men" Number="46" Volume="1991" Year="1995">
       <Id>ef6c3585-bbf9-4133-9655-2d56fa0f61d2</Id>
     </Book>
-    <Book Series="X-Men" Number="47" Volume="1991" Year="1995" Format="Main Series">
+    <Book Series="X-Men" Number="47" Volume="1991" Year="1995">
       <Id>930c2733-e6a0-4709-949d-ff479a72eb00</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="327" Volume="1981" Year="1995" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="327" Volume="1981" Year="1995">
       <Id>1f5841a3-0ef5-4876-806f-2b3ad144945f</Id>
     </Book>
-    <Book Series="X-Man" Number="11" Volume="1995" Year="1996" Format="Main Series">
+    <Book Series="X-Man" Number="11" Volume="1995" Year="1996">
       <Id>8afaafa5-0fe2-497a-8275-f1f632ac9419</Id>
     </Book>
-    <Book Series="X-Factor" Number="117" Volume="1986" Year="1995" Format="Main Series">
+    <Book Series="X-Factor" Number="117" Volume="1986" Year="1995">
       <Id>2283532e-dbae-4363-a730-7b2e582e0ac3</Id>
     </Book>
-    <Book Series="X-Factor" Number="118" Volume="1986" Year="1996" Format="Main Series">
+    <Book Series="X-Factor" Number="118" Volume="1986" Year="1996">
       <Id>56efbd2e-1ff0-4eb0-a261-bf9e2b4a6658</Id>
     </Book>
-    <Book Series="Wolverine" Number="96" Volume="1988" Year="1995" Format="Main Series">
+    <Book Series="Wolverine" Number="96" Volume="1988" Year="1995">
       <Id>332cee8f-abbc-450c-8a32-c697ed891cb7</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="9" Volume="1993" Year="1995" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="9" Volume="1993" Year="1995">
       <Id>cc81aea7-f4fd-49d5-8c63-d79ab6708620</Id>
     </Book>
-    <Book Series="Cable" Number="26" Volume="1993" Year="1995" Format="Main Series">
+    <Book Series="Cable" Number="26" Volume="1993" Year="1995">
       <Id>b41ff6e9-07b7-40fa-ac26-584133a0bd3c</Id>
     </Book>
-    <Book Series="Cable" Number="27" Volume="1993" Year="1996" Format="Main Series">
+    <Book Series="Cable" Number="27" Volume="1993" Year="1996">
       <Id>eac0e813-c283-4c0d-b77e-8c22e3a54f99</Id>
     </Book>
-    <Book Series="Cable" Number="28" Volume="1993" Year="1996" Format="Main Series">
+    <Book Series="Cable" Number="28" Volume="1993" Year="1996">
       <Id>f5212e59-81bd-4d7b-ae99-a25944a6816d</Id>
     </Book>
-    <Book Series="X-Force / Cable Annual '95" Number="1" Volume="1995" Year="1995" Format="Annual">
+    <Book Series="X-Force / Cable Annual '95" Number="1" Volume="1995" Year="1995">
       <Id>8fe9c347-343a-4276-bb94-ed62dd23b925</Id>
     </Book>
-    <Book Series="X-Man" Number="12" Volume="1995" Year="1996" Format="Main Series">
+    <Book Series="X-Man" Number="12" Volume="1995" Year="1996">
       <Id>d92091bb-8123-44ab-98ad-68337ff0e68f</Id>
     </Book>
-    <Book Series="Excalibur" Number="95" Volume="1988" Year="1996" Format="Main Series">
+    <Book Series="Excalibur" Number="95" Volume="1988" Year="1996">
       <Id>7f057a29-808d-40e4-827b-d0e350c091b9</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="328" Volume="1981" Year="1996" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="328" Volume="1981" Year="1996">
       <Id>28676dcf-723f-48a9-a5d8-1affef603e02</Id>
     </Book>
-    <Book Series="Sabretooth Special" Number="1" Volume="1995" Year="1995" Format="One-Shot">
+    <Book Series="Sabretooth Special" Number="1" Volume="1995" Year="1995">
       <Id>6baf38d1-c13c-4018-931c-63c6e38461bd</Id>
     </Book>
-    <Book Series="X-Men" Number="48" Volume="1991" Year="1996" Format="Main Series">
+    <Book Series="X-Men" Number="48" Volume="1991" Year="1996">
       <Id>82631ef3-5a58-4ab8-a8bd-63f2e762e4fb</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="329" Volume="1981" Year="1996" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="329" Volume="1981" Year="1996">
       <Id>73ef14dc-8dfd-4f67-b48e-86bba8929e19</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="330" Volume="1981" Year="1996" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="330" Volume="1981" Year="1996">
       <Id>72a7aa2a-c2f2-429a-8778-5da7c8090262</Id>
     </Book>
-    <Book Series="Excalibur" Number="96" Volume="1988" Year="1996" Format="Main Series">
+    <Book Series="Excalibur" Number="96" Volume="1988" Year="1996">
       <Id>7e53f542-081a-48df-9801-087eaa2d85c7</Id>
     </Book>
-    <Book Series="Excalibur" Number="97" Volume="1988" Year="1996" Format="Main Series">
+    <Book Series="Excalibur" Number="97" Volume="1988" Year="1996">
       <Id>d391dfaf-e463-4b35-9139-d09a4e52c51d</Id>
     </Book>
-    <Book Series="X-Force" Number="49" Volume="1991" Year="1995" Format="Main Series">
+    <Book Series="X-Force" Number="49" Volume="1991" Year="1995">
       <Id>d833f03b-a3ca-46e0-ac43-b20af836c71c</Id>
     </Book>
-    <Book Series="X-Force" Number="50" Volume="1991" Year="1996" Format="Main Series">
+    <Book Series="X-Force" Number="50" Volume="1991" Year="1996">
       <Id>53722df6-430f-466d-9124-2a0285586ad6</Id>
     </Book>
-    <Book Series="X-Force" Number="51" Volume="1991" Year="1996" Format="Main Series">
+    <Book Series="X-Force" Number="51" Volume="1991" Year="1996">
       <Id>19531947-1386-4e99-8299-b74812ef55b8</Id>
     </Book>
-    <Book Series="X-Men" Number="49" Volume="1991" Year="1996" Format="Main Series">
+    <Book Series="X-Men" Number="49" Volume="1991" Year="1996">
       <Id>18f56636-dee7-4314-9215-aaba5ffccb38</Id>
     </Book>
-    <Book Series="X-Factor" Number="119" Volume="1986" Year="1996" Format="Main Series">
+    <Book Series="X-Factor" Number="119" Volume="1986" Year="1996">
       <Id>b559d246-2ee4-4de0-8011-131b2e982bfa</Id>
     </Book>
-    <Book Series="Cable" Number="29" Volume="1993" Year="1996" Format="Main Series">
+    <Book Series="Cable" Number="29" Volume="1993" Year="1996">
       <Id>55978873-787b-4662-b772-5e70f2167f3b</Id>
     </Book>
-    <Book Series="X-Man" Number="13" Volume="1995" Year="1996" Format="Main Series">
+    <Book Series="X-Man" Number="13" Volume="1995" Year="1996">
       <Id>1952908a-6260-40c6-a275-1cfbcf073954</Id>
     </Book>
-    <Book Series="X-Factor" Number="120" Volume="1986" Year="1996" Format="Main Series">
+    <Book Series="X-Factor" Number="120" Volume="1986" Year="1996">
       <Id>8259539d-f554-45e8-996f-170aa1c95db4</Id>
     </Book>
-    <Book Series="X-Factor" Number="121" Volume="1986" Year="1996" Format="Main Series">
+    <Book Series="X-Factor" Number="121" Volume="1986" Year="1996">
       <Id>80e05642-48d3-48a4-b5dc-ff5a9089536a</Id>
     </Book>
-    <Book Series="X-Men" Number="50" Volume="1991" Year="1996" Format="Main Series">
+    <Book Series="X-Men" Number="50" Volume="1991" Year="1996">
       <Id>aee62906-0de8-4cab-86b2-d538be76d180</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="10" Volume="1993" Year="1996" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="10" Volume="1993" Year="1996">
       <Id>7ea275b3-d20c-4a7f-b760-49db7a3ce4cf</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="331" Volume="1981" Year="1996" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="331" Volume="1981" Year="1996">
       <Id>630ad19a-122e-4cc5-bdeb-35fad5c57590</Id>
     </Book>
-    <Book Series="The Further Adventures of Cyclops and Phoenix" Number="1" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="The Further Adventures of Cyclops and Phoenix" Number="1" Volume="1996" Year="1996">
       <Id>b16bba72-399d-4c19-b9d2-390d1630c3b4</Id>
     </Book>
-    <Book Series="The Further Adventures of Cyclops and Phoenix" Number="2" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="The Further Adventures of Cyclops and Phoenix" Number="2" Volume="1996" Year="1996">
       <Id>9709a205-dee5-4d93-97b6-3db8015c8813</Id>
     </Book>
-    <Book Series="The Further Adventures of Cyclops and Phoenix" Number="3" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="The Further Adventures of Cyclops and Phoenix" Number="3" Volume="1996" Year="1996">
       <Id>3d8f4d53-b5c3-4754-a7da-8987b188e1bd</Id>
     </Book>
-    <Book Series="The Further Adventures of Cyclops and Phoenix" Number="4" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="The Further Adventures of Cyclops and Phoenix" Number="4" Volume="1996" Year="1996">
       <Id>04e3c897-e601-451d-bb14-95b6a289cfd3</Id>
     </Book>
-    <Book Series="X-Force" Number="52" Volume="1991" Year="1996" Format="Main Series">
+    <Book Series="X-Force" Number="52" Volume="1991" Year="1996">
       <Id>c79de9ca-6efe-450b-bbac-25536e54b56b</Id>
     </Book>
-    <Book Series="X-Force" Number="53" Volume="1991" Year="1996" Format="Main Series">
+    <Book Series="X-Force" Number="53" Volume="1991" Year="1996">
       <Id>2bf56a25-7864-40e0-8546-da0f3415e7a3</Id>
     </Book>
-    <Book Series="Cable" Number="30" Volume="1993" Year="1996" Format="Main Series">
+    <Book Series="Cable" Number="30" Volume="1993" Year="1996">
       <Id>87dd34ac-4b52-4d15-b4b5-8baeec8d9c78</Id>
     </Book>
-    <Book Series="X-Man" Number="14" Volume="1995" Year="1996" Format="Main Series">
+    <Book Series="X-Man" Number="14" Volume="1995" Year="1996">
       <Id>64ef6f85-3241-4743-a02e-a60b2a79b34a</Id>
     </Book>
-    <Book Series="Cable" Number="31" Volume="1993" Year="1996" Format="Main Series">
+    <Book Series="Cable" Number="31" Volume="1993" Year="1996">
       <Id>2140a91c-ce58-4cff-8a68-7253a8b8463c</Id>
     </Book>
-    <Book Series="X-Force" Number="54" Volume="1991" Year="1996" Format="Main Series">
+    <Book Series="X-Force" Number="54" Volume="1991" Year="1996">
       <Id>d7303f97-ba77-4d1a-94cb-a83f177fb1e0</Id>
     </Book>
-    <Book Series="X-Men vs. The Brood" Number="1" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="X-Men vs. The Brood" Number="1" Volume="1996" Year="1996">
       <Id>90041fff-a216-42d3-a988-c888fb6c08fc</Id>
     </Book>
-    <Book Series="X-Men vs. The Brood" Number="2" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="X-Men vs. The Brood" Number="2" Volume="1996" Year="1996">
       <Id>c055be32-de4d-4f2c-945d-d05e1ead499f</Id>
     </Book>
-    <Book Series="X-Men: ClanDestine" Number="1" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="X-Men: ClanDestine" Number="1" Volume="1996" Year="1996">
       <Id>bf5e4e86-f837-4a54-b4a2-301300580179</Id>
     </Book>
-    <Book Series="X-Men: ClanDestine" Number="2" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="X-Men: ClanDestine" Number="2" Volume="1996" Year="1996">
       <Id>7429284d-ec8e-460c-8ca2-471c43d202dd</Id>
     </Book>
-    <Book Series="X-Men" Number="51" Volume="1991" Year="1996" Format="Main Series">
+    <Book Series="X-Men" Number="51" Volume="1991" Year="1996">
       <Id>795d6527-ae8c-4e50-8d75-a8dc20c32874</Id>
     </Book>
-    <Book Series="X-Men" Number="52" Volume="1991" Year="1996" Format="Main Series">
+    <Book Series="X-Men" Number="52" Volume="1991" Year="1996">
       <Id>e33ba122-8a3f-4859-b26d-b5668e752a43</Id>
     </Book>
-    <Book Series="Wolverine" Number="97" Volume="1988" Year="1996" Format="Main Series">
+    <Book Series="Wolverine" Number="97" Volume="1988" Year="1996">
       <Id>470ff9d2-e7b7-424b-8dca-0d5682c48b4e</Id>
     </Book>
-    <Book Series="Wolverine" Number="98" Volume="1988" Year="1996" Format="Main Series">
+    <Book Series="Wolverine" Number="98" Volume="1988" Year="1996">
       <Id>ab65d521-9c89-49ec-a9bf-b80599c3d377</Id>
     </Book>
-    <Book Series="Wolverine" Number="99" Volume="1988" Year="1996" Format="Main Series">
+    <Book Series="Wolverine" Number="99" Volume="1988" Year="1996">
       <Id>c171aacb-a894-4641-abec-ee2822731e3b</Id>
     </Book>
-    <Book Series="Wolverine" Number="100" Volume="1988" Year="1996" Format="Main Series">
+    <Book Series="Wolverine" Number="100" Volume="1988" Year="1996">
       <Id>1f578ade-2559-473a-9c0e-c0c9ee76aa69</Id>
     </Book>
-    <Book Series="Generation X" Number="12" Volume="1994" Year="1996" Format="Main Series">
+    <Book Series="Generation X" Number="12" Volume="1994" Year="1996">
       <Id>69d68daa-a07d-4be7-9dd7-a09ae0986fea</Id>
     </Book>
-    <Book Series="Generation X" Number="13" Volume="1994" Year="1996" Format="Main Series">
+    <Book Series="Generation X" Number="13" Volume="1994" Year="1996">
       <Id>68b534d4-bcd1-4c7a-817b-cd37819f61c7</Id>
     </Book>
-    <Book Series="Generation X" Number="14" Volume="1994" Year="1996" Format="Main Series">
+    <Book Series="Generation X" Number="14" Volume="1994" Year="1996">
       <Id>2e6e58ad-714f-4678-8974-4fa96757ecd9</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="332" Volume="1981" Year="1996" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="332" Volume="1981" Year="1996">
       <Id>b0baee94-2335-4fe9-a03d-96e95e7f2059</Id>
     </Book>
-    <Book Series="Wolverine" Number="101" Volume="1988" Year="1996" Format="Main Series">
+    <Book Series="Wolverine" Number="101" Volume="1988" Year="1996">
       <Id>f85cd47c-ee31-468c-b0a0-26210d3374fa</Id>
     </Book>
-    <Book Series="X-Factor" Number="122" Volume="1986" Year="1996" Format="Main Series">
+    <Book Series="X-Factor" Number="122" Volume="1986" Year="1996">
       <Id>bd53013a-0a0b-4b1c-8c31-c8fc76bdf4f8</Id>
     </Book>
-    <Book Series="X-Factor" Number="123" Volume="1986" Year="1996" Format="Main Series">
+    <Book Series="X-Factor" Number="123" Volume="1986" Year="1996">
       <Id>eba88b3a-034a-459e-8a6d-6a8a358195cd</Id>
     </Book>
-    <Book Series="Archangel" Number="1" Volume="1996" Year="1996" Format="One-Shot">
+    <Book Series="Archangel" Number="1" Volume="1996" Year="1996">
       <Id>c14782a6-1fa0-49d9-ae0c-930b366171b1</Id>
     </Book>
-    <Book Series="Generation X" Number="15" Volume="1994" Year="1996" Format="Main Series">
+    <Book Series="Generation X" Number="15" Volume="1994" Year="1996">
       <Id>adb66333-d481-4dd5-a1f7-d7c8f3f5bcaa</Id>
     </Book>
-    <Book Series="Generation X" Number="16" Volume="1994" Year="1996" Format="Main Series">
+    <Book Series="Generation X" Number="16" Volume="1994" Year="1996">
       <Id>8787c6d3-43ed-4a1d-b0b3-19008cd47971</Id>
     </Book>
-    <Book Series="Generation X" Number="17" Volume="1994" Year="1996" Format="Main Series">
+    <Book Series="Generation X" Number="17" Volume="1994" Year="1996">
       <Id>91cd5852-61da-4496-8b23-1f10a60a7096</Id>
     </Book>
-    <Book Series="Excalibur" Number="98" Volume="1988" Year="1996" Format="Main Series">
+    <Book Series="Excalibur" Number="98" Volume="1988" Year="1996">
       <Id>fe4feb92-52cc-4873-b071-65e822400297</Id>
     </Book>
-    <Book Series="Excalibur" Number="99" Volume="1988" Year="1996" Format="Main Series">
+    <Book Series="Excalibur" Number="99" Volume="1988" Year="1996">
       <Id>dfba4195-f60b-4a2d-8e3d-2d35b42d06ef</Id>
     </Book>
-    <Book Series="X-Factor" Number="124" Volume="1986" Year="1996" Format="Main Series">
+    <Book Series="X-Factor" Number="124" Volume="1986" Year="1996">
       <Id>c2ad75e7-cc12-4936-a651-186c58c3a5a1</Id>
     </Book>
-    <Book Series="Uncanny X-Men Annual '96" Number="1" Volume="1996" Year="1996" Format="Annual">
+    <Book Series="Uncanny X-Men Annual '96" Number="1" Volume="1996" Year="1996">
       <Id>e81d709a-04e6-4c93-bc5e-d111e088cfdf</Id>
     </Book>
-    <Book Series="XSE" Number="1" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="XSE" Number="1" Volume="1996" Year="1996">
       <Id>46c43a12-7878-4069-a256-554aba70151c</Id>
     </Book>
-    <Book Series="XSE" Number="2" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="XSE" Number="2" Volume="1996" Year="1996">
       <Id>b24bf4bf-b409-4296-8ace-7cd57ec51c15</Id>
     </Book>
-    <Book Series="XSE" Number="3" Volume="1996" Year="1997" Format="Limited Series">
+    <Book Series="XSE" Number="3" Volume="1996" Year="1997">
       <Id>e97f4f46-63a5-4eb1-b7ec-df61eb61f54c</Id>
     </Book>
-    <Book Series="XSE" Number="4" Volume="1996" Year="1997" Format="Limited Series">
+    <Book Series="XSE" Number="4" Volume="1996" Year="1997">
       <Id>3adf60c0-499a-4df0-a4c4-26f85dcbfbf6</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="333" Volume="1981" Year="1996" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="333" Volume="1981" Year="1996">
       <Id>7ed829ab-28e6-462f-aa97-44674b14e381</Id>
     </Book>
-    <Book Series="X-Force" Number="55" Volume="1991" Year="1996" Format="Main Series">
+    <Book Series="X-Force" Number="55" Volume="1991" Year="1996">
       <Id>19a7da90-9150-44ff-b195-6ce8039addc3</Id>
     </Book>
-    <Book Series="X-Force" Number="56" Volume="1991" Year="1996" Format="Main Series">
+    <Book Series="X-Force" Number="56" Volume="1991" Year="1996">
       <Id>9ab4e19e-82b3-4bad-93b6-901daf4467ce</Id>
     </Book>
-    <Book Series="Wolverine" Number="102" Volume="1988" Year="1996" Format="Main Series">
+    <Book Series="Wolverine" Number="102" Volume="1988" Year="1996">
       <Id>e586afca-bb84-47a8-804e-713aa4296538</Id>
     </Book>
-    <Book Series="Wolverine" Number="103" Volume="1988" Year="1996" Format="Main Series">
+    <Book Series="Wolverine" Number="103" Volume="1988" Year="1996">
       <Id>859c3346-fc52-4cb9-8353-39e46f489751</Id>
     </Book>
-    <Book Series="X-Man" Number="15" Volume="1995" Year="1996" Format="Main Series">
+    <Book Series="X-Man" Number="15" Volume="1995" Year="1996">
       <Id>8ba38e04-c6cc-4562-9af0-dae0863cedd6</Id>
     </Book>
-    <Book Series="X-Man" Number="16" Volume="1995" Year="1996" Format="Main Series">
+    <Book Series="X-Man" Number="16" Volume="1995" Year="1996">
       <Id>7d2c39d6-f9fb-42c5-a5b1-9a253758db31</Id>
     </Book>
-    <Book Series="X-Man" Number="17" Volume="1995" Year="1996" Format="Main Series">
+    <Book Series="X-Man" Number="17" Volume="1995" Year="1996">
       <Id>71f80b46-f61d-44bf-bff5-77f68940a0c3</Id>
     </Book>
-    <Book Series="Cable" Number="32" Volume="1993" Year="1996" Format="Main Series">
+    <Book Series="Cable" Number="32" Volume="1993" Year="1996">
       <Id>e604ed09-709f-4b72-9873-e77857c388ca</Id>
     </Book>
-    <Book Series="Cable" Number="33" Volume="1993" Year="1996" Format="Main Series">
+    <Book Series="Cable" Number="33" Volume="1993" Year="1996">
       <Id>d28583e7-4ed9-4f6f-9564-ca25d1550d78</Id>
     </Book>
-    <Book Series="X-Men" Number="53" Volume="1991" Year="1996" Format="Main Series">
+    <Book Series="X-Men" Number="53" Volume="1991" Year="1996">
       <Id>3e1c253f-87ba-4a9c-bc8f-0747ac74d5c7</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="11" Volume="1993" Year="1996" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="11" Volume="1993" Year="1996">
       <Id>26c28f9d-b334-412c-87dc-ef835cbc1d8f</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="334" Volume="1981" Year="1996" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="334" Volume="1981" Year="1996">
       <Id>73324805-3234-47e0-a36c-282a45c296b6</Id>
     </Book>
-    <Book Series="X-Men" Number="54" Volume="1991" Year="1996" Format="Main Series">
+    <Book Series="X-Men" Number="54" Volume="1991" Year="1996">
       <Id>f1e74e7b-b431-4e25-9be3-d76cf1ed98f5</Id>
     </Book>
-    <Book Series="Onslaught: X-Men" Number="1" Volume="1996" Year="1996" Format="Crossover">
+    <Book Series="Onslaught: X-Men" Number="1" Volume="1996" Year="1996">
       <Id>378e982d-0f5e-4c76-aa58-cbd31baf75d7</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="335" Volume="1981" Year="1996" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="335" Volume="1981" Year="1996">
       <Id>8840e6d7-f7d0-4a46-9230-a1cd750c09d1</Id>
     </Book>
-    <Book Series="X-Man" Number="18" Volume="1995" Year="1996" Format="Main Series">
+    <Book Series="X-Man" Number="18" Volume="1995" Year="1996">
       <Id>21ffb9c1-0555-4ae9-a6e4-d8373fb81605</Id>
     </Book>
-    <Book Series="X-Force" Number="57" Volume="1991" Year="1996" Format="Main Series">
+    <Book Series="X-Force" Number="57" Volume="1991" Year="1996">
       <Id>f764744c-782c-4cfb-b5fe-ec760ca9ec42</Id>
     </Book>
-    <Book Series="Cable" Number="34" Volume="1993" Year="1996" Format="Main Series">
+    <Book Series="Cable" Number="34" Volume="1993" Year="1996">
       <Id>2b4a1be3-498b-4453-a43d-6ab471a57d45</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="444" Volume="1968" Year="1996" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="444" Volume="1968" Year="1996">
       <Id>07809b8f-2358-4ff2-bd0d-72418e44b64c</Id>
     </Book>
-    <Book Series="The Avengers" Number="401" Volume="1963" Year="1996" Format="Main Series">
+    <Book Series="The Avengers" Number="401" Volume="1963" Year="1996">
       <Id>aee8a271-0204-4c05-bb57-7e7dad9248fa</Id>
     </Book>
-    <Book Series="Excalibur" Number="100" Volume="1988" Year="1996" Format="Main Series">
+    <Book Series="Excalibur" Number="100" Volume="1988" Year="1996">
       <Id>50b8a316-4fe3-45a3-ae4b-12004f5bad6b</Id>
     </Book>
-    <Book Series="X-Factor" Number="125" Volume="1986" Year="1996" Format="Main Series">
+    <Book Series="X-Factor" Number="125" Volume="1986" Year="1996">
       <Id>f14a75e6-040f-427d-97b2-a6f8c1bc8169</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="415" Volume="1961" Year="1996" Format="Main Series">
+    <Book Series="Fantastic Four" Number="415" Volume="1961" Year="1996">
       <Id>1ea1fbee-1a31-4b68-969e-4c6e476ed7ad</Id>
     </Book>
-    <Book Series="Generation X" Number="18" Volume="1994" Year="1996" Format="Main Series">
+    <Book Series="Generation X" Number="18" Volume="1994" Year="1996">
       <Id>d7f2e777-c07e-4abd-afd8-28ffd59495b8</Id>
     </Book>
-    <Book Series="Wolverine" Number="104" Volume="1988" Year="1996" Format="Main Series">
+    <Book Series="Wolverine" Number="104" Volume="1988" Year="1996">
       <Id>64184ead-7007-4c4f-8afc-b8dfbb96ca8d</Id>
     </Book>
-    <Book Series="X-Men" Number="55" Volume="1991" Year="1996" Format="Main Series">
+    <Book Series="X-Men" Number="55" Volume="1991" Year="1996">
       <Id>4fed135f-c567-481a-9ef9-b096ce5a23f6</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="336" Volume="1981" Year="1996" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="336" Volume="1981" Year="1996">
       <Id>a45a60c5-1f1b-4e0a-aeb5-efc560a885f8</Id>
     </Book>
-    <Book Series="X-Factor" Number="126" Volume="1986" Year="1996" Format="Main Series">
+    <Book Series="X-Factor" Number="126" Volume="1986" Year="1996">
       <Id>69c50943-cf0f-4234-bd42-d18fadf6cd90</Id>
     </Book>
-    <Book Series="Cable" Number="35" Volume="1993" Year="1996" Format="Main Series">
+    <Book Series="Cable" Number="35" Volume="1993" Year="1996">
       <Id>70b2d982-8731-40ab-a13a-38755ea3e394</Id>
     </Book>
-    <Book Series="X-Force" Number="58" Volume="1991" Year="1996" Format="Main Series">
+    <Book Series="X-Force" Number="58" Volume="1991" Year="1996">
       <Id>98b5ec0a-5292-4509-932f-5243850c0ea9</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="445" Volume="1968" Year="1996" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="445" Volume="1968" Year="1996">
       <Id>1e21de15-e857-4241-a165-9927360a57fa</Id>
     </Book>
-    <Book Series="The Avengers" Number="402" Volume="1963" Year="1996" Format="Main Series">
+    <Book Series="The Avengers" Number="402" Volume="1963" Year="1996">
       <Id>5ce99ebc-185c-4606-b19f-7fd6af024610</Id>
     </Book>
-    <Book Series="X-Man" Number="19" Volume="1995" Year="1996" Format="Main Series">
+    <Book Series="X-Man" Number="19" Volume="1995" Year="1996">
       <Id>d1c1c094-5bd6-448f-9de7-ed128dfab2c6</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="416" Volume="1961" Year="1996" Format="Main Series">
+    <Book Series="Fantastic Four" Number="416" Volume="1961" Year="1996">
       <Id>ab25934a-d593-42b5-bb6d-802c3a443369</Id>
     </Book>
-    <Book Series="Generation X" Number="19" Volume="1994" Year="1996" Format="Main Series">
+    <Book Series="Generation X" Number="19" Volume="1994" Year="1996">
       <Id>64d41ba8-2e3b-473f-a19a-c4677b2ef125</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="415" Volume="1963" Year="1996" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="415" Volume="1963" Year="1996">
       <Id>b700c5af-ae45-4ab0-9ec2-ce0ef1c74332</Id>
     </Book>
-    <Book Series="Wolverine" Number="105" Volume="1988" Year="1996" Format="Main Series">
+    <Book Series="Wolverine" Number="105" Volume="1988" Year="1996">
       <Id>69774aa9-524c-468e-981d-b40cb57c27a4</Id>
     </Book>
-    <Book Series="Spider-Man" Number="72" Volume="1990" Year="1996" Format="Main Series">
+    <Book Series="Spider-Man" Number="72" Volume="1990" Year="1996">
       <Id>e7560f75-73f8-41d4-9cc1-625e0f37e6b0</Id>
     </Book>
-    <Book Series="X-Men" Number="56" Volume="1991" Year="1996" Format="Main Series">
+    <Book Series="X-Men" Number="56" Volume="1991" Year="1996">
       <Id>74236359-297c-48b6-ab26-169102fc082c</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="12" Volume="1993" Year="1996" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="12" Volume="1993" Year="1996">
       <Id>1eb9f075-c42e-465c-babd-d383415426ff</Id>
     </Book>
-    <Book Series="Onslaught: Marvel Universe" Number="1" Volume="1996" Year="1996" Format="Crossover">
+    <Book Series="Onslaught: Marvel Universe" Number="1" Volume="1996" Year="1996">
       <Id>ece634bb-a5de-4c95-95ea-1af6403e9f39</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="337" Volume="1981" Year="1996" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="337" Volume="1981" Year="1996">
       <Id>09285bd5-6f19-4414-a9b9-31e68a1da9d4</Id>
     </Book>
-    <Book Series="Excalibur" Number="101" Volume="1988" Year="1996" Format="Main Series">
+    <Book Series="Excalibur" Number="101" Volume="1988" Year="1996">
       <Id>4b398377-6c61-4d8f-9c2d-e46c17305d86</Id>
     </Book>
-    <Book Series="Excalibur" Number="102" Volume="1988" Year="1996" Format="Main Series">
+    <Book Series="Excalibur" Number="102" Volume="1988" Year="1996">
       <Id>0c2c43e3-c0de-4203-ae91-2ca7e1b4f184</Id>
     </Book>
-    <Book Series="X-Men" Number="57" Volume="1991" Year="1996" Format="Main Series">
+    <Book Series="X-Men" Number="57" Volume="1991" Year="1996">
       <Id>0c5ffa7c-8239-4487-bbde-35eb066a7186</Id>
     </Book>
-    <Book Series="Onslaught: Epilogue" Number="1" Volume="1997" Year="1997" Format="Crossover">
+    <Book Series="Onslaught: Epilogue" Number="1" Volume="1997" Year="1997">
       <Id>e8c51568-5fb2-4edc-a8dd-df950a627c4c</Id>
     </Book>
-    <Book Series="Cable" Number="36" Volume="1993" Year="1996" Format="Main Series">
+    <Book Series="Cable" Number="36" Volume="1993" Year="1996">
       <Id>b4c2c667-209c-41c1-98d6-8fea49ed9828</Id>
     </Book>
-    <Book Series="Generation X" Number="20" Volume="1994" Year="1996" Format="Main Series">
+    <Book Series="Generation X" Number="20" Volume="1994" Year="1996">
       <Id>c38c5e5e-a8ad-49f4-b897-2a09ebe90cfb</Id>
     </Book>
-    <Book Series="Generation X" Number="21" Volume="1994" Year="1996" Format="Main Series">
+    <Book Series="Generation X" Number="21" Volume="1994" Year="1996">
       <Id>67ccdb98-a996-4b98-8c87-6383eb6ca66e</Id>
     </Book>
-    <Book Series="X-Man" Number="20" Volume="1995" Year="1996" Format="Main Series">
+    <Book Series="X-Man" Number="20" Volume="1995" Year="1996">
       <Id>903affbe-c3c8-488b-98df-2d7843fdb86c</Id>
     </Book>
-    <Book Series="Mystique &amp; Sabretooth" Number="1" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Mystique &amp; Sabretooth" Number="1" Volume="1996" Year="1996">
       <Id>e1062f49-1acb-4a42-9678-884f32af4f9d</Id>
     </Book>
-    <Book Series="Mystique &amp; Sabretooth" Number="2" Volume="1996" Year="1997" Format="Limited Series">
+    <Book Series="Mystique &amp; Sabretooth" Number="2" Volume="1996" Year="1997">
       <Id>74783dcf-e4c2-4cda-99f1-cb8b2c85a3ad</Id>
     </Book>
-    <Book Series="Mystique &amp; Sabretooth" Number="3" Volume="1996" Year="1997" Format="Limited Series">
+    <Book Series="Mystique &amp; Sabretooth" Number="3" Volume="1996" Year="1997">
       <Id>e677b856-1fbf-46cc-9a94-ca8796733554</Id>
     </Book>
-    <Book Series="Mystique &amp; Sabretooth" Number="4" Volume="1996" Year="1997" Format="Limited Series">
+    <Book Series="Mystique &amp; Sabretooth" Number="4" Volume="1996" Year="1997">
       <Id>cc539f7c-8640-4d2b-a71b-cef4d4ca70a0</Id>
     </Book>
-    <Book Series="X-Force" Number="59" Volume="1991" Year="1996" Format="Main Series">
+    <Book Series="X-Force" Number="59" Volume="1991" Year="1996">
       <Id>6cf92a6d-a4bb-41b0-a28d-0f6e65096a8c</Id>
     </Book>
-    <Book Series="X-Force" Number="60" Volume="1991" Year="1996" Format="Main Series">
+    <Book Series="X-Force" Number="60" Volume="1991" Year="1996">
       <Id>0450619f-94a7-4b70-80c1-ef4dd6812baf</Id>
     </Book>
-    <Book Series="X-Force" Number="61" Volume="1991" Year="1996" Format="Main Series">
+    <Book Series="X-Force" Number="61" Volume="1991" Year="1996">
       <Id>c7bc8523-c0bb-4aae-bf6e-6e1cc230daf2</Id>
     </Book>
-    <Book Series="Wolverine" Number="106" Volume="1988" Year="1996" Format="Main Series">
+    <Book Series="Wolverine" Number="106" Volume="1988" Year="1996">
       <Id>2ed9b70f-e677-4ae1-97de-f69774db8b87</Id>
     </Book>
-    <Book Series="X-Factor" Number="127" Volume="1986" Year="1996" Format="Main Series">
+    <Book Series="X-Factor" Number="127" Volume="1986" Year="1996">
       <Id>78b86f8a-af1f-4146-afeb-13e1fb57d81d</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="338" Volume="1981" Year="1996" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="338" Volume="1981" Year="1996">
       <Id>c24533b2-0bb8-44a6-b207-bafe680684df</Id>
     </Book>
-    <Book Series="Pryde and Wisdom" Number="1" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Pryde and Wisdom" Number="1" Volume="1996" Year="1996">
       <Id>52c3460d-203c-4aca-bb32-3c2919397905</Id>
     </Book>
-    <Book Series="Pryde and Wisdom" Number="2" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Pryde and Wisdom" Number="2" Volume="1996" Year="1996">
       <Id>b17ca171-10cb-4b9c-bee2-53a41369afd9</Id>
     </Book>
-    <Book Series="Pryde and Wisdom" Number="3" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Pryde and Wisdom" Number="3" Volume="1996" Year="1996">
       <Id>594c311a-53b3-4e6d-86c9-26b4e5d2747a</Id>
     </Book>
-    <Book Series="X-Men Annual '96" Number="1" Volume="1996" Year="1996" Format="Annual">
+    <Book Series="X-Men Annual '96" Number="1" Volume="1996" Year="1996">
       <Id>a7eb069d-e399-42ae-bb41-5a1214be850c</Id>
     </Book>
-    <Book Series="The Rise of Apocalypse" Number="1" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="The Rise of Apocalypse" Number="1" Volume="1996" Year="1996">
       <Id>01e2a72b-1be5-4822-9d5e-0d032b0c9d97</Id>
     </Book>
-    <Book Series="The Rise of Apocalypse" Number="2" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="The Rise of Apocalypse" Number="2" Volume="1996" Year="1996">
       <Id>2a3ac229-0ccc-4582-926f-c083309f76c6</Id>
     </Book>
-    <Book Series="The Rise of Apocalypse" Number="3" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="The Rise of Apocalypse" Number="3" Volume="1996" Year="1996">
       <Id>8edf4b68-e6ca-4fff-b10d-2c9a4f9d2790</Id>
     </Book>
-    <Book Series="The Rise of Apocalypse" Number="4" Volume="1996" Year="1997" Format="Limited Series">
+    <Book Series="The Rise of Apocalypse" Number="4" Volume="1996" Year="1997">
       <Id>a071173d-579e-41f8-bd32-eddb19cb810f</Id>
     </Book>
-    <Book Series="X-Men" Number="58" Volume="1991" Year="1996" Format="Main Series">
+    <Book Series="X-Men" Number="58" Volume="1991" Year="1996">
       <Id>f7642da9-9d2d-451c-9a14-3a0f51c0d74f</Id>
     </Book>
-    <Book Series="X-Man" Number="21" Volume="1995" Year="1996" Format="Main Series">
+    <Book Series="X-Man" Number="21" Volume="1995" Year="1996">
       <Id>ff223a14-bfda-4e55-b60a-c5ff6d1a4eb9</Id>
     </Book>
-    <Book Series="Excalibur" Number="103" Volume="1988" Year="1996" Format="Main Series">
+    <Book Series="Excalibur" Number="103" Volume="1988" Year="1996">
       <Id>334b8cd4-be12-41ac-945e-56aba504868b</Id>
     </Book>
-    <Book Series="X-Force / Cable Annual '96" Number="1" Volume="1996" Year="1996" Format="Annual">
+    <Book Series="X-Force / Cable Annual '96" Number="1" Volume="1996" Year="1996">
       <Id>ff604c04-7122-490c-90e1-9c051651b170</Id>
     </Book>
-    <Book Series="X-Force" Number="62" Volume="1991" Year="1997" Format="Main Series">
+    <Book Series="X-Force" Number="62" Volume="1991" Year="1997">
       <Id>98f66427-969b-40b9-9ed6-808dcc02b131</Id>
     </Book>
   </Books>

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 005.cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 005.cbl
@@ -1,930 +1,931 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>X-Men - Part 5</Name>
+  <Name>X-Men - Part 005</Name>
+  <NumIssues>308</NumIssues>
   <Books>
     <Book Series="Bishop" Number="1" Volume="1994" Year="1994">
-      <Id>0f879a9c-a0d4-4666-8451-d8bf23b19cf8</Id>
+      <Database Name="cv" Series="5277" Issue="40119" />
     </Book>
     <Book Series="Bishop" Number="2" Volume="1994" Year="1995">
-      <Id>30a01bb0-4874-441a-95ac-0ac5aada043c</Id>
+      <Database Name="cv" Series="5277" Issue="40362" />
     </Book>
     <Book Series="Bishop" Number="3" Volume="1994" Year="1995">
-      <Id>aa9477be-271b-491b-b66a-c224f70d30b6</Id>
+      <Database Name="cv" Series="5277" Issue="40491" />
     </Book>
     <Book Series="Bishop" Number="4" Volume="1994" Year="1995">
-      <Id>dfe515ea-9122-4339-aee0-079d3d472077</Id>
+      <Database Name="cv" Series="5277" Issue="40626" />
     </Book>
     <Book Series="X-Factor" Number="107" Volume="1986" Year="1994">
-      <Id>6a53b8a3-247a-4c1f-9bc7-fc38bbd082e3</Id>
+      <Database Name="cv" Series="3657" Issue="65688" />
     </Book>
     <Book Series="X-Force" Number="40" Volume="1991" Year="1994">
-      <Id>8c3de41d-8722-4016-9efd-537b124974cd</Id>
+      <Database Name="cv" Series="4604" Issue="64514" />
     </Book>
     <Book Series="X-Force" Number="41" Volume="1991" Year="1994">
-      <Id>a3865772-9827-4bb2-9916-6c048c89db80</Id>
+      <Database Name="cv" Series="4604" Issue="64515" />
     </Book>
     <Book Series="X-Men Unlimited" Number="7" Volume="1993" Year="1994">
-      <Id>b555ef66-26de-43ce-97a7-6fb6bbbdf060</Id>
+      <Database Name="cv" Series="5066" Issue="40090" />
     </Book>
     <Book Series="Wolverine" Number="88" Volume="1988" Year="1994">
-      <Id>9bba1d96-8be8-4863-ab58-dd2d3b7ed9e8</Id>
+      <Database Name="cv" Series="4250" Issue="40118" />
     </Book>
     <Book Series="Cable" Number="17" Volume="1993" Year="1994">
-      <Id>e65335e2-2fb9-4bfc-8841-5ee5f0820d8b</Id>
+      <Database Name="cv" Series="4993" Issue="39967" />
     </Book>
     <Book Series="Cable" Number="18" Volume="1993" Year="1994">
-      <Id>492d39bb-a6ba-4151-b9bd-2f834663df1a</Id>
+      <Database Name="cv" Series="4993" Issue="40120" />
     </Book>
     <Book Series="Cable" Number="19" Volume="1993" Year="1995">
-      <Id>3daeecad-4e19-402a-8c13-182bf64f7c63</Id>
+      <Database Name="cv" Series="4993" Issue="40363" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="318" Volume="1981" Year="1994">
-      <Id>3b6ae773-7ed7-4bc3-a9d7-8e99e4209a77</Id>
+      <Database Name="cv" Series="3092" Issue="39975" />
     </Book>
     <Book Series="X-Men" Number="38" Volume="1991" Year="1994">
-      <Id>3a3aae83-35db-4083-9752-e8b44579335c</Id>
+      <Database Name="cv" Series="4605" Issue="65739" />
     </Book>
     <Book Series="Generation X" Number="1" Volume="1994" Year="1994">
-      <Id>58697acc-e7f9-40fc-a55f-459830218f5e</Id>
+      <Database Name="cv" Series="5300" Issue="39935" />
     </Book>
     <Book Series="Generation X" Number="2" Volume="1994" Year="1994">
-      <Id>ec3a8cdd-40b4-4d6b-bc8c-4ba15a02777d</Id>
+      <Database Name="cv" Series="5300" Issue="40077" />
     </Book>
     <Book Series="Generation X" Number="3" Volume="1994" Year="1995">
-      <Id>6fb4727e-ea5a-46ee-bc34-260aa24204a3</Id>
+      <Database Name="cv" Series="5300" Issue="40318" />
     </Book>
     <Book Series="X-Men" Number="39" Volume="1991" Year="1994">
-      <Id>318193c1-2c2d-47a8-b10b-87b4336133fe</Id>
+      <Database Name="cv" Series="4605" Issue="65740" />
     </Book>
     <Book Series="Rogue" Number="1" Volume="1995" Year="1995">
-      <Id>25a8854c-6c90-4a0e-8cb7-7e25e2fefa20</Id>
+      <Database Name="cv" Series="7193" Issue="66410" />
     </Book>
     <Book Series="Rogue" Number="2" Volume="1995" Year="1995">
-      <Id>2fd1b5bb-c0ff-408e-a3f4-92f1e3a11567</Id>
+      <Database Name="cv" Series="7193" Issue="51329" />
     </Book>
     <Book Series="Rogue" Number="3" Volume="1995" Year="1995">
-      <Id>e6106078-95c0-40d6-985a-9520c0d4f8ce</Id>
+      <Database Name="cv" Series="7193" Issue="51330" />
     </Book>
     <Book Series="Rogue" Number="4" Volume="1995" Year="1995">
-      <Id>fae973ac-3abe-4406-aa0a-324cfebff6db</Id>
+      <Database Name="cv" Series="7193" Issue="51331" />
     </Book>
     <Book Series="Wolverine" Number="89" Volume="1988" Year="1995">
-      <Id>2ad2f317-6af9-4eb6-90ff-36922ff47666</Id>
+      <Database Name="cv" Series="4250" Issue="40361" />
     </Book>
     <Book Series="X-Force" Number="42" Volume="1991" Year="1995">
-      <Id>41282380-b429-44c5-b977-3bb61ad5beed</Id>
+      <Database Name="cv" Series="4604" Issue="64516" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="319" Volume="1981" Year="1994">
-      <Id>85e0d238-f207-493a-9f41-a0ebab1b116c</Id>
+      <Database Name="cv" Series="3092" Issue="40115" />
     </Book>
     <Book Series="X-Factor" Number="108" Volume="1986" Year="1994">
-      <Id>5493b918-fd31-4a49-ba67-08e960dd0e2f</Id>
+      <Database Name="cv" Series="3657" Issue="65689" />
     </Book>
     <Book Series="X-Factor" Number="109" Volume="1986" Year="1994">
-      <Id>298e7d0f-a07d-4187-9176-20bbcf4cd96a</Id>
+      <Database Name="cv" Series="3657" Issue="65690" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="320" Volume="1981" Year="1995">
-      <Id>b33a3ba7-36ae-4783-9244-4c44b1fa4600</Id>
+      <Database Name="cv" Series="3092" Issue="40358" />
     </Book>
     <Book Series="X-Men" Number="40" Volume="1991" Year="1995">
-      <Id>4d9ba072-66e6-46dc-ba83-4eb343e3b72b</Id>
+      <Database Name="cv" Series="4605" Issue="65741" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="321" Volume="1981" Year="1995">
-      <Id>91cc9375-1de9-402e-82ab-d853f3bb2d28</Id>
+      <Database Name="cv" Series="3092" Issue="40487" />
     </Book>
     <Book Series="Cable" Number="20" Volume="1993" Year="1995">
-      <Id>7d7afb0d-89df-4298-a8e8-10fffa77a0c9</Id>
+      <Database Name="cv" Series="4993" Issue="40492" />
     </Book>
     <Book Series="X-Men" Number="41" Volume="1991" Year="1995">
-      <Id>886f7e57-49c8-4629-b3b8-a7864e222fb5</Id>
+      <Database Name="cv" Series="4605" Issue="65742" />
     </Book>
     <Book Series="X-Factor" Number="110" Volume="1986" Year="1995">
-      <Id>cea71b92-39d1-4056-a035-e8375eefe5d0</Id>
+      <Database Name="cv" Series="3657" Issue="65691" />
     </Book>
     <Book Series="X-Factor" Number="111" Volume="1986" Year="1995">
-      <Id>5b27e0a0-1b08-4cfe-a1a2-cae6fcc58378</Id>
+      <Database Name="cv" Series="3657" Issue="65692" />
     </Book>
     <Book Series="Wolverine" Number="90" Volume="1988" Year="1995">
-      <Id>8e63517a-d3bb-44be-83e7-4718d484c761</Id>
+      <Database Name="cv" Series="4250" Issue="40490" />
     </Book>
     <Book Series="Generation X" Number="4" Volume="1994" Year="1995">
-      <Id>2fc597df-232a-45df-8ece-713c3b442fcd</Id>
+      <Database Name="cv" Series="5300" Issue="40455" />
     </Book>
     <Book Series="Excalibur" Number="86" Volume="1988" Year="1995">
-      <Id>9ae5dc98-f5e6-43ce-9f6e-77f6a900aca1</Id>
+      <Database Name="cv" Series="4052" Issue="66372" />
     </Book>
     <Book Series="X-Force" Number="43" Volume="1991" Year="1995">
-      <Id>046584cb-7862-488b-9e5f-ae1f406091ab</Id>
+      <Database Name="cv" Series="4604" Issue="64517" />
     </Book>
     <Book Series="X-Men Chronicles" Number="1" Volume="1995" Year="1995">
-      <Id>c0738a6b-82ea-4c1c-aa27-4ff33d68a734</Id>
+      <Database Name="cv" Series="18037" Issue="105613" />
     </Book>
     <Book Series="X-Man" Number="-1" Volume="1995" Year="1997">
-      <Id>fe990795-c474-48be-8257-aebca9b2587e</Id>
+      <Database Name="cv" Series="5567" Issue="43887" />
     </Book>
     <Book Series="X-Men Chronicles" Number="2" Volume="1995" Year="1995">
-      <Id>e41065cb-2145-4679-9356-3eeb043e9272</Id>
+      <Database Name="cv" Series="18037" Issue="105648" />
     </Book>
     <Book Series="Tales from the Age of Apocalypse" Number="1" Volume="1996" Year="1996">
-      <Id>2a290e06-187b-41c2-9814-f29a6b689e67</Id>
+      <Database Name="cv" Series="18054" Issue="105734" />
     </Book>
     <Book Series="Blink" Number="1" Volume="2001" Year="2001">
-      <Id>871dc3c2-9485-4f31-b010-485fa53d1f2a</Id>
+      <Database Name="cv" Series="6985" Issue="49461" />
     </Book>
     <Book Series="Blink" Number="2" Volume="2001" Year="2001">
-      <Id>b940d7ba-4fbe-4ed4-8c4b-91f33d285541</Id>
+      <Database Name="cv" Series="6985" Issue="49462" />
     </Book>
     <Book Series="Blink" Number="3" Volume="2001" Year="2001">
-      <Id>09b40643-1c2c-443b-ae8b-45805eea2cb7</Id>
+      <Database Name="cv" Series="6985" Issue="49463" />
     </Book>
     <Book Series="Blink" Number="4" Volume="2001" Year="2001">
-      <Id>78964e7b-d10a-45d2-b015-f6d1aff6497f</Id>
+      <Database Name="cv" Series="6985" Issue="49464" />
     </Book>
     <Book Series="X-Men Alpha" Number="1" Volume="1995" Year="1995">
-      <Id>c7bdbc33-48f3-4eac-8db9-2d30091cfa69</Id>
+      <Database Name="cv" Series="18051" Issue="105731" />
     </Book>
     <Book Series="Generation Next" Number="1" Volume="1995" Year="1995">
-      <Id>aacafac8-86e4-47c8-9d8d-9613767e2807</Id>
+      <Database Name="cv" Series="5547" Issue="40589" />
     </Book>
     <Book Series="Astonishing X-Men" Number="1" Volume="1995" Year="1995">
-      <Id>8cced9a9-8628-4ff6-af10-5bcae9edd8f0</Id>
+      <Database Name="cv" Series="5536" Issue="40582" />
     </Book>
     <Book Series="X-Calibre" Number="1" Volume="1995" Year="1995">
-      <Id>6299f31f-5a84-44c7-a1d0-6e5a58a96f73</Id>
+      <Database Name="cv" Series="5566" Issue="40600" />
     </Book>
-    <Book Series="Gambit &amp; The X-Ternals" Number="1" Volume="1995" Year="1995">
-      <Id>cf57b814-d417-4db2-ba86-3ef75cc82595</Id>
+    <Book Series="Gambit &#38; The X-Ternals" Number="1" Volume="1995" Year="1995">
+      <Database Name="cv" Series="5546" Issue="40588" />
     </Book>
     <Book Series="Weapon X" Number="1" Volume="1995" Year="1995">
-      <Id>d2548111-5a82-4523-8332-d474ac2d59fd</Id>
+      <Database Name="cv" Series="5564" Issue="40598" />
     </Book>
     <Book Series="Amazing X-Men" Number="1" Volume="1995" Year="1995">
-      <Id>c8ced0cf-bd4e-4062-86c5-4e79cb528f53</Id>
+      <Database Name="cv" Series="5535" Issue="40581" />
     </Book>
     <Book Series="Factor X" Number="1" Volume="1995" Year="1995">
-      <Id>2399f53e-b799-43e0-8cbb-2f73afaed13b</Id>
+      <Database Name="cv" Series="5543" Issue="40587" />
     </Book>
     <Book Series="X-Man" Number="1" Volume="1995" Year="1995">
-      <Id>b6798426-9d74-40ef-99c8-1f93f433796c</Id>
+      <Database Name="cv" Series="5567" Issue="40601" />
     </Book>
     <Book Series="Amazing X-Men" Number="2" Volume="1995" Year="1995">
-      <Id>b983bd3a-e086-4c54-b033-e8bc49629fa0</Id>
+      <Database Name="cv" Series="5535" Issue="105543" />
     </Book>
     <Book Series="Factor X" Number="2" Volume="1995" Year="1995">
-      <Id>b9b9391f-5041-4fdc-a3be-14dd72a37819</Id>
+      <Database Name="cv" Series="5543" Issue="40726" />
     </Book>
     <Book Series="Generation Next" Number="2" Volume="1995" Year="1995">
-      <Id>c2e391e5-50c5-4b65-8f9d-28c2bb42caa9</Id>
+      <Database Name="cv" Series="5547" Issue="40729" />
     </Book>
     <Book Series="Weapon X" Number="2" Volume="1995" Year="1995">
-      <Id>bb034f44-dbb6-4e7a-831e-d03efdc07263</Id>
+      <Database Name="cv" Series="5564" Issue="40733" />
     </Book>
-    <Book Series="Gambit &amp; The X-Ternals" Number="2" Volume="1995" Year="1995">
-      <Id>7573426b-cadb-4615-b593-61ad8849edff</Id>
+    <Book Series="Gambit &#38; The X-Ternals" Number="2" Volume="1995" Year="1995">
+      <Database Name="cv" Series="5546" Issue="40728" />
     </Book>
     <Book Series="X-Calibre" Number="2" Volume="1995" Year="1995">
-      <Id>153b9675-efcd-4e56-a3e9-6c6bbdd2e724</Id>
+      <Database Name="cv" Series="5566" Issue="40735" />
     </Book>
     <Book Series="Astonishing X-Men" Number="2" Volume="1995" Year="1995">
-      <Id>075ce8e4-8193-4380-9a5d-6311691c436b</Id>
+      <Database Name="cv" Series="5536" Issue="40720" />
     </Book>
     <Book Series="X-Man" Number="2" Volume="1995" Year="1995">
-      <Id>6069ba8f-3bd2-43a7-94be-449eefd17bd1</Id>
+      <Database Name="cv" Series="5567" Issue="40736" />
     </Book>
     <Book Series="Astonishing X-Men" Number="3" Volume="1995" Year="1995">
-      <Id>ff18452d-55fd-475e-8884-38b3ccb64d9b</Id>
+      <Database Name="cv" Series="5536" Issue="40845" />
     </Book>
     <Book Series="Factor X" Number="3" Volume="1995" Year="1995">
-      <Id>c1abb1ec-152c-4f7c-9634-2eb001ea6ded</Id>
+      <Database Name="cv" Series="5543" Issue="40850" />
     </Book>
     <Book Series="X-Universe" Number="1" Volume="1995" Year="1995">
-      <Id>f1f9d17a-e52d-4fa4-aa3b-b053a338209a</Id>
+      <Database Name="cv" Series="5572" Issue="40864" />
     </Book>
     <Book Series="Amazing X-Men" Number="3" Volume="1995" Year="1995">
-      <Id>9cb82af3-5376-4dcb-8c72-e3ffa4876135</Id>
+      <Database Name="cv" Series="5535" Issue="40844" />
     </Book>
     <Book Series="X-Calibre" Number="3" Volume="1995" Year="1995">
-      <Id>c4179eed-a589-40cf-a237-2da2723aefae</Id>
+      <Database Name="cv" Series="5566" Issue="40861" />
     </Book>
     <Book Series="Weapon X" Number="3" Volume="1995" Year="1995">
-      <Id>cf185a36-1858-4e28-a1c2-eca13a3a1142</Id>
+      <Database Name="cv" Series="5564" Issue="40859" />
     </Book>
-    <Book Series="Gambit &amp; The X-Ternals" Number="3" Volume="1995" Year="1995">
-      <Id>0dc276ae-c375-4bab-a079-df7f9df22124</Id>
+    <Book Series="Gambit &#38; The X-Ternals" Number="3" Volume="1995" Year="1995">
+      <Database Name="cv" Series="5546" Issue="40852" />
     </Book>
     <Book Series="Generation Next" Number="3" Volume="1995" Year="1995">
-      <Id>8d8901a0-c27d-41f9-853b-ba067cb40b01</Id>
+      <Database Name="cv" Series="5547" Issue="40853" />
     </Book>
     <Book Series="X-Man" Number="3" Volume="1995" Year="1995">
-      <Id>3025bf4f-d549-4574-8cf9-3007cb4c45ec</Id>
+      <Database Name="cv" Series="5567" Issue="40862" />
     </Book>
     <Book Series="Astonishing X-Men" Number="4" Volume="1995" Year="1995">
-      <Id>0dd9b1f0-860e-4235-b813-3fd480a781dc</Id>
+      <Database Name="cv" Series="5536" Issue="40968" />
     </Book>
     <Book Series="Generation Next" Number="4" Volume="1995" Year="1995">
-      <Id>591ba345-2564-4380-911c-4f0025c3cf25</Id>
+      <Database Name="cv" Series="5547" Issue="40977" />
     </Book>
     <Book Series="X-Calibre" Number="4" Volume="1995" Year="1995">
-      <Id>ac85a233-7c1f-476e-97bc-2a9484ed64eb</Id>
+      <Database Name="cv" Series="5566" Issue="40984" />
     </Book>
     <Book Series="X-Man" Number="4" Volume="1995" Year="1995">
-      <Id>934d12ae-ef45-4635-aeb2-7acfbb76db24</Id>
+      <Database Name="cv" Series="5567" Issue="40985" />
     </Book>
     <Book Series="Factor X" Number="4" Volume="1995" Year="1995">
-      <Id>a8136807-4d04-4967-a17b-1e2560be1928</Id>
+      <Database Name="cv" Series="5543" Issue="40973" />
     </Book>
-    <Book Series="Gambit &amp; The X-Ternals" Number="4" Volume="1995" Year="1995">
-      <Id>5f5ae3cd-921b-4236-ba9d-46c3b20b7552</Id>
+    <Book Series="Gambit &#38; The X-Ternals" Number="4" Volume="1995" Year="1995">
+      <Database Name="cv" Series="5546" Issue="40976" />
     </Book>
     <Book Series="Amazing X-Men" Number="4" Volume="1995" Year="1995">
-      <Id>8219d545-3edc-4b1f-826a-563e3ea33423</Id>
+      <Database Name="cv" Series="5535" Issue="40967" />
     </Book>
     <Book Series="Weapon X" Number="4" Volume="1995" Year="1995">
-      <Id>67215d65-d31f-467b-8a9c-9357a25d8b13</Id>
+      <Database Name="cv" Series="5564" Issue="40982" />
     </Book>
     <Book Series="X-Universe" Number="2" Volume="1995" Year="1995">
-      <Id>b2e98eef-9857-4637-8209-c7d9bdea3745</Id>
+      <Database Name="cv" Series="5572" Issue="40988" />
     </Book>
     <Book Series="X-Men Omega" Number="1" Volume="1995" Year="1995">
-      <Id>b2cd265a-e64e-47a8-a683-fdd55a4a270e</Id>
+      <Database Name="cv" Series="18093" Issue="105975" />
     </Book>
     <Book Series="X-Men: Age of Apocalypse" Number="1" Volume="2005" Year="2005">
-      <Id>ef9e8c8d-00df-435b-b572-afa7bb4025e7</Id>
+      <Database Name="cv" Series="11501" Issue="101450" />
     </Book>
     <Book Series="X-Men: Age of Apocalypse" Number="2" Volume="2005" Year="2005">
-      <Id>ef4d2110-e409-4ad3-adb1-0ee287eecc1d</Id>
+      <Database Name="cv" Series="11501" Issue="101451" />
     </Book>
     <Book Series="X-Men: Age of Apocalypse" Number="3" Volume="2005" Year="2005">
-      <Id>9a7e2e0c-e5fb-424d-bae3-eed9948d93b5</Id>
+      <Database Name="cv" Series="11501" Issue="101452" />
     </Book>
     <Book Series="X-Men: Age of Apocalypse" Number="4" Volume="2005" Year="2005">
-      <Id>6bcea370-3a0e-4213-9f5f-a444420ffba7</Id>
+      <Database Name="cv" Series="11501" Issue="101453" />
     </Book>
     <Book Series="X-Men: Age of Apocalypse" Number="5" Volume="2005" Year="2005">
-      <Id>6d31c2be-c614-4c9e-a8f1-77742b4b1cd8</Id>
+      <Database Name="cv" Series="11501" Issue="101454" />
     </Book>
     <Book Series="X-Men: Age of Apocalypse" Number="6" Volume="2005" Year="2005">
-      <Id>b288d53e-ec3a-4390-867e-d222325707de</Id>
+      <Database Name="cv" Series="11501" Issue="101455" />
     </Book>
     <Book Series="X-Men: Prime" Number="1" Volume="1995" Year="1995">
-      <Id>a114cd8a-400e-4cd2-93bf-2c129210f7e8</Id>
+      <Database Name="cv" Series="18154" Issue="106333" />
     </Book>
     <Book Series="X-Man" Number="5" Volume="1995" Year="1995">
-      <Id>1003af90-c7b1-4d6c-bd20-aff110ae2009</Id>
+      <Database Name="cv" Series="5567" Issue="41120" />
     </Book>
     <Book Series="Excalibur" Number="87" Volume="1988" Year="1995">
-      <Id>fafbe7bf-7fd7-4d1b-815f-275c3b7a4907</Id>
+      <Database Name="cv" Series="4052" Issue="66373" />
     </Book>
     <Book Series="Wolverine" Number="91" Volume="1988" Year="1995">
-      <Id>17f903d7-3dfe-414d-bcb4-1f3bc7e6f687</Id>
+      <Database Name="cv" Series="4250" Issue="41146" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="322" Volume="1981" Year="1995">
-      <Id>57e39fd6-667f-4987-abe3-041338aa55a1</Id>
+      <Database Name="cv" Series="3092" Issue="41143" />
     </Book>
     <Book Series="X-Men" Number="42" Volume="1991" Year="1995">
-      <Id>b0a2793f-58d1-49d9-8cfc-368e8062a73e</Id>
+      <Database Name="cv" Series="4605" Issue="65743" />
     </Book>
     <Book Series="X-Men" Number="43" Volume="1991" Year="1995">
-      <Id>fe0ce201-c9b5-4e4a-bb69-3d8c9b9e41e5</Id>
+      <Database Name="cv" Series="4605" Issue="65744" />
     </Book>
     <Book Series="X-Men" Number="44" Volume="1991" Year="1995">
-      <Id>011b70b2-1f6a-422e-923d-8abafab7b82f</Id>
+      <Database Name="cv" Series="4605" Issue="65745" />
     </Book>
     <Book Series="Cable" Number="21" Volume="1993" Year="1995">
-      <Id>b671cdd0-5db7-4b9e-ae40-014c140dc5c2</Id>
+      <Database Name="cv" Series="4993" Issue="41136" />
     </Book>
     <Book Series="X-Force" Number="44" Volume="1991" Year="1995">
-      <Id>f39b5fce-4e17-4a08-a19a-0936ca6cb959</Id>
+      <Database Name="cv" Series="4604" Issue="64518" />
     </Book>
     <Book Series="X-Man" Number="6" Volume="1995" Year="1995">
-      <Id>7800b521-a12a-4ba9-af7e-f25e0159d6f6</Id>
+      <Database Name="cv" Series="5567" Issue="41260" />
     </Book>
     <Book Series="X-Factor" Number="112" Volume="1986" Year="1995">
-      <Id>6ddf0e3b-4312-495f-8d92-4d1f5761bc9e</Id>
+      <Database Name="cv" Series="3657" Issue="65693" />
     </Book>
     <Book Series="X-Factor" Number="113" Volume="1986" Year="1995">
-      <Id>c54e89f8-ed76-4013-b70c-e2eaad818cbf</Id>
+      <Database Name="cv" Series="3657" Issue="107197" />
     </Book>
     <Book Series="Cable" Number="22" Volume="1993" Year="1995">
-      <Id>8da2ba37-c48d-42c3-aef2-1f2e3c291e93</Id>
+      <Database Name="cv" Series="4993" Issue="41282" />
     </Book>
-    <Book Series="Wolverine Annual '95" Number="1" Volume="1995" Year="1995">
-      <Id>438984c9-5f47-4ecb-ad51-1eb07f9fbb4f</Id>
+    <Book Series="Wolverine '95" Number="1" Volume="1995" Year="1995">
+      <Database Name="cv" Series="27130" Issue="164831" />
     </Book>
     <Book Series="X-Force" Number="45" Volume="1991" Year="1995">
-      <Id>1d6025fb-1083-495e-9a26-c1170af25ca0</Id>
+      <Database Name="cv" Series="4604" Issue="64519" />
     </Book>
     <Book Series="X-Force" Number="46" Volume="1991" Year="1995">
-      <Id>95ce1c52-9385-40eb-9852-1439930432fa</Id>
+      <Database Name="cv" Series="4604" Issue="64520" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="323" Volume="1981" Year="1995">
-      <Id>89734e82-e0df-43ad-9f56-44dca0c7304b</Id>
+      <Database Name="cv" Series="3092" Issue="41278" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="324" Volume="1981" Year="1995">
-      <Id>711d13b8-bcd5-472d-894e-446da1539001</Id>
+      <Database Name="cv" Series="3092" Issue="41411" />
     </Book>
     <Book Series="Wolverine" Number="92" Volume="1988" Year="1995">
-      <Id>8c1596fa-be54-4f47-9ebf-3f441a1d557d</Id>
+      <Database Name="cv" Series="4250" Issue="41281" />
     </Book>
     <Book Series="Generation X" Number="5" Volume="1994" Year="1995">
-      <Id>3ec80e3d-6bfe-43e7-8e57-58b0dae96e15</Id>
+      <Database Name="cv" Series="5300" Issue="41114" />
     </Book>
     <Book Series="Generation X" Number="6" Volume="1994" Year="1995">
-      <Id>6f4714a4-73a1-4a10-9dec-833f3386c9c0</Id>
+      <Database Name="cv" Series="5300" Issue="41254" />
     </Book>
     <Book Series="X-Force" Number="47" Volume="1991" Year="1995">
-      <Id>fcd426ea-1257-4e9f-a38c-bf2c4bb8cc59</Id>
+      <Database Name="cv" Series="4604" Issue="64521" />
     </Book>
     <Book Series="X-Factor" Number="114" Volume="1986" Year="1995">
-      <Id>5210d24b-3594-427e-9675-baeaa62bae63</Id>
+      <Database Name="cv" Series="3657" Issue="65694" />
     </Book>
     <Book Series="Excalibur" Number="88" Volume="1988" Year="1995">
-      <Id>4aeb2502-2144-46fe-9375-cea24eaa0a1d</Id>
+      <Database Name="cv" Series="4052" Issue="66374" />
     </Book>
     <Book Series="Excalibur" Number="89" Volume="1988" Year="1995">
-      <Id>059f243d-9d8b-48f9-bdfa-d636b06d98ea</Id>
+      <Database Name="cv" Series="4052" Issue="41383" />
     </Book>
     <Book Series="Excalibur" Number="90" Volume="1988" Year="1995">
-      <Id>23e684ff-aaa7-4e28-a1de-4564bd0c883e</Id>
+      <Database Name="cv" Series="4052" Issue="66376" />
     </Book>
     <Book Series="Wolverine: Knight of Terra" Number="1" Volume="1995" Year="1995">
-      <Id>5ea9aa1e-b0e6-4f94-aabc-e2b2a55c8682</Id>
+      <Database Name="cv" Series="30409" Issue="187291" />
     </Book>
     <Book Series="Starjammers" Number="1" Volume="1995" Year="1995">
-      <Id>3c6ade65-6154-4b14-b3ff-8e1eb8b884bd</Id>
+      <Database Name="cv" Series="7192" Issue="51326" />
     </Book>
     <Book Series="Starjammers" Number="2" Volume="1995" Year="1995">
-      <Id>cfe6940d-94a2-4a0d-839c-14916aba6d24</Id>
+      <Database Name="cv" Series="7192" Issue="51327" />
     </Book>
     <Book Series="Starjammers" Number="3" Volume="1995" Year="1995">
-      <Id>82030bac-f667-4f65-8123-c989c813c708</Id>
+      <Database Name="cv" Series="7192" Issue="51328" />
     </Book>
     <Book Series="Starjammers" Number="4" Volume="1995" Year="1996">
-      <Id>e65e5c9f-4c1a-41ab-8e64-e51e19fd8166</Id>
+      <Database Name="cv" Series="7192" Issue="107991" />
     </Book>
     <Book Series="X-Man" Number="7" Volume="1995" Year="1995">
-      <Id>6d2d39aa-f3b1-4c5e-a4b8-60c4beb3f0e6</Id>
+      <Database Name="cv" Series="5567" Issue="41390" />
     </Book>
-    <Book Series="X-Men Annual '95" Number="1" Volume="1995" Year="1995">
-      <Id>3ccf9a99-696e-4ef1-a35f-88d162ccaa14</Id>
+    <Book Series="X-Men '95" Number="1" Volume="1995" Year="1995">
+      <Database Name="cv" Series="60462" Issue="178116" />
     </Book>
     <Book Series="Wolverine" Number="93" Volume="1988" Year="1995">
-      <Id>c3d31580-96d4-4ac9-8624-1bf7a8127805</Id>
+      <Database Name="cv" Series="4250" Issue="41414" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="325" Volume="1981" Year="1995">
-      <Id>443b3a50-0847-42fe-bd5c-f405696b4214</Id>
+      <Database Name="cv" Series="3092" Issue="41537" />
     </Book>
     <Book Series="X-Men" Number="45" Volume="1991" Year="1995">
-      <Id>ca3e2367-0dec-4e4b-b4c0-6b46915a0d96</Id>
+      <Database Name="cv" Series="4605" Issue="65746" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="326" Volume="1981" Year="1995">
-      <Id>ee2119dc-1039-4c8e-b8ac-662e46fce4e8</Id>
+      <Database Name="cv" Series="3092" Issue="41660" />
     </Book>
     <Book Series="X-Factor" Number="115" Volume="1986" Year="1995">
-      <Id>f67f07fd-a4a6-40f6-8500-36b0cc32d5ce</Id>
+      <Database Name="cv" Series="3657" Issue="65695" />
     </Book>
     <Book Series="X-Men Unlimited" Number="8" Volume="1993" Year="1995">
-      <Id>c6d52d78-9460-4027-a473-03387cd6babf</Id>
+      <Database Name="cv" Series="5066" Issue="41521" />
     </Book>
     <Book Series="Wolverine" Number="94" Volume="1988" Year="1995">
-      <Id>790d2a70-d212-4b5f-be54-c15a816ecb7f</Id>
+      <Database Name="cv" Series="4250" Issue="41540" />
     </Book>
     <Book Series="Storm" Number="1" Volume="1996" Year="1996">
-      <Id>e0b98444-7861-420b-bfc5-80090bcc8061</Id>
+      <Database Name="cv" Series="7191" Issue="107612" />
     </Book>
     <Book Series="Storm" Number="2" Volume="1996" Year="1996">
-      <Id>c71f542e-c0ea-476a-b860-96aa25d91a98</Id>
+      <Database Name="cv" Series="7191" Issue="51324" />
     </Book>
     <Book Series="Storm" Number="3" Volume="1996" Year="1996">
-      <Id>f9c44871-9aa8-48e9-9b36-2f8b2d15a003</Id>
+      <Database Name="cv" Series="7191" Issue="107621" />
     </Book>
     <Book Series="Storm" Number="4" Volume="1996" Year="1996">
-      <Id>0f9a76cd-58f7-4107-b2e7-cde7ce54169f</Id>
+      <Database Name="cv" Series="7191" Issue="51325" />
     </Book>
     <Book Series="X-Men: Books of Askani" Number="1" Volume="1995" Year="1995">
-      <Id>68a8b1c9-8c94-40a4-aac5-182fac374aa4</Id>
+      <Database Name="cv" Series="18153" Issue="106330" />
     </Book>
     <Book Series="Askani'Son" Number="1" Volume="1996" Year="1996">
-      <Id>1afac113-9b8f-4142-b3b2-763c2b21d04a</Id>
+      <Database Name="cv" Series="18151" Issue="106318" />
     </Book>
     <Book Series="Askani'Son" Number="2" Volume="1996" Year="1996">
-      <Id>77a9fad8-b4b0-4af3-9777-da2aa983da40</Id>
+      <Database Name="cv" Series="18151" Issue="106322" />
     </Book>
     <Book Series="Askani'Son" Number="3" Volume="1996" Year="1996">
-      <Id>a23a637d-b0e4-4fa7-8525-4c652f4a6c99</Id>
+      <Database Name="cv" Series="18151" Issue="106323" />
     </Book>
     <Book Series="Askani'Son" Number="4" Volume="1996" Year="1996">
-      <Id>841a47e8-4abe-45ca-b8f2-4ca340c589f7</Id>
+      <Database Name="cv" Series="18151" Issue="106324" />
     </Book>
     <Book Series="Cable" Number="23" Volume="1993" Year="1995">
-      <Id>03b7465d-a50d-4ceb-90ed-ae3b8f076712</Id>
+      <Database Name="cv" Series="4993" Issue="106738" />
     </Book>
     <Book Series="Cable" Number="24" Volume="1993" Year="1995">
-      <Id>3bbf784d-fa9b-4b5e-86a4-d8fefb0ad088</Id>
+      <Database Name="cv" Series="4993" Issue="41532" />
     </Book>
     <Book Series="Cable" Number="25" Volume="1993" Year="1995">
-      <Id>4a0dc050-56cd-48ae-b871-35bddb8e55ec</Id>
+      <Database Name="cv" Series="4993" Issue="41655" />
     </Book>
     <Book Series="X-Man" Number="8" Volume="1995" Year="1995">
-      <Id>e962d7d6-60e4-489b-9ed1-9424db55ad53</Id>
+      <Database Name="cv" Series="5567" Issue="41519" />
     </Book>
     <Book Series="X-Man" Number="9" Volume="1995" Year="1995">
-      <Id>e092f9d1-5419-4c88-a095-cf29f3ba47f6</Id>
+      <Database Name="cv" Series="5567" Issue="41647" />
     </Book>
     <Book Series="X-Man" Number="10" Volume="1995" Year="1995">
-      <Id>c34f2a7e-502a-49a0-8bdb-232e3654825d</Id>
+      <Database Name="cv" Series="5567" Issue="41776" />
     </Book>
     <Book Series="Wolverine/Gambit: Victims" Number="1" Volume="1995" Year="1995">
-      <Id>2c3adfaf-79fc-4030-bc45-735d17fb4398</Id>
+      <Database Name="cv" Series="7182" Issue="106516" />
     </Book>
     <Book Series="Wolverine/Gambit: Victims" Number="2" Volume="1995" Year="1995">
-      <Id>bfce13cb-19ca-4fbf-a1c6-eb9aa5463c85</Id>
+      <Database Name="cv" Series="7182" Issue="51308" />
     </Book>
     <Book Series="Wolverine/Gambit: Victims" Number="3" Volume="1995" Year="1995">
-      <Id>419108f9-bfd2-4028-bd38-bc2457b5abbc</Id>
+      <Database Name="cv" Series="7182" Issue="51309" />
     </Book>
     <Book Series="Wolverine/Gambit: Victims" Number="4" Volume="1995" Year="1995">
-      <Id>e66b724e-e1e1-48eb-96bb-5459f5a25632</Id>
+      <Database Name="cv" Series="7182" Issue="51310" />
     </Book>
     <Book Series="Excalibur" Number="91" Volume="1988" Year="1995">
-      <Id>ade33538-5792-4918-a042-d05bac4b95e5</Id>
+      <Database Name="cv" Series="4052" Issue="41641" />
     </Book>
     <Book Series="Excalibur" Number="92" Volume="1988" Year="1995">
-      <Id>089a0f50-32ce-40b1-89a4-78f7eb775a62</Id>
+      <Database Name="cv" Series="4052" Issue="66377" />
     </Book>
     <Book Series="Generation X" Number="7" Volume="1994" Year="1995">
-      <Id>1d0a1e65-2386-4b37-89ad-6e1bbccb953d</Id>
+      <Database Name="cv" Series="5300" Issue="41384" />
     </Book>
     <Book Series="Generation X" Number="8" Volume="1994" Year="1995">
-      <Id>4bd6814c-dc27-4d37-b14a-2842241b78d6</Id>
+      <Database Name="cv" Series="5300" Issue="41515" />
     </Book>
     <Book Series="Generation X" Number="9" Volume="1994" Year="1995">
-      <Id>8a45cfa0-adf7-48b2-baaf-f5ff58da82d2</Id>
+      <Database Name="cv" Series="5300" Issue="41642" />
     </Book>
     <Book Series="X-Force" Number="48" Volume="1991" Year="1995">
-      <Id>f2870d7f-5f9d-4c6d-9ec7-91080ea08f26</Id>
+      <Database Name="cv" Series="4604" Issue="64522" />
     </Book>
-    <Book Series="Uncanny X-Men Annual '95" Number="1" Volume="1995" Year="1995">
-      <Id>765f9510-94b2-4758-a703-e62e96a2d0a1</Id>
+    <Book Series="Uncanny X-Men '95" Number="1" Volume="1995" Year="1995">
+      <Database Name="cv" Series="60468" Issue="136045" />
     </Book>
     <Book Series="Excalibur" Number="93" Volume="1988" Year="1996">
-      <Id>c92790af-aedf-4e9f-97c6-de660ac2cb0e</Id>
+      <Database Name="cv" Series="4052" Issue="66378" />
     </Book>
     <Book Series="Wolverine" Number="95" Volume="1988" Year="1995">
-      <Id>0016f1bd-a03e-444d-bf88-b3c617bebcfe</Id>
+      <Database Name="cv" Series="4250" Issue="41663" />
     </Book>
     <Book Series="X-Factor" Number="116" Volume="1986" Year="1995">
-      <Id>e8407bb9-bfc6-4e53-a28a-b08547d36424</Id>
+      <Database Name="cv" Series="3657" Issue="65696" />
     </Book>
-    <Book Series="Generation X Annual '95" Number="1" Volume="1995" Year="1995">
-      <Id>b8e07ecf-a6ab-4e66-87bc-5d199206eaae</Id>
+    <Book Series="Generation X '95" Number="1" Volume="1995" Year="1995">
+      <Database Name="cv" Series="18594" Issue="109694" />
     </Book>
     <Book Series="Generation X" Number="10" Volume="1994" Year="1995">
-      <Id>57bae7bc-f40a-41dd-a62f-b3cce6be3432</Id>
+      <Database Name="cv" Series="5300" Issue="41769" />
     </Book>
     <Book Series="Generation X" Number="11" Volume="1994" Year="1996">
-      <Id>4e42796b-7b8c-4ec0-a0f5-4b367e4a24d2</Id>
+      <Database Name="cv" Series="5300" Issue="41988" />
     </Book>
     <Book Series="Excalibur" Number="94" Volume="1988" Year="1996">
-      <Id>feab2a74-3a10-4115-be0f-71c39452ec4b</Id>
+      <Database Name="cv" Series="4052" Issue="66379" />
     </Book>
     <Book Series="X-Men" Number="46" Volume="1991" Year="1995">
-      <Id>ef6c3585-bbf9-4133-9655-2d56fa0f61d2</Id>
+      <Database Name="cv" Series="4605" Issue="65747" />
     </Book>
     <Book Series="X-Men" Number="47" Volume="1991" Year="1995">
-      <Id>930c2733-e6a0-4709-949d-ff479a72eb00</Id>
+      <Database Name="cv" Series="4605" Issue="65748" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="327" Volume="1981" Year="1995">
-      <Id>1f5841a3-0ef5-4876-806f-2b3ad144945f</Id>
+      <Database Name="cv" Series="3092" Issue="41787" />
     </Book>
     <Book Series="X-Man" Number="11" Volume="1995" Year="1996">
-      <Id>8afaafa5-0fe2-497a-8275-f1f632ac9419</Id>
+      <Database Name="cv" Series="5567" Issue="41993" />
     </Book>
     <Book Series="X-Factor" Number="117" Volume="1986" Year="1995">
-      <Id>2283532e-dbae-4363-a730-7b2e582e0ac3</Id>
+      <Database Name="cv" Series="3657" Issue="65697" />
     </Book>
     <Book Series="X-Factor" Number="118" Volume="1986" Year="1996">
-      <Id>56efbd2e-1ff0-4eb0-a261-bf9e2b4a6658</Id>
+      <Database Name="cv" Series="3657" Issue="65698" />
     </Book>
     <Book Series="Wolverine" Number="96" Volume="1988" Year="1995">
-      <Id>332cee8f-abbc-450c-8a32-c697ed891cb7</Id>
+      <Database Name="cv" Series="4250" Issue="41789" />
     </Book>
     <Book Series="X-Men Unlimited" Number="9" Volume="1993" Year="1995">
-      <Id>cc81aea7-f4fd-49d5-8c63-d79ab6708620</Id>
+      <Database Name="cv" Series="5066" Issue="41778" />
     </Book>
     <Book Series="Cable" Number="26" Volume="1993" Year="1995">
-      <Id>b41ff6e9-07b7-40fa-ac26-584133a0bd3c</Id>
+      <Database Name="cv" Series="4993" Issue="41790" />
     </Book>
     <Book Series="Cable" Number="27" Volume="1993" Year="1996">
-      <Id>eac0e813-c283-4c0d-b77e-8c22e3a54f99</Id>
+      <Database Name="cv" Series="4993" Issue="42008" />
     </Book>
     <Book Series="Cable" Number="28" Volume="1993" Year="1996">
-      <Id>f5212e59-81bd-4d7b-ae99-a25944a6816d</Id>
+      <Database Name="cv" Series="4993" Issue="42115" />
     </Book>
-    <Book Series="X-Force / Cable Annual '95" Number="1" Volume="1995" Year="1995">
-      <Id>8fe9c347-343a-4276-bb94-ed62dd23b925</Id>
+    <Book Series="X-Force / Cable '95" Number="1" Volume="1995" Year="1995">
+      <Database Name="cv" Series="20136" Issue="120182" />
     </Book>
     <Book Series="X-Man" Number="12" Volume="1995" Year="1996">
-      <Id>d92091bb-8123-44ab-98ad-68337ff0e68f</Id>
+      <Database Name="cv" Series="5567" Issue="42101" />
     </Book>
     <Book Series="Excalibur" Number="95" Volume="1988" Year="1996">
-      <Id>7f057a29-808d-40e4-827b-d0e350c091b9</Id>
+      <Database Name="cv" Series="4052" Issue="42205" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="328" Volume="1981" Year="1996">
-      <Id>28676dcf-723f-48a9-a5d8-1affef603e02</Id>
+      <Database Name="cv" Series="3092" Issue="42004" />
     </Book>
     <Book Series="Sabretooth Special" Number="1" Volume="1995" Year="1995">
-      <Id>6baf38d1-c13c-4018-931c-63c6e38461bd</Id>
+      <Database Name="cv" Series="18269" Issue="106977" />
     </Book>
     <Book Series="X-Men" Number="48" Volume="1991" Year="1996">
-      <Id>82631ef3-5a58-4ab8-a8bd-63f2e762e4fb</Id>
+      <Database Name="cv" Series="4605" Issue="65749" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="329" Volume="1981" Year="1996">
-      <Id>73ef14dc-8dfd-4f67-b48e-86bba8929e19</Id>
+      <Database Name="cv" Series="3092" Issue="42112" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="330" Volume="1981" Year="1996">
-      <Id>72a7aa2a-c2f2-429a-8778-5da7c8090262</Id>
+      <Database Name="cv" Series="3092" Issue="42223" />
     </Book>
     <Book Series="Excalibur" Number="96" Volume="1988" Year="1996">
-      <Id>7e53f542-081a-48df-9801-087eaa2d85c7</Id>
+      <Database Name="cv" Series="4052" Issue="42302" />
     </Book>
     <Book Series="Excalibur" Number="97" Volume="1988" Year="1996">
-      <Id>d391dfaf-e463-4b35-9139-d09a4e52c51d</Id>
+      <Database Name="cv" Series="4052" Issue="66380" />
     </Book>
     <Book Series="X-Force" Number="49" Volume="1991" Year="1995">
-      <Id>d833f03b-a3ca-46e0-ac43-b20af836c71c</Id>
+      <Database Name="cv" Series="4604" Issue="64523" />
     </Book>
     <Book Series="X-Force" Number="50" Volume="1991" Year="1996">
-      <Id>53722df6-430f-466d-9124-2a0285586ad6</Id>
+      <Database Name="cv" Series="4604" Issue="64524" />
     </Book>
     <Book Series="X-Force" Number="51" Volume="1991" Year="1996">
-      <Id>19531947-1386-4e99-8299-b74812ef55b8</Id>
+      <Database Name="cv" Series="4604" Issue="64525" />
     </Book>
     <Book Series="X-Men" Number="49" Volume="1991" Year="1996">
-      <Id>18f56636-dee7-4314-9215-aaba5ffccb38</Id>
+      <Database Name="cv" Series="4605" Issue="106669" />
     </Book>
     <Book Series="X-Factor" Number="119" Volume="1986" Year="1996">
-      <Id>b559d246-2ee4-4de0-8011-131b2e982bfa</Id>
+      <Database Name="cv" Series="3657" Issue="107216" />
     </Book>
     <Book Series="Cable" Number="29" Volume="1993" Year="1996">
-      <Id>55978873-787b-4662-b772-5e70f2167f3b</Id>
+      <Database Name="cv" Series="4993" Issue="106739" />
     </Book>
     <Book Series="X-Man" Number="13" Volume="1995" Year="1996">
-      <Id>1952908a-6260-40c6-a275-1cfbcf073954</Id>
+      <Database Name="cv" Series="5567" Issue="42212" />
     </Book>
     <Book Series="X-Factor" Number="120" Volume="1986" Year="1996">
-      <Id>8259539d-f554-45e8-996f-170aa1c95db4</Id>
+      <Database Name="cv" Series="3657" Issue="65699" />
     </Book>
     <Book Series="X-Factor" Number="121" Volume="1986" Year="1996">
-      <Id>80e05642-48d3-48a4-b5dc-ff5a9089536a</Id>
+      <Database Name="cv" Series="3657" Issue="65700" />
     </Book>
     <Book Series="X-Men" Number="50" Volume="1991" Year="1996">
-      <Id>aee62906-0de8-4cab-86b2-d538be76d180</Id>
+      <Database Name="cv" Series="4605" Issue="65750" />
     </Book>
     <Book Series="X-Men Unlimited" Number="10" Volume="1993" Year="1996">
-      <Id>7ea275b3-d20c-4a7f-b760-49db7a3ce4cf</Id>
+      <Database Name="cv" Series="5066" Issue="42213" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="331" Volume="1981" Year="1996">
-      <Id>630ad19a-122e-4cc5-bdeb-35fad5c57590</Id>
+      <Database Name="cv" Series="3092" Issue="107106" />
     </Book>
     <Book Series="The Further Adventures of Cyclops and Phoenix" Number="1" Volume="1996" Year="1996">
-      <Id>b16bba72-399d-4c19-b9d2-390d1630c3b4</Id>
+      <Database Name="cv" Series="7190" Issue="51320" />
     </Book>
     <Book Series="The Further Adventures of Cyclops and Phoenix" Number="2" Volume="1996" Year="1996">
-      <Id>9709a205-dee5-4d93-97b6-3db8015c8813</Id>
+      <Database Name="cv" Series="7190" Issue="51321" />
     </Book>
     <Book Series="The Further Adventures of Cyclops and Phoenix" Number="3" Volume="1996" Year="1996">
-      <Id>3d8f4d53-b5c3-4754-a7da-8987b188e1bd</Id>
+      <Database Name="cv" Series="7190" Issue="51322" />
     </Book>
     <Book Series="The Further Adventures of Cyclops and Phoenix" Number="4" Volume="1996" Year="1996">
-      <Id>04e3c897-e601-451d-bb14-95b6a289cfd3</Id>
+      <Database Name="cv" Series="7190" Issue="51323" />
     </Book>
     <Book Series="X-Force" Number="52" Volume="1991" Year="1996">
-      <Id>c79de9ca-6efe-450b-bbac-25536e54b56b</Id>
+      <Database Name="cv" Series="4604" Issue="64526" />
     </Book>
     <Book Series="X-Force" Number="53" Volume="1991" Year="1996">
-      <Id>2bf56a25-7864-40e0-8546-da0f3415e7a3</Id>
+      <Database Name="cv" Series="4604" Issue="64527" />
     </Book>
     <Book Series="Cable" Number="30" Volume="1993" Year="1996">
-      <Id>87dd34ac-4b52-4d15-b4b5-8baeec8d9c78</Id>
+      <Database Name="cv" Series="4993" Issue="42327" />
     </Book>
     <Book Series="X-Man" Number="14" Volume="1995" Year="1996">
-      <Id>64ef6f85-3241-4743-a02e-a60b2a79b34a</Id>
+      <Database Name="cv" Series="5567" Issue="42307" />
     </Book>
     <Book Series="Cable" Number="31" Volume="1993" Year="1996">
-      <Id>2140a91c-ce58-4cff-8a68-7253a8b8463c</Id>
+      <Database Name="cv" Series="4993" Issue="42419" />
     </Book>
     <Book Series="X-Force" Number="54" Volume="1991" Year="1996">
-      <Id>d7303f97-ba77-4d1a-94cb-a83f177fb1e0</Id>
+      <Database Name="cv" Series="4604" Issue="64528" />
     </Book>
     <Book Series="X-Men vs. The Brood" Number="1" Volume="1996" Year="1996">
-      <Id>90041fff-a216-42d3-a988-c888fb6c08fc</Id>
+      <Database Name="cv" Series="18316" Issue="107262" />
     </Book>
     <Book Series="X-Men vs. The Brood" Number="2" Volume="1996" Year="1996">
-      <Id>c055be32-de4d-4f2c-945d-d05e1ead499f</Id>
+      <Database Name="cv" Series="18316" Issue="107297" />
     </Book>
     <Book Series="X-Men: ClanDestine" Number="1" Volume="1996" Year="1996">
-      <Id>bf5e4e86-f837-4a54-b4a2-301300580179</Id>
+      <Database Name="cv" Series="5797" Issue="42889" />
     </Book>
     <Book Series="X-Men: ClanDestine" Number="2" Volume="1996" Year="1996">
-      <Id>7429284d-ec8e-460c-8ca2-471c43d202dd</Id>
+      <Database Name="cv" Series="5797" Issue="42995" />
     </Book>
     <Book Series="X-Men" Number="51" Volume="1991" Year="1996">
-      <Id>795d6527-ae8c-4e50-8d75-a8dc20c32874</Id>
+      <Database Name="cv" Series="4605" Issue="65751" />
     </Book>
     <Book Series="X-Men" Number="52" Volume="1991" Year="1996">
-      <Id>e33ba122-8a3f-4859-b26d-b5668e752a43</Id>
+      <Database Name="cv" Series="4605" Issue="65752" />
     </Book>
     <Book Series="Wolverine" Number="97" Volume="1988" Year="1996">
-      <Id>470ff9d2-e7b7-424b-8dca-0d5682c48b4e</Id>
+      <Database Name="cv" Series="4250" Issue="42006" />
     </Book>
     <Book Series="Wolverine" Number="98" Volume="1988" Year="1996">
-      <Id>ab65d521-9c89-49ec-a9bf-b80599c3d377</Id>
+      <Database Name="cv" Series="4250" Issue="42114" />
     </Book>
     <Book Series="Wolverine" Number="99" Volume="1988" Year="1996">
-      <Id>c171aacb-a894-4641-abec-ee2822731e3b</Id>
+      <Database Name="cv" Series="4250" Issue="42225" />
     </Book>
     <Book Series="Wolverine" Number="100" Volume="1988" Year="1996">
-      <Id>1f578ade-2559-473a-9c0e-c0c9ee76aa69</Id>
+      <Database Name="cv" Series="4250" Issue="42326" />
     </Book>
     <Book Series="Generation X" Number="12" Volume="1994" Year="1996">
-      <Id>69d68daa-a07d-4be7-9dd7-a09ae0986fea</Id>
+      <Database Name="cv" Series="5300" Issue="105433" />
     </Book>
     <Book Series="Generation X" Number="13" Volume="1994" Year="1996">
-      <Id>68b534d4-bcd1-4c7a-817b-cd37819f61c7</Id>
+      <Database Name="cv" Series="5300" Issue="42206" />
     </Book>
     <Book Series="Generation X" Number="14" Volume="1994" Year="1996">
-      <Id>2e6e58ad-714f-4678-8974-4fa96757ecd9</Id>
+      <Database Name="cv" Series="5300" Issue="105434" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="332" Volume="1981" Year="1996">
-      <Id>b0baee94-2335-4fe9-a03d-96e95e7f2059</Id>
+      <Database Name="cv" Series="3092" Issue="42416" />
     </Book>
     <Book Series="Wolverine" Number="101" Volume="1988" Year="1996">
-      <Id>f85cd47c-ee31-468c-b0a0-26210d3374fa</Id>
+      <Database Name="cv" Series="4250" Issue="42418" />
     </Book>
     <Book Series="X-Factor" Number="122" Volume="1986" Year="1996">
-      <Id>bd53013a-0a0b-4b1c-8c31-c8fc76bdf4f8</Id>
+      <Database Name="cv" Series="3657" Issue="65701" />
     </Book>
     <Book Series="X-Factor" Number="123" Volume="1986" Year="1996">
-      <Id>eba88b3a-034a-459e-8a6d-6a8a358195cd</Id>
+      <Database Name="cv" Series="3657" Issue="65702" />
     </Book>
     <Book Series="Archangel" Number="1" Volume="1996" Year="1996">
-      <Id>c14782a6-1fa0-49d9-ae0c-930b366171b1</Id>
+      <Database Name="cv" Series="18148" Issue="106315" />
     </Book>
     <Book Series="Generation X" Number="15" Volume="1994" Year="1996">
-      <Id>adb66333-d481-4dd5-a1f7-d7c8f3f5bcaa</Id>
+      <Database Name="cv" Series="5300" Issue="42398" />
     </Book>
     <Book Series="Generation X" Number="16" Volume="1994" Year="1996">
-      <Id>8787c6d3-43ed-4a1d-b0b3-19008cd47971</Id>
+      <Database Name="cv" Series="5300" Issue="42491" />
     </Book>
     <Book Series="Generation X" Number="17" Volume="1994" Year="1996">
-      <Id>91cd5852-61da-4496-8b23-1f10a60a7096</Id>
+      <Database Name="cv" Series="5300" Issue="42602" />
     </Book>
     <Book Series="Excalibur" Number="98" Volume="1988" Year="1996">
-      <Id>fe4feb92-52cc-4873-b071-65e822400297</Id>
+      <Database Name="cv" Series="4052" Issue="66381" />
     </Book>
     <Book Series="Excalibur" Number="99" Volume="1988" Year="1996">
-      <Id>dfba4195-f60b-4a2d-8e3d-2d35b42d06ef</Id>
+      <Database Name="cv" Series="4052" Issue="66382" />
     </Book>
     <Book Series="X-Factor" Number="124" Volume="1986" Year="1996">
-      <Id>c2ad75e7-cc12-4936-a651-186c58c3a5a1</Id>
+      <Database Name="cv" Series="3657" Issue="65703" />
     </Book>
-    <Book Series="Uncanny X-Men Annual '96" Number="1" Volume="1996" Year="1996">
-      <Id>e81d709a-04e6-4c93-bc5e-d111e088cfdf</Id>
+    <Book Series="Uncanny X-Men '96" Number="1" Volume="1996" Year="1996">
+      <Database Name="cv" Series="60469" Issue="136046" />
     </Book>
     <Book Series="XSE" Number="1" Volume="1996" Year="1996">
-      <Id>46c43a12-7878-4069-a256-554aba70151c</Id>
+      <Database Name="cv" Series="18353" Issue="107618" />
     </Book>
     <Book Series="XSE" Number="2" Volume="1996" Year="1996">
-      <Id>b24bf4bf-b409-4296-8ace-7cd57ec51c15</Id>
+      <Database Name="cv" Series="18353" Issue="107894" />
     </Book>
     <Book Series="XSE" Number="3" Volume="1996" Year="1997">
-      <Id>e97f4f46-63a5-4eb1-b7ec-df61eb61f54c</Id>
+      <Database Name="cv" Series="18353" Issue="107896" />
     </Book>
     <Book Series="XSE" Number="4" Volume="1996" Year="1997">
-      <Id>3adf60c0-499a-4df0-a4c4-26f85dcbfbf6</Id>
+      <Database Name="cv" Series="18353" Issue="107897" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="333" Volume="1981" Year="1996">
-      <Id>7ed829ab-28e6-462f-aa97-44674b14e381</Id>
+      <Database Name="cv" Series="3092" Issue="65133" />
     </Book>
     <Book Series="X-Force" Number="55" Volume="1991" Year="1996">
-      <Id>19a7da90-9150-44ff-b195-6ce8039addc3</Id>
+      <Database Name="cv" Series="4604" Issue="64529" />
     </Book>
     <Book Series="X-Force" Number="56" Volume="1991" Year="1996">
-      <Id>9ab4e19e-82b3-4bad-93b6-901daf4467ce</Id>
+      <Database Name="cv" Series="4604" Issue="64530" />
     </Book>
     <Book Series="Wolverine" Number="102" Volume="1988" Year="1996">
-      <Id>e586afca-bb84-47a8-804e-713aa4296538</Id>
+      <Database Name="cv" Series="4250" Issue="42517" />
     </Book>
     <Book Series="Wolverine" Number="103" Volume="1988" Year="1996">
-      <Id>859c3346-fc52-4cb9-8353-39e46f489751</Id>
+      <Database Name="cv" Series="4250" Issue="51171" />
     </Book>
     <Book Series="X-Man" Number="15" Volume="1995" Year="1996">
-      <Id>8ba38e04-c6cc-4562-9af0-dae0863cedd6</Id>
+      <Database Name="cv" Series="5567" Issue="42403" />
     </Book>
     <Book Series="X-Man" Number="16" Volume="1995" Year="1996">
-      <Id>7d2c39d6-f9fb-42c5-a5b1-9a253758db31</Id>
+      <Database Name="cv" Series="5567" Issue="42499" />
     </Book>
     <Book Series="X-Man" Number="17" Volume="1995" Year="1996">
-      <Id>71f80b46-f61d-44bf-bff5-77f68940a0c3</Id>
+      <Database Name="cv" Series="5567" Issue="42607" />
     </Book>
     <Book Series="Cable" Number="32" Volume="1993" Year="1996">
-      <Id>e604ed09-709f-4b72-9873-e77857c388ca</Id>
+      <Database Name="cv" Series="4993" Issue="135788" />
     </Book>
     <Book Series="Cable" Number="33" Volume="1993" Year="1996">
-      <Id>d28583e7-4ed9-4f6f-9564-ca25d1550d78</Id>
+      <Database Name="cv" Series="4993" Issue="42621" />
     </Book>
     <Book Series="X-Men" Number="53" Volume="1991" Year="1996">
-      <Id>3e1c253f-87ba-4a9c-bc8f-0747ac74d5c7</Id>
+      <Database Name="cv" Series="4605" Issue="65753" />
     </Book>
     <Book Series="X-Men Unlimited" Number="11" Volume="1993" Year="1996">
-      <Id>26c28f9d-b334-412c-87dc-ef835cbc1d8f</Id>
+      <Database Name="cv" Series="5066" Issue="42500" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="334" Volume="1981" Year="1996">
-      <Id>73324805-3234-47e0-a36c-282a45c296b6</Id>
+      <Database Name="cv" Series="3092" Issue="42619" />
     </Book>
     <Book Series="X-Men" Number="54" Volume="1991" Year="1996">
-      <Id>f1e74e7b-b431-4e25-9be3-d76cf1ed98f5</Id>
+      <Database Name="cv" Series="4605" Issue="65754" />
     </Book>
     <Book Series="Onslaught: X-Men" Number="1" Volume="1996" Year="1996">
-      <Id>378e982d-0f5e-4c76-aa58-cbd31baf75d7</Id>
+      <Database Name="cv" Series="18280" Issue="107021" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="335" Volume="1981" Year="1996">
-      <Id>8840e6d7-f7d0-4a46-9230-a1cd750c09d1</Id>
+      <Database Name="cv" Series="3092" Issue="42719" />
     </Book>
     <Book Series="X-Man" Number="18" Volume="1995" Year="1996">
-      <Id>21ffb9c1-0555-4ae9-a6e4-d8373fb81605</Id>
+      <Database Name="cv" Series="5567" Issue="42705" />
     </Book>
     <Book Series="X-Force" Number="57" Volume="1991" Year="1996">
-      <Id>f764744c-782c-4cfb-b5fe-ec760ca9ec42</Id>
+      <Database Name="cv" Series="4604" Issue="64531" />
     </Book>
     <Book Series="Cable" Number="34" Volume="1993" Year="1996">
-      <Id>2b4a1be3-498b-4453-a43d-6ab471a57d45</Id>
+      <Database Name="cv" Series="4993" Issue="42721" />
     </Book>
     <Book Series="The Incredible Hulk" Number="444" Volume="1968" Year="1996">
-      <Id>07809b8f-2358-4ff2-bd0d-72418e44b64c</Id>
+      <Database Name="cv" Series="2406" Issue="42701" />
     </Book>
     <Book Series="The Avengers" Number="401" Volume="1963" Year="1996">
-      <Id>aee8a271-0204-4c05-bb57-7e7dad9248fa</Id>
+      <Database Name="cv" Series="2128" Issue="42697" />
     </Book>
     <Book Series="Excalibur" Number="100" Volume="1988" Year="1996">
-      <Id>50b8a316-4fe3-45a3-ae4b-12004f5bad6b</Id>
+      <Database Name="cv" Series="4052" Issue="66383" />
     </Book>
     <Book Series="X-Factor" Number="125" Volume="1986" Year="1996">
-      <Id>f14a75e6-040f-427d-97b2-a6f8c1bc8169</Id>
+      <Database Name="cv" Series="3657" Issue="107220" />
     </Book>
     <Book Series="Fantastic Four" Number="415" Volume="1961" Year="1996">
-      <Id>1ea1fbee-1a31-4b68-969e-4c6e476ed7ad</Id>
+      <Database Name="cv" Series="2045" Issue="77595" />
     </Book>
     <Book Series="Generation X" Number="18" Volume="1994" Year="1996">
-      <Id>d7f2e777-c07e-4abd-afd8-28ffd59495b8</Id>
+      <Database Name="cv" Series="5300" Issue="42700" />
     </Book>
     <Book Series="Wolverine" Number="104" Volume="1988" Year="1996">
-      <Id>64184ead-7007-4c4f-8afc-b8dfbb96ca8d</Id>
+      <Database Name="cv" Series="4250" Issue="51172" />
     </Book>
     <Book Series="X-Men" Number="55" Volume="1991" Year="1996">
-      <Id>4fed135f-c567-481a-9ef9-b096ce5a23f6</Id>
+      <Database Name="cv" Series="4605" Issue="65755" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="336" Volume="1981" Year="1996">
-      <Id>a45a60c5-1f1b-4e0a-aeb5-efc560a885f8</Id>
+      <Database Name="cv" Series="3092" Issue="42814" />
     </Book>
     <Book Series="X-Factor" Number="126" Volume="1986" Year="1996">
-      <Id>69c50943-cf0f-4234-bd42-d18fadf6cd90</Id>
+      <Database Name="cv" Series="3657" Issue="65704" />
     </Book>
     <Book Series="Cable" Number="35" Volume="1993" Year="1996">
-      <Id>70b2d982-8731-40ab-a13a-38755ea3e394</Id>
+      <Database Name="cv" Series="4993" Issue="42816" />
     </Book>
     <Book Series="X-Force" Number="58" Volume="1991" Year="1996">
-      <Id>98b5ec0a-5292-4509-932f-5243850c0ea9</Id>
+      <Database Name="cv" Series="4604" Issue="64532" />
     </Book>
     <Book Series="The Incredible Hulk" Number="445" Volume="1968" Year="1996">
-      <Id>1e21de15-e857-4241-a165-9927360a57fa</Id>
+      <Database Name="cv" Series="2406" Issue="42795" />
     </Book>
     <Book Series="The Avengers" Number="402" Volume="1963" Year="1996">
-      <Id>5ce99ebc-185c-4606-b19f-7fd6af024610</Id>
+      <Database Name="cv" Series="2128" Issue="42792" />
     </Book>
     <Book Series="X-Man" Number="19" Volume="1995" Year="1996">
-      <Id>d1c1c094-5bd6-448f-9de7-ed128dfab2c6</Id>
+      <Database Name="cv" Series="5567" Issue="42801" />
     </Book>
     <Book Series="Fantastic Four" Number="416" Volume="1961" Year="1996">
-      <Id>ab25934a-d593-42b5-bb6d-802c3a443369</Id>
+      <Database Name="cv" Series="2045" Issue="77596" />
     </Book>
     <Book Series="Generation X" Number="19" Volume="1994" Year="1996">
-      <Id>64d41ba8-2e3b-473f-a19a-c4677b2ef125</Id>
+      <Database Name="cv" Series="5300" Issue="42794" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="415" Volume="1963" Year="1996">
-      <Id>b700c5af-ae45-4ab0-9ec2-ce0ef1c74332</Id>
+      <Database Name="cv" Series="2127" Issue="64453" />
     </Book>
     <Book Series="Wolverine" Number="105" Volume="1988" Year="1996">
-      <Id>69774aa9-524c-468e-981d-b40cb57c27a4</Id>
+      <Database Name="cv" Series="4250" Issue="51173" />
     </Book>
     <Book Series="Spider-Man" Number="72" Volume="1990" Year="1996">
-      <Id>e7560f75-73f8-41d4-9cc1-625e0f37e6b0</Id>
+      <Database Name="cv" Series="4421" Issue="64650" />
     </Book>
     <Book Series="X-Men" Number="56" Volume="1991" Year="1996">
-      <Id>74236359-297c-48b6-ab26-169102fc082c</Id>
+      <Database Name="cv" Series="4605" Issue="65756" />
     </Book>
     <Book Series="X-Men Unlimited" Number="12" Volume="1993" Year="1996">
-      <Id>1eb9f075-c42e-465c-babd-d383415426ff</Id>
+      <Database Name="cv" Series="5066" Issue="42802" />
     </Book>
     <Book Series="Onslaught: Marvel Universe" Number="1" Volume="1996" Year="1996">
-      <Id>ece634bb-a5de-4c95-95ea-1af6403e9f39</Id>
+      <Database Name="cv" Series="18278" Issue="107019" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="337" Volume="1981" Year="1996">
-      <Id>09285bd5-6f19-4414-a9b9-31e68a1da9d4</Id>
+      <Database Name="cv" Series="3092" Issue="42904" />
     </Book>
     <Book Series="Excalibur" Number="101" Volume="1988" Year="1996">
-      <Id>4b398377-6c61-4d8f-9c2d-e46c17305d86</Id>
+      <Database Name="cv" Series="4052" Issue="66384" />
     </Book>
     <Book Series="Excalibur" Number="102" Volume="1988" Year="1996">
-      <Id>0c2c43e3-c0de-4203-ae91-2ca7e1b4f184</Id>
+      <Database Name="cv" Series="4052" Issue="66385" />
     </Book>
     <Book Series="X-Men" Number="57" Volume="1991" Year="1996">
-      <Id>0c5ffa7c-8239-4487-bbde-35eb066a7186</Id>
+      <Database Name="cv" Series="4605" Issue="65757" />
     </Book>
     <Book Series="Onslaught: Epilogue" Number="1" Volume="1997" Year="1997">
-      <Id>e8c51568-5fb2-4edc-a8dd-df950a627c4c</Id>
+      <Database Name="cv" Series="18279" Issue="107020" />
     </Book>
     <Book Series="Cable" Number="36" Volume="1993" Year="1996">
-      <Id>b4c2c667-209c-41c1-98d6-8fea49ed9828</Id>
+      <Database Name="cv" Series="4993" Issue="65631" />
     </Book>
     <Book Series="Generation X" Number="20" Volume="1994" Year="1996">
-      <Id>c38c5e5e-a8ad-49f4-b897-2a09ebe90cfb</Id>
+      <Database Name="cv" Series="5300" Issue="42881" />
     </Book>
     <Book Series="Generation X" Number="21" Volume="1994" Year="1996">
-      <Id>67ccdb98-a996-4b98-8c87-6383eb6ca66e</Id>
+      <Database Name="cv" Series="5300" Issue="42982" />
     </Book>
     <Book Series="X-Man" Number="20" Volume="1995" Year="1996">
-      <Id>903affbe-c3c8-488b-98df-2d7843fdb86c</Id>
+      <Database Name="cv" Series="5567" Issue="42888" />
     </Book>
-    <Book Series="Mystique &amp; Sabretooth" Number="1" Volume="1996" Year="1996">
-      <Id>e1062f49-1acb-4a42-9678-884f32af4f9d</Id>
+    <Book Series="Mystique &#38; Sabretooth" Number="1" Volume="1996" Year="1996">
+      <Database Name="cv" Series="5787" Issue="43117" />
     </Book>
-    <Book Series="Mystique &amp; Sabretooth" Number="2" Volume="1996" Year="1997">
-      <Id>74783dcf-e4c2-4cda-99f1-cb8b2c85a3ad</Id>
+    <Book Series="Mystique &#38; Sabretooth" Number="2" Volume="1996" Year="1997">
+      <Database Name="cv" Series="5787" Issue="43313" />
     </Book>
-    <Book Series="Mystique &amp; Sabretooth" Number="3" Volume="1996" Year="1997">
-      <Id>e677b856-1fbf-46cc-9a94-ca8796733554</Id>
+    <Book Series="Mystique &#38; Sabretooth" Number="3" Volume="1996" Year="1997">
+      <Database Name="cv" Series="5787" Issue="43425" />
     </Book>
-    <Book Series="Mystique &amp; Sabretooth" Number="4" Volume="1996" Year="1997">
-      <Id>cc539f7c-8640-4d2b-a71b-cef4d4ca70a0</Id>
+    <Book Series="Mystique &#38; Sabretooth" Number="4" Volume="1996" Year="1997">
+      <Database Name="cv" Series="5787" Issue="43519" />
     </Book>
     <Book Series="X-Force" Number="59" Volume="1991" Year="1996">
-      <Id>6cf92a6d-a4bb-41b0-a28d-0f6e65096a8c</Id>
+      <Database Name="cv" Series="4604" Issue="64533" />
     </Book>
     <Book Series="X-Force" Number="60" Volume="1991" Year="1996">
-      <Id>0450619f-94a7-4b70-80c1-ef4dd6812baf</Id>
+      <Database Name="cv" Series="4604" Issue="64534" />
     </Book>
     <Book Series="X-Force" Number="61" Volume="1991" Year="1996">
-      <Id>c7bc8523-c0bb-4aae-bf6e-6e1cc230daf2</Id>
+      <Database Name="cv" Series="4604" Issue="64535" />
     </Book>
     <Book Series="Wolverine" Number="106" Volume="1988" Year="1996">
-      <Id>2ed9b70f-e677-4ae1-97de-f69774db8b87</Id>
+      <Database Name="cv" Series="4250" Issue="51174" />
     </Book>
     <Book Series="X-Factor" Number="127" Volume="1986" Year="1996">
-      <Id>78b86f8a-af1f-4146-afeb-13e1fb57d81d</Id>
+      <Database Name="cv" Series="3657" Issue="65705" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="338" Volume="1981" Year="1996">
-      <Id>c24533b2-0bb8-44a6-b207-bafe680684df</Id>
+      <Database Name="cv" Series="3092" Issue="43004" />
     </Book>
     <Book Series="Pryde and Wisdom" Number="1" Volume="1996" Year="1996">
-      <Id>52c3460d-203c-4aca-bb32-3c2919397905</Id>
+      <Database Name="cv" Series="5785" Issue="42797" />
     </Book>
     <Book Series="Pryde and Wisdom" Number="2" Volume="1996" Year="1996">
-      <Id>b17ca171-10cb-4b9c-bee2-53a41369afd9</Id>
+      <Database Name="cv" Series="5785" Issue="42885" />
     </Book>
     <Book Series="Pryde and Wisdom" Number="3" Volume="1996" Year="1996">
-      <Id>594c311a-53b3-4e6d-86c9-26b4e5d2747a</Id>
+      <Database Name="cv" Series="5785" Issue="42986" />
     </Book>
-    <Book Series="X-Men Annual '96" Number="1" Volume="1996" Year="1996">
-      <Id>a7eb069d-e399-42ae-bb41-5a1214be850c</Id>
+    <Book Series="X-Men '96" Number="1" Volume="1996" Year="1996">
+      <Database Name="cv" Series="20710" Issue="178122" />
     </Book>
     <Book Series="The Rise of Apocalypse" Number="1" Volume="1996" Year="1996">
-      <Id>01e2a72b-1be5-4822-9d5e-0d032b0c9d97</Id>
+      <Database Name="cv" Series="18414" Issue="107982" />
     </Book>
     <Book Series="The Rise of Apocalypse" Number="2" Volume="1996" Year="1996">
-      <Id>2a3ac229-0ccc-4582-926f-c083309f76c6</Id>
+      <Database Name="cv" Series="18414" Issue="108008" />
     </Book>
     <Book Series="The Rise of Apocalypse" Number="3" Volume="1996" Year="1996">
-      <Id>8edf4b68-e6ca-4fff-b10d-2c9a4f9d2790</Id>
+      <Database Name="cv" Series="18414" Issue="108009" />
     </Book>
     <Book Series="The Rise of Apocalypse" Number="4" Volume="1996" Year="1997">
-      <Id>a071173d-579e-41f8-bd32-eddb19cb810f</Id>
+      <Database Name="cv" Series="18414" Issue="108012" />
     </Book>
     <Book Series="X-Men" Number="58" Volume="1991" Year="1996">
-      <Id>f7642da9-9d2d-451c-9a14-3a0f51c0d74f</Id>
+      <Database Name="cv" Series="4605" Issue="65758" />
     </Book>
     <Book Series="X-Man" Number="21" Volume="1995" Year="1996">
-      <Id>ff223a14-bfda-4e55-b60a-c5ff6d1a4eb9</Id>
+      <Database Name="cv" Series="5567" Issue="42994" />
     </Book>
     <Book Series="Excalibur" Number="103" Volume="1988" Year="1996">
-      <Id>334b8cd4-be12-41ac-945e-56aba504868b</Id>
+      <Database Name="cv" Series="4052" Issue="66386" />
     </Book>
-    <Book Series="X-Force / Cable Annual '96" Number="1" Volume="1996" Year="1996">
-      <Id>ff604c04-7122-490c-90e1-9c051651b170</Id>
+    <Book Series="X-Force / Cable '96" Number="1" Volume="1996" Year="1996">
+      <Database Name="cv" Series="20138" Issue="120187" />
     </Book>
     <Book Series="X-Force" Number="62" Volume="1991" Year="1997">
-      <Id>98f66427-969b-40b9-9ed6-808dcc02b131</Id>
+      <Database Name="cv" Series="4604" Issue="64536" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 006.cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 006.cbl
@@ -1,924 +1,925 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>X-Men - Part 6</Name>
+  <Name>X-Men - Part 006</Name>
+  <NumIssues>306</NumIssues>
   <Books>
     <Book Series="The Beast" Number="1" Volume="1997" Year="1997">
-      <Id>2ad558e3-3d91-4a1f-a6f1-922b28d5918e</Id>
+      <Database Name="cv" Series="22443" Issue="134699" />
     </Book>
     <Book Series="The Beast" Number="2" Volume="1997" Year="1997">
-      <Id>4fd1dbc8-9c2e-4379-997b-4df934a891da</Id>
+      <Database Name="cv" Series="22443" Issue="134700" />
     </Book>
     <Book Series="The Beast" Number="3" Volume="1997" Year="1997">
-      <Id>dea18b9d-7acd-4abb-b83d-5cd06c9f2097</Id>
+      <Database Name="cv" Series="22443" Issue="134701" />
     </Book>
     <Book Series="Generation X" Number="22" Volume="1994" Year="1996">
-      <Id>e1130dda-e249-48be-a692-1d86de3d3945</Id>
+      <Database Name="cv" Series="5300" Issue="43076" />
     </Book>
-    <Book Series="Generation X Annual '96" Number="1" Volume="1996" Year="1996">
-      <Id>1ceac618-71eb-4b73-87a3-e76e0261188d</Id>
+    <Book Series="Generation X '96" Number="1" Volume="1996" Year="1996">
+      <Database Name="cv" Series="60443" Issue="109932" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="339" Volume="1981" Year="1996">
-      <Id>0a7bcd13-72ab-4969-9290-8b1d1ec9f2e9</Id>
+      <Database Name="cv" Series="3092" Issue="43105" />
     </Book>
     <Book Series="X-Men" Number="59" Volume="1991" Year="1996">
-      <Id>6f69fe8d-fb6c-4abb-a15c-46d36fb974dd</Id>
+      <Database Name="cv" Series="4605" Issue="65759" />
     </Book>
-    <Book Series="Wolverine Annual '96" Number="1" Volume="1996" Year="1996">
-      <Id>9831d3c0-aca7-4bd4-ac80-ee22e8d759ae</Id>
+    <Book Series="Wolverine '96" Number="1" Volume="1996" Year="1996">
+      <Database Name="cv" Series="27145" Issue="164958" />
     </Book>
     <Book Series="X-Men Unlimited" Number="13" Volume="1993" Year="1996">
-      <Id>107f7787-7c68-4096-bc68-181099e18ec3</Id>
+      <Database Name="cv" Series="5066" Issue="43092" />
     </Book>
     <Book Series="Logan: Shadow Society" Number="1" Volume="1996" Year="1996">
-      <Id>7338db04-e9ee-4d6a-9374-e6e21d392e37</Id>
+      <Database Name="cv" Series="28565" Issue="175968" />
     </Book>
     <Book Series="Wolverine" Number="107" Volume="1988" Year="1996">
-      <Id>3539e3ea-ed6b-4fd1-a26d-5ffa475d38dc</Id>
+      <Database Name="cv" Series="4250" Issue="51175" />
     </Book>
     <Book Series="Wolverine" Number="108" Volume="1988" Year="1996">
-      <Id>5575d922-b3e1-45c6-9f0d-d699ba24093c</Id>
+      <Database Name="cv" Series="4250" Issue="51176" />
     </Book>
     <Book Series="Wolverine" Number="109" Volume="1988" Year="1997">
-      <Id>69da0909-ac6b-4caf-87ac-567efd309a0d</Id>
+      <Database Name="cv" Series="4250" Issue="51177" />
     </Book>
     <Book Series="X-Man" Number="22" Volume="1995" Year="1996">
-      <Id>1c418271-ff43-4ebc-b595-8e95ebf43ce9</Id>
+      <Database Name="cv" Series="5567" Issue="43091" />
     </Book>
     <Book Series="Excalibur" Number="104" Volume="1988" Year="1996">
-      <Id>04d1d374-f745-4238-ba12-efe90e5befd9</Id>
+      <Database Name="cv" Series="4052" Issue="66387" />
     </Book>
     <Book Series="Excalibur" Number="105" Volume="1988" Year="1997">
-      <Id>d596d9c2-324f-42dc-b8c8-280860f4124b</Id>
+      <Database Name="cv" Series="4052" Issue="66388" />
     </Book>
     <Book Series="Wolverine" Number="110" Volume="1988" Year="1997">
-      <Id>4e9ebf52-cb76-4440-904a-df0c463b6308</Id>
+      <Database Name="cv" Series="4250" Issue="51178" />
     </Book>
     <Book Series="Venom: Tooth and Claw" Number="1" Volume="1996" Year="1996">
-      <Id>79d0eea2-211d-4bec-86d9-f6d4a2aad9c3</Id>
+      <Database Name="cv" Series="11033" Issue="96324" />
     </Book>
-    <Book Series="Venom: Tooth and Claw" Number="2" Volume="1996" Year="1997">
-      <Id>4ac90be6-287f-464e-9daa-69bb614b7934</Id>
+    <Book Series="Venom: Tooth and Claw" Number="2" Volume="1996" Year="1996">
+      <Database Name="cv" Series="11033" Issue="96325" />
     </Book>
     <Book Series="Venom: Tooth and Claw" Number="3" Volume="1996" Year="1997">
-      <Id>be590a25-c7d6-41cd-ae1f-41625d18ccf2</Id>
+      <Database Name="cv" Series="11033" Issue="96326" />
     </Book>
     <Book Series="Cable" Number="37" Volume="1993" Year="1996">
-      <Id>3444f1aa-ce22-402a-89d4-911d9deae7f4</Id>
+      <Database Name="cv" Series="4993" Issue="43006" />
     </Book>
     <Book Series="Cable" Number="38" Volume="1993" Year="1996">
-      <Id>ceafef35-bf35-46a5-be36-e88fe608a43c</Id>
+      <Database Name="cv" Series="4993" Issue="43107" />
     </Book>
     <Book Series="Cable" Number="39" Volume="1993" Year="1997">
-      <Id>e1748f19-29ad-40cd-a0d3-1eda6ae67f06</Id>
+      <Database Name="cv" Series="4993" Issue="43303" />
     </Book>
     <Book Series="Excalibur" Number="106" Volume="1988" Year="1997">
-      <Id>41595012-9020-487d-92c5-0a2489d3c7e4</Id>
+      <Database Name="cv" Series="4052" Issue="66389" />
     </Book>
     <Book Series="Magneto" Number="1" Volume="1996" Year="1996">
-      <Id>573aeaf7-156d-4eb3-be85-ef17a18b12c8</Id>
+      <Database Name="cv" Series="7196" Issue="106972" />
     </Book>
     <Book Series="Magneto" Number="2" Volume="1996" Year="1996">
-      <Id>4fc09de6-26a9-4e8b-afc0-18299f3d09f5</Id>
+      <Database Name="cv" Series="7196" Issue="51334" />
     </Book>
     <Book Series="Magneto" Number="3" Volume="1996" Year="1997">
-      <Id>7bf608b0-8764-4aa1-b0f9-97a69e0b6646</Id>
+      <Database Name="cv" Series="7196" Issue="51335" />
     </Book>
     <Book Series="Magneto" Number="4" Volume="1996" Year="1997">
-      <Id>ee9df9e5-2797-4194-90d5-3a5c09704165</Id>
+      <Database Name="cv" Series="7196" Issue="51336" />
     </Book>
     <Book Series="X-Factor" Number="128" Volume="1986" Year="1996">
-      <Id>72834d1f-fc3a-40b7-81a1-9c4999c218a2</Id>
+      <Database Name="cv" Series="3657" Issue="65706" />
     </Book>
     <Book Series="X-Factor" Number="129" Volume="1986" Year="1996">
-      <Id>33571707-0d1c-46e4-9711-2c95b66f0317</Id>
+      <Database Name="cv" Series="3657" Issue="65707" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="340" Volume="1981" Year="1997">
-      <Id>fa72317d-82e8-4d77-990d-ad795980983e</Id>
+      <Database Name="cv" Series="3092" Issue="107107" />
     </Book>
     <Book Series="X-Factor" Number="130" Volume="1986" Year="1997">
-      <Id>0d5d6b10-617e-4e35-969e-875d2717e373</Id>
+      <Database Name="cv" Series="3657" Issue="65708" />
     </Book>
     <Book Series="Wolverine" Number="111" Volume="1988" Year="1997">
-      <Id>a7f8df16-78e6-460c-9a82-d7ca15e1ada6</Id>
+      <Database Name="cv" Series="4250" Issue="51179" />
     </Book>
     <Book Series="X-Men" Number="60" Volume="1991" Year="1997">
-      <Id>001f4dd1-a83c-4d4c-ad38-ebaae912d6de</Id>
+      <Database Name="cv" Series="4605" Issue="65760" />
     </Book>
     <Book Series="X-Men" Number="61" Volume="1991" Year="1997">
-      <Id>3cb8671f-494a-4971-8861-d759d0c7c7de</Id>
+      <Database Name="cv" Series="4605" Issue="65761" />
     </Book>
     <Book Series="Cable" Number="40" Volume="1993" Year="1997">
-      <Id>5dc44058-22a6-4493-87b0-448899886576</Id>
+      <Database Name="cv" Series="4993" Issue="43413" />
     </Book>
     <Book Series="Generation X" Number="23" Volume="1994" Year="1997">
-      <Id>ba12a4b4-a3e7-42c3-b6be-311844bbe834</Id>
+      <Database Name="cv" Series="5300" Issue="43272" />
     </Book>
-    <Book Series="X-Men Annual '97" Number="1" Volume="1997" Year="1997">
-      <Id>94479c85-2e1a-406d-95c0-c93e785c9843</Id>
+    <Book Series="X-Men '97" Number="1" Volume="1997" Year="1997">
+      <Database Name="cv" Series="60464" Issue="161832" />
     </Book>
     <Book Series="X-Men Unlimited" Number="14" Volume="1993" Year="1997">
-      <Id>5616b410-b880-4f7a-b94c-459840a32850</Id>
+      <Database Name="cv" Series="5066" Issue="43496" />
     </Book>
     <Book Series="Juggernaut" Number="1" Volume="1997" Year="1997">
-      <Id>92112f46-f6e8-4db8-8047-11dcae1b879c</Id>
+      <Database Name="cv" Series="18263" Issue="106949" />
     </Book>
     <Book Series="X-Man" Number="23" Volume="1995" Year="1997">
-      <Id>d86a91c0-29e6-45b2-b670-1846a80b5edc</Id>
+      <Database Name="cv" Series="5567" Issue="43285" />
     </Book>
-    <Book Series="X-Man Annual '96" Number="1" Volume="1996" Year="1996">
-      <Id>a5408825-7e9e-4af5-aa59-16171c10f066</Id>
+    <Book Series="X-Man '96" Number="1" Volume="1996" Year="1996">
+      <Database Name="cv" Series="18050" Issue="105728" />
     </Book>
     <Book Series="Cable" Number="41" Volume="1993" Year="1997">
-      <Id>f3b40d75-13a5-4db0-844e-54660052de7f</Id>
+      <Database Name="cv" Series="4993" Issue="43509" />
     </Book>
     <Book Series="Domino" Number="1" Volume="1997" Year="1997">
-      <Id>36db6d7c-9eff-4b2c-9dce-7ff062ec3992</Id>
+      <Database Name="cv" Series="22683" Issue="136041" />
     </Book>
     <Book Series="Domino" Number="2" Volume="1997" Year="1997">
-      <Id>668fad9e-2879-4503-9660-073a4f86222d</Id>
+      <Database Name="cv" Series="22683" Issue="136042" />
     </Book>
     <Book Series="Domino" Number="3" Volume="1997" Year="1997">
-      <Id>6cf6adaf-58aa-4b5e-909d-871d195b479c</Id>
+      <Database Name="cv" Series="22683" Issue="136043" />
     </Book>
     <Book Series="X-Force" Number="63" Volume="1991" Year="1997">
-      <Id>59c96560-491c-47a2-9643-0dc9602b6b55</Id>
+      <Database Name="cv" Series="4604" Issue="64537" />
     </Book>
     <Book Series="X-Force" Number="64" Volume="1991" Year="1997">
-      <Id>16e97464-f4ec-4ed1-9ab6-67d58f3bdbea</Id>
+      <Database Name="cv" Series="4604" Issue="64538" />
     </Book>
     <Book Series="X-Factor" Number="131" Volume="1986" Year="1997">
-      <Id>666cf685-1a91-4c3c-885a-b879eaf091a1</Id>
+      <Database Name="cv" Series="3657" Issue="65709" />
     </Book>
     <Book Series="Cable" Number="42" Volume="1993" Year="1997">
-      <Id>c1b858c2-04f3-4b34-9870-14ad7659ee7e</Id>
+      <Database Name="cv" Series="4993" Issue="43607" />
     </Book>
     <Book Series="X-Men Unlimited" Number="15" Volume="1993" Year="1997">
-      <Id>840994e1-74c0-4e9a-a6c0-253831e72648</Id>
+      <Database Name="cv" Series="5066" Issue="43785" />
     </Book>
     <Book Series="X-Man" Number="24" Volume="1995" Year="1997">
-      <Id>1b711bfe-f2e4-4779-8009-68aa45a3ea98</Id>
+      <Database Name="cv" Series="5567" Issue="43397" />
     </Book>
     <Book Series="X-Man" Number="25" Volume="1995" Year="1997">
-      <Id>adbf148d-423a-448f-bfec-226ce5ff7718</Id>
+      <Database Name="cv" Series="5567" Issue="43495" />
     </Book>
     <Book Series="Cable" Number="43" Volume="1993" Year="1997">
-      <Id>1929a739-e740-4778-a08e-b950e70693c2</Id>
+      <Database Name="cv" Series="4993" Issue="117068" />
     </Book>
     <Book Series="Cable" Number="44" Volume="1993" Year="1997">
-      <Id>05fa0e15-6bc1-4483-885e-12a457c8f8ee</Id>
+      <Database Name="cv" Series="4993" Issue="65632" />
     </Book>
     <Book Series="Generation X" Number="24" Volume="1994" Year="1997">
-      <Id>728b670e-1589-4c11-b8c1-46a7b5792461</Id>
+      <Database Name="cv" Series="5300" Issue="43382" />
     </Book>
     <Book Series="Imperial Guard" Number="1" Volume="1997" Year="1997">
-      <Id>bdd62f3c-b4d9-4d36-b50a-798fa7f2b502</Id>
+      <Database Name="cv" Series="18172" Issue="106404" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="341" Volume="1981" Year="1997">
-      <Id>c185f15f-2784-4c73-b715-f9af98c0fdd1</Id>
+      <Database Name="cv" Series="3092" Issue="43411" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="342" Volume="1981" Year="1997">
-      <Id>568bba1e-cfc7-452a-97ef-f6abc48b51e4</Id>
+      <Database Name="cv" Series="3092" Issue="43506" />
     </Book>
     <Book Series="Imperial Guard" Number="2" Volume="1997" Year="1997">
-      <Id>57c772fe-dba9-4bdc-9349-59a00e5d1e3a</Id>
+      <Database Name="cv" Series="18172" Issue="106418" />
     </Book>
     <Book Series="Imperial Guard" Number="3" Volume="1997" Year="1997">
-      <Id>35d20c61-b363-4801-b2ed-469f8309ccff</Id>
+      <Database Name="cv" Series="18172" Issue="106419" />
     </Book>
-    <Book Series="Generation X Annual '97" Number="1" Volume="1997" Year="1997">
-      <Id>5351e59e-d255-42d5-8d11-e586988ed7d9</Id>
+    <Book Series="Generation X '97" Number="1" Volume="1997" Year="1997">
+      <Database Name="cv" Series="60444" Issue="123437" />
     </Book>
     <Book Series="Generation X" Number="25" Volume="1994" Year="1997">
-      <Id>526762c5-681f-4869-a7e7-48d8babdfac1</Id>
+      <Database Name="cv" Series="5300" Issue="43482" />
     </Book>
-    <Book Series="X-Force / Cable Annual '97" Number="1" Volume="1997" Year="1997">
-      <Id>31374b4b-f4b2-46ab-9b5f-14315fb93ae5</Id>
+    <Book Series="X-Force / Cable '97" Number="1" Volume="1997" Year="1997">
+      <Database Name="cv" Series="20139" Issue="120196" />
     </Book>
     <Book Series="X-Factor" Number="132" Volume="1986" Year="1997">
-      <Id>bc79c28f-fc76-48c7-9ade-b66095605108</Id>
+      <Database Name="cv" Series="3657" Issue="65710" />
     </Book>
     <Book Series="X-Factor" Number="133" Volume="1986" Year="1997">
-      <Id>dd7da5f8-6375-446c-8d80-3a8289014bac</Id>
+      <Database Name="cv" Series="3657" Issue="65711" />
     </Book>
     <Book Series="Excalibur" Number="107" Volume="1988" Year="1997">
-      <Id>f39b69af-85b3-4491-88eb-084333aef00f</Id>
+      <Database Name="cv" Series="4052" Issue="43481" />
     </Book>
     <Book Series="X-Man" Number="26" Volume="1995" Year="1997">
-      <Id>dbd22bdc-80df-4890-a52c-03b9045f27cd</Id>
+      <Database Name="cv" Series="5567" Issue="43594" />
     </Book>
     <Book Series="X-Factor" Number="134" Volume="1986" Year="1997">
-      <Id>0af56127-4c17-43cd-b84e-7858cc9991f6</Id>
+      <Database Name="cv" Series="3657" Issue="65712" />
     </Book>
     <Book Series="Excalibur" Number="108" Volume="1988" Year="1997">
-      <Id>664fdd70-7147-4565-b14f-0fba19d0ecda</Id>
+      <Database Name="cv" Series="4052" Issue="43577" />
     </Book>
     <Book Series="Excalibur" Number="109" Volume="1988" Year="1997">
-      <Id>bc88d127-8a92-4a89-bb36-0e3528db80d2</Id>
+      <Database Name="cv" Series="4052" Issue="66391" />
     </Book>
     <Book Series="Excalibur" Number="110" Volume="1988" Year="1997">
-      <Id>3dabb50f-f453-4c1d-9441-ffdd8d19c229</Id>
+      <Database Name="cv" Series="4052" Issue="66392" />
     </Book>
     <Book Series="X-Man" Number="27" Volume="1995" Year="1997">
-      <Id>267abb73-9762-4442-918c-2eb53d64b242</Id>
+      <Database Name="cv" Series="5567" Issue="43696" />
     </Book>
     <Book Series="X-Man" Number="28" Volume="1995" Year="1997">
-      <Id>1680d6e1-62be-4d6e-a3ed-d667e3ea90c3</Id>
+      <Database Name="cv" Series="5567" Issue="43784" />
     </Book>
     <Book Series="X-Man" Number="29" Volume="1995" Year="1997">
-      <Id>0ccfd0e5-d5c9-4105-a3a9-fc655968b0a5</Id>
+      <Database Name="cv" Series="5567" Issue="43984" />
     </Book>
     <Book Series="X-Factor" Number="135" Volume="1986" Year="1997">
-      <Id>bb70f693-2454-4b08-af5d-443a0d43b220</Id>
+      <Database Name="cv" Series="3657" Issue="65713" />
     </Book>
     <Book Series="X-Force" Number="65" Volume="1991" Year="1997">
-      <Id>e236bae2-4885-43aa-aedb-89056e98d501</Id>
+      <Database Name="cv" Series="4604" Issue="64539" />
     </Book>
     <Book Series="X-Force" Number="66" Volume="1991" Year="1997">
-      <Id>249613f9-1d3b-449d-96ad-14e449e461a0</Id>
+      <Database Name="cv" Series="4604" Issue="152910" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="343" Volume="1981" Year="1997">
-      <Id>9432bef5-73d6-4585-a5fb-db4c37e7389c</Id>
+      <Database Name="cv" Series="3092" Issue="43604" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="344" Volume="1981" Year="1997">
-      <Id>59154bf7-1ace-4ab3-8e7f-76a059b64d77</Id>
+      <Database Name="cv" Series="3092" Issue="65134" />
     </Book>
     <Book Series="Excalibur" Number="111" Volume="1988" Year="1997">
-      <Id>fc2fc05b-737e-424f-8196-ee7bea21ae0e</Id>
+      <Database Name="cv" Series="4052" Issue="66393" />
     </Book>
     <Book Series="Excalibur" Number="112" Volume="1988" Year="1997">
-      <Id>836a82da-4b4a-442d-9e04-128735a358a9</Id>
+      <Database Name="cv" Series="4052" Issue="66394" />
     </Book>
     <Book Series="Excalibur" Number="113" Volume="1988" Year="1997">
-      <Id>832955ec-4179-491f-8ef4-fa8753355093</Id>
+      <Database Name="cv" Series="4052" Issue="66395" />
     </Book>
-    <Book Series="Uncanny X-Men Annual '97" Number="1" Volume="1997" Year="1997">
-      <Id>c200c588-a485-4f21-959a-4fcd5a9af35b</Id>
+    <Book Series="Uncanny X-Men '97" Number="1" Volume="1997" Year="1997">
+      <Database Name="cv" Series="60470" Issue="136051" />
     </Book>
     <Book Series="Wolverine" Number="112" Volume="1988" Year="1997">
-      <Id>411e74ce-4bdb-4a22-b912-a31602ec9d5b</Id>
+      <Database Name="cv" Series="4250" Issue="51180" />
     </Book>
     <Book Series="Wolverine" Number="113" Volume="1988" Year="1997">
-      <Id>8b033b90-0512-4d14-ab17-a1ddf868ae34</Id>
+      <Database Name="cv" Series="4250" Issue="51181" />
     </Book>
     <Book Series="Wolverine" Number="114" Volume="1988" Year="1997">
-      <Id>25c108cf-326b-4d36-b34a-41c3fce67b17</Id>
+      <Database Name="cv" Series="4250" Issue="51182" />
     </Book>
-    <Book Series="Psylocke &amp; Archangel: Crimson Dawn" Number="1" Volume="1997" Year="1997">
-      <Id>11d487ca-7329-4dc4-acbf-8e4b94c5bfb9</Id>
+    <Book Series="Psylocke &#38; Archangel: Crimson Dawn" Number="1" Volume="1997" Year="1997">
+      <Database Name="cv" Series="20650" Issue="123844" />
     </Book>
-    <Book Series="Psylocke &amp; Archangel: Crimson Dawn" Number="2" Volume="1997" Year="1997">
-      <Id>58b611ff-84d3-47e5-bc43-bab6459f90d0</Id>
+    <Book Series="Psylocke &#38; Archangel: Crimson Dawn" Number="2" Volume="1997" Year="1997">
+      <Database Name="cv" Series="20650" Issue="135794" />
     </Book>
-    <Book Series="Psylocke &amp; Archangel: Crimson Dawn" Number="3" Volume="1997" Year="1997">
-      <Id>7ee27649-f3f2-4db0-a274-7dee6c9fe75c</Id>
+    <Book Series="Psylocke &#38; Archangel: Crimson Dawn" Number="3" Volume="1997" Year="1997">
+      <Database Name="cv" Series="20650" Issue="135795" />
     </Book>
-    <Book Series="Psylocke &amp; Archangel: Crimson Dawn" Number="4" Volume="1997" Year="1997">
-      <Id>11d890ea-73cb-4276-992a-54381adbf9bd</Id>
+    <Book Series="Psylocke &#38; Archangel: Crimson Dawn" Number="4" Volume="1997" Year="1997">
+      <Database Name="cv" Series="20650" Issue="135796" />
     </Book>
     <Book Series="Generation X" Number="26" Volume="1994" Year="1997">
-      <Id>95a3da93-da25-4a97-9ade-6e19c898d651</Id>
+      <Database Name="cv" Series="5300" Issue="43578" />
     </Book>
     <Book Series="Generation X" Number="27" Volume="1994" Year="1997">
-      <Id>3d384864-ff9a-4812-ae4a-2d4df466298e</Id>
+      <Database Name="cv" Series="5300" Issue="43683" />
     </Book>
     <Book Series="X-Men" Number="62" Volume="1991" Year="1997">
-      <Id>df5a1143-b752-439f-a90e-a9c52bd45443</Id>
+      <Database Name="cv" Series="4605" Issue="65762" />
     </Book>
     <Book Series="X-Men" Number="63" Volume="1991" Year="1997">
-      <Id>5b1e2499-99a6-441d-ae33-14db7eb1fc28</Id>
+      <Database Name="cv" Series="4605" Issue="65763" />
     </Book>
     <Book Series="X-Men" Number="64" Volume="1991" Year="1997">
-      <Id>202e2a84-399e-4d00-abb7-a24ae5225145</Id>
+      <Database Name="cv" Series="4605" Issue="65764" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="345" Volume="1981" Year="1997">
-      <Id>2e7514ca-c8c9-4cc0-9a10-cc3ebf0ebed5</Id>
+      <Database Name="cv" Series="3092" Issue="43801" />
     </Book>
     <Book Series="Generation X" Number="28" Volume="1994" Year="1997">
-      <Id>2f38590a-2cc5-4109-9a5f-c00e5161f607</Id>
+      <Database Name="cv" Series="5300" Issue="43772" />
     </Book>
     <Book Series="X-Men" Number="65" Volume="1991" Year="1997">
-      <Id>4e7acc36-0fe1-4885-9d70-ced1a68ed498</Id>
+      <Database Name="cv" Series="4605" Issue="65765" />
     </Book>
     <Book Series="X-Force" Number="67" Volume="1991" Year="1997">
-      <Id>501462eb-927c-449f-a057-2d8a440d75a4</Id>
+      <Database Name="cv" Series="4604" Issue="64540" />
     </Book>
     <Book Series="Cable" Number="-1" Volume="1993" Year="1997">
-      <Id>1ef6cd64-d5e3-48b7-8e52-7b7407a0bbc1</Id>
+      <Database Name="cv" Series="4993" Issue="43910" />
     </Book>
     <Book Series="Generation X" Number="-1" Volume="1994" Year="1997">
-      <Id>c73df6b6-0806-4940-8d8b-466c505b2718</Id>
+      <Database Name="cv" Series="5300" Issue="43873" />
     </Book>
     <Book Series="X-Factor" Number="-1" Volume="1986" Year="1997">
-      <Id>95355fc3-78d5-4b48-824d-f80dd909bee0</Id>
+      <Database Name="cv" Series="3657" Issue="83136" />
     </Book>
     <Book Series="X-Force" Number="-1" Volume="1991" Year="1997">
-      <Id>efce28f8-54a4-417c-8933-e71dc6bcde22</Id>
+      <Database Name="cv" Series="4604" Issue="64588" />
     </Book>
     <Book Series="Wolverine" Number="-1" Volume="1988" Year="1997">
-      <Id>39b6d797-e296-4037-ab00-79a834d9ac5e</Id>
+      <Database Name="cv" Series="4250" Issue="51183" />
     </Book>
     <Book Series="Excalibur" Number="-1" Volume="1988" Year="1997">
-      <Id>cc996841-9f99-46ca-8fa2-c79f6b5b9554</Id>
+      <Database Name="cv" Series="4052" Issue="66390" />
     </Book>
     <Book Series="X-Men" Number="-1" Volume="1991" Year="1997">
-      <Id>429e228e-7345-4155-a8af-e42a070f8e09</Id>
+      <Database Name="cv" Series="4605" Issue="125026" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="-1" Volume="1981" Year="1997">
-      <Id>741b29a2-9f3f-4936-b456-5f4b99cb2fd1</Id>
+      <Database Name="cv" Series="3092" Issue="43915" />
     </Book>
     <Book Series="X-Factor" Number="136" Volume="1986" Year="1997">
-      <Id>af8b7323-1f95-497c-8968-5f55d9287637</Id>
+      <Database Name="cv" Series="3657" Issue="65714" />
     </Book>
     <Book Series="X-Factor" Number="137" Volume="1986" Year="1997">
-      <Id>9783a274-3de6-4dde-816b-a502b604d469</Id>
+      <Database Name="cv" Series="3657" Issue="65715" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="346" Volume="1981" Year="1997">
-      <Id>7744c90b-7f6c-4bae-93d8-d71e4344422f</Id>
+      <Database Name="cv" Series="3092" Issue="44006" />
     </Book>
     <Book Series="Cable" Number="45" Volume="1993" Year="1997">
-      <Id>c9b734e0-fe54-4f17-bd88-9bf2e4e0e5b5</Id>
+      <Database Name="cv" Series="4993" Issue="44004" />
     </Book>
     <Book Series="X-Force" Number="68" Volume="1991" Year="1997">
-      <Id>af4d3324-b4f7-4c51-85e4-b6200652f279</Id>
+      <Database Name="cv" Series="4604" Issue="64541" />
     </Book>
     <Book Series="Cable" Number="46" Volume="1993" Year="1997">
-      <Id>bef1f602-27f3-4e51-a0a7-6fb260e62eba</Id>
+      <Database Name="cv" Series="4993" Issue="44117" />
     </Book>
     <Book Series="X-Force" Number="69" Volume="1991" Year="1997">
-      <Id>628f93f1-9498-44c2-a379-d2214a45c0e8</Id>
+      <Database Name="cv" Series="4604" Issue="64542" />
     </Book>
     <Book Series="Cable" Number="47" Volume="1993" Year="1997">
-      <Id>1ea9fbd6-675a-471c-8de9-53ee86add241</Id>
+      <Database Name="cv" Series="4993" Issue="44220" />
     </Book>
     <Book Series="Generation X" Number="29" Volume="1994" Year="1997">
-      <Id>252d1296-eb28-4d13-92d9-a7e69bfa001f</Id>
+      <Database Name="cv" Series="5300" Issue="43971" />
     </Book>
     <Book Series="X-Men" Number="66" Volume="1991" Year="1997">
-      <Id>26b0f8ee-c3f1-4acd-8cb3-362a0241172f</Id>
+      <Database Name="cv" Series="4605" Issue="65766" />
     </Book>
     <Book Series="Wolverine" Number="115" Volume="1988" Year="1997">
-      <Id>77e0cb0b-9a57-4eb6-86c0-80b542f73672</Id>
+      <Database Name="cv" Series="4250" Issue="51184" />
     </Book>
     <Book Series="X-Men" Number="67" Volume="1991" Year="1997">
-      <Id>1fa49a69-1d57-48ff-b2fb-0af356c8a499</Id>
+      <Database Name="cv" Series="4605" Issue="65767" />
     </Book>
     <Book Series="Wolverine" Number="116" Volume="1988" Year="1997">
-      <Id>1a684782-59b6-42f0-afb4-5c586dacc400</Id>
+      <Database Name="cv" Series="4250" Issue="51185" />
     </Book>
     <Book Series="Generation X" Number="30" Volume="1994" Year="1997">
-      <Id>2cce1689-4324-41f0-8db4-fec711825812</Id>
+      <Database Name="cv" Series="5300" Issue="44081" />
     </Book>
     <Book Series="Generation X" Number="31" Volume="1994" Year="1997">
-      <Id>10ac6cc5-f137-4224-882d-c22c7cb3a9f7</Id>
+      <Database Name="cv" Series="5300" Issue="83096" />
     </Book>
     <Book Series="X-Men" Number="68" Volume="1991" Year="1997">
-      <Id>2fc51121-7099-4875-993f-4c166a4f06ad</Id>
+      <Database Name="cv" Series="4605" Issue="65768" />
     </Book>
     <Book Series="Wolverine" Number="117" Volume="1988" Year="1997">
-      <Id>67ff0d04-833e-46bf-94da-8b0da7f67bb8</Id>
+      <Database Name="cv" Series="4250" Issue="51186" />
     </Book>
     <Book Series="X-Men" Number="69" Volume="1991" Year="1997">
-      <Id>ff10f745-15cb-4607-8784-4048ce7ee709</Id>
+      <Database Name="cv" Series="4605" Issue="65769" />
     </Book>
     <Book Series="Wolverine" Number="118" Volume="1988" Year="1997">
-      <Id>64bc4239-58aa-4e87-9f43-de26023bf497</Id>
+      <Database Name="cv" Series="4250" Issue="51187" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="347" Volume="1981" Year="1997">
-      <Id>63979955-8a6e-4eca-a573-fd1d92b97010</Id>
+      <Database Name="cv" Series="3092" Issue="44121" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="348" Volume="1981" Year="1997">
-      <Id>b9c86b2c-cccc-4342-bf41-c11afd58c9c3</Id>
+      <Database Name="cv" Series="3092" Issue="44226" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="349" Volume="1981" Year="1997">
-      <Id>c8903dec-c1a8-44bb-9c59-0da1a0cf97c8</Id>
+      <Database Name="cv" Series="3092" Issue="44332" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="350" Volume="1981" Year="1997">
-      <Id>8a73a2d3-51ad-4b20-a6bc-4e5883b40250</Id>
+      <Database Name="cv" Series="3092" Issue="109910" />
     </Book>
     <Book Series="X-Men" Number="70" Volume="1991" Year="1997">
-      <Id>29a689f6-84d4-45c3-9b2d-07e5e1f2343a</Id>
+      <Database Name="cv" Series="4605" Issue="65770" />
     </Book>
     <Book Series="X-Force" Number="70" Volume="1991" Year="1997">
-      <Id>4717df98-2d6a-47d7-8f91-fd8b02bf0e33</Id>
+      <Database Name="cv" Series="4604" Issue="64543" />
     </Book>
     <Book Series="Cable" Number="48" Volume="1993" Year="1997">
-      <Id>1dfbd237-88b1-4071-935b-6907614a91ee</Id>
+      <Database Name="cv" Series="4993" Issue="66212" />
     </Book>
     <Book Series="Cable" Number="49" Volume="1993" Year="1997">
-      <Id>ee2edcd7-3fa9-491d-a057-fde0ce905dd5</Id>
+      <Database Name="cv" Series="4993" Issue="135789" />
     </Book>
     <Book Series="Cable" Number="50" Volume="1993" Year="1998">
-      <Id>6f0c7fba-4102-481c-ab85-d9ffa52a7ec0</Id>
+      <Database Name="cv" Series="4993" Issue="44598" />
     </Book>
     <Book Series="Cable" Number="51" Volume="1993" Year="1998">
-      <Id>35edb63e-bf58-4c22-a354-d59fe4a3bebb</Id>
+      <Database Name="cv" Series="4993" Issue="65633" />
     </Book>
     <Book Series="Cable" Number="52" Volume="1993" Year="1998">
-      <Id>4e10303b-4cd5-42a3-8cd5-9e0f9fc98569</Id>
+      <Database Name="cv" Series="4993" Issue="135790" />
     </Book>
     <Book Series="Cable" Number="53" Volume="1993" Year="1998">
-      <Id>fef7b916-d88b-452d-b5ba-248367e68eb1</Id>
+      <Database Name="cv" Series="4993" Issue="65634" />
     </Book>
     <Book Series="Cable" Number="54" Volume="1993" Year="1998">
-      <Id>71add785-a27a-47ef-aadb-318373e69940</Id>
+      <Database Name="cv" Series="4993" Issue="135791" />
     </Book>
     <Book Series="X-Factor" Number="138" Volume="1986" Year="1997">
-      <Id>3ebc6785-6fb9-4353-8c3e-b07c45dc0f94</Id>
+      <Database Name="cv" Series="3657" Issue="65716" />
     </Book>
-    <Book Series="Wolverine Annual '97" Number="1" Volume="1997" Year="1997">
-      <Id>1ca181f7-3c24-46be-a25e-7a10a7507f1d</Id>
+    <Book Series="Wolverine '97" Number="1" Volume="1997" Year="1998">
+      <Database Name="cv" Series="27129" Issue="164830" />
     </Book>
     <Book Series="Excalibur" Number="114" Volume="1988" Year="1997">
-      <Id>ad12a7dd-26ca-47c2-a930-1dde011b344a</Id>
+      <Database Name="cv" Series="4052" Issue="66396" />
     </Book>
     <Book Series="New Mutants: Truth or Death" Number="1" Volume="1997" Year="1997">
-      <Id>6b29e6a0-0966-4f54-a999-d0be6ce8e674</Id>
+      <Database Name="cv" Series="6012" Issue="44299" />
     </Book>
     <Book Series="New Mutants: Truth or Death" Number="2" Volume="1997" Year="1997">
-      <Id>97151cd3-0bcf-4ba2-acff-dddec81d5d95</Id>
+      <Database Name="cv" Series="6012" Issue="44396" />
     </Book>
     <Book Series="New Mutants: Truth or Death" Number="3" Volume="1997" Year="1998">
-      <Id>2ee0dabc-567f-4b53-a71a-ebe05f04d128</Id>
+      <Database Name="cv" Series="6012" Issue="44566" />
     </Book>
     <Book Series="X-Man" Number="31" Volume="1995" Year="1997">
-      <Id>9555a6d2-e50e-4f14-a8bb-f01839bcd20d</Id>
+      <Database Name="cv" Series="5567" Issue="44202" />
     </Book>
-    <Book Series="X-Man Annual '97" Number="1" Volume="1997" Year="1997">
-      <Id>ff400c37-dc72-47b2-9eef-1ee378fab37d</Id>
+    <Book Series="X-Man '97" Number="1" Volume="1997" Year="1997">
+      <Database Name="cv" Series="39814" Issue="269206" />
     </Book>
     <Book Series="X-Factor" Number="139" Volume="1986" Year="1997">
-      <Id>fd9777a0-3c8f-4e99-a3e2-6a83b96cc6c5</Id>
+      <Database Name="cv" Series="3657" Issue="65717" />
     </Book>
     <Book Series="X-Men Unlimited" Number="17" Volume="1993" Year="1997">
-      <Id>b2ca56b5-61a3-428c-89d5-596591dcc945</Id>
+      <Database Name="cv" Series="5066" Issue="44409" />
     </Book>
     <Book Series="X-Force" Number="71" Volume="1991" Year="1997">
-      <Id>5bb3c260-a7f1-4c25-a376-d7c049b296d3</Id>
+      <Database Name="cv" Series="4604" Issue="64544" />
     </Book>
     <Book Series="X-Force" Number="72" Volume="1991" Year="1997">
-      <Id>bb494ec9-0cd2-49cb-8cb3-7ef1e7475024</Id>
+      <Database Name="cv" Series="4604" Issue="64545" />
     </Book>
     <Book Series="Generation X" Number="32" Volume="1994" Year="1997">
-      <Id>c01b2ece-1fd1-4b7e-b806-076111483288</Id>
+      <Database Name="cv" Series="5300" Issue="83097" />
     </Book>
     <Book Series="Kitty Pryde, Agent of S.H.I.E.L.D." Number="1" Volume="1997" Year="1997">
-      <Id>0797c103-e49b-40eb-9598-a2e2e4b1b394</Id>
+      <Database Name="cv" Series="6009" Issue="44438" />
     </Book>
     <Book Series="Kitty Pryde, Agent of S.H.I.E.L.D." Number="2" Volume="1997" Year="1998">
-      <Id>7a9bb1bf-d358-466c-891a-2bf0d2a61fbd</Id>
+      <Database Name="cv" Series="6009" Issue="44616" />
     </Book>
     <Book Series="Kitty Pryde, Agent of S.H.I.E.L.D." Number="3" Volume="1997" Year="1998">
-      <Id>61d42df3-1087-44c8-bd60-4d584d0aa501</Id>
+      <Database Name="cv" Series="6009" Issue="44724" />
     </Book>
     <Book Series="X-Factor" Number="140" Volume="1986" Year="1997">
-      <Id>0f57fe11-8fb9-4aad-add6-876ac89c5b8a</Id>
+      <Database Name="cv" Series="3657" Issue="129885" />
     </Book>
     <Book Series="X-Factor" Number="141" Volume="1986" Year="1998">
-      <Id>639699f4-fbb3-40ad-89fa-dde45df72c74</Id>
+      <Database Name="cv" Series="3657" Issue="129886" />
     </Book>
     <Book Series="Wolverine" Number="119" Volume="1988" Year="1997">
-      <Id>eeba6036-f765-482d-93b5-4abaa967fd43</Id>
+      <Database Name="cv" Series="4250" Issue="51188" />
     </Book>
     <Book Series="Wolverine" Number="120" Volume="1988" Year="1998">
-      <Id>c278f418-7a8e-421a-8b0d-80b934a22a8e</Id>
+      <Database Name="cv" Series="4250" Issue="51189" />
     </Book>
     <Book Series="Wolverine" Number="121" Volume="1988" Year="1998">
-      <Id>e9290a99-6f6e-4b83-a3fe-a18b1cde05d2</Id>
+      <Database Name="cv" Series="4250" Issue="51190" />
     </Book>
     <Book Series="Wolverine" Number="122" Volume="1988" Year="1998">
-      <Id>2982d64a-9301-49a0-a05e-5a9abac3a12c</Id>
+      <Database Name="cv" Series="4250" Issue="51191" />
     </Book>
     <Book Series="Generation X" Number="33" Volume="1994" Year="1997">
-      <Id>a4f1b49a-eece-42e9-bbff-06c96dff3786</Id>
+      <Database Name="cv" Series="5300" Issue="83098" />
     </Book>
     <Book Series="Excalibur" Number="115" Volume="1988" Year="1997">
-      <Id>880931e8-b4b9-40bd-9f3f-db427c660f64</Id>
+      <Database Name="cv" Series="4052" Issue="66397" />
     </Book>
     <Book Series="Gambit" Number="1" Volume="1997" Year="1997">
-      <Id>e2deef52-87cc-4dfa-9e7b-46a89d1b2179</Id>
+      <Database Name="cv" Series="11879" Issue="103942" />
     </Book>
     <Book Series="Gambit" Number="2" Volume="1997" Year="1997">
-      <Id>3f2a5504-5f90-4de8-b1f7-fb9bcb0ba701</Id>
+      <Database Name="cv" Series="11879" Issue="103943" />
     </Book>
     <Book Series="Gambit" Number="3" Volume="1997" Year="1997">
-      <Id>02e02b40-10bf-4aed-82c0-52c7153c070a</Id>
+      <Database Name="cv" Series="11879" Issue="103944" />
     </Book>
     <Book Series="Gambit" Number="4" Volume="1997" Year="1997">
-      <Id>cb3fb5a4-6434-46ca-b340-86c1ff8f4d07</Id>
+      <Database Name="cv" Series="11879" Issue="103945" />
     </Book>
     <Book Series="X-Force" Number="73" Volume="1991" Year="1998">
-      <Id>b8057e71-e460-433a-b9ef-0a3dc24d4b7b</Id>
+      <Database Name="cv" Series="4604" Issue="64546" />
     </Book>
     <Book Series="X-Force" Number="74" Volume="1991" Year="1998">
-      <Id>761875e9-407a-46c4-9a7f-1c1c0eccfc08</Id>
+      <Database Name="cv" Series="4604" Issue="64547" />
     </Book>
     <Book Series="Generation X" Number="34" Volume="1994" Year="1998">
-      <Id>a64d3e4c-80ac-407b-a24c-707d8e2216a0</Id>
+      <Database Name="cv" Series="5300" Issue="83099" />
     </Book>
     <Book Series="Generation X" Number="35" Volume="1994" Year="1998">
-      <Id>b0593db7-f55a-40f1-acae-2d571ddf2bb1</Id>
+      <Database Name="cv" Series="5300" Issue="83100" />
     </Book>
     <Book Series="Generation X Holiday Special" Number="1" Volume="1998" Year="1998">
-      <Id>1693aca9-c339-4c46-8b68-bd5ac62124cc</Id>
+      <Database Name="cv" Series="19089" Issue="114006" />
     </Book>
     <Book Series="Generation X" Number="36" Volume="1994" Year="1998">
-      <Id>21924821-6add-4a52-86da-d760d1799fe3</Id>
+      <Database Name="cv" Series="5300" Issue="83101" />
     </Book>
     <Book Series="Generation X" Number="37" Volume="1994" Year="1998">
-      <Id>0e9ee2b9-9b1e-49b4-b792-8ed5b5dce158</Id>
+      <Database Name="cv" Series="5300" Issue="83102" />
     </Book>
     <Book Series="Generation X" Number="38" Volume="1994" Year="1998">
-      <Id>df73fa61-32c5-4552-a20f-8b4778ef0cc4</Id>
+      <Database Name="cv" Series="5300" Issue="83103" />
     </Book>
     <Book Series="Generation X" Number="39" Volume="1994" Year="1998">
-      <Id>0f7a6a4e-2f42-4114-84df-099765b4d2a8</Id>
+      <Database Name="cv" Series="5300" Issue="83104" />
     </Book>
     <Book Series="X-Men Unlimited" Number="18" Volume="1993" Year="1998">
-      <Id>6447ebcb-cc78-4178-bde0-614c3aa324b1</Id>
+      <Database Name="cv" Series="5066" Issue="44872" />
     </Book>
     <Book Series="X-Men" Number="71" Volume="1991" Year="1998">
-      <Id>d56a0066-0469-4e87-a511-65f7a0a6b050</Id>
+      <Database Name="cv" Series="4605" Issue="65771" />
     </Book>
     <Book Series="X-Men" Number="72" Volume="1991" Year="1998">
-      <Id>58995c2b-3970-412d-b90f-b94b44dc387f</Id>
+      <Database Name="cv" Series="4605" Issue="65772" />
     </Book>
     <Book Series="Excalibur" Number="116" Volume="1988" Year="1998">
-      <Id>b9f0e7bb-7613-4ed0-bcb0-de6637040556</Id>
+      <Database Name="cv" Series="4052" Issue="66398" />
     </Book>
     <Book Series="Excalibur" Number="117" Volume="1988" Year="1998">
-      <Id>17fca4e0-2d96-4f41-8ea6-541630f024d9</Id>
+      <Database Name="cv" Series="4052" Issue="66399" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="351" Volume="1981" Year="1998">
-      <Id>ef8f94cc-4cae-4043-9a45-fa303e19574b</Id>
+      <Database Name="cv" Series="3092" Issue="65135" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="352" Volume="1981" Year="1998">
-      <Id>353c0434-4211-4bdf-9b66-ebac877f13c5</Id>
+      <Database Name="cv" Series="3092" Issue="44712" />
     </Book>
     <Book Series="X-Man" Number="32" Volume="1995" Year="1997">
-      <Id>7859459b-ab0d-469d-9ff9-19d0d17a4ae6</Id>
+      <Database Name="cv" Series="5567" Issue="44311" />
     </Book>
     <Book Series="X-Man" Number="33" Volume="1995" Year="1997">
-      <Id>bd36cb57-d9aa-418c-83ab-eda3ece9a7c2</Id>
+      <Database Name="cv" Series="5567" Issue="44408" />
     </Book>
     <Book Series="X-Force" Number="75" Volume="1991" Year="1998">
-      <Id>b4c67a07-78c8-4fd1-ae8f-14f91df7fc2e</Id>
+      <Database Name="cv" Series="4604" Issue="64548" />
     </Book>
     <Book Series="X-Factor" Number="142" Volume="1986" Year="1998">
-      <Id>d6097d2f-b9f8-40ae-b161-507525f3f7e9</Id>
+      <Database Name="cv" Series="3657" Issue="65718" />
     </Book>
     <Book Series="X-Force" Number="76" Volume="1991" Year="1998">
-      <Id>8159c273-ce60-454e-b2a7-a6064c39e4f0</Id>
+      <Database Name="cv" Series="4604" Issue="64549" />
     </Book>
-    <Book Series="Cable / Machine Man Annual '98" Number="1" Volume="1998" Year="1998">
-      <Id>328c7968-35ae-48c7-9d7b-cb8924c0db8b</Id>
+    <Book Series="Cable / Machine Man '98" Number="1" Volume="1998" Year="1998">
+      <Database Name="cv" Series="18365" Issue="117675" />
     </Book>
-    <Book Series="Machine Man / Bastion Annual '98" Number="1998" Volume="1998" Year="1998">
-      <Id>b3aecf91-db13-4926-8619-6774ab85ca38</Id>
+    <Book Series="Machine Man / Bastion '98" Number="1" Volume="1998" Year="1998">
+      <Database Name="cv" Series="26009" Issue="153754" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="353" Volume="1981" Year="1998">
-      <Id>47ed2213-cdc7-4c51-a2a4-e66c2287012d</Id>
+      <Database Name="cv" Series="3092" Issue="44810" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="354" Volume="1981" Year="1998">
-      <Id>cc4a0649-0428-4970-848e-a40dc2ac9e55</Id>
+      <Database Name="cv" Series="3092" Issue="44896" />
     </Book>
     <Book Series="X-Man" Number="34" Volume="1995" Year="1998">
-      <Id>6a5c59c7-49a0-4e52-85fa-12333c2ac6ab</Id>
+      <Database Name="cv" Series="5567" Issue="44578" />
     </Book>
     <Book Series="X-Man" Number="35" Volume="1995" Year="1998">
-      <Id>2cd014c7-ffa3-43d5-8c75-3ee582bef2e1</Id>
+      <Database Name="cv" Series="5567" Issue="44688" />
     </Book>
     <Book Series="X-Man" Number="36" Volume="1995" Year="1998">
-      <Id>428b6663-3e44-49f2-844a-cd30bdb0dd06</Id>
+      <Database Name="cv" Series="5567" Issue="44832" />
     </Book>
     <Book Series="X-Man" Number="37" Volume="1995" Year="1998">
-      <Id>4f4eb140-9f7d-4c9c-a13e-79b7ba10cb69</Id>
+      <Database Name="cv" Series="5567" Issue="44878" />
     </Book>
     <Book Series="X-Man" Number="38" Volume="1995" Year="1998">
-      <Id>863282a1-5fc2-42f0-bc76-a44aefa9c176</Id>
+      <Database Name="cv" Series="5567" Issue="45048" />
     </Book>
     <Book Series="X-Factor" Number="143" Volume="1986" Year="1998">
-      <Id>06c9f73d-b2f4-4361-82ce-9f2b45a3b16c</Id>
+      <Database Name="cv" Series="3657" Issue="65719" />
     </Book>
     <Book Series="X-Factor" Number="144" Volume="1986" Year="1998">
-      <Id>7ec89b66-1856-4384-8513-abff402919ac</Id>
+      <Database Name="cv" Series="3657" Issue="65720" />
     </Book>
     <Book Series="X-Factor" Number="145" Volume="1986" Year="1998">
-      <Id>1f50327a-9483-4288-a8e7-f21f82e75569</Id>
+      <Database Name="cv" Series="3657" Issue="65721" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="355" Volume="1981" Year="1998">
-      <Id>05a599b7-a85c-4db5-9b0d-2173d3a28b0d</Id>
+      <Database Name="cv" Series="3092" Issue="44982" />
     </Book>
     <Book Series="X-Men" Number="73" Volume="1991" Year="1998">
-      <Id>01a2e432-1b01-4e35-b0e7-a23f7ab7c0f5</Id>
+      <Database Name="cv" Series="4605" Issue="65773" />
     </Book>
     <Book Series="Wolverine" Number="123" Volume="1988" Year="1998">
-      <Id>f54a5f8f-563b-4078-b9d9-0952e2f9e595</Id>
+      <Database Name="cv" Series="4250" Issue="51192" />
     </Book>
     <Book Series="Wolverine" Number="124" Volume="1988" Year="1998">
-      <Id>fd642122-e1d2-4019-9c90-c12d4d07f775</Id>
+      <Database Name="cv" Series="4250" Issue="51193" />
     </Book>
     <Book Series="X-Force" Number="77" Volume="1991" Year="1998">
-      <Id>4290822f-baca-4689-b2b7-bb663255a8e3</Id>
+      <Database Name="cv" Series="4604" Issue="64550" />
     </Book>
     <Book Series="Excalibur" Number="118" Volume="1988" Year="1998">
-      <Id>27ae7786-e04d-46b7-bc4e-8720ecda133f</Id>
+      <Database Name="cv" Series="4052" Issue="66400" />
     </Book>
     <Book Series="Excalibur" Number="119" Volume="1988" Year="1998">
-      <Id>96044916-365c-44c2-9d82-60780b16f36e</Id>
+      <Database Name="cv" Series="4052" Issue="66401" />
     </Book>
     <Book Series="Excalibur" Number="120" Volume="1988" Year="1998">
-      <Id>1d9aba7a-db77-4965-8c3f-792a8cab853d</Id>
+      <Database Name="cv" Series="4052" Issue="66402" />
     </Book>
     <Book Series="Excalibur" Number="121" Volume="1988" Year="1998">
-      <Id>bd908b98-a54c-4809-b6d8-f37ee0165f5c</Id>
+      <Database Name="cv" Series="4052" Issue="66403" />
     </Book>
     <Book Series="Excalibur" Number="122" Volume="1988" Year="1998">
-      <Id>2a75d3b3-f5b1-4213-a111-b5ecdb1c1b5d</Id>
+      <Database Name="cv" Series="4052" Issue="66404" />
     </Book>
     <Book Series="Excalibur" Number="123" Volume="1988" Year="1998">
-      <Id>b7e67bf1-76cd-4bcb-ad04-45044ae03f08</Id>
+      <Database Name="cv" Series="4052" Issue="66405" />
     </Book>
     <Book Series="X-Men Unlimited" Number="19" Volume="1993" Year="1998">
-      <Id>801fc9cb-b352-4c84-8ccd-d913d327346f</Id>
+      <Database Name="cv" Series="5066" Issue="45047" />
     </Book>
     <Book Series="X-Factor" Number="146" Volume="1986" Year="1998">
-      <Id>19f181fc-5cbe-45f7-a13b-977bad92d90b</Id>
+      <Database Name="cv" Series="3657" Issue="65722" />
     </Book>
     <Book Series="Cable" Number="55" Volume="1993" Year="1998">
-      <Id>a6c551c5-d0b8-4c86-a0b9-99fdcaeda511</Id>
+      <Database Name="cv" Series="4993" Issue="135792" />
     </Book>
     <Book Series="Cable" Number="56" Volume="1993" Year="1998">
-      <Id>12bbef11-7eae-4ffd-a0da-fbaef1c388ba</Id>
+      <Database Name="cv" Series="4993" Issue="65635" />
     </Book>
     <Book Series="X-Force" Number="78" Volume="1991" Year="1998">
-      <Id>49c0409c-296d-4ca5-bca1-125976c010cf</Id>
+      <Database Name="cv" Series="4604" Issue="64551" />
     </Book>
     <Book Series="X-Force" Number="79" Volume="1991" Year="1998">
-      <Id>9c216da5-aab4-41e5-9296-c648b15f643a</Id>
+      <Database Name="cv" Series="4604" Issue="64552" />
     </Book>
     <Book Series="X-Force" Number="80" Volume="1991" Year="1998">
-      <Id>662039a1-eafd-4683-a0f0-a0ba028cde7d</Id>
+      <Database Name="cv" Series="4604" Issue="152909" />
     </Book>
     <Book Series="X-Man" Number="39" Volume="1995" Year="1998">
-      <Id>d0199d61-83b9-4d2c-87a7-a1d0a2c0ebd9</Id>
+      <Database Name="cv" Series="5567" Issue="45130" />
     </Book>
     <Book Series="X-Man" Number="40" Volume="1995" Year="1998">
-      <Id>c39cc808-d3eb-4791-8c66-ce2df69e2e2b</Id>
+      <Database Name="cv" Series="5567" Issue="45182" />
     </Book>
     <Book Series="Generation X" Number="40" Volume="1994" Year="1998">
-      <Id>e48d2d25-0977-430f-a171-19a8e3647228</Id>
+      <Database Name="cv" Series="5300" Issue="83105" />
     </Book>
     <Book Series="Generation X" Number="41" Volume="1994" Year="1998">
-      <Id>a7ac5a45-b983-4412-bd3f-66d121deccad</Id>
+      <Database Name="cv" Series="5300" Issue="83106" />
     </Book>
     <Book Series="X-Factor" Number="147" Volume="1986" Year="1998">
-      <Id>ef86af77-87fd-40fa-aa49-2b1f7f696ca6</Id>
+      <Database Name="cv" Series="3657" Issue="65723" />
     </Book>
     <Book Series="Wolverine" Number="125" Volume="1988" Year="1998">
-      <Id>0a745cb5-4996-43e4-9f21-619becdd5afd</Id>
+      <Database Name="cv" Series="4250" Issue="51194" />
     </Book>
     <Book Series="Wolverine" Number="126" Volume="1988" Year="1998">
-      <Id>9a255ec5-544c-4498-804b-45e1f30935c0</Id>
+      <Database Name="cv" Series="4250" Issue="68985" />
     </Book>
     <Book Series="Wolverine" Number="127" Volume="1988" Year="1998">
-      <Id>fb8a4149-9ae8-4ec0-8373-c5c7c4b6b988</Id>
+      <Database Name="cv" Series="4250" Issue="51195" />
     </Book>
     <Book Series="Wolverine" Number="128" Volume="1988" Year="1998">
-      <Id>2c556f63-137e-4b0b-afd3-4753610283a6</Id>
+      <Database Name="cv" Series="4250" Issue="51196" />
     </Book>
     <Book Series="Wolverine" Number="129" Volume="1988" Year="1998">
-      <Id>f6ae5a6b-dfa1-4e5c-a068-23d01b19cb4d</Id>
+      <Database Name="cv" Series="4250" Issue="51197" />
     </Book>
     <Book Series="Wolverine" Number="130" Volume="1988" Year="1998">
-      <Id>93eb65ff-46b4-48c1-8b52-6bc6dad4a46b</Id>
+      <Database Name="cv" Series="4250" Issue="51198" />
     </Book>
     <Book Series="X-Force" Number="81" Volume="1991" Year="1998">
-      <Id>bfdf504f-b550-42b6-bced-f767229b4835</Id>
+      <Database Name="cv" Series="4604" Issue="64553" />
     </Book>
     <Book Series="X-Force" Number="82" Volume="1991" Year="1998">
-      <Id>5627d6cf-bf1e-491f-bb9b-4306eb8a3057</Id>
+      <Database Name="cv" Series="4604" Issue="64554" />
     </Book>
     <Book Series="X-Men" Number="74" Volume="1991" Year="1998">
-      <Id>eea932af-bdd1-4c4b-817e-757fce30a73f</Id>
+      <Database Name="cv" Series="4605" Issue="65774" />
     </Book>
     <Book Series="X-Men" Number="75" Volume="1991" Year="1998">
-      <Id>11323559-dfe9-475e-807b-522b8b30e492</Id>
+      <Database Name="cv" Series="4605" Issue="65775" />
     </Book>
     <Book Series="X-Men" Number="76" Volume="1991" Year="1998">
-      <Id>0211fc94-eae9-47be-b25b-0d791c6ecf8e</Id>
+      <Database Name="cv" Series="4605" Issue="65776" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="356" Volume="1981" Year="1998">
-      <Id>986c3ae0-d48f-4cd9-b698-52b19369a5ca</Id>
+      <Database Name="cv" Series="3092" Issue="45067" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="357" Volume="1981" Year="1998">
-      <Id>41185e73-0b01-4b28-adec-10f8de506c23</Id>
+      <Database Name="cv" Series="3092" Issue="45179" />
     </Book>
     <Book Series="X-Men" Number="77" Volume="1991" Year="1998">
-      <Id>f46fa652-0a3c-4b6e-aa86-c6b26aece896</Id>
+      <Database Name="cv" Series="4605" Issue="65777" />
     </Book>
     <Book Series="X-Men" Number="78" Volume="1991" Year="1998">
-      <Id>21922a2a-2347-49ea-9cd1-ca69317fbe9a</Id>
+      <Database Name="cv" Series="4605" Issue="131381" />
     </Book>
     <Book Series="X-Man" Number="41" Volume="1995" Year="1998">
-      <Id>8a79fd7e-6dce-41f4-bfdb-9dbc286fc70b</Id>
+      <Database Name="cv" Series="5567" Issue="45216" />
     </Book>
     <Book Series="Cable" Number="57" Volume="1993" Year="1998">
-      <Id>cb105a6e-399c-48bb-9002-d50f1e6efc72</Id>
+      <Database Name="cv" Series="4993" Issue="65636" />
     </Book>
     <Book Series="Cable" Number="58" Volume="1993" Year="1998">
-      <Id>fda4b505-53e4-44d6-85e5-b3d3d2ede0e2</Id>
+      <Database Name="cv" Series="4993" Issue="65637" />
     </Book>
     <Book Series="Generation X" Number="42" Volume="1994" Year="1998">
-      <Id>4415b357-d8aa-48a7-a292-9baef4fad026</Id>
+      <Database Name="cv" Series="5300" Issue="83107" />
     </Book>
     <Book Series="Generation X" Number="43" Volume="1994" Year="1998">
-      <Id>73e2dcd5-5a0c-4a33-a90c-808e5a3e22eb</Id>
+      <Database Name="cv" Series="5300" Issue="83108" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="358" Volume="1981" Year="1998">
-      <Id>c558f881-2a0e-4c16-90d5-79580a6c197e</Id>
+      <Database Name="cv" Series="3092" Issue="45237" />
     </Book>
     <Book Series="X-Men Unlimited" Number="20" Volume="1993" Year="1998">
-      <Id>4b31388b-fa66-4d7c-b04c-e976dc1a0604</Id>
+      <Database Name="cv" Series="5066" Issue="45305" />
     </Book>
-    <Book Series="X-Man / Hulk Annual '98" Number="1" Volume="1998" Year="1998">
-      <Id>9d0c3c0a-7176-42a9-b292-ec205702df8e</Id>
+    <Book Series="X-Man / Hulk '98" Number="1" Volume="1998" Year="1998">
+      <Database Name="cv" Series="28192" Issue="173329" />
     </Book>
     <Book Series="Excalibur" Number="124" Volume="1988" Year="1998">
-      <Id>2cb95614-6c74-41a6-9bdc-cdf30927e808</Id>
+      <Database Name="cv" Series="4052" Issue="66406" />
     </Book>
     <Book Series="Excalibur" Number="125" Volume="1988" Year="1998">
-      <Id>06416ddf-2aff-4e60-8bc9-ce4879fbf3ff</Id>
+      <Database Name="cv" Series="4052" Issue="66407" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="359" Volume="1981" Year="1998">
-      <Id>4e8a1865-efaa-4668-bbcb-faf9ab81adc3</Id>
+      <Database Name="cv" Series="3092" Issue="45332" />
     </Book>
     <Book Series="X-Factor" Number="148" Volume="1986" Year="1998">
-      <Id>9663705b-3b46-435d-ae66-31d7925e8205</Id>
+      <Database Name="cv" Series="3657" Issue="65724" />
     </Book>
     <Book Series="X-Factor" Number="149" Volume="1986" Year="1998">
-      <Id>06422618-417d-4d4c-ba30-659ca7a69297</Id>
+      <Database Name="cv" Series="3657" Issue="65725" />
     </Book>
-    <Book Series="Uncanny X-Men / Fantastic Four Annual '98" Number="1" Volume="1998" Year="1998">
-      <Id>87d43f87-1286-45eb-9b1e-a164a3e4d9a4</Id>
+    <Book Series="Uncanny X-Men / Fantastic Four '98" Number="1" Volume="1998" Year="1998">
+      <Database Name="cv" Series="30468" Issue="187571" />
     </Book>
     <Book Series="X-Men" Number="79" Volume="1991" Year="1998">
-      <Id>74227829-a9bb-43b7-bbcb-30f0dabd965e</Id>
+      <Database Name="cv" Series="4605" Issue="65778" />
     </Book>
     <Book Series="X-Men Unlimited" Number="21" Volume="1993" Year="1998">
-      <Id>204d4bca-4d61-463a-8527-04abea1ef938</Id>
+      <Database Name="cv" Series="5066" Issue="45502" />
     </Book>
     <Book Series="Cable" Number="59" Volume="1993" Year="1998">
-      <Id>9d3f9831-b429-4cfc-abe6-9d84264151b2</Id>
+      <Database Name="cv" Series="4993" Issue="65638" />
     </Book>
     <Book Series="Cable" Number="60" Volume="1993" Year="1998">
-      <Id>c7aeb710-dcd8-4497-8490-418d716b0255</Id>
+      <Database Name="cv" Series="4993" Issue="65639" />
     </Book>
     <Book Series="Cable" Number="61" Volume="1993" Year="1998">
-      <Id>b3d12a51-6cf0-4a9c-8b32-b2641beeabd8</Id>
+      <Database Name="cv" Series="4993" Issue="65640" />
     </Book>
     <Book Series="Cable" Number="62" Volume="1993" Year="1998">
-      <Id>5ab49a16-acb9-4195-b59b-8f0418a1f03d</Id>
+      <Database Name="cv" Series="4993" Issue="65641" />
     </Book>
     <Book Series="X-Force" Number="83" Volume="1991" Year="1998">
-      <Id>6f215df3-3c02-49e7-8ab1-41715d365f44</Id>
+      <Database Name="cv" Series="4604" Issue="152908" />
     </Book>
     <Book Series="X-Force" Number="84" Volume="1991" Year="1998">
-      <Id>3669c6b4-5c31-46ae-8c95-2de21a9b8331</Id>
+      <Database Name="cv" Series="4604" Issue="64555" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="360" Volume="1981" Year="1998">
-      <Id>8d37def8-f6e4-4610-9c2f-8e07002bae38</Id>
+      <Database Name="cv" Series="3092" Issue="45397" />
     </Book>
     <Book Series="X-Men" Number="80" Volume="1991" Year="1998">
-      <Id>2ba8963b-1af9-4176-bbcb-61b6adb827a0</Id>
+      <Database Name="cv" Series="4605" Issue="65779" />
     </Book>
     <Book Series="Generation X" Number="44" Volume="1994" Year="1998">
-      <Id>f3428186-76c1-4740-bec7-1f49414198f4</Id>
+      <Database Name="cv" Series="5300" Issue="83109" />
     </Book>
     <Book Series="Generation X" Number="45" Volume="1994" Year="1998">
-      <Id>763bf697-550a-4ca3-a6d0-33c25c9d3272</Id>
+      <Database Name="cv" Series="5300" Issue="83110" />
     </Book>
     <Book Series="Generation X" Number="46" Volume="1994" Year="1998">
-      <Id>02ab9ecb-47fd-4e50-8396-4b51c91c540d</Id>
+      <Database Name="cv" Series="5300" Issue="83111" />
     </Book>
     <Book Series="Generation X" Number="47" Volume="1994" Year="1999">
-      <Id>9c288e34-9691-4e72-8b8f-a74a7ea16f59</Id>
+      <Database Name="cv" Series="5300" Issue="83112" />
     </Book>
     <Book Series="X-Force" Number="85" Volume="1991" Year="1999">
-      <Id>3bb3c6f7-75bf-4071-94e1-112aad93b5ca</Id>
+      <Database Name="cv" Series="4604" Issue="64556" />
     </Book>
-    <Book Series="X-Force / Champions Annual '98" Number="98" Volume="1998" Year="1998">
-      <Id>4805d585-f179-4a10-8760-89eb3befac38</Id>
+    <Book Series="X-Force / Champions '98" Number="1" Volume="1998" Year="1998">
+      <Database Name="cv" Series="34173" Issue="222916" />
     </Book>
     <Book Series="X-Man" Number="42" Volume="1995" Year="1998">
-      <Id>2826f7c3-68fa-4b30-bc33-0b47a54270e3</Id>
+      <Database Name="cv" Series="5567" Issue="45306" />
     </Book>
     <Book Series="X-Man" Number="43" Volume="1995" Year="1998">
-      <Id>80cb8573-2aa2-4b75-87f0-f9d54e73c6cc</Id>
+      <Database Name="cv" Series="5567" Issue="45372" />
     </Book>
     <Book Series="X-Man" Number="44" Volume="1995" Year="1998">
-      <Id>90e63aac-627d-473e-9b11-89c998d3003c</Id>
+      <Database Name="cv" Series="5567" Issue="45439" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="361" Volume="1981" Year="1998">
-      <Id>24d8ac68-b1ca-4240-afa7-2d3507a1d036</Id>
+      <Database Name="cv" Series="3092" Issue="45469" />
     </Book>
     <Book Series="X-Men" Number="81" Volume="1991" Year="1998">
-      <Id>eb36fec1-28cb-4e43-a567-a022d335d204</Id>
+      <Database Name="cv" Series="4605" Issue="65780" />
     </Book>
     <Book Series="Wolverine" Number="131" Volume="1988" Year="1998">
-      <Id>2ff1a4f1-a297-453e-91db-3c5e86a5eef0</Id>
+      <Database Name="cv" Series="4250" Issue="68986" />
     </Book>
     <Book Series="Wolverine" Number="132" Volume="1988" Year="1998">
-      <Id>a1dba5d0-dbcc-476a-ac28-d8dc944dcffc</Id>
+      <Database Name="cv" Series="4250" Issue="51199" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="362" Volume="1981" Year="1998">
-      <Id>34d18f96-0ac0-4aff-b60c-b2517ac898a3</Id>
+      <Database Name="cv" Series="3092" Issue="45528" />
     </Book>
     <Book Series="X-Men" Number="82" Volume="1991" Year="1998">
-      <Id>682b79c5-0c59-4123-b57f-4f7991e49cb7</Id>
+      <Database Name="cv" Series="4605" Issue="65781" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="363" Volume="1981" Year="1999">
-      <Id>7db9e73b-77c8-4655-8dbb-5d8e3e1a4653</Id>
+      <Database Name="cv" Series="3092" Issue="45620" />
     </Book>
     <Book Series="X-Men" Number="83" Volume="1991" Year="1999">
-      <Id>a34f3117-5d0f-4180-93fe-cc695cd5a6b4</Id>
+      <Database Name="cv" Series="4605" Issue="65782" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="364" Volume="1981" Year="1999">
-      <Id>37c2a933-f28a-4a45-bf7b-082d57d8ac14</Id>
+      <Database Name="cv" Series="3092" Issue="45649" />
     </Book>
     <Book Series="X-Men" Number="84" Volume="1991" Year="1999">
-      <Id>170bd29e-e06e-48d6-963b-ba357b511d3f</Id>
+      <Database Name="cv" Series="4605" Issue="65783" />
     </Book>
     <Book Series="X-Men Unlimited" Number="22" Volume="1993" Year="1999">
-      <Id>2314fff2-7b76-4629-ab55-ab1e51ed344a</Id>
+      <Database Name="cv" Series="5066" Issue="45718" />
     </Book>
-    <Book Series="X-Men / Dr. Doom Annual '98" Number="1" Volume="1998" Year="1998">
-      <Id>514d700f-fca8-4592-8664-7f9156eeaf58</Id>
+    <Book Series="X-Men / Dr. Doom '98" Number="1" Volume="1998" Year="1998">
+      <Database Name="cv" Series="26316" Issue="178128" />
     </Book>
     <Book Series="Wolverine" Number="133" Volume="1988" Year="1999">
-      <Id>2f0d2919-3d7b-4d52-81b1-1fdc0d602b3d</Id>
+      <Database Name="cv" Series="4250" Issue="51200" />
     </Book>
     <Book Series="Wolverine" Number="134" Volume="1988" Year="1999">
-      <Id>f36f8688-d9fb-4739-8668-bf1af65a9671</Id>
+      <Database Name="cv" Series="4250" Issue="51201" />
     </Book>
     <Book Series="Wolverine" Number="135" Volume="1988" Year="1999">
-      <Id>99e9ba00-de93-43f1-a308-bbaa9a8ddf5c</Id>
+      <Database Name="cv" Series="4250" Issue="51202" />
     </Book>
     <Book Series="Wolverine" Number="136" Volume="1988" Year="1999">
-      <Id>b4471f0f-3826-4f99-aa5c-b5e1637080cd</Id>
+      <Database Name="cv" Series="4250" Issue="51203" />
     </Book>
     <Book Series="Wolverine" Number="137" Volume="1988" Year="1999">
-      <Id>f338baee-ee3d-473e-a239-9b3504da6d0c</Id>
+      <Database Name="cv" Series="4250" Issue="51204" />
     </Book>
     <Book Series="Wolverine" Number="138" Volume="1988" Year="1999">
-      <Id>39076393-71da-4f95-8ad0-8558ec401347</Id>
+      <Database Name="cv" Series="4250" Issue="51205" />
     </Book>
     <Book Series="X-Force" Number="86" Volume="1991" Year="1999">
-      <Id>4fb9e603-efe6-4c15-87e9-935b45571151</Id>
+      <Database Name="cv" Series="4604" Issue="64557" />
     </Book>
     <Book Series="X-Man" Number="45" Volume="1995" Year="1998">
-      <Id>28d24dcb-e34f-4ad6-80a3-8ad014f3b1c7</Id>
+      <Database Name="cv" Series="5567" Issue="45503" />
     </Book>
     <Book Series="X-Man" Number="46" Volume="1995" Year="1999">
-      <Id>91eaac41-844e-4c8c-97dc-b0423d8d3eb7</Id>
+      <Database Name="cv" Series="5567" Issue="45556" />
     </Book>
     <Book Series="Cable" Number="63" Volume="1993" Year="1999">
-      <Id>87196378-3155-4ea3-bb18-34f665bba64c</Id>
+      <Database Name="cv" Series="4993" Issue="65642" />
     </Book>
     <Book Series="X-Man" Number="47" Volume="1995" Year="1999">
-      <Id>5eb9b271-3b6b-4d66-928e-29b3dc1c344b</Id>
+      <Database Name="cv" Series="5567" Issue="45594" />
     </Book>
-    <Book Series="Wolverine Annual 1999" Number="1" Volume="1999" Year="1999">
-      <Id>d2a38dd7-f2a2-4037-b6d1-154253e12052</Id>
+    <Book Series="Wolverine 1999" Number="1" Volume="1999" Year="2000">
+      <Database Name="cv" Series="27150" Issue="164990" />
     </Book>
     <Book Series="Wolverine" Number="139" Volume="1988" Year="1999">
-      <Id>d11e3877-870a-4d7e-bbd4-092017b65d07</Id>
+      <Database Name="cv" Series="4250" Issue="51206" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="365" Volume="1981" Year="1999">
-      <Id>0c5d19f9-624c-4f3d-ab99-a2e45c543a01</Id>
+      <Database Name="cv" Series="3092" Issue="45681" />
     </Book>
     <Book Series="Cable" Number="64" Volume="1993" Year="1999">
-      <Id>a729336a-364d-43a9-8d66-33607efecf87</Id>
+      <Database Name="cv" Series="4993" Issue="65643" />
     </Book>
     <Book Series="Gambit" Number="1" Volume="1999" Year="1999">
-      <Id>aa2bcc35-8696-4ddb-a6a8-cd4d4b280765</Id>
+      <Database Name="cv" Series="9111" Issue="66890" />
     </Book>
-    <Book Series="Generation X / Dracula Annual '98" Number="1" Volume="1998" Year="1998">
-      <Id>cea6c93c-b9c6-494f-8e07-2bd3bf9c2d25</Id>
+    <Book Series="Generation X / Dracula '98" Number="1" Volume="1998" Year="1998">
+      <Database Name="cv" Series="60445" Issue="123569" />
     </Book>
     <Book Series="Generation X" Number="48" Volume="1994" Year="1999">
-      <Id>ed2fc8bb-1067-4b21-a0e6-dce10b4eea6a</Id>
+      <Database Name="cv" Series="5300" Issue="83113" />
     </Book>
     <Book Series="Generation X" Number="49" Volume="1994" Year="1999">
-      <Id>3f75652a-4f60-4ae6-a138-7a98058688f5</Id>
+      <Database Name="cv" Series="5300" Issue="83114" />
     </Book>
     <Book Series="X-Man" Number="48" Volume="1995" Year="1999">
-      <Id>40776cb1-ccd3-4093-97a0-e50d290b034c</Id>
+      <Database Name="cv" Series="5567" Issue="45655" />
     </Book>
     <Book Series="X-Man" Number="49" Volume="1995" Year="1999">
-      <Id>fe837312-189a-4ac8-8197-ef07588fa7ad</Id>
+      <Database Name="cv" Series="5567" Issue="45719" />
     </Book>
     <Book Series="Cable" Number="65" Volume="1993" Year="1999">
-      <Id>fb6bc689-1ae1-4f80-bd4c-6d021fbb9556</Id>
+      <Database Name="cv" Series="4993" Issue="65644" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 006.cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 006.cbl
@@ -2,922 +2,922 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>X-Men - Part 6</Name>
   <Books>
-    <Book Series="The Beast" Number="1" Volume="1997" Year="1997" Format="Limited Series">
+    <Book Series="The Beast" Number="1" Volume="1997" Year="1997">
       <Id>2ad558e3-3d91-4a1f-a6f1-922b28d5918e</Id>
     </Book>
-    <Book Series="The Beast" Number="2" Volume="1997" Year="1997" Format="Limited Series">
+    <Book Series="The Beast" Number="2" Volume="1997" Year="1997">
       <Id>4fd1dbc8-9c2e-4379-997b-4df934a891da</Id>
     </Book>
-    <Book Series="The Beast" Number="3" Volume="1997" Year="1997" Format="Limited Series">
+    <Book Series="The Beast" Number="3" Volume="1997" Year="1997">
       <Id>dea18b9d-7acd-4abb-b83d-5cd06c9f2097</Id>
     </Book>
-    <Book Series="Generation X" Number="22" Volume="1994" Year="1996" Format="Main Series">
+    <Book Series="Generation X" Number="22" Volume="1994" Year="1996">
       <Id>e1130dda-e249-48be-a692-1d86de3d3945</Id>
     </Book>
-    <Book Series="Generation X Annual '96" Number="1" Volume="1996" Year="1996" Format="Annual">
+    <Book Series="Generation X Annual '96" Number="1" Volume="1996" Year="1996">
       <Id>1ceac618-71eb-4b73-87a3-e76e0261188d</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="339" Volume="1981" Year="1996" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="339" Volume="1981" Year="1996">
       <Id>0a7bcd13-72ab-4969-9290-8b1d1ec9f2e9</Id>
     </Book>
-    <Book Series="X-Men" Number="59" Volume="1991" Year="1996" Format="Main Series">
+    <Book Series="X-Men" Number="59" Volume="1991" Year="1996">
       <Id>6f69fe8d-fb6c-4abb-a15c-46d36fb974dd</Id>
     </Book>
-    <Book Series="Wolverine Annual '96" Number="1" Volume="1996" Year="1996" Format="Annual">
+    <Book Series="Wolverine Annual '96" Number="1" Volume="1996" Year="1996">
       <Id>9831d3c0-aca7-4bd4-ac80-ee22e8d759ae</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="13" Volume="1993" Year="1996" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="13" Volume="1993" Year="1996">
       <Id>107f7787-7c68-4096-bc68-181099e18ec3</Id>
     </Book>
-    <Book Series="Logan: Shadow Society" Number="1" Volume="1996" Year="1996" Format="One-Shot">
+    <Book Series="Logan: Shadow Society" Number="1" Volume="1996" Year="1996">
       <Id>7338db04-e9ee-4d6a-9374-e6e21d392e37</Id>
     </Book>
-    <Book Series="Wolverine" Number="107" Volume="1988" Year="1996" Format="Main Series">
+    <Book Series="Wolverine" Number="107" Volume="1988" Year="1996">
       <Id>3539e3ea-ed6b-4fd1-a26d-5ffa475d38dc</Id>
     </Book>
-    <Book Series="Wolverine" Number="108" Volume="1988" Year="1996" Format="Main Series">
+    <Book Series="Wolverine" Number="108" Volume="1988" Year="1996">
       <Id>5575d922-b3e1-45c6-9f0d-d699ba24093c</Id>
     </Book>
-    <Book Series="Wolverine" Number="109" Volume="1988" Year="1997" Format="Main Series">
+    <Book Series="Wolverine" Number="109" Volume="1988" Year="1997">
       <Id>69da0909-ac6b-4caf-87ac-567efd309a0d</Id>
     </Book>
-    <Book Series="X-Man" Number="22" Volume="1995" Year="1996" Format="Main Series">
+    <Book Series="X-Man" Number="22" Volume="1995" Year="1996">
       <Id>1c418271-ff43-4ebc-b595-8e95ebf43ce9</Id>
     </Book>
-    <Book Series="Excalibur" Number="104" Volume="1988" Year="1996" Format="Main Series">
+    <Book Series="Excalibur" Number="104" Volume="1988" Year="1996">
       <Id>04d1d374-f745-4238-ba12-efe90e5befd9</Id>
     </Book>
-    <Book Series="Excalibur" Number="105" Volume="1988" Year="1997" Format="Main Series">
+    <Book Series="Excalibur" Number="105" Volume="1988" Year="1997">
       <Id>d596d9c2-324f-42dc-b8c8-280860f4124b</Id>
     </Book>
-    <Book Series="Wolverine" Number="110" Volume="1988" Year="1997" Format="Main Series">
+    <Book Series="Wolverine" Number="110" Volume="1988" Year="1997">
       <Id>4e9ebf52-cb76-4440-904a-df0c463b6308</Id>
     </Book>
-    <Book Series="Venom: Tooth and Claw" Number="1" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Venom: Tooth and Claw" Number="1" Volume="1996" Year="1996">
       <Id>79d0eea2-211d-4bec-86d9-f6d4a2aad9c3</Id>
     </Book>
-    <Book Series="Venom: Tooth and Claw" Number="2" Volume="1996" Year="1997" Format="Limited Series">
+    <Book Series="Venom: Tooth and Claw" Number="2" Volume="1996" Year="1997">
       <Id>4ac90be6-287f-464e-9daa-69bb614b7934</Id>
     </Book>
-    <Book Series="Venom: Tooth and Claw" Number="3" Volume="1996" Year="1997" Format="Limited Series">
+    <Book Series="Venom: Tooth and Claw" Number="3" Volume="1996" Year="1997">
       <Id>be590a25-c7d6-41cd-ae1f-41625d18ccf2</Id>
     </Book>
-    <Book Series="Cable" Number="37" Volume="1993" Year="1996" Format="Main Series">
+    <Book Series="Cable" Number="37" Volume="1993" Year="1996">
       <Id>3444f1aa-ce22-402a-89d4-911d9deae7f4</Id>
     </Book>
-    <Book Series="Cable" Number="38" Volume="1993" Year="1996" Format="Main Series">
+    <Book Series="Cable" Number="38" Volume="1993" Year="1996">
       <Id>ceafef35-bf35-46a5-be36-e88fe608a43c</Id>
     </Book>
-    <Book Series="Cable" Number="39" Volume="1993" Year="1997" Format="Main Series">
+    <Book Series="Cable" Number="39" Volume="1993" Year="1997">
       <Id>e1748f19-29ad-40cd-a0d3-1eda6ae67f06</Id>
     </Book>
-    <Book Series="Excalibur" Number="106" Volume="1988" Year="1997" Format="Main Series">
+    <Book Series="Excalibur" Number="106" Volume="1988" Year="1997">
       <Id>41595012-9020-487d-92c5-0a2489d3c7e4</Id>
     </Book>
-    <Book Series="Magneto" Number="1" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Magneto" Number="1" Volume="1996" Year="1996">
       <Id>573aeaf7-156d-4eb3-be85-ef17a18b12c8</Id>
     </Book>
-    <Book Series="Magneto" Number="2" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Magneto" Number="2" Volume="1996" Year="1996">
       <Id>4fc09de6-26a9-4e8b-afc0-18299f3d09f5</Id>
     </Book>
-    <Book Series="Magneto" Number="3" Volume="1996" Year="1997" Format="Limited Series">
+    <Book Series="Magneto" Number="3" Volume="1996" Year="1997">
       <Id>7bf608b0-8764-4aa1-b0f9-97a69e0b6646</Id>
     </Book>
-    <Book Series="Magneto" Number="4" Volume="1996" Year="1997" Format="Limited Series">
+    <Book Series="Magneto" Number="4" Volume="1996" Year="1997">
       <Id>ee9df9e5-2797-4194-90d5-3a5c09704165</Id>
     </Book>
-    <Book Series="X-Factor" Number="128" Volume="1986" Year="1996" Format="Main Series">
+    <Book Series="X-Factor" Number="128" Volume="1986" Year="1996">
       <Id>72834d1f-fc3a-40b7-81a1-9c4999c218a2</Id>
     </Book>
-    <Book Series="X-Factor" Number="129" Volume="1986" Year="1996" Format="Main Series">
+    <Book Series="X-Factor" Number="129" Volume="1986" Year="1996">
       <Id>33571707-0d1c-46e4-9711-2c95b66f0317</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="340" Volume="1981" Year="1997" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="340" Volume="1981" Year="1997">
       <Id>fa72317d-82e8-4d77-990d-ad795980983e</Id>
     </Book>
-    <Book Series="X-Factor" Number="130" Volume="1986" Year="1997" Format="Main Series">
+    <Book Series="X-Factor" Number="130" Volume="1986" Year="1997">
       <Id>0d5d6b10-617e-4e35-969e-875d2717e373</Id>
     </Book>
-    <Book Series="Wolverine" Number="111" Volume="1988" Year="1997" Format="Main Series">
+    <Book Series="Wolverine" Number="111" Volume="1988" Year="1997">
       <Id>a7f8df16-78e6-460c-9a82-d7ca15e1ada6</Id>
     </Book>
-    <Book Series="X-Men" Number="60" Volume="1991" Year="1997" Format="Main Series">
+    <Book Series="X-Men" Number="60" Volume="1991" Year="1997">
       <Id>001f4dd1-a83c-4d4c-ad38-ebaae912d6de</Id>
     </Book>
-    <Book Series="X-Men" Number="61" Volume="1991" Year="1997" Format="Main Series">
+    <Book Series="X-Men" Number="61" Volume="1991" Year="1997">
       <Id>3cb8671f-494a-4971-8861-d759d0c7c7de</Id>
     </Book>
-    <Book Series="Cable" Number="40" Volume="1993" Year="1997" Format="Main Series">
+    <Book Series="Cable" Number="40" Volume="1993" Year="1997">
       <Id>5dc44058-22a6-4493-87b0-448899886576</Id>
     </Book>
-    <Book Series="Generation X" Number="23" Volume="1994" Year="1997" Format="Main Series">
+    <Book Series="Generation X" Number="23" Volume="1994" Year="1997">
       <Id>ba12a4b4-a3e7-42c3-b6be-311844bbe834</Id>
     </Book>
-    <Book Series="X-Men Annual '97" Number="1" Volume="1997" Year="1997" Format="Annual">
+    <Book Series="X-Men Annual '97" Number="1" Volume="1997" Year="1997">
       <Id>94479c85-2e1a-406d-95c0-c93e785c9843</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="14" Volume="1993" Year="1997" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="14" Volume="1993" Year="1997">
       <Id>5616b410-b880-4f7a-b94c-459840a32850</Id>
     </Book>
-    <Book Series="Juggernaut" Number="1" Volume="1997" Year="1997" Format="One-Shot">
+    <Book Series="Juggernaut" Number="1" Volume="1997" Year="1997">
       <Id>92112f46-f6e8-4db8-8047-11dcae1b879c</Id>
     </Book>
-    <Book Series="X-Man" Number="23" Volume="1995" Year="1997" Format="Main Series">
+    <Book Series="X-Man" Number="23" Volume="1995" Year="1997">
       <Id>d86a91c0-29e6-45b2-b670-1846a80b5edc</Id>
     </Book>
-    <Book Series="X-Man Annual '96" Number="1" Volume="1996" Year="1996" Format="Annual">
+    <Book Series="X-Man Annual '96" Number="1" Volume="1996" Year="1996">
       <Id>a5408825-7e9e-4af5-aa59-16171c10f066</Id>
     </Book>
-    <Book Series="Cable" Number="41" Volume="1993" Year="1997" Format="Main Series">
+    <Book Series="Cable" Number="41" Volume="1993" Year="1997">
       <Id>f3b40d75-13a5-4db0-844e-54660052de7f</Id>
     </Book>
-    <Book Series="Domino" Number="1" Volume="1997" Year="1997" Format="Limited Series">
+    <Book Series="Domino" Number="1" Volume="1997" Year="1997">
       <Id>36db6d7c-9eff-4b2c-9dce-7ff062ec3992</Id>
     </Book>
-    <Book Series="Domino" Number="2" Volume="1997" Year="1997" Format="Limited Series">
+    <Book Series="Domino" Number="2" Volume="1997" Year="1997">
       <Id>668fad9e-2879-4503-9660-073a4f86222d</Id>
     </Book>
-    <Book Series="Domino" Number="3" Volume="1997" Year="1997" Format="Limited Series">
+    <Book Series="Domino" Number="3" Volume="1997" Year="1997">
       <Id>6cf6adaf-58aa-4b5e-909d-871d195b479c</Id>
     </Book>
-    <Book Series="X-Force" Number="63" Volume="1991" Year="1997" Format="Main Series">
+    <Book Series="X-Force" Number="63" Volume="1991" Year="1997">
       <Id>59c96560-491c-47a2-9643-0dc9602b6b55</Id>
     </Book>
-    <Book Series="X-Force" Number="64" Volume="1991" Year="1997" Format="Main Series">
+    <Book Series="X-Force" Number="64" Volume="1991" Year="1997">
       <Id>16e97464-f4ec-4ed1-9ab6-67d58f3bdbea</Id>
     </Book>
-    <Book Series="X-Factor" Number="131" Volume="1986" Year="1997" Format="Main Series">
+    <Book Series="X-Factor" Number="131" Volume="1986" Year="1997">
       <Id>666cf685-1a91-4c3c-885a-b879eaf091a1</Id>
     </Book>
-    <Book Series="Cable" Number="42" Volume="1993" Year="1997" Format="Main Series">
+    <Book Series="Cable" Number="42" Volume="1993" Year="1997">
       <Id>c1b858c2-04f3-4b34-9870-14ad7659ee7e</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="15" Volume="1993" Year="1997" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="15" Volume="1993" Year="1997">
       <Id>840994e1-74c0-4e9a-a6c0-253831e72648</Id>
     </Book>
-    <Book Series="X-Man" Number="24" Volume="1995" Year="1997" Format="Main Series">
+    <Book Series="X-Man" Number="24" Volume="1995" Year="1997">
       <Id>1b711bfe-f2e4-4779-8009-68aa45a3ea98</Id>
     </Book>
-    <Book Series="X-Man" Number="25" Volume="1995" Year="1997" Format="Main Series">
+    <Book Series="X-Man" Number="25" Volume="1995" Year="1997">
       <Id>adbf148d-423a-448f-bfec-226ce5ff7718</Id>
     </Book>
-    <Book Series="Cable" Number="43" Volume="1993" Year="1997" Format="Main Series">
+    <Book Series="Cable" Number="43" Volume="1993" Year="1997">
       <Id>1929a739-e740-4778-a08e-b950e70693c2</Id>
     </Book>
-    <Book Series="Cable" Number="44" Volume="1993" Year="1997" Format="Main Series">
+    <Book Series="Cable" Number="44" Volume="1993" Year="1997">
       <Id>05fa0e15-6bc1-4483-885e-12a457c8f8ee</Id>
     </Book>
-    <Book Series="Generation X" Number="24" Volume="1994" Year="1997" Format="Main Series">
+    <Book Series="Generation X" Number="24" Volume="1994" Year="1997">
       <Id>728b670e-1589-4c11-b8c1-46a7b5792461</Id>
     </Book>
-    <Book Series="Imperial Guard" Number="1" Volume="1997" Year="1997" Format="Limited Series">
+    <Book Series="Imperial Guard" Number="1" Volume="1997" Year="1997">
       <Id>bdd62f3c-b4d9-4d36-b50a-798fa7f2b502</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="341" Volume="1981" Year="1997" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="341" Volume="1981" Year="1997">
       <Id>c185f15f-2784-4c73-b715-f9af98c0fdd1</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="342" Volume="1981" Year="1997" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="342" Volume="1981" Year="1997">
       <Id>568bba1e-cfc7-452a-97ef-f6abc48b51e4</Id>
     </Book>
-    <Book Series="Imperial Guard" Number="2" Volume="1997" Year="1997" Format="Limited Series">
+    <Book Series="Imperial Guard" Number="2" Volume="1997" Year="1997">
       <Id>57c772fe-dba9-4bdc-9349-59a00e5d1e3a</Id>
     </Book>
-    <Book Series="Imperial Guard" Number="3" Volume="1997" Year="1997" Format="Limited Series">
+    <Book Series="Imperial Guard" Number="3" Volume="1997" Year="1997">
       <Id>35d20c61-b363-4801-b2ed-469f8309ccff</Id>
     </Book>
-    <Book Series="Generation X Annual '97" Number="1" Volume="1997" Year="1997" Format="Annual">
+    <Book Series="Generation X Annual '97" Number="1" Volume="1997" Year="1997">
       <Id>5351e59e-d255-42d5-8d11-e586988ed7d9</Id>
     </Book>
-    <Book Series="Generation X" Number="25" Volume="1994" Year="1997" Format="Main Series">
+    <Book Series="Generation X" Number="25" Volume="1994" Year="1997">
       <Id>526762c5-681f-4869-a7e7-48d8babdfac1</Id>
     </Book>
-    <Book Series="X-Force / Cable Annual '97" Number="1" Volume="1997" Year="1997" Format="Annual">
+    <Book Series="X-Force / Cable Annual '97" Number="1" Volume="1997" Year="1997">
       <Id>31374b4b-f4b2-46ab-9b5f-14315fb93ae5</Id>
     </Book>
-    <Book Series="X-Factor" Number="132" Volume="1986" Year="1997" Format="Main Series">
+    <Book Series="X-Factor" Number="132" Volume="1986" Year="1997">
       <Id>bc79c28f-fc76-48c7-9ade-b66095605108</Id>
     </Book>
-    <Book Series="X-Factor" Number="133" Volume="1986" Year="1997" Format="Main Series">
+    <Book Series="X-Factor" Number="133" Volume="1986" Year="1997">
       <Id>dd7da5f8-6375-446c-8d80-3a8289014bac</Id>
     </Book>
-    <Book Series="Excalibur" Number="107" Volume="1988" Year="1997" Format="Main Series">
+    <Book Series="Excalibur" Number="107" Volume="1988" Year="1997">
       <Id>f39b69af-85b3-4491-88eb-084333aef00f</Id>
     </Book>
-    <Book Series="X-Man" Number="26" Volume="1995" Year="1997" Format="Main Series">
+    <Book Series="X-Man" Number="26" Volume="1995" Year="1997">
       <Id>dbd22bdc-80df-4890-a52c-03b9045f27cd</Id>
     </Book>
-    <Book Series="X-Factor" Number="134" Volume="1986" Year="1997" Format="Main Series">
+    <Book Series="X-Factor" Number="134" Volume="1986" Year="1997">
       <Id>0af56127-4c17-43cd-b84e-7858cc9991f6</Id>
     </Book>
-    <Book Series="Excalibur" Number="108" Volume="1988" Year="1997" Format="Main Series">
+    <Book Series="Excalibur" Number="108" Volume="1988" Year="1997">
       <Id>664fdd70-7147-4565-b14f-0fba19d0ecda</Id>
     </Book>
-    <Book Series="Excalibur" Number="109" Volume="1988" Year="1997" Format="Main Series">
+    <Book Series="Excalibur" Number="109" Volume="1988" Year="1997">
       <Id>bc88d127-8a92-4a89-bb36-0e3528db80d2</Id>
     </Book>
-    <Book Series="Excalibur" Number="110" Volume="1988" Year="1997" Format="Main Series">
+    <Book Series="Excalibur" Number="110" Volume="1988" Year="1997">
       <Id>3dabb50f-f453-4c1d-9441-ffdd8d19c229</Id>
     </Book>
-    <Book Series="X-Man" Number="27" Volume="1995" Year="1997" Format="Main Series">
+    <Book Series="X-Man" Number="27" Volume="1995" Year="1997">
       <Id>267abb73-9762-4442-918c-2eb53d64b242</Id>
     </Book>
-    <Book Series="X-Man" Number="28" Volume="1995" Year="1997" Format="Main Series">
+    <Book Series="X-Man" Number="28" Volume="1995" Year="1997">
       <Id>1680d6e1-62be-4d6e-a3ed-d667e3ea90c3</Id>
     </Book>
-    <Book Series="X-Man" Number="29" Volume="1995" Year="1997" Format="Main Series">
+    <Book Series="X-Man" Number="29" Volume="1995" Year="1997">
       <Id>0ccfd0e5-d5c9-4105-a3a9-fc655968b0a5</Id>
     </Book>
-    <Book Series="X-Factor" Number="135" Volume="1986" Year="1997" Format="Main Series">
+    <Book Series="X-Factor" Number="135" Volume="1986" Year="1997">
       <Id>bb70f693-2454-4b08-af5d-443a0d43b220</Id>
     </Book>
-    <Book Series="X-Force" Number="65" Volume="1991" Year="1997" Format="Main Series">
+    <Book Series="X-Force" Number="65" Volume="1991" Year="1997">
       <Id>e236bae2-4885-43aa-aedb-89056e98d501</Id>
     </Book>
-    <Book Series="X-Force" Number="66" Volume="1991" Year="1997" Format="Main Series">
+    <Book Series="X-Force" Number="66" Volume="1991" Year="1997">
       <Id>249613f9-1d3b-449d-96ad-14e449e461a0</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="343" Volume="1981" Year="1997" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="343" Volume="1981" Year="1997">
       <Id>9432bef5-73d6-4585-a5fb-db4c37e7389c</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="344" Volume="1981" Year="1997" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="344" Volume="1981" Year="1997">
       <Id>59154bf7-1ace-4ab3-8e7f-76a059b64d77</Id>
     </Book>
-    <Book Series="Excalibur" Number="111" Volume="1988" Year="1997" Format="Main Series">
+    <Book Series="Excalibur" Number="111" Volume="1988" Year="1997">
       <Id>fc2fc05b-737e-424f-8196-ee7bea21ae0e</Id>
     </Book>
-    <Book Series="Excalibur" Number="112" Volume="1988" Year="1997" Format="Main Series">
+    <Book Series="Excalibur" Number="112" Volume="1988" Year="1997">
       <Id>836a82da-4b4a-442d-9e04-128735a358a9</Id>
     </Book>
-    <Book Series="Excalibur" Number="113" Volume="1988" Year="1997" Format="Main Series">
+    <Book Series="Excalibur" Number="113" Volume="1988" Year="1997">
       <Id>832955ec-4179-491f-8ef4-fa8753355093</Id>
     </Book>
-    <Book Series="Uncanny X-Men Annual '97" Number="1" Volume="1997" Year="1997" Format="Annual">
+    <Book Series="Uncanny X-Men Annual '97" Number="1" Volume="1997" Year="1997">
       <Id>c200c588-a485-4f21-959a-4fcd5a9af35b</Id>
     </Book>
-    <Book Series="Wolverine" Number="112" Volume="1988" Year="1997" Format="Main Series">
+    <Book Series="Wolverine" Number="112" Volume="1988" Year="1997">
       <Id>411e74ce-4bdb-4a22-b912-a31602ec9d5b</Id>
     </Book>
-    <Book Series="Wolverine" Number="113" Volume="1988" Year="1997" Format="Main Series">
+    <Book Series="Wolverine" Number="113" Volume="1988" Year="1997">
       <Id>8b033b90-0512-4d14-ab17-a1ddf868ae34</Id>
     </Book>
-    <Book Series="Wolverine" Number="114" Volume="1988" Year="1997" Format="Main Series">
+    <Book Series="Wolverine" Number="114" Volume="1988" Year="1997">
       <Id>25c108cf-326b-4d36-b34a-41c3fce67b17</Id>
     </Book>
-    <Book Series="Psylocke &amp; Archangel: Crimson Dawn" Number="1" Volume="1997" Year="1997" Format="Limited Series">
+    <Book Series="Psylocke &amp; Archangel: Crimson Dawn" Number="1" Volume="1997" Year="1997">
       <Id>11d487ca-7329-4dc4-acbf-8e4b94c5bfb9</Id>
     </Book>
-    <Book Series="Psylocke &amp; Archangel: Crimson Dawn" Number="2" Volume="1997" Year="1997" Format="Limited Series">
+    <Book Series="Psylocke &amp; Archangel: Crimson Dawn" Number="2" Volume="1997" Year="1997">
       <Id>58b611ff-84d3-47e5-bc43-bab6459f90d0</Id>
     </Book>
-    <Book Series="Psylocke &amp; Archangel: Crimson Dawn" Number="3" Volume="1997" Year="1997" Format="Limited Series">
+    <Book Series="Psylocke &amp; Archangel: Crimson Dawn" Number="3" Volume="1997" Year="1997">
       <Id>7ee27649-f3f2-4db0-a274-7dee6c9fe75c</Id>
     </Book>
-    <Book Series="Psylocke &amp; Archangel: Crimson Dawn" Number="4" Volume="1997" Year="1997" Format="Limited Series">
+    <Book Series="Psylocke &amp; Archangel: Crimson Dawn" Number="4" Volume="1997" Year="1997">
       <Id>11d890ea-73cb-4276-992a-54381adbf9bd</Id>
     </Book>
-    <Book Series="Generation X" Number="26" Volume="1994" Year="1997" Format="Main Series">
+    <Book Series="Generation X" Number="26" Volume="1994" Year="1997">
       <Id>95a3da93-da25-4a97-9ade-6e19c898d651</Id>
     </Book>
-    <Book Series="Generation X" Number="27" Volume="1994" Year="1997" Format="Main Series">
+    <Book Series="Generation X" Number="27" Volume="1994" Year="1997">
       <Id>3d384864-ff9a-4812-ae4a-2d4df466298e</Id>
     </Book>
-    <Book Series="X-Men" Number="62" Volume="1991" Year="1997" Format="Main Series">
+    <Book Series="X-Men" Number="62" Volume="1991" Year="1997">
       <Id>df5a1143-b752-439f-a90e-a9c52bd45443</Id>
     </Book>
-    <Book Series="X-Men" Number="63" Volume="1991" Year="1997" Format="Main Series">
+    <Book Series="X-Men" Number="63" Volume="1991" Year="1997">
       <Id>5b1e2499-99a6-441d-ae33-14db7eb1fc28</Id>
     </Book>
-    <Book Series="X-Men" Number="64" Volume="1991" Year="1997" Format="Main Series">
+    <Book Series="X-Men" Number="64" Volume="1991" Year="1997">
       <Id>202e2a84-399e-4d00-abb7-a24ae5225145</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="345" Volume="1981" Year="1997" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="345" Volume="1981" Year="1997">
       <Id>2e7514ca-c8c9-4cc0-9a10-cc3ebf0ebed5</Id>
     </Book>
-    <Book Series="Generation X" Number="28" Volume="1994" Year="1997" Format="Main Series">
+    <Book Series="Generation X" Number="28" Volume="1994" Year="1997">
       <Id>2f38590a-2cc5-4109-9a5f-c00e5161f607</Id>
     </Book>
-    <Book Series="X-Men" Number="65" Volume="1991" Year="1997" Format="Main Series">
+    <Book Series="X-Men" Number="65" Volume="1991" Year="1997">
       <Id>4e7acc36-0fe1-4885-9d70-ced1a68ed498</Id>
     </Book>
-    <Book Series="X-Force" Number="67" Volume="1991" Year="1997" Format="Main Series">
+    <Book Series="X-Force" Number="67" Volume="1991" Year="1997">
       <Id>501462eb-927c-449f-a057-2d8a440d75a4</Id>
     </Book>
-    <Book Series="Cable" Number="-1" Volume="1993" Year="1997" Format="Main Series">
+    <Book Series="Cable" Number="-1" Volume="1993" Year="1997">
       <Id>1ef6cd64-d5e3-48b7-8e52-7b7407a0bbc1</Id>
     </Book>
-    <Book Series="Generation X" Number="-1" Volume="1994" Year="1997" Format="Main Series">
+    <Book Series="Generation X" Number="-1" Volume="1994" Year="1997">
       <Id>c73df6b6-0806-4940-8d8b-466c505b2718</Id>
     </Book>
-    <Book Series="X-Factor" Number="-1" Volume="1986" Year="1997" Format="Main Series">
+    <Book Series="X-Factor" Number="-1" Volume="1986" Year="1997">
       <Id>95355fc3-78d5-4b48-824d-f80dd909bee0</Id>
     </Book>
-    <Book Series="X-Force" Number="-1" Volume="1991" Year="1997" Format="Main Series">
+    <Book Series="X-Force" Number="-1" Volume="1991" Year="1997">
       <Id>efce28f8-54a4-417c-8933-e71dc6bcde22</Id>
     </Book>
-    <Book Series="Wolverine" Number="-1" Volume="1988" Year="1997" Format="Main Series">
+    <Book Series="Wolverine" Number="-1" Volume="1988" Year="1997">
       <Id>39b6d797-e296-4037-ab00-79a834d9ac5e</Id>
     </Book>
-    <Book Series="Excalibur" Number="-1" Volume="1988" Year="1997" Format="Main Series">
+    <Book Series="Excalibur" Number="-1" Volume="1988" Year="1997">
       <Id>cc996841-9f99-46ca-8fa2-c79f6b5b9554</Id>
     </Book>
-    <Book Series="X-Men" Number="-1" Volume="1991" Year="1997" Format="Main Series">
+    <Book Series="X-Men" Number="-1" Volume="1991" Year="1997">
       <Id>429e228e-7345-4155-a8af-e42a070f8e09</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="-1" Volume="1981" Year="1997" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="-1" Volume="1981" Year="1997">
       <Id>741b29a2-9f3f-4936-b456-5f4b99cb2fd1</Id>
     </Book>
-    <Book Series="X-Factor" Number="136" Volume="1986" Year="1997" Format="Main Series">
+    <Book Series="X-Factor" Number="136" Volume="1986" Year="1997">
       <Id>af8b7323-1f95-497c-8968-5f55d9287637</Id>
     </Book>
-    <Book Series="X-Factor" Number="137" Volume="1986" Year="1997" Format="Main Series">
+    <Book Series="X-Factor" Number="137" Volume="1986" Year="1997">
       <Id>9783a274-3de6-4dde-816b-a502b604d469</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="346" Volume="1981" Year="1997" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="346" Volume="1981" Year="1997">
       <Id>7744c90b-7f6c-4bae-93d8-d71e4344422f</Id>
     </Book>
-    <Book Series="Cable" Number="45" Volume="1993" Year="1997" Format="Main Series">
+    <Book Series="Cable" Number="45" Volume="1993" Year="1997">
       <Id>c9b734e0-fe54-4f17-bd88-9bf2e4e0e5b5</Id>
     </Book>
-    <Book Series="X-Force" Number="68" Volume="1991" Year="1997" Format="Main Series">
+    <Book Series="X-Force" Number="68" Volume="1991" Year="1997">
       <Id>af4d3324-b4f7-4c51-85e4-b6200652f279</Id>
     </Book>
-    <Book Series="Cable" Number="46" Volume="1993" Year="1997" Format="Main Series">
+    <Book Series="Cable" Number="46" Volume="1993" Year="1997">
       <Id>bef1f602-27f3-4e51-a0a7-6fb260e62eba</Id>
     </Book>
-    <Book Series="X-Force" Number="69" Volume="1991" Year="1997" Format="Main Series">
+    <Book Series="X-Force" Number="69" Volume="1991" Year="1997">
       <Id>628f93f1-9498-44c2-a379-d2214a45c0e8</Id>
     </Book>
-    <Book Series="Cable" Number="47" Volume="1993" Year="1997" Format="Main Series">
+    <Book Series="Cable" Number="47" Volume="1993" Year="1997">
       <Id>1ea9fbd6-675a-471c-8de9-53ee86add241</Id>
     </Book>
-    <Book Series="Generation X" Number="29" Volume="1994" Year="1997" Format="Main Series">
+    <Book Series="Generation X" Number="29" Volume="1994" Year="1997">
       <Id>252d1296-eb28-4d13-92d9-a7e69bfa001f</Id>
     </Book>
-    <Book Series="X-Men" Number="66" Volume="1991" Year="1997" Format="Main Series">
+    <Book Series="X-Men" Number="66" Volume="1991" Year="1997">
       <Id>26b0f8ee-c3f1-4acd-8cb3-362a0241172f</Id>
     </Book>
-    <Book Series="Wolverine" Number="115" Volume="1988" Year="1997" Format="Main Series">
+    <Book Series="Wolverine" Number="115" Volume="1988" Year="1997">
       <Id>77e0cb0b-9a57-4eb6-86c0-80b542f73672</Id>
     </Book>
-    <Book Series="X-Men" Number="67" Volume="1991" Year="1997" Format="Main Series">
+    <Book Series="X-Men" Number="67" Volume="1991" Year="1997">
       <Id>1fa49a69-1d57-48ff-b2fb-0af356c8a499</Id>
     </Book>
-    <Book Series="Wolverine" Number="116" Volume="1988" Year="1997" Format="Main Series">
+    <Book Series="Wolverine" Number="116" Volume="1988" Year="1997">
       <Id>1a684782-59b6-42f0-afb4-5c586dacc400</Id>
     </Book>
-    <Book Series="Generation X" Number="30" Volume="1994" Year="1997" Format="Main Series">
+    <Book Series="Generation X" Number="30" Volume="1994" Year="1997">
       <Id>2cce1689-4324-41f0-8db4-fec711825812</Id>
     </Book>
-    <Book Series="Generation X" Number="31" Volume="1994" Year="1997" Format="Main Series">
+    <Book Series="Generation X" Number="31" Volume="1994" Year="1997">
       <Id>10ac6cc5-f137-4224-882d-c22c7cb3a9f7</Id>
     </Book>
-    <Book Series="X-Men" Number="68" Volume="1991" Year="1997" Format="Main Series">
+    <Book Series="X-Men" Number="68" Volume="1991" Year="1997">
       <Id>2fc51121-7099-4875-993f-4c166a4f06ad</Id>
     </Book>
-    <Book Series="Wolverine" Number="117" Volume="1988" Year="1997" Format="Main Series">
+    <Book Series="Wolverine" Number="117" Volume="1988" Year="1997">
       <Id>67ff0d04-833e-46bf-94da-8b0da7f67bb8</Id>
     </Book>
-    <Book Series="X-Men" Number="69" Volume="1991" Year="1997" Format="Main Series">
+    <Book Series="X-Men" Number="69" Volume="1991" Year="1997">
       <Id>ff10f745-15cb-4607-8784-4048ce7ee709</Id>
     </Book>
-    <Book Series="Wolverine" Number="118" Volume="1988" Year="1997" Format="Main Series">
+    <Book Series="Wolverine" Number="118" Volume="1988" Year="1997">
       <Id>64bc4239-58aa-4e87-9f43-de26023bf497</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="347" Volume="1981" Year="1997" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="347" Volume="1981" Year="1997">
       <Id>63979955-8a6e-4eca-a573-fd1d92b97010</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="348" Volume="1981" Year="1997" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="348" Volume="1981" Year="1997">
       <Id>b9c86b2c-cccc-4342-bf41-c11afd58c9c3</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="349" Volume="1981" Year="1997" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="349" Volume="1981" Year="1997">
       <Id>c8903dec-c1a8-44bb-9c59-0da1a0cf97c8</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="350" Volume="1981" Year="1997" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="350" Volume="1981" Year="1997">
       <Id>8a73a2d3-51ad-4b20-a6bc-4e5883b40250</Id>
     </Book>
-    <Book Series="X-Men" Number="70" Volume="1991" Year="1997" Format="Main Series">
+    <Book Series="X-Men" Number="70" Volume="1991" Year="1997">
       <Id>29a689f6-84d4-45c3-9b2d-07e5e1f2343a</Id>
     </Book>
-    <Book Series="X-Force" Number="70" Volume="1991" Year="1997" Format="Main Series">
+    <Book Series="X-Force" Number="70" Volume="1991" Year="1997">
       <Id>4717df98-2d6a-47d7-8f91-fd8b02bf0e33</Id>
     </Book>
-    <Book Series="Cable" Number="48" Volume="1993" Year="1997" Format="Main Series">
+    <Book Series="Cable" Number="48" Volume="1993" Year="1997">
       <Id>1dfbd237-88b1-4071-935b-6907614a91ee</Id>
     </Book>
-    <Book Series="Cable" Number="49" Volume="1993" Year="1997" Format="Main Series">
+    <Book Series="Cable" Number="49" Volume="1993" Year="1997">
       <Id>ee2edcd7-3fa9-491d-a057-fde0ce905dd5</Id>
     </Book>
-    <Book Series="Cable" Number="50" Volume="1993" Year="1998" Format="Main Series">
+    <Book Series="Cable" Number="50" Volume="1993" Year="1998">
       <Id>6f0c7fba-4102-481c-ab85-d9ffa52a7ec0</Id>
     </Book>
-    <Book Series="Cable" Number="51" Volume="1993" Year="1998" Format="Main Series">
+    <Book Series="Cable" Number="51" Volume="1993" Year="1998">
       <Id>35edb63e-bf58-4c22-a354-d59fe4a3bebb</Id>
     </Book>
-    <Book Series="Cable" Number="52" Volume="1993" Year="1998" Format="Main Series">
+    <Book Series="Cable" Number="52" Volume="1993" Year="1998">
       <Id>4e10303b-4cd5-42a3-8cd5-9e0f9fc98569</Id>
     </Book>
-    <Book Series="Cable" Number="53" Volume="1993" Year="1998" Format="Main Series">
+    <Book Series="Cable" Number="53" Volume="1993" Year="1998">
       <Id>fef7b916-d88b-452d-b5ba-248367e68eb1</Id>
     </Book>
-    <Book Series="Cable" Number="54" Volume="1993" Year="1998" Format="Main Series">
+    <Book Series="Cable" Number="54" Volume="1993" Year="1998">
       <Id>71add785-a27a-47ef-aadb-318373e69940</Id>
     </Book>
-    <Book Series="X-Factor" Number="138" Volume="1986" Year="1997" Format="Main Series">
+    <Book Series="X-Factor" Number="138" Volume="1986" Year="1997">
       <Id>3ebc6785-6fb9-4353-8c3e-b07c45dc0f94</Id>
     </Book>
-    <Book Series="Wolverine Annual '97" Number="1" Volume="1997" Year="1997" Format="Annual">
+    <Book Series="Wolverine Annual '97" Number="1" Volume="1997" Year="1997">
       <Id>1ca181f7-3c24-46be-a25e-7a10a7507f1d</Id>
     </Book>
-    <Book Series="Excalibur" Number="114" Volume="1988" Year="1997" Format="Main Series">
+    <Book Series="Excalibur" Number="114" Volume="1988" Year="1997">
       <Id>ad12a7dd-26ca-47c2-a930-1dde011b344a</Id>
     </Book>
-    <Book Series="New Mutants: Truth or Death" Number="1" Volume="1997" Year="1997" Format="Limited Series">
+    <Book Series="New Mutants: Truth or Death" Number="1" Volume="1997" Year="1997">
       <Id>6b29e6a0-0966-4f54-a999-d0be6ce8e674</Id>
     </Book>
-    <Book Series="New Mutants: Truth or Death" Number="2" Volume="1997" Year="1997" Format="Limited Series">
+    <Book Series="New Mutants: Truth or Death" Number="2" Volume="1997" Year="1997">
       <Id>97151cd3-0bcf-4ba2-acff-dddec81d5d95</Id>
     </Book>
-    <Book Series="New Mutants: Truth or Death" Number="3" Volume="1997" Year="1998" Format="Limited Series">
+    <Book Series="New Mutants: Truth or Death" Number="3" Volume="1997" Year="1998">
       <Id>2ee0dabc-567f-4b53-a71a-ebe05f04d128</Id>
     </Book>
-    <Book Series="X-Man" Number="31" Volume="1995" Year="1997" Format="Main Series">
+    <Book Series="X-Man" Number="31" Volume="1995" Year="1997">
       <Id>9555a6d2-e50e-4f14-a8bb-f01839bcd20d</Id>
     </Book>
-    <Book Series="X-Man Annual '97" Number="1" Volume="1997" Year="1997" Format="Annual">
+    <Book Series="X-Man Annual '97" Number="1" Volume="1997" Year="1997">
       <Id>ff400c37-dc72-47b2-9eef-1ee378fab37d</Id>
     </Book>
-    <Book Series="X-Factor" Number="139" Volume="1986" Year="1997" Format="Main Series">
+    <Book Series="X-Factor" Number="139" Volume="1986" Year="1997">
       <Id>fd9777a0-3c8f-4e99-a3e2-6a83b96cc6c5</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="17" Volume="1993" Year="1997" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="17" Volume="1993" Year="1997">
       <Id>b2ca56b5-61a3-428c-89d5-596591dcc945</Id>
     </Book>
-    <Book Series="X-Force" Number="71" Volume="1991" Year="1997" Format="Main Series">
+    <Book Series="X-Force" Number="71" Volume="1991" Year="1997">
       <Id>5bb3c260-a7f1-4c25-a376-d7c049b296d3</Id>
     </Book>
-    <Book Series="X-Force" Number="72" Volume="1991" Year="1997" Format="Main Series">
+    <Book Series="X-Force" Number="72" Volume="1991" Year="1997">
       <Id>bb494ec9-0cd2-49cb-8cb3-7ef1e7475024</Id>
     </Book>
-    <Book Series="Generation X" Number="32" Volume="1994" Year="1997" Format="Main Series">
+    <Book Series="Generation X" Number="32" Volume="1994" Year="1997">
       <Id>c01b2ece-1fd1-4b7e-b806-076111483288</Id>
     </Book>
-    <Book Series="Kitty Pryde, Agent of S.H.I.E.L.D." Number="1" Volume="1997" Year="1997" Format="Limited Series">
+    <Book Series="Kitty Pryde, Agent of S.H.I.E.L.D." Number="1" Volume="1997" Year="1997">
       <Id>0797c103-e49b-40eb-9598-a2e2e4b1b394</Id>
     </Book>
-    <Book Series="Kitty Pryde, Agent of S.H.I.E.L.D." Number="2" Volume="1997" Year="1998" Format="Limited Series">
+    <Book Series="Kitty Pryde, Agent of S.H.I.E.L.D." Number="2" Volume="1997" Year="1998">
       <Id>7a9bb1bf-d358-466c-891a-2bf0d2a61fbd</Id>
     </Book>
-    <Book Series="Kitty Pryde, Agent of S.H.I.E.L.D." Number="3" Volume="1997" Year="1998" Format="Limited Series">
+    <Book Series="Kitty Pryde, Agent of S.H.I.E.L.D." Number="3" Volume="1997" Year="1998">
       <Id>61d42df3-1087-44c8-bd60-4d584d0aa501</Id>
     </Book>
-    <Book Series="X-Factor" Number="140" Volume="1986" Year="1997" Format="Main Series">
+    <Book Series="X-Factor" Number="140" Volume="1986" Year="1997">
       <Id>0f57fe11-8fb9-4aad-add6-876ac89c5b8a</Id>
     </Book>
-    <Book Series="X-Factor" Number="141" Volume="1986" Year="1998" Format="Main Series">
+    <Book Series="X-Factor" Number="141" Volume="1986" Year="1998">
       <Id>639699f4-fbb3-40ad-89fa-dde45df72c74</Id>
     </Book>
-    <Book Series="Wolverine" Number="119" Volume="1988" Year="1997" Format="Main Series">
+    <Book Series="Wolverine" Number="119" Volume="1988" Year="1997">
       <Id>eeba6036-f765-482d-93b5-4abaa967fd43</Id>
     </Book>
-    <Book Series="Wolverine" Number="120" Volume="1988" Year="1998" Format="Main Series">
+    <Book Series="Wolverine" Number="120" Volume="1988" Year="1998">
       <Id>c278f418-7a8e-421a-8b0d-80b934a22a8e</Id>
     </Book>
-    <Book Series="Wolverine" Number="121" Volume="1988" Year="1998" Format="Main Series">
+    <Book Series="Wolverine" Number="121" Volume="1988" Year="1998">
       <Id>e9290a99-6f6e-4b83-a3fe-a18b1cde05d2</Id>
     </Book>
-    <Book Series="Wolverine" Number="122" Volume="1988" Year="1998" Format="Main Series">
+    <Book Series="Wolverine" Number="122" Volume="1988" Year="1998">
       <Id>2982d64a-9301-49a0-a05e-5a9abac3a12c</Id>
     </Book>
-    <Book Series="Generation X" Number="33" Volume="1994" Year="1997" Format="Main Series">
+    <Book Series="Generation X" Number="33" Volume="1994" Year="1997">
       <Id>a4f1b49a-eece-42e9-bbff-06c96dff3786</Id>
     </Book>
-    <Book Series="Excalibur" Number="115" Volume="1988" Year="1997" Format="Main Series">
+    <Book Series="Excalibur" Number="115" Volume="1988" Year="1997">
       <Id>880931e8-b4b9-40bd-9f3f-db427c660f64</Id>
     </Book>
-    <Book Series="Gambit" Number="1" Volume="1997" Year="1997" Format="Limited Series">
+    <Book Series="Gambit" Number="1" Volume="1997" Year="1997">
       <Id>e2deef52-87cc-4dfa-9e7b-46a89d1b2179</Id>
     </Book>
-    <Book Series="Gambit" Number="2" Volume="1997" Year="1997" Format="Limited Series">
+    <Book Series="Gambit" Number="2" Volume="1997" Year="1997">
       <Id>3f2a5504-5f90-4de8-b1f7-fb9bcb0ba701</Id>
     </Book>
-    <Book Series="Gambit" Number="3" Volume="1997" Year="1997" Format="Limited Series">
+    <Book Series="Gambit" Number="3" Volume="1997" Year="1997">
       <Id>02e02b40-10bf-4aed-82c0-52c7153c070a</Id>
     </Book>
-    <Book Series="Gambit" Number="4" Volume="1997" Year="1997" Format="Limited Series">
+    <Book Series="Gambit" Number="4" Volume="1997" Year="1997">
       <Id>cb3fb5a4-6434-46ca-b340-86c1ff8f4d07</Id>
     </Book>
-    <Book Series="X-Force" Number="73" Volume="1991" Year="1998" Format="Main Series">
+    <Book Series="X-Force" Number="73" Volume="1991" Year="1998">
       <Id>b8057e71-e460-433a-b9ef-0a3dc24d4b7b</Id>
     </Book>
-    <Book Series="X-Force" Number="74" Volume="1991" Year="1998" Format="Main Series">
+    <Book Series="X-Force" Number="74" Volume="1991" Year="1998">
       <Id>761875e9-407a-46c4-9a7f-1c1c0eccfc08</Id>
     </Book>
-    <Book Series="Generation X" Number="34" Volume="1994" Year="1998" Format="Main Series">
+    <Book Series="Generation X" Number="34" Volume="1994" Year="1998">
       <Id>a64d3e4c-80ac-407b-a24c-707d8e2216a0</Id>
     </Book>
-    <Book Series="Generation X" Number="35" Volume="1994" Year="1998" Format="Main Series">
+    <Book Series="Generation X" Number="35" Volume="1994" Year="1998">
       <Id>b0593db7-f55a-40f1-acae-2d571ddf2bb1</Id>
     </Book>
-    <Book Series="Generation X Holiday Special" Number="1" Volume="1998" Year="1998" Format="Main Series">
+    <Book Series="Generation X Holiday Special" Number="1" Volume="1998" Year="1998">
       <Id>1693aca9-c339-4c46-8b68-bd5ac62124cc</Id>
     </Book>
-    <Book Series="Generation X" Number="36" Volume="1994" Year="1998" Format="Main Series">
+    <Book Series="Generation X" Number="36" Volume="1994" Year="1998">
       <Id>21924821-6add-4a52-86da-d760d1799fe3</Id>
     </Book>
-    <Book Series="Generation X" Number="37" Volume="1994" Year="1998" Format="Main Series">
+    <Book Series="Generation X" Number="37" Volume="1994" Year="1998">
       <Id>0e9ee2b9-9b1e-49b4-b792-8ed5b5dce158</Id>
     </Book>
-    <Book Series="Generation X" Number="38" Volume="1994" Year="1998" Format="Main Series">
+    <Book Series="Generation X" Number="38" Volume="1994" Year="1998">
       <Id>df73fa61-32c5-4552-a20f-8b4778ef0cc4</Id>
     </Book>
-    <Book Series="Generation X" Number="39" Volume="1994" Year="1998" Format="Main Series">
+    <Book Series="Generation X" Number="39" Volume="1994" Year="1998">
       <Id>0f7a6a4e-2f42-4114-84df-099765b4d2a8</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="18" Volume="1993" Year="1998" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="18" Volume="1993" Year="1998">
       <Id>6447ebcb-cc78-4178-bde0-614c3aa324b1</Id>
     </Book>
-    <Book Series="X-Men" Number="71" Volume="1991" Year="1998" Format="Main Series">
+    <Book Series="X-Men" Number="71" Volume="1991" Year="1998">
       <Id>d56a0066-0469-4e87-a511-65f7a0a6b050</Id>
     </Book>
-    <Book Series="X-Men" Number="72" Volume="1991" Year="1998" Format="Main Series">
+    <Book Series="X-Men" Number="72" Volume="1991" Year="1998">
       <Id>58995c2b-3970-412d-b90f-b94b44dc387f</Id>
     </Book>
-    <Book Series="Excalibur" Number="116" Volume="1988" Year="1998" Format="Main Series">
+    <Book Series="Excalibur" Number="116" Volume="1988" Year="1998">
       <Id>b9f0e7bb-7613-4ed0-bcb0-de6637040556</Id>
     </Book>
-    <Book Series="Excalibur" Number="117" Volume="1988" Year="1998" Format="Main Series">
+    <Book Series="Excalibur" Number="117" Volume="1988" Year="1998">
       <Id>17fca4e0-2d96-4f41-8ea6-541630f024d9</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="351" Volume="1981" Year="1998" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="351" Volume="1981" Year="1998">
       <Id>ef8f94cc-4cae-4043-9a45-fa303e19574b</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="352" Volume="1981" Year="1998" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="352" Volume="1981" Year="1998">
       <Id>353c0434-4211-4bdf-9b66-ebac877f13c5</Id>
     </Book>
-    <Book Series="X-Man" Number="32" Volume="1995" Year="1997" Format="Main Series">
+    <Book Series="X-Man" Number="32" Volume="1995" Year="1997">
       <Id>7859459b-ab0d-469d-9ff9-19d0d17a4ae6</Id>
     </Book>
-    <Book Series="X-Man" Number="33" Volume="1995" Year="1997" Format="Main Series">
+    <Book Series="X-Man" Number="33" Volume="1995" Year="1997">
       <Id>bd36cb57-d9aa-418c-83ab-eda3ece9a7c2</Id>
     </Book>
-    <Book Series="X-Force" Number="75" Volume="1991" Year="1998" Format="Main Series">
+    <Book Series="X-Force" Number="75" Volume="1991" Year="1998">
       <Id>b4c67a07-78c8-4fd1-ae8f-14f91df7fc2e</Id>
     </Book>
-    <Book Series="X-Factor" Number="142" Volume="1986" Year="1998" Format="Main Series">
+    <Book Series="X-Factor" Number="142" Volume="1986" Year="1998">
       <Id>d6097d2f-b9f8-40ae-b161-507525f3f7e9</Id>
     </Book>
-    <Book Series="X-Force" Number="76" Volume="1991" Year="1998" Format="Main Series">
+    <Book Series="X-Force" Number="76" Volume="1991" Year="1998">
       <Id>8159c273-ce60-454e-b2a7-a6064c39e4f0</Id>
     </Book>
-    <Book Series="Cable / Machine Man Annual '98" Number="1" Volume="1998" Year="1998" Format="Annual">
+    <Book Series="Cable / Machine Man Annual '98" Number="1" Volume="1998" Year="1998">
       <Id>328c7968-35ae-48c7-9d7b-cb8924c0db8b</Id>
     </Book>
-    <Book Series="Machine Man / Bastion Annual '98" Number="1998" Volume="1998" Year="1998" Format="Annual">
+    <Book Series="Machine Man / Bastion Annual '98" Number="1998" Volume="1998" Year="1998">
       <Id>b3aecf91-db13-4926-8619-6774ab85ca38</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="353" Volume="1981" Year="1998" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="353" Volume="1981" Year="1998">
       <Id>47ed2213-cdc7-4c51-a2a4-e66c2287012d</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="354" Volume="1981" Year="1998" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="354" Volume="1981" Year="1998">
       <Id>cc4a0649-0428-4970-848e-a40dc2ac9e55</Id>
     </Book>
-    <Book Series="X-Man" Number="34" Volume="1995" Year="1998" Format="Main Series">
+    <Book Series="X-Man" Number="34" Volume="1995" Year="1998">
       <Id>6a5c59c7-49a0-4e52-85fa-12333c2ac6ab</Id>
     </Book>
-    <Book Series="X-Man" Number="35" Volume="1995" Year="1998" Format="Main Series">
+    <Book Series="X-Man" Number="35" Volume="1995" Year="1998">
       <Id>2cd014c7-ffa3-43d5-8c75-3ee582bef2e1</Id>
     </Book>
-    <Book Series="X-Man" Number="36" Volume="1995" Year="1998" Format="Main Series">
+    <Book Series="X-Man" Number="36" Volume="1995" Year="1998">
       <Id>428b6663-3e44-49f2-844a-cd30bdb0dd06</Id>
     </Book>
-    <Book Series="X-Man" Number="37" Volume="1995" Year="1998" Format="Main Series">
+    <Book Series="X-Man" Number="37" Volume="1995" Year="1998">
       <Id>4f4eb140-9f7d-4c9c-a13e-79b7ba10cb69</Id>
     </Book>
-    <Book Series="X-Man" Number="38" Volume="1995" Year="1998" Format="Main Series">
+    <Book Series="X-Man" Number="38" Volume="1995" Year="1998">
       <Id>863282a1-5fc2-42f0-bc76-a44aefa9c176</Id>
     </Book>
-    <Book Series="X-Factor" Number="143" Volume="1986" Year="1998" Format="Main Series">
+    <Book Series="X-Factor" Number="143" Volume="1986" Year="1998">
       <Id>06c9f73d-b2f4-4361-82ce-9f2b45a3b16c</Id>
     </Book>
-    <Book Series="X-Factor" Number="144" Volume="1986" Year="1998" Format="Main Series">
+    <Book Series="X-Factor" Number="144" Volume="1986" Year="1998">
       <Id>7ec89b66-1856-4384-8513-abff402919ac</Id>
     </Book>
-    <Book Series="X-Factor" Number="145" Volume="1986" Year="1998" Format="Main Series">
+    <Book Series="X-Factor" Number="145" Volume="1986" Year="1998">
       <Id>1f50327a-9483-4288-a8e7-f21f82e75569</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="355" Volume="1981" Year="1998" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="355" Volume="1981" Year="1998">
       <Id>05a599b7-a85c-4db5-9b0d-2173d3a28b0d</Id>
     </Book>
-    <Book Series="X-Men" Number="73" Volume="1991" Year="1998" Format="Main Series">
+    <Book Series="X-Men" Number="73" Volume="1991" Year="1998">
       <Id>01a2e432-1b01-4e35-b0e7-a23f7ab7c0f5</Id>
     </Book>
-    <Book Series="Wolverine" Number="123" Volume="1988" Year="1998" Format="Main Series">
+    <Book Series="Wolverine" Number="123" Volume="1988" Year="1998">
       <Id>f54a5f8f-563b-4078-b9d9-0952e2f9e595</Id>
     </Book>
-    <Book Series="Wolverine" Number="124" Volume="1988" Year="1998" Format="Main Series">
+    <Book Series="Wolverine" Number="124" Volume="1988" Year="1998">
       <Id>fd642122-e1d2-4019-9c90-c12d4d07f775</Id>
     </Book>
-    <Book Series="X-Force" Number="77" Volume="1991" Year="1998" Format="Main Series">
+    <Book Series="X-Force" Number="77" Volume="1991" Year="1998">
       <Id>4290822f-baca-4689-b2b7-bb663255a8e3</Id>
     </Book>
-    <Book Series="Excalibur" Number="118" Volume="1988" Year="1998" Format="Main Series">
+    <Book Series="Excalibur" Number="118" Volume="1988" Year="1998">
       <Id>27ae7786-e04d-46b7-bc4e-8720ecda133f</Id>
     </Book>
-    <Book Series="Excalibur" Number="119" Volume="1988" Year="1998" Format="Main Series">
+    <Book Series="Excalibur" Number="119" Volume="1988" Year="1998">
       <Id>96044916-365c-44c2-9d82-60780b16f36e</Id>
     </Book>
-    <Book Series="Excalibur" Number="120" Volume="1988" Year="1998" Format="Main Series">
+    <Book Series="Excalibur" Number="120" Volume="1988" Year="1998">
       <Id>1d9aba7a-db77-4965-8c3f-792a8cab853d</Id>
     </Book>
-    <Book Series="Excalibur" Number="121" Volume="1988" Year="1998" Format="Main Series">
+    <Book Series="Excalibur" Number="121" Volume="1988" Year="1998">
       <Id>bd908b98-a54c-4809-b6d8-f37ee0165f5c</Id>
     </Book>
-    <Book Series="Excalibur" Number="122" Volume="1988" Year="1998" Format="Main Series">
+    <Book Series="Excalibur" Number="122" Volume="1988" Year="1998">
       <Id>2a75d3b3-f5b1-4213-a111-b5ecdb1c1b5d</Id>
     </Book>
-    <Book Series="Excalibur" Number="123" Volume="1988" Year="1998" Format="Main Series">
+    <Book Series="Excalibur" Number="123" Volume="1988" Year="1998">
       <Id>b7e67bf1-76cd-4bcb-ad04-45044ae03f08</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="19" Volume="1993" Year="1998" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="19" Volume="1993" Year="1998">
       <Id>801fc9cb-b352-4c84-8ccd-d913d327346f</Id>
     </Book>
-    <Book Series="X-Factor" Number="146" Volume="1986" Year="1998" Format="Main Series">
+    <Book Series="X-Factor" Number="146" Volume="1986" Year="1998">
       <Id>19f181fc-5cbe-45f7-a13b-977bad92d90b</Id>
     </Book>
-    <Book Series="Cable" Number="55" Volume="1993" Year="1998" Format="Main Series">
+    <Book Series="Cable" Number="55" Volume="1993" Year="1998">
       <Id>a6c551c5-d0b8-4c86-a0b9-99fdcaeda511</Id>
     </Book>
-    <Book Series="Cable" Number="56" Volume="1993" Year="1998" Format="Main Series">
+    <Book Series="Cable" Number="56" Volume="1993" Year="1998">
       <Id>12bbef11-7eae-4ffd-a0da-fbaef1c388ba</Id>
     </Book>
-    <Book Series="X-Force" Number="78" Volume="1991" Year="1998" Format="Main Series">
+    <Book Series="X-Force" Number="78" Volume="1991" Year="1998">
       <Id>49c0409c-296d-4ca5-bca1-125976c010cf</Id>
     </Book>
-    <Book Series="X-Force" Number="79" Volume="1991" Year="1998" Format="Main Series">
+    <Book Series="X-Force" Number="79" Volume="1991" Year="1998">
       <Id>9c216da5-aab4-41e5-9296-c648b15f643a</Id>
     </Book>
-    <Book Series="X-Force" Number="80" Volume="1991" Year="1998" Format="Main Series">
+    <Book Series="X-Force" Number="80" Volume="1991" Year="1998">
       <Id>662039a1-eafd-4683-a0f0-a0ba028cde7d</Id>
     </Book>
-    <Book Series="X-Man" Number="39" Volume="1995" Year="1998" Format="Main Series">
+    <Book Series="X-Man" Number="39" Volume="1995" Year="1998">
       <Id>d0199d61-83b9-4d2c-87a7-a1d0a2c0ebd9</Id>
     </Book>
-    <Book Series="X-Man" Number="40" Volume="1995" Year="1998" Format="Main Series">
+    <Book Series="X-Man" Number="40" Volume="1995" Year="1998">
       <Id>c39cc808-d3eb-4791-8c66-ce2df69e2e2b</Id>
     </Book>
-    <Book Series="Generation X" Number="40" Volume="1994" Year="1998" Format="Main Series">
+    <Book Series="Generation X" Number="40" Volume="1994" Year="1998">
       <Id>e48d2d25-0977-430f-a171-19a8e3647228</Id>
     </Book>
-    <Book Series="Generation X" Number="41" Volume="1994" Year="1998" Format="Main Series">
+    <Book Series="Generation X" Number="41" Volume="1994" Year="1998">
       <Id>a7ac5a45-b983-4412-bd3f-66d121deccad</Id>
     </Book>
-    <Book Series="X-Factor" Number="147" Volume="1986" Year="1998" Format="Main Series">
+    <Book Series="X-Factor" Number="147" Volume="1986" Year="1998">
       <Id>ef86af77-87fd-40fa-aa49-2b1f7f696ca6</Id>
     </Book>
-    <Book Series="Wolverine" Number="125" Volume="1988" Year="1998" Format="Main Series">
+    <Book Series="Wolverine" Number="125" Volume="1988" Year="1998">
       <Id>0a745cb5-4996-43e4-9f21-619becdd5afd</Id>
     </Book>
-    <Book Series="Wolverine" Number="126" Volume="1988" Year="1998" Format="Main Series">
+    <Book Series="Wolverine" Number="126" Volume="1988" Year="1998">
       <Id>9a255ec5-544c-4498-804b-45e1f30935c0</Id>
     </Book>
-    <Book Series="Wolverine" Number="127" Volume="1988" Year="1998" Format="Main Series">
+    <Book Series="Wolverine" Number="127" Volume="1988" Year="1998">
       <Id>fb8a4149-9ae8-4ec0-8373-c5c7c4b6b988</Id>
     </Book>
-    <Book Series="Wolverine" Number="128" Volume="1988" Year="1998" Format="Main Series">
+    <Book Series="Wolverine" Number="128" Volume="1988" Year="1998">
       <Id>2c556f63-137e-4b0b-afd3-4753610283a6</Id>
     </Book>
-    <Book Series="Wolverine" Number="129" Volume="1988" Year="1998" Format="Main Series">
+    <Book Series="Wolverine" Number="129" Volume="1988" Year="1998">
       <Id>f6ae5a6b-dfa1-4e5c-a068-23d01b19cb4d</Id>
     </Book>
-    <Book Series="Wolverine" Number="130" Volume="1988" Year="1998" Format="Main Series">
+    <Book Series="Wolverine" Number="130" Volume="1988" Year="1998">
       <Id>93eb65ff-46b4-48c1-8b52-6bc6dad4a46b</Id>
     </Book>
-    <Book Series="X-Force" Number="81" Volume="1991" Year="1998" Format="Main Series">
+    <Book Series="X-Force" Number="81" Volume="1991" Year="1998">
       <Id>bfdf504f-b550-42b6-bced-f767229b4835</Id>
     </Book>
-    <Book Series="X-Force" Number="82" Volume="1991" Year="1998" Format="Main Series">
+    <Book Series="X-Force" Number="82" Volume="1991" Year="1998">
       <Id>5627d6cf-bf1e-491f-bb9b-4306eb8a3057</Id>
     </Book>
-    <Book Series="X-Men" Number="74" Volume="1991" Year="1998" Format="Main Series">
+    <Book Series="X-Men" Number="74" Volume="1991" Year="1998">
       <Id>eea932af-bdd1-4c4b-817e-757fce30a73f</Id>
     </Book>
-    <Book Series="X-Men" Number="75" Volume="1991" Year="1998" Format="Main Series">
+    <Book Series="X-Men" Number="75" Volume="1991" Year="1998">
       <Id>11323559-dfe9-475e-807b-522b8b30e492</Id>
     </Book>
-    <Book Series="X-Men" Number="76" Volume="1991" Year="1998" Format="Main Series">
+    <Book Series="X-Men" Number="76" Volume="1991" Year="1998">
       <Id>0211fc94-eae9-47be-b25b-0d791c6ecf8e</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="356" Volume="1981" Year="1998" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="356" Volume="1981" Year="1998">
       <Id>986c3ae0-d48f-4cd9-b698-52b19369a5ca</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="357" Volume="1981" Year="1998" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="357" Volume="1981" Year="1998">
       <Id>41185e73-0b01-4b28-adec-10f8de506c23</Id>
     </Book>
-    <Book Series="X-Men" Number="77" Volume="1991" Year="1998" Format="Main Series">
+    <Book Series="X-Men" Number="77" Volume="1991" Year="1998">
       <Id>f46fa652-0a3c-4b6e-aa86-c6b26aece896</Id>
     </Book>
-    <Book Series="X-Men" Number="78" Volume="1991" Year="1998" Format="Main Series">
+    <Book Series="X-Men" Number="78" Volume="1991" Year="1998">
       <Id>21922a2a-2347-49ea-9cd1-ca69317fbe9a</Id>
     </Book>
-    <Book Series="X-Man" Number="41" Volume="1995" Year="1998" Format="Main Series">
+    <Book Series="X-Man" Number="41" Volume="1995" Year="1998">
       <Id>8a79fd7e-6dce-41f4-bfdb-9dbc286fc70b</Id>
     </Book>
-    <Book Series="Cable" Number="57" Volume="1993" Year="1998" Format="Main Series">
+    <Book Series="Cable" Number="57" Volume="1993" Year="1998">
       <Id>cb105a6e-399c-48bb-9002-d50f1e6efc72</Id>
     </Book>
-    <Book Series="Cable" Number="58" Volume="1993" Year="1998" Format="Main Series">
+    <Book Series="Cable" Number="58" Volume="1993" Year="1998">
       <Id>fda4b505-53e4-44d6-85e5-b3d3d2ede0e2</Id>
     </Book>
-    <Book Series="Generation X" Number="42" Volume="1994" Year="1998" Format="Main Series">
+    <Book Series="Generation X" Number="42" Volume="1994" Year="1998">
       <Id>4415b357-d8aa-48a7-a292-9baef4fad026</Id>
     </Book>
-    <Book Series="Generation X" Number="43" Volume="1994" Year="1998" Format="Main Series">
+    <Book Series="Generation X" Number="43" Volume="1994" Year="1998">
       <Id>73e2dcd5-5a0c-4a33-a90c-808e5a3e22eb</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="358" Volume="1981" Year="1998" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="358" Volume="1981" Year="1998">
       <Id>c558f881-2a0e-4c16-90d5-79580a6c197e</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="20" Volume="1993" Year="1998" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="20" Volume="1993" Year="1998">
       <Id>4b31388b-fa66-4d7c-b04c-e976dc1a0604</Id>
     </Book>
-    <Book Series="X-Man / Hulk Annual '98" Number="1" Volume="1998" Year="1998" Format="Annual">
+    <Book Series="X-Man / Hulk Annual '98" Number="1" Volume="1998" Year="1998">
       <Id>9d0c3c0a-7176-42a9-b292-ec205702df8e</Id>
     </Book>
-    <Book Series="Excalibur" Number="124" Volume="1988" Year="1998" Format="Main Series">
+    <Book Series="Excalibur" Number="124" Volume="1988" Year="1998">
       <Id>2cb95614-6c74-41a6-9bdc-cdf30927e808</Id>
     </Book>
-    <Book Series="Excalibur" Number="125" Volume="1988" Year="1998" Format="Main Series">
+    <Book Series="Excalibur" Number="125" Volume="1988" Year="1998">
       <Id>06416ddf-2aff-4e60-8bc9-ce4879fbf3ff</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="359" Volume="1981" Year="1998" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="359" Volume="1981" Year="1998">
       <Id>4e8a1865-efaa-4668-bbcb-faf9ab81adc3</Id>
     </Book>
-    <Book Series="X-Factor" Number="148" Volume="1986" Year="1998" Format="Main Series">
+    <Book Series="X-Factor" Number="148" Volume="1986" Year="1998">
       <Id>9663705b-3b46-435d-ae66-31d7925e8205</Id>
     </Book>
-    <Book Series="X-Factor" Number="149" Volume="1986" Year="1998" Format="Main Series">
+    <Book Series="X-Factor" Number="149" Volume="1986" Year="1998">
       <Id>06422618-417d-4d4c-ba30-659ca7a69297</Id>
     </Book>
-    <Book Series="Uncanny X-Men / Fantastic Four Annual '98" Number="1" Volume="1998" Year="1998" Format="Annual">
+    <Book Series="Uncanny X-Men / Fantastic Four Annual '98" Number="1" Volume="1998" Year="1998">
       <Id>87d43f87-1286-45eb-9b1e-a164a3e4d9a4</Id>
     </Book>
-    <Book Series="X-Men" Number="79" Volume="1991" Year="1998" Format="Main Series">
+    <Book Series="X-Men" Number="79" Volume="1991" Year="1998">
       <Id>74227829-a9bb-43b7-bbcb-30f0dabd965e</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="21" Volume="1993" Year="1998" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="21" Volume="1993" Year="1998">
       <Id>204d4bca-4d61-463a-8527-04abea1ef938</Id>
     </Book>
-    <Book Series="Cable" Number="59" Volume="1993" Year="1998" Format="Main Series">
+    <Book Series="Cable" Number="59" Volume="1993" Year="1998">
       <Id>9d3f9831-b429-4cfc-abe6-9d84264151b2</Id>
     </Book>
-    <Book Series="Cable" Number="60" Volume="1993" Year="1998" Format="Main Series">
+    <Book Series="Cable" Number="60" Volume="1993" Year="1998">
       <Id>c7aeb710-dcd8-4497-8490-418d716b0255</Id>
     </Book>
-    <Book Series="Cable" Number="61" Volume="1993" Year="1998" Format="Main Series">
+    <Book Series="Cable" Number="61" Volume="1993" Year="1998">
       <Id>b3d12a51-6cf0-4a9c-8b32-b2641beeabd8</Id>
     </Book>
-    <Book Series="Cable" Number="62" Volume="1993" Year="1998" Format="Main Series">
+    <Book Series="Cable" Number="62" Volume="1993" Year="1998">
       <Id>5ab49a16-acb9-4195-b59b-8f0418a1f03d</Id>
     </Book>
-    <Book Series="X-Force" Number="83" Volume="1991" Year="1998" Format="Main Series">
+    <Book Series="X-Force" Number="83" Volume="1991" Year="1998">
       <Id>6f215df3-3c02-49e7-8ab1-41715d365f44</Id>
     </Book>
-    <Book Series="X-Force" Number="84" Volume="1991" Year="1998" Format="Main Series">
+    <Book Series="X-Force" Number="84" Volume="1991" Year="1998">
       <Id>3669c6b4-5c31-46ae-8c95-2de21a9b8331</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="360" Volume="1981" Year="1998" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="360" Volume="1981" Year="1998">
       <Id>8d37def8-f6e4-4610-9c2f-8e07002bae38</Id>
     </Book>
-    <Book Series="X-Men" Number="80" Volume="1991" Year="1998" Format="Main Series">
+    <Book Series="X-Men" Number="80" Volume="1991" Year="1998">
       <Id>2ba8963b-1af9-4176-bbcb-61b6adb827a0</Id>
     </Book>
-    <Book Series="Generation X" Number="44" Volume="1994" Year="1998" Format="Main Series">
+    <Book Series="Generation X" Number="44" Volume="1994" Year="1998">
       <Id>f3428186-76c1-4740-bec7-1f49414198f4</Id>
     </Book>
-    <Book Series="Generation X" Number="45" Volume="1994" Year="1998" Format="Main Series">
+    <Book Series="Generation X" Number="45" Volume="1994" Year="1998">
       <Id>763bf697-550a-4ca3-a6d0-33c25c9d3272</Id>
     </Book>
-    <Book Series="Generation X" Number="46" Volume="1994" Year="1998" Format="Main Series">
+    <Book Series="Generation X" Number="46" Volume="1994" Year="1998">
       <Id>02ab9ecb-47fd-4e50-8396-4b51c91c540d</Id>
     </Book>
-    <Book Series="Generation X" Number="47" Volume="1994" Year="1999" Format="Main Series">
+    <Book Series="Generation X" Number="47" Volume="1994" Year="1999">
       <Id>9c288e34-9691-4e72-8b8f-a74a7ea16f59</Id>
     </Book>
-    <Book Series="X-Force" Number="85" Volume="1991" Year="1999" Format="Main Series">
+    <Book Series="X-Force" Number="85" Volume="1991" Year="1999">
       <Id>3bb3c6f7-75bf-4071-94e1-112aad93b5ca</Id>
     </Book>
-    <Book Series="X-Force / Champions Annual '98" Number="98" Volume="1998" Year="1998" Format="Annual">
+    <Book Series="X-Force / Champions Annual '98" Number="98" Volume="1998" Year="1998">
       <Id>4805d585-f179-4a10-8760-89eb3befac38</Id>
     </Book>
-    <Book Series="X-Man" Number="42" Volume="1995" Year="1998" Format="Main Series">
+    <Book Series="X-Man" Number="42" Volume="1995" Year="1998">
       <Id>2826f7c3-68fa-4b30-bc33-0b47a54270e3</Id>
     </Book>
-    <Book Series="X-Man" Number="43" Volume="1995" Year="1998" Format="Main Series">
+    <Book Series="X-Man" Number="43" Volume="1995" Year="1998">
       <Id>80cb8573-2aa2-4b75-87f0-f9d54e73c6cc</Id>
     </Book>
-    <Book Series="X-Man" Number="44" Volume="1995" Year="1998" Format="Main Series">
+    <Book Series="X-Man" Number="44" Volume="1995" Year="1998">
       <Id>90e63aac-627d-473e-9b11-89c998d3003c</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="361" Volume="1981" Year="1998" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="361" Volume="1981" Year="1998">
       <Id>24d8ac68-b1ca-4240-afa7-2d3507a1d036</Id>
     </Book>
-    <Book Series="X-Men" Number="81" Volume="1991" Year="1998" Format="Main Series">
+    <Book Series="X-Men" Number="81" Volume="1991" Year="1998">
       <Id>eb36fec1-28cb-4e43-a567-a022d335d204</Id>
     </Book>
-    <Book Series="Wolverine" Number="131" Volume="1988" Year="1998" Format="Main Series">
+    <Book Series="Wolverine" Number="131" Volume="1988" Year="1998">
       <Id>2ff1a4f1-a297-453e-91db-3c5e86a5eef0</Id>
     </Book>
-    <Book Series="Wolverine" Number="132" Volume="1988" Year="1998" Format="Main Series">
+    <Book Series="Wolverine" Number="132" Volume="1988" Year="1998">
       <Id>a1dba5d0-dbcc-476a-ac28-d8dc944dcffc</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="362" Volume="1981" Year="1998" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="362" Volume="1981" Year="1998">
       <Id>34d18f96-0ac0-4aff-b60c-b2517ac898a3</Id>
     </Book>
-    <Book Series="X-Men" Number="82" Volume="1991" Year="1998" Format="Main Series">
+    <Book Series="X-Men" Number="82" Volume="1991" Year="1998">
       <Id>682b79c5-0c59-4123-b57f-4f7991e49cb7</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="363" Volume="1981" Year="1999" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="363" Volume="1981" Year="1999">
       <Id>7db9e73b-77c8-4655-8dbb-5d8e3e1a4653</Id>
     </Book>
-    <Book Series="X-Men" Number="83" Volume="1991" Year="1999" Format="Main Series">
+    <Book Series="X-Men" Number="83" Volume="1991" Year="1999">
       <Id>a34f3117-5d0f-4180-93fe-cc695cd5a6b4</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="364" Volume="1981" Year="1999" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="364" Volume="1981" Year="1999">
       <Id>37c2a933-f28a-4a45-bf7b-082d57d8ac14</Id>
     </Book>
-    <Book Series="X-Men" Number="84" Volume="1991" Year="1999" Format="Main Series">
+    <Book Series="X-Men" Number="84" Volume="1991" Year="1999">
       <Id>170bd29e-e06e-48d6-963b-ba357b511d3f</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="22" Volume="1993" Year="1999" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="22" Volume="1993" Year="1999">
       <Id>2314fff2-7b76-4629-ab55-ab1e51ed344a</Id>
     </Book>
-    <Book Series="X-Men / Dr. Doom Annual '98" Number="1" Volume="1998" Year="1998" Format="Annual">
+    <Book Series="X-Men / Dr. Doom Annual '98" Number="1" Volume="1998" Year="1998">
       <Id>514d700f-fca8-4592-8664-7f9156eeaf58</Id>
     </Book>
-    <Book Series="Wolverine" Number="133" Volume="1988" Year="1999" Format="Main Series">
+    <Book Series="Wolverine" Number="133" Volume="1988" Year="1999">
       <Id>2f0d2919-3d7b-4d52-81b1-1fdc0d602b3d</Id>
     </Book>
-    <Book Series="Wolverine" Number="134" Volume="1988" Year="1999" Format="Main Series">
+    <Book Series="Wolverine" Number="134" Volume="1988" Year="1999">
       <Id>f36f8688-d9fb-4739-8668-bf1af65a9671</Id>
     </Book>
-    <Book Series="Wolverine" Number="135" Volume="1988" Year="1999" Format="Main Series">
+    <Book Series="Wolverine" Number="135" Volume="1988" Year="1999">
       <Id>99e9ba00-de93-43f1-a308-bbaa9a8ddf5c</Id>
     </Book>
-    <Book Series="Wolverine" Number="136" Volume="1988" Year="1999" Format="Main Series">
+    <Book Series="Wolverine" Number="136" Volume="1988" Year="1999">
       <Id>b4471f0f-3826-4f99-aa5c-b5e1637080cd</Id>
     </Book>
-    <Book Series="Wolverine" Number="137" Volume="1988" Year="1999" Format="Main Series">
+    <Book Series="Wolverine" Number="137" Volume="1988" Year="1999">
       <Id>f338baee-ee3d-473e-a239-9b3504da6d0c</Id>
     </Book>
-    <Book Series="Wolverine" Number="138" Volume="1988" Year="1999" Format="Main Series">
+    <Book Series="Wolverine" Number="138" Volume="1988" Year="1999">
       <Id>39076393-71da-4f95-8ad0-8558ec401347</Id>
     </Book>
-    <Book Series="X-Force" Number="86" Volume="1991" Year="1999" Format="Main Series">
+    <Book Series="X-Force" Number="86" Volume="1991" Year="1999">
       <Id>4fb9e603-efe6-4c15-87e9-935b45571151</Id>
     </Book>
-    <Book Series="X-Man" Number="45" Volume="1995" Year="1998" Format="Main Series">
+    <Book Series="X-Man" Number="45" Volume="1995" Year="1998">
       <Id>28d24dcb-e34f-4ad6-80a3-8ad014f3b1c7</Id>
     </Book>
-    <Book Series="X-Man" Number="46" Volume="1995" Year="1999" Format="Main Series">
+    <Book Series="X-Man" Number="46" Volume="1995" Year="1999">
       <Id>91eaac41-844e-4c8c-97dc-b0423d8d3eb7</Id>
     </Book>
-    <Book Series="Cable" Number="63" Volume="1993" Year="1999" Format="Main Series">
+    <Book Series="Cable" Number="63" Volume="1993" Year="1999">
       <Id>87196378-3155-4ea3-bb18-34f665bba64c</Id>
     </Book>
-    <Book Series="X-Man" Number="47" Volume="1995" Year="1999" Format="Main Series">
+    <Book Series="X-Man" Number="47" Volume="1995" Year="1999">
       <Id>5eb9b271-3b6b-4d66-928e-29b3dc1c344b</Id>
     </Book>
-    <Book Series="Wolverine Annual 1999" Number="1" Volume="1999" Year="1999" Format="Annual">
+    <Book Series="Wolverine Annual 1999" Number="1" Volume="1999" Year="1999">
       <Id>d2a38dd7-f2a2-4037-b6d1-154253e12052</Id>
     </Book>
-    <Book Series="Wolverine" Number="139" Volume="1988" Year="1999" Format="Main Series">
+    <Book Series="Wolverine" Number="139" Volume="1988" Year="1999">
       <Id>d11e3877-870a-4d7e-bbd4-092017b65d07</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="365" Volume="1981" Year="1999" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="365" Volume="1981" Year="1999">
       <Id>0c5d19f9-624c-4f3d-ab99-a2e45c543a01</Id>
     </Book>
-    <Book Series="Cable" Number="64" Volume="1993" Year="1999" Format="Main Series">
+    <Book Series="Cable" Number="64" Volume="1993" Year="1999">
       <Id>a729336a-364d-43a9-8d66-33607efecf87</Id>
     </Book>
-    <Book Series="Gambit" Number="1" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Gambit" Number="1" Volume="1999" Year="1999">
       <Id>aa2bcc35-8696-4ddb-a6a8-cd4d4b280765</Id>
     </Book>
-    <Book Series="Generation X / Dracula Annual '98" Number="1" Volume="1998" Year="1998" Format="Annual">
+    <Book Series="Generation X / Dracula Annual '98" Number="1" Volume="1998" Year="1998">
       <Id>cea6c93c-b9c6-494f-8e07-2bd3bf9c2d25</Id>
     </Book>
-    <Book Series="Generation X" Number="48" Volume="1994" Year="1999" Format="Main Series">
+    <Book Series="Generation X" Number="48" Volume="1994" Year="1999">
       <Id>ed2fc8bb-1067-4b21-a0e6-dce10b4eea6a</Id>
     </Book>
-    <Book Series="Generation X" Number="49" Volume="1994" Year="1999" Format="Main Series">
+    <Book Series="Generation X" Number="49" Volume="1994" Year="1999">
       <Id>3f75652a-4f60-4ae6-a138-7a98058688f5</Id>
     </Book>
-    <Book Series="X-Man" Number="48" Volume="1995" Year="1999" Format="Main Series">
+    <Book Series="X-Man" Number="48" Volume="1995" Year="1999">
       <Id>40776cb1-ccd3-4093-97a0-e50d290b034c</Id>
     </Book>
-    <Book Series="X-Man" Number="49" Volume="1995" Year="1999" Format="Main Series">
+    <Book Series="X-Man" Number="49" Volume="1995" Year="1999">
       <Id>fe837312-189a-4ac8-8197-ef07588fa7ad</Id>
     </Book>
-    <Book Series="Cable" Number="65" Volume="1993" Year="1999" Format="Main Series">
+    <Book Series="Cable" Number="65" Volume="1993" Year="1999">
       <Id>fb6bc689-1ae1-4f80-bd4c-6d021fbb9556</Id>
     </Book>
   </Books>

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 007.cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 007.cbl
@@ -1,885 +1,886 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>X-Men - Part 7</Name>
+  <Name>X-Men - Part 007</Name>
+  <NumIssues>293</NumIssues>
   <Books>
     <Book Series="X-Men" Number="85" Volume="1991" Year="1999">
-      <Id>99aa26bb-fbf4-45a8-8bfa-6bce5e9f12ab</Id>
+      <Database Name="cv" Series="4605" Issue="65784" />
     </Book>
     <Book Series="X-Men: Magneto War" Number="1" Volume="1999" Year="1999">
-      <Id>e7863bbf-be45-4cb5-ab46-c2aa9834e55e</Id>
+      <Database Name="cv" Series="21069" Issue="126243" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="366" Volume="1981" Year="1999">
-      <Id>e55cecf8-0bc4-4dbc-82f7-59a0b8e58310</Id>
+      <Database Name="cv" Series="3092" Issue="45736" />
     </Book>
     <Book Series="X-Men" Number="86" Volume="1991" Year="1999">
-      <Id>c09ea68f-df18-4a20-b37e-71b4475f099b</Id>
+      <Database Name="cv" Series="4605" Issue="65785" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="367" Volume="1981" Year="1999">
-      <Id>29420292-a224-4e75-a25d-ab800b2b8d64</Id>
+      <Database Name="cv" Series="3092" Issue="45785" />
     </Book>
     <Book Series="X-Men" Number="87" Volume="1991" Year="1999">
-      <Id>05c39225-ce6e-4565-81dd-84a9ca468950</Id>
+      <Database Name="cv" Series="4605" Issue="65786" />
     </Book>
     <Book Series="Cable" Number="66" Volume="1993" Year="1999">
-      <Id>108197a2-d29c-4c30-80e0-28b8427c5440</Id>
+      <Database Name="cv" Series="4993" Issue="65645" />
     </Book>
     <Book Series="Cable" Number="67" Volume="1993" Year="1999">
-      <Id>a31abfce-4a3e-41a9-ae65-edcbd17d5196</Id>
+      <Database Name="cv" Series="4993" Issue="113729" />
     </Book>
     <Book Series="Cable" Number="68" Volume="1993" Year="1999">
-      <Id>033cd58c-ee1b-439d-bc9c-8cb392ac231d</Id>
+      <Database Name="cv" Series="4993" Issue="65646" />
     </Book>
     <Book Series="Cable" Number="69" Volume="1993" Year="1999">
-      <Id>574980cd-fd1d-448f-a9cb-c30965449010</Id>
+      <Database Name="cv" Series="4993" Issue="65647" />
     </Book>
     <Book Series="Cable" Number="70" Volume="1993" Year="1999">
-      <Id>70097f9d-f41e-4fa8-8c96-5561d1d88d96</Id>
+      <Database Name="cv" Series="4993" Issue="65648" />
     </Book>
     <Book Series="Generation X" Number="50" Volume="1994" Year="1999">
-      <Id>088fcb05-ac06-4841-9352-953215e8b79a</Id>
+      <Database Name="cv" Series="5300" Issue="83115" />
     </Book>
     <Book Series="X-Man" Number="50" Volume="1995" Year="1999">
-      <Id>6304c23b-0cd2-4d9a-be0e-8d0893dbfeb1</Id>
+      <Database Name="cv" Series="5567" Issue="45771" />
     </Book>
     <Book Series="X-Man" Number="51" Volume="1995" Year="1999">
-      <Id>abc6773c-a98f-488c-b901-e69acd847950</Id>
+      <Database Name="cv" Series="5567" Issue="74573" />
     </Book>
     <Book Series="X-Man" Number="52" Volume="1995" Year="1999">
-      <Id>b6282e69-c2f6-4583-bf55-e4f6f5bd8e36</Id>
+      <Database Name="cv" Series="5567" Issue="74574" />
     </Book>
     <Book Series="Generation X" Number="51" Volume="1994" Year="1999">
-      <Id>0c3d8e42-d717-46be-9742-7801bfae4ed2</Id>
+      <Database Name="cv" Series="5300" Issue="83116" />
     </Book>
     <Book Series="X-Men Unlimited" Number="23" Volume="1993" Year="1999">
-      <Id>9317ab2e-5858-49fb-912b-5cdfe7bdd3c6</Id>
+      <Database Name="cv" Series="5066" Issue="70496" />
     </Book>
     <Book Series="X-Force" Number="87" Volume="1991" Year="1999">
-      <Id>cd8ea8cd-4b2d-40f7-a9a8-fb189aea1f93</Id>
+      <Database Name="cv" Series="4604" Issue="64558" />
     </Book>
     <Book Series="X-Force" Number="88" Volume="1991" Year="1999">
-      <Id>c6a57ad3-86e0-4328-824f-0bcb5995b8fd</Id>
+      <Database Name="cv" Series="4604" Issue="64559" />
     </Book>
     <Book Series="X-Force" Number="89" Volume="1991" Year="1999">
-      <Id>e5773400-2161-469d-b648-ff704c0a2b95</Id>
+      <Database Name="cv" Series="4604" Issue="64560" />
     </Book>
     <Book Series="X-Force" Number="90" Volume="1991" Year="1999">
-      <Id>1245025a-2ee8-4528-b474-8d1987e4e289</Id>
+      <Database Name="cv" Series="4604" Issue="64561" />
     </Book>
     <Book Series="Gambit" Number="2" Volume="1999" Year="1999">
-      <Id>3079b504-42d8-46b5-a61f-e436b45c2ed6</Id>
+      <Database Name="cv" Series="9111" Issue="66891" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="368" Volume="1981" Year="1999">
-      <Id>08efbea8-01c3-41d0-973d-247ab5b8f138</Id>
+      <Database Name="cv" Series="3092" Issue="45834" />
     </Book>
     <Book Series="X-Men" Number="88" Volume="1991" Year="1999">
-      <Id>eda79271-1d97-40af-9480-7609ac752c32</Id>
+      <Database Name="cv" Series="4605" Issue="65787" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="369" Volume="1981" Year="1999">
-      <Id>d5a2c2eb-1504-4bf1-bdab-7420862e0e08</Id>
+      <Database Name="cv" Series="3092" Issue="45878" />
     </Book>
     <Book Series="Magneto Rex" Number="1" Volume="1999" Year="1999">
-      <Id>cee9486a-ad56-452d-aa64-ee1f7bbc4b55</Id>
+      <Database Name="cv" Series="20474" Issue="122575" />
     </Book>
     <Book Series="Magneto Rex" Number="2" Volume="1999" Year="1999">
-      <Id>6a0e24f3-9f0e-4f76-899f-4610674ce701</Id>
+      <Database Name="cv" Series="20474" Issue="122578" />
     </Book>
     <Book Series="Magneto Rex" Number="3" Volume="1999" Year="1999">
-      <Id>7f85f77e-e19e-4f52-af82-2ad2bd8401ad</Id>
+      <Database Name="cv" Series="20474" Issue="122579" />
     </Book>
     <Book Series="X-Man" Number="53" Volume="1995" Year="1999">
-      <Id>288d2bc8-01cf-4966-8b7d-d09483cd5c26</Id>
+      <Database Name="cv" Series="5567" Issue="74575" />
     </Book>
     <Book Series="X-Man" Number="54" Volume="1995" Year="1999">
-      <Id>67b84a5d-743d-4634-81fd-848388054e28</Id>
+      <Database Name="cv" Series="5567" Issue="132382" />
     </Book>
     <Book Series="X-Man" Number="55" Volume="1995" Year="1999">
-      <Id>a185cbdb-1c3e-45a4-9f27-2c2fe5578cc2</Id>
+      <Database Name="cv" Series="5567" Issue="132383" />
     </Book>
     <Book Series="X-Men" Number="89" Volume="1991" Year="1999">
-      <Id>1486741c-72f3-44a5-a4a2-f77367360903</Id>
+      <Database Name="cv" Series="4605" Issue="65788" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="370" Volume="1981" Year="1999">
-      <Id>bef079fc-5cbe-45e4-89bb-c0836aac3c72</Id>
+      <Database Name="cv" Series="3092" Issue="65136" />
     </Book>
     <Book Series="X-Men" Number="90" Volume="1991" Year="1999">
-      <Id>8d147102-70d5-44ac-a10a-54280a04dfc6</Id>
+      <Database Name="cv" Series="4605" Issue="65789" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="371" Volume="1981" Year="1999">
-      <Id>84c64f56-dad5-42a6-a238-210859156ec2</Id>
+      <Database Name="cv" Series="3092" Issue="65137" />
     </Book>
     <Book Series="X-Men" Number="91" Volume="1991" Year="1999">
-      <Id>7829738a-283c-46c4-b767-8cf628f64370</Id>
+      <Database Name="cv" Series="4605" Issue="65790" />
     </Book>
-    <Book Series="X-Men Annual 1999" Number="1" Volume="1999" Year="1999">
-      <Id>95578fa3-78a7-435c-87bc-e90f04b4d1ff</Id>
+    <Book Series="X-Men 1999" Number="1" Volume="1999" Year="1999">
+      <Database Name="cv" Series="60463" Issue="156744" />
     </Book>
     <Book Series="Generation X" Number="52" Volume="1994" Year="1999">
-      <Id>065e58dc-0892-46bf-bd25-481833257f2c</Id>
+      <Database Name="cv" Series="5300" Issue="83117" />
     </Book>
     <Book Series="Wolverine" Number="140" Volume="1988" Year="1999">
-      <Id>21ceea86-51aa-4268-96da-978de94af267</Id>
+      <Database Name="cv" Series="4250" Issue="51207" />
     </Book>
     <Book Series="X-Men Unlimited" Number="24" Volume="1993" Year="1999">
-      <Id>d303ff4c-628b-4616-9dcf-cf2fc8c778c0</Id>
+      <Database Name="cv" Series="5066" Issue="70497" />
     </Book>
     <Book Series="X-Force" Number="91" Volume="1991" Year="1999">
-      <Id>249b130c-b37f-4010-b9a0-366c603397b9</Id>
+      <Database Name="cv" Series="4604" Issue="64562" />
     </Book>
     <Book Series="X-Force" Number="92" Volume="1991" Year="1999">
-      <Id>a7a0b13d-8c4f-49d6-ab21-64d9f4da6edb</Id>
+      <Database Name="cv" Series="4604" Issue="64563" />
     </Book>
     <Book Series="X-Force" Number="93" Volume="1991" Year="1999">
-      <Id>fceef34d-1f02-498d-a452-98df762739c4</Id>
+      <Database Name="cv" Series="4604" Issue="64564" />
     </Book>
     <Book Series="Gambit" Number="3" Volume="1999" Year="1999">
-      <Id>8cc0c332-64c1-4fae-a66c-4eebdddd6874</Id>
+      <Database Name="cv" Series="9111" Issue="135212" />
     </Book>
     <Book Series="Gambit" Number="4" Volume="1999" Year="1999">
-      <Id>bef2e696-78ed-4965-8dcc-5c533356dd31</Id>
+      <Database Name="cv" Series="9111" Issue="66892" />
     </Book>
     <Book Series="Gambit" Number="5" Volume="1999" Year="1999">
-      <Id>335e2e4f-2ea9-4729-86d1-23d488244203</Id>
+      <Database Name="cv" Series="9111" Issue="66893" />
     </Book>
     <Book Series="Generation X" Number="53" Volume="1994" Year="1999">
-      <Id>ae612fee-0dee-44b4-9481-ef20cded857a</Id>
+      <Database Name="cv" Series="5300" Issue="83118" />
     </Book>
     <Book Series="Generation X" Number="54" Volume="1994" Year="1999">
-      <Id>3415b1b6-619d-4bd4-83f8-2136491f6575</Id>
+      <Database Name="cv" Series="5300" Issue="83119" />
     </Book>
     <Book Series="Generation X" Number="55" Volume="1994" Year="1999">
-      <Id>e49e6545-859f-4be0-99ad-e8f984169860</Id>
+      <Database Name="cv" Series="5300" Issue="83120" />
     </Book>
     <Book Series="Generation X" Number="56" Volume="1994" Year="1999">
-      <Id>36296946-66d9-4b58-ab7f-f37449c00743</Id>
+      <Database Name="cv" Series="5300" Issue="83121" />
     </Book>
     <Book Series="Generation X" Number="57" Volume="1994" Year="1999">
-      <Id>cc53e2e0-ddd3-4fad-acdb-1d487fd047d7</Id>
+      <Database Name="cv" Series="5300" Issue="83122" />
     </Book>
     <Book Series="Wolverine" Number="141" Volume="1988" Year="1999">
-      <Id>24d9ed0e-f6b1-416d-9b30-be45c8ff2439</Id>
+      <Database Name="cv" Series="4250" Issue="51208" />
     </Book>
     <Book Series="Wolverine" Number="142" Volume="1988" Year="1999">
-      <Id>3b344513-a67f-4601-8e4e-4af2926b7696</Id>
+      <Database Name="cv" Series="4250" Issue="51209" />
     </Book>
     <Book Series="Wolverine" Number="143" Volume="1988" Year="1999">
-      <Id>f55781ef-fef1-473f-b6c5-9484539a55a2</Id>
+      <Database Name="cv" Series="4250" Issue="51210" />
     </Book>
     <Book Series="Wolverine" Number="144" Volume="1988" Year="1999">
-      <Id>d73e5641-10f7-4b59-b49e-fc64437cf093</Id>
+      <Database Name="cv" Series="4250" Issue="51211" />
     </Book>
     <Book Series="Generation X" Number="58" Volume="1994" Year="1999">
-      <Id>7ca94765-3dd5-430c-82a9-5b01aa7fcdce</Id>
+      <Database Name="cv" Series="5300" Issue="83123" />
     </Book>
     <Book Series="X-Force" Number="94" Volume="1991" Year="1999">
-      <Id>813564c7-d5e2-49d2-bec4-f97cded8d24d</Id>
+      <Database Name="cv" Series="4604" Issue="64565" />
     </Book>
     <Book Series="X-Force" Number="95" Volume="1991" Year="1999">
-      <Id>bc78bbec-9c61-4dd8-9112-8c2141e2adaa</Id>
+      <Database Name="cv" Series="4604" Issue="64566" />
     </Book>
-    <Book Series="X-Force Annual 1999" Number="1" Volume="1999" Year="1999">
-      <Id>21eaa074-285c-48b2-9e19-5a3e94eec56d</Id>
+    <Book Series="X-Force 1999" Number="1" Volume="1999" Year="1999">
+      <Database Name="cv" Series="22686" Issue="136060" />
     </Book>
     <Book Series="X-Force" Number="96" Volume="1991" Year="1999">
-      <Id>5dea15b1-f42e-403d-95b0-85d6049cb8ee</Id>
+      <Database Name="cv" Series="4604" Issue="64567" />
     </Book>
     <Book Series="X-Force" Number="97" Volume="1991" Year="1999">
-      <Id>6626867e-1b09-4f16-ae78-07d964d3e0c0</Id>
+      <Database Name="cv" Series="4604" Issue="64568" />
     </Book>
-    <Book Series="Cable Annual 1999" Number="1" Volume="1999" Year="1999">
-      <Id>1797e0ec-8a1b-4216-a765-86c5a46450c0</Id>
+    <Book Series="Cable 1999" Number="1" Volume="1999" Year="1999">
+      <Database Name="cv" Series="20140" Issue="120198" />
     </Book>
     <Book Series="Cable" Number="71" Volume="1993" Year="1999">
-      <Id>f32bf9e5-bdfe-4934-9e44-ac2020e0f758</Id>
+      <Database Name="cv" Series="4993" Issue="65649" />
     </Book>
     <Book Series="Gambit" Number="6" Volume="1999" Year="1999">
-      <Id>08fb9f9e-a059-4cc0-96f9-90d9ac6e546a</Id>
+      <Database Name="cv" Series="9111" Issue="66894" />
     </Book>
     <Book Series="Gambit" Number="7" Volume="1999" Year="1999">
-      <Id>77a9a134-6e3e-4981-aef5-0c3ab97eac44</Id>
+      <Database Name="cv" Series="9111" Issue="66895" />
     </Book>
-    <Book Series="Gambit Annual 1999" Number="1" Volume="1999" Year="1999">
-      <Id>51ae1221-2eff-4034-9dbd-69f255cd1490</Id>
+    <Book Series="Gambit 1999" Number="1" Volume="1999" Year="1999">
+      <Database Name="cv" Series="22700" Issue="136123" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="372" Volume="1981" Year="1999">
-      <Id>fed52782-c7f7-40ac-afd0-51883ebcfa87</Id>
+      <Database Name="cv" Series="3092" Issue="65138" />
     </Book>
     <Book Series="X-Men" Number="92" Volume="1991" Year="1999">
-      <Id>78bf8a6b-f221-40a5-a727-13b349d6de5a</Id>
+      <Database Name="cv" Series="4605" Issue="65791" />
     </Book>
     <Book Series="Gambit" Number="8" Volume="1999" Year="1999">
-      <Id>8c092f12-8962-48d2-abef-eb936041a4e7</Id>
+      <Database Name="cv" Series="9111" Issue="66896" />
     </Book>
     <Book Series="Gambit" Number="9" Volume="1999" Year="1999">
-      <Id>d579a156-3cae-423c-b3e1-c3d0fe906ddb</Id>
+      <Database Name="cv" Series="9111" Issue="66897" />
     </Book>
     <Book Series="Astonishing X-Men" Number="1" Volume="1999" Year="1999">
-      <Id>cf0c2941-8b53-4062-9e0b-296d6675c2ba</Id>
+      <Database Name="cv" Series="18027" Issue="105554" />
     </Book>
     <Book Series="Astonishing X-Men" Number="2" Volume="1999" Year="1999">
-      <Id>5a4b73f9-2080-44a6-bc32-76d6f15eced9</Id>
+      <Database Name="cv" Series="18027" Issue="105591" />
     </Book>
     <Book Series="Astonishing X-Men" Number="3" Volume="1999" Year="1999">
-      <Id>d84d5447-a067-4953-aa26-ea02455c6919</Id>
+      <Database Name="cv" Series="18027" Issue="105592" />
     </Book>
-    <Book Series="Generation X Annual 1999" Number="1" Volume="1999" Year="1999">
-      <Id>39e5f7ee-0123-4cdb-b1f9-2c79185c1f20</Id>
+    <Book Series="Generation X 1999" Number="1" Volume="1999" Year="1999">
+      <Database Name="cv" Series="60446" Issue="123625" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="373" Volume="1981" Year="1999">
-      <Id>bb99aa3d-26eb-421d-b5b4-d0164f10b694</Id>
+      <Database Name="cv" Series="3092" Issue="150001" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="374" Volume="1981" Year="1999">
-      <Id>da73cbfc-8f51-4d10-8da9-2d447218ca1f</Id>
+      <Database Name="cv" Series="3092" Issue="65139" />
     </Book>
     <Book Series="X-Men" Number="93" Volume="1991" Year="1999">
-      <Id>032f75e9-4412-471c-9489-8766b05f09d3</Id>
+      <Database Name="cv" Series="4605" Issue="65792" />
     </Book>
     <Book Series="X-Men" Number="94" Volume="1991" Year="1999">
-      <Id>233ca281-b0f6-40bf-bdcf-f9abcca23300</Id>
+      <Database Name="cv" Series="4605" Issue="65793" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="375" Volume="1981" Year="1999">
-      <Id>cd48c969-b117-40b2-b418-a82a994b0836</Id>
+      <Database Name="cv" Series="3092" Issue="65140" />
     </Book>
     <Book Series="X-Men" Number="95" Volume="1991" Year="1999">
-      <Id>47fb24c9-60e1-48f0-a381-ae9cabf27cde</Id>
+      <Database Name="cv" Series="4605" Issue="65794" />
     </Book>
     <Book Series="X-Men Unlimited" Number="25" Volume="1993" Year="1999">
-      <Id>d110ebdc-ff17-4158-85ab-6b86e3147895</Id>
+      <Database Name="cv" Series="5066" Issue="70498" />
     </Book>
     <Book Series="Generation X" Number="59" Volume="1994" Year="2000">
-      <Id>77bdfedb-1cca-46e5-9e60-ec62c746c2f1</Id>
+      <Database Name="cv" Series="5300" Issue="83124" />
     </Book>
     <Book Series="Gambit" Number="10" Volume="1999" Year="1999">
-      <Id>edb61f77-6b8b-4f2b-bab2-a45a4bd47060</Id>
+      <Database Name="cv" Series="9111" Issue="66898" />
     </Book>
     <Book Series="X-Man" Number="56" Volume="1995" Year="1999">
-      <Id>598f3ea5-3ef2-439d-9cc3-4a997a39d20c</Id>
+      <Database Name="cv" Series="5567" Issue="132384" />
     </Book>
     <Book Series="X-Man" Number="57" Volume="1995" Year="1999">
-      <Id>a7b0176a-d643-4eb8-b0bc-a58daab0181d</Id>
+      <Database Name="cv" Series="5567" Issue="132385" />
     </Book>
     <Book Series="X-Man" Number="58" Volume="1995" Year="1999">
-      <Id>5e32af29-86f4-4cac-af54-99f0e4e8bdbf</Id>
+      <Database Name="cv" Series="5567" Issue="132386" />
     </Book>
     <Book Series="Wolverine" Number="145" Volume="1988" Year="1999">
-      <Id>f1fc1fd5-2bba-45ac-b7c3-669d2614ddc9</Id>
+      <Database Name="cv" Series="4250" Issue="51212" />
     </Book>
     <Book Series="Cable" Number="72" Volume="1993" Year="1999">
-      <Id>e0f42e1c-526d-4006-b4c2-017fa47edab4</Id>
+      <Database Name="cv" Series="4993" Issue="65650" />
     </Book>
     <Book Series="Cable" Number="73" Volume="1993" Year="1999">
-      <Id>c1e1343a-818b-4ed0-a632-f6eec24692d6</Id>
+      <Database Name="cv" Series="4993" Issue="65651" />
     </Book>
     <Book Series="Cable" Number="74" Volume="1993" Year="1999">
-      <Id>fe7aedb2-b674-4418-bb41-cfd3fd10584a</Id>
+      <Database Name="cv" Series="4993" Issue="65652" />
     </Book>
     <Book Series="X-Men: Phoenix" Number="1" Volume="1999" Year="1999">
-      <Id>197b8ef1-06c5-4239-8c08-8332d0eab9ab</Id>
+      <Database Name="cv" Series="9200" Issue="135694" />
     </Book>
     <Book Series="X-Men: Phoenix" Number="2" Volume="1999" Year="2000">
-      <Id>d61daa36-ab93-4062-9951-59fbf7d38928</Id>
+      <Database Name="cv" Series="9200" Issue="135695" />
     </Book>
     <Book Series="X-Men: Phoenix" Number="3" Volume="1999" Year="2000">
-      <Id>8a52d473-be4b-4350-bc21-0e9ca285076a</Id>
+      <Database Name="cv" Series="9200" Issue="135696" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="376" Volume="1981" Year="2000">
-      <Id>f25ac862-ce2d-4d78-bb04-d8f4d85c56d5</Id>
+      <Database Name="cv" Series="3092" Issue="65141" />
     </Book>
     <Book Series="Cable" Number="75" Volume="1993" Year="2000">
-      <Id>c09058f8-7c41-483e-8360-76a9b1635297</Id>
+      <Database Name="cv" Series="4993" Issue="65653" />
     </Book>
     <Book Series="X-Man" Number="59" Volume="1995" Year="2000">
-      <Id>bc30ee98-0929-49b5-afa7-eb919a912864</Id>
+      <Database Name="cv" Series="5567" Issue="132387" />
     </Book>
     <Book Series="X-Men" Number="96" Volume="1991" Year="2000">
-      <Id>6920dff3-7983-4ab3-9a89-b5fd48c084c4</Id>
+      <Database Name="cv" Series="4605" Issue="65795" />
     </Book>
     <Book Series="Wolverine" Number="146" Volume="1988" Year="2000">
-      <Id>e531c36d-35f1-461d-befc-cc6744f5d454</Id>
+      <Database Name="cv" Series="4250" Issue="51213" />
     </Book>
     <Book Series="Wolverine" Number="147" Volume="1988" Year="2000">
-      <Id>1ac850d9-6e94-41c5-b535-54194f3a90a0</Id>
+      <Database Name="cv" Series="4250" Issue="51214" />
     </Book>
     <Book Series="X-Man" Number="60" Volume="1995" Year="2000">
-      <Id>ce7a4619-bf1e-4b58-8032-281f71a4c37e</Id>
+      <Database Name="cv" Series="5567" Issue="136073" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="377" Volume="1981" Year="2000">
-      <Id>6682b278-b7e5-4c4e-99c4-a043bab577c1</Id>
+      <Database Name="cv" Series="3092" Issue="65143" />
     </Book>
     <Book Series="Cable" Number="76" Volume="1993" Year="2000">
-      <Id>8cbdaf77-4fdc-45a2-9398-fe823fe31f29</Id>
+      <Database Name="cv" Series="4993" Issue="65654" />
     </Book>
     <Book Series="X-Men" Number="97" Volume="1991" Year="2000">
-      <Id>477657fa-b9c9-4e6d-a875-5125899c0e27</Id>
+      <Database Name="cv" Series="4605" Issue="65796" />
     </Book>
-    <Book Series="Uncanny X-Men Annual 1999" Number="1" Volume="1999" Year="2000">
-      <Id>640f0205-aa63-4b51-a3fc-4e0b6158fa7b</Id>
+    <Book Series="Uncanny X-Men 1999" Number="1" Volume="1999" Year="2000">
+      <Database Name="cv" Series="60492" Issue="136052" />
     </Book>
     <Book Series="Generation X" Number="60" Volume="1994" Year="2000">
-      <Id>af189672-f43c-46e3-95f6-d14c776e0031</Id>
+      <Database Name="cv" Series="5300" Issue="83125" />
     </Book>
     <Book Series="Generation X" Number="61" Volume="1994" Year="2000">
-      <Id>0fcda9d0-6cc8-492a-b69d-b5ae254940bf</Id>
+      <Database Name="cv" Series="5300" Issue="83126" />
     </Book>
     <Book Series="X-Force" Number="98" Volume="1991" Year="2000">
-      <Id>d8c0d175-c300-47fa-9d2e-2cf6a7890f23</Id>
+      <Database Name="cv" Series="4604" Issue="110432" />
     </Book>
     <Book Series="X-Force" Number="99" Volume="1991" Year="2000">
-      <Id>7893ccd6-fd77-48fa-a7e5-b24002cca88d</Id>
+      <Database Name="cv" Series="4604" Issue="64569" />
     </Book>
     <Book Series="X-Force" Number="100" Volume="1991" Year="2000">
-      <Id>73aa5601-3ed3-40d7-87c1-eb43985ff997</Id>
+      <Database Name="cv" Series="4604" Issue="64570" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="378" Volume="1981" Year="2000">
-      <Id>79209f01-4dd5-4d20-897d-358825f89d0d</Id>
+      <Database Name="cv" Series="3092" Issue="65145" />
     </Book>
     <Book Series="Cable" Number="77" Volume="1993" Year="2000">
-      <Id>6e9543ac-c60a-4e35-a4a2-132fc270ef6e</Id>
+      <Database Name="cv" Series="4993" Issue="65655" />
     </Book>
     <Book Series="X-Men Unlimited" Number="26" Volume="1993" Year="2000">
-      <Id>10063d14-347c-49ff-8e97-0b276e92f318</Id>
+      <Database Name="cv" Series="5066" Issue="106027" />
     </Book>
     <Book Series="Wolverine" Number="148" Volume="1988" Year="2000">
-      <Id>e527c456-b0e2-41d7-bc0f-21745b14ad9a</Id>
+      <Database Name="cv" Series="4250" Issue="51215" />
     </Book>
     <Book Series="X-Men" Number="98" Volume="1991" Year="2000">
-      <Id>06a2a9e5-d920-4e7d-99b9-2774788c4ec1</Id>
+      <Database Name="cv" Series="4605" Issue="65797" />
     </Book>
     <Book Series="X-Man" Number="61" Volume="1995" Year="2000">
-      <Id>a62c76b1-7502-479d-9a80-0c7ab27d258b</Id>
+      <Database Name="cv" Series="5567" Issue="132388" />
     </Book>
     <Book Series="X-Man" Number="62" Volume="1995" Year="2000">
-      <Id>81fee2a5-5bbe-4bea-a2f6-d3eac318406a</Id>
+      <Database Name="cv" Series="5567" Issue="132389" />
     </Book>
     <Book Series="Gambit" Number="11" Volume="1999" Year="1999">
-      <Id>09cb8364-dd1b-4e7d-b9af-255d6f539e8a</Id>
+      <Database Name="cv" Series="9111" Issue="66899" />
     </Book>
     <Book Series="Gambit" Number="12" Volume="1999" Year="2000">
-      <Id>062149f8-36e5-43cb-a355-88d1b96d8dab</Id>
+      <Database Name="cv" Series="9111" Issue="66900" />
     </Book>
     <Book Series="Gambit" Number="13" Volume="1999" Year="2000">
-      <Id>82c99bc3-91c0-4662-b1d6-d59f4f6e4345</Id>
+      <Database Name="cv" Series="9111" Issue="66901" />
     </Book>
     <Book Series="Gambit" Number="14" Volume="1999" Year="2000">
-      <Id>d139f086-9de1-44d8-a436-d32ef1ae0256</Id>
+      <Database Name="cv" Series="9111" Issue="66902" />
     </Book>
     <Book Series="X-Men: The Hellfire Club" Number="1" Volume="2000" Year="2000">
-      <Id>c11a609d-786d-45e8-b9d5-45af2bb7f229</Id>
+      <Database Name="cv" Series="22614" Issue="135742" />
     </Book>
     <Book Series="X-Men: The Hellfire Club" Number="2" Volume="2000" Year="2000">
-      <Id>1fa32845-dd68-480b-b3e9-3b04876e906b</Id>
+      <Database Name="cv" Series="22614" Issue="135746" />
     </Book>
     <Book Series="X-Men: The Hellfire Club" Number="3" Volume="2000" Year="2000">
-      <Id>f81ad50e-9491-49a1-9b05-1f30013bd842</Id>
+      <Database Name="cv" Series="22614" Issue="135747" />
     </Book>
     <Book Series="X-Men: The Hellfire Club" Number="4" Volume="2000" Year="2000">
-      <Id>5cda1931-0345-41f7-943d-26128d8b6c3a</Id>
+      <Database Name="cv" Series="22614" Issue="135748" />
     </Book>
     <Book Series="Gambit" Number="15" Volume="1999" Year="2000">
-      <Id>9b03b5db-3cb1-451e-a008-5506839bb93b</Id>
+      <Database Name="cv" Series="9111" Issue="66903" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="379" Volume="1981" Year="2000">
-      <Id>cf9bc9c4-014a-4e16-87fd-01ec75713b9c</Id>
+      <Database Name="cv" Series="3092" Issue="65148" />
     </Book>
     <Book Series="X-Force" Number="101" Volume="1991" Year="2000">
-      <Id>c06aa323-a799-4978-a847-4285453ba1ea</Id>
+      <Database Name="cv" Series="4604" Issue="64571" />
     </Book>
     <Book Series="Cable" Number="78" Volume="1993" Year="2000">
-      <Id>1f516e5e-4930-4fdd-8878-2851a9c71ec2</Id>
+      <Database Name="cv" Series="4993" Issue="65656" />
     </Book>
     <Book Series="Wolverine" Number="149" Volume="1988" Year="2000">
-      <Id>a42f26c9-8c60-46bc-9d51-2d7236db0327</Id>
+      <Database Name="cv" Series="4250" Issue="51216" />
     </Book>
     <Book Series="X-Men" Number="99" Volume="1991" Year="2000">
-      <Id>01a3eac1-0c79-4cb4-9dd2-833cbae3dd42</Id>
+      <Database Name="cv" Series="4605" Issue="65798" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="380" Volume="1981" Year="2000">
-      <Id>77f4e940-00f0-4eb7-b5c9-17344936346b</Id>
+      <Database Name="cv" Series="3092" Issue="65150" />
     </Book>
     <Book Series="Gambit" Number="16" Volume="1999" Year="2000">
-      <Id>78b7ae2e-0869-4a2e-8152-dd7c963b8b62</Id>
+      <Database Name="cv" Series="9111" Issue="66904" />
     </Book>
     <Book Series="Magneto Dark Seduction" Number="1" Volume="2000" Year="2000">
-      <Id>c7acaf26-d7b1-4c89-949f-7a87bcb226b4</Id>
+      <Database Name="cv" Series="20099" Issue="123857" />
     </Book>
     <Book Series="Magneto Dark Seduction" Number="2" Volume="2000" Year="2000">
-      <Id>cab3648a-f0dc-4d9a-bebb-88210f78b6d7</Id>
+      <Database Name="cv" Series="20099" Issue="123861" />
     </Book>
     <Book Series="Magneto Dark Seduction" Number="3" Volume="2000" Year="2000">
-      <Id>7f3ce95c-2c3e-4daf-910d-785e35acf010</Id>
+      <Database Name="cv" Series="20099" Issue="123750" />
     </Book>
     <Book Series="Magneto Dark Seduction" Number="4" Volume="2000" Year="2000">
-      <Id>61a88b92-6f8f-4b72-8c28-6d34f5f31c66</Id>
+      <Database Name="cv" Series="20099" Issue="119973" />
     </Book>
     <Book Series="Generation X" Number="62" Volume="1994" Year="2000">
-      <Id>fc77099d-9429-41e8-89e2-5287b85a4270</Id>
+      <Database Name="cv" Series="5300" Issue="83127" />
     </Book>
     <Book Series="Generation X" Number="63" Volume="1994" Year="2000">
-      <Id>4baf2fcf-7977-4af0-9f5f-e4cba2906634</Id>
+      <Database Name="cv" Series="5300" Issue="46672" />
     </Book>
     <Book Series="Generation X" Number="64" Volume="1994" Year="2000">
-      <Id>9b1c4ebc-c8e5-4fa8-9f1e-674fbe7ecb2f</Id>
+      <Database Name="cv" Series="5300" Issue="46673" />
     </Book>
     <Book Series="Generation X" Number="65" Volume="1994" Year="2000">
-      <Id>197ddaab-b15b-4b96-868a-68d69328bfc9</Id>
+      <Database Name="cv" Series="5300" Issue="46674" />
     </Book>
     <Book Series="Generation X" Number="66" Volume="1994" Year="2000">
-      <Id>1a434542-8f11-45b0-a002-5a149ce83354</Id>
+      <Database Name="cv" Series="5300" Issue="46675" />
     </Book>
     <Book Series="Generation X" Number="67" Volume="1994" Year="2000">
-      <Id>0d81333d-e6eb-4f98-ada8-5482957a555a</Id>
+      <Database Name="cv" Series="5300" Issue="46676" />
     </Book>
     <Book Series="Generation X" Number="68" Volume="1994" Year="2000">
-      <Id>b61cf2d1-9aef-4763-bede-8d04b1836f08</Id>
+      <Database Name="cv" Series="5300" Issue="83128" />
     </Book>
     <Book Series="Generation X" Number="69" Volume="1994" Year="2000">
-      <Id>642f9852-6349-46e6-9286-4f115bfc8c73</Id>
+      <Database Name="cv" Series="5300" Issue="83129" />
     </Book>
     <Book Series="Generation X" Number="70" Volume="1994" Year="2000">
-      <Id>33368588-0226-4f9a-bdbd-1b5be32b3658</Id>
+      <Database Name="cv" Series="5300" Issue="83130" />
     </Book>
     <Book Series="Cable" Number="79" Volume="1993" Year="2000">
-      <Id>c58aa3e5-57db-4a24-94bc-a38da0c6b9e8</Id>
+      <Database Name="cv" Series="4993" Issue="65657" />
     </Book>
     <Book Series="Cable" Number="80" Volume="1993" Year="2000">
-      <Id>f39a5a1c-f82a-4651-b24a-e420a707863f</Id>
+      <Database Name="cv" Series="4993" Issue="65658" />
     </Book>
     <Book Series="Cable" Number="81" Volume="1993" Year="2000">
-      <Id>88364fca-fe4f-4311-b834-2b74cff5a660</Id>
+      <Database Name="cv" Series="4993" Issue="65659" />
     </Book>
     <Book Series="Cable" Number="82" Volume="1993" Year="2000">
-      <Id>cff88c0c-7e7c-486e-bb9a-820c8b7cec61</Id>
+      <Database Name="cv" Series="4993" Issue="65660" />
     </Book>
     <Book Series="Cable" Number="83" Volume="1993" Year="2000">
-      <Id>0354a668-89c8-4844-a165-6ad7cef98761</Id>
+      <Database Name="cv" Series="4993" Issue="65661" />
     </Book>
     <Book Series="Cable" Number="84" Volume="1993" Year="2000">
-      <Id>866f610b-b1a6-49dd-a4cb-dc396c78a63f</Id>
+      <Database Name="cv" Series="4993" Issue="65662" />
     </Book>
     <Book Series="X-Force" Number="102" Volume="1991" Year="2000">
-      <Id>1a4691e3-6bc7-4aaa-a202-890b835da218</Id>
+      <Database Name="cv" Series="4604" Issue="64572" />
     </Book>
     <Book Series="X-Force" Number="103" Volume="1991" Year="2000">
-      <Id>bc58c53f-41af-4f73-827e-e2463849b78c</Id>
+      <Database Name="cv" Series="4604" Issue="64573" />
     </Book>
     <Book Series="X-Force" Number="104" Volume="1991" Year="2000">
-      <Id>2a17a4a2-e827-42a9-9d48-f9f45d17a8f6</Id>
+      <Database Name="cv" Series="4604" Issue="64574" />
     </Book>
     <Book Series="X-Force" Number="105" Volume="1991" Year="2000">
-      <Id>f3e784bd-5e02-4a2a-a93b-b8e342fa1b3e</Id>
+      <Database Name="cv" Series="4604" Issue="64575" />
     </Book>
     <Book Series="Gambit" Number="17" Volume="1999" Year="2000">
-      <Id>1bbfa0b3-31b4-495f-a6de-fbeaebd4cdc3</Id>
+      <Database Name="cv" Series="9111" Issue="66905" />
     </Book>
     <Book Series="Gambit" Number="18" Volume="1999" Year="2000">
-      <Id>d42a8b7d-3408-4aa4-8d81-43e271ca8a00</Id>
+      <Database Name="cv" Series="9111" Issue="66906" />
     </Book>
     <Book Series="Gambit" Number="19" Volume="1999" Year="2000">
-      <Id>a9ebb5fe-cbab-42d9-85d2-d0a0dbfcf279</Id>
+      <Database Name="cv" Series="9111" Issue="66907" />
     </Book>
-    <Book Series="Gambit Annual 2000" Number="1" Volume="2000" Year="2000">
-      <Id>98035f2e-83ed-4a13-8346-cc711796d2db</Id>
+    <Book Series="Gambit 2000" Number="1" Volume="2000" Year="2000">
+      <Database Name="cv" Series="60498" Issue="136124" />
     </Book>
     <Book Series="X-Man" Number="67" Volume="1995" Year="2000">
-      <Id>9615a7a8-bbba-44bd-abac-f52ffcdf0352</Id>
+      <Database Name="cv" Series="5567" Issue="74589" />
     </Book>
     <Book Series="X-Man" Number="68" Volume="1995" Year="2000">
-      <Id>3fcea555-fed7-4a97-925d-e2f893f0b09d</Id>
+      <Database Name="cv" Series="5567" Issue="74590" />
     </Book>
     <Book Series="X-Man" Number="69" Volume="1995" Year="2000">
-      <Id>f59d6452-8ac8-4487-b7e9-f6e0c7299d5c</Id>
+      <Database Name="cv" Series="5567" Issue="74591" />
     </Book>
     <Book Series="X-Man" Number="70" Volume="1995" Year="2000">
-      <Id>8de0b49a-3a2f-40f4-93bb-87309aff1f7b</Id>
+      <Database Name="cv" Series="5567" Issue="74592" />
     </Book>
     <Book Series="X-Force" Number="106" Volume="1991" Year="2000">
-      <Id>98ec792a-0ccd-4f1d-afcc-506899b70199</Id>
+      <Database Name="cv" Series="4604" Issue="64576" />
     </Book>
     <Book Series="X-Force" Number="107" Volume="1991" Year="2000">
-      <Id>3d971c79-d7de-4142-b7a8-967acfbb02c4</Id>
+      <Database Name="cv" Series="4604" Issue="64577" />
     </Book>
     <Book Series="X-Force" Number="108" Volume="1991" Year="2000">
-      <Id>0611aaa5-d5f2-4b82-9bbb-cf39798ee9f8</Id>
+      <Database Name="cv" Series="4604" Issue="64578" />
     </Book>
     <Book Series="X-Force" Number="109" Volume="1991" Year="2000">
-      <Id>e71b479d-c28e-46d9-b2d0-56cc12e55f68</Id>
+      <Database Name="cv" Series="4604" Issue="64579" />
     </Book>
     <Book Series="Gambit" Number="20" Volume="1999" Year="2000">
-      <Id>dce38943-3bd5-4f5a-9642-8b9de6be29eb</Id>
+      <Database Name="cv" Series="9111" Issue="66908" />
     </Book>
     <Book Series="X-Men Unlimited" Number="27" Volume="1993" Year="2000">
-      <Id>6da21ebe-2f22-4300-a111-c17beddc3de8</Id>
+      <Database Name="cv" Series="5066" Issue="106076" />
     </Book>
     <Book Series="X-Men: Black Sun" Number="1" Volume="2000" Year="2000">
-      <Id>d9aeb159-d024-41e3-8b17-a9d82d8918a0</Id>
+      <Database Name="cv" Series="18655" Issue="110125" />
     </Book>
     <Book Series="X-Men: Black Sun" Number="2" Volume="2000" Year="2000">
-      <Id>8dd6ad91-27b9-41ec-b8a3-41878155f7db</Id>
+      <Database Name="cv" Series="18655" Issue="110131" />
     </Book>
     <Book Series="X-Men: Black Sun" Number="3" Volume="2000" Year="2000">
-      <Id>8491fc43-4eda-4f20-bfef-1aab841f1863</Id>
+      <Database Name="cv" Series="18655" Issue="110132" />
     </Book>
     <Book Series="X-Men: Black Sun" Number="4" Volume="2000" Year="2000">
-      <Id>eb39b065-d005-4673-927a-3c649ab16650</Id>
+      <Database Name="cv" Series="18655" Issue="110133" />
     </Book>
     <Book Series="X-Men: Black Sun" Number="5" Volume="2000" Year="2000">
-      <Id>dbc007d9-337e-4dd8-873d-b495ef7e3d35</Id>
+      <Database Name="cv" Series="18655" Issue="110134" />
     </Book>
     <Book Series="X-Men: Magik" Number="1" Volume="2000" Year="2000">
-      <Id>a6a3b2d1-5556-43e7-918c-f03c4ce22a6b</Id>
+      <Database Name="cv" Series="11667" Issue="103140" />
     </Book>
     <Book Series="X-Men: Magik" Number="2" Volume="2000" Year="2001">
-      <Id>13950fc7-39ad-4a9d-b8b4-274f65653cd6</Id>
+      <Database Name="cv" Series="11667" Issue="103141" />
     </Book>
     <Book Series="X-Men: Magik" Number="3" Volume="2000" Year="2001">
-      <Id>46ce2010-d19e-4e85-8cf2-47bbe6284fee</Id>
+      <Database Name="cv" Series="11667" Issue="103142" />
     </Book>
     <Book Series="X-Men: Magik" Number="4" Volume="2000" Year="2001">
-      <Id>0de3a156-1091-4731-a23d-218073110713</Id>
+      <Database Name="cv" Series="11667" Issue="103143" />
     </Book>
     <Book Series="X-Men" Number="100" Volume="1991" Year="2000">
-      <Id>f664b296-ce10-41f2-b08b-109bda8bf3da</Id>
+      <Database Name="cv" Series="4605" Issue="65799" />
     </Book>
     <Book Series="X-Men" Number="101" Volume="1991" Year="2000">
-      <Id>890a62ec-61e5-4e23-9b4e-730fb000e22b</Id>
+      <Database Name="cv" Series="4605" Issue="65800" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="381" Volume="1981" Year="2000">
-      <Id>fe7e1f3c-0fa0-4801-8c6a-1217825ba8a9</Id>
+      <Database Name="cv" Series="3092" Issue="65152" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="382" Volume="1981" Year="2000">
-      <Id>66d3be7e-b18b-4d13-8386-0f260df82638</Id>
+      <Database Name="cv" Series="3092" Issue="65154" />
     </Book>
     <Book Series="Wolverine" Number="150" Volume="1988" Year="2000">
-      <Id>be3500bd-6bfa-4759-bd42-badddca4419f</Id>
+      <Database Name="cv" Series="4250" Issue="51217" />
     </Book>
     <Book Series="Wolverine" Number="151" Volume="1988" Year="2000">
-      <Id>b492a1bc-e9dd-44f5-b437-5d057bc70dbb</Id>
+      <Database Name="cv" Series="4250" Issue="51218" />
     </Book>
     <Book Series="Wolverine" Number="152" Volume="1988" Year="2000">
-      <Id>31d78b3a-0757-4257-940d-55d2cd17d4fb</Id>
+      <Database Name="cv" Series="4250" Issue="51219" />
     </Book>
     <Book Series="Wolverine" Number="153" Volume="1988" Year="2000">
-      <Id>8bc22894-b11a-41aa-a0a7-568897237636</Id>
+      <Database Name="cv" Series="4250" Issue="51220" />
     </Book>
     <Book Series="X-Men" Number="102" Volume="1991" Year="2000">
-      <Id>6e996ff8-cc87-4e97-9897-d4f78f117cd8</Id>
+      <Database Name="cv" Series="4605" Issue="65801" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="383" Volume="1981" Year="2000">
-      <Id>3b71db4b-60cf-4300-b412-a6dfee69eeef</Id>
+      <Database Name="cv" Series="3092" Issue="65156" />
     </Book>
-    <Book Series="X-Men Annual 2000" Number="1" Volume="2000" Year="2000">
-      <Id>ff9a11aa-3189-4852-a50f-1c8ac02ec7f4</Id>
+    <Book Series="X-Men 2000" Number="1" Volume="2000" Year="2000">
+      <Database Name="cv" Series="60465" Issue="166208" />
     </Book>
     <Book Series="X-Men" Number="103" Volume="1991" Year="2000">
-      <Id>a6780495-e03e-48a0-b2bf-1f67cb5ba932</Id>
+      <Database Name="cv" Series="4605" Issue="65802" />
     </Book>
     <Book Series="X-Men Unlimited" Number="28" Volume="1993" Year="2000">
-      <Id>6853555d-0e47-4687-82f1-557a28aa8be9</Id>
+      <Database Name="cv" Series="5066" Issue="106085" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="384" Volume="1981" Year="2000">
-      <Id>c1355daa-0a5a-4c3d-8f6e-71d82253fda7</Id>
+      <Database Name="cv" Series="3092" Issue="65159" />
     </Book>
     <Book Series="X-Men" Number="104" Volume="1991" Year="2000">
-      <Id>225f1d3b-c4da-4d4a-bd3c-9dba84c87144</Id>
+      <Database Name="cv" Series="4605" Issue="65803" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="385" Volume="1981" Year="2000">
-      <Id>34297f01-69bc-4b4c-8c61-49a96bfa0666</Id>
+      <Database Name="cv" Series="3092" Issue="65160" />
     </Book>
     <Book Series="X-Men Forever" Number="1" Volume="2001" Year="2001">
-      <Id>9ed1817b-cf73-479f-a2b0-3c19e34e4e25</Id>
+      <Database Name="cv" Series="9197" Issue="70453" />
     </Book>
     <Book Series="X-Men Forever" Number="2" Volume="2001" Year="2001">
-      <Id>d525d01d-58d7-4dd9-b29d-50bb3a1396d4</Id>
+      <Database Name="cv" Series="9197" Issue="70454" />
     </Book>
     <Book Series="X-Men Forever" Number="3" Volume="2001" Year="2001">
-      <Id>cde4801f-3e7d-489d-962a-18f2f0084a85</Id>
+      <Database Name="cv" Series="9197" Issue="70455" />
     </Book>
     <Book Series="X-Men Forever" Number="4" Volume="2001" Year="2001">
-      <Id>0bdfe13b-15ff-491d-ac71-d0585447017b</Id>
+      <Database Name="cv" Series="9197" Issue="70456" />
     </Book>
     <Book Series="X-Men Forever" Number="5" Volume="2001" Year="2001">
-      <Id>dd46ba3c-01b4-4ed9-b023-9b739d76d5e8</Id>
+      <Database Name="cv" Series="9197" Issue="70457" />
     </Book>
     <Book Series="X-Men Forever" Number="6" Volume="2001" Year="2001">
-      <Id>212eac3b-e5f4-4b24-bbb7-43ec59cd6b4f</Id>
+      <Database Name="cv" Series="9197" Issue="70458" />
     </Book>
     <Book Series="Gambit" Number="21" Volume="1999" Year="2000">
-      <Id>ac152936-b6e3-43b7-a39d-46404d2b5a80</Id>
+      <Database Name="cv" Series="9111" Issue="66909" />
     </Book>
     <Book Series="X-Men" Number="105" Volume="1991" Year="2000">
-      <Id>a42f9f8e-4ed3-40fa-8942-fd0bac95399e</Id>
+      <Database Name="cv" Series="4605" Issue="65804" />
     </Book>
     <Book Series="X-Men" Number="106" Volume="1991" Year="2000">
-      <Id>68d784d9-be5b-4ee0-9575-205242cb91ca</Id>
+      <Database Name="cv" Series="4605" Issue="65805" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="386" Volume="1981" Year="2000">
-      <Id>20cccd3b-90ed-46b1-802e-fed6b6a521ed</Id>
+      <Database Name="cv" Series="3092" Issue="65162" />
     </Book>
     <Book Series="Gambit" Number="22" Volume="1999" Year="2000">
-      <Id>95a49d65-9d13-4fac-9f62-4276aae401a5</Id>
+      <Database Name="cv" Series="9111" Issue="66910" />
     </Book>
     <Book Series="X-Man" Number="63" Volume="1995" Year="2000">
-      <Id>19fead17-ead0-42c3-8923-ee8287d0ead6</Id>
+      <Database Name="cv" Series="5567" Issue="132390" />
     </Book>
     <Book Series="X-Man" Number="64" Volume="1995" Year="2000">
-      <Id>7e5c36d5-8d0b-4c8a-ada0-d0f7cdfe33fe</Id>
+      <Database Name="cv" Series="5567" Issue="74586" />
     </Book>
     <Book Series="X-Man" Number="65" Volume="1995" Year="2000">
-      <Id>31336917-b99f-4ff7-aa55-cfecb7be10f0</Id>
+      <Database Name="cv" Series="5567" Issue="74587" />
     </Book>
     <Book Series="X-Man" Number="66" Volume="1995" Year="2000">
-      <Id>6843ac3e-bd81-43ec-8559-0339caa8e30a</Id>
+      <Database Name="cv" Series="5567" Issue="74588" />
     </Book>
     <Book Series="Maximum Security" Number="1" Volume="2000" Year="2000">
-      <Id>abe01708-cfc0-4228-89ee-821842ceed2f</Id>
+      <Database Name="cv" Series="20450" Issue="122425" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="387" Volume="1981" Year="2000">
-      <Id>00b01556-ad3b-497d-832e-f2513ba498d0</Id>
+      <Database Name="cv" Series="3092" Issue="65163" />
     </Book>
     <Book Series="Maximum Security" Number="2" Volume="2000" Year="2000">
-      <Id>a666a62c-0ca8-4a1a-8681-4634b49416c9</Id>
+      <Database Name="cv" Series="20450" Issue="122440" />
     </Book>
     <Book Series="Bishop: The Last X-Man" Number="15" Volume="1999" Year="2000">
-      <Id>240d2579-7e18-4073-b365-ddde851cccff</Id>
+      <Database Name="cv" Series="6352" Issue="65824" />
     </Book>
     <Book Series="X-Men" Number="107" Volume="1991" Year="2000">
-      <Id>55b1db03-b745-4ad9-a0a2-364b09cc49ed</Id>
+      <Database Name="cv" Series="4605" Issue="65806" />
     </Book>
     <Book Series="Gambit" Number="23" Volume="1999" Year="2000">
-      <Id>5bb3b67a-61d9-4f9c-8eff-a1380afee175</Id>
+      <Database Name="cv" Series="9111" Issue="66911" />
     </Book>
     <Book Series="X-Men Unlimited" Number="29" Volume="1993" Year="2000">
-      <Id>8a6ef3ca-772f-4f14-9e23-cf7d55ed9f08</Id>
+      <Database Name="cv" Series="5066" Issue="106106" />
     </Book>
     <Book Series="Maximum Security" Number="3" Volume="2000" Year="2001">
-      <Id>bffc72c8-44eb-4899-9d1b-e7f4e748099e</Id>
+      <Database Name="cv" Series="20450" Issue="122495" />
     </Book>
     <Book Series="Cable" Number="85" Volume="1993" Year="2000">
-      <Id>e0a57d27-8c1e-4607-8a0f-e8259765aeea</Id>
+      <Database Name="cv" Series="4993" Issue="65663" />
     </Book>
     <Book Series="Cable" Number="86" Volume="1993" Year="2000">
-      <Id>e79749ab-54fb-494b-8af3-191d32d2c806</Id>
+      <Database Name="cv" Series="4993" Issue="65664" />
     </Book>
     <Book Series="Wolverine" Number="154" Volume="1988" Year="2000">
-      <Id>0ade6b75-610a-4ad8-99d2-0a15695d0a6d</Id>
+      <Database Name="cv" Series="4250" Issue="51221" />
     </Book>
     <Book Series="Wolverine" Number="155" Volume="1988" Year="2000">
-      <Id>949f3b4a-ebe4-4d44-9753-3063babc54d3</Id>
+      <Database Name="cv" Series="4250" Issue="51222" />
     </Book>
     <Book Series="Wolverine" Number="156" Volume="1988" Year="2000">
-      <Id>264e5a28-5618-4010-a0b7-2499afcc70b6</Id>
+      <Database Name="cv" Series="4250" Issue="51223" />
     </Book>
     <Book Series="Wolverine" Number="157" Volume="1988" Year="2000">
-      <Id>92d81bcb-d8cc-4dde-919e-71520ca08b05</Id>
+      <Database Name="cv" Series="4250" Issue="51224" />
     </Book>
-    <Book Series="Wolverine Annual 2000" Number="1" Volume="2000" Year="2001">
-      <Id>3e9c7675-b340-486f-90a3-6b30af33b5a6</Id>
+    <Book Series="Wolverine 2000" Number="1" Volume="2000" Year="2001">
+      <Database Name="cv" Series="27131" Issue="164832" />
     </Book>
     <Book Series="X-Force" Number="110" Volume="1991" Year="2001">
-      <Id>d3949aac-98c7-4837-a891-14d0a4d7c291</Id>
+      <Database Name="cv" Series="4604" Issue="64580" />
     </Book>
     <Book Series="X-Force" Number="111" Volume="1991" Year="2001">
-      <Id>b1f11454-be98-4e52-a883-d4d5d5984fb7</Id>
+      <Database Name="cv" Series="4604" Issue="64581" />
     </Book>
     <Book Series="X-Force" Number="112" Volume="1991" Year="2001">
-      <Id>5c68ecb6-22c1-498c-8514-bd38cc85e6b5</Id>
+      <Database Name="cv" Series="4604" Issue="64582" />
     </Book>
     <Book Series="X-Force" Number="113" Volume="1991" Year="2001">
-      <Id>c6697ce2-9aba-4643-b317-76005735fbb5</Id>
+      <Database Name="cv" Series="4604" Issue="64583" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="388" Volume="1981" Year="2000">
-      <Id>4e10a38d-ca36-47a6-9149-544cf7b05edc</Id>
+      <Database Name="cv" Series="3092" Issue="65166" />
     </Book>
     <Book Series="Cable" Number="87" Volume="1993" Year="2001">
-      <Id>967947b2-b28d-420b-bf2e-8bfa8410203a</Id>
+      <Database Name="cv" Series="4993" Issue="65665" />
     </Book>
     <Book Series="Bishop: The Last X-Man" Number="16" Volume="1999" Year="2001">
-      <Id>7fe1a974-5feb-4ee8-823e-69bb17b7c0b3</Id>
+      <Database Name="cv" Series="6352" Issue="65825" />
     </Book>
     <Book Series="X-Men" Number="108" Volume="1991" Year="2001">
-      <Id>b59b7986-932d-4ab9-b988-e77be5c2a97c</Id>
+      <Database Name="cv" Series="4605" Issue="65807" />
     </Book>
     <Book Series="X-Force" Number="114" Volume="1991" Year="2001">
-      <Id>a76f6eb5-30a2-49db-9fe1-ed269737ce70</Id>
+      <Database Name="cv" Series="4604" Issue="64584" />
     </Book>
     <Book Series="X-Force" Number="115" Volume="1991" Year="2001">
-      <Id>b52b1a64-858d-4110-adb8-973cce78b100</Id>
+      <Database Name="cv" Series="4604" Issue="64585" />
     </Book>
     <Book Series="Generation X" Number="71" Volume="1994" Year="2001">
-      <Id>ce93e04c-2f5f-4b63-963a-30250dd885dc</Id>
+      <Database Name="cv" Series="5300" Issue="83131" />
     </Book>
     <Book Series="Generation X" Number="72" Volume="1994" Year="2001">
-      <Id>a6bf0630-c1a3-45ea-87e9-43bf202d53b8</Id>
+      <Database Name="cv" Series="5300" Issue="83132" />
     </Book>
     <Book Series="Generation X" Number="73" Volume="1994" Year="2001">
-      <Id>6d252b37-6b52-49c1-95c5-cd2b026db783</Id>
+      <Database Name="cv" Series="5300" Issue="83133" />
     </Book>
     <Book Series="Generation X" Number="74" Volume="1994" Year="2001">
-      <Id>c3a5376f-8f98-42d9-834c-de8fc630da8d</Id>
+      <Database Name="cv" Series="5300" Issue="83134" />
     </Book>
     <Book Series="Wolverine" Number="158" Volume="1988" Year="2001">
-      <Id>2ec82d8e-ac76-4f8d-b52c-fc2dbae86eee</Id>
+      <Database Name="cv" Series="4250" Issue="51225" />
     </Book>
     <Book Series="Gambit" Number="24" Volume="1999" Year="2001">
-      <Id>d02c1fd9-54ad-4667-b991-f5d77fe90a1c</Id>
+      <Database Name="cv" Series="9111" Issue="66912" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="389" Volume="1981" Year="2001">
-      <Id>10a72bf9-2238-4ba3-94d8-bdb9ecd41467</Id>
+      <Database Name="cv" Series="3092" Issue="65168" />
     </Book>
     <Book Series="X-Men Unlimited" Number="33" Volume="1993" Year="2001">
-      <Id>8c4e5c5a-f02c-4c2f-bb95-01b87d7c0616</Id>
+      <Database Name="cv" Series="5066" Issue="106890" />
     </Book>
     <Book Series="Cable" Number="88" Volume="1993" Year="2001">
-      <Id>512b0724-a804-40a5-a534-8680c3a908e7</Id>
+      <Database Name="cv" Series="4993" Issue="65666" />
     </Book>
     <Book Series="Wolverine" Number="159" Volume="1988" Year="2001">
-      <Id>ca3a8dbb-68a9-4412-b7b2-38c91eed64d6</Id>
+      <Database Name="cv" Series="4250" Issue="51226" />
     </Book>
     <Book Series="Wolverine" Number="160" Volume="1988" Year="2001">
-      <Id>c58824a2-565d-4730-9e46-5497192a6d9a</Id>
+      <Database Name="cv" Series="4250" Issue="51227" />
     </Book>
     <Book Series="Wolverine" Number="161" Volume="1988" Year="2001">
-      <Id>9831eb0c-0ae0-462b-a961-fa4902b5dedb</Id>
+      <Database Name="cv" Series="4250" Issue="51228" />
     </Book>
     <Book Series="X-Men" Number="109" Volume="1991" Year="2001">
-      <Id>5a4c6961-ffda-494c-aeb1-b9f3210d5588</Id>
+      <Database Name="cv" Series="4605" Issue="65808" />
     </Book>
-    <Book Series="Uncanny X-Men Annual 2000" Number="1" Volume="2000" Year="2001">
-      <Id>59b1e85b-755d-4b2e-b237-04abda94b24e</Id>
+    <Book Series="Uncanny X-Men 2000" Number="1" Volume="2000" Year="2001">
+      <Database Name="cv" Series="60471" Issue="136053" />
     </Book>
     <Book Series="X-Men: The Search For Cyclops" Number="1" Volume="2000" Year="2000">
-      <Id>966715a0-a6d7-41fb-8adb-ff72520f1156</Id>
+      <Database Name="cv" Series="7198" Issue="51339" />
     </Book>
     <Book Series="X-Men: The Search For Cyclops" Number="2" Volume="2000" Year="2001">
-      <Id>c7c64e16-3a2e-49e0-9743-bbc77132beb1</Id>
+      <Database Name="cv" Series="7198" Issue="51340" />
     </Book>
     <Book Series="X-Men: The Search For Cyclops" Number="3" Volume="2000" Year="2001">
-      <Id>12ddb4d6-885f-456b-8cdf-3cdbde0f68b3</Id>
+      <Database Name="cv" Series="7198" Issue="51341" />
     </Book>
     <Book Series="X-Men: The Search For Cyclops" Number="4" Volume="2000" Year="2001">
-      <Id>10d403c0-9784-4a02-acaf-e4cd79d80968</Id>
+      <Database Name="cv" Series="7198" Issue="51342" />
     </Book>
     <Book Series="Cable" Number="89" Volume="1993" Year="2001">
-      <Id>a51fae4f-e71a-43f7-9b17-1a12806af5cc</Id>
+      <Database Name="cv" Series="4993" Issue="65667" />
     </Book>
     <Book Series="Cable" Number="90" Volume="1993" Year="2001">
-      <Id>b3a499e2-2da6-4889-b64c-6c8c5953fdf8</Id>
+      <Database Name="cv" Series="4993" Issue="65668" />
     </Book>
     <Book Series="Cable" Number="91" Volume="1993" Year="2001">
-      <Id>b91c77d6-c02c-4ec1-9a74-49b1acc8e5b8</Id>
+      <Database Name="cv" Series="4993" Issue="65669" />
     </Book>
     <Book Series="Cable" Number="92" Volume="1993" Year="2001">
-      <Id>a4df0fa9-9bef-4672-93f7-a0bffca010fc</Id>
+      <Database Name="cv" Series="4993" Issue="65670" />
     </Book>
     <Book Series="Cable" Number="93" Volume="1993" Year="2001">
-      <Id>9459e465-80b8-49c6-8f61-85667f9058f1</Id>
+      <Database Name="cv" Series="4993" Issue="65671" />
     </Book>
     <Book Series="Cable" Number="94" Volume="1993" Year="2001">
-      <Id>efc80d8b-a4dc-4544-ba4b-13128c139121</Id>
+      <Database Name="cv" Series="4993" Issue="65672" />
     </Book>
     <Book Series="Cable" Number="95" Volume="1993" Year="2001">
-      <Id>abbbf07e-f7d3-4d94-bb11-8638c817c513</Id>
+      <Database Name="cv" Series="4993" Issue="65673" />
     </Book>
     <Book Series="Gambit" Number="25" Volume="1999" Year="2001">
-      <Id>754fe60e-dde5-479c-970a-5f25e7218239</Id>
+      <Database Name="cv" Series="9111" Issue="66913" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="390" Volume="1981" Year="2001">
-      <Id>ad909ce1-79db-4817-98e5-7dbf0f9a290a</Id>
+      <Database Name="cv" Series="3092" Issue="65170" />
     </Book>
     <Book Series="X-Men" Number="110" Volume="1991" Year="2001">
-      <Id>635f650b-7de9-468b-bce0-c883d219f51f</Id>
+      <Database Name="cv" Series="4605" Issue="65809" />
     </Book>
     <Book Series="X-Men Unlimited" Number="30" Volume="1993" Year="2001">
-      <Id>e3fd3cc5-430e-4ced-8639-5f3524b7e42b</Id>
+      <Database Name="cv" Series="5066" Issue="106126" />
     </Book>
     <Book Series="X-Men Unlimited" Number="31" Volume="1993" Year="2001">
-      <Id>d0c691ed-e6d0-4e0a-87e9-01264de591a9</Id>
+      <Database Name="cv" Series="5066" Issue="106300" />
     </Book>
     <Book Series="Wolverine" Number="162" Volume="1988" Year="2001">
-      <Id>cf8d9554-da6a-42ad-ba44-3405adec880b</Id>
+      <Database Name="cv" Series="4250" Issue="51229" />
     </Book>
     <Book Series="Wolverine" Number="163" Volume="1988" Year="2001">
-      <Id>32c5d493-f9e8-4346-8049-359aff87ca34</Id>
+      <Database Name="cv" Series="4250" Issue="51230" />
     </Book>
     <Book Series="Wolverine" Number="164" Volume="1988" Year="2001">
-      <Id>188c0cc9-62ce-4fd5-8aa3-0f8fb29a028d</Id>
+      <Database Name="cv" Series="4250" Issue="51231" />
     </Book>
     <Book Series="Wolverine" Number="165" Volume="1988" Year="2001">
-      <Id>9ce83605-c56c-43ba-8a13-af3c1883e870</Id>
+      <Database Name="cv" Series="4250" Issue="89836" />
     </Book>
     <Book Series="Wolverine" Number="166" Volume="1988" Year="2001">
-      <Id>fb781764-83cb-4ee6-85a3-74a195dc1f96</Id>
+      <Database Name="cv" Series="4250" Issue="51232" />
     </Book>
     <Book Series="Wolverine" Number="167" Volume="1988" Year="2001">
-      <Id>b97c9ff7-4ed0-4e32-8281-85d93000113b</Id>
+      <Database Name="cv" Series="4250" Issue="51233" />
     </Book>
     <Book Series="Wolverine" Number="168" Volume="1988" Year="2001">
-      <Id>bd0f42e9-aefa-4045-a826-340779af0241</Id>
+      <Database Name="cv" Series="4250" Issue="64485" />
     </Book>
     <Book Series="Wolverine" Number="169" Volume="1988" Year="2001">
-      <Id>3ee51f65-3534-4a70-b20c-e64041702339</Id>
+      <Database Name="cv" Series="4250" Issue="64486" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="391" Volume="1981" Year="2001">
-      <Id>11c80758-2c07-41ce-b2df-4e40e9771c8d</Id>
+      <Database Name="cv" Series="3092" Issue="65172" />
     </Book>
     <Book Series="Cable" Number="96" Volume="1993" Year="2001">
-      <Id>d991d00f-e374-4f88-9a7f-ffa370ac60f2</Id>
+      <Database Name="cv" Series="4993" Issue="65674" />
     </Book>
     <Book Series="X-Men Unlimited" Number="32" Volume="1993" Year="2001">
-      <Id>27662678-c4ef-47c9-8a71-81afc364cc1b</Id>
+      <Database Name="cv" Series="5066" Issue="106522" />
     </Book>
     <Book Series="X-Men" Number="111" Volume="1991" Year="2001">
-      <Id>e4829375-c84b-4855-bb58-5ec9a74d7b7a</Id>
+      <Database Name="cv" Series="4605" Issue="65810" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="392" Volume="1981" Year="2001">
-      <Id>a45d49b2-e29d-427a-9396-a62bac481ffe</Id>
+      <Database Name="cv" Series="3092" Issue="65175" />
     </Book>
     <Book Series="X-Men" Number="112" Volume="1991" Year="2001">
-      <Id>e46c4693-ca02-4fd3-8ea2-f46a153b6cfe</Id>
+      <Database Name="cv" Series="4605" Issue="65811" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="393" Volume="1981" Year="2001">
-      <Id>dfcebdea-2f9b-437c-b2b5-712b4f29fdaa</Id>
+      <Database Name="cv" Series="3092" Issue="105595" />
     </Book>
     <Book Series="X-Men" Number="113" Volume="1991" Year="2001">
-      <Id>a70f4703-9bb9-443a-9d45-2964293f3104</Id>
+      <Database Name="cv" Series="4605" Issue="65812" />
     </Book>
     <Book Series="Cable" Number="97" Volume="1993" Year="2001">
-      <Id>208368c1-0049-44eb-a7af-61ca946874f9</Id>
+      <Database Name="cv" Series="4993" Issue="65675" />
     </Book>
     <Book Series="Cable" Number="98" Volume="1993" Year="2001">
-      <Id>a13bb8be-556c-4ac3-a06e-af9fb8eab3f9</Id>
+      <Database Name="cv" Series="4993" Issue="65676" />
     </Book>
     <Book Series="Cable" Number="99" Volume="1993" Year="2002">
-      <Id>af89af2d-62fc-452e-ab1f-a3c11e165519</Id>
+      <Database Name="cv" Series="4993" Issue="65677" />
     </Book>
     <Book Series="Cable" Number="100" Volume="1993" Year="2002">
-      <Id>aef94823-f79b-47e1-8e1d-d1b95377a107</Id>
+      <Database Name="cv" Series="4993" Issue="65678" />
     </Book>
     <Book Series="X-Man" Number="71" Volume="1995" Year="2001">
-      <Id>ce8ee883-cd7c-4f96-8ca7-eea3c16e0d51</Id>
+      <Database Name="cv" Series="5567" Issue="74593" />
     </Book>
     <Book Series="X-Man" Number="72" Volume="1995" Year="2001">
-      <Id>8b8fd697-b7e8-480f-8996-2faaa6b327f5</Id>
+      <Database Name="cv" Series="5567" Issue="74594" />
     </Book>
     <Book Series="X-Man" Number="73" Volume="1995" Year="2001">
-      <Id>46fe1c7d-f73a-45b5-9985-2e538b6001b9</Id>
+      <Database Name="cv" Series="5567" Issue="74595" />
     </Book>
     <Book Series="X-Man" Number="74" Volume="1995" Year="2001">
-      <Id>01d48668-8d63-431e-8420-98e4dbb09d6a</Id>
+      <Database Name="cv" Series="5567" Issue="132657" />
     </Book>
     <Book Series="X-Man" Number="75" Volume="1995" Year="2001">
-      <Id>4a01e8d5-cccc-459e-896b-5945610c7ce5</Id>
+      <Database Name="cv" Series="5567" Issue="132827" />
     </Book>
     <Book Series="Cable" Number="101" Volume="1993" Year="2002">
-      <Id>224a803a-387c-4792-a07b-dab90a2cd8e7</Id>
+      <Database Name="cv" Series="4993" Issue="65679" />
     </Book>
     <Book Series="Cable" Number="102" Volume="1993" Year="2002">
-      <Id>875ae1c1-cdbb-413c-9805-aad756e93c98</Id>
+      <Database Name="cv" Series="4993" Issue="65680" />
     </Book>
     <Book Series="Cable" Number="103" Volume="1993" Year="2002">
-      <Id>809d4ad7-e036-4e25-91a0-3d6f80181a7b</Id>
+      <Database Name="cv" Series="4993" Issue="65681" />
     </Book>
     <Book Series="Cable" Number="104" Volume="1993" Year="2002">
-      <Id>55f5eacf-b00d-4545-a900-37f1ffad65e8</Id>
+      <Database Name="cv" Series="4993" Issue="136026" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 007.cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 007.cbl
@@ -2,883 +2,883 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>X-Men - Part 7</Name>
   <Books>
-    <Book Series="X-Men" Number="85" Volume="1991" Year="1999" Format="Main Series">
+    <Book Series="X-Men" Number="85" Volume="1991" Year="1999">
       <Id>99aa26bb-fbf4-45a8-8bfa-6bce5e9f12ab</Id>
     </Book>
-    <Book Series="X-Men: Magneto War" Number="1" Volume="1999" Year="1999" Format="One-Shot">
+    <Book Series="X-Men: Magneto War" Number="1" Volume="1999" Year="1999">
       <Id>e7863bbf-be45-4cb5-ab46-c2aa9834e55e</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="366" Volume="1981" Year="1999" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="366" Volume="1981" Year="1999">
       <Id>e55cecf8-0bc4-4dbc-82f7-59a0b8e58310</Id>
     </Book>
-    <Book Series="X-Men" Number="86" Volume="1991" Year="1999" Format="Main Series">
+    <Book Series="X-Men" Number="86" Volume="1991" Year="1999">
       <Id>c09ea68f-df18-4a20-b37e-71b4475f099b</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="367" Volume="1981" Year="1999" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="367" Volume="1981" Year="1999">
       <Id>29420292-a224-4e75-a25d-ab800b2b8d64</Id>
     </Book>
-    <Book Series="X-Men" Number="87" Volume="1991" Year="1999" Format="Main Series">
+    <Book Series="X-Men" Number="87" Volume="1991" Year="1999">
       <Id>05c39225-ce6e-4565-81dd-84a9ca468950</Id>
     </Book>
-    <Book Series="Cable" Number="66" Volume="1993" Year="1999" Format="Main Series">
+    <Book Series="Cable" Number="66" Volume="1993" Year="1999">
       <Id>108197a2-d29c-4c30-80e0-28b8427c5440</Id>
     </Book>
-    <Book Series="Cable" Number="67" Volume="1993" Year="1999" Format="Main Series">
+    <Book Series="Cable" Number="67" Volume="1993" Year="1999">
       <Id>a31abfce-4a3e-41a9-ae65-edcbd17d5196</Id>
     </Book>
-    <Book Series="Cable" Number="68" Volume="1993" Year="1999" Format="Main Series">
+    <Book Series="Cable" Number="68" Volume="1993" Year="1999">
       <Id>033cd58c-ee1b-439d-bc9c-8cb392ac231d</Id>
     </Book>
-    <Book Series="Cable" Number="69" Volume="1993" Year="1999" Format="Main Series">
+    <Book Series="Cable" Number="69" Volume="1993" Year="1999">
       <Id>574980cd-fd1d-448f-a9cb-c30965449010</Id>
     </Book>
-    <Book Series="Cable" Number="70" Volume="1993" Year="1999" Format="Main Series">
+    <Book Series="Cable" Number="70" Volume="1993" Year="1999">
       <Id>70097f9d-f41e-4fa8-8c96-5561d1d88d96</Id>
     </Book>
-    <Book Series="Generation X" Number="50" Volume="1994" Year="1999" Format="Main Series">
+    <Book Series="Generation X" Number="50" Volume="1994" Year="1999">
       <Id>088fcb05-ac06-4841-9352-953215e8b79a</Id>
     </Book>
-    <Book Series="X-Man" Number="50" Volume="1995" Year="1999" Format="Main Series">
+    <Book Series="X-Man" Number="50" Volume="1995" Year="1999">
       <Id>6304c23b-0cd2-4d9a-be0e-8d0893dbfeb1</Id>
     </Book>
-    <Book Series="X-Man" Number="51" Volume="1995" Year="1999" Format="Main Series">
+    <Book Series="X-Man" Number="51" Volume="1995" Year="1999">
       <Id>abc6773c-a98f-488c-b901-e69acd847950</Id>
     </Book>
-    <Book Series="X-Man" Number="52" Volume="1995" Year="1999" Format="Main Series">
+    <Book Series="X-Man" Number="52" Volume="1995" Year="1999">
       <Id>b6282e69-c2f6-4583-bf55-e4f6f5bd8e36</Id>
     </Book>
-    <Book Series="Generation X" Number="51" Volume="1994" Year="1999" Format="Main Series">
+    <Book Series="Generation X" Number="51" Volume="1994" Year="1999">
       <Id>0c3d8e42-d717-46be-9742-7801bfae4ed2</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="23" Volume="1993" Year="1999" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="23" Volume="1993" Year="1999">
       <Id>9317ab2e-5858-49fb-912b-5cdfe7bdd3c6</Id>
     </Book>
-    <Book Series="X-Force" Number="87" Volume="1991" Year="1999" Format="Main Series">
+    <Book Series="X-Force" Number="87" Volume="1991" Year="1999">
       <Id>cd8ea8cd-4b2d-40f7-a9a8-fb189aea1f93</Id>
     </Book>
-    <Book Series="X-Force" Number="88" Volume="1991" Year="1999" Format="Main Series">
+    <Book Series="X-Force" Number="88" Volume="1991" Year="1999">
       <Id>c6a57ad3-86e0-4328-824f-0bcb5995b8fd</Id>
     </Book>
-    <Book Series="X-Force" Number="89" Volume="1991" Year="1999" Format="Main Series">
+    <Book Series="X-Force" Number="89" Volume="1991" Year="1999">
       <Id>e5773400-2161-469d-b648-ff704c0a2b95</Id>
     </Book>
-    <Book Series="X-Force" Number="90" Volume="1991" Year="1999" Format="Main Series">
+    <Book Series="X-Force" Number="90" Volume="1991" Year="1999">
       <Id>1245025a-2ee8-4528-b474-8d1987e4e289</Id>
     </Book>
-    <Book Series="Gambit" Number="2" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Gambit" Number="2" Volume="1999" Year="1999">
       <Id>3079b504-42d8-46b5-a61f-e436b45c2ed6</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="368" Volume="1981" Year="1999" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="368" Volume="1981" Year="1999">
       <Id>08efbea8-01c3-41d0-973d-247ab5b8f138</Id>
     </Book>
-    <Book Series="X-Men" Number="88" Volume="1991" Year="1999" Format="Main Series">
+    <Book Series="X-Men" Number="88" Volume="1991" Year="1999">
       <Id>eda79271-1d97-40af-9480-7609ac752c32</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="369" Volume="1981" Year="1999" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="369" Volume="1981" Year="1999">
       <Id>d5a2c2eb-1504-4bf1-bdab-7420862e0e08</Id>
     </Book>
-    <Book Series="Magneto Rex" Number="1" Volume="1999" Year="1999" Format="Limited Series">
+    <Book Series="Magneto Rex" Number="1" Volume="1999" Year="1999">
       <Id>cee9486a-ad56-452d-aa64-ee1f7bbc4b55</Id>
     </Book>
-    <Book Series="Magneto Rex" Number="2" Volume="1999" Year="1999" Format="Limited Series">
+    <Book Series="Magneto Rex" Number="2" Volume="1999" Year="1999">
       <Id>6a0e24f3-9f0e-4f76-899f-4610674ce701</Id>
     </Book>
-    <Book Series="Magneto Rex" Number="3" Volume="1999" Year="1999" Format="Limited Series">
+    <Book Series="Magneto Rex" Number="3" Volume="1999" Year="1999">
       <Id>7f85f77e-e19e-4f52-af82-2ad2bd8401ad</Id>
     </Book>
-    <Book Series="X-Man" Number="53" Volume="1995" Year="1999" Format="Main Series">
+    <Book Series="X-Man" Number="53" Volume="1995" Year="1999">
       <Id>288d2bc8-01cf-4966-8b7d-d09483cd5c26</Id>
     </Book>
-    <Book Series="X-Man" Number="54" Volume="1995" Year="1999" Format="Main Series">
+    <Book Series="X-Man" Number="54" Volume="1995" Year="1999">
       <Id>67b84a5d-743d-4634-81fd-848388054e28</Id>
     </Book>
-    <Book Series="X-Man" Number="55" Volume="1995" Year="1999" Format="Main Series">
+    <Book Series="X-Man" Number="55" Volume="1995" Year="1999">
       <Id>a185cbdb-1c3e-45a4-9f27-2c2fe5578cc2</Id>
     </Book>
-    <Book Series="X-Men" Number="89" Volume="1991" Year="1999" Format="Main Series">
+    <Book Series="X-Men" Number="89" Volume="1991" Year="1999">
       <Id>1486741c-72f3-44a5-a4a2-f77367360903</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="370" Volume="1981" Year="1999" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="370" Volume="1981" Year="1999">
       <Id>bef079fc-5cbe-45e4-89bb-c0836aac3c72</Id>
     </Book>
-    <Book Series="X-Men" Number="90" Volume="1991" Year="1999" Format="Main Series">
+    <Book Series="X-Men" Number="90" Volume="1991" Year="1999">
       <Id>8d147102-70d5-44ac-a10a-54280a04dfc6</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="371" Volume="1981" Year="1999" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="371" Volume="1981" Year="1999">
       <Id>84c64f56-dad5-42a6-a238-210859156ec2</Id>
     </Book>
-    <Book Series="X-Men" Number="91" Volume="1991" Year="1999" Format="Main Series">
+    <Book Series="X-Men" Number="91" Volume="1991" Year="1999">
       <Id>7829738a-283c-46c4-b767-8cf628f64370</Id>
     </Book>
-    <Book Series="X-Men Annual 1999" Number="1" Volume="1999" Year="1999" Format="Annual">
+    <Book Series="X-Men Annual 1999" Number="1" Volume="1999" Year="1999">
       <Id>95578fa3-78a7-435c-87bc-e90f04b4d1ff</Id>
     </Book>
-    <Book Series="Generation X" Number="52" Volume="1994" Year="1999" Format="Main Series">
+    <Book Series="Generation X" Number="52" Volume="1994" Year="1999">
       <Id>065e58dc-0892-46bf-bd25-481833257f2c</Id>
     </Book>
-    <Book Series="Wolverine" Number="140" Volume="1988" Year="1999" Format="Main Series">
+    <Book Series="Wolverine" Number="140" Volume="1988" Year="1999">
       <Id>21ceea86-51aa-4268-96da-978de94af267</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="24" Volume="1993" Year="1999" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="24" Volume="1993" Year="1999">
       <Id>d303ff4c-628b-4616-9dcf-cf2fc8c778c0</Id>
     </Book>
-    <Book Series="X-Force" Number="91" Volume="1991" Year="1999" Format="Main Series">
+    <Book Series="X-Force" Number="91" Volume="1991" Year="1999">
       <Id>249b130c-b37f-4010-b9a0-366c603397b9</Id>
     </Book>
-    <Book Series="X-Force" Number="92" Volume="1991" Year="1999" Format="Main Series">
+    <Book Series="X-Force" Number="92" Volume="1991" Year="1999">
       <Id>a7a0b13d-8c4f-49d6-ab21-64d9f4da6edb</Id>
     </Book>
-    <Book Series="X-Force" Number="93" Volume="1991" Year="1999" Format="Main Series">
+    <Book Series="X-Force" Number="93" Volume="1991" Year="1999">
       <Id>fceef34d-1f02-498d-a452-98df762739c4</Id>
     </Book>
-    <Book Series="Gambit" Number="3" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Gambit" Number="3" Volume="1999" Year="1999">
       <Id>8cc0c332-64c1-4fae-a66c-4eebdddd6874</Id>
     </Book>
-    <Book Series="Gambit" Number="4" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Gambit" Number="4" Volume="1999" Year="1999">
       <Id>bef2e696-78ed-4965-8dcc-5c533356dd31</Id>
     </Book>
-    <Book Series="Gambit" Number="5" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Gambit" Number="5" Volume="1999" Year="1999">
       <Id>335e2e4f-2ea9-4729-86d1-23d488244203</Id>
     </Book>
-    <Book Series="Generation X" Number="53" Volume="1994" Year="1999" Format="Main Series">
+    <Book Series="Generation X" Number="53" Volume="1994" Year="1999">
       <Id>ae612fee-0dee-44b4-9481-ef20cded857a</Id>
     </Book>
-    <Book Series="Generation X" Number="54" Volume="1994" Year="1999" Format="Main Series">
+    <Book Series="Generation X" Number="54" Volume="1994" Year="1999">
       <Id>3415b1b6-619d-4bd4-83f8-2136491f6575</Id>
     </Book>
-    <Book Series="Generation X" Number="55" Volume="1994" Year="1999" Format="Main Series">
+    <Book Series="Generation X" Number="55" Volume="1994" Year="1999">
       <Id>e49e6545-859f-4be0-99ad-e8f984169860</Id>
     </Book>
-    <Book Series="Generation X" Number="56" Volume="1994" Year="1999" Format="Main Series">
+    <Book Series="Generation X" Number="56" Volume="1994" Year="1999">
       <Id>36296946-66d9-4b58-ab7f-f37449c00743</Id>
     </Book>
-    <Book Series="Generation X" Number="57" Volume="1994" Year="1999" Format="Main Series">
+    <Book Series="Generation X" Number="57" Volume="1994" Year="1999">
       <Id>cc53e2e0-ddd3-4fad-acdb-1d487fd047d7</Id>
     </Book>
-    <Book Series="Wolverine" Number="141" Volume="1988" Year="1999" Format="Main Series">
+    <Book Series="Wolverine" Number="141" Volume="1988" Year="1999">
       <Id>24d9ed0e-f6b1-416d-9b30-be45c8ff2439</Id>
     </Book>
-    <Book Series="Wolverine" Number="142" Volume="1988" Year="1999" Format="Main Series">
+    <Book Series="Wolverine" Number="142" Volume="1988" Year="1999">
       <Id>3b344513-a67f-4601-8e4e-4af2926b7696</Id>
     </Book>
-    <Book Series="Wolverine" Number="143" Volume="1988" Year="1999" Format="Main Series">
+    <Book Series="Wolverine" Number="143" Volume="1988" Year="1999">
       <Id>f55781ef-fef1-473f-b6c5-9484539a55a2</Id>
     </Book>
-    <Book Series="Wolverine" Number="144" Volume="1988" Year="1999" Format="Main Series">
+    <Book Series="Wolverine" Number="144" Volume="1988" Year="1999">
       <Id>d73e5641-10f7-4b59-b49e-fc64437cf093</Id>
     </Book>
-    <Book Series="Generation X" Number="58" Volume="1994" Year="1999" Format="Main Series">
+    <Book Series="Generation X" Number="58" Volume="1994" Year="1999">
       <Id>7ca94765-3dd5-430c-82a9-5b01aa7fcdce</Id>
     </Book>
-    <Book Series="X-Force" Number="94" Volume="1991" Year="1999" Format="Main Series">
+    <Book Series="X-Force" Number="94" Volume="1991" Year="1999">
       <Id>813564c7-d5e2-49d2-bec4-f97cded8d24d</Id>
     </Book>
-    <Book Series="X-Force" Number="95" Volume="1991" Year="1999" Format="Main Series">
+    <Book Series="X-Force" Number="95" Volume="1991" Year="1999">
       <Id>bc78bbec-9c61-4dd8-9112-8c2141e2adaa</Id>
     </Book>
-    <Book Series="X-Force Annual 1999" Number="1" Volume="1999" Year="1999" Format="Annual">
+    <Book Series="X-Force Annual 1999" Number="1" Volume="1999" Year="1999">
       <Id>21eaa074-285c-48b2-9e19-5a3e94eec56d</Id>
     </Book>
-    <Book Series="X-Force" Number="96" Volume="1991" Year="1999" Format="Main Series">
+    <Book Series="X-Force" Number="96" Volume="1991" Year="1999">
       <Id>5dea15b1-f42e-403d-95b0-85d6049cb8ee</Id>
     </Book>
-    <Book Series="X-Force" Number="97" Volume="1991" Year="1999" Format="Main Series">
+    <Book Series="X-Force" Number="97" Volume="1991" Year="1999">
       <Id>6626867e-1b09-4f16-ae78-07d964d3e0c0</Id>
     </Book>
-    <Book Series="Cable Annual 1999" Number="1" Volume="1999" Year="1999" Format="Annual">
+    <Book Series="Cable Annual 1999" Number="1" Volume="1999" Year="1999">
       <Id>1797e0ec-8a1b-4216-a765-86c5a46450c0</Id>
     </Book>
-    <Book Series="Cable" Number="71" Volume="1993" Year="1999" Format="Main Series">
+    <Book Series="Cable" Number="71" Volume="1993" Year="1999">
       <Id>f32bf9e5-bdfe-4934-9e44-ac2020e0f758</Id>
     </Book>
-    <Book Series="Gambit" Number="6" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Gambit" Number="6" Volume="1999" Year="1999">
       <Id>08fb9f9e-a059-4cc0-96f9-90d9ac6e546a</Id>
     </Book>
-    <Book Series="Gambit" Number="7" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Gambit" Number="7" Volume="1999" Year="1999">
       <Id>77a9a134-6e3e-4981-aef5-0c3ab97eac44</Id>
     </Book>
-    <Book Series="Gambit Annual 1999" Number="1" Volume="1999" Year="1999" Format="Annual">
+    <Book Series="Gambit Annual 1999" Number="1" Volume="1999" Year="1999">
       <Id>51ae1221-2eff-4034-9dbd-69f255cd1490</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="372" Volume="1981" Year="1999" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="372" Volume="1981" Year="1999">
       <Id>fed52782-c7f7-40ac-afd0-51883ebcfa87</Id>
     </Book>
-    <Book Series="X-Men" Number="92" Volume="1991" Year="1999" Format="Main Series">
+    <Book Series="X-Men" Number="92" Volume="1991" Year="1999">
       <Id>78bf8a6b-f221-40a5-a727-13b349d6de5a</Id>
     </Book>
-    <Book Series="Gambit" Number="8" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Gambit" Number="8" Volume="1999" Year="1999">
       <Id>8c092f12-8962-48d2-abef-eb936041a4e7</Id>
     </Book>
-    <Book Series="Gambit" Number="9" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Gambit" Number="9" Volume="1999" Year="1999">
       <Id>d579a156-3cae-423c-b3e1-c3d0fe906ddb</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="1" Volume="1999" Year="1999" Format="Limited Series">
+    <Book Series="Astonishing X-Men" Number="1" Volume="1999" Year="1999">
       <Id>cf0c2941-8b53-4062-9e0b-296d6675c2ba</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="2" Volume="1999" Year="1999" Format="Limited Series">
+    <Book Series="Astonishing X-Men" Number="2" Volume="1999" Year="1999">
       <Id>5a4b73f9-2080-44a6-bc32-76d6f15eced9</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="3" Volume="1999" Year="1999" Format="Limited Series">
+    <Book Series="Astonishing X-Men" Number="3" Volume="1999" Year="1999">
       <Id>d84d5447-a067-4953-aa26-ea02455c6919</Id>
     </Book>
-    <Book Series="Generation X Annual 1999" Number="1" Volume="1999" Year="1999" Format="Annual">
+    <Book Series="Generation X Annual 1999" Number="1" Volume="1999" Year="1999">
       <Id>39e5f7ee-0123-4cdb-b1f9-2c79185c1f20</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="373" Volume="1981" Year="1999" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="373" Volume="1981" Year="1999">
       <Id>bb99aa3d-26eb-421d-b5b4-d0164f10b694</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="374" Volume="1981" Year="1999" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="374" Volume="1981" Year="1999">
       <Id>da73cbfc-8f51-4d10-8da9-2d447218ca1f</Id>
     </Book>
-    <Book Series="X-Men" Number="93" Volume="1991" Year="1999" Format="Main Series">
+    <Book Series="X-Men" Number="93" Volume="1991" Year="1999">
       <Id>032f75e9-4412-471c-9489-8766b05f09d3</Id>
     </Book>
-    <Book Series="X-Men" Number="94" Volume="1991" Year="1999" Format="Main Series">
+    <Book Series="X-Men" Number="94" Volume="1991" Year="1999">
       <Id>233ca281-b0f6-40bf-bdcf-f9abcca23300</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="375" Volume="1981" Year="1999" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="375" Volume="1981" Year="1999">
       <Id>cd48c969-b117-40b2-b418-a82a994b0836</Id>
     </Book>
-    <Book Series="X-Men" Number="95" Volume="1991" Year="1999" Format="Main Series">
+    <Book Series="X-Men" Number="95" Volume="1991" Year="1999">
       <Id>47fb24c9-60e1-48f0-a381-ae9cabf27cde</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="25" Volume="1993" Year="1999" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="25" Volume="1993" Year="1999">
       <Id>d110ebdc-ff17-4158-85ab-6b86e3147895</Id>
     </Book>
-    <Book Series="Generation X" Number="59" Volume="1994" Year="2000" Format="Main Series">
+    <Book Series="Generation X" Number="59" Volume="1994" Year="2000">
       <Id>77bdfedb-1cca-46e5-9e60-ec62c746c2f1</Id>
     </Book>
-    <Book Series="Gambit" Number="10" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Gambit" Number="10" Volume="1999" Year="1999">
       <Id>edb61f77-6b8b-4f2b-bab2-a45a4bd47060</Id>
     </Book>
-    <Book Series="X-Man" Number="56" Volume="1995" Year="1999" Format="Main Series">
+    <Book Series="X-Man" Number="56" Volume="1995" Year="1999">
       <Id>598f3ea5-3ef2-439d-9cc3-4a997a39d20c</Id>
     </Book>
-    <Book Series="X-Man" Number="57" Volume="1995" Year="1999" Format="Main Series">
+    <Book Series="X-Man" Number="57" Volume="1995" Year="1999">
       <Id>a7b0176a-d643-4eb8-b0bc-a58daab0181d</Id>
     </Book>
-    <Book Series="X-Man" Number="58" Volume="1995" Year="1999" Format="Main Series">
+    <Book Series="X-Man" Number="58" Volume="1995" Year="1999">
       <Id>5e32af29-86f4-4cac-af54-99f0e4e8bdbf</Id>
     </Book>
-    <Book Series="Wolverine" Number="145" Volume="1988" Year="1999" Format="Main Series">
+    <Book Series="Wolverine" Number="145" Volume="1988" Year="1999">
       <Id>f1fc1fd5-2bba-45ac-b7c3-669d2614ddc9</Id>
     </Book>
-    <Book Series="Cable" Number="72" Volume="1993" Year="1999" Format="Main Series">
+    <Book Series="Cable" Number="72" Volume="1993" Year="1999">
       <Id>e0f42e1c-526d-4006-b4c2-017fa47edab4</Id>
     </Book>
-    <Book Series="Cable" Number="73" Volume="1993" Year="1999" Format="Main Series">
+    <Book Series="Cable" Number="73" Volume="1993" Year="1999">
       <Id>c1e1343a-818b-4ed0-a632-f6eec24692d6</Id>
     </Book>
-    <Book Series="Cable" Number="74" Volume="1993" Year="1999" Format="Main Series">
+    <Book Series="Cable" Number="74" Volume="1993" Year="1999">
       <Id>fe7aedb2-b674-4418-bb41-cfd3fd10584a</Id>
     </Book>
-    <Book Series="X-Men: Phoenix" Number="1" Volume="1999" Year="1999" Format="Limited Series">
+    <Book Series="X-Men: Phoenix" Number="1" Volume="1999" Year="1999">
       <Id>197b8ef1-06c5-4239-8c08-8332d0eab9ab</Id>
     </Book>
-    <Book Series="X-Men: Phoenix" Number="2" Volume="1999" Year="2000" Format="Limited Series">
+    <Book Series="X-Men: Phoenix" Number="2" Volume="1999" Year="2000">
       <Id>d61daa36-ab93-4062-9951-59fbf7d38928</Id>
     </Book>
-    <Book Series="X-Men: Phoenix" Number="3" Volume="1999" Year="2000" Format="Limited Series">
+    <Book Series="X-Men: Phoenix" Number="3" Volume="1999" Year="2000">
       <Id>8a52d473-be4b-4350-bc21-0e9ca285076a</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="376" Volume="1981" Year="2000" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="376" Volume="1981" Year="2000">
       <Id>f25ac862-ce2d-4d78-bb04-d8f4d85c56d5</Id>
     </Book>
-    <Book Series="Cable" Number="75" Volume="1993" Year="2000" Format="Main Series">
+    <Book Series="Cable" Number="75" Volume="1993" Year="2000">
       <Id>c09058f8-7c41-483e-8360-76a9b1635297</Id>
     </Book>
-    <Book Series="X-Man" Number="59" Volume="1995" Year="2000" Format="Main Series">
+    <Book Series="X-Man" Number="59" Volume="1995" Year="2000">
       <Id>bc30ee98-0929-49b5-afa7-eb919a912864</Id>
     </Book>
-    <Book Series="X-Men" Number="96" Volume="1991" Year="2000" Format="Main Series">
+    <Book Series="X-Men" Number="96" Volume="1991" Year="2000">
       <Id>6920dff3-7983-4ab3-9a89-b5fd48c084c4</Id>
     </Book>
-    <Book Series="Wolverine" Number="146" Volume="1988" Year="2000" Format="Main Series">
+    <Book Series="Wolverine" Number="146" Volume="1988" Year="2000">
       <Id>e531c36d-35f1-461d-befc-cc6744f5d454</Id>
     </Book>
-    <Book Series="Wolverine" Number="147" Volume="1988" Year="2000" Format="Main Series">
+    <Book Series="Wolverine" Number="147" Volume="1988" Year="2000">
       <Id>1ac850d9-6e94-41c5-b535-54194f3a90a0</Id>
     </Book>
-    <Book Series="X-Man" Number="60" Volume="1995" Year="2000" Format="Main Series">
+    <Book Series="X-Man" Number="60" Volume="1995" Year="2000">
       <Id>ce7a4619-bf1e-4b58-8032-281f71a4c37e</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="377" Volume="1981" Year="2000" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="377" Volume="1981" Year="2000">
       <Id>6682b278-b7e5-4c4e-99c4-a043bab577c1</Id>
     </Book>
-    <Book Series="Cable" Number="76" Volume="1993" Year="2000" Format="Main Series">
+    <Book Series="Cable" Number="76" Volume="1993" Year="2000">
       <Id>8cbdaf77-4fdc-45a2-9398-fe823fe31f29</Id>
     </Book>
-    <Book Series="X-Men" Number="97" Volume="1991" Year="2000" Format="Main Series">
+    <Book Series="X-Men" Number="97" Volume="1991" Year="2000">
       <Id>477657fa-b9c9-4e6d-a875-5125899c0e27</Id>
     </Book>
-    <Book Series="Uncanny X-Men Annual 1999" Number="1" Volume="1999" Year="2000" Format="Annual">
+    <Book Series="Uncanny X-Men Annual 1999" Number="1" Volume="1999" Year="2000">
       <Id>640f0205-aa63-4b51-a3fc-4e0b6158fa7b</Id>
     </Book>
-    <Book Series="Generation X" Number="60" Volume="1994" Year="2000" Format="Main Series">
+    <Book Series="Generation X" Number="60" Volume="1994" Year="2000">
       <Id>af189672-f43c-46e3-95f6-d14c776e0031</Id>
     </Book>
-    <Book Series="Generation X" Number="61" Volume="1994" Year="2000" Format="Main Series">
+    <Book Series="Generation X" Number="61" Volume="1994" Year="2000">
       <Id>0fcda9d0-6cc8-492a-b69d-b5ae254940bf</Id>
     </Book>
-    <Book Series="X-Force" Number="98" Volume="1991" Year="2000" Format="Main Series">
+    <Book Series="X-Force" Number="98" Volume="1991" Year="2000">
       <Id>d8c0d175-c300-47fa-9d2e-2cf6a7890f23</Id>
     </Book>
-    <Book Series="X-Force" Number="99" Volume="1991" Year="2000" Format="Main Series">
+    <Book Series="X-Force" Number="99" Volume="1991" Year="2000">
       <Id>7893ccd6-fd77-48fa-a7e5-b24002cca88d</Id>
     </Book>
-    <Book Series="X-Force" Number="100" Volume="1991" Year="2000" Format="Main Series">
+    <Book Series="X-Force" Number="100" Volume="1991" Year="2000">
       <Id>73aa5601-3ed3-40d7-87c1-eb43985ff997</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="378" Volume="1981" Year="2000" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="378" Volume="1981" Year="2000">
       <Id>79209f01-4dd5-4d20-897d-358825f89d0d</Id>
     </Book>
-    <Book Series="Cable" Number="77" Volume="1993" Year="2000" Format="Main Series">
+    <Book Series="Cable" Number="77" Volume="1993" Year="2000">
       <Id>6e9543ac-c60a-4e35-a4a2-132fc270ef6e</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="26" Volume="1993" Year="2000" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="26" Volume="1993" Year="2000">
       <Id>10063d14-347c-49ff-8e97-0b276e92f318</Id>
     </Book>
-    <Book Series="Wolverine" Number="148" Volume="1988" Year="2000" Format="Main Series">
+    <Book Series="Wolverine" Number="148" Volume="1988" Year="2000">
       <Id>e527c456-b0e2-41d7-bc0f-21745b14ad9a</Id>
     </Book>
-    <Book Series="X-Men" Number="98" Volume="1991" Year="2000" Format="Main Series">
+    <Book Series="X-Men" Number="98" Volume="1991" Year="2000">
       <Id>06a2a9e5-d920-4e7d-99b9-2774788c4ec1</Id>
     </Book>
-    <Book Series="X-Man" Number="61" Volume="1995" Year="2000" Format="Main Series">
+    <Book Series="X-Man" Number="61" Volume="1995" Year="2000">
       <Id>a62c76b1-7502-479d-9a80-0c7ab27d258b</Id>
     </Book>
-    <Book Series="X-Man" Number="62" Volume="1995" Year="2000" Format="Main Series">
+    <Book Series="X-Man" Number="62" Volume="1995" Year="2000">
       <Id>81fee2a5-5bbe-4bea-a2f6-d3eac318406a</Id>
     </Book>
-    <Book Series="Gambit" Number="11" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Gambit" Number="11" Volume="1999" Year="1999">
       <Id>09cb8364-dd1b-4e7d-b9af-255d6f539e8a</Id>
     </Book>
-    <Book Series="Gambit" Number="12" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Gambit" Number="12" Volume="1999" Year="2000">
       <Id>062149f8-36e5-43cb-a355-88d1b96d8dab</Id>
     </Book>
-    <Book Series="Gambit" Number="13" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Gambit" Number="13" Volume="1999" Year="2000">
       <Id>82c99bc3-91c0-4662-b1d6-d59f4f6e4345</Id>
     </Book>
-    <Book Series="Gambit" Number="14" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Gambit" Number="14" Volume="1999" Year="2000">
       <Id>d139f086-9de1-44d8-a436-d32ef1ae0256</Id>
     </Book>
-    <Book Series="X-Men: The Hellfire Club" Number="1" Volume="2000" Year="2000" Format="Limited Series">
+    <Book Series="X-Men: The Hellfire Club" Number="1" Volume="2000" Year="2000">
       <Id>c11a609d-786d-45e8-b9d5-45af2bb7f229</Id>
     </Book>
-    <Book Series="X-Men: The Hellfire Club" Number="2" Volume="2000" Year="2000" Format="Limited Series">
+    <Book Series="X-Men: The Hellfire Club" Number="2" Volume="2000" Year="2000">
       <Id>1fa32845-dd68-480b-b3e9-3b04876e906b</Id>
     </Book>
-    <Book Series="X-Men: The Hellfire Club" Number="3" Volume="2000" Year="2000" Format="Limited Series">
+    <Book Series="X-Men: The Hellfire Club" Number="3" Volume="2000" Year="2000">
       <Id>f81ad50e-9491-49a1-9b05-1f30013bd842</Id>
     </Book>
-    <Book Series="X-Men: The Hellfire Club" Number="4" Volume="2000" Year="2000" Format="Limited Series">
+    <Book Series="X-Men: The Hellfire Club" Number="4" Volume="2000" Year="2000">
       <Id>5cda1931-0345-41f7-943d-26128d8b6c3a</Id>
     </Book>
-    <Book Series="Gambit" Number="15" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Gambit" Number="15" Volume="1999" Year="2000">
       <Id>9b03b5db-3cb1-451e-a008-5506839bb93b</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="379" Volume="1981" Year="2000" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="379" Volume="1981" Year="2000">
       <Id>cf9bc9c4-014a-4e16-87fd-01ec75713b9c</Id>
     </Book>
-    <Book Series="X-Force" Number="101" Volume="1991" Year="2000" Format="Main Series">
+    <Book Series="X-Force" Number="101" Volume="1991" Year="2000">
       <Id>c06aa323-a799-4978-a847-4285453ba1ea</Id>
     </Book>
-    <Book Series="Cable" Number="78" Volume="1993" Year="2000" Format="Main Series">
+    <Book Series="Cable" Number="78" Volume="1993" Year="2000">
       <Id>1f516e5e-4930-4fdd-8878-2851a9c71ec2</Id>
     </Book>
-    <Book Series="Wolverine" Number="149" Volume="1988" Year="2000" Format="Main Series">
+    <Book Series="Wolverine" Number="149" Volume="1988" Year="2000">
       <Id>a42f26c9-8c60-46bc-9d51-2d7236db0327</Id>
     </Book>
-    <Book Series="X-Men" Number="99" Volume="1991" Year="2000" Format="Main Series">
+    <Book Series="X-Men" Number="99" Volume="1991" Year="2000">
       <Id>01a3eac1-0c79-4cb4-9dd2-833cbae3dd42</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="380" Volume="1981" Year="2000" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="380" Volume="1981" Year="2000">
       <Id>77f4e940-00f0-4eb7-b5c9-17344936346b</Id>
     </Book>
-    <Book Series="Gambit" Number="16" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Gambit" Number="16" Volume="1999" Year="2000">
       <Id>78b7ae2e-0869-4a2e-8152-dd7c963b8b62</Id>
     </Book>
-    <Book Series="Magneto Dark Seduction" Number="1" Volume="2000" Year="2000" Format="Limited Series">
+    <Book Series="Magneto Dark Seduction" Number="1" Volume="2000" Year="2000">
       <Id>c7acaf26-d7b1-4c89-949f-7a87bcb226b4</Id>
     </Book>
-    <Book Series="Magneto Dark Seduction" Number="2" Volume="2000" Year="2000" Format="Limited Series">
+    <Book Series="Magneto Dark Seduction" Number="2" Volume="2000" Year="2000">
       <Id>cab3648a-f0dc-4d9a-bebb-88210f78b6d7</Id>
     </Book>
-    <Book Series="Magneto Dark Seduction" Number="3" Volume="2000" Year="2000" Format="Limited Series">
+    <Book Series="Magneto Dark Seduction" Number="3" Volume="2000" Year="2000">
       <Id>7f3ce95c-2c3e-4daf-910d-785e35acf010</Id>
     </Book>
-    <Book Series="Magneto Dark Seduction" Number="4" Volume="2000" Year="2000" Format="Limited Series">
+    <Book Series="Magneto Dark Seduction" Number="4" Volume="2000" Year="2000">
       <Id>61a88b92-6f8f-4b72-8c28-6d34f5f31c66</Id>
     </Book>
-    <Book Series="Generation X" Number="62" Volume="1994" Year="2000" Format="Main Series">
+    <Book Series="Generation X" Number="62" Volume="1994" Year="2000">
       <Id>fc77099d-9429-41e8-89e2-5287b85a4270</Id>
     </Book>
-    <Book Series="Generation X" Number="63" Volume="1994" Year="2000" Format="Main Series">
+    <Book Series="Generation X" Number="63" Volume="1994" Year="2000">
       <Id>4baf2fcf-7977-4af0-9f5f-e4cba2906634</Id>
     </Book>
-    <Book Series="Generation X" Number="64" Volume="1994" Year="2000" Format="Main Series">
+    <Book Series="Generation X" Number="64" Volume="1994" Year="2000">
       <Id>9b1c4ebc-c8e5-4fa8-9f1e-674fbe7ecb2f</Id>
     </Book>
-    <Book Series="Generation X" Number="65" Volume="1994" Year="2000" Format="Main Series">
+    <Book Series="Generation X" Number="65" Volume="1994" Year="2000">
       <Id>197ddaab-b15b-4b96-868a-68d69328bfc9</Id>
     </Book>
-    <Book Series="Generation X" Number="66" Volume="1994" Year="2000" Format="Main Series">
+    <Book Series="Generation X" Number="66" Volume="1994" Year="2000">
       <Id>1a434542-8f11-45b0-a002-5a149ce83354</Id>
     </Book>
-    <Book Series="Generation X" Number="67" Volume="1994" Year="2000" Format="Main Series">
+    <Book Series="Generation X" Number="67" Volume="1994" Year="2000">
       <Id>0d81333d-e6eb-4f98-ada8-5482957a555a</Id>
     </Book>
-    <Book Series="Generation X" Number="68" Volume="1994" Year="2000" Format="Main Series">
+    <Book Series="Generation X" Number="68" Volume="1994" Year="2000">
       <Id>b61cf2d1-9aef-4763-bede-8d04b1836f08</Id>
     </Book>
-    <Book Series="Generation X" Number="69" Volume="1994" Year="2000" Format="Main Series">
+    <Book Series="Generation X" Number="69" Volume="1994" Year="2000">
       <Id>642f9852-6349-46e6-9286-4f115bfc8c73</Id>
     </Book>
-    <Book Series="Generation X" Number="70" Volume="1994" Year="2000" Format="Main Series">
+    <Book Series="Generation X" Number="70" Volume="1994" Year="2000">
       <Id>33368588-0226-4f9a-bdbd-1b5be32b3658</Id>
     </Book>
-    <Book Series="Cable" Number="79" Volume="1993" Year="2000" Format="Main Series">
+    <Book Series="Cable" Number="79" Volume="1993" Year="2000">
       <Id>c58aa3e5-57db-4a24-94bc-a38da0c6b9e8</Id>
     </Book>
-    <Book Series="Cable" Number="80" Volume="1993" Year="2000" Format="Main Series">
+    <Book Series="Cable" Number="80" Volume="1993" Year="2000">
       <Id>f39a5a1c-f82a-4651-b24a-e420a707863f</Id>
     </Book>
-    <Book Series="Cable" Number="81" Volume="1993" Year="2000" Format="Main Series">
+    <Book Series="Cable" Number="81" Volume="1993" Year="2000">
       <Id>88364fca-fe4f-4311-b834-2b74cff5a660</Id>
     </Book>
-    <Book Series="Cable" Number="82" Volume="1993" Year="2000" Format="Main Series">
+    <Book Series="Cable" Number="82" Volume="1993" Year="2000">
       <Id>cff88c0c-7e7c-486e-bb9a-820c8b7cec61</Id>
     </Book>
-    <Book Series="Cable" Number="83" Volume="1993" Year="2000" Format="Main Series">
+    <Book Series="Cable" Number="83" Volume="1993" Year="2000">
       <Id>0354a668-89c8-4844-a165-6ad7cef98761</Id>
     </Book>
-    <Book Series="Cable" Number="84" Volume="1993" Year="2000" Format="Main Series">
+    <Book Series="Cable" Number="84" Volume="1993" Year="2000">
       <Id>866f610b-b1a6-49dd-a4cb-dc396c78a63f</Id>
     </Book>
-    <Book Series="X-Force" Number="102" Volume="1991" Year="2000" Format="Main Series">
+    <Book Series="X-Force" Number="102" Volume="1991" Year="2000">
       <Id>1a4691e3-6bc7-4aaa-a202-890b835da218</Id>
     </Book>
-    <Book Series="X-Force" Number="103" Volume="1991" Year="2000" Format="Main Series">
+    <Book Series="X-Force" Number="103" Volume="1991" Year="2000">
       <Id>bc58c53f-41af-4f73-827e-e2463849b78c</Id>
     </Book>
-    <Book Series="X-Force" Number="104" Volume="1991" Year="2000" Format="Main Series">
+    <Book Series="X-Force" Number="104" Volume="1991" Year="2000">
       <Id>2a17a4a2-e827-42a9-9d48-f9f45d17a8f6</Id>
     </Book>
-    <Book Series="X-Force" Number="105" Volume="1991" Year="2000" Format="Main Series">
+    <Book Series="X-Force" Number="105" Volume="1991" Year="2000">
       <Id>f3e784bd-5e02-4a2a-a93b-b8e342fa1b3e</Id>
     </Book>
-    <Book Series="Gambit" Number="17" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Gambit" Number="17" Volume="1999" Year="2000">
       <Id>1bbfa0b3-31b4-495f-a6de-fbeaebd4cdc3</Id>
     </Book>
-    <Book Series="Gambit" Number="18" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Gambit" Number="18" Volume="1999" Year="2000">
       <Id>d42a8b7d-3408-4aa4-8d81-43e271ca8a00</Id>
     </Book>
-    <Book Series="Gambit" Number="19" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Gambit" Number="19" Volume="1999" Year="2000">
       <Id>a9ebb5fe-cbab-42d9-85d2-d0a0dbfcf279</Id>
     </Book>
-    <Book Series="Gambit Annual 2000" Number="1" Volume="2000" Year="2000" Format="Annual">
+    <Book Series="Gambit Annual 2000" Number="1" Volume="2000" Year="2000">
       <Id>98035f2e-83ed-4a13-8346-cc711796d2db</Id>
     </Book>
-    <Book Series="X-Man" Number="67" Volume="1995" Year="2000" Format="Main Series">
+    <Book Series="X-Man" Number="67" Volume="1995" Year="2000">
       <Id>9615a7a8-bbba-44bd-abac-f52ffcdf0352</Id>
     </Book>
-    <Book Series="X-Man" Number="68" Volume="1995" Year="2000" Format="Main Series">
+    <Book Series="X-Man" Number="68" Volume="1995" Year="2000">
       <Id>3fcea555-fed7-4a97-925d-e2f893f0b09d</Id>
     </Book>
-    <Book Series="X-Man" Number="69" Volume="1995" Year="2000" Format="Main Series">
+    <Book Series="X-Man" Number="69" Volume="1995" Year="2000">
       <Id>f59d6452-8ac8-4487-b7e9-f6e0c7299d5c</Id>
     </Book>
-    <Book Series="X-Man" Number="70" Volume="1995" Year="2000" Format="Main Series">
+    <Book Series="X-Man" Number="70" Volume="1995" Year="2000">
       <Id>8de0b49a-3a2f-40f4-93bb-87309aff1f7b</Id>
     </Book>
-    <Book Series="X-Force" Number="106" Volume="1991" Year="2000" Format="Main Series">
+    <Book Series="X-Force" Number="106" Volume="1991" Year="2000">
       <Id>98ec792a-0ccd-4f1d-afcc-506899b70199</Id>
     </Book>
-    <Book Series="X-Force" Number="107" Volume="1991" Year="2000" Format="Main Series">
+    <Book Series="X-Force" Number="107" Volume="1991" Year="2000">
       <Id>3d971c79-d7de-4142-b7a8-967acfbb02c4</Id>
     </Book>
-    <Book Series="X-Force" Number="108" Volume="1991" Year="2000" Format="Main Series">
+    <Book Series="X-Force" Number="108" Volume="1991" Year="2000">
       <Id>0611aaa5-d5f2-4b82-9bbb-cf39798ee9f8</Id>
     </Book>
-    <Book Series="X-Force" Number="109" Volume="1991" Year="2000" Format="Main Series">
+    <Book Series="X-Force" Number="109" Volume="1991" Year="2000">
       <Id>e71b479d-c28e-46d9-b2d0-56cc12e55f68</Id>
     </Book>
-    <Book Series="Gambit" Number="20" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Gambit" Number="20" Volume="1999" Year="2000">
       <Id>dce38943-3bd5-4f5a-9642-8b9de6be29eb</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="27" Volume="1993" Year="2000" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="27" Volume="1993" Year="2000">
       <Id>6da21ebe-2f22-4300-a111-c17beddc3de8</Id>
     </Book>
-    <Book Series="X-Men: Black Sun" Number="1" Volume="2000" Year="2000" Format="Limited Series">
+    <Book Series="X-Men: Black Sun" Number="1" Volume="2000" Year="2000">
       <Id>d9aeb159-d024-41e3-8b17-a9d82d8918a0</Id>
     </Book>
-    <Book Series="X-Men: Black Sun" Number="2" Volume="2000" Year="2000" Format="Limited Series">
+    <Book Series="X-Men: Black Sun" Number="2" Volume="2000" Year="2000">
       <Id>8dd6ad91-27b9-41ec-b8a3-41878155f7db</Id>
     </Book>
-    <Book Series="X-Men: Black Sun" Number="3" Volume="2000" Year="2000" Format="Limited Series">
+    <Book Series="X-Men: Black Sun" Number="3" Volume="2000" Year="2000">
       <Id>8491fc43-4eda-4f20-bfef-1aab841f1863</Id>
     </Book>
-    <Book Series="X-Men: Black Sun" Number="4" Volume="2000" Year="2000" Format="Limited Series">
+    <Book Series="X-Men: Black Sun" Number="4" Volume="2000" Year="2000">
       <Id>eb39b065-d005-4673-927a-3c649ab16650</Id>
     </Book>
-    <Book Series="X-Men: Black Sun" Number="5" Volume="2000" Year="2000" Format="Limited Series">
+    <Book Series="X-Men: Black Sun" Number="5" Volume="2000" Year="2000">
       <Id>dbc007d9-337e-4dd8-873d-b495ef7e3d35</Id>
     </Book>
-    <Book Series="X-Men: Magik" Number="1" Volume="2000" Year="2000" Format="Limited Series">
+    <Book Series="X-Men: Magik" Number="1" Volume="2000" Year="2000">
       <Id>a6a3b2d1-5556-43e7-918c-f03c4ce22a6b</Id>
     </Book>
-    <Book Series="X-Men: Magik" Number="2" Volume="2000" Year="2001" Format="Limited Series">
+    <Book Series="X-Men: Magik" Number="2" Volume="2000" Year="2001">
       <Id>13950fc7-39ad-4a9d-b8b4-274f65653cd6</Id>
     </Book>
-    <Book Series="X-Men: Magik" Number="3" Volume="2000" Year="2001" Format="Limited Series">
+    <Book Series="X-Men: Magik" Number="3" Volume="2000" Year="2001">
       <Id>46ce2010-d19e-4e85-8cf2-47bbe6284fee</Id>
     </Book>
-    <Book Series="X-Men: Magik" Number="4" Volume="2000" Year="2001" Format="Limited Series">
+    <Book Series="X-Men: Magik" Number="4" Volume="2000" Year="2001">
       <Id>0de3a156-1091-4731-a23d-218073110713</Id>
     </Book>
-    <Book Series="X-Men" Number="100" Volume="1991" Year="2000" Format="Main Series">
+    <Book Series="X-Men" Number="100" Volume="1991" Year="2000">
       <Id>f664b296-ce10-41f2-b08b-109bda8bf3da</Id>
     </Book>
-    <Book Series="X-Men" Number="101" Volume="1991" Year="2000" Format="Main Series">
+    <Book Series="X-Men" Number="101" Volume="1991" Year="2000">
       <Id>890a62ec-61e5-4e23-9b4e-730fb000e22b</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="381" Volume="1981" Year="2000" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="381" Volume="1981" Year="2000">
       <Id>fe7e1f3c-0fa0-4801-8c6a-1217825ba8a9</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="382" Volume="1981" Year="2000" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="382" Volume="1981" Year="2000">
       <Id>66d3be7e-b18b-4d13-8386-0f260df82638</Id>
     </Book>
-    <Book Series="Wolverine" Number="150" Volume="1988" Year="2000" Format="Main Series">
+    <Book Series="Wolverine" Number="150" Volume="1988" Year="2000">
       <Id>be3500bd-6bfa-4759-bd42-badddca4419f</Id>
     </Book>
-    <Book Series="Wolverine" Number="151" Volume="1988" Year="2000" Format="Main Series">
+    <Book Series="Wolverine" Number="151" Volume="1988" Year="2000">
       <Id>b492a1bc-e9dd-44f5-b437-5d057bc70dbb</Id>
     </Book>
-    <Book Series="Wolverine" Number="152" Volume="1988" Year="2000" Format="Main Series">
+    <Book Series="Wolverine" Number="152" Volume="1988" Year="2000">
       <Id>31d78b3a-0757-4257-940d-55d2cd17d4fb</Id>
     </Book>
-    <Book Series="Wolverine" Number="153" Volume="1988" Year="2000" Format="Main Series">
+    <Book Series="Wolverine" Number="153" Volume="1988" Year="2000">
       <Id>8bc22894-b11a-41aa-a0a7-568897237636</Id>
     </Book>
-    <Book Series="X-Men" Number="102" Volume="1991" Year="2000" Format="Main Series">
+    <Book Series="X-Men" Number="102" Volume="1991" Year="2000">
       <Id>6e996ff8-cc87-4e97-9897-d4f78f117cd8</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="383" Volume="1981" Year="2000" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="383" Volume="1981" Year="2000">
       <Id>3b71db4b-60cf-4300-b412-a6dfee69eeef</Id>
     </Book>
-    <Book Series="X-Men Annual 2000" Number="1" Volume="2000" Year="2000" Format="Annual">
+    <Book Series="X-Men Annual 2000" Number="1" Volume="2000" Year="2000">
       <Id>ff9a11aa-3189-4852-a50f-1c8ac02ec7f4</Id>
     </Book>
-    <Book Series="X-Men" Number="103" Volume="1991" Year="2000" Format="Main Series">
+    <Book Series="X-Men" Number="103" Volume="1991" Year="2000">
       <Id>a6780495-e03e-48a0-b2bf-1f67cb5ba932</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="28" Volume="1993" Year="2000" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="28" Volume="1993" Year="2000">
       <Id>6853555d-0e47-4687-82f1-557a28aa8be9</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="384" Volume="1981" Year="2000" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="384" Volume="1981" Year="2000">
       <Id>c1355daa-0a5a-4c3d-8f6e-71d82253fda7</Id>
     </Book>
-    <Book Series="X-Men" Number="104" Volume="1991" Year="2000" Format="Main Series">
+    <Book Series="X-Men" Number="104" Volume="1991" Year="2000">
       <Id>225f1d3b-c4da-4d4a-bd3c-9dba84c87144</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="385" Volume="1981" Year="2000" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="385" Volume="1981" Year="2000">
       <Id>34297f01-69bc-4b4c-8c61-49a96bfa0666</Id>
     </Book>
-    <Book Series="X-Men Forever" Number="1" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="X-Men Forever" Number="1" Volume="2001" Year="2001">
       <Id>9ed1817b-cf73-479f-a2b0-3c19e34e4e25</Id>
     </Book>
-    <Book Series="X-Men Forever" Number="2" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="X-Men Forever" Number="2" Volume="2001" Year="2001">
       <Id>d525d01d-58d7-4dd9-b29d-50bb3a1396d4</Id>
     </Book>
-    <Book Series="X-Men Forever" Number="3" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="X-Men Forever" Number="3" Volume="2001" Year="2001">
       <Id>cde4801f-3e7d-489d-962a-18f2f0084a85</Id>
     </Book>
-    <Book Series="X-Men Forever" Number="4" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="X-Men Forever" Number="4" Volume="2001" Year="2001">
       <Id>0bdfe13b-15ff-491d-ac71-d0585447017b</Id>
     </Book>
-    <Book Series="X-Men Forever" Number="5" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="X-Men Forever" Number="5" Volume="2001" Year="2001">
       <Id>dd46ba3c-01b4-4ed9-b023-9b739d76d5e8</Id>
     </Book>
-    <Book Series="X-Men Forever" Number="6" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="X-Men Forever" Number="6" Volume="2001" Year="2001">
       <Id>212eac3b-e5f4-4b24-bbb7-43ec59cd6b4f</Id>
     </Book>
-    <Book Series="Gambit" Number="21" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Gambit" Number="21" Volume="1999" Year="2000">
       <Id>ac152936-b6e3-43b7-a39d-46404d2b5a80</Id>
     </Book>
-    <Book Series="X-Men" Number="105" Volume="1991" Year="2000" Format="Main Series">
+    <Book Series="X-Men" Number="105" Volume="1991" Year="2000">
       <Id>a42f9f8e-4ed3-40fa-8942-fd0bac95399e</Id>
     </Book>
-    <Book Series="X-Men" Number="106" Volume="1991" Year="2000" Format="Main Series">
+    <Book Series="X-Men" Number="106" Volume="1991" Year="2000">
       <Id>68d784d9-be5b-4ee0-9575-205242cb91ca</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="386" Volume="1981" Year="2000" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="386" Volume="1981" Year="2000">
       <Id>20cccd3b-90ed-46b1-802e-fed6b6a521ed</Id>
     </Book>
-    <Book Series="Gambit" Number="22" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Gambit" Number="22" Volume="1999" Year="2000">
       <Id>95a49d65-9d13-4fac-9f62-4276aae401a5</Id>
     </Book>
-    <Book Series="X-Man" Number="63" Volume="1995" Year="2000" Format="Main Series">
+    <Book Series="X-Man" Number="63" Volume="1995" Year="2000">
       <Id>19fead17-ead0-42c3-8923-ee8287d0ead6</Id>
     </Book>
-    <Book Series="X-Man" Number="64" Volume="1995" Year="2000" Format="Main Series">
+    <Book Series="X-Man" Number="64" Volume="1995" Year="2000">
       <Id>7e5c36d5-8d0b-4c8a-ada0-d0f7cdfe33fe</Id>
     </Book>
-    <Book Series="X-Man" Number="65" Volume="1995" Year="2000" Format="Main Series">
+    <Book Series="X-Man" Number="65" Volume="1995" Year="2000">
       <Id>31336917-b99f-4ff7-aa55-cfecb7be10f0</Id>
     </Book>
-    <Book Series="X-Man" Number="66" Volume="1995" Year="2000" Format="Main Series">
+    <Book Series="X-Man" Number="66" Volume="1995" Year="2000">
       <Id>6843ac3e-bd81-43ec-8559-0339caa8e30a</Id>
     </Book>
-    <Book Series="Maximum Security" Number="1" Volume="2000" Year="2000" Format="Limited Series">
+    <Book Series="Maximum Security" Number="1" Volume="2000" Year="2000">
       <Id>abe01708-cfc0-4228-89ee-821842ceed2f</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="387" Volume="1981" Year="2000" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="387" Volume="1981" Year="2000">
       <Id>00b01556-ad3b-497d-832e-f2513ba498d0</Id>
     </Book>
-    <Book Series="Maximum Security" Number="2" Volume="2000" Year="2000" Format="Limited Series">
+    <Book Series="Maximum Security" Number="2" Volume="2000" Year="2000">
       <Id>a666a62c-0ca8-4a1a-8681-4634b49416c9</Id>
     </Book>
-    <Book Series="Bishop: The Last X-Man" Number="15" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Bishop: The Last X-Man" Number="15" Volume="1999" Year="2000">
       <Id>240d2579-7e18-4073-b365-ddde851cccff</Id>
     </Book>
-    <Book Series="X-Men" Number="107" Volume="1991" Year="2000" Format="Main Series">
+    <Book Series="X-Men" Number="107" Volume="1991" Year="2000">
       <Id>55b1db03-b745-4ad9-a0a2-364b09cc49ed</Id>
     </Book>
-    <Book Series="Gambit" Number="23" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Gambit" Number="23" Volume="1999" Year="2000">
       <Id>5bb3b67a-61d9-4f9c-8eff-a1380afee175</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="29" Volume="1993" Year="2000" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="29" Volume="1993" Year="2000">
       <Id>8a6ef3ca-772f-4f14-9e23-cf7d55ed9f08</Id>
     </Book>
-    <Book Series="Maximum Security" Number="3" Volume="2000" Year="2001" Format="Limited Series">
+    <Book Series="Maximum Security" Number="3" Volume="2000" Year="2001">
       <Id>bffc72c8-44eb-4899-9d1b-e7f4e748099e</Id>
     </Book>
-    <Book Series="Cable" Number="85" Volume="1993" Year="2000" Format="Main Series">
+    <Book Series="Cable" Number="85" Volume="1993" Year="2000">
       <Id>e0a57d27-8c1e-4607-8a0f-e8259765aeea</Id>
     </Book>
-    <Book Series="Cable" Number="86" Volume="1993" Year="2000" Format="Main Series">
+    <Book Series="Cable" Number="86" Volume="1993" Year="2000">
       <Id>e79749ab-54fb-494b-8af3-191d32d2c806</Id>
     </Book>
-    <Book Series="Wolverine" Number="154" Volume="1988" Year="2000" Format="Main Series">
+    <Book Series="Wolverine" Number="154" Volume="1988" Year="2000">
       <Id>0ade6b75-610a-4ad8-99d2-0a15695d0a6d</Id>
     </Book>
-    <Book Series="Wolverine" Number="155" Volume="1988" Year="2000" Format="Main Series">
+    <Book Series="Wolverine" Number="155" Volume="1988" Year="2000">
       <Id>949f3b4a-ebe4-4d44-9753-3063babc54d3</Id>
     </Book>
-    <Book Series="Wolverine" Number="156" Volume="1988" Year="2000" Format="Main Series">
+    <Book Series="Wolverine" Number="156" Volume="1988" Year="2000">
       <Id>264e5a28-5618-4010-a0b7-2499afcc70b6</Id>
     </Book>
-    <Book Series="Wolverine" Number="157" Volume="1988" Year="2000" Format="Main Series">
+    <Book Series="Wolverine" Number="157" Volume="1988" Year="2000">
       <Id>92d81bcb-d8cc-4dde-919e-71520ca08b05</Id>
     </Book>
-    <Book Series="Wolverine Annual 2000" Number="1" Volume="2000" Year="2001" Format="Annual">
+    <Book Series="Wolverine Annual 2000" Number="1" Volume="2000" Year="2001">
       <Id>3e9c7675-b340-486f-90a3-6b30af33b5a6</Id>
     </Book>
-    <Book Series="X-Force" Number="110" Volume="1991" Year="2001" Format="Main Series">
+    <Book Series="X-Force" Number="110" Volume="1991" Year="2001">
       <Id>d3949aac-98c7-4837-a891-14d0a4d7c291</Id>
     </Book>
-    <Book Series="X-Force" Number="111" Volume="1991" Year="2001" Format="Main Series">
+    <Book Series="X-Force" Number="111" Volume="1991" Year="2001">
       <Id>b1f11454-be98-4e52-a883-d4d5d5984fb7</Id>
     </Book>
-    <Book Series="X-Force" Number="112" Volume="1991" Year="2001" Format="Main Series">
+    <Book Series="X-Force" Number="112" Volume="1991" Year="2001">
       <Id>5c68ecb6-22c1-498c-8514-bd38cc85e6b5</Id>
     </Book>
-    <Book Series="X-Force" Number="113" Volume="1991" Year="2001" Format="Main Series">
+    <Book Series="X-Force" Number="113" Volume="1991" Year="2001">
       <Id>c6697ce2-9aba-4643-b317-76005735fbb5</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="388" Volume="1981" Year="2000" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="388" Volume="1981" Year="2000">
       <Id>4e10a38d-ca36-47a6-9149-544cf7b05edc</Id>
     </Book>
-    <Book Series="Cable" Number="87" Volume="1993" Year="2001" Format="Main Series">
+    <Book Series="Cable" Number="87" Volume="1993" Year="2001">
       <Id>967947b2-b28d-420b-bf2e-8bfa8410203a</Id>
     </Book>
-    <Book Series="Bishop: The Last X-Man" Number="16" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Bishop: The Last X-Man" Number="16" Volume="1999" Year="2001">
       <Id>7fe1a974-5feb-4ee8-823e-69bb17b7c0b3</Id>
     </Book>
-    <Book Series="X-Men" Number="108" Volume="1991" Year="2001" Format="Main Series">
+    <Book Series="X-Men" Number="108" Volume="1991" Year="2001">
       <Id>b59b7986-932d-4ab9-b988-e77be5c2a97c</Id>
     </Book>
-    <Book Series="X-Force" Number="114" Volume="1991" Year="2001" Format="Main Series">
+    <Book Series="X-Force" Number="114" Volume="1991" Year="2001">
       <Id>a76f6eb5-30a2-49db-9fe1-ed269737ce70</Id>
     </Book>
-    <Book Series="X-Force" Number="115" Volume="1991" Year="2001" Format="Main Series">
+    <Book Series="X-Force" Number="115" Volume="1991" Year="2001">
       <Id>b52b1a64-858d-4110-adb8-973cce78b100</Id>
     </Book>
-    <Book Series="Generation X" Number="71" Volume="1994" Year="2001" Format="Main Series">
+    <Book Series="Generation X" Number="71" Volume="1994" Year="2001">
       <Id>ce93e04c-2f5f-4b63-963a-30250dd885dc</Id>
     </Book>
-    <Book Series="Generation X" Number="72" Volume="1994" Year="2001" Format="Main Series">
+    <Book Series="Generation X" Number="72" Volume="1994" Year="2001">
       <Id>a6bf0630-c1a3-45ea-87e9-43bf202d53b8</Id>
     </Book>
-    <Book Series="Generation X" Number="73" Volume="1994" Year="2001" Format="Main Series">
+    <Book Series="Generation X" Number="73" Volume="1994" Year="2001">
       <Id>6d252b37-6b52-49c1-95c5-cd2b026db783</Id>
     </Book>
-    <Book Series="Generation X" Number="74" Volume="1994" Year="2001" Format="Main Series">
+    <Book Series="Generation X" Number="74" Volume="1994" Year="2001">
       <Id>c3a5376f-8f98-42d9-834c-de8fc630da8d</Id>
     </Book>
-    <Book Series="Wolverine" Number="158" Volume="1988" Year="2001" Format="Main Series">
+    <Book Series="Wolverine" Number="158" Volume="1988" Year="2001">
       <Id>2ec82d8e-ac76-4f8d-b52c-fc2dbae86eee</Id>
     </Book>
-    <Book Series="Gambit" Number="24" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Gambit" Number="24" Volume="1999" Year="2001">
       <Id>d02c1fd9-54ad-4667-b991-f5d77fe90a1c</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="389" Volume="1981" Year="2001" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="389" Volume="1981" Year="2001">
       <Id>10a72bf9-2238-4ba3-94d8-bdb9ecd41467</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="33" Volume="1993" Year="2001" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="33" Volume="1993" Year="2001">
       <Id>8c4e5c5a-f02c-4c2f-bb95-01b87d7c0616</Id>
     </Book>
-    <Book Series="Cable" Number="88" Volume="1993" Year="2001" Format="Main Series">
+    <Book Series="Cable" Number="88" Volume="1993" Year="2001">
       <Id>512b0724-a804-40a5-a534-8680c3a908e7</Id>
     </Book>
-    <Book Series="Wolverine" Number="159" Volume="1988" Year="2001" Format="Main Series">
+    <Book Series="Wolverine" Number="159" Volume="1988" Year="2001">
       <Id>ca3a8dbb-68a9-4412-b7b2-38c91eed64d6</Id>
     </Book>
-    <Book Series="Wolverine" Number="160" Volume="1988" Year="2001" Format="Main Series">
+    <Book Series="Wolverine" Number="160" Volume="1988" Year="2001">
       <Id>c58824a2-565d-4730-9e46-5497192a6d9a</Id>
     </Book>
-    <Book Series="Wolverine" Number="161" Volume="1988" Year="2001" Format="Main Series">
+    <Book Series="Wolverine" Number="161" Volume="1988" Year="2001">
       <Id>9831eb0c-0ae0-462b-a961-fa4902b5dedb</Id>
     </Book>
-    <Book Series="X-Men" Number="109" Volume="1991" Year="2001" Format="Main Series">
+    <Book Series="X-Men" Number="109" Volume="1991" Year="2001">
       <Id>5a4c6961-ffda-494c-aeb1-b9f3210d5588</Id>
     </Book>
-    <Book Series="Uncanny X-Men Annual 2000" Number="1" Volume="2000" Year="2001" Format="Annual">
+    <Book Series="Uncanny X-Men Annual 2000" Number="1" Volume="2000" Year="2001">
       <Id>59b1e85b-755d-4b2e-b237-04abda94b24e</Id>
     </Book>
-    <Book Series="X-Men: The Search For Cyclops" Number="1" Volume="2000" Year="2000" Format="Limited Series">
+    <Book Series="X-Men: The Search For Cyclops" Number="1" Volume="2000" Year="2000">
       <Id>966715a0-a6d7-41fb-8adb-ff72520f1156</Id>
     </Book>
-    <Book Series="X-Men: The Search For Cyclops" Number="2" Volume="2000" Year="2001" Format="Limited Series">
+    <Book Series="X-Men: The Search For Cyclops" Number="2" Volume="2000" Year="2001">
       <Id>c7c64e16-3a2e-49e0-9743-bbc77132beb1</Id>
     </Book>
-    <Book Series="X-Men: The Search For Cyclops" Number="3" Volume="2000" Year="2001" Format="Limited Series">
+    <Book Series="X-Men: The Search For Cyclops" Number="3" Volume="2000" Year="2001">
       <Id>12ddb4d6-885f-456b-8cdf-3cdbde0f68b3</Id>
     </Book>
-    <Book Series="X-Men: The Search For Cyclops" Number="4" Volume="2000" Year="2001" Format="Limited Series">
+    <Book Series="X-Men: The Search For Cyclops" Number="4" Volume="2000" Year="2001">
       <Id>10d403c0-9784-4a02-acaf-e4cd79d80968</Id>
     </Book>
-    <Book Series="Cable" Number="89" Volume="1993" Year="2001" Format="Main Series">
+    <Book Series="Cable" Number="89" Volume="1993" Year="2001">
       <Id>a51fae4f-e71a-43f7-9b17-1a12806af5cc</Id>
     </Book>
-    <Book Series="Cable" Number="90" Volume="1993" Year="2001" Format="Main Series">
+    <Book Series="Cable" Number="90" Volume="1993" Year="2001">
       <Id>b3a499e2-2da6-4889-b64c-6c8c5953fdf8</Id>
     </Book>
-    <Book Series="Cable" Number="91" Volume="1993" Year="2001" Format="Main Series">
+    <Book Series="Cable" Number="91" Volume="1993" Year="2001">
       <Id>b91c77d6-c02c-4ec1-9a74-49b1acc8e5b8</Id>
     </Book>
-    <Book Series="Cable" Number="92" Volume="1993" Year="2001" Format="Main Series">
+    <Book Series="Cable" Number="92" Volume="1993" Year="2001">
       <Id>a4df0fa9-9bef-4672-93f7-a0bffca010fc</Id>
     </Book>
-    <Book Series="Cable" Number="93" Volume="1993" Year="2001" Format="Main Series">
+    <Book Series="Cable" Number="93" Volume="1993" Year="2001">
       <Id>9459e465-80b8-49c6-8f61-85667f9058f1</Id>
     </Book>
-    <Book Series="Cable" Number="94" Volume="1993" Year="2001" Format="Main Series">
+    <Book Series="Cable" Number="94" Volume="1993" Year="2001">
       <Id>efc80d8b-a4dc-4544-ba4b-13128c139121</Id>
     </Book>
-    <Book Series="Cable" Number="95" Volume="1993" Year="2001" Format="Main Series">
+    <Book Series="Cable" Number="95" Volume="1993" Year="2001">
       <Id>abbbf07e-f7d3-4d94-bb11-8638c817c513</Id>
     </Book>
-    <Book Series="Gambit" Number="25" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Gambit" Number="25" Volume="1999" Year="2001">
       <Id>754fe60e-dde5-479c-970a-5f25e7218239</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="390" Volume="1981" Year="2001" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="390" Volume="1981" Year="2001">
       <Id>ad909ce1-79db-4817-98e5-7dbf0f9a290a</Id>
     </Book>
-    <Book Series="X-Men" Number="110" Volume="1991" Year="2001" Format="Main Series">
+    <Book Series="X-Men" Number="110" Volume="1991" Year="2001">
       <Id>635f650b-7de9-468b-bce0-c883d219f51f</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="30" Volume="1993" Year="2001" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="30" Volume="1993" Year="2001">
       <Id>e3fd3cc5-430e-4ced-8639-5f3524b7e42b</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="31" Volume="1993" Year="2001" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="31" Volume="1993" Year="2001">
       <Id>d0c691ed-e6d0-4e0a-87e9-01264de591a9</Id>
     </Book>
-    <Book Series="Wolverine" Number="162" Volume="1988" Year="2001" Format="Main Series">
+    <Book Series="Wolverine" Number="162" Volume="1988" Year="2001">
       <Id>cf8d9554-da6a-42ad-ba44-3405adec880b</Id>
     </Book>
-    <Book Series="Wolverine" Number="163" Volume="1988" Year="2001" Format="Main Series">
+    <Book Series="Wolverine" Number="163" Volume="1988" Year="2001">
       <Id>32c5d493-f9e8-4346-8049-359aff87ca34</Id>
     </Book>
-    <Book Series="Wolverine" Number="164" Volume="1988" Year="2001" Format="Main Series">
+    <Book Series="Wolverine" Number="164" Volume="1988" Year="2001">
       <Id>188c0cc9-62ce-4fd5-8aa3-0f8fb29a028d</Id>
     </Book>
-    <Book Series="Wolverine" Number="165" Volume="1988" Year="2001" Format="Main Series">
+    <Book Series="Wolverine" Number="165" Volume="1988" Year="2001">
       <Id>9ce83605-c56c-43ba-8a13-af3c1883e870</Id>
     </Book>
-    <Book Series="Wolverine" Number="166" Volume="1988" Year="2001" Format="Main Series">
+    <Book Series="Wolverine" Number="166" Volume="1988" Year="2001">
       <Id>fb781764-83cb-4ee6-85a3-74a195dc1f96</Id>
     </Book>
-    <Book Series="Wolverine" Number="167" Volume="1988" Year="2001" Format="Main Series">
+    <Book Series="Wolverine" Number="167" Volume="1988" Year="2001">
       <Id>b97c9ff7-4ed0-4e32-8281-85d93000113b</Id>
     </Book>
-    <Book Series="Wolverine" Number="168" Volume="1988" Year="2001" Format="Main Series">
+    <Book Series="Wolverine" Number="168" Volume="1988" Year="2001">
       <Id>bd0f42e9-aefa-4045-a826-340779af0241</Id>
     </Book>
-    <Book Series="Wolverine" Number="169" Volume="1988" Year="2001" Format="Main Series">
+    <Book Series="Wolverine" Number="169" Volume="1988" Year="2001">
       <Id>3ee51f65-3534-4a70-b20c-e64041702339</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="391" Volume="1981" Year="2001" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="391" Volume="1981" Year="2001">
       <Id>11c80758-2c07-41ce-b2df-4e40e9771c8d</Id>
     </Book>
-    <Book Series="Cable" Number="96" Volume="1993" Year="2001" Format="Main Series">
+    <Book Series="Cable" Number="96" Volume="1993" Year="2001">
       <Id>d991d00f-e374-4f88-9a7f-ffa370ac60f2</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="32" Volume="1993" Year="2001" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="32" Volume="1993" Year="2001">
       <Id>27662678-c4ef-47c9-8a71-81afc364cc1b</Id>
     </Book>
-    <Book Series="X-Men" Number="111" Volume="1991" Year="2001" Format="Main Series">
+    <Book Series="X-Men" Number="111" Volume="1991" Year="2001">
       <Id>e4829375-c84b-4855-bb58-5ec9a74d7b7a</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="392" Volume="1981" Year="2001" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="392" Volume="1981" Year="2001">
       <Id>a45d49b2-e29d-427a-9396-a62bac481ffe</Id>
     </Book>
-    <Book Series="X-Men" Number="112" Volume="1991" Year="2001" Format="Main Series">
+    <Book Series="X-Men" Number="112" Volume="1991" Year="2001">
       <Id>e46c4693-ca02-4fd3-8ea2-f46a153b6cfe</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="393" Volume="1981" Year="2001" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="393" Volume="1981" Year="2001">
       <Id>dfcebdea-2f9b-437c-b2b5-712b4f29fdaa</Id>
     </Book>
-    <Book Series="X-Men" Number="113" Volume="1991" Year="2001" Format="Main Series">
+    <Book Series="X-Men" Number="113" Volume="1991" Year="2001">
       <Id>a70f4703-9bb9-443a-9d45-2964293f3104</Id>
     </Book>
-    <Book Series="Cable" Number="97" Volume="1993" Year="2001" Format="Main Series">
+    <Book Series="Cable" Number="97" Volume="1993" Year="2001">
       <Id>208368c1-0049-44eb-a7af-61ca946874f9</Id>
     </Book>
-    <Book Series="Cable" Number="98" Volume="1993" Year="2001" Format="Main Series">
+    <Book Series="Cable" Number="98" Volume="1993" Year="2001">
       <Id>a13bb8be-556c-4ac3-a06e-af9fb8eab3f9</Id>
     </Book>
-    <Book Series="Cable" Number="99" Volume="1993" Year="2002" Format="Main Series">
+    <Book Series="Cable" Number="99" Volume="1993" Year="2002">
       <Id>af89af2d-62fc-452e-ab1f-a3c11e165519</Id>
     </Book>
-    <Book Series="Cable" Number="100" Volume="1993" Year="2002" Format="Main Series">
+    <Book Series="Cable" Number="100" Volume="1993" Year="2002">
       <Id>aef94823-f79b-47e1-8e1d-d1b95377a107</Id>
     </Book>
-    <Book Series="X-Man" Number="71" Volume="1995" Year="2001" Format="Main Series">
+    <Book Series="X-Man" Number="71" Volume="1995" Year="2001">
       <Id>ce8ee883-cd7c-4f96-8ca7-eea3c16e0d51</Id>
     </Book>
-    <Book Series="X-Man" Number="72" Volume="1995" Year="2001" Format="Main Series">
+    <Book Series="X-Man" Number="72" Volume="1995" Year="2001">
       <Id>8b8fd697-b7e8-480f-8996-2faaa6b327f5</Id>
     </Book>
-    <Book Series="X-Man" Number="73" Volume="1995" Year="2001" Format="Main Series">
+    <Book Series="X-Man" Number="73" Volume="1995" Year="2001">
       <Id>46fe1c7d-f73a-45b5-9985-2e538b6001b9</Id>
     </Book>
-    <Book Series="X-Man" Number="74" Volume="1995" Year="2001" Format="Main Series">
+    <Book Series="X-Man" Number="74" Volume="1995" Year="2001">
       <Id>01d48668-8d63-431e-8420-98e4dbb09d6a</Id>
     </Book>
-    <Book Series="X-Man" Number="75" Volume="1995" Year="2001" Format="Main Series">
+    <Book Series="X-Man" Number="75" Volume="1995" Year="2001">
       <Id>4a01e8d5-cccc-459e-896b-5945610c7ce5</Id>
     </Book>
-    <Book Series="Cable" Number="101" Volume="1993" Year="2002" Format="Main Series">
+    <Book Series="Cable" Number="101" Volume="1993" Year="2002">
       <Id>224a803a-387c-4792-a07b-dab90a2cd8e7</Id>
     </Book>
-    <Book Series="Cable" Number="102" Volume="1993" Year="2002" Format="Main Series">
+    <Book Series="Cable" Number="102" Volume="1993" Year="2002">
       <Id>875ae1c1-cdbb-413c-9805-aad756e93c98</Id>
     </Book>
-    <Book Series="Cable" Number="103" Volume="1993" Year="2002" Format="Main Series">
+    <Book Series="Cable" Number="103" Volume="1993" Year="2002">
       <Id>809d4ad7-e036-4e25-91a0-3d6f80181a7b</Id>
     </Book>
-    <Book Series="Cable" Number="104" Volume="1993" Year="2002" Format="Main Series">
+    <Book Series="Cable" Number="104" Volume="1993" Year="2002">
       <Id>55f5eacf-b00d-4545-a900-37f1ffad65e8</Id>
     </Book>
   </Books>

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 008 (Morrison Era).cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 008 (Morrison Era).cbl
@@ -1,870 +1,868 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>X-Men - Part 8 (Morrison Era)</Name>
+  <Name>X-Men - Part 008 (Morrison Era)</Name>
+  <NumIssues>287</NumIssues>
   <Books>
     <Book Series="X-Treme X-Men" Number="1" Volume="2001" Year="2001">
-      <Id>62743f92-e439-4ebb-869a-b814da4dd386</Id>
+      <Database Name="cv" Series="9411" Issue="76558" />
     </Book>
     <Book Series="X-Treme X-Men" Number="2" Volume="2001" Year="2001">
-      <Id>dce2c861-fda3-4600-83dd-6f5ae2800bfe</Id>
+      <Database Name="cv" Series="9411" Issue="76559" />
     </Book>
     <Book Series="X-Treme X-Men" Number="3" Volume="2001" Year="2001">
-      <Id>d56ceeef-b136-4040-ac14-4b1c5b5e21cc</Id>
+      <Database Name="cv" Series="9411" Issue="76560" />
     </Book>
     <Book Series="X-Treme X-Men" Number="4" Volume="2001" Year="2001">
-      <Id>d1bc18c6-5f9e-4258-a3a9-e3e96150b5a3</Id>
+      <Database Name="cv" Series="9411" Issue="76561" />
     </Book>
-    <Book Series="Wolverine Annual 2001" Number="1" Volume="2001" Year="2002">
-      <Id>6c91dcdc-515a-43e2-a88b-7e7354c4cfb5</Id>
+    <Book Series="Wolverine 2001" Number="1" Volume="2001" Year="2002">
+      <Database Name="cv" Series="27132" Issue="164833" />
     </Book>
     <Book Series="Wolverine" Number="170" Volume="1988" Year="2002">
-      <Id>87ec902f-1ced-470e-b32f-183d65222ea3</Id>
+      <Database Name="cv" Series="4250" Issue="64487" />
     </Book>
     <Book Series="Wolverine" Number="171" Volume="1988" Year="2002">
-      <Id>1b7d6505-80d5-4a3b-bbec-b3677ad89373</Id>
+      <Database Name="cv" Series="4250" Issue="89851" />
     </Book>
     <Book Series="Wolverine" Number="172" Volume="1988" Year="2002">
-      <Id>145bb971-fe8c-41cb-bda7-4dddb70c183b</Id>
+      <Database Name="cv" Series="4250" Issue="64488" />
     </Book>
-    <Book Series="Origin" Number="1" Volume="2001" Year="2001">
-      <Id>21a134b1-c1a5-46f5-b190-c77385b3f66d</Id>
+    <Book Series="Wolverine: The Origin" Number="1" Volume="2001" Year="2001">
+      <Database Name="cv" Series="18649" Issue="110022" />
     </Book>
-    <Book Series="Origin" Number="2" Volume="2001" Year="2001">
-      <Id>26cf27f2-4330-486e-8b0b-5746b16ecc81</Id>
+    <Book Series="Wolverine: The Origin" Number="2" Volume="2001" Year="2001">
+      <Database Name="cv" Series="18649" Issue="110026" />
     </Book>
-    <Book Series="Origin" Number="3" Volume="2001" Year="2002">
-      <Id>86e724f9-1ea1-42b2-ab3c-7ca4a6bc3d7c</Id>
+    <Book Series="Wolverine: The Origin" Number="3" Volume="2001" Year="2002">
+      <Database Name="cv" Series="18649" Issue="110027" />
     </Book>
-    <Book Series="Origin" Number="4" Volume="2001" Year="2002">
-      <Id>084d9a1a-ca67-4106-8768-359c10b7b1ac</Id>
+    <Book Series="Wolverine: The Origin" Number="4" Volume="2001" Year="2002">
+      <Database Name="cv" Series="18649" Issue="110028" />
     </Book>
-    <Book Series="Origin" Number="5" Volume="2001" Year="2002">
-      <Id>6aefbc13-f630-4b72-9114-9cd7a2d3e815</Id>
+    <Book Series="Wolverine: The Origin" Number="5" Volume="2001" Year="2002">
+      <Database Name="cv" Series="18649" Issue="110029" />
     </Book>
-    <Book Series="Origin" Number="6" Volume="2001" Year="2002">
-      <Id>22ba893d-0762-49c0-90e2-916c8ec82e1f</Id>
+    <Book Series="Wolverine: The Origin" Number="6" Volume="2001" Year="2002">
+      <Database Name="cv" Series="18649" Issue="110030" />
     </Book>
     <Book Series="Generation X" Number="75" Volume="1994" Year="2001">
-      <Id>489e69f1-6e16-41f5-95c5-c539847b3dfe</Id>
+      <Database Name="cv" Series="5300" Issue="83135" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="394" Volume="1981" Year="2001">
-      <Id>bdc88df8-35c7-4134-95c7-84ffa19c48b2</Id>
+      <Database Name="cv" Series="3092" Issue="65178" />
     </Book>
     <Book Series="New X-Men" Number="114" Volume="2001" Year="2001">
-      <Id>63567fa3-0b6c-445a-a123-ae2760ec6e19</Id>
+      <Database Name="cv" Series="9121" Issue="66992" />
     </Book>
     <Book Series="New X-Men" Number="115" Volume="2001" Year="2001">
-      <Id>86fa691a-2c7b-4dce-aabb-bb8519ef21aa</Id>
+      <Database Name="cv" Series="9121" Issue="66993" />
     </Book>
     <Book Series="New X-Men" Number="116" Volume="2001" Year="2001">
-      <Id>ffc4a792-1452-4aab-9da8-f6f3139217ff</Id>
+      <Database Name="cv" Series="9121" Issue="66994" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="395" Volume="1981" Year="2001">
-      <Id>853b98fa-6d23-4d4d-9cdb-bd2420ee9f95</Id>
+      <Database Name="cv" Series="3092" Issue="65180" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="396" Volume="1981" Year="2001">
-      <Id>04125895-7eb7-4684-9164-594eced3ffbd</Id>
+      <Database Name="cv" Series="3092" Issue="65182" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="397" Volume="1981" Year="2001">
-      <Id>fb3bc8c5-ad4a-47c4-b1bf-a58c816a5202</Id>
+      <Database Name="cv" Series="3092" Issue="65184" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="398" Volume="1981" Year="2001">
-      <Id>a0373f1b-041d-46d4-b2e0-e20e4b4e55cf</Id>
+      <Database Name="cv" Series="3092" Issue="65185" />
     </Book>
     <Book Series="Cyclops" Number="1" Volume="2001" Year="2001">
-      <Id>82785e0a-be26-47d0-a46a-4c9a0a80b8f7</Id>
+      <Database Name="cv" Series="9461" Issue="77799" />
     </Book>
     <Book Series="Cyclops" Number="2" Volume="2001" Year="2001">
-      <Id>fac56eca-836c-4e84-a5be-459e6d74acad</Id>
+      <Database Name="cv" Series="9461" Issue="77800" />
     </Book>
     <Book Series="Cyclops" Number="3" Volume="2001" Year="2001">
-      <Id>ae513d64-f31d-4855-be5a-c3f62187d5ee</Id>
+      <Database Name="cv" Series="9461" Issue="77801" />
     </Book>
     <Book Series="Cyclops" Number="4" Volume="2001" Year="2002">
-      <Id>db07a33f-51a6-482a-b5fa-0f027bf6048d</Id>
+      <Database Name="cv" Series="9461" Issue="77802" />
     </Book>
     <Book Series="Rogue" Number="1" Volume="2001" Year="2001">
-      <Id>5ae2f638-b92a-49e7-a5b5-f559689a58f0</Id>
+      <Database Name="cv" Series="21823" Issue="131593" />
     </Book>
     <Book Series="Rogue" Number="2" Volume="2001" Year="2001">
-      <Id>b582dd64-367d-4d92-ac05-2c9b2af3aed5</Id>
+      <Database Name="cv" Series="21823" Issue="135689" />
     </Book>
     <Book Series="Rogue" Number="3" Volume="2001" Year="2001">
-      <Id>ebcf2b6b-a8b1-40d5-bc51-6a1656a52ad2</Id>
+      <Database Name="cv" Series="21823" Issue="135690" />
     </Book>
     <Book Series="Rogue" Number="4" Volume="2001" Year="2001">
-      <Id>d6bd60a7-59f1-47d3-b284-517448bd9233</Id>
+      <Database Name="cv" Series="21823" Issue="135691" />
     </Book>
     <Book Series="Iceman" Number="1" Volume="2001" Year="2001">
-      <Id>962fa31a-18a6-4823-a378-d8c6cb6b5e30</Id>
+      <Database Name="cv" Series="9465" Issue="77818" />
     </Book>
     <Book Series="Iceman" Number="2" Volume="2001" Year="2002">
-      <Id>54ea98e2-f392-4ea3-938c-e9b3ffae1f8f</Id>
+      <Database Name="cv" Series="9465" Issue="77819" />
     </Book>
     <Book Series="Iceman" Number="3" Volume="2001" Year="2002">
-      <Id>16435ed8-c79c-44bf-ac1d-3fef7f680100</Id>
+      <Database Name="cv" Series="9465" Issue="77820" />
     </Book>
     <Book Series="Iceman" Number="4" Volume="2001" Year="2002">
-      <Id>6ee91721-0536-4781-84c7-9660cdca3986</Id>
+      <Database Name="cv" Series="9465" Issue="77821" />
     </Book>
     <Book Series="X-Treme X-Men: Savage Land" Number="1" Volume="2001" Year="2001">
-      <Id>a8dfbdfe-b32a-4f61-884a-d853d497c555</Id>
+      <Database Name="cv" Series="18959" Issue="112491" />
     </Book>
     <Book Series="X-Treme X-Men: Savage Land" Number="2" Volume="2001" Year="2001">
-      <Id>d37907f2-2caf-49ab-b366-24f37069ad3f</Id>
+      <Database Name="cv" Series="18959" Issue="112510" />
     </Book>
     <Book Series="X-Treme X-Men: Savage Land" Number="3" Volume="2001" Year="2002">
-      <Id>5ff4b9d2-d84a-45bd-9327-8bad6da46082</Id>
+      <Database Name="cv" Series="18959" Issue="112511" />
     </Book>
     <Book Series="X-Treme X-Men: Savage Land" Number="4" Volume="2001" Year="2002">
-      <Id>25973856-bc50-49d5-be47-5dcb7671e343</Id>
+      <Database Name="cv" Series="18959" Issue="112512" />
     </Book>
     <Book Series="X-Men Unlimited" Number="34" Volume="1993" Year="2002">
-      <Id>ca46eeb1-6a3b-4d42-a07a-29dfef1f690a</Id>
+      <Database Name="cv" Series="5066" Issue="109026" />
     </Book>
     <Book Series="Cable" Number="105" Volume="1993" Year="2002">
-      <Id>a8efd145-8d61-4043-9eee-21cd72647e35</Id>
+      <Database Name="cv" Series="4993" Issue="136028" />
     </Book>
     <Book Series="Cable" Number="106" Volume="1993" Year="2002">
-      <Id>d8887cfe-73d3-46bf-9e06-dc2a73a91998</Id>
+      <Database Name="cv" Series="4993" Issue="136029" />
     </Book>
     <Book Series="Cable" Number="107" Volume="1993" Year="2002">
-      <Id>5e2e9f78-69d9-44a8-97e0-8dba3136660d</Id>
+      <Database Name="cv" Series="4993" Issue="136030" />
     </Book>
     <Book Series="X-Treme X-Men" Number="5" Volume="2001" Year="2001">
-      <Id>908aaaf0-feae-4022-ade7-94e795ae5c33</Id>
+      <Database Name="cv" Series="9411" Issue="76562" />
     </Book>
     <Book Series="X-Treme X-Men" Number="6" Volume="2001" Year="2001">
-      <Id>60643a0c-bd8f-4cd5-a59b-6d928d07b872</Id>
+      <Database Name="cv" Series="9411" Issue="76563" />
     </Book>
     <Book Series="X-Treme X-Men" Number="7" Volume="2001" Year="2002">
-      <Id>3ae6237c-7afc-4db6-b1c5-9c3e84caa7ba</Id>
+      <Database Name="cv" Series="9411" Issue="76564" />
     </Book>
     <Book Series="X-Treme X-Men" Number="8" Volume="2001" Year="2002">
-      <Id>fd8b9ba1-6bc0-45ae-b5a5-fef92c36606b</Id>
+      <Database Name="cv" Series="9411" Issue="105920" />
     </Book>
     <Book Series="New X-Men" Number="117" Volume="2001" Year="2001">
-      <Id>66e278ab-1893-4fa1-8bab-2b13a047d7dd</Id>
+      <Database Name="cv" Series="9121" Issue="66995" />
     </Book>
-    <Book Series="New X-Men Annual 2001" Number="1" Volume="2001" Year="2001">
-      <Id>2d30e03a-08db-4f03-9b34-f5764589e34f</Id>
+    <Book Series="X-Men 2001" Number="1" Volume="2001" Year="2001">
+      <Database Name="cv" Series="21334" Issue="128914" />
     </Book>
     <Book Series="New X-Men" Number="118" Volume="2001" Year="2001">
-      <Id>c47c6fe6-4384-4928-97c1-ed18f41d9fcc</Id>
+      <Database Name="cv" Series="9121" Issue="78322" />
     </Book>
     <Book Series="New X-Men" Number="119" Volume="2001" Year="2001">
-      <Id>01c6a3b9-b343-4f9a-a715-0d53dc5a684b</Id>
+      <Database Name="cv" Series="9121" Issue="78323" />
     </Book>
     <Book Series="New X-Men" Number="120" Volume="2001" Year="2002">
-      <Id>813a9b99-041f-4820-8b48-18cde136e203</Id>
+      <Database Name="cv" Series="9121" Issue="78324" />
     </Book>
     <Book Series="New X-Men" Number="121" Volume="2001" Year="2002">
-      <Id>84fc8a96-40e8-45bf-8b32-24a10bcdc725</Id>
+      <Database Name="cv" Series="9121" Issue="78325" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="399" Volume="1981" Year="2001">
-      <Id>e73dc18f-0a5a-4b1f-b5fc-cf964a41e10f</Id>
+      <Database Name="cv" Series="3092" Issue="65188" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="400" Volume="1981" Year="2001">
-      <Id>6a4233fa-4752-4b29-8374-46d09b1215ef</Id>
+      <Database Name="cv" Series="3092" Issue="65190" />
     </Book>
-    <Book Series="Uncanny X-Men Annual 2001" Number="1" Volume="2001" Year="2002">
-      <Id>aa5687ad-159f-4029-b457-1a67c918a068</Id>
+    <Book Series="Uncanny X-Men 2001" Number="1" Volume="2001" Year="2002">
+      <Database Name="cv" Series="60472" Issue="136054" />
     </Book>
     <Book Series="Nightcrawler" Number="1" Volume="2002" Year="2002">
-      <Id>5b7fad4a-df84-46f2-ae5f-9adedf4166b5</Id>
+      <Database Name="cv" Series="9467" Issue="77828" />
     </Book>
     <Book Series="Nightcrawler" Number="2" Volume="2002" Year="2002">
-      <Id>99a8dd94-fd6e-4773-b101-f879e680873b</Id>
+      <Database Name="cv" Series="9467" Issue="77829" />
     </Book>
     <Book Series="Nightcrawler" Number="3" Volume="2002" Year="2002">
-      <Id>fcd9ef17-b005-4fab-8902-07341b7d3c0c</Id>
+      <Database Name="cv" Series="9467" Issue="77830" />
     </Book>
     <Book Series="Nightcrawler" Number="4" Volume="2002" Year="2002">
-      <Id>e7c036bd-5a1c-44d6-b046-36f9c9275891</Id>
+      <Database Name="cv" Series="9467" Issue="77831" />
     </Book>
     <Book Series="New X-Men" Number="122" Volume="2001" Year="2002">
-      <Id>5217079f-6a40-4952-bb33-5663b42e5983</Id>
+      <Database Name="cv" Series="9121" Issue="78326" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="401" Volume="1981" Year="2002">
-      <Id>1d4632cb-8969-44e5-b2d0-17b8c13c5775</Id>
+      <Database Name="cv" Series="3092" Issue="65192" />
     </Book>
     <Book Series="X-Treme X-Men" Number="9" Volume="2001" Year="2002">
-      <Id>50f21eba-cc07-4028-a947-1a22da8e68b5</Id>
+      <Database Name="cv" Series="9411" Issue="76565" />
     </Book>
     <Book Series="Wolverine" Number="173" Volume="1988" Year="2002">
-      <Id>9bd2e01b-a1c1-4e6c-9095-dd7ea0be659c</Id>
+      <Database Name="cv" Series="4250" Issue="64489" />
     </Book>
     <Book Series="Wolverine" Number="174" Volume="1988" Year="2002">
-      <Id>631e84af-9654-406b-b377-fb288f5368bd</Id>
+      <Database Name="cv" Series="4250" Issue="64490" />
     </Book>
     <Book Series="Wolverine" Number="175" Volume="1988" Year="2002">
-      <Id>eb438511-6ef6-48a1-a6b6-4972270edfb7</Id>
+      <Database Name="cv" Series="4250" Issue="64491" />
     </Book>
     <Book Series="Wolverine" Number="176" Volume="1988" Year="2002">
-      <Id>f72ae7ab-1b5a-4eac-a653-1b6c04686f57</Id>
+      <Database Name="cv" Series="4250" Issue="114943" />
     </Book>
     <Book Series="New X-Men" Number="123" Volume="2001" Year="2002">
-      <Id>05d9552d-b2bb-4a9a-a905-9ba9d8fca1c0</Id>
+      <Database Name="cv" Series="9121" Issue="78327" />
     </Book>
     <Book Series="New X-Men" Number="124" Volume="2001" Year="2002">
-      <Id>644ea8dd-958d-439b-9155-ff5723837d13</Id>
+      <Database Name="cv" Series="9121" Issue="78328" />
     </Book>
     <Book Series="New X-Men" Number="125" Volume="2001" Year="2002">
-      <Id>7fbb3922-0fbc-4efc-8d7d-78e8050ebddb</Id>
+      <Database Name="cv" Series="9121" Issue="78329" />
     </Book>
     <Book Series="New X-Men" Number="126" Volume="2001" Year="2002">
-      <Id>737edb55-c64c-4dd4-8e06-b1afe100879b</Id>
+      <Database Name="cv" Series="9121" Issue="78330" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="402" Volume="1981" Year="2002">
-      <Id>8dce83ad-ce06-4fa9-a2f8-fbb91c4f06e5</Id>
+      <Database Name="cv" Series="3092" Issue="65193" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="403" Volume="1981" Year="2002">
-      <Id>b309fdbd-e44c-4bf9-8fdd-01f87b110752</Id>
+      <Database Name="cv" Series="3092" Issue="65194" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="404" Volume="1981" Year="2002">
-      <Id>f6aa3cb5-5300-41bf-a8e7-3a18d56bc4b9</Id>
+      <Database Name="cv" Series="3092" Issue="105447" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="405" Volume="1981" Year="2002">
-      <Id>a47800c6-dc73-41bf-b5ff-9c1034def6a3</Id>
+      <Database Name="cv" Series="3092" Issue="105448" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="406" Volume="1981" Year="2002">
-      <Id>ed1fcca3-315c-4fab-9ec2-50059c9bffbe</Id>
+      <Database Name="cv" Series="3092" Issue="105449" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="407" Volume="1981" Year="2002">
-      <Id>632217c3-eb1a-4c0a-b223-c9b4d05d0507</Id>
+      <Database Name="cv" Series="3092" Issue="105596" />
     </Book>
     <Book Series="X-Factor" Number="1" Volume="2002" Year="2002">
-      <Id>941e11b0-aba6-4372-8e5f-25c350c1545d</Id>
+      <Database Name="cv" Series="24239" Issue="144022" />
     </Book>
     <Book Series="X-Factor" Number="2" Volume="2002" Year="2002">
-      <Id>16688544-5dec-4855-8ac9-8586f4b61b8e</Id>
+      <Database Name="cv" Series="24239" Issue="144024" />
     </Book>
     <Book Series="X-Factor" Number="3" Volume="2002" Year="2002">
-      <Id>4bfe5bd8-d9f5-4819-a06e-37103212287f</Id>
+      <Database Name="cv" Series="24239" Issue="144025" />
     </Book>
     <Book Series="X-Factor" Number="4" Volume="2002" Year="2002">
-      <Id>22f6732d-da0f-4253-a015-743a08b04eee</Id>
+      <Database Name="cv" Series="24239" Issue="144026" />
     </Book>
-    <Book Series="X-Treme X-Men Annual 2001" Number="2001" Volume="2001" Year="2001">
-      <Id>7befd40c-aaa2-4a09-904f-8d2d119f490f</Id>
+    <Book Series="X-Treme X-Men 2001" Number="1" Volume="2001" Year="2002">
+      <Database Name="cv" Series="27047" Issue="163699" />
     </Book>
     <Book Series="X-Treme X-Men" Number="10" Volume="2001" Year="2002">
-      <Id>888f669a-8a9a-488e-a349-21bcc9e6c28c</Id>
+      <Database Name="cv" Series="9411" Issue="105432" />
     </Book>
     <Book Series="X-Treme X-Men" Number="11" Volume="2001" Year="2002">
-      <Id>af6b4eca-2481-462e-bd2a-f66585079d7e</Id>
+      <Database Name="cv" Series="9411" Issue="105921" />
     </Book>
     <Book Series="X-Treme X-Men" Number="12" Volume="2001" Year="2002">
-      <Id>dd8932d4-ea58-472f-bcc1-71bae93dcfd5</Id>
+      <Database Name="cv" Series="9411" Issue="105928" />
     </Book>
     <Book Series="X-Treme X-Men" Number="13" Volume="2001" Year="2002">
-      <Id>e6ea1a26-c672-46d7-8c1f-f900effbf0b8</Id>
+      <Database Name="cv" Series="9411" Issue="105977" />
     </Book>
     <Book Series="X-Treme X-Men" Number="14" Volume="2001" Year="2002">
-      <Id>700174e5-b0ac-42f8-8aa2-6343271eb617</Id>
+      <Database Name="cv" Series="9411" Issue="105992" />
     </Book>
     <Book Series="X-Treme X-Men" Number="15" Volume="2001" Year="2002">
-      <Id>1525adeb-d5de-489d-be92-56ef1a94cf91</Id>
+      <Database Name="cv" Series="9411" Issue="105993" />
     </Book>
     <Book Series="X-Treme X-Men" Number="16" Volume="2001" Year="2002">
-      <Id>848351f2-0cf3-41ef-b1ce-3bb7c48aad19</Id>
+      <Database Name="cv" Series="9411" Issue="105994" />
     </Book>
     <Book Series="X-Treme X-Men" Number="17" Volume="2001" Year="2002">
-      <Id>b3dc12e1-4fed-4715-8f8e-40e070372a73</Id>
+      <Database Name="cv" Series="9411" Issue="106005" />
     </Book>
     <Book Series="X-Treme X-Men" Number="18" Volume="2001" Year="2002">
-      <Id>97c84dce-e08e-4d33-9353-710df3111714</Id>
+      <Database Name="cv" Series="9411" Issue="106019" />
     </Book>
     <Book Series="New X-Men" Number="127" Volume="2001" Year="2002">
-      <Id>77a3e539-85cc-471f-bc65-df24cae236a9</Id>
+      <Database Name="cv" Series="9121" Issue="78331" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="408" Volume="1981" Year="2002">
-      <Id>37703d59-14fc-44df-88f8-f0ec864d6d01</Id>
+      <Database Name="cv" Series="3092" Issue="105598" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="409" Volume="1981" Year="2002">
-      <Id>0a953dec-7ef2-479e-9fb5-cdb40dff5028</Id>
+      <Database Name="cv" Series="3092" Issue="105600" />
     </Book>
     <Book Series="X-Men Unlimited" Number="35" Volume="1993" Year="2002">
-      <Id>ec4f1f24-76be-4e26-9888-0ae1bce19f69</Id>
+      <Database Name="cv" Series="5066" Issue="113918" />
     </Book>
     <Book Series="X-Men Unlimited" Number="36" Volume="1993" Year="2002">
-      <Id>a74d44de-2897-4f8b-9801-6346650c5176</Id>
+      <Database Name="cv" Series="5066" Issue="113919" />
     </Book>
     <Book Series="X-Treme X-Men" Number="19" Volume="2001" Year="2002">
-      <Id>9977d04c-93b5-4530-81cb-d5a1063d1ae9</Id>
+      <Database Name="cv" Series="9411" Issue="106074" />
     </Book>
     <Book Series="New X-Men" Number="128" Volume="2001" Year="2002">
-      <Id>1573c90c-9313-4827-937b-177801f0f75e</Id>
+      <Database Name="cv" Series="9121" Issue="80585" />
     </Book>
     <Book Series="New X-Men" Number="129" Volume="2001" Year="2002">
-      <Id>0b83759f-a666-4b01-a568-51208a5e6078</Id>
+      <Database Name="cv" Series="9121" Issue="106089" />
     </Book>
     <Book Series="New X-Men" Number="130" Volume="2001" Year="2002">
-      <Id>74d4f2b6-e10b-4f0c-93a2-913f4c84152c</Id>
+      <Database Name="cv" Series="9121" Issue="106112" />
     </Book>
     <Book Series="New X-Men" Number="131" Volume="2001" Year="2002">
-      <Id>de3ab49b-d853-4fe1-b115-6b3fa8103a8c</Id>
+      <Database Name="cv" Series="9121" Issue="106161" />
     </Book>
     <Book Series="New X-Men" Number="132" Volume="2001" Year="2002">
-      <Id>24d3093a-8ab9-4fe5-a9cd-0a4691b4d9dc</Id>
+      <Database Name="cv" Series="9121" Issue="106564" />
     </Book>
     <Book Series="New X-Men" Number="133" Volume="2001" Year="2002">
-      <Id>5c21551f-9de2-4eb3-bc63-5ca3e0c81a1a</Id>
+      <Database Name="cv" Series="9121" Issue="106301" />
     </Book>
     <Book Series="X-Men Unlimited" Number="37" Volume="1993" Year="2002">
-      <Id>e2cd7396-7f2e-4a9d-a324-a4498cc77e1e</Id>
+      <Database Name="cv" Series="5066" Issue="110136" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="410" Volume="1981" Year="2002">
-      <Id>a3127f25-a8ff-4cbf-9845-f332eb7310ff</Id>
+      <Database Name="cv" Series="3092" Issue="105615" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="411" Volume="1981" Year="2002">
-      <Id>2e0b7d26-209b-4d58-a08d-b7b43f711a49</Id>
+      <Database Name="cv" Series="3092" Issue="105616" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="412" Volume="1981" Year="2002">
-      <Id>0a9cbea4-5c53-4edc-842f-0399544f4f8c</Id>
+      <Database Name="cv" Series="3092" Issue="105325" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="413" Volume="1981" Year="2002">
-      <Id>ad219bec-9f80-4b2a-9f39-e2a4ab095717</Id>
+      <Database Name="cv" Series="3092" Issue="107447" />
     </Book>
     <Book Series="Chamber" Number="1" Volume="2002" Year="2002">
-      <Id>108ffab0-a6de-48ad-ac03-894508aebafb</Id>
+      <Database Name="cv" Series="9459" Issue="77754" />
     </Book>
     <Book Series="Chamber" Number="2" Volume="2002" Year="2002">
-      <Id>f40e9b02-ab4f-4b1b-826e-826b39133b47</Id>
+      <Database Name="cv" Series="9459" Issue="77755" />
     </Book>
     <Book Series="Chamber" Number="3" Volume="2002" Year="2002">
-      <Id>9e01bf60-74e6-40a8-b3af-d88bb7cbb2ee</Id>
+      <Database Name="cv" Series="9459" Issue="77756" />
     </Book>
     <Book Series="Chamber" Number="4" Volume="2002" Year="2003">
-      <Id>32b30d05-121d-4428-afe5-133c9b7da652</Id>
+      <Database Name="cv" Series="9459" Issue="77757" />
     </Book>
     <Book Series="X-Treme X-Pose" Number="1" Volume="2003" Year="2003">
-      <Id>a8707f06-b91a-4adc-86df-5fbf6a2eb55a</Id>
+      <Database Name="cv" Series="25483" Issue="150334" />
     </Book>
     <Book Series="X-Treme X-Pose" Number="2" Volume="2003" Year="2003">
-      <Id>f7aed619-7b75-414e-8eea-f0353a8c8013</Id>
+      <Database Name="cv" Series="25483" Issue="150338" />
     </Book>
     <Book Series="Wolverine" Number="179" Volume="1988" Year="2002">
-      <Id>77b146f0-dfcf-46ce-8a1b-f6d10b1971b4</Id>
+      <Database Name="cv" Series="4250" Issue="93790" />
     </Book>
     <Book Series="Wolverine" Number="180" Volume="1988" Year="2002">
-      <Id>389bcfc2-d7fa-4d75-aa7d-b4a9fe986f63</Id>
+      <Database Name="cv" Series="4250" Issue="93791" />
     </Book>
     <Book Series="Wolverine" Number="181" Volume="1988" Year="2002">
-      <Id>919e2635-52f6-406e-a647-348620219860</Id>
+      <Database Name="cv" Series="4250" Issue="93792" />
     </Book>
     <Book Series="Wolverine" Number="182" Volume="1988" Year="2002">
-      <Id>89e994cf-fb93-4977-9649-9c23669abee9</Id>
+      <Database Name="cv" Series="4250" Issue="93793" />
     </Book>
     <Book Series="Wolverine" Number="183" Volume="1988" Year="2003">
-      <Id>ca13c8a9-43ba-431f-acc3-415948a2624b</Id>
+      <Database Name="cv" Series="4250" Issue="93794" />
     </Book>
     <Book Series="Wolverine" Number="184" Volume="1988" Year="2003">
-      <Id>d82065af-269e-4812-aa3e-33ed0052c23f</Id>
+      <Database Name="cv" Series="4250" Issue="93795" />
     </Book>
     <Book Series="Wolverine" Number="185" Volume="1988" Year="2003">
-      <Id>dfb7326f-59e2-4bdf-b55f-b97dc188060b</Id>
+      <Database Name="cv" Series="4250" Issue="93796" />
     </Book>
     <Book Series="X-Men Unlimited" Number="38" Volume="1993" Year="2002">
-      <Id>dbcc3f6e-9a3f-472d-be76-6c70464f44f4</Id>
+      <Database Name="cv" Series="5066" Issue="113917" />
     </Book>
     <Book Series="Mekanix" Number="1" Volume="2002" Year="2002">
-      <Id>3c39802b-1819-4ee1-98ca-bf78095f49d2</Id>
+      <Database Name="cv" Series="18131" Issue="106214" />
     </Book>
     <Book Series="Mekanix" Number="2" Volume="2002" Year="2003">
-      <Id>d86d157b-06bd-4fad-804b-581d11e0aeae</Id>
+      <Database Name="cv" Series="18131" Issue="106262" />
     </Book>
     <Book Series="Mekanix" Number="3" Volume="2002" Year="2003">
-      <Id>1ee204ef-c54c-4409-8628-a03ce77dca6d</Id>
+      <Database Name="cv" Series="18131" Issue="106263" />
     </Book>
     <Book Series="Mekanix" Number="4" Volume="2002" Year="2003">
-      <Id>2ab73faf-5534-4821-a463-b070f5fb9cad</Id>
+      <Database Name="cv" Series="18131" Issue="106264" />
     </Book>
     <Book Series="Mekanix" Number="5" Volume="2002" Year="2003">
-      <Id>596e3d40-54ae-4de6-8e84-f7219c6a012c</Id>
+      <Database Name="cv" Series="18131" Issue="106265" />
     </Book>
     <Book Series="Mekanix" Number="6" Volume="2002" Year="2003">
-      <Id>9224c9eb-2508-4c17-9063-29f26db9647f</Id>
+      <Database Name="cv" Series="18131" Issue="106266" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="414" Volume="1981" Year="2002">
-      <Id>49c8d42f-ef79-4292-a7d4-b3396ad88ef2</Id>
+      <Database Name="cv" Series="3092" Issue="107753" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="415" Volume="1981" Year="2003">
-      <Id>0fc9052a-920d-4721-ad10-48f6e5dd0924</Id>
+      <Database Name="cv" Series="3092" Issue="107764" />
     </Book>
     <Book Series="X-Men Unlimited" Number="39" Volume="1993" Year="2003">
-      <Id>a6ef0983-735a-4cb1-8d7b-8bef80f6f41f</Id>
+      <Database Name="cv" Series="5066" Issue="113916" />
     </Book>
     <Book Series="X-Men Unlimited" Number="40" Volume="1993" Year="2003">
-      <Id>4b0b1105-d981-48c1-80a1-3756416bde78</Id>
+      <Database Name="cv" Series="5066" Issue="113920" />
     </Book>
     <Book Series="X-Men Unlimited" Number="41" Volume="1993" Year="2003">
-      <Id>5bb000ce-fadb-4017-bd69-fe98aa5d0d76</Id>
+      <Database Name="cv" Series="5066" Issue="108322" />
     </Book>
     <Book Series="X-Men Unlimited" Number="42" Volume="1993" Year="2003">
-      <Id>2d7ee8f5-c378-4439-aa70-acba7e31daa5</Id>
+      <Database Name="cv" Series="5066" Issue="113921" />
     </Book>
     <Book Series="Soldier X" Number="1" Volume="2002" Year="2002">
-      <Id>c2318aa6-b5c5-4d50-93c3-0f941f837e55</Id>
+      <Database Name="cv" Series="9959" Issue="136024" />
     </Book>
     <Book Series="Soldier X" Number="2" Volume="2002" Year="2002">
-      <Id>12352ccf-58f7-4b1b-b718-90bb56038534</Id>
+      <Database Name="cv" Series="9959" Issue="136031" />
     </Book>
     <Book Series="Soldier X" Number="3" Volume="2002" Year="2002">
-      <Id>6cc734fb-3cab-43ed-851a-841829abc209</Id>
+      <Database Name="cv" Series="9959" Issue="136035" />
     </Book>
     <Book Series="Soldier X" Number="4" Volume="2002" Year="2002">
-      <Id>2193b3ac-a251-4548-9f4b-cf2158eb75ee</Id>
+      <Database Name="cv" Series="9959" Issue="136036" />
     </Book>
     <Book Series="Soldier X" Number="5" Volume="2002" Year="2003">
-      <Id>01ce5cd3-f628-4ade-9617-a741711b5e15</Id>
+      <Database Name="cv" Series="9959" Issue="136037" />
     </Book>
     <Book Series="Soldier X" Number="6" Volume="2002" Year="2003">
-      <Id>e363dfb9-5b88-49fa-b3bd-fbc4a8763ce1</Id>
+      <Database Name="cv" Series="9959" Issue="136038" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="416" Volume="1981" Year="2003">
-      <Id>473d6374-f269-4ed1-899d-c065e2b90953</Id>
+      <Database Name="cv" Series="3092" Issue="108232" />
     </Book>
     <Book Series="New X-Men" Number="134" Volume="2001" Year="2003">
-      <Id>850892f5-38c0-4f47-b41b-d7a6fa5623a5</Id>
+      <Database Name="cv" Series="9121" Issue="106499" />
     </Book>
     <Book Series="Wolverine" Number="186" Volume="1988" Year="2003">
-      <Id>83a57520-8885-446d-a711-e92fe089b5ec</Id>
+      <Database Name="cv" Series="4250" Issue="93797" />
     </Book>
     <Book Series="Soldier X" Number="7" Volume="2002" Year="2003">
-      <Id>d91761f6-638b-47ec-8bec-27a524772b4f</Id>
+      <Database Name="cv" Series="9959" Issue="136039" />
     </Book>
     <Book Series="Soldier X" Number="8" Volume="2002" Year="2003">
-      <Id>23538d34-1132-4670-98c3-ec507c830d1d</Id>
+      <Database Name="cv" Series="9959" Issue="136040" />
     </Book>
     <Book Series="X-Men Unlimited" Number="43" Volume="1993" Year="2003">
-      <Id>c2f86794-7750-489c-a22f-80c66a75ac8d</Id>
+      <Database Name="cv" Series="5066" Issue="90015" />
     </Book>
     <Book Series="X-Men Unlimited" Number="44" Volume="1993" Year="2003">
-      <Id>d4b800a0-24b3-410b-bef0-25e976ae5daf</Id>
+      <Database Name="cv" Series="5066" Issue="90016" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="417" Volume="1981" Year="2003">
-      <Id>b930ddbe-3fb8-45e9-8b6e-01eca92c0891</Id>
+      <Database Name="cv" Series="3092" Issue="105314" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="418" Volume="1981" Year="2003">
-      <Id>2db7b9f0-56d0-4b90-91e6-98098b009478</Id>
+      <Database Name="cv" Series="3092" Issue="105315" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="419" Volume="1981" Year="2003">
-      <Id>0f0ff33d-67a2-43fa-a336-0acc86e42a64</Id>
+      <Database Name="cv" Series="3092" Issue="105316" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="420" Volume="1981" Year="2003">
-      <Id>e3d86a22-3050-468a-a890-8de83d0a7c45</Id>
+      <Database Name="cv" Series="3092" Issue="105317" />
     </Book>
     <Book Series="Wolverine" Number="187" Volume="1988" Year="2003">
-      <Id>379ba03b-cfad-4229-ad52-18c1083b0f8f</Id>
+      <Database Name="cv" Series="4250" Issue="93798" />
     </Book>
     <Book Series="X-Treme X-Men" Number="20" Volume="2001" Year="2003">
-      <Id>5c4d3ef0-c554-4509-bb97-2a145c84d5bc</Id>
+      <Database Name="cv" Series="9411" Issue="106084" />
     </Book>
     <Book Series="X-Treme X-Men" Number="21" Volume="2001" Year="2003">
-      <Id>633ef17d-b4b5-4006-9949-74e869d0846e</Id>
+      <Database Name="cv" Series="9411" Issue="106125" />
     </Book>
     <Book Series="X-Treme X-Men" Number="22" Volume="2001" Year="2003">
-      <Id>708ade2e-dc74-4508-984a-2e6368e4f08c</Id>
+      <Database Name="cv" Series="9411" Issue="106162" />
     </Book>
     <Book Series="X-Treme X-Men" Number="23" Volume="2001" Year="2003">
-      <Id>67292e8a-b3ae-4bb5-acd5-4b0593a188bc</Id>
+      <Database Name="cv" Series="9411" Issue="106163" />
     </Book>
     <Book Series="Soldier X" Number="9" Volume="2002" Year="2003">
-      <Id>7919f6b5-c826-4011-9443-4f9c693ec67a</Id>
+      <Database Name="cv" Series="9959" Issue="90005" />
     </Book>
     <Book Series="Soldier X" Number="10" Volume="2002" Year="2003">
-      <Id>06a2508c-f16a-4c25-82d0-97f2870afaeb</Id>
+      <Database Name="cv" Series="9959" Issue="90006" />
     </Book>
     <Book Series="X-Men Unlimited" Number="45" Volume="1993" Year="2003">
-      <Id>b7ba4c29-dc35-489f-ac7d-3b5247658fca</Id>
+      <Database Name="cv" Series="5066" Issue="90017" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="421" Volume="1981" Year="2003">
-      <Id>c9a208a6-dd01-49f8-b8e5-aa7bc81332ad</Id>
+      <Database Name="cv" Series="3092" Issue="108246" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="422" Volume="1981" Year="2003">
-      <Id>93055ff5-f08f-49d7-8910-1199328b2168</Id>
+      <Database Name="cv" Series="3092" Issue="113233" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="423" Volume="1981" Year="2003">
-      <Id>d3df1a97-5790-42e1-99ae-453dcc0e5888</Id>
+      <Database Name="cv" Series="3092" Issue="113235" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="424" Volume="1981" Year="2003">
-      <Id>0d11e901-3e8e-4acf-b854-77a0fd59aea0</Id>
+      <Database Name="cv" Series="3092" Issue="113701" />
     </Book>
     <Book Series="New X-Men" Number="135" Volume="2001" Year="2003">
-      <Id>d47a3fcd-2e79-4ed7-ab4e-1956344670b6</Id>
+      <Database Name="cv" Series="9121" Issue="112536" />
     </Book>
     <Book Series="New X-Men" Number="136" Volume="2001" Year="2003">
-      <Id>6d9be846-5735-41a4-81c7-336b651b1eb3</Id>
+      <Database Name="cv" Series="9121" Issue="114332" />
     </Book>
     <Book Series="New X-Men" Number="137" Volume="2001" Year="2003">
-      <Id>f5722cf4-22ff-442e-9727-2af3af0e5d30</Id>
+      <Database Name="cv" Series="9121" Issue="114333" />
     </Book>
     <Book Series="New X-Men" Number="138" Volume="2001" Year="2003">
-      <Id>94204db3-b2e4-4422-9da1-459b1ddae284</Id>
+      <Database Name="cv" Series="9121" Issue="114334" />
     </Book>
     <Book Series="Wolverine" Number="188" Volume="1988" Year="2003">
-      <Id>e3577d0a-935e-4af0-9be6-08d07102e4ab</Id>
+      <Database Name="cv" Series="4250" Issue="93799" />
     </Book>
     <Book Series="Wolverine" Number="189" Volume="1988" Year="2003">
-      <Id>21166d9c-c63b-4e61-abcb-c3915360e4cd</Id>
+      <Database Name="cv" Series="4250" Issue="93800" />
     </Book>
     <Book Series="X-Treme X-Men" Number="24" Volume="2001" Year="2003">
-      <Id>6470b82d-a057-4a62-bd34-89b62655ee30</Id>
+      <Database Name="cv" Series="9411" Issue="106164" />
     </Book>
     <Book Series="Soldier X" Number="11" Volume="2002" Year="2003">
-      <Id>21731f46-8d06-404d-957c-0b38382803ff</Id>
+      <Database Name="cv" Series="9959" Issue="90007" />
     </Book>
     <Book Series="Soldier X" Number="12" Volume="2002" Year="2003">
-      <Id>05bc140f-402f-4f47-84a2-8b647da5c9c3</Id>
+      <Database Name="cv" Series="9959" Issue="90008" />
     </Book>
     <Book Series="New X-Men" Number="139" Volume="2001" Year="2003">
-      <Id>ef43d7c9-a6ea-4845-8032-2d5371fc498d</Id>
+      <Database Name="cv" Series="9121" Issue="114335" />
     </Book>
     <Book Series="New X-Men" Number="140" Volume="2001" Year="2003">
-      <Id>32f3e0bd-063d-4b9f-b7f8-cfb8b702af32</Id>
+      <Database Name="cv" Series="9121" Issue="114336" />
     </Book>
     <Book Series="New X-Men" Number="141" Volume="2001" Year="2003">
-      <Id>2ff96764-31b6-485e-b74d-0864257cd721</Id>
+      <Database Name="cv" Series="9121" Issue="114456" />
     </Book>
     <Book Series="X-Treme X-Men" Number="25" Volume="2001" Year="2003">
-      <Id>39d73f08-c75e-4145-b167-1d4390cb3e1b</Id>
+      <Database Name="cv" Series="9411" Issue="106165" />
     </Book>
     <Book Series="X-Treme X-Men" Number="26" Volume="2001" Year="2003">
-      <Id>fc7d927d-261d-48a2-ae4d-2d57b40e9286</Id>
+      <Database Name="cv" Series="9411" Issue="106179" />
     </Book>
     <Book Series="X-Treme X-Men" Number="27" Volume="2001" Year="2003">
-      <Id>0d5181ed-a0be-432e-8b9b-b7f3342658f5</Id>
+      <Database Name="cv" Series="9411" Issue="106180" />
     </Book>
     <Book Series="X-Treme X-Men" Number="28" Volume="2001" Year="2003">
-      <Id>53405467-5e10-4844-a684-80b4b3f03fc6</Id>
+      <Database Name="cv" Series="9411" Issue="106181" />
     </Book>
     <Book Series="X-Treme X-Men" Number="29" Volume="2001" Year="2003">
-      <Id>1e1f3a79-b6ad-4304-b1c6-f61c8a94115f</Id>
+      <Database Name="cv" Series="9411" Issue="106182" />
     </Book>
     <Book Series="X-Treme X-Men" Number="30" Volume="2001" Year="2003">
-      <Id>44533dfb-ab8a-4dbf-a623-18a3d75b7fac</Id>
+      <Database Name="cv" Series="9411" Issue="106222" />
     </Book>
     <Book Series="New Mutants" Number="1" Volume="2003" Year="2003">
-      <Id>3575d15f-86d3-4f4d-82d0-8cdb71b4165a</Id>
+      <Database Name="cv" Series="18351" Issue="107614" />
     </Book>
     <Book Series="New Mutants" Number="2" Volume="2003" Year="2003">
-      <Id>dc57d59f-b22e-4261-a996-aa79b2e51cd2</Id>
+      <Database Name="cv" Series="18351" Issue="107647" />
     </Book>
     <Book Series="New Mutants" Number="3" Volume="2003" Year="2003">
-      <Id>d67846d2-6ff4-4beb-a00a-62a7c1f1e76b</Id>
+      <Database Name="cv" Series="18351" Issue="107652" />
     </Book>
     <Book Series="New Mutants" Number="4" Volume="2003" Year="2003">
-      <Id>ba69e708-f947-4a67-9179-cc300026a32e</Id>
+      <Database Name="cv" Series="18351" Issue="107650" />
     </Book>
     <Book Series="New Mutants" Number="5" Volume="2003" Year="2003">
-      <Id>76861131-0a0f-4cc8-a597-10852521e4c2</Id>
+      <Database Name="cv" Series="18351" Issue="107651" />
     </Book>
     <Book Series="New Mutants" Number="6" Volume="2003" Year="2003">
-      <Id>3f330a9e-7200-4ba4-a38b-14c7caec1fc2</Id>
+      <Database Name="cv" Series="18351" Issue="108406" />
     </Book>
     <Book Series="X-Men Unlimited" Number="46" Volume="1993" Year="2003">
-      <Id>616498db-6e0f-4ba3-9f60-095f4765b1ab</Id>
+      <Database Name="cv" Series="5066" Issue="90018" />
     </Book>
     <Book Series="X-Men Unlimited" Number="47" Volume="1993" Year="2003">
-      <Id>11b33db7-8fec-47d1-90cb-aaaff5903243</Id>
+      <Database Name="cv" Series="5066" Issue="90019" />
     </Book>
     <Book Series="X-Men Unlimited" Number="48" Volume="1993" Year="2003">
-      <Id>85c84bbd-c607-4d43-bf37-5de801828578</Id>
+      <Database Name="cv" Series="5066" Issue="90020" />
     </Book>
     <Book Series="Mystique" Number="1" Volume="2003" Year="2003">
-      <Id>9dcac323-9c64-462b-921f-41b3a9330742</Id>
+      <Database Name="cv" Series="11391" Issue="99863" />
     </Book>
     <Book Series="Mystique" Number="2" Volume="2003" Year="2003">
-      <Id>29f35600-be10-416e-9f81-af4b7fdad152</Id>
+      <Database Name="cv" Series="11391" Issue="99864" />
     </Book>
     <Book Series="Mystique" Number="3" Volume="2003" Year="2003">
-      <Id>d18baa08-c46c-4aa3-ae93-a6d068d3a25a</Id>
+      <Database Name="cv" Series="11391" Issue="99865" />
     </Book>
     <Book Series="Mystique" Number="4" Volume="2003" Year="2003">
-      <Id>e7b9ec26-859d-463a-80f0-6ae3dab5c0a0</Id>
+      <Database Name="cv" Series="11391" Issue="99866" />
     </Book>
     <Book Series="Mystique" Number="5" Volume="2003" Year="2003">
-      <Id>1289f830-8867-4065-b823-f823e087d07e</Id>
+      <Database Name="cv" Series="11391" Issue="99867" />
     </Book>
     <Book Series="Mystique" Number="6" Volume="2003" Year="2003">
-      <Id>befc02c7-97ae-48c5-a14d-6dbc50d7d5ea</Id>
+      <Database Name="cv" Series="11391" Issue="99868" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="425" Volume="1981" Year="2003">
-      <Id>f84ce6cf-1346-4ef6-a862-4fb59442ffd2</Id>
+      <Database Name="cv" Series="3092" Issue="114860" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="426" Volume="1981" Year="2003">
-      <Id>df4a2c7b-45fb-4ee0-85e0-fb5ac271ec96</Id>
+      <Database Name="cv" Series="3092" Issue="114898" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="427" Volume="1981" Year="2003">
-      <Id>f9b3904b-9af2-4378-a5f8-347b5f766288</Id>
+      <Database Name="cv" Series="3092" Issue="114899" />
     </Book>
     <Book Series="X-Men Unlimited" Number="49" Volume="1993" Year="2003">
-      <Id>ed934bf0-6c74-450e-8df4-c5570cfcc12c</Id>
+      <Database Name="cv" Series="5066" Issue="90021" />
     </Book>
     <Book Series="X-Men Unlimited" Number="50" Volume="1993" Year="2003">
-      <Id>596519b6-29fa-4ac0-9577-65401998f376</Id>
+      <Database Name="cv" Series="5066" Issue="90022" />
     </Book>
     <Book Series="Emma Frost" Number="1" Volume="2003" Year="2003">
-      <Id>ac47d138-e52e-4d69-8969-be73db03499d</Id>
+      <Database Name="cv" Series="18014" Issue="105439" />
     </Book>
     <Book Series="Emma Frost" Number="2" Volume="2003" Year="2003">
-      <Id>9ee034b4-004c-4b9a-b6c2-c6c2abbd0443</Id>
+      <Database Name="cv" Series="18014" Issue="107660" />
     </Book>
     <Book Series="Emma Frost" Number="3" Volume="2003" Year="2003">
-      <Id>f477913e-8f89-43c2-8f0d-b6576e8f118f</Id>
+      <Database Name="cv" Series="18014" Issue="107661" />
     </Book>
     <Book Series="Emma Frost" Number="4" Volume="2003" Year="2003">
-      <Id>609d363a-4557-426f-a1d9-738417f4618f</Id>
+      <Database Name="cv" Series="18014" Issue="107662" />
     </Book>
     <Book Series="Emma Frost" Number="5" Volume="2003" Year="2004">
-      <Id>257e9ac2-dc49-456a-ba6e-53853de84591</Id>
+      <Database Name="cv" Series="18014" Issue="107663" />
     </Book>
     <Book Series="Emma Frost" Number="6" Volume="2003" Year="2004">
-      <Id>ce33d0f9-0110-4e25-aec5-86be7a61b05a</Id>
+      <Database Name="cv" Series="18014" Issue="107664" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="428" Volume="1981" Year="2003">
-      <Id>1d7d25ee-74d9-40c9-ad7c-a57eea1b8202</Id>
+      <Database Name="cv" Series="3092" Issue="105326" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="429" Volume="1981" Year="2003">
-      <Id>19efab09-2279-41db-abaa-fc9af493d913</Id>
+      <Database Name="cv" Series="3092" Issue="105327" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="430" Volume="1981" Year="2003">
-      <Id>e0407ec7-06ce-4b0d-90c4-ef04f5f5cb4c</Id>
+      <Database Name="cv" Series="3092" Issue="105328" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="431" Volume="1981" Year="2003">
-      <Id>8430f1bc-dadc-4f09-936c-cb28171dd158</Id>
+      <Database Name="cv" Series="3092" Issue="105329" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="432" Volume="1981" Year="2003">
-      <Id>85b192c0-c391-4055-baff-ef6ef9c2dca4</Id>
+      <Database Name="cv" Series="3092" Issue="105330" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="433" Volume="1981" Year="2004">
-      <Id>48190d97-1ec2-409a-b75f-b8ebba485729</Id>
+      <Database Name="cv" Series="3092" Issue="105331" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="434" Volume="1981" Year="2004">
-      <Id>8cf86880-c3cd-4323-a04c-c74715c434a9</Id>
-    </Book>
-    <Book Series="Wolverine" Number="0" Volume="2003" Year="2003">
-      <Id>073e2700-3460-4f68-b732-dc554062932a</Id>
+      <Database Name="cv" Series="3092" Issue="105332" />
     </Book>
     <Book Series="Wolverine" Number="1" Volume="2003" Year="2003">
-      <Id>a672a827-8956-4ce6-8ab2-4cc480584f3b</Id>
+      <Database Name="cv" Series="10809" Issue="92137" />
     </Book>
     <Book Series="Wolverine" Number="2" Volume="2003" Year="2003">
-      <Id>1c4cafbf-ca61-4559-991c-6c374b67cd58</Id>
+      <Database Name="cv" Series="10809" Issue="92138" />
     </Book>
     <Book Series="Wolverine" Number="3" Volume="2003" Year="2003">
-      <Id>43966b3e-8871-46cf-bcc4-5c5827265b8a</Id>
+      <Database Name="cv" Series="10809" Issue="92139" />
     </Book>
     <Book Series="Wolverine" Number="4" Volume="2003" Year="2003">
-      <Id>c482bc2c-8960-47ed-8cae-90d11269c16b</Id>
+      <Database Name="cv" Series="10809" Issue="92140" />
     </Book>
     <Book Series="Wolverine" Number="5" Volume="2003" Year="2003">
-      <Id>495f3abd-c5c8-49b8-b59f-7be1ba8e474f</Id>
+      <Database Name="cv" Series="10809" Issue="92141" />
     </Book>
     <Book Series="Wolverine" Number="6" Volume="2003" Year="2003">
-      <Id>ca1d16d0-b240-48fd-b3be-e28dd0fc3521</Id>
+      <Database Name="cv" Series="10809" Issue="92142" />
     </Book>
     <Book Series="New Mutants" Number="7" Volume="2003" Year="2004">
-      <Id>5c4ae3b3-ab33-447c-b9b0-b479e3e63542</Id>
+      <Database Name="cv" Series="18351" Issue="108407" />
     </Book>
     <Book Series="New Mutants" Number="8" Volume="2003" Year="2004">
-      <Id>91cdcf83-64e8-47e7-8a35-57219b95d657</Id>
+      <Database Name="cv" Series="18351" Issue="108408" />
     </Book>
     <Book Series="New Mutants" Number="9" Volume="2003" Year="2004">
-      <Id>1c144e92-5f10-4df0-b681-b51e54a3c848</Id>
+      <Database Name="cv" Series="18351" Issue="108409" />
     </Book>
     <Book Series="New Mutants" Number="10" Volume="2003" Year="2004">
-      <Id>64ece120-c823-405f-ae25-028c7416be29</Id>
+      <Database Name="cv" Series="18351" Issue="108410" />
     </Book>
     <Book Series="New Mutants" Number="11" Volume="2003" Year="2004">
-      <Id>97c34de0-67ab-4641-8ccd-1a94eca2a45c</Id>
+      <Database Name="cv" Series="18351" Issue="108411" />
     </Book>
     <Book Series="New Mutants" Number="12" Volume="2003" Year="2004">
-      <Id>d87d22d7-f99e-49b4-9d78-411e5acc74a4</Id>
+      <Database Name="cv" Series="18351" Issue="108412" />
     </Book>
     <Book Series="X-Treme X-Men" Number="31" Volume="2001" Year="2003">
-      <Id>73724f9a-e027-49b3-9f76-1dfc4b21b03c</Id>
+      <Database Name="cv" Series="9411" Issue="106228" />
     </Book>
     <Book Series="X-Treme X-Men" Number="32" Volume="2001" Year="2003">
-      <Id>9b89aeb0-08a7-43ca-a34a-9f1aca0f7cdf</Id>
+      <Database Name="cv" Series="9411" Issue="106269" />
     </Book>
     <Book Series="X-Treme X-Men" Number="33" Volume="2001" Year="2003">
-      <Id>535d6b33-a82c-4486-b171-9f86970b10b3</Id>
+      <Database Name="cv" Series="9411" Issue="106299" />
     </Book>
     <Book Series="X-Treme X-Men" Number="34" Volume="2001" Year="2004">
-      <Id>50ba64a8-26ee-46d4-807c-faba0742c20d</Id>
+      <Database Name="cv" Series="9411" Issue="106305" />
     </Book>
     <Book Series="X-Treme X-Men" Number="35" Volume="2001" Year="2004">
-      <Id>aca8b2fc-bd67-4776-8bc9-f10d819acd0c</Id>
+      <Database Name="cv" Series="9411" Issue="106347" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="435" Volume="1981" Year="2004">
-      <Id>61ff31ff-dd4e-4890-b86f-4c45efb6e7f6</Id>
+      <Database Name="cv" Series="3092" Issue="107775" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="436" Volume="1981" Year="2004">
-      <Id>6440ac98-f669-466a-b260-604ecfcf3787</Id>
+      <Database Name="cv" Series="3092" Issue="107776" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="437" Volume="1981" Year="2004">
-      <Id>837165a4-a76d-4a9f-97b7-d300ab44ecd2</Id>
+      <Database Name="cv" Series="3092" Issue="112326" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="438" Volume="1981" Year="2004">
-      <Id>5360ca19-00ff-49df-a9b1-393dd506bc45</Id>
+      <Database Name="cv" Series="3092" Issue="112327" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="439" Volume="1981" Year="2004">
-      <Id>42dae2ef-9c10-40af-9882-95ddf6b67dd8</Id>
+      <Database Name="cv" Series="3092" Issue="113375" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="440" Volume="1981" Year="2004">
-      <Id>2b016aaf-8d1a-44ea-9209-e7e517b877f9</Id>
+      <Database Name="cv" Series="3092" Issue="105557" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="441" Volume="1981" Year="2004">
-      <Id>9ad97c9c-cc94-4f16-83a7-36990928fbfc</Id>
+      <Database Name="cv" Series="3092" Issue="105558" />
     </Book>
     <Book Series="Mystique" Number="7" Volume="2003" Year="2003">
-      <Id>b9187a06-3a3e-4aeb-85d6-a15a74337220</Id>
+      <Database Name="cv" Series="11391" Issue="99869" />
     </Book>
     <Book Series="Mystique" Number="8" Volume="2003" Year="2004">
-      <Id>05b4455b-26bd-4ce5-945a-5059cb0f4f2f</Id>
+      <Database Name="cv" Series="11391" Issue="99870" />
     </Book>
     <Book Series="Mystique" Number="9" Volume="2003" Year="2004">
-      <Id>6d227ece-3d43-48dd-83c4-c48a92e8029e</Id>
+      <Database Name="cv" Series="11391" Issue="99871" />
     </Book>
     <Book Series="Mystique" Number="10" Volume="2003" Year="2004">
-      <Id>ac0b7292-3490-4417-b3a9-556afe696536</Id>
+      <Database Name="cv" Series="11391" Issue="99872" />
     </Book>
     <Book Series="Mystique" Number="11" Volume="2003" Year="2004">
-      <Id>7521e714-9a9e-4190-b9ec-098eb955dd7d</Id>
+      <Database Name="cv" Series="11391" Issue="99873" />
     </Book>
     <Book Series="Mystique" Number="12" Volume="2003" Year="2004">
-      <Id>5b6e16e8-f9fa-4881-a841-2b7bdc0a9203</Id>
+      <Database Name="cv" Series="11391" Issue="99874" />
     </Book>
     <Book Series="Mystique" Number="13" Volume="2003" Year="2004">
-      <Id>46d91d4e-eea0-4fe9-bf49-f4e2d9c81491</Id>
+      <Database Name="cv" Series="11391" Issue="99875" />
     </Book>
     <Book Series="X-Treme X-Men" Number="36" Volume="2001" Year="2004">
-      <Id>5f5c9384-a02f-4fbe-8c55-10595dd0dc86</Id>
+      <Database Name="cv" Series="9411" Issue="106351" />
     </Book>
     <Book Series="X-Treme X-Men" Number="37" Volume="2001" Year="2004">
-      <Id>38bbdf47-6c48-4e5e-ae26-5476000183fc</Id>
+      <Database Name="cv" Series="9411" Issue="106354" />
     </Book>
     <Book Series="X-Treme X-Men" Number="38" Volume="2001" Year="2004">
-      <Id>5352f48f-7e7a-4bfe-9653-ce869f708ae2</Id>
+      <Database Name="cv" Series="9411" Issue="106368" />
     </Book>
     <Book Series="X-Treme X-Men" Number="39" Volume="2001" Year="2004">
-      <Id>4d7d5b6f-094b-4f07-a031-f45bd4dcc879</Id>
+      <Database Name="cv" Series="9411" Issue="106369" />
     </Book>
     <Book Series="Wolverine" Number="7" Volume="2003" Year="2004">
-      <Id>5c73c59b-168c-4a11-9a76-d5277d0c2fcb</Id>
+      <Database Name="cv" Series="10809" Issue="92143" />
     </Book>
     <Book Series="Wolverine" Number="8" Volume="2003" Year="2004">
-      <Id>68b11f22-610d-47fb-8e71-8dac03e735bf</Id>
+      <Database Name="cv" Series="10809" Issue="92144" />
     </Book>
     <Book Series="Wolverine" Number="9" Volume="2003" Year="2004">
-      <Id>0074bc43-7039-4b3f-b666-28a712adabfc</Id>
+      <Database Name="cv" Series="10809" Issue="92145" />
     </Book>
     <Book Series="Wolverine" Number="10" Volume="2003" Year="2004">
-      <Id>a53fc0a0-3ea0-4324-81d8-cc9dc4800b27</Id>
+      <Database Name="cv" Series="10809" Issue="92146" />
     </Book>
     <Book Series="Wolverine" Number="11" Volume="2003" Year="2004">
-      <Id>d43e8513-cf78-4c9f-b6dd-ea8960b11b4a</Id>
+      <Database Name="cv" Series="10809" Issue="92147" />
     </Book>
     <Book Series="Wolverine" Number="12" Volume="2003" Year="2004">
-      <Id>37f0d700-a81f-42a9-b843-a08df02eebfe</Id>
+      <Database Name="cv" Series="10809" Issue="92148" />
     </Book>
     <Book Series="X-Men Unlimited" Number="1" Volume="2004" Year="2004">
-      <Id>495369b1-bdb1-419c-9d64-a284f9f03e7a</Id>
+      <Database Name="cv" Series="10745" Issue="90577" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="1" Volume="2004" Year="2004">
-      <Id>c4e71850-f50e-412b-9212-747e8a164817</Id>
+    <Book Series="Cable &#38; Deadpool" Number="1" Volume="2004" Year="2004">
+      <Database Name="cv" Series="18070" Issue="105801" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="2" Volume="2004" Year="2004">
-      <Id>dbb7f404-6c57-4219-9497-090cf0a1827e</Id>
+    <Book Series="Cable &#38; Deadpool" Number="2" Volume="2004" Year="2004">
+      <Database Name="cv" Series="18070" Issue="105828" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="3" Volume="2004" Year="2004">
-      <Id>713593e3-ad61-4f3d-8f7d-b70c8d34f93c</Id>
+    <Book Series="Cable &#38; Deadpool" Number="3" Volume="2004" Year="2004">
+      <Database Name="cv" Series="18070" Issue="105829" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="4" Volume="2004" Year="2004">
-      <Id>d953830f-a036-4041-bcd5-c166d31fc45c</Id>
+    <Book Series="Cable &#38; Deadpool" Number="4" Volume="2004" Year="2004">
+      <Database Name="cv" Series="18070" Issue="105831" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="5" Volume="2004" Year="2004">
-      <Id>f5193b81-0860-4b9f-ba03-7e2825a08a19</Id>
+    <Book Series="Cable &#38; Deadpool" Number="5" Volume="2004" Year="2004">
+      <Database Name="cv" Series="18070" Issue="105830" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="6" Volume="2004" Year="2004">
-      <Id>68eac69c-00f1-46d9-a772-449bc3995ce4</Id>
+    <Book Series="Cable &#38; Deadpool" Number="6" Volume="2004" Year="2004">
+      <Database Name="cv" Series="18070" Issue="105832" />
     </Book>
     <Book Series="New X-Men" Number="142" Volume="2001" Year="2003">
-      <Id>f50cc228-56e4-4380-b204-fb1f5f8ca455</Id>
+      <Database Name="cv" Series="9121" Issue="114457" />
     </Book>
     <Book Series="New X-Men" Number="143" Volume="2001" Year="2003">
-      <Id>06794df9-2e5a-4276-8152-f3b211acc68c</Id>
+      <Database Name="cv" Series="9121" Issue="114449" />
     </Book>
     <Book Series="New X-Men" Number="144" Volume="2001" Year="2003">
-      <Id>1d66868e-c4c4-40ed-80bc-c4800150db11</Id>
+      <Database Name="cv" Series="9121" Issue="114450" />
     </Book>
     <Book Series="New X-Men" Number="145" Volume="2001" Year="2003">
-      <Id>6eec12ba-143c-46e0-905c-dc3baa371c5c</Id>
+      <Database Name="cv" Series="9121" Issue="114453" />
     </Book>
     <Book Series="New X-Men" Number="146" Volume="2001" Year="2003">
-      <Id>be27149d-f279-4fe7-b38a-48a4d569dfe0</Id>
+      <Database Name="cv" Series="9121" Issue="114451" />
     </Book>
     <Book Series="New X-Men" Number="147" Volume="2001" Year="2003">
-      <Id>aefab12d-c3aa-4cdc-a121-5a7c4ea5989d</Id>
+      <Database Name="cv" Series="9121" Issue="114452" />
     </Book>
     <Book Series="New X-Men" Number="148" Volume="2001" Year="2003">
-      <Id>63a1ec55-5808-4f17-8ab0-6bb11cc33cab</Id>
+      <Database Name="cv" Series="9121" Issue="114454" />
     </Book>
     <Book Series="New X-Men" Number="149" Volume="2001" Year="2004">
-      <Id>9512fa8a-54f5-45e8-8810-bda54dbf0611</Id>
+      <Database Name="cv" Series="9121" Issue="114458" />
     </Book>
     <Book Series="New X-Men" Number="150" Volume="2001" Year="2004">
-      <Id>dd0c8022-e598-48fb-b985-374ccec04a70</Id>
+      <Database Name="cv" Series="9121" Issue="114459" />
     </Book>
     <Book Series="X-Treme X-Men" Number="40" Volume="2001" Year="2004">
-      <Id>c38342e6-d8ea-4b1b-9e61-bd9eccb1add9</Id>
+      <Database Name="cv" Series="9411" Issue="106402" />
     </Book>
     <Book Series="X-Treme X-Men" Number="41" Volume="2001" Year="2004">
-      <Id>debd34d3-51ea-4cb0-9a5a-de50fe763bbe</Id>
+      <Database Name="cv" Series="9411" Issue="106436" />
     </Book>
     <Book Series="X-Treme X-Men" Number="42" Volume="2001" Year="2004">
-      <Id>1d647620-183a-44c6-9889-af8c85e0d80e</Id>
+      <Database Name="cv" Series="9411" Issue="106441" />
     </Book>
     <Book Series="X-Treme X-Men" Number="43" Volume="2001" Year="2004">
-      <Id>ed73f106-f60c-4ff4-9f78-7ce974f322b7</Id>
+      <Database Name="cv" Series="9411" Issue="106462" />
     </Book>
     <Book Series="X-Treme X-Men" Number="44" Volume="2001" Year="2004">
-      <Id>79aa9e72-9be5-4f16-9e8b-af22e42d7b21</Id>
+      <Database Name="cv" Series="9411" Issue="106463" />
     </Book>
     <Book Series="X-Treme X-Men" Number="45" Volume="2001" Year="2004">
-      <Id>2a387fde-f44b-4a87-a5e2-44e8ef52df6e</Id>
+      <Database Name="cv" Series="9411" Issue="106464" />
     </Book>
     <Book Series="New X-Men" Number="151" Volume="2001" Year="2004">
-      <Id>6ffa92a7-81dd-4c86-9225-51088f0592e4</Id>
+      <Database Name="cv" Series="9121" Issue="106245" />
     </Book>
     <Book Series="New X-Men" Number="152" Volume="2001" Year="2004">
-      <Id>0b797651-2f2b-4060-a7f2-5a4b6611082b</Id>
+      <Database Name="cv" Series="9121" Issue="106246" />
     </Book>
     <Book Series="New X-Men" Number="153" Volume="2001" Year="2004">
-      <Id>410d5dd9-4a4b-41c9-b268-948db675245f</Id>
+      <Database Name="cv" Series="9121" Issue="106247" />
     </Book>
     <Book Series="New X-Men" Number="154" Volume="2001" Year="2004">
-      <Id>ec6bec49-2006-4935-9d6a-398a21d100ed</Id>
+      <Database Name="cv" Series="9121" Issue="106248" />
     </Book>
     <Book Series="New X-Men" Number="155" Volume="2001" Year="2004">
-      <Id>c48e9a0e-7a62-4def-bd6f-dd8db28468fb</Id>
+      <Database Name="cv" Series="9121" Issue="106437" />
     </Book>
     <Book Series="New X-Men" Number="156" Volume="2001" Year="2004">
-      <Id>6663430d-b9ef-42b7-afa1-893f995a4bf8</Id>
+      <Database Name="cv" Series="9121" Issue="106438" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="442" Volume="1981" Year="2004">
-      <Id>9acbdb6a-b89d-43f0-9729-1cc9a32b2e0d</Id>
+      <Database Name="cv" Series="3092" Issue="105559" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="443" Volume="1981" Year="2004">
-      <Id>e6cd4f0f-5797-4920-8202-1d408c99e1cc</Id>
+      <Database Name="cv" Series="3092" Issue="105560" />
     </Book>
     <Book Series="New Mutants" Number="13" Volume="2003" Year="2004">
-      <Id>64a245c0-2b18-4e3a-bc1e-cd704dcc5f31</Id>
+      <Database Name="cv" Series="18351" Issue="108413" />
     </Book>
     <Book Series="X-Treme X-Men" Number="46" Volume="2001" Year="2004">
-      <Id>477c5510-06fd-4bba-8173-a0e17d5bf10b</Id>
+      <Database Name="cv" Series="9411" Issue="106465" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 008 (Morrison Era).cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 008 (Morrison Era).cbl
@@ -2,868 +2,868 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>X-Men - Part 8 (Morrison Era)</Name>
   <Books>
-    <Book Series="X-Treme X-Men" Number="1" Volume="2001" Year="2001" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="1" Volume="2001" Year="2001">
       <Id>62743f92-e439-4ebb-869a-b814da4dd386</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="2" Volume="2001" Year="2001" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="2" Volume="2001" Year="2001">
       <Id>dce2c861-fda3-4600-83dd-6f5ae2800bfe</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="3" Volume="2001" Year="2001" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="3" Volume="2001" Year="2001">
       <Id>d56ceeef-b136-4040-ac14-4b1c5b5e21cc</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="4" Volume="2001" Year="2001" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="4" Volume="2001" Year="2001">
       <Id>d1bc18c6-5f9e-4258-a3a9-e3e96150b5a3</Id>
     </Book>
-    <Book Series="Wolverine Annual 2001" Number="1" Volume="2001" Year="2002" Format="Annual">
+    <Book Series="Wolverine Annual 2001" Number="1" Volume="2001" Year="2002">
       <Id>6c91dcdc-515a-43e2-a88b-7e7354c4cfb5</Id>
     </Book>
-    <Book Series="Wolverine" Number="170" Volume="1988" Year="2002" Format="Main Series">
+    <Book Series="Wolverine" Number="170" Volume="1988" Year="2002">
       <Id>87ec902f-1ced-470e-b32f-183d65222ea3</Id>
     </Book>
-    <Book Series="Wolverine" Number="171" Volume="1988" Year="2002" Format="Main Series">
+    <Book Series="Wolverine" Number="171" Volume="1988" Year="2002">
       <Id>1b7d6505-80d5-4a3b-bbec-b3677ad89373</Id>
     </Book>
-    <Book Series="Wolverine" Number="172" Volume="1988" Year="2002" Format="Main Series">
+    <Book Series="Wolverine" Number="172" Volume="1988" Year="2002">
       <Id>145bb971-fe8c-41cb-bda7-4dddb70c183b</Id>
     </Book>
-    <Book Series="Origin" Number="1" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Origin" Number="1" Volume="2001" Year="2001">
       <Id>21a134b1-c1a5-46f5-b190-c77385b3f66d</Id>
     </Book>
-    <Book Series="Origin" Number="2" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Origin" Number="2" Volume="2001" Year="2001">
       <Id>26cf27f2-4330-486e-8b0b-5746b16ecc81</Id>
     </Book>
-    <Book Series="Origin" Number="3" Volume="2001" Year="2002" Format="Limited Series">
+    <Book Series="Origin" Number="3" Volume="2001" Year="2002">
       <Id>86e724f9-1ea1-42b2-ab3c-7ca4a6bc3d7c</Id>
     </Book>
-    <Book Series="Origin" Number="4" Volume="2001" Year="2002" Format="Limited Series">
+    <Book Series="Origin" Number="4" Volume="2001" Year="2002">
       <Id>084d9a1a-ca67-4106-8768-359c10b7b1ac</Id>
     </Book>
-    <Book Series="Origin" Number="5" Volume="2001" Year="2002" Format="Limited Series">
+    <Book Series="Origin" Number="5" Volume="2001" Year="2002">
       <Id>6aefbc13-f630-4b72-9114-9cd7a2d3e815</Id>
     </Book>
-    <Book Series="Origin" Number="6" Volume="2001" Year="2002" Format="Limited Series">
+    <Book Series="Origin" Number="6" Volume="2001" Year="2002">
       <Id>22ba893d-0762-49c0-90e2-916c8ec82e1f</Id>
     </Book>
-    <Book Series="Generation X" Number="75" Volume="1994" Year="2001" Format="Main Series">
+    <Book Series="Generation X" Number="75" Volume="1994" Year="2001">
       <Id>489e69f1-6e16-41f5-95c5-c539847b3dfe</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="394" Volume="1981" Year="2001" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="394" Volume="1981" Year="2001">
       <Id>bdc88df8-35c7-4134-95c7-84ffa19c48b2</Id>
     </Book>
-    <Book Series="New X-Men" Number="114" Volume="2001" Year="2001" Format="Main Series">
+    <Book Series="New X-Men" Number="114" Volume="2001" Year="2001">
       <Id>63567fa3-0b6c-445a-a123-ae2760ec6e19</Id>
     </Book>
-    <Book Series="New X-Men" Number="115" Volume="2001" Year="2001" Format="Main Series">
+    <Book Series="New X-Men" Number="115" Volume="2001" Year="2001">
       <Id>86fa691a-2c7b-4dce-aabb-bb8519ef21aa</Id>
     </Book>
-    <Book Series="New X-Men" Number="116" Volume="2001" Year="2001" Format="Main Series">
+    <Book Series="New X-Men" Number="116" Volume="2001" Year="2001">
       <Id>ffc4a792-1452-4aab-9da8-f6f3139217ff</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="395" Volume="1981" Year="2001" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="395" Volume="1981" Year="2001">
       <Id>853b98fa-6d23-4d4d-9cdb-bd2420ee9f95</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="396" Volume="1981" Year="2001" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="396" Volume="1981" Year="2001">
       <Id>04125895-7eb7-4684-9164-594eced3ffbd</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="397" Volume="1981" Year="2001" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="397" Volume="1981" Year="2001">
       <Id>fb3bc8c5-ad4a-47c4-b1bf-a58c816a5202</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="398" Volume="1981" Year="2001" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="398" Volume="1981" Year="2001">
       <Id>a0373f1b-041d-46d4-b2e0-e20e4b4e55cf</Id>
     </Book>
-    <Book Series="Cyclops" Number="1" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Cyclops" Number="1" Volume="2001" Year="2001">
       <Id>82785e0a-be26-47d0-a46a-4c9a0a80b8f7</Id>
     </Book>
-    <Book Series="Cyclops" Number="2" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Cyclops" Number="2" Volume="2001" Year="2001">
       <Id>fac56eca-836c-4e84-a5be-459e6d74acad</Id>
     </Book>
-    <Book Series="Cyclops" Number="3" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Cyclops" Number="3" Volume="2001" Year="2001">
       <Id>ae513d64-f31d-4855-be5a-c3f62187d5ee</Id>
     </Book>
-    <Book Series="Cyclops" Number="4" Volume="2001" Year="2002" Format="Limited Series">
+    <Book Series="Cyclops" Number="4" Volume="2001" Year="2002">
       <Id>db07a33f-51a6-482a-b5fa-0f027bf6048d</Id>
     </Book>
-    <Book Series="Rogue" Number="1" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Rogue" Number="1" Volume="2001" Year="2001">
       <Id>5ae2f638-b92a-49e7-a5b5-f559689a58f0</Id>
     </Book>
-    <Book Series="Rogue" Number="2" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Rogue" Number="2" Volume="2001" Year="2001">
       <Id>b582dd64-367d-4d92-ac05-2c9b2af3aed5</Id>
     </Book>
-    <Book Series="Rogue" Number="3" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Rogue" Number="3" Volume="2001" Year="2001">
       <Id>ebcf2b6b-a8b1-40d5-bc51-6a1656a52ad2</Id>
     </Book>
-    <Book Series="Rogue" Number="4" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Rogue" Number="4" Volume="2001" Year="2001">
       <Id>d6bd60a7-59f1-47d3-b284-517448bd9233</Id>
     </Book>
-    <Book Series="Iceman" Number="1" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Iceman" Number="1" Volume="2001" Year="2001">
       <Id>962fa31a-18a6-4823-a378-d8c6cb6b5e30</Id>
     </Book>
-    <Book Series="Iceman" Number="2" Volume="2001" Year="2002" Format="Limited Series">
+    <Book Series="Iceman" Number="2" Volume="2001" Year="2002">
       <Id>54ea98e2-f392-4ea3-938c-e9b3ffae1f8f</Id>
     </Book>
-    <Book Series="Iceman" Number="3" Volume="2001" Year="2002" Format="Limited Series">
+    <Book Series="Iceman" Number="3" Volume="2001" Year="2002">
       <Id>16435ed8-c79c-44bf-ac1d-3fef7f680100</Id>
     </Book>
-    <Book Series="Iceman" Number="4" Volume="2001" Year="2002" Format="Limited Series">
+    <Book Series="Iceman" Number="4" Volume="2001" Year="2002">
       <Id>6ee91721-0536-4781-84c7-9660cdca3986</Id>
     </Book>
-    <Book Series="X-Treme X-Men: Savage Land" Number="1" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="X-Treme X-Men: Savage Land" Number="1" Volume="2001" Year="2001">
       <Id>a8dfbdfe-b32a-4f61-884a-d853d497c555</Id>
     </Book>
-    <Book Series="X-Treme X-Men: Savage Land" Number="2" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="X-Treme X-Men: Savage Land" Number="2" Volume="2001" Year="2001">
       <Id>d37907f2-2caf-49ab-b366-24f37069ad3f</Id>
     </Book>
-    <Book Series="X-Treme X-Men: Savage Land" Number="3" Volume="2001" Year="2002" Format="Limited Series">
+    <Book Series="X-Treme X-Men: Savage Land" Number="3" Volume="2001" Year="2002">
       <Id>5ff4b9d2-d84a-45bd-9327-8bad6da46082</Id>
     </Book>
-    <Book Series="X-Treme X-Men: Savage Land" Number="4" Volume="2001" Year="2002" Format="Limited Series">
+    <Book Series="X-Treme X-Men: Savage Land" Number="4" Volume="2001" Year="2002">
       <Id>25973856-bc50-49d5-be47-5dcb7671e343</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="34" Volume="1993" Year="2002" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="34" Volume="1993" Year="2002">
       <Id>ca46eeb1-6a3b-4d42-a07a-29dfef1f690a</Id>
     </Book>
-    <Book Series="Cable" Number="105" Volume="1993" Year="2002" Format="Main Series">
+    <Book Series="Cable" Number="105" Volume="1993" Year="2002">
       <Id>a8efd145-8d61-4043-9eee-21cd72647e35</Id>
     </Book>
-    <Book Series="Cable" Number="106" Volume="1993" Year="2002" Format="Main Series">
+    <Book Series="Cable" Number="106" Volume="1993" Year="2002">
       <Id>d8887cfe-73d3-46bf-9e06-dc2a73a91998</Id>
     </Book>
-    <Book Series="Cable" Number="107" Volume="1993" Year="2002" Format="Main Series">
+    <Book Series="Cable" Number="107" Volume="1993" Year="2002">
       <Id>5e2e9f78-69d9-44a8-97e0-8dba3136660d</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="5" Volume="2001" Year="2001" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="5" Volume="2001" Year="2001">
       <Id>908aaaf0-feae-4022-ade7-94e795ae5c33</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="6" Volume="2001" Year="2001" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="6" Volume="2001" Year="2001">
       <Id>60643a0c-bd8f-4cd5-a59b-6d928d07b872</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="7" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="7" Volume="2001" Year="2002">
       <Id>3ae6237c-7afc-4db6-b1c5-9c3e84caa7ba</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="8" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="8" Volume="2001" Year="2002">
       <Id>fd8b9ba1-6bc0-45ae-b5a5-fef92c36606b</Id>
     </Book>
-    <Book Series="New X-Men" Number="117" Volume="2001" Year="2001" Format="Main Series">
+    <Book Series="New X-Men" Number="117" Volume="2001" Year="2001">
       <Id>66e278ab-1893-4fa1-8bab-2b13a047d7dd</Id>
     </Book>
-    <Book Series="New X-Men Annual 2001" Number="1" Volume="2001" Year="2001" Format="Annual">
+    <Book Series="New X-Men Annual 2001" Number="1" Volume="2001" Year="2001">
       <Id>2d30e03a-08db-4f03-9b34-f5764589e34f</Id>
     </Book>
-    <Book Series="New X-Men" Number="118" Volume="2001" Year="2001" Format="Main Series">
+    <Book Series="New X-Men" Number="118" Volume="2001" Year="2001">
       <Id>c47c6fe6-4384-4928-97c1-ed18f41d9fcc</Id>
     </Book>
-    <Book Series="New X-Men" Number="119" Volume="2001" Year="2001" Format="Main Series">
+    <Book Series="New X-Men" Number="119" Volume="2001" Year="2001">
       <Id>01c6a3b9-b343-4f9a-a715-0d53dc5a684b</Id>
     </Book>
-    <Book Series="New X-Men" Number="120" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="New X-Men" Number="120" Volume="2001" Year="2002">
       <Id>813a9b99-041f-4820-8b48-18cde136e203</Id>
     </Book>
-    <Book Series="New X-Men" Number="121" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="New X-Men" Number="121" Volume="2001" Year="2002">
       <Id>84fc8a96-40e8-45bf-8b32-24a10bcdc725</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="399" Volume="1981" Year="2001" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="399" Volume="1981" Year="2001">
       <Id>e73dc18f-0a5a-4b1f-b5fc-cf964a41e10f</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="400" Volume="1981" Year="2001" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="400" Volume="1981" Year="2001">
       <Id>6a4233fa-4752-4b29-8374-46d09b1215ef</Id>
     </Book>
-    <Book Series="Uncanny X-Men Annual 2001" Number="1" Volume="2001" Year="2002" Format="Annual">
+    <Book Series="Uncanny X-Men Annual 2001" Number="1" Volume="2001" Year="2002">
       <Id>aa5687ad-159f-4029-b457-1a67c918a068</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="1" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="Nightcrawler" Number="1" Volume="2002" Year="2002">
       <Id>5b7fad4a-df84-46f2-ae5f-9adedf4166b5</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="2" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="Nightcrawler" Number="2" Volume="2002" Year="2002">
       <Id>99a8dd94-fd6e-4773-b101-f879e680873b</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="3" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="Nightcrawler" Number="3" Volume="2002" Year="2002">
       <Id>fcd9ef17-b005-4fab-8902-07341b7d3c0c</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="4" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="Nightcrawler" Number="4" Volume="2002" Year="2002">
       <Id>e7c036bd-5a1c-44d6-b046-36f9c9275891</Id>
     </Book>
-    <Book Series="New X-Men" Number="122" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="New X-Men" Number="122" Volume="2001" Year="2002">
       <Id>5217079f-6a40-4952-bb33-5663b42e5983</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="401" Volume="1981" Year="2002" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="401" Volume="1981" Year="2002">
       <Id>1d4632cb-8969-44e5-b2d0-17b8c13c5775</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="9" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="9" Volume="2001" Year="2002">
       <Id>50f21eba-cc07-4028-a947-1a22da8e68b5</Id>
     </Book>
-    <Book Series="Wolverine" Number="173" Volume="1988" Year="2002" Format="Main Series">
+    <Book Series="Wolverine" Number="173" Volume="1988" Year="2002">
       <Id>9bd2e01b-a1c1-4e6c-9095-dd7ea0be659c</Id>
     </Book>
-    <Book Series="Wolverine" Number="174" Volume="1988" Year="2002" Format="Main Series">
+    <Book Series="Wolverine" Number="174" Volume="1988" Year="2002">
       <Id>631e84af-9654-406b-b377-fb288f5368bd</Id>
     </Book>
-    <Book Series="Wolverine" Number="175" Volume="1988" Year="2002" Format="Main Series">
+    <Book Series="Wolverine" Number="175" Volume="1988" Year="2002">
       <Id>eb438511-6ef6-48a1-a6b6-4972270edfb7</Id>
     </Book>
-    <Book Series="Wolverine" Number="176" Volume="1988" Year="2002" Format="Main Series">
+    <Book Series="Wolverine" Number="176" Volume="1988" Year="2002">
       <Id>f72ae7ab-1b5a-4eac-a653-1b6c04686f57</Id>
     </Book>
-    <Book Series="New X-Men" Number="123" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="New X-Men" Number="123" Volume="2001" Year="2002">
       <Id>05d9552d-b2bb-4a9a-a905-9ba9d8fca1c0</Id>
     </Book>
-    <Book Series="New X-Men" Number="124" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="New X-Men" Number="124" Volume="2001" Year="2002">
       <Id>644ea8dd-958d-439b-9155-ff5723837d13</Id>
     </Book>
-    <Book Series="New X-Men" Number="125" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="New X-Men" Number="125" Volume="2001" Year="2002">
       <Id>7fbb3922-0fbc-4efc-8d7d-78e8050ebddb</Id>
     </Book>
-    <Book Series="New X-Men" Number="126" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="New X-Men" Number="126" Volume="2001" Year="2002">
       <Id>737edb55-c64c-4dd4-8e06-b1afe100879b</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="402" Volume="1981" Year="2002" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="402" Volume="1981" Year="2002">
       <Id>8dce83ad-ce06-4fa9-a2f8-fbb91c4f06e5</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="403" Volume="1981" Year="2002" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="403" Volume="1981" Year="2002">
       <Id>b309fdbd-e44c-4bf9-8fdd-01f87b110752</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="404" Volume="1981" Year="2002" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="404" Volume="1981" Year="2002">
       <Id>f6aa3cb5-5300-41bf-a8e7-3a18d56bc4b9</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="405" Volume="1981" Year="2002" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="405" Volume="1981" Year="2002">
       <Id>a47800c6-dc73-41bf-b5ff-9c1034def6a3</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="406" Volume="1981" Year="2002" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="406" Volume="1981" Year="2002">
       <Id>ed1fcca3-315c-4fab-9ec2-50059c9bffbe</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="407" Volume="1981" Year="2002" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="407" Volume="1981" Year="2002">
       <Id>632217c3-eb1a-4c0a-b223-c9b4d05d0507</Id>
     </Book>
-    <Book Series="X-Factor" Number="1" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="X-Factor" Number="1" Volume="2002" Year="2002">
       <Id>941e11b0-aba6-4372-8e5f-25c350c1545d</Id>
     </Book>
-    <Book Series="X-Factor" Number="2" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="X-Factor" Number="2" Volume="2002" Year="2002">
       <Id>16688544-5dec-4855-8ac9-8586f4b61b8e</Id>
     </Book>
-    <Book Series="X-Factor" Number="3" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="X-Factor" Number="3" Volume="2002" Year="2002">
       <Id>4bfe5bd8-d9f5-4819-a06e-37103212287f</Id>
     </Book>
-    <Book Series="X-Factor" Number="4" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="X-Factor" Number="4" Volume="2002" Year="2002">
       <Id>22f6732d-da0f-4253-a015-743a08b04eee</Id>
     </Book>
-    <Book Series="X-Treme X-Men Annual 2001" Number="2001" Volume="2001" Year="2001" Format="Annual">
+    <Book Series="X-Treme X-Men Annual 2001" Number="2001" Volume="2001" Year="2001">
       <Id>7befd40c-aaa2-4a09-904f-8d2d119f490f</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="10" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="10" Volume="2001" Year="2002">
       <Id>888f669a-8a9a-488e-a349-21bcc9e6c28c</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="11" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="11" Volume="2001" Year="2002">
       <Id>af6b4eca-2481-462e-bd2a-f66585079d7e</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="12" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="12" Volume="2001" Year="2002">
       <Id>dd8932d4-ea58-472f-bcc1-71bae93dcfd5</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="13" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="13" Volume="2001" Year="2002">
       <Id>e6ea1a26-c672-46d7-8c1f-f900effbf0b8</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="14" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="14" Volume="2001" Year="2002">
       <Id>700174e5-b0ac-42f8-8aa2-6343271eb617</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="15" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="15" Volume="2001" Year="2002">
       <Id>1525adeb-d5de-489d-be92-56ef1a94cf91</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="16" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="16" Volume="2001" Year="2002">
       <Id>848351f2-0cf3-41ef-b1ce-3bb7c48aad19</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="17" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="17" Volume="2001" Year="2002">
       <Id>b3dc12e1-4fed-4715-8f8e-40e070372a73</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="18" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="18" Volume="2001" Year="2002">
       <Id>97c84dce-e08e-4d33-9353-710df3111714</Id>
     </Book>
-    <Book Series="New X-Men" Number="127" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="New X-Men" Number="127" Volume="2001" Year="2002">
       <Id>77a3e539-85cc-471f-bc65-df24cae236a9</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="408" Volume="1981" Year="2002" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="408" Volume="1981" Year="2002">
       <Id>37703d59-14fc-44df-88f8-f0ec864d6d01</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="409" Volume="1981" Year="2002" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="409" Volume="1981" Year="2002">
       <Id>0a953dec-7ef2-479e-9fb5-cdb40dff5028</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="35" Volume="1993" Year="2002" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="35" Volume="1993" Year="2002">
       <Id>ec4f1f24-76be-4e26-9888-0ae1bce19f69</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="36" Volume="1993" Year="2002" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="36" Volume="1993" Year="2002">
       <Id>a74d44de-2897-4f8b-9801-6346650c5176</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="19" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="19" Volume="2001" Year="2002">
       <Id>9977d04c-93b5-4530-81cb-d5a1063d1ae9</Id>
     </Book>
-    <Book Series="New X-Men" Number="128" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="New X-Men" Number="128" Volume="2001" Year="2002">
       <Id>1573c90c-9313-4827-937b-177801f0f75e</Id>
     </Book>
-    <Book Series="New X-Men" Number="129" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="New X-Men" Number="129" Volume="2001" Year="2002">
       <Id>0b83759f-a666-4b01-a568-51208a5e6078</Id>
     </Book>
-    <Book Series="New X-Men" Number="130" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="New X-Men" Number="130" Volume="2001" Year="2002">
       <Id>74d4f2b6-e10b-4f0c-93a2-913f4c84152c</Id>
     </Book>
-    <Book Series="New X-Men" Number="131" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="New X-Men" Number="131" Volume="2001" Year="2002">
       <Id>de3ab49b-d853-4fe1-b115-6b3fa8103a8c</Id>
     </Book>
-    <Book Series="New X-Men" Number="132" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="New X-Men" Number="132" Volume="2001" Year="2002">
       <Id>24d3093a-8ab9-4fe5-a9cd-0a4691b4d9dc</Id>
     </Book>
-    <Book Series="New X-Men" Number="133" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="New X-Men" Number="133" Volume="2001" Year="2002">
       <Id>5c21551f-9de2-4eb3-bc63-5ca3e0c81a1a</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="37" Volume="1993" Year="2002" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="37" Volume="1993" Year="2002">
       <Id>e2cd7396-7f2e-4a9d-a324-a4498cc77e1e</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="410" Volume="1981" Year="2002" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="410" Volume="1981" Year="2002">
       <Id>a3127f25-a8ff-4cbf-9845-f332eb7310ff</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="411" Volume="1981" Year="2002" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="411" Volume="1981" Year="2002">
       <Id>2e0b7d26-209b-4d58-a08d-b7b43f711a49</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="412" Volume="1981" Year="2002" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="412" Volume="1981" Year="2002">
       <Id>0a9cbea4-5c53-4edc-842f-0399544f4f8c</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="413" Volume="1981" Year="2002" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="413" Volume="1981" Year="2002">
       <Id>ad219bec-9f80-4b2a-9f39-e2a4ab095717</Id>
     </Book>
-    <Book Series="Chamber" Number="1" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="Chamber" Number="1" Volume="2002" Year="2002">
       <Id>108ffab0-a6de-48ad-ac03-894508aebafb</Id>
     </Book>
-    <Book Series="Chamber" Number="2" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="Chamber" Number="2" Volume="2002" Year="2002">
       <Id>f40e9b02-ab4f-4b1b-826e-826b39133b47</Id>
     </Book>
-    <Book Series="Chamber" Number="3" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="Chamber" Number="3" Volume="2002" Year="2002">
       <Id>9e01bf60-74e6-40a8-b3af-d88bb7cbb2ee</Id>
     </Book>
-    <Book Series="Chamber" Number="4" Volume="2002" Year="2003" Format="Limited Series">
+    <Book Series="Chamber" Number="4" Volume="2002" Year="2003">
       <Id>32b30d05-121d-4428-afe5-133c9b7da652</Id>
     </Book>
-    <Book Series="X-Treme X-Pose" Number="1" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="X-Treme X-Pose" Number="1" Volume="2003" Year="2003">
       <Id>a8707f06-b91a-4adc-86df-5fbf6a2eb55a</Id>
     </Book>
-    <Book Series="X-Treme X-Pose" Number="2" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="X-Treme X-Pose" Number="2" Volume="2003" Year="2003">
       <Id>f7aed619-7b75-414e-8eea-f0353a8c8013</Id>
     </Book>
-    <Book Series="Wolverine" Number="179" Volume="1988" Year="2002" Format="Main Series">
+    <Book Series="Wolverine" Number="179" Volume="1988" Year="2002">
       <Id>77b146f0-dfcf-46ce-8a1b-f6d10b1971b4</Id>
     </Book>
-    <Book Series="Wolverine" Number="180" Volume="1988" Year="2002" Format="Main Series">
+    <Book Series="Wolverine" Number="180" Volume="1988" Year="2002">
       <Id>389bcfc2-d7fa-4d75-aa7d-b4a9fe986f63</Id>
     </Book>
-    <Book Series="Wolverine" Number="181" Volume="1988" Year="2002" Format="Main Series">
+    <Book Series="Wolverine" Number="181" Volume="1988" Year="2002">
       <Id>919e2635-52f6-406e-a647-348620219860</Id>
     </Book>
-    <Book Series="Wolverine" Number="182" Volume="1988" Year="2002" Format="Main Series">
+    <Book Series="Wolverine" Number="182" Volume="1988" Year="2002">
       <Id>89e994cf-fb93-4977-9649-9c23669abee9</Id>
     </Book>
-    <Book Series="Wolverine" Number="183" Volume="1988" Year="2003" Format="Main Series">
+    <Book Series="Wolverine" Number="183" Volume="1988" Year="2003">
       <Id>ca13c8a9-43ba-431f-acc3-415948a2624b</Id>
     </Book>
-    <Book Series="Wolverine" Number="184" Volume="1988" Year="2003" Format="Main Series">
+    <Book Series="Wolverine" Number="184" Volume="1988" Year="2003">
       <Id>d82065af-269e-4812-aa3e-33ed0052c23f</Id>
     </Book>
-    <Book Series="Wolverine" Number="185" Volume="1988" Year="2003" Format="Main Series">
+    <Book Series="Wolverine" Number="185" Volume="1988" Year="2003">
       <Id>dfb7326f-59e2-4bdf-b55f-b97dc188060b</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="38" Volume="1993" Year="2002" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="38" Volume="1993" Year="2002">
       <Id>dbcc3f6e-9a3f-472d-be76-6c70464f44f4</Id>
     </Book>
-    <Book Series="Mekanix" Number="1" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="Mekanix" Number="1" Volume="2002" Year="2002">
       <Id>3c39802b-1819-4ee1-98ca-bf78095f49d2</Id>
     </Book>
-    <Book Series="Mekanix" Number="2" Volume="2002" Year="2003" Format="Limited Series">
+    <Book Series="Mekanix" Number="2" Volume="2002" Year="2003">
       <Id>d86d157b-06bd-4fad-804b-581d11e0aeae</Id>
     </Book>
-    <Book Series="Mekanix" Number="3" Volume="2002" Year="2003" Format="Limited Series">
+    <Book Series="Mekanix" Number="3" Volume="2002" Year="2003">
       <Id>1ee204ef-c54c-4409-8628-a03ce77dca6d</Id>
     </Book>
-    <Book Series="Mekanix" Number="4" Volume="2002" Year="2003" Format="Limited Series">
+    <Book Series="Mekanix" Number="4" Volume="2002" Year="2003">
       <Id>2ab73faf-5534-4821-a463-b070f5fb9cad</Id>
     </Book>
-    <Book Series="Mekanix" Number="5" Volume="2002" Year="2003" Format="Limited Series">
+    <Book Series="Mekanix" Number="5" Volume="2002" Year="2003">
       <Id>596e3d40-54ae-4de6-8e84-f7219c6a012c</Id>
     </Book>
-    <Book Series="Mekanix" Number="6" Volume="2002" Year="2003" Format="Limited Series">
+    <Book Series="Mekanix" Number="6" Volume="2002" Year="2003">
       <Id>9224c9eb-2508-4c17-9063-29f26db9647f</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="414" Volume="1981" Year="2002" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="414" Volume="1981" Year="2002">
       <Id>49c8d42f-ef79-4292-a7d4-b3396ad88ef2</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="415" Volume="1981" Year="2003" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="415" Volume="1981" Year="2003">
       <Id>0fc9052a-920d-4721-ad10-48f6e5dd0924</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="39" Volume="1993" Year="2003" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="39" Volume="1993" Year="2003">
       <Id>a6ef0983-735a-4cb1-8d7b-8bef80f6f41f</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="40" Volume="1993" Year="2003" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="40" Volume="1993" Year="2003">
       <Id>4b0b1105-d981-48c1-80a1-3756416bde78</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="41" Volume="1993" Year="2003" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="41" Volume="1993" Year="2003">
       <Id>5bb000ce-fadb-4017-bd69-fe98aa5d0d76</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="42" Volume="1993" Year="2003" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="42" Volume="1993" Year="2003">
       <Id>2d7ee8f5-c378-4439-aa70-acba7e31daa5</Id>
     </Book>
-    <Book Series="Soldier X" Number="1" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="Soldier X" Number="1" Volume="2002" Year="2002">
       <Id>c2318aa6-b5c5-4d50-93c3-0f941f837e55</Id>
     </Book>
-    <Book Series="Soldier X" Number="2" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="Soldier X" Number="2" Volume="2002" Year="2002">
       <Id>12352ccf-58f7-4b1b-b718-90bb56038534</Id>
     </Book>
-    <Book Series="Soldier X" Number="3" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="Soldier X" Number="3" Volume="2002" Year="2002">
       <Id>6cc734fb-3cab-43ed-851a-841829abc209</Id>
     </Book>
-    <Book Series="Soldier X" Number="4" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="Soldier X" Number="4" Volume="2002" Year="2002">
       <Id>2193b3ac-a251-4548-9f4b-cf2158eb75ee</Id>
     </Book>
-    <Book Series="Soldier X" Number="5" Volume="2002" Year="2003" Format="Limited Series">
+    <Book Series="Soldier X" Number="5" Volume="2002" Year="2003">
       <Id>01ce5cd3-f628-4ade-9617-a741711b5e15</Id>
     </Book>
-    <Book Series="Soldier X" Number="6" Volume="2002" Year="2003" Format="Limited Series">
+    <Book Series="Soldier X" Number="6" Volume="2002" Year="2003">
       <Id>e363dfb9-5b88-49fa-b3bd-fbc4a8763ce1</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="416" Volume="1981" Year="2003" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="416" Volume="1981" Year="2003">
       <Id>473d6374-f269-4ed1-899d-c065e2b90953</Id>
     </Book>
-    <Book Series="New X-Men" Number="134" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="New X-Men" Number="134" Volume="2001" Year="2003">
       <Id>850892f5-38c0-4f47-b41b-d7a6fa5623a5</Id>
     </Book>
-    <Book Series="Wolverine" Number="186" Volume="1988" Year="2003" Format="Main Series">
+    <Book Series="Wolverine" Number="186" Volume="1988" Year="2003">
       <Id>83a57520-8885-446d-a711-e92fe089b5ec</Id>
     </Book>
-    <Book Series="Soldier X" Number="7" Volume="2002" Year="2003" Format="Limited Series">
+    <Book Series="Soldier X" Number="7" Volume="2002" Year="2003">
       <Id>d91761f6-638b-47ec-8bec-27a524772b4f</Id>
     </Book>
-    <Book Series="Soldier X" Number="8" Volume="2002" Year="2003" Format="Limited Series">
+    <Book Series="Soldier X" Number="8" Volume="2002" Year="2003">
       <Id>23538d34-1132-4670-98c3-ec507c830d1d</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="43" Volume="1993" Year="2003" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="43" Volume="1993" Year="2003">
       <Id>c2f86794-7750-489c-a22f-80c66a75ac8d</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="44" Volume="1993" Year="2003" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="44" Volume="1993" Year="2003">
       <Id>d4b800a0-24b3-410b-bef0-25e976ae5daf</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="417" Volume="1981" Year="2003" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="417" Volume="1981" Year="2003">
       <Id>b930ddbe-3fb8-45e9-8b6e-01eca92c0891</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="418" Volume="1981" Year="2003" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="418" Volume="1981" Year="2003">
       <Id>2db7b9f0-56d0-4b90-91e6-98098b009478</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="419" Volume="1981" Year="2003" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="419" Volume="1981" Year="2003">
       <Id>0f0ff33d-67a2-43fa-a336-0acc86e42a64</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="420" Volume="1981" Year="2003" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="420" Volume="1981" Year="2003">
       <Id>e3d86a22-3050-468a-a890-8de83d0a7c45</Id>
     </Book>
-    <Book Series="Wolverine" Number="187" Volume="1988" Year="2003" Format="Main Series">
+    <Book Series="Wolverine" Number="187" Volume="1988" Year="2003">
       <Id>379ba03b-cfad-4229-ad52-18c1083b0f8f</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="20" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="20" Volume="2001" Year="2003">
       <Id>5c4d3ef0-c554-4509-bb97-2a145c84d5bc</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="21" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="21" Volume="2001" Year="2003">
       <Id>633ef17d-b4b5-4006-9949-74e869d0846e</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="22" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="22" Volume="2001" Year="2003">
       <Id>708ade2e-dc74-4508-984a-2e6368e4f08c</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="23" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="23" Volume="2001" Year="2003">
       <Id>67292e8a-b3ae-4bb5-acd5-4b0593a188bc</Id>
     </Book>
-    <Book Series="Soldier X" Number="9" Volume="2002" Year="2003" Format="Limited Series">
+    <Book Series="Soldier X" Number="9" Volume="2002" Year="2003">
       <Id>7919f6b5-c826-4011-9443-4f9c693ec67a</Id>
     </Book>
-    <Book Series="Soldier X" Number="10" Volume="2002" Year="2003" Format="Limited Series">
+    <Book Series="Soldier X" Number="10" Volume="2002" Year="2003">
       <Id>06a2508c-f16a-4c25-82d0-97f2870afaeb</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="45" Volume="1993" Year="2003" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="45" Volume="1993" Year="2003">
       <Id>b7ba4c29-dc35-489f-ac7d-3b5247658fca</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="421" Volume="1981" Year="2003" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="421" Volume="1981" Year="2003">
       <Id>c9a208a6-dd01-49f8-b8e5-aa7bc81332ad</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="422" Volume="1981" Year="2003" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="422" Volume="1981" Year="2003">
       <Id>93055ff5-f08f-49d7-8910-1199328b2168</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="423" Volume="1981" Year="2003" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="423" Volume="1981" Year="2003">
       <Id>d3df1a97-5790-42e1-99ae-453dcc0e5888</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="424" Volume="1981" Year="2003" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="424" Volume="1981" Year="2003">
       <Id>0d11e901-3e8e-4acf-b854-77a0fd59aea0</Id>
     </Book>
-    <Book Series="New X-Men" Number="135" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="New X-Men" Number="135" Volume="2001" Year="2003">
       <Id>d47a3fcd-2e79-4ed7-ab4e-1956344670b6</Id>
     </Book>
-    <Book Series="New X-Men" Number="136" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="New X-Men" Number="136" Volume="2001" Year="2003">
       <Id>6d9be846-5735-41a4-81c7-336b651b1eb3</Id>
     </Book>
-    <Book Series="New X-Men" Number="137" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="New X-Men" Number="137" Volume="2001" Year="2003">
       <Id>f5722cf4-22ff-442e-9727-2af3af0e5d30</Id>
     </Book>
-    <Book Series="New X-Men" Number="138" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="New X-Men" Number="138" Volume="2001" Year="2003">
       <Id>94204db3-b2e4-4422-9da1-459b1ddae284</Id>
     </Book>
-    <Book Series="Wolverine" Number="188" Volume="1988" Year="2003" Format="Main Series">
+    <Book Series="Wolverine" Number="188" Volume="1988" Year="2003">
       <Id>e3577d0a-935e-4af0-9be6-08d07102e4ab</Id>
     </Book>
-    <Book Series="Wolverine" Number="189" Volume="1988" Year="2003" Format="Main Series">
+    <Book Series="Wolverine" Number="189" Volume="1988" Year="2003">
       <Id>21166d9c-c63b-4e61-abcb-c3915360e4cd</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="24" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="24" Volume="2001" Year="2003">
       <Id>6470b82d-a057-4a62-bd34-89b62655ee30</Id>
     </Book>
-    <Book Series="Soldier X" Number="11" Volume="2002" Year="2003" Format="Limited Series">
+    <Book Series="Soldier X" Number="11" Volume="2002" Year="2003">
       <Id>21731f46-8d06-404d-957c-0b38382803ff</Id>
     </Book>
-    <Book Series="Soldier X" Number="12" Volume="2002" Year="2003" Format="Limited Series">
+    <Book Series="Soldier X" Number="12" Volume="2002" Year="2003">
       <Id>05bc140f-402f-4f47-84a2-8b647da5c9c3</Id>
     </Book>
-    <Book Series="New X-Men" Number="139" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="New X-Men" Number="139" Volume="2001" Year="2003">
       <Id>ef43d7c9-a6ea-4845-8032-2d5371fc498d</Id>
     </Book>
-    <Book Series="New X-Men" Number="140" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="New X-Men" Number="140" Volume="2001" Year="2003">
       <Id>32f3e0bd-063d-4b9f-b7f8-cfb8b702af32</Id>
     </Book>
-    <Book Series="New X-Men" Number="141" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="New X-Men" Number="141" Volume="2001" Year="2003">
       <Id>2ff96764-31b6-485e-b74d-0864257cd721</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="25" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="25" Volume="2001" Year="2003">
       <Id>39d73f08-c75e-4145-b167-1d4390cb3e1b</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="26" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="26" Volume="2001" Year="2003">
       <Id>fc7d927d-261d-48a2-ae4d-2d57b40e9286</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="27" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="27" Volume="2001" Year="2003">
       <Id>0d5181ed-a0be-432e-8b9b-b7f3342658f5</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="28" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="28" Volume="2001" Year="2003">
       <Id>53405467-5e10-4844-a684-80b4b3f03fc6</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="29" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="29" Volume="2001" Year="2003">
       <Id>1e1f3a79-b6ad-4304-b1c6-f61c8a94115f</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="30" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="30" Volume="2001" Year="2003">
       <Id>44533dfb-ab8a-4dbf-a623-18a3d75b7fac</Id>
     </Book>
-    <Book Series="New Mutants" Number="1" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="New Mutants" Number="1" Volume="2003" Year="2003">
       <Id>3575d15f-86d3-4f4d-82d0-8cdb71b4165a</Id>
     </Book>
-    <Book Series="New Mutants" Number="2" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="New Mutants" Number="2" Volume="2003" Year="2003">
       <Id>dc57d59f-b22e-4261-a996-aa79b2e51cd2</Id>
     </Book>
-    <Book Series="New Mutants" Number="3" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="New Mutants" Number="3" Volume="2003" Year="2003">
       <Id>d67846d2-6ff4-4beb-a00a-62a7c1f1e76b</Id>
     </Book>
-    <Book Series="New Mutants" Number="4" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="New Mutants" Number="4" Volume="2003" Year="2003">
       <Id>ba69e708-f947-4a67-9179-cc300026a32e</Id>
     </Book>
-    <Book Series="New Mutants" Number="5" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="New Mutants" Number="5" Volume="2003" Year="2003">
       <Id>76861131-0a0f-4cc8-a597-10852521e4c2</Id>
     </Book>
-    <Book Series="New Mutants" Number="6" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="New Mutants" Number="6" Volume="2003" Year="2003">
       <Id>3f330a9e-7200-4ba4-a38b-14c7caec1fc2</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="46" Volume="1993" Year="2003" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="46" Volume="1993" Year="2003">
       <Id>616498db-6e0f-4ba3-9f60-095f4765b1ab</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="47" Volume="1993" Year="2003" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="47" Volume="1993" Year="2003">
       <Id>11b33db7-8fec-47d1-90cb-aaaff5903243</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="48" Volume="1993" Year="2003" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="48" Volume="1993" Year="2003">
       <Id>85c84bbd-c607-4d43-bf37-5de801828578</Id>
     </Book>
-    <Book Series="Mystique" Number="1" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Mystique" Number="1" Volume="2003" Year="2003">
       <Id>9dcac323-9c64-462b-921f-41b3a9330742</Id>
     </Book>
-    <Book Series="Mystique" Number="2" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Mystique" Number="2" Volume="2003" Year="2003">
       <Id>29f35600-be10-416e-9f81-af4b7fdad152</Id>
     </Book>
-    <Book Series="Mystique" Number="3" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Mystique" Number="3" Volume="2003" Year="2003">
       <Id>d18baa08-c46c-4aa3-ae93-a6d068d3a25a</Id>
     </Book>
-    <Book Series="Mystique" Number="4" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Mystique" Number="4" Volume="2003" Year="2003">
       <Id>e7b9ec26-859d-463a-80f0-6ae3dab5c0a0</Id>
     </Book>
-    <Book Series="Mystique" Number="5" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Mystique" Number="5" Volume="2003" Year="2003">
       <Id>1289f830-8867-4065-b823-f823e087d07e</Id>
     </Book>
-    <Book Series="Mystique" Number="6" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Mystique" Number="6" Volume="2003" Year="2003">
       <Id>befc02c7-97ae-48c5-a14d-6dbc50d7d5ea</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="425" Volume="1981" Year="2003" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="425" Volume="1981" Year="2003">
       <Id>f84ce6cf-1346-4ef6-a862-4fb59442ffd2</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="426" Volume="1981" Year="2003" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="426" Volume="1981" Year="2003">
       <Id>df4a2c7b-45fb-4ee0-85e0-fb5ac271ec96</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="427" Volume="1981" Year="2003" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="427" Volume="1981" Year="2003">
       <Id>f9b3904b-9af2-4378-a5f8-347b5f766288</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="49" Volume="1993" Year="2003" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="49" Volume="1993" Year="2003">
       <Id>ed934bf0-6c74-450e-8df4-c5570cfcc12c</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="50" Volume="1993" Year="2003" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="50" Volume="1993" Year="2003">
       <Id>596519b6-29fa-4ac0-9577-65401998f376</Id>
     </Book>
-    <Book Series="Emma Frost" Number="1" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Emma Frost" Number="1" Volume="2003" Year="2003">
       <Id>ac47d138-e52e-4d69-8969-be73db03499d</Id>
     </Book>
-    <Book Series="Emma Frost" Number="2" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Emma Frost" Number="2" Volume="2003" Year="2003">
       <Id>9ee034b4-004c-4b9a-b6c2-c6c2abbd0443</Id>
     </Book>
-    <Book Series="Emma Frost" Number="3" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Emma Frost" Number="3" Volume="2003" Year="2003">
       <Id>f477913e-8f89-43c2-8f0d-b6576e8f118f</Id>
     </Book>
-    <Book Series="Emma Frost" Number="4" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Emma Frost" Number="4" Volume="2003" Year="2003">
       <Id>609d363a-4557-426f-a1d9-738417f4618f</Id>
     </Book>
-    <Book Series="Emma Frost" Number="5" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Emma Frost" Number="5" Volume="2003" Year="2004">
       <Id>257e9ac2-dc49-456a-ba6e-53853de84591</Id>
     </Book>
-    <Book Series="Emma Frost" Number="6" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Emma Frost" Number="6" Volume="2003" Year="2004">
       <Id>ce33d0f9-0110-4e25-aec5-86be7a61b05a</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="428" Volume="1981" Year="2003" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="428" Volume="1981" Year="2003">
       <Id>1d7d25ee-74d9-40c9-ad7c-a57eea1b8202</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="429" Volume="1981" Year="2003" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="429" Volume="1981" Year="2003">
       <Id>19efab09-2279-41db-abaa-fc9af493d913</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="430" Volume="1981" Year="2003" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="430" Volume="1981" Year="2003">
       <Id>e0407ec7-06ce-4b0d-90c4-ef04f5f5cb4c</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="431" Volume="1981" Year="2003" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="431" Volume="1981" Year="2003">
       <Id>8430f1bc-dadc-4f09-936c-cb28171dd158</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="432" Volume="1981" Year="2003" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="432" Volume="1981" Year="2003">
       <Id>85b192c0-c391-4055-baff-ef6ef9c2dca4</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="433" Volume="1981" Year="2004" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="433" Volume="1981" Year="2004">
       <Id>48190d97-1ec2-409a-b75f-b8ebba485729</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="434" Volume="1981" Year="2004" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="434" Volume="1981" Year="2004">
       <Id>8cf86880-c3cd-4323-a04c-c74715c434a9</Id>
     </Book>
-    <Book Series="Wolverine" Number="0" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Wolverine" Number="0" Volume="2003" Year="2003">
       <Id>073e2700-3460-4f68-b732-dc554062932a</Id>
     </Book>
-    <Book Series="Wolverine" Number="1" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Wolverine" Number="1" Volume="2003" Year="2003">
       <Id>a672a827-8956-4ce6-8ab2-4cc480584f3b</Id>
     </Book>
-    <Book Series="Wolverine" Number="2" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Wolverine" Number="2" Volume="2003" Year="2003">
       <Id>1c4cafbf-ca61-4559-991c-6c374b67cd58</Id>
     </Book>
-    <Book Series="Wolverine" Number="3" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Wolverine" Number="3" Volume="2003" Year="2003">
       <Id>43966b3e-8871-46cf-bcc4-5c5827265b8a</Id>
     </Book>
-    <Book Series="Wolverine" Number="4" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Wolverine" Number="4" Volume="2003" Year="2003">
       <Id>c482bc2c-8960-47ed-8cae-90d11269c16b</Id>
     </Book>
-    <Book Series="Wolverine" Number="5" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Wolverine" Number="5" Volume="2003" Year="2003">
       <Id>495f3abd-c5c8-49b8-b59f-7be1ba8e474f</Id>
     </Book>
-    <Book Series="Wolverine" Number="6" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Wolverine" Number="6" Volume="2003" Year="2003">
       <Id>ca1d16d0-b240-48fd-b3be-e28dd0fc3521</Id>
     </Book>
-    <Book Series="New Mutants" Number="7" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="New Mutants" Number="7" Volume="2003" Year="2004">
       <Id>5c4ae3b3-ab33-447c-b9b0-b479e3e63542</Id>
     </Book>
-    <Book Series="New Mutants" Number="8" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="New Mutants" Number="8" Volume="2003" Year="2004">
       <Id>91cdcf83-64e8-47e7-8a35-57219b95d657</Id>
     </Book>
-    <Book Series="New Mutants" Number="9" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="New Mutants" Number="9" Volume="2003" Year="2004">
       <Id>1c144e92-5f10-4df0-b681-b51e54a3c848</Id>
     </Book>
-    <Book Series="New Mutants" Number="10" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="New Mutants" Number="10" Volume="2003" Year="2004">
       <Id>64ece120-c823-405f-ae25-028c7416be29</Id>
     </Book>
-    <Book Series="New Mutants" Number="11" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="New Mutants" Number="11" Volume="2003" Year="2004">
       <Id>97c34de0-67ab-4641-8ccd-1a94eca2a45c</Id>
     </Book>
-    <Book Series="New Mutants" Number="12" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="New Mutants" Number="12" Volume="2003" Year="2004">
       <Id>d87d22d7-f99e-49b4-9d78-411e5acc74a4</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="31" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="31" Volume="2001" Year="2003">
       <Id>73724f9a-e027-49b3-9f76-1dfc4b21b03c</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="32" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="32" Volume="2001" Year="2003">
       <Id>9b89aeb0-08a7-43ca-a34a-9f1aca0f7cdf</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="33" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="33" Volume="2001" Year="2003">
       <Id>535d6b33-a82c-4486-b171-9f86970b10b3</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="34" Volume="2001" Year="2004" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="34" Volume="2001" Year="2004">
       <Id>50ba64a8-26ee-46d4-807c-faba0742c20d</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="35" Volume="2001" Year="2004" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="35" Volume="2001" Year="2004">
       <Id>aca8b2fc-bd67-4776-8bc9-f10d819acd0c</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="435" Volume="1981" Year="2004" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="435" Volume="1981" Year="2004">
       <Id>61ff31ff-dd4e-4890-b86f-4c45efb6e7f6</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="436" Volume="1981" Year="2004" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="436" Volume="1981" Year="2004">
       <Id>6440ac98-f669-466a-b260-604ecfcf3787</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="437" Volume="1981" Year="2004" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="437" Volume="1981" Year="2004">
       <Id>837165a4-a76d-4a9f-97b7-d300ab44ecd2</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="438" Volume="1981" Year="2004" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="438" Volume="1981" Year="2004">
       <Id>5360ca19-00ff-49df-a9b1-393dd506bc45</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="439" Volume="1981" Year="2004" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="439" Volume="1981" Year="2004">
       <Id>42dae2ef-9c10-40af-9882-95ddf6b67dd8</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="440" Volume="1981" Year="2004" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="440" Volume="1981" Year="2004">
       <Id>2b016aaf-8d1a-44ea-9209-e7e517b877f9</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="441" Volume="1981" Year="2004" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="441" Volume="1981" Year="2004">
       <Id>9ad97c9c-cc94-4f16-83a7-36990928fbfc</Id>
     </Book>
-    <Book Series="Mystique" Number="7" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Mystique" Number="7" Volume="2003" Year="2003">
       <Id>b9187a06-3a3e-4aeb-85d6-a15a74337220</Id>
     </Book>
-    <Book Series="Mystique" Number="8" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Mystique" Number="8" Volume="2003" Year="2004">
       <Id>05b4455b-26bd-4ce5-945a-5059cb0f4f2f</Id>
     </Book>
-    <Book Series="Mystique" Number="9" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Mystique" Number="9" Volume="2003" Year="2004">
       <Id>6d227ece-3d43-48dd-83c4-c48a92e8029e</Id>
     </Book>
-    <Book Series="Mystique" Number="10" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Mystique" Number="10" Volume="2003" Year="2004">
       <Id>ac0b7292-3490-4417-b3a9-556afe696536</Id>
     </Book>
-    <Book Series="Mystique" Number="11" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Mystique" Number="11" Volume="2003" Year="2004">
       <Id>7521e714-9a9e-4190-b9ec-098eb955dd7d</Id>
     </Book>
-    <Book Series="Mystique" Number="12" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Mystique" Number="12" Volume="2003" Year="2004">
       <Id>5b6e16e8-f9fa-4881-a841-2b7bdc0a9203</Id>
     </Book>
-    <Book Series="Mystique" Number="13" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Mystique" Number="13" Volume="2003" Year="2004">
       <Id>46d91d4e-eea0-4fe9-bf49-f4e2d9c81491</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="36" Volume="2001" Year="2004" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="36" Volume="2001" Year="2004">
       <Id>5f5c9384-a02f-4fbe-8c55-10595dd0dc86</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="37" Volume="2001" Year="2004" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="37" Volume="2001" Year="2004">
       <Id>38bbdf47-6c48-4e5e-ae26-5476000183fc</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="38" Volume="2001" Year="2004" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="38" Volume="2001" Year="2004">
       <Id>5352f48f-7e7a-4bfe-9653-ce869f708ae2</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="39" Volume="2001" Year="2004" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="39" Volume="2001" Year="2004">
       <Id>4d7d5b6f-094b-4f07-a031-f45bd4dcc879</Id>
     </Book>
-    <Book Series="Wolverine" Number="7" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Wolverine" Number="7" Volume="2003" Year="2004">
       <Id>5c73c59b-168c-4a11-9a76-d5277d0c2fcb</Id>
     </Book>
-    <Book Series="Wolverine" Number="8" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Wolverine" Number="8" Volume="2003" Year="2004">
       <Id>68b11f22-610d-47fb-8e71-8dac03e735bf</Id>
     </Book>
-    <Book Series="Wolverine" Number="9" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Wolverine" Number="9" Volume="2003" Year="2004">
       <Id>0074bc43-7039-4b3f-b666-28a712adabfc</Id>
     </Book>
-    <Book Series="Wolverine" Number="10" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Wolverine" Number="10" Volume="2003" Year="2004">
       <Id>a53fc0a0-3ea0-4324-81d8-cc9dc4800b27</Id>
     </Book>
-    <Book Series="Wolverine" Number="11" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Wolverine" Number="11" Volume="2003" Year="2004">
       <Id>d43e8513-cf78-4c9f-b6dd-ea8960b11b4a</Id>
     </Book>
-    <Book Series="Wolverine" Number="12" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Wolverine" Number="12" Volume="2003" Year="2004">
       <Id>37f0d700-a81f-42a9-b843-a08df02eebfe</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="1" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="1" Volume="2004" Year="2004">
       <Id>495369b1-bdb1-419c-9d64-a284f9f03e7a</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="1" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="1" Volume="2004" Year="2004">
       <Id>c4e71850-f50e-412b-9212-747e8a164817</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="2" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="2" Volume="2004" Year="2004">
       <Id>dbb7f404-6c57-4219-9497-090cf0a1827e</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="3" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="3" Volume="2004" Year="2004">
       <Id>713593e3-ad61-4f3d-8f7d-b70c8d34f93c</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="4" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="4" Volume="2004" Year="2004">
       <Id>d953830f-a036-4041-bcd5-c166d31fc45c</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="5" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="5" Volume="2004" Year="2004">
       <Id>f5193b81-0860-4b9f-ba03-7e2825a08a19</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="6" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="6" Volume="2004" Year="2004">
       <Id>68eac69c-00f1-46d9-a772-449bc3995ce4</Id>
     </Book>
-    <Book Series="New X-Men" Number="142" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="New X-Men" Number="142" Volume="2001" Year="2003">
       <Id>f50cc228-56e4-4380-b204-fb1f5f8ca455</Id>
     </Book>
-    <Book Series="New X-Men" Number="143" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="New X-Men" Number="143" Volume="2001" Year="2003">
       <Id>06794df9-2e5a-4276-8152-f3b211acc68c</Id>
     </Book>
-    <Book Series="New X-Men" Number="144" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="New X-Men" Number="144" Volume="2001" Year="2003">
       <Id>1d66868e-c4c4-40ed-80bc-c4800150db11</Id>
     </Book>
-    <Book Series="New X-Men" Number="145" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="New X-Men" Number="145" Volume="2001" Year="2003">
       <Id>6eec12ba-143c-46e0-905c-dc3baa371c5c</Id>
     </Book>
-    <Book Series="New X-Men" Number="146" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="New X-Men" Number="146" Volume="2001" Year="2003">
       <Id>be27149d-f279-4fe7-b38a-48a4d569dfe0</Id>
     </Book>
-    <Book Series="New X-Men" Number="147" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="New X-Men" Number="147" Volume="2001" Year="2003">
       <Id>aefab12d-c3aa-4cdc-a121-5a7c4ea5989d</Id>
     </Book>
-    <Book Series="New X-Men" Number="148" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="New X-Men" Number="148" Volume="2001" Year="2003">
       <Id>63a1ec55-5808-4f17-8ab0-6bb11cc33cab</Id>
     </Book>
-    <Book Series="New X-Men" Number="149" Volume="2001" Year="2004" Format="Main Series">
+    <Book Series="New X-Men" Number="149" Volume="2001" Year="2004">
       <Id>9512fa8a-54f5-45e8-8810-bda54dbf0611</Id>
     </Book>
-    <Book Series="New X-Men" Number="150" Volume="2001" Year="2004" Format="Main Series">
+    <Book Series="New X-Men" Number="150" Volume="2001" Year="2004">
       <Id>dd0c8022-e598-48fb-b985-374ccec04a70</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="40" Volume="2001" Year="2004" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="40" Volume="2001" Year="2004">
       <Id>c38342e6-d8ea-4b1b-9e61-bd9eccb1add9</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="41" Volume="2001" Year="2004" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="41" Volume="2001" Year="2004">
       <Id>debd34d3-51ea-4cb0-9a5a-de50fe763bbe</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="42" Volume="2001" Year="2004" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="42" Volume="2001" Year="2004">
       <Id>1d647620-183a-44c6-9889-af8c85e0d80e</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="43" Volume="2001" Year="2004" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="43" Volume="2001" Year="2004">
       <Id>ed73f106-f60c-4ff4-9f78-7ce974f322b7</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="44" Volume="2001" Year="2004" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="44" Volume="2001" Year="2004">
       <Id>79aa9e72-9be5-4f16-9e8b-af22e42d7b21</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="45" Volume="2001" Year="2004" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="45" Volume="2001" Year="2004">
       <Id>2a387fde-f44b-4a87-a5e2-44e8ef52df6e</Id>
     </Book>
-    <Book Series="New X-Men" Number="151" Volume="2001" Year="2004" Format="Main Series">
+    <Book Series="New X-Men" Number="151" Volume="2001" Year="2004">
       <Id>6ffa92a7-81dd-4c86-9225-51088f0592e4</Id>
     </Book>
-    <Book Series="New X-Men" Number="152" Volume="2001" Year="2004" Format="Main Series">
+    <Book Series="New X-Men" Number="152" Volume="2001" Year="2004">
       <Id>0b797651-2f2b-4060-a7f2-5a4b6611082b</Id>
     </Book>
-    <Book Series="New X-Men" Number="153" Volume="2001" Year="2004" Format="Main Series">
+    <Book Series="New X-Men" Number="153" Volume="2001" Year="2004">
       <Id>410d5dd9-4a4b-41c9-b268-948db675245f</Id>
     </Book>
-    <Book Series="New X-Men" Number="154" Volume="2001" Year="2004" Format="Main Series">
+    <Book Series="New X-Men" Number="154" Volume="2001" Year="2004">
       <Id>ec6bec49-2006-4935-9d6a-398a21d100ed</Id>
     </Book>
-    <Book Series="New X-Men" Number="155" Volume="2001" Year="2004" Format="Main Series">
+    <Book Series="New X-Men" Number="155" Volume="2001" Year="2004">
       <Id>c48e9a0e-7a62-4def-bd6f-dd8db28468fb</Id>
     </Book>
-    <Book Series="New X-Men" Number="156" Volume="2001" Year="2004" Format="Main Series">
+    <Book Series="New X-Men" Number="156" Volume="2001" Year="2004">
       <Id>6663430d-b9ef-42b7-afa1-893f995a4bf8</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="442" Volume="1981" Year="2004" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="442" Volume="1981" Year="2004">
       <Id>9acbdb6a-b89d-43f0-9729-1cc9a32b2e0d</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="443" Volume="1981" Year="2004" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="443" Volume="1981" Year="2004">
       <Id>e6cd4f0f-5797-4920-8202-1d408c99e1cc</Id>
     </Book>
-    <Book Series="New Mutants" Number="13" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="New Mutants" Number="13" Volume="2003" Year="2004">
       <Id>64a245c0-2b18-4e3a-bc1e-cd704dcc5f31</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="46" Volume="2001" Year="2004" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="46" Volume="2001" Year="2004">
       <Id>477c5510-06fd-4bba-8173-a0e17d5bf10b</Id>
     </Book>
   </Books>

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 009 (X-Men Reload).cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 009 (X-Men Reload).cbl
@@ -1,777 +1,778 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>X-Men - Part 9 (X-Men Reload)</Name>
+  <Name>X-Men - Part 009 (X-Men Reload)</Name>
+  <NumIssues>257</NumIssues>
   <Books>
     <Book Series="X-Men" Number="157" Volume="2004" Year="2004">
-      <Id>72ccff43-1fc0-47a0-884a-837d71a24bf5</Id>
+      <Database Name="cv" Series="10731" Issue="90341" />
     </Book>
     <Book Series="X-Men" Number="158" Volume="2004" Year="2004">
-      <Id>62efe384-365c-4d47-8139-f8387a310323</Id>
+      <Database Name="cv" Series="10731" Issue="90342" />
     </Book>
     <Book Series="X-Men" Number="159" Volume="2004" Year="2004">
-      <Id>d993aa7f-a911-4eba-b349-5594eafbd674</Id>
+      <Database Name="cv" Series="10731" Issue="90343" />
     </Book>
     <Book Series="X-Men" Number="160" Volume="2004" Year="2004">
-      <Id>6cf41fae-c588-4928-abdb-72e56518b196</Id>
+      <Database Name="cv" Series="10731" Issue="90344" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="444" Volume="1981" Year="2004">
-      <Id>ddfa8d45-aaf3-4c5d-90c6-bce40ba3aa4f</Id>
+      <Database Name="cv" Series="3092" Issue="106450" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="445" Volume="1981" Year="2004">
-      <Id>c222e824-5d5c-496c-9363-57d7eb2878a5</Id>
+      <Database Name="cv" Series="3092" Issue="106451" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="446" Volume="1981" Year="2004">
-      <Id>4595e000-f58e-4d60-b629-dacc75376a17</Id>
+      <Database Name="cv" Series="3092" Issue="106452" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="447" Volume="1981" Year="2004">
-      <Id>32290d86-0ba4-445d-a509-aadce613f209</Id>
+      <Database Name="cv" Series="3092" Issue="106453" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="448" Volume="1981" Year="2004">
-      <Id>06e19b31-06df-469a-b94d-78292c5ebb32</Id>
+      <Database Name="cv" Series="3092" Issue="93554" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="449" Volume="1981" Year="2004">
-      <Id>f317df33-a2be-45dd-81f3-5651b8923877</Id>
+      <Database Name="cv" Series="3092" Issue="93555" />
     </Book>
     <Book Series="Astonishing X-Men" Number="1" Volume="2004" Year="2004">
-      <Id>e0b0e43c-83ac-45e3-a8ea-b6e31d1d2e9a</Id>
+      <Database Name="cv" Series="10746" Issue="90580" />
     </Book>
     <Book Series="Astonishing X-Men" Number="2" Volume="2004" Year="2004">
-      <Id>d779a506-4574-4d65-8b57-2710e9a1068d</Id>
+      <Database Name="cv" Series="10746" Issue="90581" />
     </Book>
     <Book Series="Astonishing X-Men" Number="3" Volume="2004" Year="2004">
-      <Id>eb656a7b-458f-47f7-94ed-fae5ae876641</Id>
+      <Database Name="cv" Series="10746" Issue="90583" />
     </Book>
     <Book Series="Astonishing X-Men" Number="4" Volume="2004" Year="2004">
-      <Id>2aa317ff-174e-401e-be3b-6d27e934d853</Id>
+      <Database Name="cv" Series="10746" Issue="93543" />
     </Book>
     <Book Series="Astonishing X-Men" Number="5" Volume="2004" Year="2004">
-      <Id>3ae5a5fe-2a54-48ac-8bf0-10845b2a5fd0</Id>
+      <Database Name="cv" Series="10746" Issue="93544" />
     </Book>
     <Book Series="Astonishing X-Men" Number="6" Volume="2004" Year="2004">
-      <Id>0eb175d2-980d-40c2-a3ca-75696b2295a8</Id>
+      <Database Name="cv" Series="10746" Issue="99750" />
     </Book>
     <Book Series="New X-Men" Number="1" Volume="2004" Year="2004">
-      <Id>0b949516-b3ee-41f6-8e66-b3501b18c33f</Id>
+      <Database Name="cv" Series="18078" Issue="105907" />
     </Book>
     <Book Series="New X-Men" Number="2" Volume="2004" Year="2004">
-      <Id>01ddbcac-f65b-4a43-a0bf-c12626d073dc</Id>
+      <Database Name="cv" Series="18078" Issue="106040" />
     </Book>
     <Book Series="New X-Men" Number="3" Volume="2004" Year="2004">
-      <Id>4d45405c-f0aa-4d0c-9ce0-c0be28f81257</Id>
+      <Database Name="cv" Series="18078" Issue="106041" />
     </Book>
     <Book Series="New X-Men" Number="4" Volume="2004" Year="2004">
-      <Id>95485610-3317-4268-941f-85dcaf4a369f</Id>
+      <Database Name="cv" Series="18078" Issue="106150" />
     </Book>
     <Book Series="New X-Men" Number="5" Volume="2004" Year="2004">
-      <Id>a6332446-2db2-4586-a090-a2de2752291e</Id>
+      <Database Name="cv" Series="18078" Issue="106151" />
     </Book>
     <Book Series="New X-Men" Number="6" Volume="2004" Year="2004">
-      <Id>6a2b6f6c-3609-4f2c-ac70-f1fa6cdc3715</Id>
+      <Database Name="cv" Series="18078" Issue="106152" />
     </Book>
     <Book Series="Excalibur" Number="1" Volume="2004" Year="2004">
-      <Id>b3764b34-2ab1-4f64-a6ef-f1e23d30300c</Id>
+      <Database Name="cv" Series="11292" Issue="99098" />
     </Book>
     <Book Series="Excalibur" Number="2" Volume="2004" Year="2004">
-      <Id>a8a8f9ea-201d-401d-8fbc-e5c60ee3e06b</Id>
+      <Database Name="cv" Series="11292" Issue="99099" />
     </Book>
     <Book Series="Excalibur" Number="3" Volume="2004" Year="2004">
-      <Id>51ec79cf-d39f-45dc-b4cb-833d61d75a8c</Id>
+      <Database Name="cv" Series="11292" Issue="99100" />
     </Book>
     <Book Series="Excalibur" Number="4" Volume="2004" Year="2004">
-      <Id>aae91147-2e5b-48b4-8ae0-801f93df9948</Id>
+      <Database Name="cv" Series="11292" Issue="99101" />
     </Book>
     <Book Series="X-Men Unlimited" Number="2" Volume="2004" Year="2004">
-      <Id>8aad2ce5-feda-48ef-aa0b-ed5ea6271512</Id>
+      <Database Name="cv" Series="10745" Issue="90578" />
     </Book>
     <Book Series="District X" Number="1" Volume="2004" Year="2004">
-      <Id>e5ab9859-7075-463f-b542-7b7e8c2201a5</Id>
+      <Database Name="cv" Series="19327" Issue="116029" />
     </Book>
     <Book Series="District X" Number="2" Volume="2004" Year="2004">
-      <Id>050d6de9-4d8e-413b-b555-107bf8bc5984</Id>
+      <Database Name="cv" Series="19327" Issue="116067" />
     </Book>
     <Book Series="District X" Number="3" Volume="2004" Year="2004">
-      <Id>af00b028-c361-4f72-b622-dd3863a958ac</Id>
+      <Database Name="cv" Series="19327" Issue="116069" />
     </Book>
     <Book Series="District X" Number="4" Volume="2004" Year="2004">
-      <Id>603c5d6d-4f9c-4ea4-ae1b-cd0b1d1c307a</Id>
+      <Database Name="cv" Series="19327" Issue="116070" />
     </Book>
     <Book Series="District X" Number="5" Volume="2004" Year="2004">
-      <Id>60e80b47-207b-4c41-b800-27a12cc45e94</Id>
+      <Database Name="cv" Series="19327" Issue="116071" />
     </Book>
     <Book Series="District X" Number="6" Volume="2004" Year="2004">
-      <Id>1186156b-0134-411d-b3d4-ab529d262ff1</Id>
+      <Database Name="cv" Series="19327" Issue="116072" />
     </Book>
     <Book Series="Emma Frost" Number="7" Volume="2003" Year="2004">
-      <Id>4bcd9a0f-a75c-42ba-ad13-cf537df4f8a9</Id>
+      <Database Name="cv" Series="18014" Issue="107668" />
     </Book>
     <Book Series="Emma Frost" Number="8" Volume="2003" Year="2004">
-      <Id>0bb6c47c-c3e0-41cc-ae85-1f6d191167d1</Id>
+      <Database Name="cv" Series="18014" Issue="107671" />
     </Book>
     <Book Series="Emma Frost" Number="9" Volume="2003" Year="2004">
-      <Id>d56af3d4-120e-4577-9c71-15cf8a62c096</Id>
+      <Database Name="cv" Series="18014" Issue="107667" />
     </Book>
     <Book Series="Emma Frost" Number="10" Volume="2003" Year="2004">
-      <Id>1a334453-0a7a-4b08-a3ac-54d3c1d961a5</Id>
+      <Database Name="cv" Series="18014" Issue="107674" />
     </Book>
     <Book Series="Emma Frost" Number="11" Volume="2003" Year="2004">
-      <Id>8e98d634-a09e-49c1-879f-ebdb37c3a463</Id>
+      <Database Name="cv" Series="18014" Issue="107673" />
     </Book>
     <Book Series="Emma Frost" Number="12" Volume="2003" Year="2004">
-      <Id>c72641a1-846e-480f-9f01-b9a4fe8d2fd0</Id>
+      <Database Name="cv" Series="18014" Issue="107670" />
     </Book>
     <Book Series="Wolverine" Number="13" Volume="2003" Year="2004">
-      <Id>a5d3adda-5f1c-47af-8049-b852d2fbe12d</Id>
+      <Database Name="cv" Series="10809" Issue="92149" />
     </Book>
     <Book Series="Wolverine" Number="14" Volume="2003" Year="2004">
-      <Id>bfbc7c40-040f-43b6-81d7-c5a72481e08e</Id>
+      <Database Name="cv" Series="10809" Issue="92150" />
     </Book>
     <Book Series="Wolverine" Number="15" Volume="2003" Year="2004">
-      <Id>4a4d7716-4fb5-4d72-a2e6-3b7134587de8</Id>
+      <Database Name="cv" Series="10809" Issue="92151" />
     </Book>
     <Book Series="Wolverine" Number="16" Volume="2003" Year="2004">
-      <Id>b6da8525-fcc2-4302-98aa-973c5d19eb3c</Id>
+      <Database Name="cv" Series="10809" Issue="96816" />
     </Book>
     <Book Series="Wolverine" Number="17" Volume="2003" Year="2004">
-      <Id>a52248ce-2fb5-427f-b2d6-69ff9c2fbd8f</Id>
+      <Database Name="cv" Series="10809" Issue="96817" />
     </Book>
     <Book Series="Wolverine" Number="18" Volume="2003" Year="2004">
-      <Id>246ca6b1-10da-454c-ad44-0d42b148b96d</Id>
+      <Database Name="cv" Series="10809" Issue="96818" />
     </Book>
     <Book Series="Wolverine" Number="19" Volume="2003" Year="2004">
-      <Id>a8779026-088e-4b63-9871-e2df11980414</Id>
+      <Database Name="cv" Series="10809" Issue="96819" />
     </Book>
     <Book Series="Mystique" Number="14" Volume="2003" Year="2004">
-      <Id>c26934e0-ef1e-4877-8be2-ac6ff5b52909</Id>
+      <Database Name="cv" Series="11391" Issue="99876" />
     </Book>
     <Book Series="Mystique" Number="15" Volume="2003" Year="2004">
-      <Id>df90800a-d224-467d-9870-8a1074426c38</Id>
+      <Database Name="cv" Series="11391" Issue="99877" />
     </Book>
     <Book Series="Mystique" Number="16" Volume="2003" Year="2004">
-      <Id>dd700509-c6f6-4b07-b7af-daab8cc27253</Id>
+      <Database Name="cv" Series="11391" Issue="99878" />
     </Book>
     <Book Series="Mystique" Number="17" Volume="2003" Year="2004">
-      <Id>1ae00fa0-76e5-4af4-9530-a6e2a5509410</Id>
+      <Database Name="cv" Series="11391" Issue="99879" />
     </Book>
     <Book Series="Mystique" Number="18" Volume="2003" Year="2004">
-      <Id>035d5edc-98c1-49d4-b31c-7d8c26e93d4a</Id>
+      <Database Name="cv" Series="11391" Issue="99880" />
     </Book>
     <Book Series="X-Men Unlimited" Number="3" Volume="2004" Year="2004">
-      <Id>b316ea34-f411-4d2e-91c0-8918e15b5675</Id>
+      <Database Name="cv" Series="10745" Issue="90579" />
     </Book>
     <Book Series="Emma Frost" Number="13" Volume="2003" Year="2004">
-      <Id>db60fb60-d884-4761-883d-33e44fb6959d</Id>
+      <Database Name="cv" Series="18014" Issue="107676" />
     </Book>
     <Book Series="Emma Frost" Number="14" Volume="2003" Year="2004">
-      <Id>ecb0237b-8e6f-4b15-9b8d-a6e68343c2c9</Id>
+      <Database Name="cv" Series="18014" Issue="107665" />
     </Book>
     <Book Series="Emma Frost" Number="15" Volume="2003" Year="2004">
-      <Id>108f2390-904e-4577-a45a-849ec463e1b1</Id>
+      <Database Name="cv" Series="18014" Issue="107669" />
     </Book>
     <Book Series="Emma Frost" Number="16" Volume="2003" Year="2004">
-      <Id>4f1235f6-5512-447a-ac04-1311df444895</Id>
+      <Database Name="cv" Series="18014" Issue="107672" />
     </Book>
     <Book Series="Emma Frost" Number="17" Volume="2003" Year="2005">
-      <Id>ee5b6f1e-0a35-4fbe-9b00-701180c0ea16</Id>
+      <Database Name="cv" Series="18014" Issue="107666" />
     </Book>
     <Book Series="Emma Frost" Number="18" Volume="2003" Year="2005">
-      <Id>598ae177-788e-410e-8376-1db111640d1b</Id>
+      <Database Name="cv" Series="18014" Issue="107675" />
     </Book>
     <Book Series="Rogue" Number="1" Volume="2004" Year="2004">
-      <Id>f0b8c573-2c2a-42e3-8f54-b5731ea6e9e8</Id>
+      <Database Name="cv" Series="19612" Issue="117667" />
     </Book>
     <Book Series="Rogue" Number="2" Volume="2004" Year="2004">
-      <Id>5c135518-f8de-4fab-87a2-7020b376dc6d</Id>
+      <Database Name="cv" Series="19612" Issue="117747" />
     </Book>
     <Book Series="Rogue" Number="3" Volume="2004" Year="2004">
-      <Id>abc95102-d75d-4706-b002-d859e71de2b1</Id>
+      <Database Name="cv" Series="19612" Issue="117748" />
     </Book>
     <Book Series="Rogue" Number="4" Volume="2004" Year="2004">
-      <Id>f69c5299-202f-423b-bc33-ad81369567a6</Id>
+      <Database Name="cv" Series="19612" Issue="117749" />
     </Book>
     <Book Series="Rogue" Number="5" Volume="2004" Year="2005">
-      <Id>63341033-1ab8-4a63-9357-ba7214219133</Id>
+      <Database Name="cv" Series="19612" Issue="117751" />
     </Book>
     <Book Series="Rogue" Number="6" Volume="2004" Year="2005">
-      <Id>696dec5b-4464-4cd6-bd51-533c283d8a46</Id>
+      <Database Name="cv" Series="19612" Issue="117752" />
     </Book>
     <Book Series="Mystique" Number="19" Volume="2003" Year="2004">
-      <Id>8213cc1e-b38a-4403-9527-e9f4a86c80fb</Id>
+      <Database Name="cv" Series="11391" Issue="99881" />
     </Book>
     <Book Series="Mystique" Number="20" Volume="2003" Year="2004">
-      <Id>83810ac8-bca4-4fd6-93d6-a34f3a0226ac</Id>
+      <Database Name="cv" Series="11391" Issue="99882" />
     </Book>
     <Book Series="Mystique" Number="21" Volume="2003" Year="2005">
-      <Id>b0e6839f-9cf4-410f-be57-45fce983fd65</Id>
+      <Database Name="cv" Series="11391" Issue="99883" />
     </Book>
     <Book Series="Mystique" Number="22" Volume="2003" Year="2005">
-      <Id>6bea5f3d-98c6-496a-837a-c7d3574cacea</Id>
+      <Database Name="cv" Series="11391" Issue="99884" />
     </Book>
     <Book Series="Mystique" Number="23" Volume="2003" Year="2005">
-      <Id>ddc77ca8-d51f-4e2b-b81e-b36c0f19fee3</Id>
+      <Database Name="cv" Series="11391" Issue="99885" />
     </Book>
     <Book Series="Mystique" Number="24" Volume="2003" Year="2005">
-      <Id>9b0298ef-3cde-487e-91be-d5580bdb6bdd</Id>
+      <Database Name="cv" Series="11391" Issue="99886" />
     </Book>
     <Book Series="Jubilee" Number="1" Volume="2004" Year="2004">
-      <Id>d57653e0-21cc-4a7a-913f-84e53f4c50be</Id>
+      <Database Name="cv" Series="18650" Issue="110036" />
     </Book>
     <Book Series="Jubilee" Number="2" Volume="2004" Year="2004">
-      <Id>67b19c59-1992-4da2-af4e-4537dc09ccc0</Id>
+      <Database Name="cv" Series="18650" Issue="110049" />
     </Book>
     <Book Series="Jubilee" Number="3" Volume="2004" Year="2005">
-      <Id>5f9c531a-27c2-4127-b800-93769645acf7</Id>
+      <Database Name="cv" Series="18650" Issue="110050" />
     </Book>
     <Book Series="Jubilee" Number="4" Volume="2004" Year="2005">
-      <Id>8128118c-22d4-4d67-84b4-626d906daf75</Id>
+      <Database Name="cv" Series="18650" Issue="110051" />
     </Book>
     <Book Series="Jubilee" Number="5" Volume="2004" Year="2005">
-      <Id>d744f39e-0c6c-4054-a2cb-467293f84a5d</Id>
+      <Database Name="cv" Series="18650" Issue="110122" />
     </Book>
     <Book Series="Jubilee" Number="6" Volume="2004" Year="2005">
-      <Id>51bd7224-8c07-4f09-a7dd-65f05cbdb55c</Id>
+      <Database Name="cv" Series="18650" Issue="110123" />
     </Book>
     <Book Series="Madrox" Number="1" Volume="2004" Year="2004">
-      <Id>6dac0636-5087-4447-9bd2-3225621f98f3</Id>
+      <Database Name="cv" Series="11181" Issue="97934" />
     </Book>
     <Book Series="Madrox" Number="2" Volume="2004" Year="2004">
-      <Id>07881242-2739-443b-a7d8-da3ca93dacb8</Id>
+      <Database Name="cv" Series="11181" Issue="97935" />
     </Book>
     <Book Series="Madrox" Number="3" Volume="2004" Year="2005">
-      <Id>57574ce6-d6d5-4d1f-aa46-0626b553b425</Id>
+      <Database Name="cv" Series="11181" Issue="114063" />
     </Book>
     <Book Series="Madrox" Number="4" Volume="2004" Year="2005">
-      <Id>a9b3a4e2-a909-4196-b1d4-52d60a0adbf0</Id>
+      <Database Name="cv" Series="11181" Issue="114064" />
     </Book>
     <Book Series="Madrox" Number="5" Volume="2004" Year="2005">
-      <Id>5778600a-1f88-4271-a557-749c95a40e81</Id>
+      <Database Name="cv" Series="11181" Issue="114065" />
     </Book>
     <Book Series="Nightcrawler" Number="1" Volume="2004" Year="2004">
-      <Id>c57e1597-d876-4c2a-bd9e-0795666560e4</Id>
+      <Database Name="cv" Series="18700" Issue="110544" />
     </Book>
     <Book Series="Nightcrawler" Number="2" Volume="2004" Year="2004">
-      <Id>41380e6d-ba81-4d6d-b25b-81f812d49d7e</Id>
+      <Database Name="cv" Series="18700" Issue="110610" />
     </Book>
     <Book Series="Nightcrawler" Number="3" Volume="2004" Year="2005">
-      <Id>4ccda2de-e25c-43f2-af3d-76bcf74ec410</Id>
+      <Database Name="cv" Series="18700" Issue="110663" />
     </Book>
     <Book Series="Nightcrawler" Number="4" Volume="2004" Year="2005">
-      <Id>5cb1c51e-1631-48e9-88aa-12b944993a9f</Id>
+      <Database Name="cv" Series="18700" Issue="110977" />
     </Book>
     <Book Series="X-Men Unlimited" Number="4" Volume="2004" Year="2004">
-      <Id>adb42a74-e1a0-45a8-ad05-b9b86eedb524</Id>
+      <Database Name="cv" Series="10745" Issue="101010" />
     </Book>
     <Book Series="X-Men Unlimited" Number="5" Volume="2004" Year="2004">
-      <Id>13134df7-effe-4154-84f2-c0f52d4158e8</Id>
+      <Database Name="cv" Series="10745" Issue="101011" />
     </Book>
     <Book Series="X-Men Unlimited" Number="6" Volume="2004" Year="2005">
-      <Id>faf2508b-a2d5-4ea6-87e8-35f3d853120b</Id>
+      <Database Name="cv" Series="10745" Issue="101012" />
     </Book>
     <Book Series="Sabretooth" Number="1" Volume="2004" Year="2004">
-      <Id>984763b7-b22c-4d6a-8a64-0bcd2f1bd2d4</Id>
+      <Database Name="cv" Series="22216" Issue="133585" />
     </Book>
     <Book Series="Sabretooth" Number="2" Volume="2004" Year="2004">
-      <Id>0cdee0fd-7f7c-4585-acbd-423be883b967</Id>
+      <Database Name="cv" Series="22216" Issue="133586" />
     </Book>
     <Book Series="Sabretooth" Number="3" Volume="2004" Year="2005">
-      <Id>954ed957-d280-49ba-a9d5-2fc182459b57</Id>
+      <Database Name="cv" Series="22216" Issue="133587" />
     </Book>
     <Book Series="Sabretooth" Number="4" Volume="2004" Year="2005">
-      <Id>a3fb3791-4868-414b-a023-3c0a04d5eed1</Id>
+      <Database Name="cv" Series="22216" Issue="133588" />
     </Book>
     <Book Series="NYX" Number="1" Volume="2003" Year="2003">
-      <Id>8976ddb3-3000-482f-b00e-e7614279319d</Id>
+      <Database Name="cv" Series="17987" Issue="105318" />
     </Book>
     <Book Series="NYX" Number="2" Volume="2003" Year="2004">
-      <Id>82cecef5-51fd-4400-b811-440162347854</Id>
+      <Database Name="cv" Series="17987" Issue="105410" />
     </Book>
     <Book Series="NYX" Number="3" Volume="2003" Year="2004">
-      <Id>81934bd3-99b2-4aa7-8d9f-07753a4f1617</Id>
+      <Database Name="cv" Series="17987" Issue="105411" />
     </Book>
     <Book Series="NYX" Number="4" Volume="2003" Year="2004">
-      <Id>88899fb5-c6eb-49c2-9124-04ed98ff36e1</Id>
+      <Database Name="cv" Series="17987" Issue="105412" />
     </Book>
     <Book Series="NYX" Number="5" Volume="2003" Year="2004">
-      <Id>59d002bd-0dbe-4955-a8c9-a3c4be6effe3</Id>
+      <Database Name="cv" Series="17987" Issue="105413" />
     </Book>
     <Book Series="NYX" Number="6" Volume="2003" Year="2005">
-      <Id>d018396d-7195-439a-a394-f9702262dd2d</Id>
+      <Database Name="cv" Series="17987" Issue="107239" />
     </Book>
     <Book Series="NYX" Number="7" Volume="2003" Year="2005">
-      <Id>d66be0d8-572c-4a86-aafc-1c73d34b5cd2</Id>
+      <Database Name="cv" Series="17987" Issue="107240" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="450" Volume="1981" Year="2004">
-      <Id>9e49cf9b-7ec1-4fa7-8319-4ebe0065964f</Id>
+      <Database Name="cv" Series="3092" Issue="96810" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="451" Volume="1981" Year="2004">
-      <Id>fbf28be5-4a17-42ee-8ccd-b91cf9afb601</Id>
+      <Database Name="cv" Series="3092" Issue="96811" />
     </Book>
     <Book Series="X-Men" Number="161" Volume="2004" Year="2004">
-      <Id>a9df6851-1456-443f-9a4c-448d8df50028</Id>
+      <Database Name="cv" Series="10731" Issue="99627" />
     </Book>
     <Book Series="X-Men" Number="162" Volume="2004" Year="2004">
-      <Id>3e96d828-dce0-42fb-9df1-1f530cf2421d</Id>
+      <Database Name="cv" Series="10731" Issue="99628" />
     </Book>
     <Book Series="X-Men" Number="163" Volume="2004" Year="2004">
-      <Id>67039a64-5d95-4b97-9598-8b759e6400fe</Id>
+      <Database Name="cv" Series="10731" Issue="99629" />
     </Book>
     <Book Series="X-Men" Number="164" Volume="2004" Year="2005">
-      <Id>9379a8d6-7454-48bb-a5d8-04f804aaa06c</Id>
+      <Database Name="cv" Series="10731" Issue="99630" />
     </Book>
     <Book Series="X-Men" Number="165" Volume="2004" Year="2005">
-      <Id>7f412dd9-6a84-4a13-84b0-d77088e9f78a</Id>
+      <Database Name="cv" Series="10731" Issue="99631" />
     </Book>
     <Book Series="Excalibur" Number="5" Volume="2004" Year="2004">
-      <Id>c3fb4539-6f1d-4609-8379-d664b5ef2a3e</Id>
+      <Database Name="cv" Series="11292" Issue="99102" />
     </Book>
     <Book Series="Excalibur" Number="6" Volume="2004" Year="2004">
-      <Id>2def3fc2-ae22-4ead-9565-003dc00b6149</Id>
+      <Database Name="cv" Series="11292" Issue="99103" />
     </Book>
     <Book Series="Excalibur" Number="7" Volume="2004" Year="2005">
-      <Id>fe48d570-689d-4aea-9f00-da48964ec93e</Id>
+      <Database Name="cv" Series="11292" Issue="99104" />
     </Book>
     <Book Series="New X-Men" Number="7" Volume="2004" Year="2005">
-      <Id>b6b79020-8076-46be-b281-6e29a20daf96</Id>
+      <Database Name="cv" Series="18078" Issue="106270" />
     </Book>
     <Book Series="New X-Men" Number="8" Volume="2004" Year="2005">
-      <Id>c8a2c140-cfbb-4717-ad8b-6b365bd6b834</Id>
+      <Database Name="cv" Series="18078" Issue="106271" />
     </Book>
     <Book Series="New X-Men" Number="9" Volume="2004" Year="2005">
-      <Id>3fdb44ed-808d-4bfa-8857-ed4d5d60857a</Id>
+      <Database Name="cv" Series="18078" Issue="106276" />
     </Book>
     <Book Series="District X" Number="7" Volume="2004" Year="2005">
-      <Id>9285804e-e5e0-4bd1-8a8b-1ff0881ec7b4</Id>
+      <Database Name="cv" Series="19327" Issue="118019" />
     </Book>
     <Book Series="District X" Number="8" Volume="2004" Year="2005">
-      <Id>14aab028-128d-4069-9f48-42f8ffe10888</Id>
+      <Database Name="cv" Series="19327" Issue="120737" />
     </Book>
     <Book Series="District X" Number="9" Volume="2004" Year="2005">
-      <Id>7965cfc3-4a35-4798-80cd-e0b8f6e238c4</Id>
+      <Database Name="cv" Series="19327" Issue="120738" />
     </Book>
     <Book Series="District X" Number="10" Volume="2004" Year="2005">
-      <Id>2c6a117a-dbc3-45ae-ae45-338132d42694</Id>
+      <Database Name="cv" Series="19327" Issue="120739" />
     </Book>
     <Book Series="District X" Number="11" Volume="2004" Year="2005">
-      <Id>1d9f0313-8c65-4534-a7be-dcbbfa864929</Id>
+      <Database Name="cv" Series="19327" Issue="120740" />
     </Book>
     <Book Series="District X" Number="12" Volume="2004" Year="2005">
-      <Id>7070a1be-652f-4330-9fd3-ec2d1a038d30</Id>
+      <Database Name="cv" Series="19327" Issue="120741" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="7" Volume="2004" Year="2004">
-      <Id>0103f037-1066-419b-b09f-4e9414cb8c43</Id>
+    <Book Series="Cable &#38; Deadpool" Number="7" Volume="2004" Year="2004">
+      <Database Name="cv" Series="18070" Issue="105842" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="8" Volume="2004" Year="2004">
-      <Id>f242a1df-c584-43d9-b181-573305e7c124</Id>
+    <Book Series="Cable &#38; Deadpool" Number="8" Volume="2004" Year="2004">
+      <Database Name="cv" Series="18070" Issue="105843" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="9" Volume="2004" Year="2005">
-      <Id>b3d8735b-4269-4d9f-9eda-6940a610a436</Id>
+    <Book Series="Cable &#38; Deadpool" Number="9" Volume="2004" Year="2005">
+      <Database Name="cv" Series="18070" Issue="105851" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="10" Volume="2004" Year="2005">
-      <Id>0a490cbb-4fce-410e-88ba-b13822c2533b</Id>
+    <Book Series="Cable &#38; Deadpool" Number="10" Volume="2004" Year="2005">
+      <Database Name="cv" Series="18070" Issue="105863" />
     </Book>
     <Book Series="Gambit" Number="1" Volume="2004" Year="2004">
-      <Id>ab5830c0-db20-411c-bc7f-801afee2d8c6</Id>
+      <Database Name="cv" Series="11880" Issue="103946" />
     </Book>
     <Book Series="Gambit" Number="2" Volume="2004" Year="2004">
-      <Id>c6ce3779-8fed-4eae-b262-fb0aaaf9e8ef</Id>
+      <Database Name="cv" Series="11880" Issue="103947" />
     </Book>
     <Book Series="Gambit" Number="3" Volume="2004" Year="2004">
-      <Id>c6da162b-f0c2-4eb8-ac2c-5708ec82001b</Id>
+      <Database Name="cv" Series="11880" Issue="103948" />
     </Book>
     <Book Series="Gambit" Number="4" Volume="2004" Year="2005">
-      <Id>3278c4e8-ce96-4617-9b96-e838ba5a33c6</Id>
+      <Database Name="cv" Series="11880" Issue="103949" />
     </Book>
     <Book Series="Gambit" Number="5" Volume="2004" Year="2005">
-      <Id>21bf3e5e-79fa-47f6-9293-b2c32fba13bd</Id>
+      <Database Name="cv" Series="11880" Issue="133267" />
     </Book>
     <Book Series="Gambit" Number="6" Volume="2004" Year="2005">
-      <Id>6c03d305-5950-49a4-9816-76e31dcb8b4c</Id>
+      <Database Name="cv" Series="11880" Issue="133268" />
     </Book>
     <Book Series="Nightcrawler" Number="5" Volume="2004" Year="2005">
-      <Id>28de4d90-44c9-4074-8667-c16708dd4f9d</Id>
+      <Database Name="cv" Series="18700" Issue="111146" />
     </Book>
     <Book Series="Nightcrawler" Number="6" Volume="2004" Year="2005">
-      <Id>88492efd-84d4-4eba-a03f-9390258cd954</Id>
+      <Database Name="cv" Series="18700" Issue="111147" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="452" Volume="1981" Year="2005">
-      <Id>4d6cfa93-8c52-40ac-9b97-87016a2a55b7</Id>
+      <Database Name="cv" Series="3092" Issue="96812" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="453" Volume="1981" Year="2005">
-      <Id>9088f166-6482-41c9-a66e-6f653e3c5811</Id>
+      <Database Name="cv" Series="3092" Issue="97419" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="454" Volume="1981" Year="2005">
-      <Id>2cd47faf-a9fd-4e60-ab25-255f72f8d448</Id>
+      <Database Name="cv" Series="3092" Issue="99475" />
     </Book>
     <Book Series="X-Men" Number="166" Volume="2004" Year="2005">
-      <Id>b07e85f2-6c65-4aa0-b9a5-7048cbddd1d1</Id>
+      <Database Name="cv" Series="10731" Issue="99632" />
     </Book>
     <Book Series="X-Men" Number="167" Volume="2004" Year="2005">
-      <Id>a30f893e-e187-4c16-985d-a8ef6bc2499c</Id>
+      <Database Name="cv" Series="10731" Issue="101015" />
     </Book>
     <Book Series="X-Men" Number="168" Volume="2004" Year="2005">
-      <Id>a4d1fa3c-1adf-4788-9980-4abe54917a05</Id>
+      <Database Name="cv" Series="10731" Issue="101016" />
     </Book>
     <Book Series="X-Men" Number="169" Volume="2004" Year="2005">
-      <Id>d1632b18-4cf4-40fb-8947-219d3be41b29</Id>
+      <Database Name="cv" Series="10731" Issue="101017" />
     </Book>
     <Book Series="X-Men" Number="170" Volume="2004" Year="2005">
-      <Id>ca2df375-9426-470d-8ced-5fe51cac9948</Id>
+      <Database Name="cv" Series="10731" Issue="106156" />
     </Book>
     <Book Series="Excalibur" Number="8" Volume="2004" Year="2005">
-      <Id>ef63de7e-40b2-4ac2-9de3-52e289667b9a</Id>
+      <Database Name="cv" Series="11292" Issue="99105" />
     </Book>
     <Book Series="Excalibur" Number="9" Volume="2004" Year="2005">
-      <Id>b383c2f5-1469-4f1c-8713-c7378f02061b</Id>
+      <Database Name="cv" Series="11292" Issue="101043" />
     </Book>
     <Book Series="Excalibur" Number="10" Volume="2004" Year="2005">
-      <Id>ab0e3415-0579-4b54-8167-e2847183a276</Id>
+      <Database Name="cv" Series="11292" Issue="101044" />
     </Book>
     <Book Series="Gambit" Number="7" Volume="2004" Year="2005">
-      <Id>2da16bca-6c8f-4d81-afa0-8cef56587c32</Id>
+      <Database Name="cv" Series="11880" Issue="136112" />
     </Book>
     <Book Series="Gambit" Number="8" Volume="2004" Year="2005">
-      <Id>dc498d3d-704a-4046-b364-5be3c9da47be</Id>
+      <Database Name="cv" Series="11880" Issue="133269" />
     </Book>
     <Book Series="Gambit" Number="9" Volume="2004" Year="2005">
-      <Id>8d73a1a8-9ea8-4c81-b98e-7702f8af918c</Id>
+      <Database Name="cv" Series="11880" Issue="136113" />
     </Book>
     <Book Series="Gambit" Number="10" Volume="2004" Year="2005">
-      <Id>0a661b0e-cb11-450e-ace1-a8de357ceec6</Id>
+      <Database Name="cv" Series="11880" Issue="136114" />
     </Book>
     <Book Series="Gambit" Number="11" Volume="2004" Year="2005">
-      <Id>0d7a963f-e0ff-4479-94dd-b805ab29babb</Id>
+      <Database Name="cv" Series="11880" Issue="136115" />
     </Book>
     <Book Series="Gambit" Number="12" Volume="2004" Year="2005">
-      <Id>ef898a19-90fd-42eb-9d0f-509106453405</Id>
+      <Database Name="cv" Series="11880" Issue="136116" />
     </Book>
     <Book Series="New X-Men" Number="10" Volume="2004" Year="2005">
-      <Id>34db4549-a892-4f8b-8c11-806497622c48</Id>
+      <Database Name="cv" Series="18078" Issue="106272" />
     </Book>
     <Book Series="New X-Men" Number="11" Volume="2004" Year="2005">
-      <Id>31e93c5a-6d14-4179-9c0c-b7237d31ba0d</Id>
+      <Database Name="cv" Series="18078" Issue="106273" />
     </Book>
     <Book Series="New X-Men" Number="12" Volume="2004" Year="2005">
-      <Id>f8aef496-6509-4337-8b3a-1453837172b0</Id>
+      <Database Name="cv" Series="18078" Issue="106274" />
     </Book>
     <Book Series="District X" Number="13" Volume="2004" Year="2005">
-      <Id>edff7d14-5c98-4251-b181-84efbf361b4e</Id>
+      <Database Name="cv" Series="19327" Issue="126234" />
     </Book>
     <Book Series="District X" Number="14" Volume="2004" Year="2005">
-      <Id>f2e55cf7-183a-4a8b-998b-2c73b09b56c3</Id>
+      <Database Name="cv" Series="19327" Issue="126233" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="11" Volume="2004" Year="2005">
-      <Id>c0c7510a-e659-44a1-91ad-4d8f457df6b3</Id>
+    <Book Series="Cable &#38; Deadpool" Number="11" Volume="2004" Year="2005">
+      <Database Name="cv" Series="18070" Issue="105862" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="12" Volume="2004" Year="2005">
-      <Id>756c7fe1-9793-4834-b352-40691d0c851d</Id>
+    <Book Series="Cable &#38; Deadpool" Number="12" Volume="2004" Year="2005">
+      <Database Name="cv" Series="18070" Issue="105864" />
     </Book>
     <Book Series="X-Force" Number="1" Volume="2004" Year="2004">
-      <Id>b5d52a28-2686-4cad-8208-2a4c9be74752</Id>
+      <Database Name="cv" Series="10761" Issue="91363" />
     </Book>
     <Book Series="X-Force" Number="2" Volume="2004" Year="2004">
-      <Id>c08cdabd-ef2b-4f4c-9128-16d1c0e1f0c9</Id>
+      <Database Name="cv" Series="10761" Issue="93552" />
     </Book>
     <Book Series="X-Force" Number="3" Volume="2004" Year="2004">
-      <Id>56376991-7f5b-4334-b7f1-15f05da7a18f</Id>
+      <Database Name="cv" Series="10761" Issue="93553" />
     </Book>
     <Book Series="X-Force" Number="4" Volume="2004" Year="2005">
-      <Id>502cc938-1e5a-496d-bd63-40bc9aa397f7</Id>
+      <Database Name="cv" Series="10761" Issue="106765" />
     </Book>
     <Book Series="X-Force" Number="5" Volume="2004" Year="2005">
-      <Id>308b8d77-cc98-49c3-99ac-987554a55308</Id>
+      <Database Name="cv" Series="10761" Issue="106767" />
     </Book>
     <Book Series="X-Force" Number="6" Volume="2004" Year="2005">
-      <Id>c5e605fa-d4ca-4ae4-992e-f7d50adb12c3</Id>
+      <Database Name="cv" Series="10761" Issue="106768" />
     </Book>
     <Book Series="Nightcrawler" Number="7" Volume="2004" Year="2005">
-      <Id>9c1986cd-cdb4-450f-ba0a-f5b491b180ce</Id>
+      <Database Name="cv" Series="18700" Issue="111272" />
     </Book>
     <Book Series="Nightcrawler" Number="8" Volume="2004" Year="2005">
-      <Id>09a4cd40-a099-495a-9206-b0b25a2f2106</Id>
+      <Database Name="cv" Series="18700" Issue="111273" />
     </Book>
     <Book Series="Nightcrawler" Number="9" Volume="2004" Year="2005">
-      <Id>64b659f7-4281-4cfc-a2cb-64e4644ef470</Id>
+      <Database Name="cv" Series="18700" Issue="111274" />
     </Book>
     <Book Series="Nightcrawler" Number="10" Volume="2004" Year="2005">
-      <Id>e8bcf0ee-7dda-419b-aa29-6c6e0712bf39</Id>
+      <Database Name="cv" Series="18700" Issue="111367" />
     </Book>
     <Book Series="Nightcrawler" Number="11" Volume="2004" Year="2005">
-      <Id>c614a355-eed4-43c1-ae57-078baa66e76a</Id>
+      <Database Name="cv" Series="18700" Issue="111368" />
     </Book>
     <Book Series="Nightcrawler" Number="12" Volume="2004" Year="2006">
-      <Id>e3aed113-e8fe-4256-8b0b-dd0e43c0f9ca</Id>
+      <Database Name="cv" Series="18700" Issue="111369" />
     </Book>
     <Book Series="X-23" Number="1" Volume="2005" Year="2005">
-      <Id>53a07b6e-cdcc-4b46-84ae-6c705070ffee</Id>
+      <Database Name="cv" Series="18176" Issue="106461" />
     </Book>
     <Book Series="X-23" Number="2" Volume="2005" Year="2005">
-      <Id>acded7b2-6b93-4356-809b-7d8d5f9322da</Id>
+      <Database Name="cv" Series="18176" Issue="106471" />
     </Book>
     <Book Series="X-23" Number="3" Volume="2005" Year="2005">
-      <Id>bfabbc8d-30b1-490a-bfd5-0cf2a90216b7</Id>
+      <Database Name="cv" Series="18176" Issue="106472" />
     </Book>
     <Book Series="X-23" Number="4" Volume="2005" Year="2005">
-      <Id>ca21c2cb-0f38-4eff-8594-4e8da77959ae</Id>
+      <Database Name="cv" Series="18176" Issue="106473" />
     </Book>
     <Book Series="X-23" Number="5" Volume="2005" Year="2005">
-      <Id>d5a3b7e5-3477-4282-9fb8-f3de07cd2a7b</Id>
+      <Database Name="cv" Series="18176" Issue="106497" />
     </Book>
     <Book Series="X-23" Number="6" Volume="2005" Year="2005">
-      <Id>0790691d-f5dd-4b57-9200-35d67330122c</Id>
+      <Database Name="cv" Series="18176" Issue="106498" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="455" Volume="1981" Year="2005">
-      <Id>1e4962b4-3b39-45f7-a8cb-7a5798c38e74</Id>
+      <Database Name="cv" Series="3092" Issue="99476" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="456" Volume="1981" Year="2005">
-      <Id>cfd6b340-a851-4e86-beee-a1bfa9307f7d</Id>
+      <Database Name="cv" Series="3092" Issue="99894" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="457" Volume="1981" Year="2005">
-      <Id>cd9ca46b-1c0b-46c8-9fde-af0049d745b5</Id>
+      <Database Name="cv" Series="3092" Issue="101001" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="458" Volume="1981" Year="2005">
-      <Id>0780260e-49cf-4195-88d1-b1f5a0bbbfc2</Id>
+      <Database Name="cv" Series="3092" Issue="101002" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="459" Volume="1981" Year="2005">
-      <Id>a3007673-6b4f-435d-b843-56497ff9b0d0</Id>
+      <Database Name="cv" Series="3092" Issue="106561" />
     </Book>
     <Book Series="X-Men: Phoenix - Endsong" Number="1" Volume="2005" Year="2005">
-      <Id>8b2e52b9-f0e6-47ec-8cfb-43603499d047</Id>
+      <Database Name="cv" Series="11353" Issue="99607" />
     </Book>
     <Book Series="X-Men: Phoenix - Endsong" Number="2" Volume="2005" Year="2005">
-      <Id>2c16cb16-2ced-427d-b8d1-092d40ce2795</Id>
+      <Database Name="cv" Series="11353" Issue="99608" />
     </Book>
     <Book Series="X-Men: Phoenix - Endsong" Number="3" Volume="2005" Year="2005">
-      <Id>f701f06f-f9a5-4f8c-bb65-a7308bf27648</Id>
+      <Database Name="cv" Series="11353" Issue="99609" />
     </Book>
     <Book Series="X-Men: Phoenix - Endsong" Number="4" Volume="2005" Year="2005">
-      <Id>7d521daf-6747-4893-8f8f-53f02489df0e</Id>
+      <Database Name="cv" Series="11353" Issue="99610" />
     </Book>
     <Book Series="X-Men: Phoenix - Endsong" Number="5" Volume="2005" Year="2005">
-      <Id>deee531a-97f2-423d-aaa4-5afccbc1f247</Id>
+      <Database Name="cv" Series="11353" Issue="99611" />
     </Book>
     <Book Series="Wolverine" Number="20" Volume="2003" Year="2004">
-      <Id>2a419262-5192-41bc-959d-337d47b4d795</Id>
+      <Database Name="cv" Series="10809" Issue="96820" />
     </Book>
     <Book Series="Wolverine" Number="21" Volume="2003" Year="2004">
-      <Id>913d95c9-b0f2-4688-b259-2a947f91912d</Id>
+      <Database Name="cv" Series="10809" Issue="96821" />
     </Book>
     <Book Series="Wolverine" Number="22" Volume="2003" Year="2005">
-      <Id>e66ecdff-5d56-43e5-b443-6a0ffa5639ad</Id>
+      <Database Name="cv" Series="10809" Issue="97343" />
     </Book>
     <Book Series="Wolverine" Number="23" Volume="2003" Year="2005">
-      <Id>8b5bf2b3-1aca-457c-9c8e-1c85e31682b4</Id>
+      <Database Name="cv" Series="10809" Issue="97344" />
     </Book>
     <Book Series="Wolverine" Number="24" Volume="2003" Year="2005">
-      <Id>948901d8-eb19-4e4a-bb1e-f533adcc53c5</Id>
+      <Database Name="cv" Series="10809" Issue="99465" />
     </Book>
     <Book Series="Wolverine" Number="25" Volume="2003" Year="2005">
-      <Id>d2bdd37e-0852-4d57-95db-c08577637c0f</Id>
+      <Database Name="cv" Series="10809" Issue="99466" />
     </Book>
     <Book Series="Wolverine" Number="26" Volume="2003" Year="2005">
-      <Id>3f07235b-60b1-43d2-add5-526fc5394dac</Id>
+      <Database Name="cv" Series="10809" Issue="100863" />
     </Book>
     <Book Series="Wolverine" Number="27" Volume="2003" Year="2005">
-      <Id>1cfe0909-b85b-464b-a271-cd04603a1a3e</Id>
+      <Database Name="cv" Series="10809" Issue="100864" />
     </Book>
     <Book Series="Wolverine" Number="28" Volume="2003" Year="2005">
-      <Id>6027e31a-73ab-4176-8d62-0c67ced2314d</Id>
+      <Database Name="cv" Series="10809" Issue="114060" />
     </Book>
     <Book Series="Wolverine" Number="29" Volume="2003" Year="2005">
-      <Id>f6b3537a-f9a7-415a-8cbc-3382825267d5</Id>
+      <Database Name="cv" Series="10809" Issue="114508" />
     </Book>
     <Book Series="Wolverine" Number="30" Volume="2003" Year="2005">
-      <Id>d0ef834a-9824-46c4-a87a-db60e28af7ac</Id>
+      <Database Name="cv" Series="10809" Issue="114509" />
     </Book>
     <Book Series="Wolverine" Number="31" Volume="2003" Year="2005">
-      <Id>3f3ee8f9-6123-40db-9b70-216c863472d1</Id>
+      <Database Name="cv" Series="10809" Issue="114510" />
     </Book>
     <Book Series="New X-Men" Number="13" Volume="2004" Year="2005">
-      <Id>fd6276d1-4a76-4f85-b185-0ce9c04268b4</Id>
+      <Database Name="cv" Series="18078" Issue="106275" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="460" Volume="1981" Year="2005">
-      <Id>56f1d031-897c-4cfa-8c9e-14ca62cc388c</Id>
+      <Database Name="cv" Series="3092" Issue="106562" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="461" Volume="1981" Year="2005">
-      <Id>3f84e334-4a29-46bf-b650-8d2a2b49f3c2</Id>
+      <Database Name="cv" Series="3092" Issue="106563" />
     </Book>
     <Book Series="Astonishing X-Men" Number="7" Volume="2004" Year="2005">
-      <Id>725001c7-9ad7-4c13-9287-6234bffa1373</Id>
+      <Database Name="cv" Series="10746" Issue="99751" />
     </Book>
     <Book Series="Astonishing X-Men" Number="8" Volume="2004" Year="2005">
-      <Id>a59672c0-cd7d-4941-886b-c1ee9252556c</Id>
+      <Database Name="cv" Series="10746" Issue="99752" />
     </Book>
     <Book Series="Astonishing X-Men" Number="9" Volume="2004" Year="2005">
-      <Id>cdea2ec1-5179-46f0-b7c6-a02a65088d82</Id>
+      <Database Name="cv" Series="10746" Issue="106131" />
     </Book>
     <Book Series="Astonishing X-Men" Number="10" Volume="2004" Year="2005">
-      <Id>873b0d14-f30f-4c41-8329-1b34597cd291</Id>
+      <Database Name="cv" Series="10746" Issue="106670" />
     </Book>
     <Book Series="Astonishing X-Men" Number="11" Volume="2004" Year="2005">
-      <Id>341bd351-09d0-4e14-b137-6fefdf94025a</Id>
+      <Database Name="cv" Series="10746" Issue="106671" />
     </Book>
     <Book Series="Astonishing X-Men" Number="12" Volume="2004" Year="2005">
-      <Id>a506b885-5c44-40c2-bbb1-0421396ac8d8</Id>
+      <Database Name="cv" Series="10746" Issue="106676" />
     </Book>
     <Book Series="Rogue" Number="7" Volume="2004" Year="2005">
-      <Id>1741b3be-03ec-4201-b422-07db24d05b27</Id>
+      <Database Name="cv" Series="19612" Issue="117832" />
     </Book>
     <Book Series="Rogue" Number="8" Volume="2004" Year="2005">
-      <Id>01222723-241b-44b3-9a61-82cd77c001d8</Id>
+      <Database Name="cv" Series="19612" Issue="117834" />
     </Book>
     <Book Series="Rogue" Number="9" Volume="2004" Year="2005">
-      <Id>bda8e635-e91b-4830-be5f-20a4cd5de5ad</Id>
+      <Database Name="cv" Series="19612" Issue="117835" />
     </Book>
     <Book Series="Rogue" Number="10" Volume="2004" Year="2005">
-      <Id>228d076c-1a86-4625-a2ba-4bcdd3e1ad29</Id>
+      <Database Name="cv" Series="19612" Issue="117836" />
     </Book>
     <Book Series="Rogue" Number="11" Volume="2004" Year="2005">
-      <Id>b77e525a-cb11-48eb-b6c7-744f41355d29</Id>
+      <Database Name="cv" Series="19612" Issue="117838" />
     </Book>
     <Book Series="Rogue" Number="12" Volume="2004" Year="2005">
-      <Id>2f9310cb-cb89-43c4-8e19-f6e60de9bc32</Id>
+      <Database Name="cv" Series="19612" Issue="117837" />
     </Book>
     <Book Series="X-Men" Number="171" Volume="2004" Year="2005">
-      <Id>143fe411-91fa-43c8-8071-69bfb952bffc</Id>
+      <Database Name="cv" Series="10731" Issue="106170" />
     </Book>
     <Book Series="X-Men" Number="172" Volume="2004" Year="2005">
-      <Id>0af3c655-52bb-4537-95e2-62273e6d5060</Id>
+      <Database Name="cv" Series="10731" Issue="106171" />
     </Book>
     <Book Series="X-Men" Number="173" Volume="2004" Year="2005">
-      <Id>0d4c7158-5f51-4694-9cea-b9651c51fde2</Id>
+      <Database Name="cv" Series="10731" Issue="106172" />
     </Book>
     <Book Series="X-Men" Number="174" Volume="2004" Year="2005">
-      <Id>01d89000-966b-4dfb-a513-c7e848847c32</Id>
+      <Database Name="cv" Series="10731" Issue="106173" />
     </Book>
     <Book Series="X-Men Unlimited" Number="7" Volume="2004" Year="2005">
-      <Id>c92e4ca1-56a2-4014-a12b-5be664c6bed4</Id>
+      <Database Name="cv" Series="10745" Issue="101013" />
     </Book>
     <Book Series="X-Men Unlimited" Number="8" Volume="2004" Year="2005">
-      <Id>a1868cba-b7a6-4547-bc38-494aceebd8ea</Id>
+      <Database Name="cv" Series="10745" Issue="101014" />
     </Book>
     <Book Series="X-Men Unlimited" Number="9" Volume="2004" Year="2005">
-      <Id>b11a8685-9ee2-40b9-be3f-01dd886e9429</Id>
+      <Database Name="cv" Series="10745" Issue="113637" />
     </Book>
     <Book Series="X-Men Unlimited" Number="10" Volume="2004" Year="2005">
-      <Id>25268769-9f71-48cf-a4c9-46a159bf6c95</Id>
+      <Database Name="cv" Series="10745" Issue="113636" />
     </Book>
     <Book Series="New X-Men" Number="14" Volume="2004" Year="2005">
-      <Id>49ea0d87-a118-4cd4-a8c5-bdbd03f7a2a6</Id>
+      <Database Name="cv" Series="18078" Issue="106281" />
     </Book>
     <Book Series="New X-Men" Number="15" Volume="2004" Year="2005">
-      <Id>0719661f-b695-4387-9de5-1a2a55ce5fe3</Id>
+      <Database Name="cv" Series="18078" Issue="106292" />
     </Book>
     <Book Series="New X-Men: Hellions" Number="1" Volume="2005" Year="2005">
-      <Id>cfc9b5a2-be37-46e6-98c5-d4b64fd18cd3</Id>
+      <Database Name="cv" Series="18173" Issue="106415" />
     </Book>
     <Book Series="New X-Men: Hellions" Number="2" Volume="2005" Year="2005">
-      <Id>099a2244-b22a-4031-a360-95574fcc1733</Id>
+      <Database Name="cv" Series="18173" Issue="106424" />
     </Book>
     <Book Series="New X-Men: Hellions" Number="3" Volume="2005" Year="2005">
-      <Id>ccb8673e-ace3-4af9-98cb-83f394211a2c</Id>
+      <Database Name="cv" Series="18173" Issue="106425" />
     </Book>
     <Book Series="New X-Men: Hellions" Number="4" Volume="2005" Year="2005">
-      <Id>e8b1fd5f-47a2-4181-b6ea-5fb8554c88b1</Id>
+      <Database Name="cv" Series="18173" Issue="106426" />
     </Book>
     <Book Series="New X-Men: Academy X Yearbook" Number="1" Volume="2005" Year="2005">
-      <Id>d77ca8ff-4675-476f-b32a-1390d5ee9783</Id>
+      <Database Name="cv" Series="18147" Issue="106307" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="15" Volume="2004" Year="2005">
-      <Id>a3509de5-57e9-45a4-8a3c-f4c93a0a824d</Id>
+    <Book Series="Cable &#38; Deadpool" Number="15" Volume="2004" Year="2005">
+      <Database Name="cv" Series="18070" Issue="106392" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="16" Volume="2004" Year="2005">
-      <Id>0c11ca34-1694-4f09-9407-4e8e26e69ed1</Id>
+    <Book Series="Cable &#38; Deadpool" Number="16" Volume="2004" Year="2005">
+      <Database Name="cv" Series="18070" Issue="106393" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="17" Volume="2004" Year="2005">
-      <Id>1dee4534-eaaa-4f75-9dbd-eb0f703cf5b3</Id>
+    <Book Series="Cable &#38; Deadpool" Number="17" Volume="2004" Year="2005">
+      <Database Name="cv" Series="18070" Issue="106394" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="18" Volume="2004" Year="2005">
-      <Id>d0078c14-4024-4e20-bb14-dbf80702c80b</Id>
+    <Book Series="Cable &#38; Deadpool" Number="18" Volume="2004" Year="2005">
+      <Database Name="cv" Series="18070" Issue="106395" />
     </Book>
     <Book Series="X-Men Unlimited" Number="11" Volume="2004" Year="2005">
-      <Id>acc173e2-a077-46be-8df8-20d6beac09e3</Id>
+      <Database Name="cv" Series="10745" Issue="113639" />
     </Book>
     <Book Series="X-Men Unlimited" Number="12" Volume="2004" Year="2006">
-      <Id>e303690c-5f29-4cbd-8568-db441064f25e</Id>
+      <Database Name="cv" Series="10745" Issue="113640" />
     </Book>
     <Book Series="Wolverine" Number="32" Volume="2003" Year="2005">
-      <Id>2a078344-ea4b-4cef-85a6-e99f0d7140f3</Id>
+      <Database Name="cv" Series="10809" Issue="114056" />
     </Book>
-    <Book Series="X-Men: Kitty Pryde - Shadow &amp; Flame" Number="1" Volume="2005" Year="2005">
-      <Id>9c53f7b8-cd18-4915-8fc8-997c7f3d347c</Id>
+    <Book Series="X-Men: Kitty Pryde - Shadow &#38; Flame" Number="1" Volume="2005" Year="2005">
+      <Database Name="cv" Series="20131" Issue="120170" />
     </Book>
-    <Book Series="X-Men: Kitty Pryde - Shadow &amp; Flame" Number="2" Volume="2005" Year="2005">
-      <Id>606a3bd7-5f04-4ead-8563-eb1557c1e1b8</Id>
+    <Book Series="X-Men: Kitty Pryde - Shadow &#38; Flame" Number="2" Volume="2005" Year="2005">
+      <Database Name="cv" Series="20131" Issue="120189" />
     </Book>
-    <Book Series="X-Men: Kitty Pryde - Shadow &amp; Flame" Number="3" Volume="2005" Year="2005">
-      <Id>44183854-0c25-422b-8d63-a3ebce27f01e</Id>
+    <Book Series="X-Men: Kitty Pryde - Shadow &#38; Flame" Number="3" Volume="2005" Year="2005">
+      <Database Name="cv" Series="20131" Issue="120192" />
     </Book>
-    <Book Series="X-Men: Kitty Pryde - Shadow &amp; Flame" Number="4" Volume="2005" Year="2005">
-      <Id>a7eeff31-c326-42b9-93d1-5d158cfd9174</Id>
+    <Book Series="X-Men: Kitty Pryde - Shadow &#38; Flame" Number="4" Volume="2005" Year="2005">
+      <Database Name="cv" Series="20131" Issue="120190" />
     </Book>
-    <Book Series="X-Men: Kitty Pryde - Shadow &amp; Flame" Number="5" Volume="2005" Year="2005">
-      <Id>e3b36c15-decc-44e6-b7b9-9e2f5d900e1a</Id>
+    <Book Series="X-Men: Kitty Pryde - Shadow &#38; Flame" Number="5" Volume="2005" Year="2005">
+      <Database Name="cv" Series="20131" Issue="120193" />
     </Book>
     <Book Series="X-Men: Colossus Bloodline" Number="1" Volume="2005" Year="2005">
-      <Id>dc29d154-f8f5-46ed-82cc-93921e232f3b</Id>
+      <Database Name="cv" Series="18699" Issue="110540" />
     </Book>
     <Book Series="X-Men: Colossus Bloodline" Number="2" Volume="2005" Year="2005">
-      <Id>cb312150-b722-41b9-b43d-17ffa66f3954</Id>
+      <Database Name="cv" Series="18699" Issue="110638" />
     </Book>
     <Book Series="X-Men: Colossus Bloodline" Number="3" Volume="2005" Year="2006">
-      <Id>137cfa81-9cde-429b-87c8-8cd73a18629e</Id>
+      <Database Name="cv" Series="18699" Issue="110818" />
     </Book>
     <Book Series="X-Men: Colossus Bloodline" Number="4" Volume="2005" Year="2006">
-      <Id>f0c3463d-45c0-4aa8-81fb-32d8a0ed3cc5</Id>
+      <Database Name="cv" Series="18699" Issue="110819" />
     </Book>
     <Book Series="X-Men: Colossus Bloodline" Number="5" Volume="2005" Year="2006">
-      <Id>c701c079-a85c-442d-95be-3f608a541eb4</Id>
+      <Database Name="cv" Series="18699" Issue="110820" />
     </Book>
     <Book Series="Ororo: Before the Storm" Number="1" Volume="2005" Year="2005">
-      <Id>a44b8d2a-d6b2-4eae-8373-b80d0da0b616</Id>
+      <Database Name="cv" Series="18075" Issue="105857" />
     </Book>
     <Book Series="Ororo: Before the Storm" Number="2" Volume="2005" Year="2005">
-      <Id>dc190647-58d0-4890-acae-69bf20057565</Id>
+      <Database Name="cv" Series="18075" Issue="105858" />
     </Book>
     <Book Series="Ororo: Before the Storm" Number="3" Volume="2005" Year="2005">
-      <Id>4f09f0c7-6842-4903-bc68-93d49c9e2760</Id>
+      <Database Name="cv" Series="18075" Issue="105859" />
     </Book>
     <Book Series="Ororo: Before the Storm" Number="4" Volume="2005" Year="2005">
-      <Id>d77b74c6-cc56-4cd3-90c7-10adb6da1faf</Id>
+      <Database Name="cv" Series="18075" Issue="105860" />
     </Book>
     <Book Series="X-Men" Number="175" Volume="2004" Year="2005">
-      <Id>dce959c0-5895-4abe-bc7d-445bb3fbe9ea</Id>
+      <Database Name="cv" Series="10731" Issue="106174" />
     </Book>
     <Book Series="Black Panther" Number="8" Volume="2005" Year="2005">
-      <Id>904e246e-022f-4abb-975f-8e8962814166</Id>
+      <Database Name="cv" Series="11502" Issue="126179" />
     </Book>
     <Book Series="X-Men" Number="176" Volume="2004" Year="2005">
-      <Id>56527222-c3ce-4a66-8f04-11154801371a</Id>
+      <Database Name="cv" Series="10731" Issue="106175" />
     </Book>
     <Book Series="Black Panther" Number="9" Volume="2005" Year="2005">
-      <Id>600ca6f0-d912-4d6e-bd53-1d4787ef978a</Id>
+      <Database Name="cv" Series="11502" Issue="126180" />
     </Book>
     <Book Series="Excalibur" Number="11" Volume="2004" Year="2005">
-      <Id>d5deabbc-9771-4dbc-958d-1d6e1cdad296</Id>
+      <Database Name="cv" Series="11292" Issue="101045" />
     </Book>
     <Book Series="Excalibur" Number="12" Volume="2004" Year="2005">
-      <Id>baae3c3e-1865-4c56-a2b1-a758c27629aa</Id>
+      <Database Name="cv" Series="11292" Issue="101046" />
     </Book>
     <Book Series="Excalibur" Number="13" Volume="2004" Year="2005">
-      <Id>f663eee8-fdd3-40ec-bcab-68df98fbd3a0</Id>
+      <Database Name="cv" Series="11292" Issue="120015" />
     </Book>
     <Book Series="Excalibur" Number="14" Volume="2004" Year="2005">
-      <Id>69eb68da-3325-4d3a-a108-d4c6c40b434d</Id>
+      <Database Name="cv" Series="11292" Issue="117978" />
     </Book>
     <Book Series="X-Men/Spider-Man" Number="1" Volume="2009" Year="2009">
-      <Id>9bf47542-f0d1-4132-916d-df74253e054c</Id>
+      <Database Name="cv" Series="23606" Issue="141555" />
     </Book>
     <Book Series="X-Men/Spider-Man" Number="2" Volume="2009" Year="2009">
-      <Id>5a8ffacb-aa68-4cb6-b85d-9892b9ab125a</Id>
+      <Database Name="cv" Series="23606" Issue="145746" />
     </Book>
     <Book Series="X-Men/Spider-Man" Number="3" Volume="2009" Year="2009">
-      <Id>77ba230a-365b-4d67-9991-8e59263b1b40</Id>
+      <Database Name="cv" Series="23606" Issue="150052" />
     </Book>
     <Book Series="X-Men/Spider-Man" Number="4" Volume="2009" Year="2009">
-      <Id>3de4ce7a-67da-4b0f-87bf-f4fe3503750d</Id>
+      <Database Name="cv" Series="23606" Issue="153074" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 009 (X-Men Reload).cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 009 (X-Men Reload).cbl
@@ -2,775 +2,775 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>X-Men - Part 9 (X-Men Reload)</Name>
   <Books>
-    <Book Series="X-Men" Number="157" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="X-Men" Number="157" Volume="2004" Year="2004">
       <Id>72ccff43-1fc0-47a0-884a-837d71a24bf5</Id>
     </Book>
-    <Book Series="X-Men" Number="158" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="X-Men" Number="158" Volume="2004" Year="2004">
       <Id>62efe384-365c-4d47-8139-f8387a310323</Id>
     </Book>
-    <Book Series="X-Men" Number="159" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="X-Men" Number="159" Volume="2004" Year="2004">
       <Id>d993aa7f-a911-4eba-b349-5594eafbd674</Id>
     </Book>
-    <Book Series="X-Men" Number="160" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="X-Men" Number="160" Volume="2004" Year="2004">
       <Id>6cf41fae-c588-4928-abdb-72e56518b196</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="444" Volume="1981" Year="2004" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="444" Volume="1981" Year="2004">
       <Id>ddfa8d45-aaf3-4c5d-90c6-bce40ba3aa4f</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="445" Volume="1981" Year="2004" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="445" Volume="1981" Year="2004">
       <Id>c222e824-5d5c-496c-9363-57d7eb2878a5</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="446" Volume="1981" Year="2004" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="446" Volume="1981" Year="2004">
       <Id>4595e000-f58e-4d60-b629-dacc75376a17</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="447" Volume="1981" Year="2004" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="447" Volume="1981" Year="2004">
       <Id>32290d86-0ba4-445d-a509-aadce613f209</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="448" Volume="1981" Year="2004" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="448" Volume="1981" Year="2004">
       <Id>06e19b31-06df-469a-b94d-78292c5ebb32</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="449" Volume="1981" Year="2004" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="449" Volume="1981" Year="2004">
       <Id>f317df33-a2be-45dd-81f3-5651b8923877</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="1" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="1" Volume="2004" Year="2004">
       <Id>e0b0e43c-83ac-45e3-a8ea-b6e31d1d2e9a</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="2" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="2" Volume="2004" Year="2004">
       <Id>d779a506-4574-4d65-8b57-2710e9a1068d</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="3" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="3" Volume="2004" Year="2004">
       <Id>eb656a7b-458f-47f7-94ed-fae5ae876641</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="4" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="4" Volume="2004" Year="2004">
       <Id>2aa317ff-174e-401e-be3b-6d27e934d853</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="5" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="5" Volume="2004" Year="2004">
       <Id>3ae5a5fe-2a54-48ac-8bf0-10845b2a5fd0</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="6" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="6" Volume="2004" Year="2004">
       <Id>0eb175d2-980d-40c2-a3ca-75696b2295a8</Id>
     </Book>
-    <Book Series="New X-Men" Number="1" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="New X-Men" Number="1" Volume="2004" Year="2004">
       <Id>0b949516-b3ee-41f6-8e66-b3501b18c33f</Id>
     </Book>
-    <Book Series="New X-Men" Number="2" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="New X-Men" Number="2" Volume="2004" Year="2004">
       <Id>01ddbcac-f65b-4a43-a0bf-c12626d073dc</Id>
     </Book>
-    <Book Series="New X-Men" Number="3" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="New X-Men" Number="3" Volume="2004" Year="2004">
       <Id>4d45405c-f0aa-4d0c-9ce0-c0be28f81257</Id>
     </Book>
-    <Book Series="New X-Men" Number="4" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="New X-Men" Number="4" Volume="2004" Year="2004">
       <Id>95485610-3317-4268-941f-85dcaf4a369f</Id>
     </Book>
-    <Book Series="New X-Men" Number="5" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="New X-Men" Number="5" Volume="2004" Year="2004">
       <Id>a6332446-2db2-4586-a090-a2de2752291e</Id>
     </Book>
-    <Book Series="New X-Men" Number="6" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="New X-Men" Number="6" Volume="2004" Year="2004">
       <Id>6a2b6f6c-3609-4f2c-ac70-f1fa6cdc3715</Id>
     </Book>
-    <Book Series="Excalibur" Number="1" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Excalibur" Number="1" Volume="2004" Year="2004">
       <Id>b3764b34-2ab1-4f64-a6ef-f1e23d30300c</Id>
     </Book>
-    <Book Series="Excalibur" Number="2" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Excalibur" Number="2" Volume="2004" Year="2004">
       <Id>a8a8f9ea-201d-401d-8fbc-e5c60ee3e06b</Id>
     </Book>
-    <Book Series="Excalibur" Number="3" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Excalibur" Number="3" Volume="2004" Year="2004">
       <Id>51ec79cf-d39f-45dc-b4cb-833d61d75a8c</Id>
     </Book>
-    <Book Series="Excalibur" Number="4" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Excalibur" Number="4" Volume="2004" Year="2004">
       <Id>aae91147-2e5b-48b4-8ae0-801f93df9948</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="2" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="2" Volume="2004" Year="2004">
       <Id>8aad2ce5-feda-48ef-aa0b-ed5ea6271512</Id>
     </Book>
-    <Book Series="District X" Number="1" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="District X" Number="1" Volume="2004" Year="2004">
       <Id>e5ab9859-7075-463f-b542-7b7e8c2201a5</Id>
     </Book>
-    <Book Series="District X" Number="2" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="District X" Number="2" Volume="2004" Year="2004">
       <Id>050d6de9-4d8e-413b-b555-107bf8bc5984</Id>
     </Book>
-    <Book Series="District X" Number="3" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="District X" Number="3" Volume="2004" Year="2004">
       <Id>af00b028-c361-4f72-b622-dd3863a958ac</Id>
     </Book>
-    <Book Series="District X" Number="4" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="District X" Number="4" Volume="2004" Year="2004">
       <Id>603c5d6d-4f9c-4ea4-ae1b-cd0b1d1c307a</Id>
     </Book>
-    <Book Series="District X" Number="5" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="District X" Number="5" Volume="2004" Year="2004">
       <Id>60e80b47-207b-4c41-b800-27a12cc45e94</Id>
     </Book>
-    <Book Series="District X" Number="6" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="District X" Number="6" Volume="2004" Year="2004">
       <Id>1186156b-0134-411d-b3d4-ab529d262ff1</Id>
     </Book>
-    <Book Series="Emma Frost" Number="7" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Emma Frost" Number="7" Volume="2003" Year="2004">
       <Id>4bcd9a0f-a75c-42ba-ad13-cf537df4f8a9</Id>
     </Book>
-    <Book Series="Emma Frost" Number="8" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Emma Frost" Number="8" Volume="2003" Year="2004">
       <Id>0bb6c47c-c3e0-41cc-ae85-1f6d191167d1</Id>
     </Book>
-    <Book Series="Emma Frost" Number="9" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Emma Frost" Number="9" Volume="2003" Year="2004">
       <Id>d56af3d4-120e-4577-9c71-15cf8a62c096</Id>
     </Book>
-    <Book Series="Emma Frost" Number="10" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Emma Frost" Number="10" Volume="2003" Year="2004">
       <Id>1a334453-0a7a-4b08-a3ac-54d3c1d961a5</Id>
     </Book>
-    <Book Series="Emma Frost" Number="11" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Emma Frost" Number="11" Volume="2003" Year="2004">
       <Id>8e98d634-a09e-49c1-879f-ebdb37c3a463</Id>
     </Book>
-    <Book Series="Emma Frost" Number="12" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Emma Frost" Number="12" Volume="2003" Year="2004">
       <Id>c72641a1-846e-480f-9f01-b9a4fe8d2fd0</Id>
     </Book>
-    <Book Series="Wolverine" Number="13" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Wolverine" Number="13" Volume="2003" Year="2004">
       <Id>a5d3adda-5f1c-47af-8049-b852d2fbe12d</Id>
     </Book>
-    <Book Series="Wolverine" Number="14" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Wolverine" Number="14" Volume="2003" Year="2004">
       <Id>bfbc7c40-040f-43b6-81d7-c5a72481e08e</Id>
     </Book>
-    <Book Series="Wolverine" Number="15" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Wolverine" Number="15" Volume="2003" Year="2004">
       <Id>4a4d7716-4fb5-4d72-a2e6-3b7134587de8</Id>
     </Book>
-    <Book Series="Wolverine" Number="16" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Wolverine" Number="16" Volume="2003" Year="2004">
       <Id>b6da8525-fcc2-4302-98aa-973c5d19eb3c</Id>
     </Book>
-    <Book Series="Wolverine" Number="17" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Wolverine" Number="17" Volume="2003" Year="2004">
       <Id>a52248ce-2fb5-427f-b2d6-69ff9c2fbd8f</Id>
     </Book>
-    <Book Series="Wolverine" Number="18" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Wolverine" Number="18" Volume="2003" Year="2004">
       <Id>246ca6b1-10da-454c-ad44-0d42b148b96d</Id>
     </Book>
-    <Book Series="Wolverine" Number="19" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Wolverine" Number="19" Volume="2003" Year="2004">
       <Id>a8779026-088e-4b63-9871-e2df11980414</Id>
     </Book>
-    <Book Series="Mystique" Number="14" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Mystique" Number="14" Volume="2003" Year="2004">
       <Id>c26934e0-ef1e-4877-8be2-ac6ff5b52909</Id>
     </Book>
-    <Book Series="Mystique" Number="15" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Mystique" Number="15" Volume="2003" Year="2004">
       <Id>df90800a-d224-467d-9870-8a1074426c38</Id>
     </Book>
-    <Book Series="Mystique" Number="16" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Mystique" Number="16" Volume="2003" Year="2004">
       <Id>dd700509-c6f6-4b07-b7af-daab8cc27253</Id>
     </Book>
-    <Book Series="Mystique" Number="17" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Mystique" Number="17" Volume="2003" Year="2004">
       <Id>1ae00fa0-76e5-4af4-9530-a6e2a5509410</Id>
     </Book>
-    <Book Series="Mystique" Number="18" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Mystique" Number="18" Volume="2003" Year="2004">
       <Id>035d5edc-98c1-49d4-b31c-7d8c26e93d4a</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="3" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="3" Volume="2004" Year="2004">
       <Id>b316ea34-f411-4d2e-91c0-8918e15b5675</Id>
     </Book>
-    <Book Series="Emma Frost" Number="13" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Emma Frost" Number="13" Volume="2003" Year="2004">
       <Id>db60fb60-d884-4761-883d-33e44fb6959d</Id>
     </Book>
-    <Book Series="Emma Frost" Number="14" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Emma Frost" Number="14" Volume="2003" Year="2004">
       <Id>ecb0237b-8e6f-4b15-9b8d-a6e68343c2c9</Id>
     </Book>
-    <Book Series="Emma Frost" Number="15" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Emma Frost" Number="15" Volume="2003" Year="2004">
       <Id>108f2390-904e-4577-a45a-849ec463e1b1</Id>
     </Book>
-    <Book Series="Emma Frost" Number="16" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Emma Frost" Number="16" Volume="2003" Year="2004">
       <Id>4f1235f6-5512-447a-ac04-1311df444895</Id>
     </Book>
-    <Book Series="Emma Frost" Number="17" Volume="2003" Year="2005" Format="Main Series">
+    <Book Series="Emma Frost" Number="17" Volume="2003" Year="2005">
       <Id>ee5b6f1e-0a35-4fbe-9b00-701180c0ea16</Id>
     </Book>
-    <Book Series="Emma Frost" Number="18" Volume="2003" Year="2005" Format="Main Series">
+    <Book Series="Emma Frost" Number="18" Volume="2003" Year="2005">
       <Id>598ae177-788e-410e-8376-1db111640d1b</Id>
     </Book>
-    <Book Series="Rogue" Number="1" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Rogue" Number="1" Volume="2004" Year="2004">
       <Id>f0b8c573-2c2a-42e3-8f54-b5731ea6e9e8</Id>
     </Book>
-    <Book Series="Rogue" Number="2" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Rogue" Number="2" Volume="2004" Year="2004">
       <Id>5c135518-f8de-4fab-87a2-7020b376dc6d</Id>
     </Book>
-    <Book Series="Rogue" Number="3" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Rogue" Number="3" Volume="2004" Year="2004">
       <Id>abc95102-d75d-4706-b002-d859e71de2b1</Id>
     </Book>
-    <Book Series="Rogue" Number="4" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Rogue" Number="4" Volume="2004" Year="2004">
       <Id>f69c5299-202f-423b-bc33-ad81369567a6</Id>
     </Book>
-    <Book Series="Rogue" Number="5" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Rogue" Number="5" Volume="2004" Year="2005">
       <Id>63341033-1ab8-4a63-9357-ba7214219133</Id>
     </Book>
-    <Book Series="Rogue" Number="6" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Rogue" Number="6" Volume="2004" Year="2005">
       <Id>696dec5b-4464-4cd6-bd51-533c283d8a46</Id>
     </Book>
-    <Book Series="Mystique" Number="19" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Mystique" Number="19" Volume="2003" Year="2004">
       <Id>8213cc1e-b38a-4403-9527-e9f4a86c80fb</Id>
     </Book>
-    <Book Series="Mystique" Number="20" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Mystique" Number="20" Volume="2003" Year="2004">
       <Id>83810ac8-bca4-4fd6-93d6-a34f3a0226ac</Id>
     </Book>
-    <Book Series="Mystique" Number="21" Volume="2003" Year="2005" Format="Main Series">
+    <Book Series="Mystique" Number="21" Volume="2003" Year="2005">
       <Id>b0e6839f-9cf4-410f-be57-45fce983fd65</Id>
     </Book>
-    <Book Series="Mystique" Number="22" Volume="2003" Year="2005" Format="Main Series">
+    <Book Series="Mystique" Number="22" Volume="2003" Year="2005">
       <Id>6bea5f3d-98c6-496a-837a-c7d3574cacea</Id>
     </Book>
-    <Book Series="Mystique" Number="23" Volume="2003" Year="2005" Format="Main Series">
+    <Book Series="Mystique" Number="23" Volume="2003" Year="2005">
       <Id>ddc77ca8-d51f-4e2b-b81e-b36c0f19fee3</Id>
     </Book>
-    <Book Series="Mystique" Number="24" Volume="2003" Year="2005" Format="Main Series">
+    <Book Series="Mystique" Number="24" Volume="2003" Year="2005">
       <Id>9b0298ef-3cde-487e-91be-d5580bdb6bdd</Id>
     </Book>
-    <Book Series="Jubilee" Number="1" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Jubilee" Number="1" Volume="2004" Year="2004">
       <Id>d57653e0-21cc-4a7a-913f-84e53f4c50be</Id>
     </Book>
-    <Book Series="Jubilee" Number="2" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Jubilee" Number="2" Volume="2004" Year="2004">
       <Id>67b19c59-1992-4da2-af4e-4537dc09ccc0</Id>
     </Book>
-    <Book Series="Jubilee" Number="3" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="Jubilee" Number="3" Volume="2004" Year="2005">
       <Id>5f9c531a-27c2-4127-b800-93769645acf7</Id>
     </Book>
-    <Book Series="Jubilee" Number="4" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="Jubilee" Number="4" Volume="2004" Year="2005">
       <Id>8128118c-22d4-4d67-84b4-626d906daf75</Id>
     </Book>
-    <Book Series="Jubilee" Number="5" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="Jubilee" Number="5" Volume="2004" Year="2005">
       <Id>d744f39e-0c6c-4054-a2cb-467293f84a5d</Id>
     </Book>
-    <Book Series="Jubilee" Number="6" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="Jubilee" Number="6" Volume="2004" Year="2005">
       <Id>51bd7224-8c07-4f09-a7dd-65f05cbdb55c</Id>
     </Book>
-    <Book Series="Madrox" Number="1" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Madrox" Number="1" Volume="2004" Year="2004">
       <Id>6dac0636-5087-4447-9bd2-3225621f98f3</Id>
     </Book>
-    <Book Series="Madrox" Number="2" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Madrox" Number="2" Volume="2004" Year="2004">
       <Id>07881242-2739-443b-a7d8-da3ca93dacb8</Id>
     </Book>
-    <Book Series="Madrox" Number="3" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="Madrox" Number="3" Volume="2004" Year="2005">
       <Id>57574ce6-d6d5-4d1f-aa46-0626b553b425</Id>
     </Book>
-    <Book Series="Madrox" Number="4" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="Madrox" Number="4" Volume="2004" Year="2005">
       <Id>a9b3a4e2-a909-4196-b1d4-52d60a0adbf0</Id>
     </Book>
-    <Book Series="Madrox" Number="5" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="Madrox" Number="5" Volume="2004" Year="2005">
       <Id>5778600a-1f88-4271-a557-749c95a40e81</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="1" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Nightcrawler" Number="1" Volume="2004" Year="2004">
       <Id>c57e1597-d876-4c2a-bd9e-0795666560e4</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="2" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Nightcrawler" Number="2" Volume="2004" Year="2004">
       <Id>41380e6d-ba81-4d6d-b25b-81f812d49d7e</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="3" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Nightcrawler" Number="3" Volume="2004" Year="2005">
       <Id>4ccda2de-e25c-43f2-af3d-76bcf74ec410</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="4" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Nightcrawler" Number="4" Volume="2004" Year="2005">
       <Id>5cb1c51e-1631-48e9-88aa-12b944993a9f</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="4" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="4" Volume="2004" Year="2004">
       <Id>adb42a74-e1a0-45a8-ad05-b9b86eedb524</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="5" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="5" Volume="2004" Year="2004">
       <Id>13134df7-effe-4154-84f2-c0f52d4158e8</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="6" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="6" Volume="2004" Year="2005">
       <Id>faf2508b-a2d5-4ea6-87e8-35f3d853120b</Id>
     </Book>
-    <Book Series="Sabretooth" Number="1" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Sabretooth" Number="1" Volume="2004" Year="2004">
       <Id>984763b7-b22c-4d6a-8a64-0bcd2f1bd2d4</Id>
     </Book>
-    <Book Series="Sabretooth" Number="2" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Sabretooth" Number="2" Volume="2004" Year="2004">
       <Id>0cdee0fd-7f7c-4585-acbd-423be883b967</Id>
     </Book>
-    <Book Series="Sabretooth" Number="3" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="Sabretooth" Number="3" Volume="2004" Year="2005">
       <Id>954ed957-d280-49ba-a9d5-2fc182459b57</Id>
     </Book>
-    <Book Series="Sabretooth" Number="4" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="Sabretooth" Number="4" Volume="2004" Year="2005">
       <Id>a3fb3791-4868-414b-a023-3c0a04d5eed1</Id>
     </Book>
-    <Book Series="NYX" Number="1" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="NYX" Number="1" Volume="2003" Year="2003">
       <Id>8976ddb3-3000-482f-b00e-e7614279319d</Id>
     </Book>
-    <Book Series="NYX" Number="2" Volume="2003" Year="2004" Format="Limited Series">
+    <Book Series="NYX" Number="2" Volume="2003" Year="2004">
       <Id>82cecef5-51fd-4400-b811-440162347854</Id>
     </Book>
-    <Book Series="NYX" Number="3" Volume="2003" Year="2004" Format="Limited Series">
+    <Book Series="NYX" Number="3" Volume="2003" Year="2004">
       <Id>81934bd3-99b2-4aa7-8d9f-07753a4f1617</Id>
     </Book>
-    <Book Series="NYX" Number="4" Volume="2003" Year="2004" Format="Limited Series">
+    <Book Series="NYX" Number="4" Volume="2003" Year="2004">
       <Id>88899fb5-c6eb-49c2-9124-04ed98ff36e1</Id>
     </Book>
-    <Book Series="NYX" Number="5" Volume="2003" Year="2004" Format="Limited Series">
+    <Book Series="NYX" Number="5" Volume="2003" Year="2004">
       <Id>59d002bd-0dbe-4955-a8c9-a3c4be6effe3</Id>
     </Book>
-    <Book Series="NYX" Number="6" Volume="2003" Year="2005" Format="Limited Series">
+    <Book Series="NYX" Number="6" Volume="2003" Year="2005">
       <Id>d018396d-7195-439a-a394-f9702262dd2d</Id>
     </Book>
-    <Book Series="NYX" Number="7" Volume="2003" Year="2005" Format="Limited Series">
+    <Book Series="NYX" Number="7" Volume="2003" Year="2005">
       <Id>d66be0d8-572c-4a86-aafc-1c73d34b5cd2</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="450" Volume="1981" Year="2004" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="450" Volume="1981" Year="2004">
       <Id>9e49cf9b-7ec1-4fa7-8319-4ebe0065964f</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="451" Volume="1981" Year="2004" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="451" Volume="1981" Year="2004">
       <Id>fbf28be5-4a17-42ee-8ccd-b91cf9afb601</Id>
     </Book>
-    <Book Series="X-Men" Number="161" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="X-Men" Number="161" Volume="2004" Year="2004">
       <Id>a9df6851-1456-443f-9a4c-448d8df50028</Id>
     </Book>
-    <Book Series="X-Men" Number="162" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="X-Men" Number="162" Volume="2004" Year="2004">
       <Id>3e96d828-dce0-42fb-9df1-1f530cf2421d</Id>
     </Book>
-    <Book Series="X-Men" Number="163" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="X-Men" Number="163" Volume="2004" Year="2004">
       <Id>67039a64-5d95-4b97-9598-8b759e6400fe</Id>
     </Book>
-    <Book Series="X-Men" Number="164" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="X-Men" Number="164" Volume="2004" Year="2005">
       <Id>9379a8d6-7454-48bb-a5d8-04f804aaa06c</Id>
     </Book>
-    <Book Series="X-Men" Number="165" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="X-Men" Number="165" Volume="2004" Year="2005">
       <Id>7f412dd9-6a84-4a13-84b0-d77088e9f78a</Id>
     </Book>
-    <Book Series="Excalibur" Number="5" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Excalibur" Number="5" Volume="2004" Year="2004">
       <Id>c3fb4539-6f1d-4609-8379-d664b5ef2a3e</Id>
     </Book>
-    <Book Series="Excalibur" Number="6" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Excalibur" Number="6" Volume="2004" Year="2004">
       <Id>2def3fc2-ae22-4ead-9565-003dc00b6149</Id>
     </Book>
-    <Book Series="Excalibur" Number="7" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Excalibur" Number="7" Volume="2004" Year="2005">
       <Id>fe48d570-689d-4aea-9f00-da48964ec93e</Id>
     </Book>
-    <Book Series="New X-Men" Number="7" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="New X-Men" Number="7" Volume="2004" Year="2005">
       <Id>b6b79020-8076-46be-b281-6e29a20daf96</Id>
     </Book>
-    <Book Series="New X-Men" Number="8" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="New X-Men" Number="8" Volume="2004" Year="2005">
       <Id>c8a2c140-cfbb-4717-ad8b-6b365bd6b834</Id>
     </Book>
-    <Book Series="New X-Men" Number="9" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="New X-Men" Number="9" Volume="2004" Year="2005">
       <Id>3fdb44ed-808d-4bfa-8857-ed4d5d60857a</Id>
     </Book>
-    <Book Series="District X" Number="7" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="District X" Number="7" Volume="2004" Year="2005">
       <Id>9285804e-e5e0-4bd1-8a8b-1ff0881ec7b4</Id>
     </Book>
-    <Book Series="District X" Number="8" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="District X" Number="8" Volume="2004" Year="2005">
       <Id>14aab028-128d-4069-9f48-42f8ffe10888</Id>
     </Book>
-    <Book Series="District X" Number="9" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="District X" Number="9" Volume="2004" Year="2005">
       <Id>7965cfc3-4a35-4798-80cd-e0b8f6e238c4</Id>
     </Book>
-    <Book Series="District X" Number="10" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="District X" Number="10" Volume="2004" Year="2005">
       <Id>2c6a117a-dbc3-45ae-ae45-338132d42694</Id>
     </Book>
-    <Book Series="District X" Number="11" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="District X" Number="11" Volume="2004" Year="2005">
       <Id>1d9f0313-8c65-4534-a7be-dcbbfa864929</Id>
     </Book>
-    <Book Series="District X" Number="12" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="District X" Number="12" Volume="2004" Year="2005">
       <Id>7070a1be-652f-4330-9fd3-ec2d1a038d30</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="7" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="7" Volume="2004" Year="2004">
       <Id>0103f037-1066-419b-b09f-4e9414cb8c43</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="8" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="8" Volume="2004" Year="2004">
       <Id>f242a1df-c584-43d9-b181-573305e7c124</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="9" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="9" Volume="2004" Year="2005">
       <Id>b3d8735b-4269-4d9f-9eda-6940a610a436</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="10" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="10" Volume="2004" Year="2005">
       <Id>0a490cbb-4fce-410e-88ba-b13822c2533b</Id>
     </Book>
-    <Book Series="Gambit" Number="1" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Gambit" Number="1" Volume="2004" Year="2004">
       <Id>ab5830c0-db20-411c-bc7f-801afee2d8c6</Id>
     </Book>
-    <Book Series="Gambit" Number="2" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Gambit" Number="2" Volume="2004" Year="2004">
       <Id>c6ce3779-8fed-4eae-b262-fb0aaaf9e8ef</Id>
     </Book>
-    <Book Series="Gambit" Number="3" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Gambit" Number="3" Volume="2004" Year="2004">
       <Id>c6da162b-f0c2-4eb8-ac2c-5708ec82001b</Id>
     </Book>
-    <Book Series="Gambit" Number="4" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Gambit" Number="4" Volume="2004" Year="2005">
       <Id>3278c4e8-ce96-4617-9b96-e838ba5a33c6</Id>
     </Book>
-    <Book Series="Gambit" Number="5" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Gambit" Number="5" Volume="2004" Year="2005">
       <Id>21bf3e5e-79fa-47f6-9293-b2c32fba13bd</Id>
     </Book>
-    <Book Series="Gambit" Number="6" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Gambit" Number="6" Volume="2004" Year="2005">
       <Id>6c03d305-5950-49a4-9816-76e31dcb8b4c</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="5" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Nightcrawler" Number="5" Volume="2004" Year="2005">
       <Id>28de4d90-44c9-4074-8667-c16708dd4f9d</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="6" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Nightcrawler" Number="6" Volume="2004" Year="2005">
       <Id>88492efd-84d4-4eba-a03f-9390258cd954</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="452" Volume="1981" Year="2005" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="452" Volume="1981" Year="2005">
       <Id>4d6cfa93-8c52-40ac-9b97-87016a2a55b7</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="453" Volume="1981" Year="2005" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="453" Volume="1981" Year="2005">
       <Id>9088f166-6482-41c9-a66e-6f653e3c5811</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="454" Volume="1981" Year="2005" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="454" Volume="1981" Year="2005">
       <Id>2cd47faf-a9fd-4e60-ab25-255f72f8d448</Id>
     </Book>
-    <Book Series="X-Men" Number="166" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="X-Men" Number="166" Volume="2004" Year="2005">
       <Id>b07e85f2-6c65-4aa0-b9a5-7048cbddd1d1</Id>
     </Book>
-    <Book Series="X-Men" Number="167" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="X-Men" Number="167" Volume="2004" Year="2005">
       <Id>a30f893e-e187-4c16-985d-a8ef6bc2499c</Id>
     </Book>
-    <Book Series="X-Men" Number="168" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="X-Men" Number="168" Volume="2004" Year="2005">
       <Id>a4d1fa3c-1adf-4788-9980-4abe54917a05</Id>
     </Book>
-    <Book Series="X-Men" Number="169" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="X-Men" Number="169" Volume="2004" Year="2005">
       <Id>d1632b18-4cf4-40fb-8947-219d3be41b29</Id>
     </Book>
-    <Book Series="X-Men" Number="170" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="X-Men" Number="170" Volume="2004" Year="2005">
       <Id>ca2df375-9426-470d-8ced-5fe51cac9948</Id>
     </Book>
-    <Book Series="Excalibur" Number="8" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Excalibur" Number="8" Volume="2004" Year="2005">
       <Id>ef63de7e-40b2-4ac2-9de3-52e289667b9a</Id>
     </Book>
-    <Book Series="Excalibur" Number="9" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Excalibur" Number="9" Volume="2004" Year="2005">
       <Id>b383c2f5-1469-4f1c-8713-c7378f02061b</Id>
     </Book>
-    <Book Series="Excalibur" Number="10" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Excalibur" Number="10" Volume="2004" Year="2005">
       <Id>ab0e3415-0579-4b54-8167-e2847183a276</Id>
     </Book>
-    <Book Series="Gambit" Number="7" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Gambit" Number="7" Volume="2004" Year="2005">
       <Id>2da16bca-6c8f-4d81-afa0-8cef56587c32</Id>
     </Book>
-    <Book Series="Gambit" Number="8" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Gambit" Number="8" Volume="2004" Year="2005">
       <Id>dc498d3d-704a-4046-b364-5be3c9da47be</Id>
     </Book>
-    <Book Series="Gambit" Number="9" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Gambit" Number="9" Volume="2004" Year="2005">
       <Id>8d73a1a8-9ea8-4c81-b98e-7702f8af918c</Id>
     </Book>
-    <Book Series="Gambit" Number="10" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Gambit" Number="10" Volume="2004" Year="2005">
       <Id>0a661b0e-cb11-450e-ace1-a8de357ceec6</Id>
     </Book>
-    <Book Series="Gambit" Number="11" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Gambit" Number="11" Volume="2004" Year="2005">
       <Id>0d7a963f-e0ff-4479-94dd-b805ab29babb</Id>
     </Book>
-    <Book Series="Gambit" Number="12" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Gambit" Number="12" Volume="2004" Year="2005">
       <Id>ef898a19-90fd-42eb-9d0f-509106453405</Id>
     </Book>
-    <Book Series="New X-Men" Number="10" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="New X-Men" Number="10" Volume="2004" Year="2005">
       <Id>34db4549-a892-4f8b-8c11-806497622c48</Id>
     </Book>
-    <Book Series="New X-Men" Number="11" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="New X-Men" Number="11" Volume="2004" Year="2005">
       <Id>31e93c5a-6d14-4179-9c0c-b7237d31ba0d</Id>
     </Book>
-    <Book Series="New X-Men" Number="12" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="New X-Men" Number="12" Volume="2004" Year="2005">
       <Id>f8aef496-6509-4337-8b3a-1453837172b0</Id>
     </Book>
-    <Book Series="District X" Number="13" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="District X" Number="13" Volume="2004" Year="2005">
       <Id>edff7d14-5c98-4251-b181-84efbf361b4e</Id>
     </Book>
-    <Book Series="District X" Number="14" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="District X" Number="14" Volume="2004" Year="2005">
       <Id>f2e55cf7-183a-4a8b-998b-2c73b09b56c3</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="11" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="11" Volume="2004" Year="2005">
       <Id>c0c7510a-e659-44a1-91ad-4d8f457df6b3</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="12" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="12" Volume="2004" Year="2005">
       <Id>756c7fe1-9793-4834-b352-40691d0c851d</Id>
     </Book>
-    <Book Series="X-Force" Number="1" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="X-Force" Number="1" Volume="2004" Year="2004">
       <Id>b5d52a28-2686-4cad-8208-2a4c9be74752</Id>
     </Book>
-    <Book Series="X-Force" Number="2" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="X-Force" Number="2" Volume="2004" Year="2004">
       <Id>c08cdabd-ef2b-4f4c-9128-16d1c0e1f0c9</Id>
     </Book>
-    <Book Series="X-Force" Number="3" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="X-Force" Number="3" Volume="2004" Year="2004">
       <Id>56376991-7f5b-4334-b7f1-15f05da7a18f</Id>
     </Book>
-    <Book Series="X-Force" Number="4" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="X-Force" Number="4" Volume="2004" Year="2005">
       <Id>502cc938-1e5a-496d-bd63-40bc9aa397f7</Id>
     </Book>
-    <Book Series="X-Force" Number="5" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="X-Force" Number="5" Volume="2004" Year="2005">
       <Id>308b8d77-cc98-49c3-99ac-987554a55308</Id>
     </Book>
-    <Book Series="X-Force" Number="6" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="X-Force" Number="6" Volume="2004" Year="2005">
       <Id>c5e605fa-d4ca-4ae4-992e-f7d50adb12c3</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="7" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Nightcrawler" Number="7" Volume="2004" Year="2005">
       <Id>9c1986cd-cdb4-450f-ba0a-f5b491b180ce</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="8" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Nightcrawler" Number="8" Volume="2004" Year="2005">
       <Id>09a4cd40-a099-495a-9206-b0b25a2f2106</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="9" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Nightcrawler" Number="9" Volume="2004" Year="2005">
       <Id>64b659f7-4281-4cfc-a2cb-64e4644ef470</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="10" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Nightcrawler" Number="10" Volume="2004" Year="2005">
       <Id>e8bcf0ee-7dda-419b-aa29-6c6e0712bf39</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="11" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Nightcrawler" Number="11" Volume="2004" Year="2005">
       <Id>c614a355-eed4-43c1-ae57-078baa66e76a</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="12" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="Nightcrawler" Number="12" Volume="2004" Year="2006">
       <Id>e3aed113-e8fe-4256-8b0b-dd0e43c0f9ca</Id>
     </Book>
-    <Book Series="X-23" Number="1" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="X-23" Number="1" Volume="2005" Year="2005">
       <Id>53a07b6e-cdcc-4b46-84ae-6c705070ffee</Id>
     </Book>
-    <Book Series="X-23" Number="2" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="X-23" Number="2" Volume="2005" Year="2005">
       <Id>acded7b2-6b93-4356-809b-7d8d5f9322da</Id>
     </Book>
-    <Book Series="X-23" Number="3" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="X-23" Number="3" Volume="2005" Year="2005">
       <Id>bfabbc8d-30b1-490a-bfd5-0cf2a90216b7</Id>
     </Book>
-    <Book Series="X-23" Number="4" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="X-23" Number="4" Volume="2005" Year="2005">
       <Id>ca21c2cb-0f38-4eff-8594-4e8da77959ae</Id>
     </Book>
-    <Book Series="X-23" Number="5" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="X-23" Number="5" Volume="2005" Year="2005">
       <Id>d5a3b7e5-3477-4282-9fb8-f3de07cd2a7b</Id>
     </Book>
-    <Book Series="X-23" Number="6" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="X-23" Number="6" Volume="2005" Year="2005">
       <Id>0790691d-f5dd-4b57-9200-35d67330122c</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="455" Volume="1981" Year="2005" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="455" Volume="1981" Year="2005">
       <Id>1e4962b4-3b39-45f7-a8cb-7a5798c38e74</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="456" Volume="1981" Year="2005" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="456" Volume="1981" Year="2005">
       <Id>cfd6b340-a851-4e86-beee-a1bfa9307f7d</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="457" Volume="1981" Year="2005" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="457" Volume="1981" Year="2005">
       <Id>cd9ca46b-1c0b-46c8-9fde-af0049d745b5</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="458" Volume="1981" Year="2005" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="458" Volume="1981" Year="2005">
       <Id>0780260e-49cf-4195-88d1-b1f5a0bbbfc2</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="459" Volume="1981" Year="2005" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="459" Volume="1981" Year="2005">
       <Id>a3007673-6b4f-435d-b843-56497ff9b0d0</Id>
     </Book>
-    <Book Series="X-Men: Phoenix - Endsong" Number="1" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="X-Men: Phoenix - Endsong" Number="1" Volume="2005" Year="2005">
       <Id>8b2e52b9-f0e6-47ec-8cfb-43603499d047</Id>
     </Book>
-    <Book Series="X-Men: Phoenix - Endsong" Number="2" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="X-Men: Phoenix - Endsong" Number="2" Volume="2005" Year="2005">
       <Id>2c16cb16-2ced-427d-b8d1-092d40ce2795</Id>
     </Book>
-    <Book Series="X-Men: Phoenix - Endsong" Number="3" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="X-Men: Phoenix - Endsong" Number="3" Volume="2005" Year="2005">
       <Id>f701f06f-f9a5-4f8c-bb65-a7308bf27648</Id>
     </Book>
-    <Book Series="X-Men: Phoenix - Endsong" Number="4" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="X-Men: Phoenix - Endsong" Number="4" Volume="2005" Year="2005">
       <Id>7d521daf-6747-4893-8f8f-53f02489df0e</Id>
     </Book>
-    <Book Series="X-Men: Phoenix - Endsong" Number="5" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="X-Men: Phoenix - Endsong" Number="5" Volume="2005" Year="2005">
       <Id>deee531a-97f2-423d-aaa4-5afccbc1f247</Id>
     </Book>
-    <Book Series="Wolverine" Number="20" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Wolverine" Number="20" Volume="2003" Year="2004">
       <Id>2a419262-5192-41bc-959d-337d47b4d795</Id>
     </Book>
-    <Book Series="Wolverine" Number="21" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Wolverine" Number="21" Volume="2003" Year="2004">
       <Id>913d95c9-b0f2-4688-b259-2a947f91912d</Id>
     </Book>
-    <Book Series="Wolverine" Number="22" Volume="2003" Year="2005" Format="Main Series">
+    <Book Series="Wolverine" Number="22" Volume="2003" Year="2005">
       <Id>e66ecdff-5d56-43e5-b443-6a0ffa5639ad</Id>
     </Book>
-    <Book Series="Wolverine" Number="23" Volume="2003" Year="2005" Format="Main Series">
+    <Book Series="Wolverine" Number="23" Volume="2003" Year="2005">
       <Id>8b5bf2b3-1aca-457c-9c8e-1c85e31682b4</Id>
     </Book>
-    <Book Series="Wolverine" Number="24" Volume="2003" Year="2005" Format="Main Series">
+    <Book Series="Wolverine" Number="24" Volume="2003" Year="2005">
       <Id>948901d8-eb19-4e4a-bb1e-f533adcc53c5</Id>
     </Book>
-    <Book Series="Wolverine" Number="25" Volume="2003" Year="2005" Format="Main Series">
+    <Book Series="Wolverine" Number="25" Volume="2003" Year="2005">
       <Id>d2bdd37e-0852-4d57-95db-c08577637c0f</Id>
     </Book>
-    <Book Series="Wolverine" Number="26" Volume="2003" Year="2005" Format="Main Series">
+    <Book Series="Wolverine" Number="26" Volume="2003" Year="2005">
       <Id>3f07235b-60b1-43d2-add5-526fc5394dac</Id>
     </Book>
-    <Book Series="Wolverine" Number="27" Volume="2003" Year="2005" Format="Main Series">
+    <Book Series="Wolverine" Number="27" Volume="2003" Year="2005">
       <Id>1cfe0909-b85b-464b-a271-cd04603a1a3e</Id>
     </Book>
-    <Book Series="Wolverine" Number="28" Volume="2003" Year="2005" Format="Main Series">
+    <Book Series="Wolverine" Number="28" Volume="2003" Year="2005">
       <Id>6027e31a-73ab-4176-8d62-0c67ced2314d</Id>
     </Book>
-    <Book Series="Wolverine" Number="29" Volume="2003" Year="2005" Format="Main Series">
+    <Book Series="Wolverine" Number="29" Volume="2003" Year="2005">
       <Id>f6b3537a-f9a7-415a-8cbc-3382825267d5</Id>
     </Book>
-    <Book Series="Wolverine" Number="30" Volume="2003" Year="2005" Format="Main Series">
+    <Book Series="Wolverine" Number="30" Volume="2003" Year="2005">
       <Id>d0ef834a-9824-46c4-a87a-db60e28af7ac</Id>
     </Book>
-    <Book Series="Wolverine" Number="31" Volume="2003" Year="2005" Format="Main Series">
+    <Book Series="Wolverine" Number="31" Volume="2003" Year="2005">
       <Id>3f3ee8f9-6123-40db-9b70-216c863472d1</Id>
     </Book>
-    <Book Series="New X-Men" Number="13" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="New X-Men" Number="13" Volume="2004" Year="2005">
       <Id>fd6276d1-4a76-4f85-b185-0ce9c04268b4</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="460" Volume="1981" Year="2005" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="460" Volume="1981" Year="2005">
       <Id>56f1d031-897c-4cfa-8c9e-14ca62cc388c</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="461" Volume="1981" Year="2005" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="461" Volume="1981" Year="2005">
       <Id>3f84e334-4a29-46bf-b650-8d2a2b49f3c2</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="7" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="7" Volume="2004" Year="2005">
       <Id>725001c7-9ad7-4c13-9287-6234bffa1373</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="8" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="8" Volume="2004" Year="2005">
       <Id>a59672c0-cd7d-4941-886b-c1ee9252556c</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="9" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="9" Volume="2004" Year="2005">
       <Id>cdea2ec1-5179-46f0-b7c6-a02a65088d82</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="10" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="10" Volume="2004" Year="2005">
       <Id>873b0d14-f30f-4c41-8329-1b34597cd291</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="11" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="11" Volume="2004" Year="2005">
       <Id>341bd351-09d0-4e14-b137-6fefdf94025a</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="12" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="12" Volume="2004" Year="2005">
       <Id>a506b885-5c44-40c2-bbb1-0421396ac8d8</Id>
     </Book>
-    <Book Series="Rogue" Number="7" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Rogue" Number="7" Volume="2004" Year="2005">
       <Id>1741b3be-03ec-4201-b422-07db24d05b27</Id>
     </Book>
-    <Book Series="Rogue" Number="8" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Rogue" Number="8" Volume="2004" Year="2005">
       <Id>01222723-241b-44b3-9a61-82cd77c001d8</Id>
     </Book>
-    <Book Series="Rogue" Number="9" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Rogue" Number="9" Volume="2004" Year="2005">
       <Id>bda8e635-e91b-4830-be5f-20a4cd5de5ad</Id>
     </Book>
-    <Book Series="Rogue" Number="10" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Rogue" Number="10" Volume="2004" Year="2005">
       <Id>228d076c-1a86-4625-a2ba-4bcdd3e1ad29</Id>
     </Book>
-    <Book Series="Rogue" Number="11" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Rogue" Number="11" Volume="2004" Year="2005">
       <Id>b77e525a-cb11-48eb-b6c7-744f41355d29</Id>
     </Book>
-    <Book Series="Rogue" Number="12" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Rogue" Number="12" Volume="2004" Year="2005">
       <Id>2f9310cb-cb89-43c4-8e19-f6e60de9bc32</Id>
     </Book>
-    <Book Series="X-Men" Number="171" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="X-Men" Number="171" Volume="2004" Year="2005">
       <Id>143fe411-91fa-43c8-8071-69bfb952bffc</Id>
     </Book>
-    <Book Series="X-Men" Number="172" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="X-Men" Number="172" Volume="2004" Year="2005">
       <Id>0af3c655-52bb-4537-95e2-62273e6d5060</Id>
     </Book>
-    <Book Series="X-Men" Number="173" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="X-Men" Number="173" Volume="2004" Year="2005">
       <Id>0d4c7158-5f51-4694-9cea-b9651c51fde2</Id>
     </Book>
-    <Book Series="X-Men" Number="174" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="X-Men" Number="174" Volume="2004" Year="2005">
       <Id>01d89000-966b-4dfb-a513-c7e848847c32</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="7" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="7" Volume="2004" Year="2005">
       <Id>c92e4ca1-56a2-4014-a12b-5be664c6bed4</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="8" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="8" Volume="2004" Year="2005">
       <Id>a1868cba-b7a6-4547-bc38-494aceebd8ea</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="9" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="9" Volume="2004" Year="2005">
       <Id>b11a8685-9ee2-40b9-be3f-01dd886e9429</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="10" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="10" Volume="2004" Year="2005">
       <Id>25268769-9f71-48cf-a4c9-46a159bf6c95</Id>
     </Book>
-    <Book Series="New X-Men" Number="14" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="New X-Men" Number="14" Volume="2004" Year="2005">
       <Id>49ea0d87-a118-4cd4-a8c5-bdbd03f7a2a6</Id>
     </Book>
-    <Book Series="New X-Men" Number="15" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="New X-Men" Number="15" Volume="2004" Year="2005">
       <Id>0719661f-b695-4387-9de5-1a2a55ce5fe3</Id>
     </Book>
-    <Book Series="New X-Men: Hellions" Number="1" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="New X-Men: Hellions" Number="1" Volume="2005" Year="2005">
       <Id>cfc9b5a2-be37-46e6-98c5-d4b64fd18cd3</Id>
     </Book>
-    <Book Series="New X-Men: Hellions" Number="2" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="New X-Men: Hellions" Number="2" Volume="2005" Year="2005">
       <Id>099a2244-b22a-4031-a360-95574fcc1733</Id>
     </Book>
-    <Book Series="New X-Men: Hellions" Number="3" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="New X-Men: Hellions" Number="3" Volume="2005" Year="2005">
       <Id>ccb8673e-ace3-4af9-98cb-83f394211a2c</Id>
     </Book>
-    <Book Series="New X-Men: Hellions" Number="4" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="New X-Men: Hellions" Number="4" Volume="2005" Year="2005">
       <Id>e8b1fd5f-47a2-4181-b6ea-5fb8554c88b1</Id>
     </Book>
-    <Book Series="New X-Men: Academy X Yearbook" Number="1" Volume="2005" Year="2005" Format="One-Shot">
+    <Book Series="New X-Men: Academy X Yearbook" Number="1" Volume="2005" Year="2005">
       <Id>d77ca8ff-4675-476f-b32a-1390d5ee9783</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="15" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="15" Volume="2004" Year="2005">
       <Id>a3509de5-57e9-45a4-8a3c-f4c93a0a824d</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="16" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="16" Volume="2004" Year="2005">
       <Id>0c11ca34-1694-4f09-9407-4e8e26e69ed1</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="17" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="17" Volume="2004" Year="2005">
       <Id>1dee4534-eaaa-4f75-9dbd-eb0f703cf5b3</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="18" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="18" Volume="2004" Year="2005">
       <Id>d0078c14-4024-4e20-bb14-dbf80702c80b</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="11" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="11" Volume="2004" Year="2005">
       <Id>acc173e2-a077-46be-8df8-20d6beac09e3</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="12" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="12" Volume="2004" Year="2006">
       <Id>e303690c-5f29-4cbd-8568-db441064f25e</Id>
     </Book>
-    <Book Series="Wolverine" Number="32" Volume="2003" Year="2005" Format="Main Series">
+    <Book Series="Wolverine" Number="32" Volume="2003" Year="2005">
       <Id>2a078344-ea4b-4cef-85a6-e99f0d7140f3</Id>
     </Book>
-    <Book Series="X-Men: Kitty Pryde - Shadow &amp; Flame" Number="1" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="X-Men: Kitty Pryde - Shadow &amp; Flame" Number="1" Volume="2005" Year="2005">
       <Id>9c53f7b8-cd18-4915-8fc8-997c7f3d347c</Id>
     </Book>
-    <Book Series="X-Men: Kitty Pryde - Shadow &amp; Flame" Number="2" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="X-Men: Kitty Pryde - Shadow &amp; Flame" Number="2" Volume="2005" Year="2005">
       <Id>606a3bd7-5f04-4ead-8563-eb1557c1e1b8</Id>
     </Book>
-    <Book Series="X-Men: Kitty Pryde - Shadow &amp; Flame" Number="3" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="X-Men: Kitty Pryde - Shadow &amp; Flame" Number="3" Volume="2005" Year="2005">
       <Id>44183854-0c25-422b-8d63-a3ebce27f01e</Id>
     </Book>
-    <Book Series="X-Men: Kitty Pryde - Shadow &amp; Flame" Number="4" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="X-Men: Kitty Pryde - Shadow &amp; Flame" Number="4" Volume="2005" Year="2005">
       <Id>a7eeff31-c326-42b9-93d1-5d158cfd9174</Id>
     </Book>
-    <Book Series="X-Men: Kitty Pryde - Shadow &amp; Flame" Number="5" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="X-Men: Kitty Pryde - Shadow &amp; Flame" Number="5" Volume="2005" Year="2005">
       <Id>e3b36c15-decc-44e6-b7b9-9e2f5d900e1a</Id>
     </Book>
-    <Book Series="X-Men: Colossus Bloodline" Number="1" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="X-Men: Colossus Bloodline" Number="1" Volume="2005" Year="2005">
       <Id>dc29d154-f8f5-46ed-82cc-93921e232f3b</Id>
     </Book>
-    <Book Series="X-Men: Colossus Bloodline" Number="2" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="X-Men: Colossus Bloodline" Number="2" Volume="2005" Year="2005">
       <Id>cb312150-b722-41b9-b43d-17ffa66f3954</Id>
     </Book>
-    <Book Series="X-Men: Colossus Bloodline" Number="3" Volume="2005" Year="2006" Format="Limited Series">
+    <Book Series="X-Men: Colossus Bloodline" Number="3" Volume="2005" Year="2006">
       <Id>137cfa81-9cde-429b-87c8-8cd73a18629e</Id>
     </Book>
-    <Book Series="X-Men: Colossus Bloodline" Number="4" Volume="2005" Year="2006" Format="Limited Series">
+    <Book Series="X-Men: Colossus Bloodline" Number="4" Volume="2005" Year="2006">
       <Id>f0c3463d-45c0-4aa8-81fb-32d8a0ed3cc5</Id>
     </Book>
-    <Book Series="X-Men: Colossus Bloodline" Number="5" Volume="2005" Year="2006" Format="Limited Series">
+    <Book Series="X-Men: Colossus Bloodline" Number="5" Volume="2005" Year="2006">
       <Id>c701c079-a85c-442d-95be-3f608a541eb4</Id>
     </Book>
-    <Book Series="Ororo: Before the Storm" Number="1" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Ororo: Before the Storm" Number="1" Volume="2005" Year="2005">
       <Id>a44b8d2a-d6b2-4eae-8373-b80d0da0b616</Id>
     </Book>
-    <Book Series="Ororo: Before the Storm" Number="2" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Ororo: Before the Storm" Number="2" Volume="2005" Year="2005">
       <Id>dc190647-58d0-4890-acae-69bf20057565</Id>
     </Book>
-    <Book Series="Ororo: Before the Storm" Number="3" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Ororo: Before the Storm" Number="3" Volume="2005" Year="2005">
       <Id>4f09f0c7-6842-4903-bc68-93d49c9e2760</Id>
     </Book>
-    <Book Series="Ororo: Before the Storm" Number="4" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Ororo: Before the Storm" Number="4" Volume="2005" Year="2005">
       <Id>d77b74c6-cc56-4cd3-90c7-10adb6da1faf</Id>
     </Book>
-    <Book Series="X-Men" Number="175" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="X-Men" Number="175" Volume="2004" Year="2005">
       <Id>dce959c0-5895-4abe-bc7d-445bb3fbe9ea</Id>
     </Book>
-    <Book Series="Black Panther" Number="8" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Black Panther" Number="8" Volume="2005" Year="2005">
       <Id>904e246e-022f-4abb-975f-8e8962814166</Id>
     </Book>
-    <Book Series="X-Men" Number="176" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="X-Men" Number="176" Volume="2004" Year="2005">
       <Id>56527222-c3ce-4a66-8f04-11154801371a</Id>
     </Book>
-    <Book Series="Black Panther" Number="9" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Black Panther" Number="9" Volume="2005" Year="2005">
       <Id>600ca6f0-d912-4d6e-bd53-1d4787ef978a</Id>
     </Book>
-    <Book Series="Excalibur" Number="11" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Excalibur" Number="11" Volume="2004" Year="2005">
       <Id>d5deabbc-9771-4dbc-958d-1d6e1cdad296</Id>
     </Book>
-    <Book Series="Excalibur" Number="12" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Excalibur" Number="12" Volume="2004" Year="2005">
       <Id>baae3c3e-1865-4c56-a2b1-a758c27629aa</Id>
     </Book>
-    <Book Series="Excalibur" Number="13" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Excalibur" Number="13" Volume="2004" Year="2005">
       <Id>f663eee8-fdd3-40ec-bcab-68df98fbd3a0</Id>
     </Book>
-    <Book Series="Excalibur" Number="14" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Excalibur" Number="14" Volume="2004" Year="2005">
       <Id>69eb68da-3325-4d3a-a108-d4c6c40b434d</Id>
     </Book>
-    <Book Series="X-Men/Spider-Man" Number="1" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="X-Men/Spider-Man" Number="1" Volume="2009" Year="2009">
       <Id>9bf47542-f0d1-4132-916d-df74253e054c</Id>
     </Book>
-    <Book Series="X-Men/Spider-Man" Number="2" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="X-Men/Spider-Man" Number="2" Volume="2009" Year="2009">
       <Id>5a8ffacb-aa68-4cb6-b85d-9892b9ab125a</Id>
     </Book>
-    <Book Series="X-Men/Spider-Man" Number="3" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="X-Men/Spider-Man" Number="3" Volume="2009" Year="2009">
       <Id>77ba230a-365b-4d67-9991-8e59263b1b40</Id>
     </Book>
-    <Book Series="X-Men/Spider-Man" Number="4" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="X-Men/Spider-Man" Number="4" Volume="2009" Year="2009">
       <Id>3de4ce7a-67da-4b0f-87bf-f4fe3503750d</Id>
     </Book>
   </Books>

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 010 (Decimation).cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 010 (Decimation).cbl
@@ -2,922 +2,922 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>X-Men - Part 10 (Decimation)</Name>
   <Books>
-    <Book Series="House of M" Number="1" Volume="2005" Year="2005" Format="Crossover">
+    <Book Series="House of M" Number="1" Volume="2005" Year="2005">
       <Id>87c12880-5952-4edd-87b2-17ca0f8a8412</Id>
     </Book>
-    <Book Series="House of M" Number="2" Volume="2005" Year="2005" Format="Crossover">
+    <Book Series="House of M" Number="2" Volume="2005" Year="2005">
       <Id>cd404553-6dd2-46e2-a706-b44501cceeb5</Id>
     </Book>
-    <Book Series="House of M" Number="3" Volume="2005" Year="2005" Format="Crossover">
+    <Book Series="House of M" Number="3" Volume="2005" Year="2005">
       <Id>52c3157a-6b7b-4a3f-93a3-5c65d8105904</Id>
     </Book>
-    <Book Series="House of M" Number="4" Volume="2005" Year="2005" Format="Crossover">
+    <Book Series="House of M" Number="4" Volume="2005" Year="2005">
       <Id>a9152579-cd4a-4fcf-a9fc-a28706d29844</Id>
     </Book>
-    <Book Series="House of M" Number="5" Volume="2005" Year="2005" Format="Crossover">
+    <Book Series="House of M" Number="5" Volume="2005" Year="2005">
       <Id>83190f73-884a-416f-968b-d52aaebeacf9</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="462" Volume="1981" Year="2005" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="462" Volume="1981" Year="2005">
       <Id>970fb26f-86c9-47d9-84b4-59f2bda6d691</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="463" Volume="1981" Year="2005" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="463" Volume="1981" Year="2005">
       <Id>cdee3cd3-5c59-4ca8-9a4b-5f27717ccd87</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="464" Volume="1981" Year="2005" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="464" Volume="1981" Year="2005">
       <Id>dce60ecb-03fc-4895-85c3-72d9fb438136</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="465" Volume="1981" Year="2005" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="465" Volume="1981" Year="2005">
       <Id>9043d10a-a05a-448f-b530-a8bcc20afe2a</Id>
     </Book>
-    <Book Series="House of M" Number="6" Volume="2005" Year="2005" Format="Crossover">
+    <Book Series="House of M" Number="6" Volume="2005" Year="2005">
       <Id>4e3ef330-2fe0-4dbb-9f12-13b2c25ec7ae</Id>
     </Book>
-    <Book Series="House of M" Number="7" Volume="2005" Year="2005" Format="Crossover">
+    <Book Series="House of M" Number="7" Volume="2005" Year="2005">
       <Id>f0bdd681-2378-4e2d-a243-4b14799eb6ca</Id>
     </Book>
-    <Book Series="House of M" Number="8" Volume="2005" Year="2005" Format="Crossover">
+    <Book Series="House of M" Number="8" Volume="2005" Year="2005">
       <Id>8a2532e6-142d-45e2-ac8a-f8a8548d6e7b</Id>
     </Book>
-    <Book Series="Decimation: House of M - The Day After" Number="1" Volume="2006" Year="2006" Format="Crossover">
+    <Book Series="Decimation: House of M - The Day After" Number="1" Volume="2006" Year="2006">
       <Id>616c2697-c037-435f-9b4f-d7d55a056496</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="19" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="19" Volume="2004" Year="2005">
       <Id>8919e2d5-f38c-4d3e-b80a-52e88de1723b</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="20" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="20" Volume="2004" Year="2005">
       <Id>3660e479-122b-4833-97d6-800b354b0086</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="21" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="21" Volume="2004" Year="2005">
       <Id>0df40f9e-e7cb-4be0-a0e6-88ff38deb301</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="22" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="22" Volume="2004" Year="2006">
       <Id>b00f33e8-93ca-477c-846c-4d1794dea533</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="23" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="23" Volume="2004" Year="2006">
       <Id>aa4d86d4-7c6b-497d-beaf-4c494bd5fb71</Id>
     </Book>
-    <Book Series="X-Men" Number="177" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="X-Men" Number="177" Volume="2004" Year="2006">
       <Id>3c62b1bb-e911-438f-8155-60b86cf7c0fa</Id>
     </Book>
-    <Book Series="X-Men" Number="178" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="X-Men" Number="178" Volume="2004" Year="2006">
       <Id>bcbaddcc-57ec-4ace-ab6c-be67496078c9</Id>
     </Book>
-    <Book Series="X-Men" Number="179" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="X-Men" Number="179" Volume="2004" Year="2006">
       <Id>b2810cc8-a351-427c-8ab2-6b70c9bfb1ef</Id>
     </Book>
-    <Book Series="New X-Men" Number="20" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="New X-Men" Number="20" Volume="2004" Year="2006">
       <Id>e7c9c97d-505c-49e4-8a4b-45aeece08176</Id>
     </Book>
-    <Book Series="New X-Men" Number="21" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="New X-Men" Number="21" Volume="2004" Year="2006">
       <Id>41bc728f-6a30-49b6-a491-dad365feb6fa</Id>
     </Book>
-    <Book Series="New X-Men" Number="22" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="New X-Men" Number="22" Volume="2004" Year="2006">
       <Id>23b2dc51-ebe6-4c06-af36-f87a0212efac</Id>
     </Book>
-    <Book Series="New X-Men" Number="23" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="New X-Men" Number="23" Volume="2004" Year="2006">
       <Id>c72f861a-790d-4bd6-b7e0-6e55e3701233</Id>
     </Book>
-    <Book Series="Generation M" Number="1" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="Generation M" Number="1" Volume="2006" Year="2006">
       <Id>54fde146-3635-4532-82b8-6c6c733a7b39</Id>
     </Book>
-    <Book Series="Generation M" Number="2" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="Generation M" Number="2" Volume="2006" Year="2006">
       <Id>84471d5b-931d-448e-9c2e-7b0cd894759f</Id>
     </Book>
-    <Book Series="Generation M" Number="3" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="Generation M" Number="3" Volume="2006" Year="2006">
       <Id>e026fe08-1d23-4ad6-aada-5191e9ac9991</Id>
     </Book>
-    <Book Series="Generation M" Number="4" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="Generation M" Number="4" Volume="2006" Year="2006">
       <Id>5fa12503-a50d-4343-b329-f5479f548c96</Id>
     </Book>
-    <Book Series="Generation M" Number="5" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="Generation M" Number="5" Volume="2006" Year="2006">
       <Id>0b9b1bbf-e4e2-4001-9c2f-401ab6a1ef17</Id>
     </Book>
-    <Book Series="X-Men: The 198" Number="1" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="X-Men: The 198" Number="1" Volume="2006" Year="2006">
       <Id>49749ed2-c719-4072-9622-10c65728285e</Id>
     </Book>
-    <Book Series="X-Men: The 198" Number="2" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="X-Men: The 198" Number="2" Volume="2006" Year="2006">
       <Id>6fc0f84c-d285-404d-b191-885ad09ec2dd</Id>
     </Book>
-    <Book Series="X-Men: The 198" Number="3" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="X-Men: The 198" Number="3" Volume="2006" Year="2006">
       <Id>c40a7eb4-682a-4030-897b-b8ad3f1e99d2</Id>
     </Book>
-    <Book Series="X-Men: The 198" Number="4" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="X-Men: The 198" Number="4" Volume="2006" Year="2006">
       <Id>e59533e9-15cf-4d5a-a0ce-ebb858860a96</Id>
     </Book>
-    <Book Series="X-Men: The 198" Number="5" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="X-Men: The 198" Number="5" Volume="2006" Year="2006">
       <Id>1ad1f619-0a56-4516-95b5-d12449329b98</Id>
     </Book>
-    <Book Series="X-Factor" Number="1" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="X-Factor" Number="1" Volume="2006" Year="2006">
       <Id>febc74e5-7e2e-49de-b13f-d8e1191fccf1</Id>
     </Book>
-    <Book Series="X-Factor" Number="2" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="X-Factor" Number="2" Volume="2006" Year="2006">
       <Id>bd300888-dec3-41a9-b890-8ae04e0df09a</Id>
     </Book>
-    <Book Series="X-Factor" Number="3" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="X-Factor" Number="3" Volume="2006" Year="2006">
       <Id>1f7117be-4183-4375-8385-c36ff8926b9c</Id>
     </Book>
-    <Book Series="X-Factor" Number="4" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="X-Factor" Number="4" Volume="2006" Year="2006">
       <Id>70faa9f6-6138-47de-8013-02e2b878e5a2</Id>
     </Book>
-    <Book Series="X-Factor" Number="5" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="X-Factor" Number="5" Volume="2006" Year="2006">
       <Id>5816c436-5318-48ed-bd2b-09b99891f24b</Id>
     </Book>
-    <Book Series="X-Factor" Number="6" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="X-Factor" Number="6" Volume="2006" Year="2006">
       <Id>c2d61d1b-9792-447c-ba0c-290e2f6d8dd2</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="13" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="13" Volume="2004" Year="2006">
       <Id>57f0f942-9b25-4746-9adc-3996a3673a6f</Id>
     </Book>
-    <Book Series="New Excalibur" Number="1" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="New Excalibur" Number="1" Volume="2006" Year="2006">
       <Id>de9957e2-4a29-4b88-9831-1a402a3c12cb</Id>
     </Book>
-    <Book Series="New Excalibur" Number="2" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="New Excalibur" Number="2" Volume="2006" Year="2006">
       <Id>1f637856-2542-4851-b28b-2a2787b57c4e</Id>
     </Book>
-    <Book Series="New Excalibur" Number="3" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="New Excalibur" Number="3" Volume="2006" Year="2006">
       <Id>8acd56b1-7723-4123-a992-bbe6e7c15a55</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="466" Volume="1981" Year="2006" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="466" Volume="1981" Year="2006">
       <Id>de98f448-c6b4-49a0-be41-795dd62e01a3</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="467" Volume="1981" Year="2006" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="467" Volume="1981" Year="2006">
       <Id>e0c819d2-d200-4931-902f-0f55ad9bc9db</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="468" Volume="1981" Year="2006" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="468" Volume="1981" Year="2006">
       <Id>10fb0335-1b49-42c0-bb27-c4a7ebf79342</Id>
     </Book>
-    <Book Series="New Excalibur" Number="4" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="New Excalibur" Number="4" Volume="2006" Year="2006">
       <Id>5575c0db-1e78-46c3-bb8e-198cace2e31f</Id>
     </Book>
-    <Book Series="New Excalibur" Number="5" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="New Excalibur" Number="5" Volume="2006" Year="2006">
       <Id>3456cffe-b8ac-477f-853b-f047a443978f</Id>
     </Book>
-    <Book Series="New Excalibur" Number="6" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="New Excalibur" Number="6" Volume="2006" Year="2006">
       <Id>42724a90-5969-4890-b416-9be5a2757afd</Id>
     </Book>
-    <Book Series="New Excalibur" Number="7" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="New Excalibur" Number="7" Volume="2006" Year="2006">
       <Id>135dfb02-f769-4b9c-ba6f-4b9a4b9af8f9</Id>
     </Book>
-    <Book Series="New X-Men" Number="24" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="New X-Men" Number="24" Volume="2004" Year="2006">
       <Id>f7059c0f-2c6c-4af0-8d9f-94e39a663aae</Id>
     </Book>
-    <Book Series="New X-Men" Number="25" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="New X-Men" Number="25" Volume="2004" Year="2006">
       <Id>87193059-deac-4b80-93b4-eb0c038e42af</Id>
     </Book>
-    <Book Series="New X-Men" Number="26" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="New X-Men" Number="26" Volume="2004" Year="2006">
       <Id>06328000-0e6c-489c-8ae4-74c79b831728</Id>
     </Book>
-    <Book Series="New X-Men" Number="27" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="New X-Men" Number="27" Volume="2004" Year="2006">
       <Id>1da5cb64-6f2e-4b3a-a9c1-d9d647b93070</Id>
     </Book>
-    <Book Series="Wolverine" Number="36" Volume="2003" Year="2006" Format="Main Series">
+    <Book Series="Wolverine" Number="36" Volume="2003" Year="2006">
       <Id>896bea5c-2ed3-4b4e-b038-080137ca582b</Id>
     </Book>
-    <Book Series="Wolverine" Number="37" Volume="2003" Year="2006" Format="Main Series">
+    <Book Series="Wolverine" Number="37" Volume="2003" Year="2006">
       <Id>92682c09-0b7d-4cd0-ab83-4f059194ea4b</Id>
     </Book>
-    <Book Series="Wolverine" Number="38" Volume="2003" Year="2006" Format="Main Series">
+    <Book Series="Wolverine" Number="38" Volume="2003" Year="2006">
       <Id>0ae634f4-bbd6-4308-9b3e-34fac14107d2</Id>
     </Book>
-    <Book Series="Wolverine" Number="39" Volume="2003" Year="2006" Format="Main Series">
+    <Book Series="Wolverine" Number="39" Volume="2003" Year="2006">
       <Id>38f70d86-2dc0-4a00-858e-65550730bfb6</Id>
     </Book>
-    <Book Series="Wolverine" Number="40" Volume="2003" Year="2006" Format="Main Series">
+    <Book Series="Wolverine" Number="40" Volume="2003" Year="2006">
       <Id>317cf935-6649-47e2-b024-c6c82eb205a0</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="1" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="1" Volume="2006" Year="2006">
       <Id>1fd20722-da14-4d02-b8e6-0122c65b9bd6</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="2" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="2" Volume="2006" Year="2006">
       <Id>efaff90f-5507-4d14-b601-be6ad7afea09</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="3" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="3" Volume="2006" Year="2006">
       <Id>03ce76bb-9c60-4235-859e-ae585e51032a</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="4" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="4" Volume="2006" Year="2006">
       <Id>f6a244dc-7c58-4318-8f5c-010d57103e02</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="5" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="5" Volume="2006" Year="2006">
       <Id>ed4f5ebc-8a95-4a89-87ea-951582c98827</Id>
     </Book>
-    <Book Series="Wolverine" Number="41" Volume="2003" Year="2006" Format="Main Series">
+    <Book Series="Wolverine" Number="41" Volume="2003" Year="2006">
       <Id>4485820b-2111-4d70-8390-642103741d70</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="24" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="24" Volume="2004" Year="2006">
       <Id>8c87523d-8c2a-4f5f-b116-f34f5d2e4493</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="25" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="25" Volume="2004" Year="2006">
       <Id>5eab3d8d-3d33-4114-9007-bb3663e60648</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="26" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="26" Volume="2004" Year="2006">
       <Id>875264c4-f277-4256-a41f-d4a22f9c62f7</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="27" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="27" Volume="2004" Year="2006">
       <Id>80d99c66-0761-4feb-b2eb-4d7a9ce4a6bb</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="469" Volume="1981" Year="2006" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="469" Volume="1981" Year="2006">
       <Id>9fd6e35b-91c2-49c7-88e5-d59ada5819d5</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="470" Volume="1981" Year="2006" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="470" Volume="1981" Year="2006">
       <Id>5c281fdf-b75d-4262-a958-56de04aaed41</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="471" Volume="1981" Year="2006" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="471" Volume="1981" Year="2006">
       <Id>67d78338-1cba-4d32-9699-e2945ebc871d</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="472" Volume="1981" Year="2006" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="472" Volume="1981" Year="2006">
       <Id>61d631d2-993c-4424-bb78-036e2dea73c9</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="473" Volume="1981" Year="2006" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="473" Volume="1981" Year="2006">
       <Id>6ab44203-ba8f-4549-8029-853e66b69f2a</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="474" Volume="1981" Year="2006" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="474" Volume="1981" Year="2006">
       <Id>1f5a017f-ce2d-4f00-b4fe-98f71d66e5cd</Id>
     </Book>
-    <Book Series="X-Men Unlimited" Number="14" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="X-Men Unlimited" Number="14" Volume="2004" Year="2006">
       <Id>ea24bf3b-d554-4606-ad14-2c7dfe04ed3a</Id>
     </Book>
-    <Book Series="Giant-Size Wolverine" Number="1" Volume="2006" Year="2006" Format="Giant Size">
+    <Book Series="Giant-Size Wolverine" Number="1" Volume="2006" Year="2006">
       <Id>21e67476-c838-414c-830f-e824b0c86633</Id>
     </Book>
-    <Book Series="New Excalibur" Number="8" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="New Excalibur" Number="8" Volume="2006" Year="2006">
       <Id>2d408a77-5615-43bc-bd10-5e4009b7130d</Id>
     </Book>
-    <Book Series="New Excalibur" Number="9" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="New Excalibur" Number="9" Volume="2006" Year="2006">
       <Id>cd933bcd-f1b0-41e5-b005-910da17e301e</Id>
     </Book>
-    <Book Series="Uncanny X-Men Annual" Number="1" Volume="2006" Year="2006" Format="Annual">
+    <Book Series="Uncanny X-Men Annual" Number="1" Volume="2006" Year="2006">
       <Id>bfdc739e-2c5f-43a0-a61d-6f8ce58caa64</Id>
     </Book>
-    <Book Series="Storm" Number="1" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="Storm" Number="1" Volume="2006" Year="2006">
       <Id>93477a0e-f3ea-4a0d-9d4e-0597c59fe3ad</Id>
     </Book>
-    <Book Series="Storm" Number="2" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="Storm" Number="2" Volume="2006" Year="2006">
       <Id>a15c6246-9080-45ee-9df0-5b5f5150bf38</Id>
     </Book>
-    <Book Series="Storm" Number="3" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="Storm" Number="3" Volume="2006" Year="2006">
       <Id>60990175-5a68-44bd-a6a2-61356d8b4814</Id>
     </Book>
-    <Book Series="Storm" Number="4" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="Storm" Number="4" Volume="2006" Year="2006">
       <Id>c7e38ae7-4835-43a3-8691-6b0cb5340615</Id>
     </Book>
-    <Book Series="Storm" Number="5" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="Storm" Number="5" Volume="2006" Year="2006">
       <Id>ceffcf46-a74b-443e-91d6-df57494cc446</Id>
     </Book>
-    <Book Series="Storm" Number="6" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="Storm" Number="6" Volume="2006" Year="2006">
       <Id>cd0a5397-dece-43f6-8aa3-965d1d8b9ac9</Id>
     </Book>
-    <Book Series="Black Panther" Number="14" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Black Panther" Number="14" Volume="2005" Year="2006">
       <Id>768dac24-39ee-41ca-b3c9-7ae88edffb23</Id>
     </Book>
-    <Book Series="Black Panther" Number="15" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Black Panther" Number="15" Volume="2005" Year="2006">
       <Id>b7299f2f-1ad5-4d63-ba08-aa8508768b5b</Id>
     </Book>
-    <Book Series="Black Panther" Number="16" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Black Panther" Number="16" Volume="2005" Year="2006">
       <Id>60d7cb62-fa79-424c-8cf0-7c06028bab5e</Id>
     </Book>
-    <Book Series="Black Panther" Number="17" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Black Panther" Number="17" Volume="2005" Year="2006">
       <Id>27245776-966c-4ef5-995b-bb6956d8c706</Id>
     </Book>
-    <Book Series="Black Panther" Number="18" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Black Panther" Number="18" Volume="2005" Year="2006">
       <Id>a424936e-092b-4b61-ad62-e8d0e11929f3</Id>
     </Book>
-    <Book Series="X-Men/Runaways" Number="1" Volume="2006" Year="2006" Format="One-Shot">
+    <Book Series="X-Men/Runaways" Number="1" Volume="2006" Year="2006">
       <Id>0d71d699-bd29-42a3-bca9-9aa3a6e70f51</Id>
     </Book>
-    <Book Series="X-Men" Number="180" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="X-Men" Number="180" Volume="2004" Year="2006">
       <Id>3f2c16bf-e0f0-4fb1-86e9-6da6bd1d6ed8</Id>
     </Book>
-    <Book Series="X-Men" Number="181" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="X-Men" Number="181" Volume="2004" Year="2006">
       <Id>14f78566-69c5-4e52-b23e-8eba4cf4322c</Id>
     </Book>
-    <Book Series="X-Men" Number="182" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="X-Men" Number="182" Volume="2004" Year="2006">
       <Id>1d3b3619-3171-4650-a047-31003e45d405</Id>
     </Book>
-    <Book Series="X-Men" Number="183" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="X-Men" Number="183" Volume="2004" Year="2006">
       <Id>2307374b-3942-4e3a-a1f6-fc371f1c4a2b</Id>
     </Book>
-    <Book Series="X-Men" Number="184" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="X-Men" Number="184" Volume="2004" Year="2006">
       <Id>ab36a6e2-8cbe-4839-a004-b6bfa1320111</Id>
     </Book>
-    <Book Series="X-Men" Number="185" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="X-Men" Number="185" Volume="2004" Year="2006">
       <Id>bed42458-d9d9-4972-a32a-cd39313bb736</Id>
     </Book>
-    <Book Series="X-Men" Number="186" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="X-Men" Number="186" Volume="2004" Year="2006">
       <Id>2dd2c291-ff6b-4967-811c-08938e524ac3</Id>
     </Book>
-    <Book Series="X-Men" Number="187" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="X-Men" Number="187" Volume="2004" Year="2006">
       <Id>8430df96-d245-412e-86a0-ef8eac68e9f9</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="28" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="28" Volume="2004" Year="2006">
       <Id>ee6f1571-905f-4f7f-997b-c4e49a7f2dd1</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="29" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="29" Volume="2004" Year="2006">
       <Id>596505f2-868e-4c4d-9609-941a02d50685</Id>
     </Book>
-    <Book Series="New Excalibur" Number="10" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="New Excalibur" Number="10" Volume="2006" Year="2006">
       <Id>28f3492d-b431-4020-8b8b-b85780cfccff</Id>
     </Book>
-    <Book Series="New Excalibur" Number="11" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="New Excalibur" Number="11" Volume="2006" Year="2006">
       <Id>1735c99b-15a9-4f67-bb52-35e6de7ee264</Id>
     </Book>
-    <Book Series="New Excalibur" Number="12" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="New Excalibur" Number="12" Volume="2006" Year="2006">
       <Id>98952ad7-cc47-4d5e-99c1-67416776e72d</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="6" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="6" Volume="2006" Year="2006">
       <Id>8245387a-5599-4b8a-a690-cfb673f16db0</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="7" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="7" Volume="2006" Year="2006">
       <Id>be9627d1-5c8a-4a7e-b057-ae5b5f067ae9</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="8" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="8" Volume="2006" Year="2007">
       <Id>3cf380d8-50e9-479a-be14-929fd2848609</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="9" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="9" Volume="2006" Year="2007">
       <Id>8c347a79-763c-4c94-b50c-5c652a8bc367</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="10" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="10" Volume="2006" Year="2007">
       <Id>e58d0088-7018-4e22-ad69-24214d5071d0</Id>
     </Book>
-    <Book Series="X-Men: Deadly Genesis" Number="1" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="X-Men: Deadly Genesis" Number="1" Volume="2006" Year="2006">
       <Id>ac340383-ba72-4ea3-9046-94caff8bb3c3</Id>
     </Book>
-    <Book Series="X-Men: Deadly Genesis" Number="2" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="X-Men: Deadly Genesis" Number="2" Volume="2006" Year="2006">
       <Id>fd4a66d6-da74-445a-9db0-6ef123ee140a</Id>
     </Book>
-    <Book Series="X-Men: Deadly Genesis" Number="3" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="X-Men: Deadly Genesis" Number="3" Volume="2006" Year="2006">
       <Id>168fd57d-062a-4a00-bfd6-bed08a5cfbe4</Id>
     </Book>
-    <Book Series="X-Men: Deadly Genesis" Number="4" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="X-Men: Deadly Genesis" Number="4" Volume="2006" Year="2006">
       <Id>fb7e653d-f30a-4445-b512-623b8d98819c</Id>
     </Book>
-    <Book Series="X-Men: Deadly Genesis" Number="5" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="X-Men: Deadly Genesis" Number="5" Volume="2006" Year="2006">
       <Id>4a8752fd-4a47-4871-a0cc-73a9e9c0a1f7</Id>
     </Book>
-    <Book Series="X-Men: Deadly Genesis" Number="6" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="X-Men: Deadly Genesis" Number="6" Volume="2006" Year="2006">
       <Id>2206e887-d7e3-40a3-9e0f-c4f7b51a4dcc</Id>
     </Book>
-    <Book Series="X-Factor" Number="7" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="X-Factor" Number="7" Volume="2006" Year="2006">
       <Id>d37207d3-7c81-4c8d-9684-f1da381f809e</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="475" Volume="1981" Year="2006" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="475" Volume="1981" Year="2006">
       <Id>3b3b647c-3b63-4df0-aa17-14a84b5780b4</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="476" Volume="1981" Year="2006" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="476" Volume="1981" Year="2006">
       <Id>edfd2313-c8da-4e05-9b63-c120e7d23af4</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="477" Volume="1981" Year="2006" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="477" Volume="1981" Year="2006">
       <Id>ceed6b0d-4af6-4281-ad54-2b730c682212</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="478" Volume="1981" Year="2006" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="478" Volume="1981" Year="2006">
       <Id>7829a396-7f3b-433b-8e83-193f8ee1b8a4</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="479" Volume="1981" Year="2006" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="479" Volume="1981" Year="2006">
       <Id>a8558345-6a6f-48c7-b1d3-82c469ee953d</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="480" Volume="1981" Year="2007" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="480" Volume="1981" Year="2007">
       <Id>6ae14c60-a4d5-4d89-80bc-be4a660a08f1</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="481" Volume="1981" Year="2007" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="481" Volume="1981" Year="2007">
       <Id>ba840893-3f1c-453f-88fe-e78bd49aa94e</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="482" Volume="1981" Year="2007" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="482" Volume="1981" Year="2007">
       <Id>4663e8a8-eeed-4d89-992e-9b362abd0e01</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="483" Volume="1981" Year="2007" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="483" Volume="1981" Year="2007">
       <Id>18340ea3-f5b8-415e-920a-57bbb841a851</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="484" Volume="1981" Year="2007" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="484" Volume="1981" Year="2007">
       <Id>b90a3caa-c748-423b-ad5c-fd3e14e47c42</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="485" Volume="1981" Year="2007" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="485" Volume="1981" Year="2007">
       <Id>6cdb07f6-c44b-4ed3-9c4f-f838f3e331db</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="486" Volume="1981" Year="2007" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="486" Volume="1981" Year="2007">
       <Id>ee963828-48cf-4940-b33f-3b471fee5db3</Id>
     </Book>
-    <Book Series="X-Men" Number="188" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="X-Men" Number="188" Volume="2004" Year="2006">
       <Id>2aef0c77-3052-43af-87b6-407f66ba971c</Id>
     </Book>
-    <Book Series="X-Men" Number="189" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="X-Men" Number="189" Volume="2004" Year="2006">
       <Id>bda64379-7761-44b4-87a2-55d75b156237</Id>
     </Book>
-    <Book Series="X-Men" Number="190" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="X-Men" Number="190" Volume="2004" Year="2006">
       <Id>c5567395-b87b-4682-819e-5f1b88538123</Id>
     </Book>
-    <Book Series="X-Men" Number="191" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="X-Men" Number="191" Volume="2004" Year="2006">
       <Id>5e6f7473-4779-4906-a454-123da19b7b94</Id>
     </Book>
-    <Book Series="X-Men" Number="192" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="X-Men" Number="192" Volume="2004" Year="2006">
       <Id>9e4fa307-da53-4928-9cd0-382e713f6f9f</Id>
     </Book>
-    <Book Series="X-Men" Number="193" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="X-Men" Number="193" Volume="2004" Year="2007">
       <Id>e79504e0-6fe1-4e61-8edf-2e75b9cea497</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="11" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="11" Volume="2006" Year="2007">
       <Id>bba6c0b7-4dd5-4616-ba21-deff04c857f7</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="12" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="12" Volume="2006" Year="2007">
       <Id>8356064e-bd47-45f6-8ed6-bc9374df42fd</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="13" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="13" Volume="2006" Year="2007">
       <Id>9a5f2afd-b781-404c-bce6-8d144d1cc29d</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="14" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="14" Volume="2006" Year="2007">
       <Id>d70474e1-7f5b-4bce-a058-ceea786368af</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="15" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="15" Volume="2006" Year="2007">
       <Id>d7c61e85-f2ef-459c-b0c6-0fb126f3b2ae</Id>
     </Book>
-    <Book Series="X-23: Target X" Number="1" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="X-23: Target X" Number="1" Volume="2007" Year="2007">
       <Id>5471e89c-d81c-45e6-be82-ec37d08004b9</Id>
     </Book>
-    <Book Series="X-23: Target X" Number="2" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="X-23: Target X" Number="2" Volume="2007" Year="2007">
       <Id>74f18dd6-c356-423b-8aa1-da3021b48324</Id>
     </Book>
-    <Book Series="X-23: Target X" Number="3" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="X-23: Target X" Number="3" Volume="2007" Year="2007">
       <Id>a6f8ca54-8467-4d7a-9f96-ef21d30909af</Id>
     </Book>
-    <Book Series="X-23: Target X" Number="4" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="X-23: Target X" Number="4" Volume="2007" Year="2007">
       <Id>609cf7f3-d199-45a3-856b-d309058f75cf</Id>
     </Book>
-    <Book Series="X-23: Target X" Number="5" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="X-23: Target X" Number="5" Volume="2007" Year="2007">
       <Id>1921a476-9283-478e-9779-30fe6b9cae20</Id>
     </Book>
-    <Book Series="X-23: Target X" Number="6" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="X-23: Target X" Number="6" Volume="2007" Year="2007">
       <Id>98be6e1f-fe07-497f-8903-8e484018fafb</Id>
     </Book>
-    <Book Series="Civil War" Number="1" Volume="2006" Year="2006" Format="Crossover">
+    <Book Series="Civil War" Number="1" Volume="2006" Year="2006">
       <Id>8a3b618d-9877-4c00-8d7f-48d65f4599dd</Id>
     </Book>
-    <Book Series="X-Factor" Number="8" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="X-Factor" Number="8" Volume="2006" Year="2006">
       <Id>76929c57-1563-4510-b4fd-63afd9125b82</Id>
     </Book>
-    <Book Series="Civil War" Number="2" Volume="2006" Year="2006" Format="Crossover">
+    <Book Series="Civil War" Number="2" Volume="2006" Year="2006">
       <Id>346dc7b4-7523-40ae-8fab-1df067deffd5</Id>
     </Book>
-    <Book Series="Civil War" Number="3" Volume="2006" Year="2006" Format="Crossover">
+    <Book Series="Civil War" Number="3" Volume="2006" Year="2006">
       <Id>7bbd5df4-e746-40d8-9ad1-b135c26c0c20</Id>
     </Book>
-    <Book Series="X-Factor" Number="9" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="X-Factor" Number="9" Volume="2006" Year="2006">
       <Id>2154a329-c011-423e-8204-772143108d0f</Id>
     </Book>
-    <Book Series="Civil War: X-Men" Number="1" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="Civil War: X-Men" Number="1" Volume="2006" Year="2006">
       <Id>5461de90-321f-4a50-a671-363c65f718cd</Id>
     </Book>
-    <Book Series="Civil War: X-Men" Number="2" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="Civil War: X-Men" Number="2" Volume="2006" Year="2006">
       <Id>6968c5bb-96a0-4d98-9883-e64c0ea8aae3</Id>
     </Book>
-    <Book Series="Civil War: X-Men" Number="3" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="Civil War: X-Men" Number="3" Volume="2006" Year="2006">
       <Id>859c1dba-6224-4f80-8e75-922afbff8fd3</Id>
     </Book>
-    <Book Series="Civil War: X-Men" Number="4" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="Civil War: X-Men" Number="4" Volume="2006" Year="2006">
       <Id>007ad541-5fd0-4c3e-9468-001edb51814e</Id>
     </Book>
-    <Book Series="Wolverine" Number="42" Volume="2003" Year="2006" Format="Main Series">
+    <Book Series="Wolverine" Number="42" Volume="2003" Year="2006">
       <Id>2b4f4ded-e9c6-4ca5-8fcf-b9765a7a763a</Id>
     </Book>
-    <Book Series="Wolverine" Number="43" Volume="2003" Year="2006" Format="Main Series">
+    <Book Series="Wolverine" Number="43" Volume="2003" Year="2006">
       <Id>6d97c452-f85c-450d-8911-455dec336ffe</Id>
     </Book>
-    <Book Series="Wolverine" Number="44" Volume="2003" Year="2006" Format="Main Series">
+    <Book Series="Wolverine" Number="44" Volume="2003" Year="2006">
       <Id>5cace29f-1810-48b6-b6ef-92232f3e3625</Id>
     </Book>
-    <Book Series="Wolverine" Number="45" Volume="2003" Year="2006" Format="Main Series">
+    <Book Series="Wolverine" Number="45" Volume="2003" Year="2006">
       <Id>59a38eaa-379d-43f9-aebb-74722ebaa11e</Id>
     </Book>
-    <Book Series="Wolverine" Number="46" Volume="2003" Year="2006" Format="Main Series">
+    <Book Series="Wolverine" Number="46" Volume="2003" Year="2006">
       <Id>c8874657-93c5-43aa-8521-f9a89b13fa4d</Id>
     </Book>
-    <Book Series="Wolverine" Number="47" Volume="2003" Year="2006" Format="Main Series">
+    <Book Series="Wolverine" Number="47" Volume="2003" Year="2006">
       <Id>7222ab98-b0a1-45dd-981f-9ceaf3d9ccd0</Id>
     </Book>
-    <Book Series="Wolverine" Number="48" Volume="2003" Year="2007" Format="Main Series">
+    <Book Series="Wolverine" Number="48" Volume="2003" Year="2007">
       <Id>c48eb10b-9a69-4e3a-9060-771a582c040f</Id>
     </Book>
-    <Book Series="X-Factor" Number="10" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="X-Factor" Number="10" Volume="2006" Year="2006">
       <Id>91c8ccb4-e614-4a7f-849c-7cbe284c5c7e</Id>
     </Book>
-    <Book Series="X-Factor" Number="11" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="X-Factor" Number="11" Volume="2006" Year="2006">
       <Id>563cadee-4b2b-4f16-a835-de4808ac0ed9</Id>
     </Book>
-    <Book Series="X-Factor" Number="12" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="X-Factor" Number="12" Volume="2006" Year="2006">
       <Id>fe81727c-699d-4e8e-8289-d57aea474055</Id>
     </Book>
-    <Book Series="Civil War" Number="5" Volume="2006" Year="2006" Format="Crossover">
+    <Book Series="Civil War" Number="5" Volume="2006" Year="2006">
       <Id>52958b4a-aa5d-4429-b844-9ca8c0ba5b02</Id>
     </Book>
-    <Book Series="Civil War" Number="6" Volume="2006" Year="2006" Format="Crossover">
+    <Book Series="Civil War" Number="6" Volume="2006" Year="2006">
       <Id>72de0c39-09f3-43a0-93dd-5d35d3c409c5</Id>
     </Book>
-    <Book Series="Civil War" Number="7" Volume="2006" Year="2007" Format="Crossover">
+    <Book Series="Civil War" Number="7" Volume="2006" Year="2007">
       <Id>88a586c8-129f-4c95-af85-aeff87628b25</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="30" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="30" Volume="2004" Year="2006">
       <Id>87748633-fe0d-4584-bf9d-af615366f9d0</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="31" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="31" Volume="2004" Year="2006">
       <Id>f79fa9b2-06c0-48b6-ba45-44b4b88c0634</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="32" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="32" Volume="2004" Year="2006">
       <Id>de3e840d-c21d-4ca3-9ded-7cf4a379328d</Id>
     </Book>
-    <Book Series="New X-Men" Number="28" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="New X-Men" Number="28" Volume="2004" Year="2006">
       <Id>27b2d390-0621-45ac-bf00-7c56e052ae1d</Id>
     </Book>
-    <Book Series="New X-Men" Number="29" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="New X-Men" Number="29" Volume="2004" Year="2006">
       <Id>08761945-1ece-46ca-8905-d59eef3df754</Id>
     </Book>
-    <Book Series="New X-Men" Number="30" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="New X-Men" Number="30" Volume="2004" Year="2006">
       <Id>f28b0062-cf7d-4010-943a-f400bd474fbe</Id>
     </Book>
-    <Book Series="New X-Men" Number="31" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="New X-Men" Number="31" Volume="2004" Year="2006">
       <Id>49a1467b-ef03-4faf-b109-4e8ee3eabb36</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="33" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="33" Volume="2004" Year="2006">
       <Id>a944b570-2df6-4118-84e3-56ecf5a6b5d5</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="34" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="34" Volume="2004" Year="2007">
       <Id>7db3126d-87b0-40a3-bf43-4519816292c9</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="35" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="35" Volume="2004" Year="2007">
       <Id>b0b93b6f-b487-424b-8956-e811cc0a28d8</Id>
     </Book>
-    <Book Series="New X-Men" Number="32" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="New X-Men" Number="32" Volume="2004" Year="2007">
       <Id>fa551843-6da4-4abd-a880-02126a59e16e</Id>
     </Book>
-    <Book Series="Wolverine" Number="49" Volume="2003" Year="2007" Format="Main Series">
+    <Book Series="Wolverine" Number="49" Volume="2003" Year="2007">
       <Id>ac2a8335-b58e-4b9b-a37a-0200c7e59edc</Id>
     </Book>
-    <Book Series="X-Factor" Number="13" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="X-Factor" Number="13" Volume="2006" Year="2007">
       <Id>0005ab35-71cc-430c-8281-1ffd31737597</Id>
     </Book>
-    <Book Series="New Excalibur" Number="13" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="New Excalibur" Number="13" Volume="2006" Year="2007">
       <Id>5a82b704-13df-4511-a68d-72e599fa3b59</Id>
     </Book>
-    <Book Series="New Excalibur" Number="14" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="New Excalibur" Number="14" Volume="2006" Year="2007">
       <Id>c9a104ec-99f8-426e-986d-0abe95eafc69</Id>
     </Book>
-    <Book Series="New Excalibur" Number="15" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="New Excalibur" Number="15" Volume="2006" Year="2007">
       <Id>d1ebebab-a7ee-43a8-a691-2997d9010dc1</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="36" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="36" Volume="2004" Year="2007">
       <Id>f71fe61c-173f-40a1-bd6f-ee90e7ac8fb6</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="37" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="37" Volume="2004" Year="2007">
       <Id>6afda3e1-2460-4d3a-96e5-cd40f2ea1aee</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="38" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="38" Volume="2004" Year="2007">
       <Id>ebdfd1e0-6faf-48a5-a783-2ab89db3da07</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="39" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="39" Volume="2004" Year="2007">
       <Id>d27a1fb4-e987-4169-9a2d-3326efd001d1</Id>
     </Book>
-    <Book Series="X-Men: Phoenix Warsong" Number="1" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="X-Men: Phoenix Warsong" Number="1" Volume="2006" Year="2006">
       <Id>63158282-af60-421a-9719-5a8bc2817e05</Id>
     </Book>
-    <Book Series="X-Men: Phoenix Warsong" Number="2" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="X-Men: Phoenix Warsong" Number="2" Volume="2006" Year="2006">
       <Id>c3d42c09-5302-40cd-8a19-5ce7642cbd42</Id>
     </Book>
-    <Book Series="X-Men: Phoenix Warsong" Number="3" Volume="2006" Year="2007" Format="Limited Series">
+    <Book Series="X-Men: Phoenix Warsong" Number="3" Volume="2006" Year="2007">
       <Id>7a531af7-826d-408f-8cd2-6c3d05df8794</Id>
     </Book>
-    <Book Series="X-Men: Phoenix Warsong" Number="4" Volume="2006" Year="2007" Format="Limited Series">
+    <Book Series="X-Men: Phoenix Warsong" Number="4" Volume="2006" Year="2007">
       <Id>e833e113-c1b8-4413-bfca-af4b531e9413</Id>
     </Book>
-    <Book Series="X-Men: Phoenix Warsong" Number="5" Volume="2006" Year="2007" Format="Limited Series">
+    <Book Series="X-Men: Phoenix Warsong" Number="5" Volume="2006" Year="2007">
       <Id>8f90b086-9054-45a1-af28-e692dc25be66</Id>
     </Book>
-    <Book Series="New X-Men" Number="33" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="New X-Men" Number="33" Volume="2004" Year="2007">
       <Id>5307005b-1e41-430d-8f4b-9b2199b17406</Id>
     </Book>
-    <Book Series="New X-Men" Number="34" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="New X-Men" Number="34" Volume="2004" Year="2007">
       <Id>317fa0c3-5ee9-422b-ac36-c77928610331</Id>
     </Book>
-    <Book Series="New X-Men" Number="35" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="New X-Men" Number="35" Volume="2004" Year="2007">
       <Id>fe597497-cc1f-4f85-8f7d-f9062400a3be</Id>
     </Book>
-    <Book Series="New X-Men" Number="36" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="New X-Men" Number="36" Volume="2004" Year="2007">
       <Id>4f63047a-d3c4-4d8c-9edc-986038d5b15e</Id>
     </Book>
-    <Book Series="New Excalibur" Number="16" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="New Excalibur" Number="16" Volume="2006" Year="2007">
       <Id>2b29565b-f05e-40fa-846c-9a2fe9f852a0</Id>
     </Book>
-    <Book Series="New Excalibur" Number="17" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="New Excalibur" Number="17" Volume="2006" Year="2007">
       <Id>cea463a0-f1dc-41e8-a533-a64dba625051</Id>
     </Book>
-    <Book Series="X-Factor" Number="14" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="X-Factor" Number="14" Volume="2006" Year="2007">
       <Id>b1310470-0670-4909-b93d-21d84cfb6f0b</Id>
     </Book>
-    <Book Series="X-Factor" Number="15" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="X-Factor" Number="15" Volume="2006" Year="2007">
       <Id>4f954017-d077-4962-bc33-8644225524bf</Id>
     </Book>
-    <Book Series="X-Factor" Number="16" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="X-Factor" Number="16" Volume="2006" Year="2007">
       <Id>bcf5fe2f-3b1d-43c1-9bef-5ae3a33c4b4b</Id>
     </Book>
-    <Book Series="X-Factor" Number="17" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="X-Factor" Number="17" Volume="2006" Year="2007">
       <Id>3d19d770-bf32-45e3-83f1-ea1e5776bc76</Id>
     </Book>
-    <Book Series="New X-Men" Number="37" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="New X-Men" Number="37" Volume="2004" Year="2007">
       <Id>314ae6d6-b177-4d66-ad2d-615babbdf7f1</Id>
     </Book>
-    <Book Series="New X-Men" Number="38" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="New X-Men" Number="38" Volume="2004" Year="2007">
       <Id>544adb84-aa1e-465b-ae3b-8e7b523c1b06</Id>
     </Book>
-    <Book Series="New X-Men" Number="39" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="New X-Men" Number="39" Volume="2004" Year="2007">
       <Id>f0843720-9ac1-4722-b78b-f8f1efaabf7e</Id>
     </Book>
-    <Book Series="New X-Men" Number="40" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="New X-Men" Number="40" Volume="2004" Year="2007">
       <Id>987f8b84-e692-488b-bcb0-63cb409f1222</Id>
     </Book>
-    <Book Series="New X-Men" Number="41" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="New X-Men" Number="41" Volume="2004" Year="2007">
       <Id>c4d8ec62-6585-4620-b481-beb80a35ed91</Id>
     </Book>
-    <Book Series="X-Factor" Number="18" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="X-Factor" Number="18" Volume="2006" Year="2007">
       <Id>f8b7953d-cdc7-4395-a7f5-2d15e2a0b9a6</Id>
     </Book>
-    <Book Series="X-Factor" Number="19" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="X-Factor" Number="19" Volume="2006" Year="2007">
       <Id>00e7d36f-812b-4274-a0b9-a0f0b59fb5fc</Id>
     </Book>
-    <Book Series="X-Factor" Number="20" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="X-Factor" Number="20" Volume="2006" Year="2007">
       <Id>5766e34b-4392-4ab2-8942-18d59df4c237</Id>
     </Book>
-    <Book Series="Wolverine" Number="50" Volume="2003" Year="2007" Format="Main Series">
+    <Book Series="Wolverine" Number="50" Volume="2003" Year="2007">
       <Id>dd1279de-d277-4dae-98f3-653614084e0b</Id>
     </Book>
-    <Book Series="Wolverine" Number="51" Volume="2003" Year="2007" Format="Main Series">
+    <Book Series="Wolverine" Number="51" Volume="2003" Year="2007">
       <Id>910b9f76-1c77-449c-8fea-1d2d0ea0f72c</Id>
     </Book>
-    <Book Series="Wolverine" Number="52" Volume="2003" Year="2007" Format="Main Series">
+    <Book Series="Wolverine" Number="52" Volume="2003" Year="2007">
       <Id>1c6dd9a6-33cb-45ac-94db-42ace7307e0f</Id>
     </Book>
-    <Book Series="Wolverine" Number="53" Volume="2003" Year="2007" Format="Main Series">
+    <Book Series="Wolverine" Number="53" Volume="2003" Year="2007">
       <Id>5caada23-094e-4c1a-bed9-2cc33fd537ad</Id>
     </Book>
-    <Book Series="Wolverine" Number="54" Volume="2003" Year="2007" Format="Main Series">
+    <Book Series="Wolverine" Number="54" Volume="2003" Year="2007">
       <Id>4c8376b6-f958-47e1-a13c-8b4a1e76efa3</Id>
     </Book>
-    <Book Series="Wolverine" Number="55" Volume="2003" Year="2007" Format="Main Series">
+    <Book Series="Wolverine" Number="55" Volume="2003" Year="2007">
       <Id>022bf787-88e2-4a59-a885-333899bf664b</Id>
     </Book>
-    <Book Series="Wolverine Annual" Number="1" Volume="2007" Year="2007" Format="Annual">
+    <Book Series="Wolverine Annual" Number="1" Volume="2007" Year="2007">
       <Id>d0f576cd-236c-4a29-9d52-097e87184ac9</Id>
     </Book>
-    <Book Series="Wolverine Origins Annual" Number="1" Volume="2007" Year="2007" Format="Annual">
+    <Book Series="Wolverine Origins Annual" Number="1" Volume="2007" Year="2007">
       <Id>34529947-38f0-4947-bd16-883d25abae15</Id>
     </Book>
-    <Book Series="Wolverine" Number="56" Volume="2003" Year="2007" Format="Main Series">
+    <Book Series="Wolverine" Number="56" Volume="2003" Year="2007">
       <Id>9bcc8055-49e9-4b10-8c10-e5edcd6badc1</Id>
     </Book>
-    <Book Series="World War Hulk: X-Men" Number="1" Volume="2007" Year="2007" Format="Crossover">
+    <Book Series="World War Hulk: X-Men" Number="1" Volume="2007" Year="2007">
       <Id>b94d41f6-4ecd-42a8-87ca-818684ed49a3</Id>
     </Book>
-    <Book Series="World War Hulk: X-Men" Number="2" Volume="2007" Year="2007" Format="Crossover">
+    <Book Series="World War Hulk: X-Men" Number="2" Volume="2007" Year="2007">
       <Id>f4ec563b-aed7-4343-a58b-653424703ddf</Id>
     </Book>
-    <Book Series="World War Hulk: X-Men" Number="3" Volume="2007" Year="2007" Format="Crossover">
+    <Book Series="World War Hulk: X-Men" Number="3" Volume="2007" Year="2007">
       <Id>efe752bb-f6e7-489e-be14-7c5e1ae6ae71</Id>
     </Book>
-    <Book Series="New Excalibur" Number="18" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="New Excalibur" Number="18" Volume="2006" Year="2007">
       <Id>df51d125-df3f-41a9-96ed-0835b186e28f</Id>
     </Book>
-    <Book Series="New Excalibur" Number="19" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="New Excalibur" Number="19" Volume="2006" Year="2007">
       <Id>8e675a6c-db36-4b3b-a3f3-a3e4a9f91516</Id>
     </Book>
-    <Book Series="New Excalibur" Number="20" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="New Excalibur" Number="20" Volume="2006" Year="2007">
       <Id>6603e668-1798-4bc4-b691-f02390189fbe</Id>
     </Book>
-    <Book Series="New Excalibur" Number="21" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="New Excalibur" Number="21" Volume="2006" Year="2007">
       <Id>2208946b-493f-4ee0-bb7d-b7c9d759b1f6</Id>
     </Book>
-    <Book Series="New Excalibur" Number="22" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="New Excalibur" Number="22" Volume="2006" Year="2007">
       <Id>d2de50ad-4a7d-41eb-91e2-74fac90efe08</Id>
     </Book>
-    <Book Series="New Excalibur" Number="23" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="New Excalibur" Number="23" Volume="2006" Year="2007">
       <Id>03a06699-9311-4883-989e-9951d3c04186</Id>
     </Book>
-    <Book Series="New Excalibur" Number="24" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="New Excalibur" Number="24" Volume="2006" Year="2007">
       <Id>75bb6d1e-ba62-43ad-bb04-477b7f1d2f01</Id>
     </Book>
-    <Book Series="X-Men: Die by the Sword" Number="1" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="X-Men: Die by the Sword" Number="1" Volume="2007" Year="2007">
       <Id>a00e23bc-d45b-436f-9307-4666500579f9</Id>
     </Book>
-    <Book Series="X-Men: Die by the Sword" Number="2" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="X-Men: Die by the Sword" Number="2" Volume="2007" Year="2007">
       <Id>1d3b4a04-3281-43fa-84aa-26685a3e02c1</Id>
     </Book>
-    <Book Series="X-Men: Die by the Sword" Number="3" Volume="2007" Year="2008" Format="Limited Series">
+    <Book Series="X-Men: Die by the Sword" Number="3" Volume="2007" Year="2008">
       <Id>5ff18c50-be0d-45d1-99e1-32b5278f6808</Id>
     </Book>
-    <Book Series="X-Men: Die by the Sword" Number="4" Volume="2007" Year="2008" Format="Limited Series">
+    <Book Series="X-Men: Die by the Sword" Number="4" Volume="2007" Year="2008">
       <Id>356f5591-227a-4887-958d-d937f542e178</Id>
     </Book>
-    <Book Series="X-Men: Die by the Sword" Number="5" Volume="2007" Year="2008" Format="Limited Series">
+    <Book Series="X-Men: Die by the Sword" Number="5" Volume="2007" Year="2008">
       <Id>b1ea65dd-8679-4eed-8067-8464aa958fb6</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="16" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="16" Volume="2006" Year="2007">
       <Id>7abb27c9-c20a-4ed3-92d9-ddcd1a3ce9b7</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="17" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="17" Volume="2006" Year="2007">
       <Id>2ffd34ec-95eb-41b6-aae0-ea3397bd685a</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="18" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="18" Volume="2006" Year="2007">
       <Id>5fa172c9-6954-4155-bf9e-7b4d1f26e910</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="19" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="19" Volume="2006" Year="2008">
       <Id>88165cdf-38d8-4e4e-a8c4-72b2673880c9</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="20" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="20" Volume="2006" Year="2008">
       <Id>6f16211d-5851-4ac2-a67a-5fd194539da4</Id>
     </Book>
-    <Book Series="Wolverine" Number="57" Volume="2003" Year="2007" Format="Main Series">
+    <Book Series="Wolverine" Number="57" Volume="2003" Year="2007">
       <Id>fdeac2eb-1e17-4684-9717-59dfa74f5978</Id>
     </Book>
-    <Book Series="Wolverine" Number="58" Volume="2003" Year="2007" Format="Main Series">
+    <Book Series="Wolverine" Number="58" Volume="2003" Year="2007">
       <Id>8beba2ff-5259-43bb-a71f-54e84e05ce12</Id>
     </Book>
-    <Book Series="Wolverine" Number="59" Volume="2003" Year="2008" Format="Main Series">
+    <Book Series="Wolverine" Number="59" Volume="2003" Year="2008">
       <Id>b5f21119-45ff-4242-bafd-c5a7cc7a91ac</Id>
     </Book>
-    <Book Series="Wolverine" Number="60" Volume="2003" Year="2008" Format="Main Series">
+    <Book Series="Wolverine" Number="60" Volume="2003" Year="2008">
       <Id>b76e05b0-5707-496d-8270-7629eec9ccf6</Id>
     </Book>
-    <Book Series="Wolverine" Number="61" Volume="2003" Year="2008" Format="Main Series">
+    <Book Series="Wolverine" Number="61" Volume="2003" Year="2008">
       <Id>b3a8f359-3fe7-4bb0-9aa9-d9b7ca554b08</Id>
     </Book>
-    <Book Series="X-Men: Emperor Vulcan" Number="1" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="X-Men: Emperor Vulcan" Number="1" Volume="2007" Year="2007">
       <Id>0d8ddf2a-6bdc-4ecd-a359-3d36b3cac3f7</Id>
     </Book>
-    <Book Series="X-Men: Emperor Vulcan" Number="2" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="X-Men: Emperor Vulcan" Number="2" Volume="2007" Year="2007">
       <Id>00a56afd-949a-4db8-896f-b4acdc7231a8</Id>
     </Book>
-    <Book Series="X-Men: Emperor Vulcan" Number="3" Volume="2007" Year="2008" Format="Limited Series">
+    <Book Series="X-Men: Emperor Vulcan" Number="3" Volume="2007" Year="2008">
       <Id>10208d6a-f371-45f9-b964-bfc2b03766f0</Id>
     </Book>
-    <Book Series="X-Men: Emperor Vulcan" Number="4" Volume="2007" Year="2008" Format="Limited Series">
+    <Book Series="X-Men: Emperor Vulcan" Number="4" Volume="2007" Year="2008">
       <Id>92db3e11-58aa-4221-9204-b851039eb249</Id>
     </Book>
-    <Book Series="X-Men: Emperor Vulcan" Number="5" Volume="2007" Year="2008" Format="Limited Series">
+    <Book Series="X-Men: Emperor Vulcan" Number="5" Volume="2007" Year="2008">
       <Id>6169bc54-8a19-4ed3-8319-6e9fb6b8aab8</Id>
     </Book>
-    <Book Series="Mystic Arcana: The Book of Marvel Magic" Number="1" Volume="2007" Year="2007" Format="One-Shot">
+    <Book Series="Mystic Arcana: The Book of Marvel Magic" Number="1" Volume="2007" Year="2007">
       <Id>00401a40-6fea-46a2-8141-4dbc7428f6a8</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="13" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="13" Volume="2004" Year="2006">
       <Id>9cf07082-2ca4-4e8d-b370-e2106a920b9d</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="14" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="14" Volume="2004" Year="2006">
       <Id>56b7f1fe-5188-4aee-a4b5-a9a9e55f3cc1</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="15" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="15" Volume="2004" Year="2006">
       <Id>4c85bb6e-adb7-40c5-b69b-094362f9482f</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="16" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="16" Volume="2004" Year="2006">
       <Id>59e36ca0-22d8-4852-a8eb-e7965e5ce275</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="17" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="17" Volume="2004" Year="2006">
       <Id>a68984dc-8bc8-482a-9fb2-41c5e6d68b08</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="18" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="18" Volume="2004" Year="2006">
       <Id>7b9a2517-3223-43a8-a69d-42d54d51b2e1</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="19" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="19" Volume="2004" Year="2007">
       <Id>9695f5ba-8fe0-4f71-add7-e90982cd0f7e</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="20" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="20" Volume="2004" Year="2007">
       <Id>83815834-0f0b-4d08-8b96-d82c7f6dfbda</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="21" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="21" Volume="2004" Year="2007">
       <Id>a53ce6b6-844b-4b0b-8e04-25aed028b50d</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="22" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="22" Volume="2004" Year="2007">
       <Id>1c4e2ea0-f24a-4677-bd0e-f23ef20d764d</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="23" Volume="2004" Year="2008" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="23" Volume="2004" Year="2008">
       <Id>6c35695a-9342-4703-8017-d07ffb21012d</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="24" Volume="2004" Year="2008" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="24" Volume="2004" Year="2008">
       <Id>b2e01c1c-79e8-4875-b27e-6054af6d7384</Id>
     </Book>
-    <Book Series="Giant-Size Astonishing X-Men" Number="1" Volume="2008" Year="2008" Format="Giant Size">
+    <Book Series="Giant-Size Astonishing X-Men" Number="1" Volume="2008" Year="2008">
       <Id>0e85ba17-5524-4c69-9bcf-58b662cec89e</Id>
     </Book>
-    <Book Series="X-Men Annual" Number="1" Volume="2007" Year="2007" Format="Annual">
+    <Book Series="X-Men Annual" Number="1" Volume="2007" Year="2007">
       <Id>8b6e4f28-ff17-4cfa-b745-a367e65e9921</Id>
     </Book>
-    <Book Series="X-Men" Number="194" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="X-Men" Number="194" Volume="2004" Year="2007">
       <Id>c79bbb58-6530-466b-9753-403e6afe42c1</Id>
     </Book>
-    <Book Series="X-Men" Number="195" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="X-Men" Number="195" Volume="2004" Year="2007">
       <Id>6137cb12-3547-48fb-bfc1-7fcd09fcd068</Id>
     </Book>
-    <Book Series="X-Men" Number="196" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="X-Men" Number="196" Volume="2004" Year="2007">
       <Id>28f3ab70-72ff-434e-bb71-35e39f0288a1</Id>
     </Book>
-    <Book Series="X-Men" Number="197" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="X-Men" Number="197" Volume="2004" Year="2007">
       <Id>81a70041-d8fe-4dd6-91f7-30085f1a9c38</Id>
     </Book>
-    <Book Series="X-Men" Number="198" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="X-Men" Number="198" Volume="2004" Year="2007">
       <Id>b4149f76-8484-4385-9c46-89aedf19a08d</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="40" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="40" Volume="2004" Year="2007">
       <Id>d89e03c5-e547-4b28-8831-771bfc307466</Id>
     </Book>
-    <Book Series="X-Men" Number="199" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="X-Men" Number="199" Volume="2004" Year="2007">
       <Id>d57d6565-5106-47ec-8dee-aaa069cf3fc4</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="41" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="41" Volume="2004" Year="2007">
       <Id>f46c3dc9-e8a6-4a23-9aa4-58a7c85b0f7b</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="42" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="42" Volume="2004" Year="2007">
       <Id>511cbfca-8230-40e6-aa37-8500f8f9abb5</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="43" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="43" Volume="2004" Year="2007">
       <Id>0f3beaa7-8712-4a8c-ac4e-f7581bff2ead</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="44" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="44" Volume="2004" Year="2007">
       <Id>69c6a501-e1d0-4364-9d06-6e396a7b6dcf</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="45" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="45" Volume="2004" Year="2007">
       <Id>918748b1-9764-4baa-acc4-b3ed79a06518</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="46" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="46" Volume="2004" Year="2007">
       <Id>fd8a4a2f-11a4-4339-bbe9-13ab53df1378</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="47" Volume="2004" Year="2008" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="47" Volume="2004" Year="2008">
       <Id>81f39687-57e7-4434-98e6-b0833402dfee</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="48" Volume="2004" Year="2008" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="48" Volume="2004" Year="2008">
       <Id>bb41deaa-3273-48a0-a332-e18481b4b598</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="49" Volume="2004" Year="2008" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="49" Volume="2004" Year="2008">
       <Id>76541937-f720-4b7f-b79b-c79ac71ee2c1</Id>
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="50" Volume="2004" Year="2008" Format="Main Series">
+    <Book Series="Cable &amp; Deadpool" Number="50" Volume="2004" Year="2008">
       <Id>c15f877d-e155-49e1-83f1-3e6ac8d7c71e</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="487" Volume="1981" Year="2007" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="487" Volume="1981" Year="2007">
       <Id>1eae77a5-0d9c-4b41-96d3-0aef5aaca5ed</Id>
     </Book>
-    <Book Series="X-Men: Endangered Species" Number="1" Volume="2008" Year="2008" Format="One-Shot">
+    <Book Series="X-Men: Endangered Species" Number="1" Volume="2008" Year="2008">
       <Id>adbb9905-c49c-4c20-8175-ec27b454c1e6</Id>
     </Book>
-    <Book Series="X-Men" Number="200" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="X-Men" Number="200" Volume="2004" Year="2007">
       <Id>6aec9746-c158-46f8-b525-aade1ec5da63</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="488" Volume="1981" Year="2007" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="488" Volume="1981" Year="2007">
       <Id>53949ca2-0a75-452e-b309-058abbe64a7c</Id>
     </Book>
-    <Book Series="X-Factor" Number="21" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="X-Factor" Number="21" Volume="2006" Year="2007">
       <Id>87599796-cd12-470b-a20c-826c285527b5</Id>
     </Book>
-    <Book Series="X-Men" Number="201" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="X-Men" Number="201" Volume="2004" Year="2007">
       <Id>07c6216c-0866-4cee-9975-abf2081c4edc</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="489" Volume="1981" Year="2007" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="489" Volume="1981" Year="2007">
       <Id>c0669b7b-3548-4c97-b04f-3e4c0b808fed</Id>
     </Book>
-    <Book Series="X-Factor" Number="22" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="X-Factor" Number="22" Volume="2006" Year="2007">
       <Id>cb856922-3ffa-4be0-966b-e592b8e70073</Id>
     </Book>
-    <Book Series="X-Men" Number="202" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="X-Men" Number="202" Volume="2004" Year="2007">
       <Id>cc4a4163-3264-47a7-9475-3b333caf2b49</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="490" Volume="1981" Year="2007" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="490" Volume="1981" Year="2007">
       <Id>40e7e80e-6dd6-4b71-8be5-010993479ba1</Id>
     </Book>
-    <Book Series="X-Factor" Number="23" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="X-Factor" Number="23" Volume="2006" Year="2007">
       <Id>28c20955-d430-4cef-a541-9079bbe6a567</Id>
     </Book>
-    <Book Series="New X-Men" Number="42" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="New X-Men" Number="42" Volume="2004" Year="2007">
       <Id>a412bcf4-c0f3-483f-93fd-c8ddddc959fd</Id>
     </Book>
-    <Book Series="X-Men" Number="203" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="X-Men" Number="203" Volume="2004" Year="2007">
       <Id>3cb1f220-3eb5-4fb6-8945-b30ec8af426b</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="491" Volume="1981" Year="2007" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="491" Volume="1981" Year="2007">
       <Id>4144c2aa-760a-4f40-bdfb-755a629c4589</Id>
     </Book>
-    <Book Series="X-Factor" Number="24" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="X-Factor" Number="24" Volume="2006" Year="2007">
       <Id>99de5e84-2985-4f72-b2ef-b484eff6df56</Id>
     </Book>
-    <Book Series="X-Men" Number="204" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="X-Men" Number="204" Volume="2004" Year="2007">
       <Id>cbcec38e-104f-493a-b292-40fc001f7c72</Id>
     </Book>
-    <Book Series="New X-Men" Number="43" Volume="2004" Year="2007" Format="Main Series">
+    <Book Series="New X-Men" Number="43" Volume="2004" Year="2007">
       <Id>6e63f8fc-1601-41ef-b703-c728fc6e43f7</Id>
     </Book>
-    <Book Series="X-Men: Magneto Testament" Number="1" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="X-Men: Magneto Testament" Number="1" Volume="2008" Year="2008">
       <Id>aac83915-9967-472a-b8af-9bb0a2b5aafd</Id>
     </Book>
-    <Book Series="X-Men: Magneto Testament" Number="2" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="X-Men: Magneto Testament" Number="2" Volume="2008" Year="2008">
       <Id>f932f004-107a-48f2-ae2c-06061ea5eddf</Id>
     </Book>
-    <Book Series="X-Men: Magneto Testament" Number="3" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="X-Men: Magneto Testament" Number="3" Volume="2008" Year="2009">
       <Id>09ed3d5e-2db7-4f79-9979-f82223f2b010</Id>
     </Book>
-    <Book Series="X-Men: Magneto Testament" Number="4" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="X-Men: Magneto Testament" Number="4" Volume="2008" Year="2009">
       <Id>c07925fa-f3bd-4dc3-bbaa-881500d0fb48</Id>
     </Book>
-    <Book Series="X-Men: Magneto Testament" Number="5" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="X-Men: Magneto Testament" Number="5" Volume="2008" Year="2009">
       <Id>d5ad7909-c53f-4e73-ba98-e7db66534186</Id>
     </Book>
   </Books>

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 010 (Decimation).cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 010 (Decimation).cbl
@@ -1,924 +1,925 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>X-Men - Part 10 (Decimation)</Name>
+  <Name>X-Men - Part 010 (Decimation)</Name>
+  <NumIssues>306</NumIssues>
   <Books>
     <Book Series="House of M" Number="1" Volume="2005" Year="2005">
-      <Id>87c12880-5952-4edd-87b2-17ca0f8a8412</Id>
+      <Database Name="cv" Series="12049" Issue="104861" />
     </Book>
     <Book Series="House of M" Number="2" Volume="2005" Year="2005">
-      <Id>cd404553-6dd2-46e2-a706-b44501cceeb5</Id>
+      <Database Name="cv" Series="12049" Issue="104862" />
     </Book>
     <Book Series="House of M" Number="3" Volume="2005" Year="2005">
-      <Id>52c3157a-6b7b-4a3f-93a3-5c65d8105904</Id>
+      <Database Name="cv" Series="12049" Issue="104863" />
     </Book>
     <Book Series="House of M" Number="4" Volume="2005" Year="2005">
-      <Id>a9152579-cd4a-4fcf-a9fc-a28706d29844</Id>
+      <Database Name="cv" Series="12049" Issue="104864" />
     </Book>
     <Book Series="House of M" Number="5" Volume="2005" Year="2005">
-      <Id>83190f73-884a-416f-968b-d52aaebeacf9</Id>
+      <Database Name="cv" Series="12049" Issue="104865" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="462" Volume="1981" Year="2005">
-      <Id>970fb26f-86c9-47d9-84b4-59f2bda6d691</Id>
+      <Database Name="cv" Series="3092" Issue="106584" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="463" Volume="1981" Year="2005">
-      <Id>cdee3cd3-5c59-4ca8-9a4b-5f27717ccd87</Id>
+      <Database Name="cv" Series="3092" Issue="106585" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="464" Volume="1981" Year="2005">
-      <Id>dce60ecb-03fc-4895-85c3-72d9fb438136</Id>
+      <Database Name="cv" Series="3092" Issue="106586" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="465" Volume="1981" Year="2005">
-      <Id>9043d10a-a05a-448f-b530-a8bcc20afe2a</Id>
+      <Database Name="cv" Series="3092" Issue="106587" />
     </Book>
     <Book Series="House of M" Number="6" Volume="2005" Year="2005">
-      <Id>4e3ef330-2fe0-4dbb-9f12-13b2c25ec7ae</Id>
+      <Database Name="cv" Series="12049" Issue="104866" />
     </Book>
     <Book Series="House of M" Number="7" Volume="2005" Year="2005">
-      <Id>f0bdd681-2378-4e2d-a243-4b14799eb6ca</Id>
+      <Database Name="cv" Series="12049" Issue="104867" />
     </Book>
     <Book Series="House of M" Number="8" Volume="2005" Year="2005">
-      <Id>8a2532e6-142d-45e2-ac8a-f8a8548d6e7b</Id>
+      <Database Name="cv" Series="12049" Issue="104868" />
     </Book>
     <Book Series="Decimation: House of M - The Day After" Number="1" Volume="2006" Year="2006">
-      <Id>616c2697-c037-435f-9b4f-d7d55a056496</Id>
+      <Database Name="cv" Series="18132" Issue="106215" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="19" Volume="2004" Year="2005">
-      <Id>8919e2d5-f38c-4d3e-b80a-52e88de1723b</Id>
+    <Book Series="Cable &#38; Deadpool" Number="19" Volume="2004" Year="2005">
+      <Database Name="cv" Series="18070" Issue="106396" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="20" Volume="2004" Year="2005">
-      <Id>3660e479-122b-4833-97d6-800b354b0086</Id>
+    <Book Series="Cable &#38; Deadpool" Number="20" Volume="2004" Year="2005">
+      <Database Name="cv" Series="18070" Issue="106407" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="21" Volume="2004" Year="2005">
-      <Id>0df40f9e-e7cb-4be0-a0e6-88ff38deb301</Id>
+    <Book Series="Cable &#38; Deadpool" Number="21" Volume="2004" Year="2005">
+      <Database Name="cv" Series="18070" Issue="106408" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="22" Volume="2004" Year="2006">
-      <Id>b00f33e8-93ca-477c-846c-4d1794dea533</Id>
+    <Book Series="Cable &#38; Deadpool" Number="22" Volume="2004" Year="2006">
+      <Database Name="cv" Series="18070" Issue="106409" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="23" Volume="2004" Year="2006">
-      <Id>aa4d86d4-7c6b-497d-beaf-4c494bd5fb71</Id>
+    <Book Series="Cable &#38; Deadpool" Number="23" Volume="2004" Year="2006">
+      <Database Name="cv" Series="18070" Issue="106410" />
     </Book>
     <Book Series="X-Men" Number="177" Volume="2004" Year="2006">
-      <Id>3c62b1bb-e911-438f-8155-60b86cf7c0fa</Id>
+      <Database Name="cv" Series="10731" Issue="106207" />
     </Book>
     <Book Series="X-Men" Number="178" Volume="2004" Year="2006">
-      <Id>bcbaddcc-57ec-4ace-ab6c-be67496078c9</Id>
+      <Database Name="cv" Series="10731" Issue="106208" />
     </Book>
     <Book Series="X-Men" Number="179" Volume="2004" Year="2006">
-      <Id>b2810cc8-a351-427c-8ab2-6b70c9bfb1ef</Id>
+      <Database Name="cv" Series="10731" Issue="106209" />
     </Book>
     <Book Series="New X-Men" Number="20" Volume="2004" Year="2006">
-      <Id>e7c9c97d-505c-49e4-8a4b-45aeece08176</Id>
+      <Database Name="cv" Series="18078" Issue="106297" />
     </Book>
     <Book Series="New X-Men" Number="21" Volume="2004" Year="2006">
-      <Id>41bc728f-6a30-49b6-a491-dad365feb6fa</Id>
+      <Database Name="cv" Series="18078" Issue="105973" />
     </Book>
     <Book Series="New X-Men" Number="22" Volume="2004" Year="2006">
-      <Id>23b2dc51-ebe6-4c06-af36-f87a0212efac</Id>
+      <Database Name="cv" Series="18078" Issue="105984" />
     </Book>
     <Book Series="New X-Men" Number="23" Volume="2004" Year="2006">
-      <Id>c72f861a-790d-4bd6-b7e0-6e55e3701233</Id>
+      <Database Name="cv" Series="18078" Issue="105955" />
     </Book>
     <Book Series="Generation M" Number="1" Volume="2006" Year="2006">
-      <Id>54fde146-3635-4532-82b8-6c6c733a7b39</Id>
+      <Database Name="cv" Series="18145" Issue="106303" />
     </Book>
     <Book Series="Generation M" Number="2" Volume="2006" Year="2006">
-      <Id>84471d5b-931d-448e-9c2e-7b0cd894759f</Id>
+      <Database Name="cv" Series="18145" Issue="106334" />
     </Book>
     <Book Series="Generation M" Number="3" Volume="2006" Year="2006">
-      <Id>e026fe08-1d23-4ad6-aada-5191e9ac9991</Id>
+      <Database Name="cv" Series="18145" Issue="106335" />
     </Book>
     <Book Series="Generation M" Number="4" Volume="2006" Year="2006">
-      <Id>5fa12503-a50d-4343-b329-f5479f548c96</Id>
+      <Database Name="cv" Series="18145" Issue="106336" />
     </Book>
     <Book Series="Generation M" Number="5" Volume="2006" Year="2006">
-      <Id>0b9b1bbf-e4e2-4001-9c2f-401ab6a1ef17</Id>
+      <Database Name="cv" Series="18145" Issue="106337" />
     </Book>
     <Book Series="X-Men: The 198" Number="1" Volume="2006" Year="2006">
-      <Id>49749ed2-c719-4072-9622-10c65728285e</Id>
+      <Database Name="cv" Series="18129" Issue="106206" />
     </Book>
     <Book Series="X-Men: The 198" Number="2" Volume="2006" Year="2006">
-      <Id>6fc0f84c-d285-404d-b191-885ad09ec2dd</Id>
+      <Database Name="cv" Series="18129" Issue="106241" />
     </Book>
     <Book Series="X-Men: The 198" Number="3" Volume="2006" Year="2006">
-      <Id>c40a7eb4-682a-4030-897b-b8ad3f1e99d2</Id>
+      <Database Name="cv" Series="18129" Issue="106242" />
     </Book>
     <Book Series="X-Men: The 198" Number="4" Volume="2006" Year="2006">
-      <Id>e59533e9-15cf-4d5a-a0ce-ebb858860a96</Id>
+      <Database Name="cv" Series="18129" Issue="106267" />
     </Book>
     <Book Series="X-Men: The 198" Number="5" Volume="2006" Year="2006">
-      <Id>1ad1f619-0a56-4516-95b5-d12449329b98</Id>
+      <Database Name="cv" Series="18129" Issue="106268" />
     </Book>
     <Book Series="X-Factor" Number="1" Volume="2006" Year="2006">
-      <Id>febc74e5-7e2e-49de-b13f-d8e1191fccf1</Id>
+      <Database Name="cv" Series="18109" Issue="106090" />
     </Book>
     <Book Series="X-Factor" Number="2" Volume="2006" Year="2006">
-      <Id>bd300888-dec3-41a9-b890-8ae04e0df09a</Id>
+      <Database Name="cv" Series="18109" Issue="106091" />
     </Book>
     <Book Series="X-Factor" Number="3" Volume="2006" Year="2006">
-      <Id>1f7117be-4183-4375-8385-c36ff8926b9c</Id>
+      <Database Name="cv" Series="18109" Issue="106092" />
     </Book>
     <Book Series="X-Factor" Number="4" Volume="2006" Year="2006">
-      <Id>70faa9f6-6138-47de-8013-02e2b878e5a2</Id>
+      <Database Name="cv" Series="18109" Issue="106093" />
     </Book>
     <Book Series="X-Factor" Number="5" Volume="2006" Year="2006">
-      <Id>5816c436-5318-48ed-bd2b-09b99891f24b</Id>
+      <Database Name="cv" Series="18109" Issue="106094" />
     </Book>
     <Book Series="X-Factor" Number="6" Volume="2006" Year="2006">
-      <Id>c2d61d1b-9792-447c-ba0c-290e2f6d8dd2</Id>
+      <Database Name="cv" Series="18109" Issue="106095" />
     </Book>
     <Book Series="X-Men Unlimited" Number="13" Volume="2004" Year="2006">
-      <Id>57f0f942-9b25-4746-9adc-3996a3673a6f</Id>
+      <Database Name="cv" Series="10745" Issue="113641" />
     </Book>
     <Book Series="New Excalibur" Number="1" Volume="2006" Year="2006">
-      <Id>de9957e2-4a29-4b88-9831-1a402a3c12cb</Id>
+      <Database Name="cv" Series="18019" Issue="106157" />
     </Book>
     <Book Series="New Excalibur" Number="2" Volume="2006" Year="2006">
-      <Id>1f637856-2542-4851-b28b-2a2787b57c4e</Id>
+      <Database Name="cv" Series="18019" Issue="106158" />
     </Book>
     <Book Series="New Excalibur" Number="3" Volume="2006" Year="2006">
-      <Id>8acd56b1-7723-4123-a992-bbe6e7c15a55</Id>
+      <Database Name="cv" Series="18019" Issue="106167" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="466" Volume="1981" Year="2006">
-      <Id>de98f448-c6b4-49a0-be41-795dd62e01a3</Id>
+      <Database Name="cv" Series="3092" Issue="106081" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="467" Volume="1981" Year="2006">
-      <Id>e0c819d2-d200-4931-902f-0f55ad9bc9db</Id>
+      <Database Name="cv" Series="3092" Issue="106082" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="468" Volume="1981" Year="2006">
-      <Id>10fb0335-1b49-42c0-bb27-c4a7ebf79342</Id>
+      <Database Name="cv" Series="3092" Issue="106083" />
     </Book>
     <Book Series="New Excalibur" Number="4" Volume="2006" Year="2006">
-      <Id>5575c0db-1e78-46c3-bb8e-198cace2e31f</Id>
+      <Database Name="cv" Series="18019" Issue="105972" />
     </Book>
     <Book Series="New Excalibur" Number="5" Volume="2006" Year="2006">
-      <Id>3456cffe-b8ac-477f-853b-f047a443978f</Id>
+      <Database Name="cv" Series="18019" Issue="106080" />
     </Book>
     <Book Series="New Excalibur" Number="6" Volume="2006" Year="2006">
-      <Id>42724a90-5969-4890-b416-9be5a2757afd</Id>
+      <Database Name="cv" Series="18019" Issue="106168" />
     </Book>
     <Book Series="New Excalibur" Number="7" Volume="2006" Year="2006">
-      <Id>135dfb02-f769-4b9c-ba6f-4b9a4b9af8f9</Id>
+      <Database Name="cv" Series="18019" Issue="106169" />
     </Book>
     <Book Series="New X-Men" Number="24" Volume="2004" Year="2006">
-      <Id>f7059c0f-2c6c-4af0-8d9f-94e39a663aae</Id>
+      <Database Name="cv" Series="18078" Issue="106023" />
     </Book>
     <Book Series="New X-Men" Number="25" Volume="2004" Year="2006">
-      <Id>87193059-deac-4b80-93b4-eb0c038e42af</Id>
+      <Database Name="cv" Series="18078" Issue="106304" />
     </Book>
     <Book Series="New X-Men" Number="26" Volume="2004" Year="2006">
-      <Id>06328000-0e6c-489c-8ae4-74c79b831728</Id>
+      <Database Name="cv" Series="18078" Issue="106343" />
     </Book>
     <Book Series="New X-Men" Number="27" Volume="2004" Year="2006">
-      <Id>1da5cb64-6f2e-4b3a-a9c1-d9d647b93070</Id>
+      <Database Name="cv" Series="18078" Issue="106344" />
     </Book>
     <Book Series="Wolverine" Number="36" Volume="2003" Year="2006">
-      <Id>896bea5c-2ed3-4b4e-b038-080137ca582b</Id>
+      <Database Name="cv" Series="10809" Issue="114519" />
     </Book>
     <Book Series="Wolverine" Number="37" Volume="2003" Year="2006">
-      <Id>92682c09-0b7d-4cd0-ab83-4f059194ea4b</Id>
+      <Database Name="cv" Series="10809" Issue="114390" />
     </Book>
     <Book Series="Wolverine" Number="38" Volume="2003" Year="2006">
-      <Id>0ae634f4-bbd6-4308-9b3e-34fac14107d2</Id>
+      <Database Name="cv" Series="10809" Issue="112980" />
     </Book>
     <Book Series="Wolverine" Number="39" Volume="2003" Year="2006">
-      <Id>38f70d86-2dc0-4a00-858e-65550730bfb6</Id>
+      <Database Name="cv" Series="10809" Issue="113029" />
     </Book>
     <Book Series="Wolverine" Number="40" Volume="2003" Year="2006">
-      <Id>317cf935-6649-47e2-b024-c6c82eb205a0</Id>
+      <Database Name="cv" Series="10809" Issue="113030" />
     </Book>
     <Book Series="Wolverine: Origins" Number="1" Volume="2006" Year="2006">
-      <Id>1fd20722-da14-4d02-b8e6-0122c65b9bd6</Id>
+      <Database Name="cv" Series="18130" Issue="106338" />
     </Book>
     <Book Series="Wolverine: Origins" Number="2" Volume="2006" Year="2006">
-      <Id>efaff90f-5507-4d14-b601-be6ad7afea09</Id>
+      <Database Name="cv" Series="18130" Issue="106339" />
     </Book>
     <Book Series="Wolverine: Origins" Number="3" Volume="2006" Year="2006">
-      <Id>03ce76bb-9c60-4235-859e-ae585e51032a</Id>
+      <Database Name="cv" Series="18130" Issue="106340" />
     </Book>
     <Book Series="Wolverine: Origins" Number="4" Volume="2006" Year="2006">
-      <Id>f6a244dc-7c58-4318-8f5c-010d57103e02</Id>
+      <Database Name="cv" Series="18130" Issue="106341" />
     </Book>
     <Book Series="Wolverine: Origins" Number="5" Volume="2006" Year="2006">
-      <Id>ed4f5ebc-8a95-4a89-87ea-951582c98827</Id>
+      <Database Name="cv" Series="18130" Issue="106356" />
     </Book>
     <Book Series="Wolverine" Number="41" Volume="2003" Year="2006">
-      <Id>4485820b-2111-4d70-8390-642103741d70</Id>
+      <Database Name="cv" Series="10809" Issue="113031" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="24" Volume="2004" Year="2006">
-      <Id>8c87523d-8c2a-4f5f-b116-f34f5d2e4493</Id>
+    <Book Series="Cable &#38; Deadpool" Number="24" Volume="2004" Year="2006">
+      <Database Name="cv" Series="18070" Issue="106411" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="25" Volume="2004" Year="2006">
-      <Id>5eab3d8d-3d33-4114-9007-bb3663e60648</Id>
+    <Book Series="Cable &#38; Deadpool" Number="25" Volume="2004" Year="2006">
+      <Database Name="cv" Series="18070" Issue="106412" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="26" Volume="2004" Year="2006">
-      <Id>875264c4-f277-4256-a41f-d4a22f9c62f7</Id>
+    <Book Series="Cable &#38; Deadpool" Number="26" Volume="2004" Year="2006">
+      <Database Name="cv" Series="18070" Issue="106413" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="27" Volume="2004" Year="2006">
-      <Id>80d99c66-0761-4feb-b2eb-4d7a9ce4a6bb</Id>
+    <Book Series="Cable &#38; Deadpool" Number="27" Volume="2004" Year="2006">
+      <Database Name="cv" Series="18070" Issue="106414" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="469" Volume="1981" Year="2006">
-      <Id>9fd6e35b-91c2-49c7-88e5-d59ada5819d5</Id>
+      <Database Name="cv" Series="3092" Issue="106192" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="470" Volume="1981" Year="2006">
-      <Id>5c281fdf-b75d-4262-a958-56de04aaed41</Id>
+      <Database Name="cv" Series="3092" Issue="106193" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="471" Volume="1981" Year="2006">
-      <Id>67d78338-1cba-4d32-9699-e2945ebc871d</Id>
+      <Database Name="cv" Series="3092" Issue="106194" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="472" Volume="1981" Year="2006">
-      <Id>61d631d2-993c-4424-bb78-036e2dea73c9</Id>
+      <Database Name="cv" Series="3092" Issue="106198" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="473" Volume="1981" Year="2006">
-      <Id>6ab44203-ba8f-4549-8029-853e66b69f2a</Id>
+      <Database Name="cv" Series="3092" Issue="106588" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="474" Volume="1981" Year="2006">
-      <Id>1f5a017f-ce2d-4f00-b4fe-98f71d66e5cd</Id>
+      <Database Name="cv" Series="3092" Issue="106589" />
     </Book>
     <Book Series="X-Men Unlimited" Number="14" Volume="2004" Year="2006">
-      <Id>ea24bf3b-d554-4606-ad14-2c7dfe04ed3a</Id>
+      <Database Name="cv" Series="10745" Issue="110284" />
     </Book>
     <Book Series="Giant-Size Wolverine" Number="1" Volume="2006" Year="2006">
-      <Id>21e67476-c838-414c-830f-e824b0c86633</Id>
+      <Database Name="cv" Series="20385" Issue="121915" />
     </Book>
     <Book Series="New Excalibur" Number="8" Volume="2006" Year="2006">
-      <Id>2d408a77-5615-43bc-bd10-5e4009b7130d</Id>
+      <Database Name="cv" Series="18019" Issue="106177" />
     </Book>
     <Book Series="New Excalibur" Number="9" Volume="2006" Year="2006">
-      <Id>cd933bcd-f1b0-41e5-b005-910da17e301e</Id>
+      <Database Name="cv" Series="18019" Issue="106178" />
     </Book>
     <Book Series="Uncanny X-Men Annual" Number="1" Volume="2006" Year="2006">
-      <Id>bfdc739e-2c5f-43a0-a61d-6f8ce58caa64</Id>
+      <Database Name="cv" Series="18405" Issue="107902" />
     </Book>
     <Book Series="Storm" Number="1" Volume="2006" Year="2006">
-      <Id>93477a0e-f3ea-4a0d-9d4e-0597c59fe3ad</Id>
+      <Database Name="cv" Series="18260" Issue="106913" />
     </Book>
     <Book Series="Storm" Number="2" Volume="2006" Year="2006">
-      <Id>a15c6246-9080-45ee-9df0-5b5f5150bf38</Id>
+      <Database Name="cv" Series="18260" Issue="109536" />
     </Book>
     <Book Series="Storm" Number="3" Volume="2006" Year="2006">
-      <Id>60990175-5a68-44bd-a6a2-61356d8b4814</Id>
+      <Database Name="cv" Series="18260" Issue="109537" />
     </Book>
     <Book Series="Storm" Number="4" Volume="2006" Year="2006">
-      <Id>c7e38ae7-4835-43a3-8691-6b0cb5340615</Id>
+      <Database Name="cv" Series="18260" Issue="109538" />
     </Book>
     <Book Series="Storm" Number="5" Volume="2006" Year="2006">
-      <Id>ceffcf46-a74b-443e-91d6-df57494cc446</Id>
+      <Database Name="cv" Series="18260" Issue="109539" />
     </Book>
     <Book Series="Storm" Number="6" Volume="2006" Year="2006">
-      <Id>cd0a5397-dece-43f6-8aa3-965d1d8b9ac9</Id>
+      <Database Name="cv" Series="18260" Issue="109540" />
     </Book>
     <Book Series="Black Panther" Number="14" Volume="2005" Year="2006">
-      <Id>768dac24-39ee-41ca-b3c9-7ae88edffb23</Id>
+      <Database Name="cv" Series="11502" Issue="107855" />
     </Book>
     <Book Series="Black Panther" Number="15" Volume="2005" Year="2006">
-      <Id>b7299f2f-1ad5-4d63-ba08-aa8508768b5b</Id>
+      <Database Name="cv" Series="11502" Issue="107856" />
     </Book>
     <Book Series="Black Panther" Number="16" Volume="2005" Year="2006">
-      <Id>60d7cb62-fa79-424c-8cf0-7c06028bab5e</Id>
+      <Database Name="cv" Series="11502" Issue="110528" />
     </Book>
     <Book Series="Black Panther" Number="17" Volume="2005" Year="2006">
-      <Id>27245776-966c-4ef5-995b-bb6956d8c706</Id>
+      <Database Name="cv" Series="11502" Issue="110605" />
     </Book>
     <Book Series="Black Panther" Number="18" Volume="2005" Year="2006">
-      <Id>a424936e-092b-4b61-ad62-e8d0e11929f3</Id>
+      <Database Name="cv" Series="11502" Issue="108675" />
     </Book>
     <Book Series="X-Men/Runaways" Number="1" Volume="2006" Year="2006">
-      <Id>0d71d699-bd29-42a3-bca9-9aa3a6e70f51</Id>
+      <Database Name="cv" Series="18056" Issue="105745" />
     </Book>
     <Book Series="X-Men" Number="180" Volume="2004" Year="2006">
-      <Id>3f2c16bf-e0f0-4fb1-86e9-6da6bd1d6ed8</Id>
+      <Database Name="cv" Series="10731" Issue="105901" />
     </Book>
     <Book Series="X-Men" Number="181" Volume="2004" Year="2006">
-      <Id>14f78566-69c5-4e52-b23e-8eba4cf4322c</Id>
+      <Database Name="cv" Series="10731" Issue="105902" />
     </Book>
     <Book Series="X-Men" Number="182" Volume="2004" Year="2006">
-      <Id>1d3b3619-3171-4650-a047-31003e45d405</Id>
+      <Database Name="cv" Series="10731" Issue="105903" />
     </Book>
     <Book Series="X-Men" Number="183" Volume="2004" Year="2006">
-      <Id>2307374b-3942-4e3a-a1f6-fc371f1c4a2b</Id>
+      <Database Name="cv" Series="10731" Issue="106021" />
     </Book>
     <Book Series="X-Men" Number="184" Volume="2004" Year="2006">
-      <Id>ab36a6e2-8cbe-4839-a004-b6bfa1320111</Id>
+      <Database Name="cv" Series="10731" Issue="106022" />
     </Book>
     <Book Series="X-Men" Number="185" Volume="2004" Year="2006">
-      <Id>bed42458-d9d9-4972-a32a-cd39313bb736</Id>
+      <Database Name="cv" Series="10731" Issue="106210" />
     </Book>
     <Book Series="X-Men" Number="186" Volume="2004" Year="2006">
-      <Id>2dd2c291-ff6b-4967-811c-08938e524ac3</Id>
+      <Database Name="cv" Series="10731" Issue="106211" />
     </Book>
     <Book Series="X-Men" Number="187" Volume="2004" Year="2006">
-      <Id>8430df96-d245-412e-86a0-ef8eac68e9f9</Id>
+      <Database Name="cv" Series="10731" Issue="106212" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="28" Volume="2004" Year="2006">
-      <Id>ee6f1571-905f-4f7f-997b-c4e49a7f2dd1</Id>
+    <Book Series="Cable &#38; Deadpool" Number="28" Volume="2004" Year="2006">
+      <Database Name="cv" Series="18070" Issue="106442" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="29" Volume="2004" Year="2006">
-      <Id>596505f2-868e-4c4d-9609-941a02d50685</Id>
+    <Book Series="Cable &#38; Deadpool" Number="29" Volume="2004" Year="2006">
+      <Database Name="cv" Series="18070" Issue="106443" />
     </Book>
     <Book Series="New Excalibur" Number="10" Volume="2006" Year="2006">
-      <Id>28f3492d-b431-4020-8b8b-b85780cfccff</Id>
+      <Database Name="cv" Series="18019" Issue="106200" />
     </Book>
     <Book Series="New Excalibur" Number="11" Volume="2006" Year="2006">
-      <Id>1735c99b-15a9-4f67-bb52-35e6de7ee264</Id>
+      <Database Name="cv" Series="18019" Issue="106201" />
     </Book>
     <Book Series="New Excalibur" Number="12" Volume="2006" Year="2006">
-      <Id>98952ad7-cc47-4d5e-99c1-67416776e72d</Id>
+      <Database Name="cv" Series="18019" Issue="106204" />
     </Book>
     <Book Series="Wolverine: Origins" Number="6" Volume="2006" Year="2006">
-      <Id>8245387a-5599-4b8a-a690-cfb673f16db0</Id>
+      <Database Name="cv" Series="18130" Issue="106998" />
     </Book>
     <Book Series="Wolverine: Origins" Number="7" Volume="2006" Year="2006">
-      <Id>be9627d1-5c8a-4a7e-b057-ae5b5f067ae9</Id>
+      <Database Name="cv" Series="18130" Issue="107300" />
     </Book>
     <Book Series="Wolverine: Origins" Number="8" Volume="2006" Year="2007">
-      <Id>3cf380d8-50e9-479a-be14-929fd2848609</Id>
+      <Database Name="cv" Series="18130" Issue="107301" />
     </Book>
     <Book Series="Wolverine: Origins" Number="9" Volume="2006" Year="2007">
-      <Id>8c347a79-763c-4c94-b50c-5c652a8bc367</Id>
+      <Database Name="cv" Series="18130" Issue="106213" />
     </Book>
     <Book Series="Wolverine: Origins" Number="10" Volume="2006" Year="2007">
-      <Id>e58d0088-7018-4e22-ad69-24214d5071d0</Id>
+      <Database Name="cv" Series="18130" Issue="106254" />
     </Book>
     <Book Series="X-Men: Deadly Genesis" Number="1" Volume="2006" Year="2006">
-      <Id>ac340383-ba72-4ea3-9046-94caff8bb3c3</Id>
+      <Database Name="cv" Series="18091" Issue="120892" />
     </Book>
     <Book Series="X-Men: Deadly Genesis" Number="2" Volume="2006" Year="2006">
-      <Id>fd4a66d6-da74-445a-9db0-6ef123ee140a</Id>
+      <Database Name="cv" Series="18091" Issue="120882" />
     </Book>
     <Book Series="X-Men: Deadly Genesis" Number="3" Volume="2006" Year="2006">
-      <Id>168fd57d-062a-4a00-bfd6-bed08a5cfbe4</Id>
+      <Database Name="cv" Series="18091" Issue="120891" />
     </Book>
     <Book Series="X-Men: Deadly Genesis" Number="4" Volume="2006" Year="2006">
-      <Id>fb7e653d-f30a-4445-b512-623b8d98819c</Id>
+      <Database Name="cv" Series="18091" Issue="105971" />
     </Book>
     <Book Series="X-Men: Deadly Genesis" Number="5" Volume="2006" Year="2006">
-      <Id>4a8752fd-4a47-4871-a0cc-73a9e9c0a1f7</Id>
+      <Database Name="cv" Series="18091" Issue="106024" />
     </Book>
     <Book Series="X-Men: Deadly Genesis" Number="6" Volume="2006" Year="2006">
-      <Id>2206e887-d7e3-40a3-9e0f-c4f7b51a4dcc</Id>
+      <Database Name="cv" Series="18091" Issue="106197" />
     </Book>
     <Book Series="X-Factor" Number="7" Volume="2006" Year="2006">
-      <Id>d37207d3-7c81-4c8d-9684-f1da381f809e</Id>
+      <Database Name="cv" Series="18109" Issue="106096" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="475" Volume="1981" Year="2006">
-      <Id>3b3b647c-3b63-4df0-aa17-14a84b5780b4</Id>
+      <Database Name="cv" Series="3092" Issue="107938" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="476" Volume="1981" Year="2006">
-      <Id>edfd2313-c8da-4e05-9b63-c120e7d23af4</Id>
+      <Database Name="cv" Series="3092" Issue="107939" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="477" Volume="1981" Year="2006">
-      <Id>ceed6b0d-4af6-4281-ad54-2b730c682212</Id>
+      <Database Name="cv" Series="3092" Issue="107940" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="478" Volume="1981" Year="2006">
-      <Id>7829a396-7f3b-433b-8e83-193f8ee1b8a4</Id>
+      <Database Name="cv" Series="3092" Issue="107941" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="479" Volume="1981" Year="2006">
-      <Id>a8558345-6a6f-48c7-b1d3-82c469ee953d</Id>
+      <Database Name="cv" Series="3092" Issue="107942" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="480" Volume="1981" Year="2007">
-      <Id>6ae14c60-a4d5-4d89-80bc-be4a660a08f1</Id>
+      <Database Name="cv" Series="3092" Issue="109939" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="481" Volume="1981" Year="2007">
-      <Id>ba840893-3f1c-453f-88fe-e78bd49aa94e</Id>
+      <Database Name="cv" Series="3092" Issue="107943" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="482" Volume="1981" Year="2007">
-      <Id>4663e8a8-eeed-4d89-992e-9b362abd0e01</Id>
+      <Database Name="cv" Series="3092" Issue="106278" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="483" Volume="1981" Year="2007">
-      <Id>18340ea3-f5b8-415e-920a-57bbb841a851</Id>
+      <Database Name="cv" Series="3092" Issue="106366" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="484" Volume="1981" Year="2007">
-      <Id>b90a3caa-c748-423b-ad5c-fd3e14e47c42</Id>
+      <Database Name="cv" Series="3092" Issue="106795" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="485" Volume="1981" Year="2007">
-      <Id>6cdb07f6-c44b-4ed3-9c4f-f838f3e331db</Id>
+      <Database Name="cv" Series="3092" Issue="108365" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="486" Volume="1981" Year="2007">
-      <Id>ee963828-48cf-4940-b33f-3b471fee5db3</Id>
+      <Database Name="cv" Series="3092" Issue="109610" />
     </Book>
     <Book Series="X-Men" Number="188" Volume="2004" Year="2006">
-      <Id>2aef0c77-3052-43af-87b6-407f66ba971c</Id>
+      <Database Name="cv" Series="10731" Issue="108778" />
     </Book>
     <Book Series="X-Men" Number="189" Volume="2004" Year="2006">
-      <Id>bda64379-7761-44b4-87a2-55d75b156237</Id>
+      <Database Name="cv" Series="10731" Issue="107955" />
     </Book>
     <Book Series="X-Men" Number="190" Volume="2004" Year="2006">
-      <Id>c5567395-b87b-4682-819e-5f1b88538123</Id>
+      <Database Name="cv" Series="10731" Issue="107956" />
     </Book>
     <Book Series="X-Men" Number="191" Volume="2004" Year="2006">
-      <Id>5e6f7473-4779-4906-a454-123da19b7b94</Id>
+      <Database Name="cv" Series="10731" Issue="107957" />
     </Book>
     <Book Series="X-Men" Number="192" Volume="2004" Year="2006">
-      <Id>9e4fa307-da53-4928-9cd0-382e713f6f9f</Id>
+      <Database Name="cv" Series="10731" Issue="107946" />
     </Book>
     <Book Series="X-Men" Number="193" Volume="2004" Year="2007">
-      <Id>e79504e0-6fe1-4e61-8edf-2e75b9cea497</Id>
+      <Database Name="cv" Series="10731" Issue="107947" />
     </Book>
     <Book Series="Wolverine: Origins" Number="11" Volume="2006" Year="2007">
-      <Id>bba6c0b7-4dd5-4616-ba21-deff04c857f7</Id>
+      <Database Name="cv" Series="18130" Issue="106470" />
     </Book>
     <Book Series="Wolverine: Origins" Number="12" Volume="2006" Year="2007">
-      <Id>8356064e-bd47-45f6-8ed6-bc9374df42fd</Id>
+      <Database Name="cv" Series="18130" Issue="106903" />
     </Book>
     <Book Series="Wolverine: Origins" Number="13" Volume="2006" Year="2007">
-      <Id>9a5f2afd-b781-404c-bce6-8d144d1cc29d</Id>
+      <Database Name="cv" Series="18130" Issue="108357" />
     </Book>
     <Book Series="Wolverine: Origins" Number="14" Volume="2006" Year="2007">
-      <Id>d70474e1-7f5b-4bce-a058-ceea786368af</Id>
+      <Database Name="cv" Series="18130" Issue="109261" />
     </Book>
     <Book Series="Wolverine: Origins" Number="15" Volume="2006" Year="2007">
-      <Id>d7c61e85-f2ef-459c-b0c6-0fb126f3b2ae</Id>
+      <Database Name="cv" Series="18130" Issue="111125" />
     </Book>
     <Book Series="X-23: Target X" Number="1" Volume="2007" Year="2007">
-      <Id>5471e89c-d81c-45e6-be82-ec37d08004b9</Id>
+      <Database Name="cv" Series="18171" Issue="106501" />
     </Book>
     <Book Series="X-23: Target X" Number="2" Volume="2007" Year="2007">
-      <Id>74f18dd6-c356-423b-8aa1-da3021b48324</Id>
+      <Database Name="cv" Series="18171" Issue="106503" />
     </Book>
     <Book Series="X-23: Target X" Number="3" Volume="2007" Year="2007">
-      <Id>a6f8ca54-8467-4d7a-9f96-ef21d30909af</Id>
+      <Database Name="cv" Series="18171" Issue="106401" />
     </Book>
     <Book Series="X-23: Target X" Number="4" Volume="2007" Year="2007">
-      <Id>609cf7f3-d199-45a3-856b-d309058f75cf</Id>
+      <Database Name="cv" Series="18171" Issue="107205" />
     </Book>
     <Book Series="X-23: Target X" Number="5" Volume="2007" Year="2007">
-      <Id>1921a476-9283-478e-9779-30fe6b9cae20</Id>
+      <Database Name="cv" Series="18171" Issue="108564" />
     </Book>
     <Book Series="X-23: Target X" Number="6" Volume="2007" Year="2007">
-      <Id>98be6e1f-fe07-497f-8903-8e484018fafb</Id>
+      <Database Name="cv" Series="18171" Issue="110025" />
     </Book>
     <Book Series="Civil War" Number="1" Volume="2006" Year="2006">
-      <Id>8a3b618d-9877-4c00-8d7f-48d65f4599dd</Id>
+      <Database Name="cv" Series="18023" Issue="105525" />
     </Book>
     <Book Series="X-Factor" Number="8" Volume="2006" Year="2006">
-      <Id>76929c57-1563-4510-b4fd-63afd9125b82</Id>
+      <Database Name="cv" Series="18109" Issue="106097" />
     </Book>
     <Book Series="Civil War" Number="2" Volume="2006" Year="2006">
-      <Id>346dc7b4-7523-40ae-8fab-1df067deffd5</Id>
+      <Database Name="cv" Series="18023" Issue="105570" />
     </Book>
     <Book Series="Civil War" Number="3" Volume="2006" Year="2006">
-      <Id>7bbd5df4-e746-40d8-9ad1-b135c26c0c20</Id>
+      <Database Name="cv" Series="18023" Issue="105624" />
     </Book>
     <Book Series="X-Factor" Number="9" Volume="2006" Year="2006">
-      <Id>2154a329-c011-423e-8204-772143108d0f</Id>
+      <Database Name="cv" Series="18109" Issue="106098" />
     </Book>
     <Book Series="Civil War: X-Men" Number="1" Volume="2006" Year="2006">
-      <Id>5461de90-321f-4a50-a671-363c65f718cd</Id>
+      <Database Name="cv" Series="18528" Issue="108786" />
     </Book>
     <Book Series="Civil War: X-Men" Number="2" Volume="2006" Year="2006">
-      <Id>6968c5bb-96a0-4d98-9883-e64c0ea8aae3</Id>
+      <Database Name="cv" Series="18528" Issue="108844" />
     </Book>
     <Book Series="Civil War: X-Men" Number="3" Volume="2006" Year="2006">
-      <Id>859c1dba-6224-4f80-8e75-922afbff8fd3</Id>
+      <Database Name="cv" Series="18528" Issue="108845" />
     </Book>
     <Book Series="Civil War: X-Men" Number="4" Volume="2006" Year="2006">
-      <Id>007ad541-5fd0-4c3e-9468-001edb51814e</Id>
+      <Database Name="cv" Series="18528" Issue="108846" />
     </Book>
     <Book Series="Wolverine" Number="42" Volume="2003" Year="2006">
-      <Id>2b4f4ded-e9c6-4ca5-8fcf-b9765a7a763a</Id>
+      <Database Name="cv" Series="10809" Issue="106974" />
     </Book>
     <Book Series="Wolverine" Number="43" Volume="2003" Year="2006">
-      <Id>6d97c452-f85c-450d-8911-455dec336ffe</Id>
+      <Database Name="cv" Series="10809" Issue="108240" />
     </Book>
     <Book Series="Wolverine" Number="44" Volume="2003" Year="2006">
-      <Id>5cace29f-1810-48b6-b6ef-92232f3e3625</Id>
+      <Database Name="cv" Series="10809" Issue="109260" />
     </Book>
     <Book Series="Wolverine" Number="45" Volume="2003" Year="2006">
-      <Id>59a38eaa-379d-43f9-aebb-74722ebaa11e</Id>
+      <Database Name="cv" Series="10809" Issue="108674" />
     </Book>
     <Book Series="Wolverine" Number="46" Volume="2003" Year="2006">
-      <Id>c8874657-93c5-43aa-8521-f9a89b13fa4d</Id>
+      <Database Name="cv" Series="10809" Issue="108678" />
     </Book>
     <Book Series="Wolverine" Number="47" Volume="2003" Year="2006">
-      <Id>7222ab98-b0a1-45dd-981f-9ceaf3d9ccd0</Id>
+      <Database Name="cv" Series="10809" Issue="108679" />
     </Book>
     <Book Series="Wolverine" Number="48" Volume="2003" Year="2007">
-      <Id>c48eb10b-9a69-4e3a-9060-771a582c040f</Id>
+      <Database Name="cv" Series="10809" Issue="108912" />
     </Book>
     <Book Series="X-Factor" Number="10" Volume="2006" Year="2006">
-      <Id>91c8ccb4-e614-4a7f-849c-7cbe284c5c7e</Id>
+      <Database Name="cv" Series="18109" Issue="106099" />
     </Book>
     <Book Series="X-Factor" Number="11" Volume="2006" Year="2006">
-      <Id>563cadee-4b2b-4f16-a835-de4808ac0ed9</Id>
+      <Database Name="cv" Series="18109" Issue="106100" />
     </Book>
     <Book Series="X-Factor" Number="12" Volume="2006" Year="2006">
-      <Id>fe81727c-699d-4e8e-8289-d57aea474055</Id>
+      <Database Name="cv" Series="18109" Issue="106101" />
     </Book>
     <Book Series="Civil War" Number="5" Volume="2006" Year="2006">
-      <Id>52958b4a-aa5d-4429-b844-9ca8c0ba5b02</Id>
+      <Database Name="cv" Series="18023" Issue="106999" />
     </Book>
     <Book Series="Civil War" Number="6" Volume="2006" Year="2006">
-      <Id>72de0c39-09f3-43a0-93dd-5d35d3c409c5</Id>
+      <Database Name="cv" Series="18023" Issue="107000" />
     </Book>
     <Book Series="Civil War" Number="7" Volume="2006" Year="2007">
-      <Id>88a586c8-129f-4c95-af85-aeff87628b25</Id>
+      <Database Name="cv" Series="18023" Issue="106626" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="30" Volume="2004" Year="2006">
-      <Id>87748633-fe0d-4584-bf9d-af615366f9d0</Id>
+    <Book Series="Cable &#38; Deadpool" Number="30" Volume="2004" Year="2006">
+      <Database Name="cv" Series="18070" Issue="106444" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="31" Volume="2004" Year="2006">
-      <Id>f79fa9b2-06c0-48b6-ba45-44b4b88c0634</Id>
+    <Book Series="Cable &#38; Deadpool" Number="31" Volume="2004" Year="2006">
+      <Database Name="cv" Series="18070" Issue="106445" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="32" Volume="2004" Year="2006">
-      <Id>de3e840d-c21d-4ca3-9ded-7cf4a379328d</Id>
+    <Book Series="Cable &#38; Deadpool" Number="32" Volume="2004" Year="2006">
+      <Database Name="cv" Series="18070" Issue="106446" />
     </Book>
     <Book Series="New X-Men" Number="28" Volume="2004" Year="2006">
-      <Id>27b2d390-0621-45ac-bf00-7c56e052ae1d</Id>
+      <Database Name="cv" Series="18078" Issue="106345" />
     </Book>
     <Book Series="New X-Men" Number="29" Volume="2004" Year="2006">
-      <Id>08761945-1ece-46ca-8905-d59eef3df754</Id>
+      <Database Name="cv" Series="18078" Issue="106346" />
     </Book>
     <Book Series="New X-Men" Number="30" Volume="2004" Year="2006">
-      <Id>f28b0062-cf7d-4010-943a-f400bd474fbe</Id>
+      <Database Name="cv" Series="18078" Issue="106357" />
     </Book>
     <Book Series="New X-Men" Number="31" Volume="2004" Year="2006">
-      <Id>49a1467b-ef03-4faf-b109-4e8ee3eabb36</Id>
+      <Database Name="cv" Series="18078" Issue="106358" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="33" Volume="2004" Year="2006">
-      <Id>a944b570-2df6-4118-84e3-56ecf5a6b5d5</Id>
+    <Book Series="Cable &#38; Deadpool" Number="33" Volume="2004" Year="2006">
+      <Database Name="cv" Series="18070" Issue="106447" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="34" Volume="2004" Year="2007">
-      <Id>7db3126d-87b0-40a3-bf43-4519816292c9</Id>
+    <Book Series="Cable &#38; Deadpool" Number="34" Volume="2004" Year="2007">
+      <Database Name="cv" Series="18070" Issue="106448" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="35" Volume="2004" Year="2007">
-      <Id>b0b93b6f-b487-424b-8956-e811cc0a28d8</Id>
+    <Book Series="Cable &#38; Deadpool" Number="35" Volume="2004" Year="2007">
+      <Database Name="cv" Series="18070" Issue="106075" />
     </Book>
     <Book Series="New X-Men" Number="32" Volume="2004" Year="2007">
-      <Id>fa551843-6da4-4abd-a880-02126a59e16e</Id>
+      <Database Name="cv" Series="18078" Issue="106359" />
     </Book>
     <Book Series="Wolverine" Number="49" Volume="2003" Year="2007">
-      <Id>ac2a8335-b58e-4b9b-a37a-0200c7e59edc</Id>
+      <Database Name="cv" Series="10809" Issue="114553" />
     </Book>
     <Book Series="X-Factor" Number="13" Volume="2006" Year="2007">
-      <Id>0005ab35-71cc-430c-8281-1ffd31737597</Id>
+      <Database Name="cv" Series="18109" Issue="106073" />
     </Book>
     <Book Series="New Excalibur" Number="13" Volume="2006" Year="2007">
-      <Id>5a82b704-13df-4511-a68d-72e599fa3b59</Id>
+      <Database Name="cv" Series="18019" Issue="105472" />
     </Book>
     <Book Series="New Excalibur" Number="14" Volume="2006" Year="2007">
-      <Id>c9a104ec-99f8-426e-986d-0abe95eafc69</Id>
+      <Database Name="cv" Series="18019" Issue="105475" />
     </Book>
     <Book Series="New Excalibur" Number="15" Volume="2006" Year="2007">
-      <Id>d1ebebab-a7ee-43a8-a691-2997d9010dc1</Id>
+      <Database Name="cv" Series="18019" Issue="106205" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="36" Volume="2004" Year="2007">
-      <Id>f71fe61c-173f-40a1-bd6f-ee90e7ac8fb6</Id>
+    <Book Series="Cable &#38; Deadpool" Number="36" Volume="2004" Year="2007">
+      <Database Name="cv" Series="18070" Issue="107058" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="37" Volume="2004" Year="2007">
-      <Id>6afda3e1-2460-4d3a-96e5-cd40f2ea1aee</Id>
+    <Book Series="Cable &#38; Deadpool" Number="37" Volume="2004" Year="2007">
+      <Database Name="cv" Series="18070" Issue="107253" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="38" Volume="2004" Year="2007">
-      <Id>ebdfd1e0-6faf-48a5-a783-2ab89db3da07</Id>
+    <Book Series="Cable &#38; Deadpool" Number="38" Volume="2004" Year="2007">
+      <Database Name="cv" Series="18070" Issue="107252" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="39" Volume="2004" Year="2007">
-      <Id>d27a1fb4-e987-4169-9a2d-3326efd001d1</Id>
+    <Book Series="Cable &#38; Deadpool" Number="39" Volume="2004" Year="2007">
+      <Database Name="cv" Series="18070" Issue="108553" />
     </Book>
     <Book Series="X-Men: Phoenix Warsong" Number="1" Volume="2006" Year="2006">
-      <Id>63158282-af60-421a-9719-5a8bc2817e05</Id>
+      <Database Name="cv" Series="18382" Issue="107768" />
     </Book>
     <Book Series="X-Men: Phoenix Warsong" Number="2" Volume="2006" Year="2006">
-      <Id>c3d42c09-5302-40cd-8a19-5ce7642cbd42</Id>
+      <Database Name="cv" Series="18382" Issue="107798" />
     </Book>
     <Book Series="X-Men: Phoenix Warsong" Number="3" Volume="2006" Year="2007">
-      <Id>7a531af7-826d-408f-8cd2-6c3d05df8794</Id>
+      <Database Name="cv" Series="18382" Issue="107799" />
     </Book>
     <Book Series="X-Men: Phoenix Warsong" Number="4" Volume="2006" Year="2007">
-      <Id>e833e113-c1b8-4413-bfca-af4b531e9413</Id>
+      <Database Name="cv" Series="18382" Issue="107803" />
     </Book>
     <Book Series="X-Men: Phoenix Warsong" Number="5" Volume="2006" Year="2007">
-      <Id>8f90b086-9054-45a1-af28-e692dc25be66</Id>
+      <Database Name="cv" Series="18382" Issue="107804" />
     </Book>
     <Book Series="New X-Men" Number="33" Volume="2004" Year="2007">
-      <Id>5307005b-1e41-430d-8f4b-9b2199b17406</Id>
+      <Database Name="cv" Series="18078" Issue="110486" />
     </Book>
     <Book Series="New X-Men" Number="34" Volume="2004" Year="2007">
-      <Id>317fa0c3-5ee9-422b-ac36-c77928610331</Id>
+      <Database Name="cv" Series="18078" Issue="110487" />
     </Book>
     <Book Series="New X-Men" Number="35" Volume="2004" Year="2007">
-      <Id>fe597497-cc1f-4f85-8f7d-f9062400a3be</Id>
+      <Database Name="cv" Series="18078" Issue="106500" />
     </Book>
     <Book Series="New X-Men" Number="36" Volume="2004" Year="2007">
-      <Id>4f63047a-d3c4-4d8c-9edc-986038d5b15e</Id>
+      <Database Name="cv" Series="18078" Issue="106930" />
     </Book>
     <Book Series="New Excalibur" Number="16" Volume="2006" Year="2007">
-      <Id>2b29565b-f05e-40fa-846c-9a2fe9f852a0</Id>
+      <Database Name="cv" Series="18019" Issue="106483" />
     </Book>
     <Book Series="New Excalibur" Number="17" Volume="2006" Year="2007">
-      <Id>cea463a0-f1dc-41e8-a533-a64dba625051</Id>
+      <Database Name="cv" Series="18019" Issue="106722" />
     </Book>
     <Book Series="X-Factor" Number="14" Volume="2006" Year="2007">
-      <Id>b1310470-0670-4909-b93d-21d84cfb6f0b</Id>
+      <Database Name="cv" Series="18109" Issue="106079" />
     </Book>
     <Book Series="X-Factor" Number="15" Volume="2006" Year="2007">
-      <Id>4f954017-d077-4962-bc33-8644225524bf</Id>
+      <Database Name="cv" Series="18109" Issue="106036" />
     </Book>
     <Book Series="X-Factor" Number="16" Volume="2006" Year="2007">
-      <Id>bcf5fe2f-3b1d-43c1-9bef-5ae3a33c4b4b</Id>
+      <Database Name="cv" Series="18109" Issue="106719" />
     </Book>
     <Book Series="X-Factor" Number="17" Volume="2006" Year="2007">
-      <Id>3d19d770-bf32-45e3-83f1-ea1e5776bc76</Id>
+      <Database Name="cv" Series="18109" Issue="107207" />
     </Book>
     <Book Series="New X-Men" Number="37" Volume="2004" Year="2007">
-      <Id>314ae6d6-b177-4d66-ad2d-615babbdf7f1</Id>
+      <Database Name="cv" Series="18078" Issue="107611" />
     </Book>
     <Book Series="New X-Men" Number="38" Volume="2004" Year="2007">
-      <Id>544adb84-aa1e-465b-ae3b-8e7b523c1b06</Id>
+      <Database Name="cv" Series="18078" Issue="107615" />
     </Book>
     <Book Series="New X-Men" Number="39" Volume="2004" Year="2007">
-      <Id>f0843720-9ac1-4722-b78b-f8f1efaabf7e</Id>
+      <Database Name="cv" Series="18078" Issue="107619" />
     </Book>
     <Book Series="New X-Men" Number="40" Volume="2004" Year="2007">
-      <Id>987f8b84-e692-488b-bcb0-63cb409f1222</Id>
+      <Database Name="cv" Series="18078" Issue="109760" />
     </Book>
     <Book Series="New X-Men" Number="41" Volume="2004" Year="2007">
-      <Id>c4d8ec62-6585-4620-b481-beb80a35ed91</Id>
+      <Database Name="cv" Series="18078" Issue="109761" />
     </Book>
     <Book Series="X-Factor" Number="18" Volume="2006" Year="2007">
-      <Id>f8b7953d-cdc7-4395-a7f5-2d15e2a0b9a6</Id>
+      <Database Name="cv" Series="18109" Issue="108557" />
     </Book>
     <Book Series="X-Factor" Number="19" Volume="2006" Year="2007">
-      <Id>00e7d36f-812b-4274-a0b9-a0f0b59fb5fc</Id>
+      <Database Name="cv" Series="18109" Issue="109701" />
     </Book>
     <Book Series="X-Factor" Number="20" Volume="2006" Year="2007">
-      <Id>5766e34b-4392-4ab2-8942-18d59df4c237</Id>
+      <Database Name="cv" Series="18109" Issue="109737" />
     </Book>
     <Book Series="Wolverine" Number="50" Volume="2003" Year="2007">
-      <Id>dd1279de-d277-4dae-98f3-653614084e0b</Id>
+      <Database Name="cv" Series="10809" Issue="106007" />
     </Book>
     <Book Series="Wolverine" Number="51" Volume="2003" Year="2007">
-      <Id>910b9f76-1c77-449c-8fea-1d2d0ea0f72c</Id>
+      <Database Name="cv" Series="10809" Issue="106709" />
     </Book>
     <Book Series="Wolverine" Number="52" Volume="2003" Year="2007">
-      <Id>1c6dd9a6-33cb-45ac-94db-42ace7307e0f</Id>
+      <Database Name="cv" Series="10809" Issue="107595" />
     </Book>
     <Book Series="Wolverine" Number="53" Volume="2003" Year="2007">
-      <Id>5caada23-094e-4c1a-bed9-2cc33fd537ad</Id>
+      <Database Name="cv" Series="10809" Issue="108791" />
     </Book>
     <Book Series="Wolverine" Number="54" Volume="2003" Year="2007">
-      <Id>4c8376b6-f958-47e1-a13c-8b4a1e76efa3</Id>
+      <Database Name="cv" Series="10809" Issue="110055" />
     </Book>
     <Book Series="Wolverine" Number="55" Volume="2003" Year="2007">
-      <Id>022bf787-88e2-4a59-a885-333899bf664b</Id>
+      <Database Name="cv" Series="10809" Issue="112001" />
     </Book>
     <Book Series="Wolverine Annual" Number="1" Volume="2007" Year="2007">
-      <Id>d0f576cd-236c-4a29-9d52-097e87184ac9</Id>
+      <Database Name="cv" Series="19222" Issue="115222" />
     </Book>
     <Book Series="Wolverine Origins Annual" Number="1" Volume="2007" Year="2007">
-      <Id>34529947-38f0-4947-bd16-883d25abae15</Id>
+      <Database Name="cv" Series="18924" Issue="111917" />
     </Book>
     <Book Series="Wolverine" Number="56" Volume="2003" Year="2007">
-      <Id>9bcc8055-49e9-4b10-8c10-e5edcd6badc1</Id>
+      <Database Name="cv" Series="10809" Issue="113777" />
     </Book>
     <Book Series="World War Hulk: X-Men" Number="1" Volume="2007" Year="2007">
-      <Id>b94d41f6-4ecd-42a8-87ca-818684ed49a3</Id>
+      <Database Name="cv" Series="18786" Issue="111036" />
     </Book>
     <Book Series="World War Hulk: X-Men" Number="2" Volume="2007" Year="2007">
-      <Id>f4ec563b-aed7-4343-a58b-653424703ddf</Id>
+      <Database Name="cv" Series="18786" Issue="111708" />
     </Book>
     <Book Series="World War Hulk: X-Men" Number="3" Volume="2007" Year="2007">
-      <Id>efe752bb-f6e7-489e-be14-7c5e1ae6ae71</Id>
+      <Database Name="cv" Series="18786" Issue="113957" />
     </Book>
     <Book Series="New Excalibur" Number="18" Volume="2006" Year="2007">
-      <Id>df51d125-df3f-41a9-96ed-0835b186e28f</Id>
+      <Database Name="cv" Series="18019" Issue="108192" />
     </Book>
     <Book Series="New Excalibur" Number="19" Volume="2006" Year="2007">
-      <Id>8e675a6c-db36-4b3b-a3f3-a3e4a9f91516</Id>
+      <Database Name="cv" Series="18019" Issue="108775" />
     </Book>
     <Book Series="New Excalibur" Number="20" Volume="2006" Year="2007">
-      <Id>6603e668-1798-4bc4-b691-f02390189fbe</Id>
+      <Database Name="cv" Series="18019" Issue="110023" />
     </Book>
     <Book Series="New Excalibur" Number="21" Volume="2006" Year="2007">
-      <Id>2208946b-493f-4ee0-bb7d-b7c9d759b1f6</Id>
+      <Database Name="cv" Series="18019" Issue="111538" />
     </Book>
     <Book Series="New Excalibur" Number="22" Volume="2006" Year="2007">
-      <Id>d2de50ad-4a7d-41eb-91e2-74fac90efe08</Id>
+      <Database Name="cv" Series="18019" Issue="113104" />
     </Book>
     <Book Series="New Excalibur" Number="23" Volume="2006" Year="2007">
-      <Id>03a06699-9311-4883-989e-9951d3c04186</Id>
+      <Database Name="cv" Series="18019" Issue="114226" />
     </Book>
     <Book Series="New Excalibur" Number="24" Volume="2006" Year="2007">
-      <Id>75bb6d1e-ba62-43ad-bb04-477b7f1d2f01</Id>
+      <Database Name="cv" Series="18019" Issue="115678" />
     </Book>
     <Book Series="X-Men: Die by the Sword" Number="1" Volume="2007" Year="2007">
-      <Id>a00e23bc-d45b-436f-9307-4666500579f9</Id>
+      <Database Name="cv" Series="19237" Issue="115387" />
     </Book>
     <Book Series="X-Men: Die by the Sword" Number="2" Volume="2007" Year="2007">
-      <Id>1d3b4a04-3281-43fa-84aa-26685a3e02c1</Id>
+      <Database Name="cv" Series="19237" Issue="118035" />
     </Book>
     <Book Series="X-Men: Die by the Sword" Number="3" Volume="2007" Year="2008">
-      <Id>5ff18c50-be0d-45d1-99e1-32b5278f6808</Id>
+      <Database Name="cv" Series="19237" Issue="118034" />
     </Book>
     <Book Series="X-Men: Die by the Sword" Number="4" Volume="2007" Year="2008">
-      <Id>356f5591-227a-4887-958d-d937f542e178</Id>
+      <Database Name="cv" Series="19237" Issue="119414" />
     </Book>
     <Book Series="X-Men: Die by the Sword" Number="5" Volume="2007" Year="2008">
-      <Id>b1ea65dd-8679-4eed-8067-8464aa958fb6</Id>
+      <Database Name="cv" Series="19237" Issue="119970" />
     </Book>
     <Book Series="Wolverine: Origins" Number="16" Volume="2006" Year="2007">
-      <Id>7abb27c9-c20a-4ed3-92d9-ddcd1a3ce9b7</Id>
+      <Database Name="cv" Series="18130" Issue="113606" />
     </Book>
     <Book Series="Wolverine: Origins" Number="17" Volume="2006" Year="2007">
-      <Id>2ffd34ec-95eb-41b6-aae0-ea3397bd685a</Id>
+      <Database Name="cv" Series="18130" Issue="114666" />
     </Book>
     <Book Series="Wolverine: Origins" Number="18" Volume="2006" Year="2007">
-      <Id>5fa172c9-6954-4155-bf9e-7b4d1f26e910</Id>
+      <Database Name="cv" Series="18130" Issue="115676" />
     </Book>
     <Book Series="Wolverine: Origins" Number="19" Volume="2006" Year="2008">
-      <Id>88165cdf-38d8-4e4e-a8c4-72b2673880c9</Id>
+      <Database Name="cv" Series="18130" Issue="118107" />
     </Book>
     <Book Series="Wolverine: Origins" Number="20" Volume="2006" Year="2008">
-      <Id>6f16211d-5851-4ac2-a67a-5fd194539da4</Id>
+      <Database Name="cv" Series="18130" Issue="120277" />
     </Book>
     <Book Series="Wolverine" Number="57" Volume="2003" Year="2007">
-      <Id>fdeac2eb-1e17-4684-9717-59dfa74f5978</Id>
+      <Database Name="cv" Series="10809" Issue="114205" />
     </Book>
     <Book Series="Wolverine" Number="58" Volume="2003" Year="2007">
-      <Id>8beba2ff-5259-43bb-a71f-54e84e05ce12</Id>
+      <Database Name="cv" Series="10809" Issue="115414" />
     </Book>
     <Book Series="Wolverine" Number="59" Volume="2003" Year="2008">
-      <Id>b5f21119-45ff-4242-bafd-c5a7cc7a91ac</Id>
+      <Database Name="cv" Series="10809" Issue="117828" />
     </Book>
     <Book Series="Wolverine" Number="60" Volume="2003" Year="2008">
-      <Id>b76e05b0-5707-496d-8270-7629eec9ccf6</Id>
+      <Database Name="cv" Series="10809" Issue="119797" />
     </Book>
     <Book Series="Wolverine" Number="61" Volume="2003" Year="2008">
-      <Id>b3a8f359-3fe7-4bb0-9aa9-d9b7ca554b08</Id>
+      <Database Name="cv" Series="10809" Issue="121051" />
     </Book>
     <Book Series="X-Men: Emperor Vulcan" Number="1" Volume="2007" Year="2007">
-      <Id>0d8ddf2a-6bdc-4ecd-a359-3d36b3cac3f7</Id>
+      <Database Name="cv" Series="19130" Issue="114391" />
     </Book>
     <Book Series="X-Men: Emperor Vulcan" Number="2" Volume="2007" Year="2007">
-      <Id>00a56afd-949a-4db8-896f-b4acdc7231a8</Id>
+      <Database Name="cv" Series="19130" Issue="115527" />
     </Book>
     <Book Series="X-Men: Emperor Vulcan" Number="3" Volume="2007" Year="2008">
-      <Id>10208d6a-f371-45f9-b964-bfc2b03766f0</Id>
+      <Database Name="cv" Series="19130" Issue="118122" />
     </Book>
     <Book Series="X-Men: Emperor Vulcan" Number="4" Volume="2007" Year="2008">
-      <Id>92db3e11-58aa-4221-9204-b851039eb249</Id>
+      <Database Name="cv" Series="19130" Issue="120631" />
     </Book>
     <Book Series="X-Men: Emperor Vulcan" Number="5" Volume="2007" Year="2008">
-      <Id>6169bc54-8a19-4ed3-8319-6e9fb6b8aab8</Id>
+      <Database Name="cv" Series="19130" Issue="122474" />
     </Book>
     <Book Series="Mystic Arcana: The Book of Marvel Magic" Number="1" Volume="2007" Year="2007">
-      <Id>00401a40-6fea-46a2-8141-4dbc7428f6a8</Id>
+      <Database Name="cv" Series="18680" Issue="110379" />
     </Book>
     <Book Series="Astonishing X-Men" Number="13" Volume="2004" Year="2006">
-      <Id>9cf07082-2ca4-4e8d-b370-e2106a920b9d</Id>
+      <Database Name="cv" Series="10746" Issue="106677" />
     </Book>
     <Book Series="Astonishing X-Men" Number="14" Volume="2004" Year="2006">
-      <Id>56b7f1fe-5188-4aee-a4b5-a9a9e55f3cc1</Id>
+      <Database Name="cv" Series="10746" Issue="106678" />
     </Book>
     <Book Series="Astonishing X-Men" Number="15" Volume="2004" Year="2006">
-      <Id>4c85bb6e-adb7-40c5-b69b-094362f9482f</Id>
+      <Database Name="cv" Series="10746" Issue="106750" />
     </Book>
     <Book Series="Astonishing X-Men" Number="16" Volume="2004" Year="2006">
-      <Id>59e36ca0-22d8-4852-a8eb-e7965e5ce275</Id>
+      <Database Name="cv" Series="10746" Issue="106751" />
     </Book>
     <Book Series="Astonishing X-Men" Number="17" Volume="2004" Year="2006">
-      <Id>a68984dc-8bc8-482a-9fb2-41c5e6d68b08</Id>
+      <Database Name="cv" Series="10746" Issue="106752" />
     </Book>
     <Book Series="Astonishing X-Men" Number="18" Volume="2004" Year="2006">
-      <Id>7b9a2517-3223-43a8-a69d-42d54d51b2e1</Id>
+      <Database Name="cv" Series="10746" Issue="106130" />
     </Book>
     <Book Series="Astonishing X-Men" Number="19" Volume="2004" Year="2007">
-      <Id>9695f5ba-8fe0-4f71-add7-e90982cd0f7e</Id>
+      <Database Name="cv" Series="10746" Issue="106105" />
     </Book>
     <Book Series="Astonishing X-Men" Number="20" Volume="2004" Year="2007">
-      <Id>83815834-0f0b-4d08-8b96-d82c7f6dfbda</Id>
+      <Database Name="cv" Series="10746" Issue="106469" />
     </Book>
     <Book Series="Astonishing X-Men" Number="21" Volume="2004" Year="2007">
-      <Id>a53ce6b6-844b-4b0b-8e04-25aed028b50d</Id>
+      <Database Name="cv" Series="10746" Issue="108923" />
     </Book>
     <Book Series="Astonishing X-Men" Number="22" Volume="2004" Year="2007">
-      <Id>1c4e2ea0-f24a-4677-bd0e-f23ef20d764d</Id>
+      <Database Name="cv" Series="10746" Issue="113737" />
     </Book>
     <Book Series="Astonishing X-Men" Number="23" Volume="2004" Year="2008">
-      <Id>6c35695a-9342-4703-8017-d07ffb21012d</Id>
+      <Database Name="cv" Series="10746" Issue="116965" />
     </Book>
     <Book Series="Astonishing X-Men" Number="24" Volume="2004" Year="2008">
-      <Id>b2e01c1c-79e8-4875-b27e-6054af6d7384</Id>
+      <Database Name="cv" Series="10746" Issue="121887" />
     </Book>
     <Book Series="Giant-Size Astonishing X-Men" Number="1" Volume="2008" Year="2008">
-      <Id>0e85ba17-5524-4c69-9bcf-58b662cec89e</Id>
+      <Database Name="cv" Series="21710" Issue="130969" />
     </Book>
     <Book Series="X-Men Annual" Number="1" Volume="2007" Year="2007">
-      <Id>8b6e4f28-ff17-4cfa-b745-a367e65e9921</Id>
+      <Database Name="cv" Series="18169" Issue="106389" />
     </Book>
     <Book Series="X-Men" Number="194" Volume="2004" Year="2007">
-      <Id>c79bbb58-6530-466b-9753-403e6afe42c1</Id>
+      <Database Name="cv" Series="10731" Issue="107948" />
     </Book>
     <Book Series="X-Men" Number="195" Volume="2004" Year="2007">
-      <Id>6137cb12-3547-48fb-bfc1-7fcd09fcd068</Id>
+      <Database Name="cv" Series="10731" Issue="106283" />
     </Book>
     <Book Series="X-Men" Number="196" Volume="2004" Year="2007">
-      <Id>28f3ab70-72ff-434e-bb71-35e39f0288a1</Id>
+      <Database Name="cv" Series="10731" Issue="106710" />
     </Book>
     <Book Series="X-Men" Number="197" Volume="2004" Year="2007">
-      <Id>81a70041-d8fe-4dd6-91f7-30085f1a9c38</Id>
+      <Database Name="cv" Series="10731" Issue="107206" />
     </Book>
     <Book Series="X-Men" Number="198" Volume="2004" Year="2007">
-      <Id>b4149f76-8484-4385-9c46-89aedf19a08d</Id>
+      <Database Name="cv" Series="10731" Issue="108555" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="40" Volume="2004" Year="2007">
-      <Id>d89e03c5-e547-4b28-8831-771bfc307466</Id>
+    <Book Series="Cable &#38; Deadpool" Number="40" Volume="2004" Year="2007">
+      <Database Name="cv" Series="18070" Issue="109608" />
     </Book>
     <Book Series="X-Men" Number="199" Volume="2004" Year="2007">
-      <Id>d57d6565-5106-47ec-8dee-aaa069cf3fc4</Id>
+      <Database Name="cv" Series="10731" Issue="109821" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="41" Volume="2004" Year="2007">
-      <Id>f46c3dc9-e8a6-4a23-9aa4-58a7c85b0f7b</Id>
+    <Book Series="Cable &#38; Deadpool" Number="41" Volume="2004" Year="2007">
+      <Database Name="cv" Series="18070" Issue="110433" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="42" Volume="2004" Year="2007">
-      <Id>511cbfca-8230-40e6-aa37-8500f8f9abb5</Id>
+    <Book Series="Cable &#38; Deadpool" Number="42" Volume="2004" Year="2007">
+      <Database Name="cv" Series="18070" Issue="111382" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="43" Volume="2004" Year="2007">
-      <Id>0f3beaa7-8712-4a8c-ac4e-f7581bff2ead</Id>
+    <Book Series="Cable &#38; Deadpool" Number="43" Volume="2004" Year="2007">
+      <Database Name="cv" Series="18070" Issue="113260" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="44" Volume="2004" Year="2007">
-      <Id>69c6a501-e1d0-4364-9d06-6e396a7b6dcf</Id>
+    <Book Series="Cable &#38; Deadpool" Number="44" Volume="2004" Year="2007">
+      <Database Name="cv" Series="18070" Issue="113776" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="45" Volume="2004" Year="2007">
-      <Id>918748b1-9764-4baa-acc4-b3ed79a06518</Id>
+    <Book Series="Cable &#38; Deadpool" Number="45" Volume="2004" Year="2007">
+      <Database Name="cv" Series="18070" Issue="115029" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="46" Volume="2004" Year="2007">
-      <Id>fd8a4a2f-11a4-4339-bbe9-13ab53df1378</Id>
+    <Book Series="Cable &#38; Deadpool" Number="46" Volume="2004" Year="2007">
+      <Database Name="cv" Series="18070" Issue="115850" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="47" Volume="2004" Year="2008">
-      <Id>81f39687-57e7-4434-98e6-b0833402dfee</Id>
+    <Book Series="Cable &#38; Deadpool" Number="47" Volume="2004" Year="2008">
+      <Database Name="cv" Series="18070" Issue="118643" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="48" Volume="2004" Year="2008">
-      <Id>bb41deaa-3273-48a0-a332-e18481b4b598</Id>
+    <Book Series="Cable &#38; Deadpool" Number="48" Volume="2004" Year="2008">
+      <Database Name="cv" Series="18070" Issue="120276" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="49" Volume="2004" Year="2008">
-      <Id>76541937-f720-4b7f-b79b-c79ac71ee2c1</Id>
+    <Book Series="Cable &#38; Deadpool" Number="49" Volume="2004" Year="2008">
+      <Database Name="cv" Series="18070" Issue="121623" />
     </Book>
-    <Book Series="Cable &amp; Deadpool" Number="50" Volume="2004" Year="2008">
-      <Id>c15f877d-e155-49e1-83f1-3e6ac8d7c71e</Id>
+    <Book Series="Cable &#38; Deadpool" Number="50" Volume="2004" Year="2008">
+      <Database Name="cv" Series="18070" Issue="123541" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="487" Volume="1981" Year="2007">
-      <Id>1eae77a5-0d9c-4b41-96d3-0aef5aaca5ed</Id>
+      <Database Name="cv" Series="3092" Issue="110274" />
     </Book>
     <Book Series="X-Men: Endangered Species" Number="1" Volume="2008" Year="2008">
-      <Id>adbb9905-c49c-4c20-8175-ec27b454c1e6</Id>
+      <Database Name="cv" Series="30728" Issue="189762" />
     </Book>
     <Book Series="X-Men" Number="200" Volume="2004" Year="2007">
-      <Id>6aec9746-c158-46f8-b525-aade1ec5da63</Id>
+      <Database Name="cv" Series="10731" Issue="111032" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="488" Volume="1981" Year="2007">
-      <Id>53949ca2-0a75-452e-b309-058abbe64a7c</Id>
+      <Database Name="cv" Series="3092" Issue="111241" />
     </Book>
     <Book Series="X-Factor" Number="21" Volume="2006" Year="2007">
-      <Id>87599796-cd12-470b-a20c-826c285527b5</Id>
+      <Database Name="cv" Series="18109" Issue="111490" />
     </Book>
     <Book Series="X-Men" Number="201" Volume="2004" Year="2007">
-      <Id>07c6216c-0866-4cee-9975-abf2081c4edc</Id>
+      <Database Name="cv" Series="10731" Issue="111931" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="489" Volume="1981" Year="2007">
-      <Id>c0669b7b-3548-4c97-b04f-3e4c0b808fed</Id>
+      <Database Name="cv" Series="3092" Issue="111383" />
     </Book>
     <Book Series="X-Factor" Number="22" Volume="2006" Year="2007">
-      <Id>cb856922-3ffa-4be0-966b-e592b8e70073</Id>
+      <Database Name="cv" Series="18109" Issue="112962" />
     </Book>
     <Book Series="X-Men" Number="202" Volume="2004" Year="2007">
-      <Id>cc4a4163-3264-47a7-9475-3b333caf2b49</Id>
+      <Database Name="cv" Series="10731" Issue="113738" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="490" Volume="1981" Year="2007">
-      <Id>40e7e80e-6dd6-4b71-8be5-010993479ba1</Id>
+      <Database Name="cv" Series="3092" Issue="114204" />
     </Book>
     <Book Series="X-Factor" Number="23" Volume="2006" Year="2007">
-      <Id>28c20955-d430-4cef-a541-9079bbe6a567</Id>
+      <Database Name="cv" Series="18109" Issue="114395" />
     </Book>
     <Book Series="New X-Men" Number="42" Volume="2004" Year="2007">
-      <Id>a412bcf4-c0f3-483f-93fd-c8ddddc959fd</Id>
+      <Database Name="cv" Series="18078" Issue="114617" />
     </Book>
     <Book Series="X-Men" Number="203" Volume="2004" Year="2007">
-      <Id>3cb1f220-3eb5-4fb6-8945-b30ec8af426b</Id>
+      <Database Name="cv" Series="10731" Issue="114946" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="491" Volume="1981" Year="2007">
-      <Id>4144c2aa-760a-4f40-bdfb-755a629c4589</Id>
+      <Database Name="cv" Series="3092" Issue="115143" />
     </Book>
     <Book Series="X-Factor" Number="24" Volume="2006" Year="2007">
-      <Id>99de5e84-2985-4f72-b2ef-b484eff6df56</Id>
+      <Database Name="cv" Series="18109" Issue="115410" />
     </Book>
     <Book Series="X-Men" Number="204" Volume="2004" Year="2007">
-      <Id>cbcec38e-104f-493a-b292-40fc001f7c72</Id>
+      <Database Name="cv" Series="10731" Issue="115779" />
     </Book>
     <Book Series="New X-Men" Number="43" Volume="2004" Year="2007">
-      <Id>6e63f8fc-1601-41ef-b703-c728fc6e43f7</Id>
+      <Database Name="cv" Series="18078" Issue="116391" />
     </Book>
     <Book Series="X-Men: Magneto Testament" Number="1" Volume="2008" Year="2008">
-      <Id>aac83915-9967-472a-b8af-9bb0a2b5aafd</Id>
+      <Database Name="cv" Series="22971" Issue="138412" />
     </Book>
     <Book Series="X-Men: Magneto Testament" Number="2" Volume="2008" Year="2008">
-      <Id>f932f004-107a-48f2-ae2c-06061ea5eddf</Id>
+      <Database Name="cv" Series="22971" Issue="140122" />
     </Book>
     <Book Series="X-Men: Magneto Testament" Number="3" Volume="2008" Year="2009">
-      <Id>09ed3d5e-2db7-4f79-9979-f82223f2b010</Id>
+      <Database Name="cv" Series="22971" Issue="141972" />
     </Book>
     <Book Series="X-Men: Magneto Testament" Number="4" Volume="2008" Year="2009">
-      <Id>c07925fa-f3bd-4dc3-bbaa-881500d0fb48</Id>
+      <Database Name="cv" Series="22971" Issue="149298" />
     </Book>
     <Book Series="X-Men: Magneto Testament" Number="5" Volume="2008" Year="2009">
-      <Id>d5ad7909-c53f-4e73-ba98-e7db66534186</Id>
+      <Database Name="cv" Series="22971" Issue="151118" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 011 (Messiah Complex).cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 011 (Messiah Complex).cbl
@@ -2,1060 +2,1060 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>X-Men - Part 11 (Messiah Complex)</Name>
   <Books>
-    <Book Series="X-Men: Messiah Complex" Number="1" Volume="2007" Year="2007" Format="One-Shot">
+    <Book Series="X-Men: Messiah Complex" Number="1" Volume="2007" Year="2007">
       <Id>2172251d-6a8b-481c-82d9-afb98b29f1c4</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="492" Volume="1981" Year="2008" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="492" Volume="1981" Year="2008">
       <Id>d199ab09-b274-48ee-b1c9-c8f5d5e34edd</Id>
     </Book>
-    <Book Series="X-Factor" Number="25" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="X-Factor" Number="25" Volume="2006" Year="2008">
       <Id>de7e3f43-5803-430f-b5d4-32209dd0b600</Id>
     </Book>
-    <Book Series="New X-Men" Number="44" Volume="2004" Year="2008" Format="Main Series">
+    <Book Series="New X-Men" Number="44" Volume="2004" Year="2008">
       <Id>bdb76c74-efaa-48d6-a6e7-56f82deb0f53</Id>
     </Book>
-    <Book Series="X-Men" Number="205" Volume="2004" Year="2008" Format="Main Series">
+    <Book Series="X-Men" Number="205" Volume="2004" Year="2008">
       <Id>22e2fb38-1807-4f15-844a-ab6e2725d9bb</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="493" Volume="1981" Year="2008" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="493" Volume="1981" Year="2008">
       <Id>a04f71e7-ded1-484a-b820-57a60e6d2010</Id>
     </Book>
-    <Book Series="X-Factor" Number="26" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="X-Factor" Number="26" Volume="2006" Year="2008">
       <Id>daff3a26-52d1-4441-8956-3cf067423d7b</Id>
     </Book>
-    <Book Series="New X-Men" Number="45" Volume="2004" Year="2008" Format="Main Series">
+    <Book Series="New X-Men" Number="45" Volume="2004" Year="2008">
       <Id>b36ff774-dcf5-43ba-b79e-ee1db30833a9</Id>
     </Book>
-    <Book Series="X-Men" Number="206" Volume="2004" Year="2008" Format="Main Series">
+    <Book Series="X-Men" Number="206" Volume="2004" Year="2008">
       <Id>06670d7a-45fb-4f2b-a1f9-b5d5dab7a395</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="494" Volume="1981" Year="2008" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="494" Volume="1981" Year="2008">
       <Id>619972bf-16e0-4e32-9262-50e2b7fd7671</Id>
     </Book>
-    <Book Series="X-Factor" Number="27" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="X-Factor" Number="27" Volume="2006" Year="2008">
       <Id>409755d2-722c-4ef7-a140-d0f172687ec3</Id>
     </Book>
-    <Book Series="New X-Men" Number="46" Volume="2004" Year="2008" Format="Main Series">
+    <Book Series="New X-Men" Number="46" Volume="2004" Year="2008">
       <Id>a1baac28-becd-402a-a462-9fe48230fc68</Id>
     </Book>
-    <Book Series="X-Men" Number="207" Volume="2004" Year="2008" Format="Main Series">
+    <Book Series="X-Men" Number="207" Volume="2004" Year="2008">
       <Id>d8068777-4034-4e5a-8328-98be6022e0d7</Id>
     </Book>
-    <Book Series="Wolverine" Number="62" Volume="2003" Year="2008" Format="Main Series">
+    <Book Series="Wolverine" Number="62" Volume="2003" Year="2008">
       <Id>8de69dca-ab8d-44a6-b498-0b516c03006a</Id>
     </Book>
-    <Book Series="Wolverine" Number="63" Volume="2003" Year="2008" Format="Main Series">
+    <Book Series="Wolverine" Number="63" Volume="2003" Year="2008">
       <Id>4beb324c-8845-411f-8820-fd816a9986e9</Id>
     </Book>
-    <Book Series="Wolverine" Number="64" Volume="2003" Year="2008" Format="Main Series">
+    <Book Series="Wolverine" Number="64" Volume="2003" Year="2008">
       <Id>16a01edf-1a55-4d1d-bbab-3b2f3d51906c</Id>
     </Book>
-    <Book Series="Wolverine" Number="65" Volume="2003" Year="2008" Format="Main Series">
+    <Book Series="Wolverine" Number="65" Volume="2003" Year="2008">
       <Id>3d2f4499-f70c-443b-a8c4-9d0257d77002</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="208" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="208" Volume="2008" Year="2008">
       <Id>20e4ed59-5360-427f-99d9-7d60a6919eae</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="209" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="209" Volume="2008" Year="2008">
       <Id>a147f93f-78e5-468e-996d-98acc7473916</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="210" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="210" Volume="2008" Year="2008">
       <Id>eca532bd-4ec9-4ed0-aef1-e04e5c1e26e5</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="211" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="211" Volume="2008" Year="2008">
       <Id>6013d187-5d5a-435f-a705-d56c0b65b483</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="212" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="212" Volume="2008" Year="2008">
       <Id>6c09a2c9-4cef-4f68-8b8e-76ade8a106eb</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="213" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="213" Volume="2008" Year="2008">
       <Id>cd8fde6c-3fe8-44a1-8323-2a67c385fc19</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="214" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="214" Volume="2008" Year="2008">
       <Id>250e276f-f392-46c2-b2cc-e6070de9eaea</Id>
     </Book>
-    <Book Series="Young X-Men" Number="1" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="Young X-Men" Number="1" Volume="2008" Year="2008">
       <Id>9ca423b6-9785-4a20-9a93-81c9fa323c68</Id>
     </Book>
-    <Book Series="Young X-Men" Number="2" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="Young X-Men" Number="2" Volume="2008" Year="2008">
       <Id>52f8abf9-581f-4b6f-82b4-a7957350c5ca</Id>
     </Book>
-    <Book Series="Young X-Men" Number="3" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="Young X-Men" Number="3" Volume="2008" Year="2008">
       <Id>6f294363-8318-4131-be88-0c6b827f20b2</Id>
     </Book>
-    <Book Series="Young X-Men" Number="4" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="Young X-Men" Number="4" Volume="2008" Year="2008">
       <Id>fa4712f4-6315-47ea-bffc-a2eacd06cda6</Id>
     </Book>
-    <Book Series="Young X-Men" Number="5" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="Young X-Men" Number="5" Volume="2008" Year="2008">
       <Id>3071f57a-0f87-4ce1-8045-496de9fc2f72</Id>
     </Book>
-    <Book Series="X-Factor" Number="28" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="X-Factor" Number="28" Volume="2006" Year="2008">
       <Id>e7212633-58a0-443e-a982-79d38dcd0382</Id>
     </Book>
-    <Book Series="X-Factor" Number="29" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="X-Factor" Number="29" Volume="2006" Year="2008">
       <Id>7bd0f496-0c1e-458b-9c46-40eb5d7edce7</Id>
     </Book>
-    <Book Series="X-Factor" Number="30" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="X-Factor" Number="30" Volume="2006" Year="2008">
       <Id>dec4c03c-6be5-4285-9fc0-1aed1dc59eea</Id>
     </Book>
-    <Book Series="X-Factor" Number="31" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="X-Factor" Number="31" Volume="2006" Year="2008">
       <Id>7be0d2fa-273e-43a2-b1f3-8bfd6f7b8410</Id>
     </Book>
-    <Book Series="X-Factor" Number="32" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="X-Factor" Number="32" Volume="2006" Year="2008">
       <Id>50aa30db-efbe-486f-8a6c-e72b5e5738e5</Id>
     </Book>
-    <Book Series="X-Force" Number="1" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="X-Force" Number="1" Volume="2008" Year="2008">
       <Id>4239d933-8be5-4a1c-be85-60c821134684</Id>
     </Book>
-    <Book Series="X-Force" Number="2" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="X-Force" Number="2" Volume="2008" Year="2008">
       <Id>395beebf-8f7f-4b1a-a72f-8b31933ba0af</Id>
     </Book>
-    <Book Series="X-Force" Number="3" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="X-Force" Number="3" Volume="2008" Year="2008">
       <Id>78567c3c-7093-4df3-b92a-85e0d74ace2b</Id>
     </Book>
-    <Book Series="X-Force" Number="4" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="X-Force" Number="4" Volume="2008" Year="2008">
       <Id>01b1b0be-46c0-4b77-8f7d-002f4413b347</Id>
     </Book>
-    <Book Series="X-Force" Number="5" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="X-Force" Number="5" Volume="2008" Year="2008">
       <Id>22c37441-eebe-45f3-94a9-2e3a866ae577</Id>
     </Book>
-    <Book Series="X-Force" Number="6" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="X-Force" Number="6" Volume="2008" Year="2008">
       <Id>e3b0024e-28f8-4f41-9b5a-ad82d46d8c34</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="495" Volume="1981" Year="2008" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="495" Volume="1981" Year="2008">
       <Id>f620083b-c8fc-491f-936b-3d85500e6584</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="496" Volume="1981" Year="2008" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="496" Volume="1981" Year="2008">
       <Id>87b1be42-34db-4055-a4ae-09061ad16991</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="497" Volume="1981" Year="2008" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="497" Volume="1981" Year="2008">
       <Id>a3ab5939-75ca-497f-a590-272c86e4c2df</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="498" Volume="1981" Year="2008" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="498" Volume="1981" Year="2008">
       <Id>c9067f5d-f2f2-4953-b4d0-dbb853430131</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="499" Volume="1981" Year="2008" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="499" Volume="1981" Year="2008">
       <Id>31ad0714-c769-42ec-8c18-c6d936783e95</Id>
     </Book>
-    <Book Series="X-Men: Divided We Stand" Number="1" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="X-Men: Divided We Stand" Number="1" Volume="2008" Year="2008">
       <Id>4df21649-db00-432a-8bbe-e85bf11095bf</Id>
     </Book>
-    <Book Series="X-Men: Divided We Stand" Number="2" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="X-Men: Divided We Stand" Number="2" Volume="2008" Year="2008">
       <Id>231e98a3-5135-418d-9551-92337515bdb8</Id>
     </Book>
-    <Book Series="Cable" Number="1" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="Cable" Number="1" Volume="2008" Year="2008">
       <Id>6a47bbfb-369e-409b-a53e-581c7e36a418</Id>
     </Book>
-    <Book Series="Cable" Number="2" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="Cable" Number="2" Volume="2008" Year="2008">
       <Id>eda0a68a-09ac-4ff9-b6ae-20daef3eff27</Id>
     </Book>
-    <Book Series="Cable" Number="3" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="Cable" Number="3" Volume="2008" Year="2008">
       <Id>162719b8-ccd8-496d-9344-f561b64f831b</Id>
     </Book>
-    <Book Series="Cable" Number="4" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="Cable" Number="4" Volume="2008" Year="2008">
       <Id>8b7d5cfd-9978-421d-b97a-1961d468f32e</Id>
     </Book>
-    <Book Series="Cable" Number="5" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="Cable" Number="5" Volume="2008" Year="2008">
       <Id>52ac93c9-19ac-474e-8d52-edc885f6e735</Id>
     </Book>
-    <Book Series="X-Force Special: Ain't No Dog" Number="1" Volume="2008" Year="2008" Format="One-Shot">
+    <Book Series="X-Force Special: Ain't No Dog" Number="1" Volume="2008" Year="2008">
       <Id>c69e8593-56b3-4443-9c42-b9048706209e</Id>
     </Book>
-    <Book Series="Logan" Number="1" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="Logan" Number="1" Volume="2008" Year="2008">
       <Id>1f24c0cd-36d3-46c7-a4f5-cf52adef26e4</Id>
     </Book>
-    <Book Series="Logan" Number="2" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="Logan" Number="2" Volume="2008" Year="2008">
       <Id>057f7cdf-94c6-4c82-826e-477bf5f77025</Id>
     </Book>
-    <Book Series="Logan" Number="3" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="Logan" Number="3" Volume="2008" Year="2008">
       <Id>90513fe2-cec1-46cb-a5b0-707681e1a879</Id>
     </Book>
-    <Book Series="Angel: Revelations" Number="1" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="Angel: Revelations" Number="1" Volume="2008" Year="2008">
       <Id>cc03b6b6-1635-462d-a1ca-dcc28a01c0cc</Id>
     </Book>
-    <Book Series="Angel: Revelations" Number="2" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="Angel: Revelations" Number="2" Volume="2008" Year="2008">
       <Id>ba928d37-6e79-4cfb-b4c8-2a951a3da59b</Id>
     </Book>
-    <Book Series="Angel: Revelations" Number="3" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="Angel: Revelations" Number="3" Volume="2008" Year="2008">
       <Id>d433db65-986b-4d00-b46f-71c60ca63325</Id>
     </Book>
-    <Book Series="Angel: Revelations" Number="4" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="Angel: Revelations" Number="4" Volume="2008" Year="2008">
       <Id>1268164d-d451-482a-b48a-ccedd52bb1ac</Id>
     </Book>
-    <Book Series="Angel: Revelations" Number="5" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="Angel: Revelations" Number="5" Volume="2008" Year="2008">
       <Id>6999e296-1380-4949-9931-e06904638e2e</Id>
     </Book>
-    <Book Series="Wolverine: Dangerous Games" Number="1" Volume="2008" Year="2008" Format="One-Shot">
+    <Book Series="Wolverine: Dangerous Games" Number="1" Volume="2008" Year="2008">
       <Id>06a3def4-f450-42c8-8feb-f118f6a032eb</Id>
     </Book>
-    <Book Series="X-Men: Kingbreaker" Number="1" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="X-Men: Kingbreaker" Number="1" Volume="2009" Year="2009">
       <Id>4eb12379-ea00-4159-8aab-ed73848076c4</Id>
     </Book>
-    <Book Series="X-Men: Kingbreaker" Number="2" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="X-Men: Kingbreaker" Number="2" Volume="2009" Year="2009">
       <Id>1bd13648-e435-4542-bd6d-9a5f5d30f0e3</Id>
     </Book>
-    <Book Series="X-Men: Kingbreaker" Number="3" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="X-Men: Kingbreaker" Number="3" Volume="2009" Year="2009">
       <Id>d3e726a1-f990-474a-9895-d05c06332f63</Id>
     </Book>
-    <Book Series="X-Men: Kingbreaker" Number="4" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="X-Men: Kingbreaker" Number="4" Volume="2009" Year="2009">
       <Id>7ca5215d-504b-464e-b7a5-34df8c3ad0d0</Id>
     </Book>
-    <Book Series="X-Men: Manifest Destiny" Number="1" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="X-Men: Manifest Destiny" Number="1" Volume="2008" Year="2008">
       <Id>c1830ac8-40ff-4188-ab74-153f2d865be0</Id>
     </Book>
-    <Book Series="X-Men: Manifest Destiny" Number="2" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="X-Men: Manifest Destiny" Number="2" Volume="2008" Year="2008">
       <Id>b6efd243-2ca9-4be6-8b97-f0933bd3461d</Id>
     </Book>
-    <Book Series="X-Men: Manifest Destiny" Number="3" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="X-Men: Manifest Destiny" Number="3" Volume="2008" Year="2009">
       <Id>566b3fe5-3c4c-4912-a930-8b76e7b46860</Id>
     </Book>
-    <Book Series="X-Men: Manifest Destiny" Number="4" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="X-Men: Manifest Destiny" Number="4" Volume="2008" Year="2009">
       <Id>86d7592a-96e5-4f87-92c4-2ea681aeb4a6</Id>
     </Book>
-    <Book Series="X-Men: Manifest Destiny" Number="5" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="X-Men: Manifest Destiny" Number="5" Volume="2008" Year="2009">
       <Id>977e3595-d2d8-4b4b-8076-010194cbc742</Id>
     </Book>
-    <Book Series="X-Men: Manifest Destiny: Nightcrawler" Number="1" Volume="2009" Year="2009" Format="One-Shot">
+    <Book Series="X-Men: Manifest Destiny: Nightcrawler" Number="1" Volume="2009" Year="2009">
       <Id>3206a18a-8f96-4b44-8959-f5c3d2feb983</Id>
     </Book>
-    <Book Series="Wolverine: Manifest Destiny" Number="1" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="Wolverine: Manifest Destiny" Number="1" Volume="2008" Year="2008">
       <Id>883733de-0f9e-4a20-8a30-5d561654f231</Id>
     </Book>
-    <Book Series="Wolverine: Manifest Destiny" Number="2" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="Wolverine: Manifest Destiny" Number="2" Volume="2008" Year="2009">
       <Id>beef014b-9bc3-4b93-825c-36bbd374a3de</Id>
     </Book>
-    <Book Series="Wolverine: Manifest Destiny" Number="3" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="Wolverine: Manifest Destiny" Number="3" Volume="2008" Year="2009">
       <Id>f953f585-5004-4d4a-a653-99951cd82caa</Id>
     </Book>
-    <Book Series="Wolverine: Manifest Destiny" Number="4" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="Wolverine: Manifest Destiny" Number="4" Volume="2008" Year="2009">
       <Id>783cf126-160d-4b1f-b0c8-5406148e147d</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="25" Volume="2004" Year="2008" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="25" Volume="2004" Year="2008">
       <Id>bf115c5f-d4ee-4ecd-95e2-1b878d093234</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="26" Volume="2004" Year="2008" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="26" Volume="2004" Year="2008">
       <Id>48dbe156-9b45-4cc0-aa1f-c2670fcdf2ef</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="27" Volume="2004" Year="2008" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="27" Volume="2004" Year="2008">
       <Id>89e65047-29ca-4981-8188-6917a5a16bac</Id>
     </Book>
-    <Book Series="Astonishing X-Men: Ghost Boxes" Number="1" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="Astonishing X-Men: Ghost Boxes" Number="1" Volume="2008" Year="2008">
       <Id>473d85c6-3f60-4e45-932a-40a387ef56ba</Id>
     </Book>
-    <Book Series="Astonishing X-Men: Ghost Boxes" Number="2" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="Astonishing X-Men: Ghost Boxes" Number="2" Volume="2008" Year="2009">
       <Id>904e3652-b778-41c2-9ff2-be3f8cf138c7</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="28" Volume="2004" Year="2009" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="28" Volume="2004" Year="2009">
       <Id>c6334284-d6c4-41fb-9402-071d36e5cbd3</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="29" Volume="2004" Year="2009" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="29" Volume="2004" Year="2009">
       <Id>61f71ac9-3750-4f47-a99a-ce3a9bccde84</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="30" Volume="2004" Year="2009" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="30" Volume="2004" Year="2009">
       <Id>fe470f48-f945-48b0-a97d-22e574a201b8</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="500" Volume="1981" Year="2008" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="500" Volume="1981" Year="2008">
       <Id>73a5941a-d76a-4f23-98a3-227acf6ebb8d</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="215" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="215" Volume="2008" Year="2008">
       <Id>17403dc5-aa0b-4b33-9799-a3fbf2a008f4</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="216" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="216" Volume="2008" Year="2008">
       <Id>c7c69562-762e-44c2-82d1-f502dfb319e3</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="21" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="21" Volume="2006" Year="2008">
       <Id>28d70dfc-62b6-443d-ba3a-29578fc9d3c2</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="22" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="22" Volume="2006" Year="2008">
       <Id>6ac42aff-b97f-44f3-9942-350c75e620e6</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="23" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="23" Volume="2006" Year="2008">
       <Id>bb338277-3835-43b3-932a-3da38eae011e</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="24" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="24" Volume="2006" Year="2008">
       <Id>af0cf4bb-b59a-44c1-9c32-9560ff5fc2a8</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="25" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="25" Volume="2006" Year="2008">
       <Id>34588b6e-704a-46ed-9269-357e5d35e313</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="26" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="26" Volume="2006" Year="2008">
       <Id>00a5eb5a-e850-4c42-a37a-84051a0421ed</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="27" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="27" Volume="2006" Year="2008">
       <Id>393e51a4-dc8d-4183-862e-d4ea98ab92b5</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="28" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="28" Volume="2006" Year="2008">
       <Id>76045c5e-ed5b-4a20-b2d5-dc3a3b574439</Id>
     </Book>
-    <Book Series="X-Men: Original Sin" Number="1" Volume="2008" Year="2008" Format="One-Shot">
+    <Book Series="X-Men: Original Sin" Number="1" Volume="2008" Year="2008">
       <Id>810949af-4c77-41db-97dc-4fb5c2766f7a</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="217" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="217" Volume="2008" Year="2008">
       <Id>7c3fc32d-03ab-4df0-9d3b-30ed5439518a</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="29" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="29" Volume="2006" Year="2008">
       <Id>4ea80b37-60aa-4efa-be48-8f175eb00c3b</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="218" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="218" Volume="2008" Year="2009">
       <Id>2c23de44-0d9a-45e9-9c45-d7855e9082b9</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="30" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="30" Volume="2006" Year="2009">
       <Id>c302f73b-6a8e-4fbc-8eec-c67297e7886d</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="501" Volume="1981" Year="2008" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="501" Volume="1981" Year="2008">
       <Id>c7c8b538-3275-4dd1-b001-5491e338eb11</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="502" Volume="1981" Year="2008" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="502" Volume="1981" Year="2008">
       <Id>357f4d0f-47a7-4ddd-9aa7-d8cb491cfa03</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="503" Volume="1981" Year="2008" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="503" Volume="1981" Year="2008">
       <Id>431fdf67-c2d8-4ef5-adfe-0169a77d22e3</Id>
     </Book>
-    <Book Series="NYX: No Way Home" Number="1" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="NYX: No Way Home" Number="1" Volume="2008" Year="2008">
       <Id>fde416f6-1d9e-4857-824f-0248ddce3b32</Id>
     </Book>
-    <Book Series="NYX: No Way Home" Number="2" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="NYX: No Way Home" Number="2" Volume="2008" Year="2008">
       <Id>02610dda-d8a0-4a05-85ec-7055f945e3ec</Id>
     </Book>
-    <Book Series="NYX: No Way Home" Number="3" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="NYX: No Way Home" Number="3" Volume="2008" Year="2008">
       <Id>27f5cc59-e32a-46fb-8032-db81cd8e8d61</Id>
     </Book>
-    <Book Series="NYX: No Way Home" Number="4" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="NYX: No Way Home" Number="4" Volume="2008" Year="2009">
       <Id>daefe79c-448a-46c7-9079-883398327031</Id>
     </Book>
-    <Book Series="NYX: No Way Home" Number="5" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="NYX: No Way Home" Number="5" Volume="2008" Year="2009">
       <Id>08948d20-85db-4a12-ab64-c4f3117f0529</Id>
     </Book>
-    <Book Series="NYX: No Way Home" Number="6" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="NYX: No Way Home" Number="6" Volume="2008" Year="2009">
       <Id>d02871f1-3471-45a4-838f-6f20cf171c62</Id>
     </Book>
-    <Book Series="Cable" Number="6" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="Cable" Number="6" Volume="2008" Year="2008">
       <Id>19732c0e-4309-4399-b8ff-1fa923441b33</Id>
     </Book>
-    <Book Series="Cable" Number="7" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="Cable" Number="7" Volume="2008" Year="2008">
       <Id>5d0f367b-52f6-4b28-8110-1da69d4fb06b</Id>
     </Book>
-    <Book Series="Cable" Number="8" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Cable" Number="8" Volume="2008" Year="2009">
       <Id>f6fe479c-56fa-46f3-bc43-f078f230bc22</Id>
     </Book>
-    <Book Series="Cable" Number="9" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Cable" Number="9" Volume="2008" Year="2009">
       <Id>8c672fa1-f1ad-4cd9-bea0-45f45aed027a</Id>
     </Book>
-    <Book Series="Cable" Number="10" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Cable" Number="10" Volume="2008" Year="2009">
       <Id>fdb4c7b1-e4db-4716-8059-d1b261ddde37</Id>
     </Book>
-    <Book Series="King-Size Cable Spectacular" Number="1" Volume="2008" Year="2008" Format="One-Shot">
+    <Book Series="King-Size Cable Spectacular" Number="1" Volume="2008" Year="2008">
       <Id>d95bc1ad-a214-4aa4-9db1-466ccec9c1ec</Id>
     </Book>
-    <Book Series="X-Factor" Number="33" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="X-Factor" Number="33" Volume="2006" Year="2008">
       <Id>f51a2ade-78d8-43ae-bc2c-22fcd476824a</Id>
     </Book>
-    <Book Series="She-Hulk" Number="31" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="She-Hulk" Number="31" Volume="2005" Year="2008">
       <Id>54fbe521-6221-4bcd-9444-38e32d486c7d</Id>
     </Book>
-    <Book Series="X-Factor" Number="34" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="X-Factor" Number="34" Volume="2006" Year="2008">
       <Id>52e5dea3-f4f6-48b3-a067-5b63d9665157</Id>
     </Book>
-    <Book Series="Secret Invasion: X-Men" Number="1" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="Secret Invasion: X-Men" Number="1" Volume="2008" Year="2008">
       <Id>98d94475-f13d-4ade-8554-134a0d221d03</Id>
     </Book>
-    <Book Series="Secret Invasion: X-Men" Number="2" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="Secret Invasion: X-Men" Number="2" Volume="2008" Year="2008">
       <Id>c516b87a-7045-4421-8abc-114e8bb4e182</Id>
     </Book>
-    <Book Series="Secret Invasion: X-Men" Number="3" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="Secret Invasion: X-Men" Number="3" Volume="2008" Year="2008">
       <Id>cce4a0e9-dc4b-4835-9836-ba2b2e73a044</Id>
     </Book>
-    <Book Series="Secret Invasion: X-Men" Number="4" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="Secret Invasion: X-Men" Number="4" Volume="2008" Year="2009">
       <Id>9db86cd5-7280-484f-824b-b4187e8f30c1</Id>
     </Book>
-    <Book Series="X-Factor: The Quick and the Dead" Number="1" Volume="2008" Year="2008" Format="One-Shot">
+    <Book Series="X-Factor: The Quick and the Dead" Number="1" Volume="2008" Year="2008">
       <Id>ccd81066-e5c4-41b7-a146-abdb337b2b92</Id>
     </Book>
-    <Book Series="X-Force" Number="7" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="X-Force" Number="7" Volume="2008" Year="2008">
       <Id>eb43a688-3c0a-4ed4-9311-81435c5e30ae</Id>
     </Book>
-    <Book Series="X-Force" Number="8" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="X-Force" Number="8" Volume="2008" Year="2008">
       <Id>56e8ad10-6816-4ce9-9d01-7831b8fac6d2</Id>
     </Book>
-    <Book Series="X-Force" Number="9" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="X-Force" Number="9" Volume="2008" Year="2009">
       <Id>50ddacb6-b4bf-4110-b06f-82043be29405</Id>
     </Book>
-    <Book Series="X-Force" Number="10" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="X-Force" Number="10" Volume="2008" Year="2009">
       <Id>f2568ec6-74e7-4ac5-a957-6202c6da2d7f</Id>
     </Book>
-    <Book Series="X-Force" Number="11" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="X-Force" Number="11" Volume="2008" Year="2009">
       <Id>286e46df-ca5c-472a-9458-241b5de8558d</Id>
     </Book>
-    <Book Series="X-Force" Number="12" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="X-Force" Number="12" Volume="2008" Year="2009">
       <Id>a775ac44-956c-447b-8ee7-70064e408bcd</Id>
     </Book>
-    <Book Series="X-Men: Worlds Apart" Number="1" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="X-Men: Worlds Apart" Number="1" Volume="2008" Year="2008">
       <Id>71285c4a-7548-4705-bbd7-29bd8003b8fc</Id>
     </Book>
-    <Book Series="X-Men: Worlds Apart" Number="2" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="X-Men: Worlds Apart" Number="2" Volume="2008" Year="2009">
       <Id>68c81ec6-2f34-4a20-8d58-3e7f94585164</Id>
     </Book>
-    <Book Series="X-Men: Worlds Apart" Number="3" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="X-Men: Worlds Apart" Number="3" Volume="2008" Year="2009">
       <Id>0ce9c510-ee6c-4008-bacb-3f918385daeb</Id>
     </Book>
-    <Book Series="X-Men: Worlds Apart" Number="4" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="X-Men: Worlds Apart" Number="4" Volume="2008" Year="2009">
       <Id>e9fd765d-49a4-4048-bc21-10d1970ca52e</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="504" Volume="1981" Year="2009" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="504" Volume="1981" Year="2009">
       <Id>753e5ec9-868d-4b54-86c9-13c9344f637c</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="505" Volume="1981" Year="2009" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="505" Volume="1981" Year="2009">
       <Id>e442971f-d30a-4d64-969a-6a8a45ed08ee</Id>
     </Book>
-    <Book Series="Uncanny X-Men Annual" Number="2" Volume="2006" Year="2009" Format="Annual">
+    <Book Series="Uncanny X-Men Annual" Number="2" Volume="2006" Year="2009">
       <Id>c2df8d04-d7c4-420c-b031-8355abfcc902</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="506" Volume="1981" Year="2009" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="506" Volume="1981" Year="2009">
       <Id>3a5b4cb8-2d6f-4ef9-89cf-b9c8e5f6f0c3</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="507" Volume="1981" Year="2009" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="507" Volume="1981" Year="2009">
       <Id>df638842-d7d6-4957-b1a3-9a4e3b179353</Id>
     </Book>
-    <Book Series="Wolverine: Flies to a Spider" Number="1" Volume="2009" Year="2009" Format="One-Shot">
+    <Book Series="Wolverine: Flies to a Spider" Number="1" Volume="2009" Year="2009">
       <Id>4a2868a2-6667-4d5b-b906-232afacf8eee</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="31" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="31" Volume="2006" Year="2009">
       <Id>38d851ac-70d6-40fe-b7d7-795ac654fa18</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="32" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="32" Volume="2006" Year="2009">
       <Id>43829512-b080-4cdd-a572-4a0baf03c81e</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="33" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="33" Volume="2006" Year="2009">
       <Id>6127acf2-db7e-43c8-8c60-d1a2715fc479</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="34" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="34" Volume="2006" Year="2009">
       <Id>f23ac0f6-b137-4f74-8a29-00400150b86b</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="35" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="35" Volume="2006" Year="2009">
       <Id>45d66f5a-c01d-4250-b476-23f566744095</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="36" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="36" Volume="2006" Year="2009">
       <Id>19765834-0c31-4c75-b163-8855058ff944</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="37" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="37" Volume="2006" Year="2009">
       <Id>35972789-4e75-40a1-bfe3-523295e4df59</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="38" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="38" Volume="2006" Year="2009">
       <Id>74ddd96a-1ae0-44fb-95fd-a7ff2f802663</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="39" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="39" Volume="2006" Year="2009">
       <Id>ab080cde-2427-4149-9a3d-ea2be1aaa767</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="40" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="40" Volume="2006" Year="2009">
       <Id>01d4f461-e4f3-4536-8cc6-5dfe06149d36</Id>
     </Book>
-    <Book Series="Young X-Men" Number="6" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="Young X-Men" Number="6" Volume="2008" Year="2008">
       <Id>898a9def-f86c-496f-896d-ef2f380a51ca</Id>
     </Book>
-    <Book Series="Young X-Men" Number="7" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="Young X-Men" Number="7" Volume="2008" Year="2008">
       <Id>6f6bea9a-ee98-443e-8040-85a31e1a4eab</Id>
     </Book>
-    <Book Series="Young X-Men" Number="8" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Young X-Men" Number="8" Volume="2008" Year="2009">
       <Id>f55199dc-51af-47f7-8064-7d32d3f9fcda</Id>
     </Book>
-    <Book Series="Young X-Men" Number="9" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Young X-Men" Number="9" Volume="2008" Year="2009">
       <Id>e7d77258-1634-423d-89ce-db166cb3e28b</Id>
     </Book>
-    <Book Series="Young X-Men" Number="10" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Young X-Men" Number="10" Volume="2008" Year="2009">
       <Id>4b6b4b08-d458-46a3-b6d2-90a77d6f3222</Id>
     </Book>
-    <Book Series="Young X-Men" Number="11" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Young X-Men" Number="11" Volume="2008" Year="2009">
       <Id>57a2069c-9de9-4ffc-bade-c18842520887</Id>
     </Book>
-    <Book Series="Young X-Men" Number="12" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Young X-Men" Number="12" Volume="2008" Year="2009">
       <Id>57bab579-499f-4263-a758-9a7575996af7</Id>
     </Book>
-    <Book Series="X-Infernus" Number="1" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="X-Infernus" Number="1" Volume="2009" Year="2009">
       <Id>a9078d6c-e53d-4039-9ff3-ddde2275a492</Id>
     </Book>
-    <Book Series="X-Infernus" Number="2" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="X-Infernus" Number="2" Volume="2009" Year="2009">
       <Id>8965113e-1927-4632-99cd-7e7a6373f804</Id>
     </Book>
-    <Book Series="X-Infernus" Number="3" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="X-Infernus" Number="3" Volume="2009" Year="2009">
       <Id>671ee091-ca32-4bdb-a744-41ff3effbd87</Id>
     </Book>
-    <Book Series="X-Infernus" Number="4" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="X-Infernus" Number="4" Volume="2009" Year="2009">
       <Id>91b4475f-9988-4581-b22d-f1351423f3af</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="508" Volume="1981" Year="2009" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="508" Volume="1981" Year="2009">
       <Id>d7763cf3-af7d-4f60-bca7-37f55e392f78</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="509" Volume="1981" Year="2009" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="509" Volume="1981" Year="2009">
       <Id>87c0fa05-16eb-4d1e-a0cb-591ef1349728</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="510" Volume="1981" Year="2009" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="510" Volume="1981" Year="2009">
       <Id>e89b403f-e1fc-420a-ad5f-188b37f24b5f</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="511" Volume="1981" Year="2009" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="511" Volume="1981" Year="2009">
       <Id>16b4ee92-b524-40d1-add4-8b905fabf130</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="512" Volume="1981" Year="2009" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="512" Volume="1981" Year="2009">
       <Id>fbb73935-ab26-4929-abba-e482b9b0df13</Id>
     </Book>
-    <Book Series="Eternals" Number="7" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Eternals" Number="7" Volume="2008" Year="2009">
       <Id>593eb97d-88f3-478a-8316-11496f9440ba</Id>
     </Book>
-    <Book Series="Eternals" Number="8" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Eternals" Number="8" Volume="2008" Year="2009">
       <Id>b714e0a8-6454-47eb-b15d-ade0e195ac6d</Id>
     </Book>
-    <Book Series="Eternals" Number="9" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Eternals" Number="9" Volume="2008" Year="2009">
       <Id>df5f8907-308e-48ec-bc21-1c24a681bdab</Id>
     </Book>
-    <Book Series="Runaways" Number="10" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Runaways" Number="10" Volume="2008" Year="2009">
       <Id>81b10103-7d5c-4a55-8814-3460bcd4824d</Id>
     </Book>
-    <Book Series="X-Factor" Number="35" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="X-Factor" Number="35" Volume="2006" Year="2008">
       <Id>9a2ab0a9-1e05-4a26-ab02-7fe5621b8d91</Id>
     </Book>
-    <Book Series="X-Factor" Number="36" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="X-Factor" Number="36" Volume="2006" Year="2008">
       <Id>807f920e-1e51-4e77-b6ef-48f30a560639</Id>
     </Book>
-    <Book Series="X-Factor" Number="37" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="X-Factor" Number="37" Volume="2006" Year="2009">
       <Id>0c26cb50-7777-4560-83e9-ccd256d5b882</Id>
     </Book>
-    <Book Series="X-Factor" Number="38" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="X-Factor" Number="38" Volume="2006" Year="2009">
       <Id>9d54422c-8034-49d1-b123-e23baef6c5c1</Id>
     </Book>
-    <Book Series="X-Factor" Number="39" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="X-Factor" Number="39" Volume="2006" Year="2009">
       <Id>95df9ade-8c99-4646-9b43-b496a659f209</Id>
     </Book>
-    <Book Series="Weapon X: First Class" Number="1" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="Weapon X: First Class" Number="1" Volume="2009" Year="2009">
       <Id>08ee0a17-3e32-4a49-a220-47ee3ad1fc8e</Id>
     </Book>
-    <Book Series="Weapon X: First Class" Number="2" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="Weapon X: First Class" Number="2" Volume="2009" Year="2009">
       <Id>5887f398-6377-45dc-97f4-6c90d3707d3b</Id>
     </Book>
-    <Book Series="Weapon X: First Class" Number="3" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="Weapon X: First Class" Number="3" Volume="2009" Year="2009">
       <Id>ba6c4ce2-982c-45f3-a09b-74997fe395bb</Id>
     </Book>
-    <Book Series="New Mutants" Number="1" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="New Mutants" Number="1" Volume="2009" Year="2009">
       <Id>a0f7d266-38f8-497d-ac2f-a17b787ecc83</Id>
     </Book>
-    <Book Series="New Mutants" Number="2" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="New Mutants" Number="2" Volume="2009" Year="2009">
       <Id>b49355bf-cf04-4f7b-a52b-39b729e31ed1</Id>
     </Book>
-    <Book Series="New Mutants" Number="3" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="New Mutants" Number="3" Volume="2009" Year="2009">
       <Id>eccb4edb-ac45-48a5-b991-b4a60f7216b6</Id>
     </Book>
-    <Book Series="New Mutants" Number="4" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="New Mutants" Number="4" Volume="2009" Year="2009">
       <Id>40cfe9a7-ae5a-4202-ba72-443376629643</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="31" Volume="2004" Year="2009" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="31" Volume="2004" Year="2009">
       <Id>8f96c962-f2cb-4262-9364-c88644668dbb</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="32" Volume="2004" Year="2010" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="32" Volume="2004" Year="2010">
       <Id>a9924e88-850b-4a7d-b63e-83b64614ff8e</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="33" Volume="2004" Year="2010" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="33" Volume="2004" Year="2010">
       <Id>013c4849-0e80-4ad8-88d2-6f6f5773fb62</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="34" Volume="2004" Year="2010" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="34" Volume="2004" Year="2010">
       <Id>1f170c86-daa5-4c7f-9911-cda44023bcbd</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="35" Volume="2004" Year="2010" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="35" Volume="2004" Year="2010">
       <Id>6bb75e92-ef17-4ade-8781-894396967482</Id>
     </Book>
-    <Book Series="Astonishing X-Men: Xenogenesis" Number="1" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Astonishing X-Men: Xenogenesis" Number="1" Volume="2010" Year="2010">
       <Id>bc0a73ce-28d3-4153-8b85-9c59817f3f1b</Id>
     </Book>
-    <Book Series="Astonishing X-Men: Xenogenesis" Number="2" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Astonishing X-Men: Xenogenesis" Number="2" Volume="2010" Year="2010">
       <Id>2f9331f3-2c89-45ef-8fe6-8dd15c6e41c9</Id>
     </Book>
-    <Book Series="Astonishing X-Men: Xenogenesis" Number="3" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Astonishing X-Men: Xenogenesis" Number="3" Volume="2010" Year="2010">
       <Id>714317c2-7543-428c-b374-4d693a00424f</Id>
     </Book>
-    <Book Series="Astonishing X-Men: Xenogenesis" Number="4" Volume="2010" Year="2011" Format="Limited Series">
+    <Book Series="Astonishing X-Men: Xenogenesis" Number="4" Volume="2010" Year="2011">
       <Id>888c8930-156c-4cb4-8067-841df664684f</Id>
     </Book>
-    <Book Series="Astonishing X-Men: Xenogenesis" Number="5" Volume="2010" Year="2011" Format="Limited Series">
+    <Book Series="Astonishing X-Men: Xenogenesis" Number="5" Volume="2010" Year="2011">
       <Id>5fc5d117-6a83-412f-8cc1-5481b756c4e1</Id>
     </Book>
-    <Book Series="Cable" Number="11" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Cable" Number="11" Volume="2008" Year="2009">
       <Id>71381a52-5db0-4683-b60c-714c1eeb8b80</Id>
     </Book>
-    <Book Series="Cable" Number="12" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Cable" Number="12" Volume="2008" Year="2009">
       <Id>33a8c27d-44da-410a-8c2b-42add049a922</Id>
     </Book>
-    <Book Series="X-Men: The Times &amp; Life of Lucas Bishop" Number="1" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="X-Men: The Times &amp; Life of Lucas Bishop" Number="1" Volume="2009" Year="2009">
       <Id>82b784f3-cc03-4d2d-90f7-84f7cafd3b86</Id>
     </Book>
-    <Book Series="X-Men: The Times &amp; Life of Lucas Bishop" Number="2" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="X-Men: The Times &amp; Life of Lucas Bishop" Number="2" Volume="2009" Year="2009">
       <Id>65501505-ab6e-4ae6-8fc3-195ba730a83a</Id>
     </Book>
-    <Book Series="X-Men: The Times &amp; Life of Lucas Bishop" Number="3" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="X-Men: The Times &amp; Life of Lucas Bishop" Number="3" Volume="2009" Year="2009">
       <Id>17ab0cb9-6bd7-426d-9d9d-92aef3d3348e</Id>
     </Book>
-    <Book Series="X-Force" Number="13" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="X-Force" Number="13" Volume="2008" Year="2009">
       <Id>35b72332-5680-45d2-9982-95099a3f33d2</Id>
     </Book>
-    <Book Series="X-Force/Cable: Messiah War" Number="1" Volume="2009" Year="2009" Format="One-Shot">
+    <Book Series="X-Force/Cable: Messiah War" Number="1" Volume="2009" Year="2009">
       <Id>7a7d0d55-ce40-48e8-8252-d71f5398185d</Id>
     </Book>
-    <Book Series="Cable" Number="13" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Cable" Number="13" Volume="2008" Year="2009">
       <Id>44fb1274-73cf-4324-b257-34b254891a97</Id>
     </Book>
-    <Book Series="X-Force" Number="14" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="X-Force" Number="14" Volume="2008" Year="2009">
       <Id>b15bd8cf-6b75-4bf8-9310-60178d710683</Id>
     </Book>
-    <Book Series="Cable" Number="14" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Cable" Number="14" Volume="2008" Year="2009">
       <Id>10fd86ce-9118-4b8c-9946-c1fc580d6d13</Id>
     </Book>
-    <Book Series="X-Force" Number="15" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="X-Force" Number="15" Volume="2008" Year="2009">
       <Id>9c200b4b-c220-44f6-8d7b-6151dc8f3527</Id>
     </Book>
-    <Book Series="Cable" Number="15" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Cable" Number="15" Volume="2008" Year="2009">
       <Id>b05872a5-8a8b-4caa-9906-73e684c574db</Id>
     </Book>
-    <Book Series="X-Force" Number="16" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="X-Force" Number="16" Volume="2008" Year="2009">
       <Id>85c86727-99c4-4993-9192-b2517e0cc3db</Id>
     </Book>
-    <Book Series="X-Men: Future History –– Messiah War Sourcebook" Number="1" Volume="2009" Year="2009" Format="One-Shot">
+    <Book Series="X-Men: Future History –– Messiah War Sourcebook" Number="1" Volume="2009" Year="2009">
       <Id>076f33e7-bbb4-4366-8997-3d4a280be2ef</Id>
     </Book>
-    <Book Series="X-Force" Number="17" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="X-Force" Number="17" Volume="2008" Year="2009">
       <Id>118fc8ce-d145-44bb-9010-07db6cd41c1f</Id>
     </Book>
-    <Book Series="X-Force" Number="18" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="X-Force" Number="18" Volume="2008" Year="2009">
       <Id>c4cbf5df-43b4-46d5-898a-5d830ef28dc1</Id>
     </Book>
-    <Book Series="X-Force" Number="19" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="X-Force" Number="19" Volume="2008" Year="2009">
       <Id>684448e4-f2d4-4d9f-953c-006b87e080fe</Id>
     </Book>
-    <Book Series="X-Force" Number="20" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="X-Force" Number="20" Volume="2008" Year="2009">
       <Id>e2ea410d-6bf1-49dc-8e07-7f7360d9f20b</Id>
     </Book>
-    <Book Series="X-Force: Sex &amp; Violence" Number="1" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="X-Force: Sex &amp; Violence" Number="1" Volume="2010" Year="2010">
       <Id>3dce2015-2bc2-4ad0-be5b-bb18dfebe0b1</Id>
     </Book>
-    <Book Series="X-Force: Sex &amp; Violence" Number="2" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="X-Force: Sex &amp; Violence" Number="2" Volume="2010" Year="2010">
       <Id>cf7f2312-afdd-4865-a8d3-619086bb7263</Id>
     </Book>
-    <Book Series="X-Force: Sex &amp; Violence" Number="3" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="X-Force: Sex &amp; Violence" Number="3" Volume="2010" Year="2010">
       <Id>83ce59c7-4335-4840-ad07-2dd51983298f</Id>
     </Book>
-    <Book Series="Thunderbolts" Number="130" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Thunderbolts" Number="130" Volume="2006" Year="2009">
       <Id>2ee5a59c-54b6-412e-a74d-d6519f2ddc48</Id>
     </Book>
-    <Book Series="Thunderbolts" Number="131" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Thunderbolts" Number="131" Volume="2006" Year="2009">
       <Id>1e618900-7f84-4c13-bec8-dbd0680335f5</Id>
     </Book>
-    <Book Series="Wolverine: First Class" Number="13" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Wolverine: First Class" Number="13" Volume="2008" Year="2009">
       <Id>2511b4b5-aa41-44a3-bbc8-55a2507db313</Id>
     </Book>
-    <Book Series="Wolverine: First Class" Number="14" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Wolverine: First Class" Number="14" Volume="2008" Year="2009">
       <Id>65b85a02-51d3-4c82-b3d1-7682f5d64c2e</Id>
     </Book>
-    <Book Series="Wolverine: First Class" Number="15" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Wolverine: First Class" Number="15" Volume="2008" Year="2009">
       <Id>7c6ddbd6-9d70-40e1-95ba-315a5754abba</Id>
     </Book>
-    <Book Series="Wolverine: First Class" Number="16" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Wolverine: First Class" Number="16" Volume="2008" Year="2009">
       <Id>a37f2238-dce2-441a-9499-0e58aaa7ea3e</Id>
     </Book>
-    <Book Series="Wolverine: Switchback" Number="1" Volume="2009" Year="2009" Format="One-Shot">
+    <Book Series="Wolverine: Switchback" Number="1" Volume="2009" Year="2009">
       <Id>52313542-5935-481d-9d9d-6767479871c8</Id>
     </Book>
-    <Book Series="Wolverine: The Anniversary" Number="1" Volume="2009" Year="2009" Format="One-Shot">
+    <Book Series="Wolverine: The Anniversary" Number="1" Volume="2009" Year="2009">
       <Id>d59000f2-43f9-4ca3-bff4-0ff2dade9072</Id>
     </Book>
-    <Book Series="Rampaging Wolverine" Number="1" Volume="2009" Year="2009" Format="One-Shot">
+    <Book Series="Rampaging Wolverine" Number="1" Volume="2009" Year="2009">
       <Id>80fa7a4e-124c-46d1-aa20-f1f203566d58</Id>
     </Book>
-    <Book Series="New Exiles" Number="16" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="New Exiles" Number="16" Volume="2008" Year="2009">
       <Id>05c32ecc-725a-4f5b-b420-54a28b92c6c7</Id>
     </Book>
-    <Book Series="New Exiles" Number="17" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="New Exiles" Number="17" Volume="2008" Year="2009">
       <Id>4787b2bc-a6aa-4a19-82c6-26be15bced20</Id>
     </Book>
-    <Book Series="New Exiles" Number="18" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="New Exiles" Number="18" Volume="2008" Year="2009">
       <Id>8fe1356b-5959-4ba1-84de-7087adbd167e</Id>
     </Book>
-    <Book Series="X-Men: Sword of the Braddocks" Number="1" Volume="2009" Year="2009" Format="One-Shot">
+    <Book Series="X-Men: Sword of the Braddocks" Number="1" Volume="2009" Year="2009">
       <Id>b669253b-b2f0-4554-87c0-d472be9dc127</Id>
     </Book>
-    <Book Series="Wolverine" Number="73" Volume="2003" Year="2009" Format="Main Series">
+    <Book Series="Wolverine" Number="73" Volume="2003" Year="2009">
       <Id>8c179d17-62c9-4571-992c-16051cfa0f11</Id>
     </Book>
-    <Book Series="Wolverine" Number="74" Volume="2003" Year="2009" Format="Main Series">
+    <Book Series="Wolverine" Number="74" Volume="2003" Year="2009">
       <Id>54ca5831-3dea-49dc-97ea-e03096150464</Id>
     </Book>
-    <Book Series="Dark Wolverine" Number="75" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Dark Wolverine" Number="75" Volume="2009" Year="2009">
       <Id>9a232e01-f187-4852-9a3f-1a4199fde378</Id>
     </Book>
-    <Book Series="Dark Wolverine" Number="76" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Dark Wolverine" Number="76" Volume="2009" Year="2009">
       <Id>e7917c36-d915-4e70-8a23-48ec40c9dacc</Id>
     </Book>
-    <Book Series="Dark Wolverine" Number="77" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Dark Wolverine" Number="77" Volume="2009" Year="2009">
       <Id>f1f9ca53-417e-485d-b0b7-263104cfdbb0</Id>
     </Book>
-    <Book Series="Wolverine: Revolver" Number="1" Volume="2009" Year="2009" Format="One-Shot">
+    <Book Series="Wolverine: Revolver" Number="1" Volume="2009" Year="2009">
       <Id>9db86b3e-ffce-4f1a-9211-d7401d1b90cf</Id>
     </Book>
-    <Book Series="Wolverine: First Class" Number="17" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Wolverine: First Class" Number="17" Volume="2008" Year="2009">
       <Id>13bf78bd-c1ad-41ef-8149-8e18690470ff</Id>
     </Book>
-    <Book Series="Wolverine: First Class" Number="18" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Wolverine: First Class" Number="18" Volume="2008" Year="2009">
       <Id>5ca47997-e44f-4a0b-bb3c-e425872b9b8e</Id>
     </Book>
-    <Book Series="Wolverine: First Class" Number="19" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Wolverine: First Class" Number="19" Volume="2008" Year="2009">
       <Id>327f37c7-26ee-49b5-bcbd-465946d1a9d6</Id>
     </Book>
-    <Book Series="Wolverine: First Class" Number="20" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Wolverine: First Class" Number="20" Volume="2008" Year="2009">
       <Id>90d642b1-52eb-4b68-ae75-90caff30a172</Id>
     </Book>
-    <Book Series="Wolverine: First Class" Number="21" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="Wolverine: First Class" Number="21" Volume="2008" Year="2010">
       <Id>6825e190-e67b-4c42-8a2a-5f4038a8100b</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="219" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="219" Volume="2008" Year="2009">
       <Id>5a82bf42-e7fb-42f3-9e20-9d89e99076e7</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="220" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="220" Volume="2008" Year="2009">
       <Id>c2f983ee-a82e-41a7-a28a-2cbe1d73ee64</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="221" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="221" Volume="2008" Year="2009">
       <Id>e74898ff-ed52-4d4a-adcb-c1241cba851f</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="222" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="222" Volume="2008" Year="2009">
       <Id>f33f2ded-acd2-467f-9f36-505c55e7d416</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="223" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="223" Volume="2008" Year="2009">
       <Id>1c273ebb-0112-41c3-9fcc-f65befad726c</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="224" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="224" Volume="2008" Year="2009">
       <Id>c01e13c1-31ba-4b59-a9bb-1bab79931375</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="225" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="225" Volume="2008" Year="2009">
       <Id>71570c58-1bf9-4197-85d1-f962380f7954</Id>
     </Book>
-    <Book Series="Dark Avengers/Uncanny X-Men: Utopia" Number="1" Volume="2009" Year="2009" Format="One-Shot">
+    <Book Series="Dark Avengers/Uncanny X-Men: Utopia" Number="1" Volume="2009" Year="2009">
       <Id>9f292f92-5382-42dc-bb80-88b04c27c8ff</Id>
     </Book>
-    <Book Series="Dark X-Men: The Beginning" Number="2" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="Dark X-Men: The Beginning" Number="2" Volume="2009" Year="2009">
       <Id>83e35db5-0567-4501-9a40-accd9df000ad</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="513" Volume="1981" Year="2009" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="513" Volume="1981" Year="2009">
       <Id>6585ec57-c16e-4230-8105-495fe4982c23</Id>
     </Book>
-    <Book Series="Dark Avengers" Number="7" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Dark Avengers" Number="7" Volume="2009" Year="2009">
       <Id>c67df123-0253-4103-ba3a-6f7ae6622cca</Id>
     </Book>
-    <Book Series="Dark X-Men: The Beginning" Number="1" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="Dark X-Men: The Beginning" Number="1" Volume="2009" Year="2009">
       <Id>a0f2e474-ad06-44fd-88f8-2abd840fbafd</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="226" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="226" Volume="2008" Year="2009">
       <Id>554d3f85-3f35-4982-952f-893ca5261ba7</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="227" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="227" Volume="2008" Year="2009">
       <Id>17b7eafc-477b-4d54-a45e-bfdbef36e1c0</Id>
     </Book>
-    <Book Series="Dark X-Men: The Beginning" Number="3" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="Dark X-Men: The Beginning" Number="3" Volume="2009" Year="2009">
       <Id>61a5f71e-96d0-4886-ad4d-47a6acaff7d6</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="514" Volume="1981" Year="2009" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="514" Volume="1981" Year="2009">
       <Id>ee587349-4e42-4449-b943-3d9f20101fc0</Id>
     </Book>
-    <Book Series="Dark Avengers" Number="8" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Dark Avengers" Number="8" Volume="2009" Year="2009">
       <Id>c11b4006-dc0b-43bc-914c-c35709b6bac5</Id>
     </Book>
-    <Book Series="Dark Avengers/Uncanny X-Men: Exodus" Number="1" Volume="2009" Year="2009" Format="One-Shot">
+    <Book Series="Dark Avengers/Uncanny X-Men: Exodus" Number="1" Volume="2009" Year="2009">
       <Id>747e3c3a-8e3f-40e2-a8b9-fc8a18e7c5b5</Id>
     </Book>
-    <Book Series="Dark X-Men: The Confession" Number="1" Volume="2009" Year="2009" Format="One-Shot">
+    <Book Series="Dark X-Men: The Confession" Number="1" Volume="2009" Year="2009">
       <Id>44a5951a-3384-4f26-b588-471e9e8bee24</Id>
     </Book>
-    <Book Series="Dark Reign: The List - X-Men" Number="1" Volume="2009" Year="2009" Format="One-Shot">
+    <Book Series="Dark Reign: The List - X-Men" Number="1" Volume="2009" Year="2009">
       <Id>6c7e570d-514c-49c0-99a3-a297cd38d183</Id>
     </Book>
-    <Book Series="Dark Reign: The List - Wolverine" Number="1" Volume="2009" Year="2009" Format="One-Shot">
+    <Book Series="Dark Reign: The List - Wolverine" Number="1" Volume="2009" Year="2009">
       <Id>e3e32528-7298-4301-9685-44454705a8a3</Id>
     </Book>
-    <Book Series="New Mutants" Number="5" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="New Mutants" Number="5" Volume="2009" Year="2009">
       <Id>c710c66b-8955-4440-8db4-6178a64c1bce</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="41" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="41" Volume="2006" Year="2009">
       <Id>1a322888-b401-4b4d-92a0-c795f7744c1e</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="42" Volume="2006" Year="2010" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="42" Volume="2006" Year="2010">
       <Id>d1e56eec-931e-4076-8371-7a072bf6b9a9</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="43" Volume="2006" Year="2010" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="43" Volume="2006" Year="2010">
       <Id>bf6b79f3-3cbd-4c68-a47b-2c7d7c46ea16</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="44" Volume="2006" Year="2010" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="44" Volume="2006" Year="2010">
       <Id>c22d9e88-adb4-4c94-b737-730dcb1a0072</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="45" Volume="2006" Year="2010" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="45" Volume="2006" Year="2010">
       <Id>5940321b-7588-4681-8bcc-15110ae5f735</Id>
     </Book>
-    <Book Series="Dark X-Men" Number="1" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Dark X-Men" Number="1" Volume="2010" Year="2010">
       <Id>88ce5194-8287-4e46-9997-547324ea0cb4</Id>
     </Book>
-    <Book Series="Dark X-Men" Number="2" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Dark X-Men" Number="2" Volume="2010" Year="2010">
       <Id>73834ae7-27a8-4d7c-a911-ab4cf9bc4239</Id>
     </Book>
-    <Book Series="Dark X-Men" Number="3" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Dark X-Men" Number="3" Volume="2010" Year="2010">
       <Id>f979a6f2-9a9f-4e18-a2ff-9d1934e6b938</Id>
     </Book>
-    <Book Series="Dark X-Men" Number="4" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Dark X-Men" Number="4" Volume="2010" Year="2010">
       <Id>862fc857-ef6c-4e2a-ab58-88fc52d2bace</Id>
     </Book>
-    <Book Series="Dark X-Men" Number="5" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Dark X-Men" Number="5" Volume="2010" Year="2010">
       <Id>36f6728b-30df-4596-ba87-dd7e65794bc0</Id>
     </Book>
-    <Book Series="Dark Wolverine" Number="78" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Dark Wolverine" Number="78" Volume="2009" Year="2009">
       <Id>56c8464f-2c3a-4048-a5b5-642f1c6d29e6</Id>
     </Book>
-    <Book Series="Dark Wolverine" Number="79" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Dark Wolverine" Number="79" Volume="2009" Year="2009">
       <Id>120fba67-c06e-4c54-aa07-419141bc5bff</Id>
     </Book>
-    <Book Series="Dark Wolverine" Number="80" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Dark Wolverine" Number="80" Volume="2009" Year="2010">
       <Id>a8dd58c1-9665-48cb-8c27-aafacca514ac</Id>
     </Book>
-    <Book Series="Dark Wolverine" Number="81" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Dark Wolverine" Number="81" Volume="2009" Year="2010">
       <Id>ef47a17e-825e-49e0-9abb-60cd436e2882</Id>
     </Book>
-    <Book Series="X-Factor" Number="40" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="X-Factor" Number="40" Volume="2006" Year="2009">
       <Id>6a7cd3e0-154d-4935-b79a-be59b257f552</Id>
     </Book>
-    <Book Series="X-Factor" Number="41" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="X-Factor" Number="41" Volume="2006" Year="2009">
       <Id>8347d48b-e033-4a84-862a-fd1ab63e9fe8</Id>
     </Book>
-    <Book Series="X-Factor" Number="42" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="X-Factor" Number="42" Volume="2006" Year="2009">
       <Id>d3d3e86d-e047-4d38-9663-fbfcff7e669a</Id>
     </Book>
-    <Book Series="X-Factor" Number="43" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="X-Factor" Number="43" Volume="2006" Year="2009">
       <Id>6f30da2a-d603-4fc3-a606-d0ad1bed74e3</Id>
     </Book>
-    <Book Series="X-Factor" Number="44" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="X-Factor" Number="44" Volume="2006" Year="2009">
       <Id>6a3bd1b9-1ac3-4793-b331-ecc0e83d13a7</Id>
     </Book>
-    <Book Series="X-Factor" Number="45" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="X-Factor" Number="45" Volume="2006" Year="2009">
       <Id>442382a5-1dfa-47c2-86a2-8ecd710686a5</Id>
     </Book>
-    <Book Series="X-Factor" Number="46" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="X-Factor" Number="46" Volume="2006" Year="2009">
       <Id>80a434d0-2f1b-4654-8184-83ca8b677588</Id>
     </Book>
-    <Book Series="X-Factor" Number="47" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="X-Factor" Number="47" Volume="2006" Year="2009">
       <Id>a2475c4e-2be3-41fb-8b04-35263e45e9b4</Id>
     </Book>
-    <Book Series="X-Factor" Number="48" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="X-Factor" Number="48" Volume="2006" Year="2009">
       <Id>175a83cb-88cf-416e-9e5d-78d3c559180a</Id>
     </Book>
-    <Book Series="X-Factor" Number="49" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="X-Factor" Number="49" Volume="2006" Year="2009">
       <Id>aa392bde-824d-4660-a9f3-6d9f8157177f</Id>
     </Book>
-    <Book Series="X-Factor" Number="50" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="X-Factor" Number="50" Volume="2006" Year="2009">
       <Id>8cc126b2-2668-43ad-a9bb-7aefa69c2c34</Id>
     </Book>
-    <Book Series="X-Factor: Layla Miller" Number="1" Volume="2008" Year="2008" Format="One-Shot">
+    <Book Series="X-Factor: Layla Miller" Number="1" Volume="2008" Year="2008">
       <Id>21d52074-540e-4bd6-8d6d-e57389ec2f85</Id>
     </Book>
-    <Book Series="X-Factor" Number="200" Volume="2006" Year="2010" Format="Main Series">
+    <Book Series="X-Factor" Number="200" Volume="2006" Year="2010">
       <Id>6c4d5121-e263-4532-9ca5-2b647c3d0e5f</Id>
     </Book>
-    <Book Series="X-Factor" Number="201" Volume="2006" Year="2010" Format="Main Series">
+    <Book Series="X-Factor" Number="201" Volume="2006" Year="2010">
       <Id>20a15582-147b-474a-a9e9-2527ca25c2d5</Id>
     </Book>
-    <Book Series="X-Factor" Number="202" Volume="2006" Year="2010" Format="Main Series">
+    <Book Series="X-Factor" Number="202" Volume="2006" Year="2010">
       <Id>55972c90-a5e8-4858-b77c-c9f11372f858</Id>
     </Book>
-    <Book Series="X-Factor" Number="203" Volume="2006" Year="2010" Format="Main Series">
+    <Book Series="X-Factor" Number="203" Volume="2006" Year="2010">
       <Id>16cf9599-aebf-4bef-bc43-9ce92ac37304</Id>
     </Book>
-    <Book Series="X-Factor" Number="204" Volume="2006" Year="2010" Format="Main Series">
+    <Book Series="X-Factor" Number="204" Volume="2006" Year="2010">
       <Id>a97915f9-dcd5-4282-9491-9753f11b529b</Id>
     </Book>
-    <Book Series="X-Factor" Number="205" Volume="2006" Year="2010" Format="Main Series">
+    <Book Series="X-Factor" Number="205" Volume="2006" Year="2010">
       <Id>d71d6c1a-6070-488a-94b4-d0bf58518102</Id>
     </Book>
-    <Book Series="X-Factor" Number="206" Volume="2006" Year="2010" Format="Main Series">
+    <Book Series="X-Factor" Number="206" Volume="2006" Year="2010">
       <Id>aac0419b-0b53-4359-b33f-60484127bcdc</Id>
     </Book>
-    <Book Series="Wolverine: The Best There Is" Number="1" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Wolverine: The Best There Is" Number="1" Volume="2011" Year="2011">
       <Id>95691a2a-2d90-42bf-990b-f483a9b9d0a2</Id>
     </Book>
-    <Book Series="Wolverine: The Best There Is" Number="2" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Wolverine: The Best There Is" Number="2" Volume="2011" Year="2011">
       <Id>99ddf808-bf05-4f9b-98de-8b06eb506828</Id>
     </Book>
-    <Book Series="Wolverine: The Best There Is" Number="3" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Wolverine: The Best There Is" Number="3" Volume="2011" Year="2011">
       <Id>1396cc25-180c-4e27-90f5-3c92d715cabe</Id>
     </Book>
-    <Book Series="Wolverine: The Best There Is" Number="4" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Wolverine: The Best There Is" Number="4" Volume="2011" Year="2011">
       <Id>d806ab2c-347f-4ee8-a77f-0e80f0ce3ce5</Id>
     </Book>
-    <Book Series="Wolverine: The Best There Is" Number="5" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Wolverine: The Best There Is" Number="5" Volume="2011" Year="2011">
       <Id>c9d2ae1a-6d91-465c-aa99-3315ab94d7c7</Id>
     </Book>
-    <Book Series="Wolverine: The Best There Is" Number="6" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Wolverine: The Best There Is" Number="6" Volume="2011" Year="2011">
       <Id>8ad0df60-01a6-4cf9-adfa-0f5d00ec5cba</Id>
     </Book>
-    <Book Series="Wolverine: The Best There Is" Number="7" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Wolverine: The Best There Is" Number="7" Volume="2011" Year="2011">
       <Id>32d4cc10-cf39-455e-8fb7-ca48182819d3</Id>
     </Book>
-    <Book Series="Wolverine: The Best There Is" Number="8" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Wolverine: The Best There Is" Number="8" Volume="2011" Year="2011">
       <Id>bdf2a305-82c4-41e8-8327-49e5f8309304</Id>
     </Book>
-    <Book Series="Wolverine: The Best There Is" Number="9" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Wolverine: The Best There Is" Number="9" Volume="2011" Year="2011">
       <Id>d9b1b586-b9dd-484c-a168-8ff81531af76</Id>
     </Book>
-    <Book Series="Psylocke" Number="2" Volume="2009" Year="2010" Format="Limited Series">
+    <Book Series="Psylocke" Number="2" Volume="2009" Year="2010">
       <Id>a5cbf969-2542-4474-9ac4-4c299b1999db</Id>
     </Book>
-    <Book Series="Wolverine: The Best There Is" Number="10" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Wolverine: The Best There Is" Number="10" Volume="2011" Year="2011">
       <Id>34f6d189-635f-4997-beb1-e024070d7173</Id>
     </Book>
-    <Book Series="Wolverine: The Best There Is" Number="11" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Wolverine: The Best There Is" Number="11" Volume="2011" Year="2012">
       <Id>af9c1020-34c8-41f8-93fa-f3f57a1aa582</Id>
     </Book>
-    <Book Series="Wolverine: The Best There Is" Number="12" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Wolverine: The Best There Is" Number="12" Volume="2011" Year="2012">
       <Id>b83edfae-02dc-4660-bc56-7daa1997208b</Id>
     </Book>
-    <Book Series="Psylocke" Number="1" Volume="2009" Year="2010" Format="Limited Series">
+    <Book Series="Psylocke" Number="1" Volume="2009" Year="2010">
       <Id>384a29b4-fa62-4a1b-94bd-ea02269fbbad</Id>
     </Book>
-    <Book Series="Psylocke" Number="3" Volume="2009" Year="2010" Format="Limited Series">
+    <Book Series="Psylocke" Number="3" Volume="2009" Year="2010">
       <Id>a7eb17c4-6a39-4277-9240-2508c53b5003</Id>
     </Book>
-    <Book Series="Psylocke" Number="4" Volume="2009" Year="2010" Format="Limited Series">
+    <Book Series="Psylocke" Number="4" Volume="2009" Year="2010">
       <Id>99cc38b8-8727-4e4a-a37a-a1f5f835d0a3</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="515" Volume="1981" Year="2009" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="515" Volume="1981" Year="2009">
       <Id>b5963bbd-8c2a-4c62-984e-fb92b8be99bb</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="516" Volume="1981" Year="2009" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="516" Volume="1981" Year="2009">
       <Id>c7c7fa8e-0df7-42da-87d2-9cbe2096e943</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="517" Volume="1981" Year="2010" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="517" Volume="1981" Year="2010">
       <Id>4609768b-0697-454d-95e1-928acae2edb0</Id>
     </Book>
-    <Book Series="Nation X" Number="1" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Nation X" Number="1" Volume="2010" Year="2010">
       <Id>5344429d-fe6e-4f75-a9b7-c9d3582b4187</Id>
     </Book>
-    <Book Series="X-Men: Legacy Annual" Number="1" Volume="2009" Year="2009" Format="Annual">
+    <Book Series="X-Men: Legacy Annual" Number="1" Volume="2009" Year="2009">
       <Id>2812920f-370a-49a4-9d9f-093f9e2d711e</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="228" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="228" Volume="2008" Year="2009">
       <Id>49e0a795-c76d-4083-a653-e7efa5bf838b</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="229" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="229" Volume="2008" Year="2010">
       <Id>897e57e1-3bc9-4e9d-8a3a-8e5054ddca1f</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="230" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="230" Volume="2008" Year="2010">
       <Id>98fbcc16-b6ab-4f13-b404-ce7d82fc29e7</Id>
     </Book>
-    <Book Series="X Necrosha: The Gathering" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="X Necrosha: The Gathering" Number="1" Volume="2010" Year="2010">
       <Id>42a6f424-1309-4010-90f8-a6bbd69c5046</Id>
     </Book>
-    <Book Series="X Necrosha" Number="1" Volume="2009" Year="2009" Format="One-Shot">
+    <Book Series="X Necrosha" Number="1" Volume="2009" Year="2009">
       <Id>2efa26cf-ed87-46b2-8516-58276e58c271</Id>
     </Book>
-    <Book Series="X-Force" Number="21" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="X-Force" Number="21" Volume="2008" Year="2010">
       <Id>9b46718d-ce3a-40d0-ac55-0795f2b6bd98</Id>
     </Book>
-    <Book Series="X-Force" Number="22" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="X-Force" Number="22" Volume="2008" Year="2010">
       <Id>75a19dbb-0835-456a-9603-9ab13abf9857</Id>
     </Book>
-    <Book Series="X-Force" Number="23" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="X-Force" Number="23" Volume="2008" Year="2010">
       <Id>60a23d2e-2fcd-4719-b61c-ac884ac9204c</Id>
     </Book>
-    <Book Series="X-Force" Number="24" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="X-Force" Number="24" Volume="2008" Year="2010">
       <Id>0d0da7ad-6986-44b7-a158-494c6bd6cdbd</Id>
     </Book>
-    <Book Series="New Mutants" Number="6" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="New Mutants" Number="6" Volume="2009" Year="2009">
       <Id>6ca30c76-f33e-429e-9e52-3a0dfb9ea833</Id>
     </Book>
-    <Book Series="New Mutants" Number="7" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="New Mutants" Number="7" Volume="2009" Year="2010">
       <Id>84fca8ae-3c7b-47c7-9fe7-bdc8ef050318</Id>
     </Book>
-    <Book Series="New Mutants" Number="8" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="New Mutants" Number="8" Volume="2009" Year="2010">
       <Id>66f14ca7-bc34-407d-ae5a-74b0fd98317a</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="231" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="231" Volume="2008" Year="2010">
       <Id>7c1aa450-14ca-47f1-be24-7904f122865f</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="232" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="232" Volume="2008" Year="2010">
       <Id>ea17ef23-e9c2-4a16-81d5-0786ccfb9612</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="233" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="233" Volume="2008" Year="2010">
       <Id>fd441421-cbbe-4066-b9f6-e2e19fd5752a</Id>
     </Book>
-    <Book Series="X-Force" Number="25" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="X-Force" Number="25" Volume="2008" Year="2010">
       <Id>abc30136-d29b-4b61-b6e5-ef9f1749279e</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="518" Volume="1981" Year="2010" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="518" Volume="1981" Year="2010">
       <Id>052dc17e-045e-4d1b-a0fd-8e76f597a214</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="519" Volume="1981" Year="2010" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="519" Volume="1981" Year="2010">
       <Id>c96883b5-6ac4-4027-a4cf-0f9843c46085</Id>
     </Book>
-    <Book Series="Nation X: X-Factor" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="Nation X: X-Factor" Number="1" Volume="2010" Year="2010">
       <Id>8edf7e2b-fa81-4673-b35a-e064bd337c45</Id>
     </Book>
-    <Book Series="Nation X" Number="2" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Nation X" Number="2" Volume="2010" Year="2010">
       <Id>85aaa17d-587b-4640-9455-f077b264573c</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="520" Volume="1981" Year="2010" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="520" Volume="1981" Year="2010">
       <Id>91b996ce-2e71-4c88-a58c-f5faa9affadc</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="521" Volume="1981" Year="2010" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="521" Volume="1981" Year="2010">
       <Id>7657db0e-1b9f-4414-87b5-b6a6c986976b</Id>
     </Book>
-    <Book Series="Nation X" Number="3" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Nation X" Number="3" Volume="2010" Year="2010">
       <Id>433724fa-297c-48d5-b652-0857deb943a6</Id>
     </Book>
-    <Book Series="Nation X" Number="4" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Nation X" Number="4" Volume="2010" Year="2010">
       <Id>f0cd3af6-fda6-42ae-b3b9-6875f1bd686f</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="522" Volume="1981" Year="2010" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="522" Volume="1981" Year="2010">
       <Id>cb3660a4-b29e-4eda-bd93-f9b0447d9bb4</Id>
     </Book>
-    <Book Series="X-Force Annual" Number="1" Volume="2010" Year="2010" Format="Annual">
+    <Book Series="X-Force Annual" Number="1" Volume="2010" Year="2010">
       <Id>3f380b4c-17fc-47a0-9acf-48b677f3200a</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="234" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="234" Volume="2008" Year="2010">
       <Id>72d6bfcf-7950-43f3-b863-8222ba4698a4</Id>
     </Book>
-    <Book Series="Dazzler" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="Dazzler" Number="1" Volume="2010" Year="2010">
       <Id>9f84caac-cc7d-4691-922e-1d851ca06f49</Id>
     </Book>
-    <Book Series="New Mutants" Number="9" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="New Mutants" Number="9" Volume="2009" Year="2010">
       <Id>7800eae2-6d97-429f-b416-0b26f1b5b3b2</Id>
     </Book>
-    <Book Series="New Mutants" Number="10" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="New Mutants" Number="10" Volume="2009" Year="2010">
       <Id>1e52bfd6-39b8-4d01-bba0-08c8836289f6</Id>
     </Book>
-    <Book Series="New Mutants" Number="11" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="New Mutants" Number="11" Volume="2009" Year="2010">
       <Id>ed1e27fa-95d4-4c0f-9686-5ac9e1c39f75</Id>
     </Book>
-    <Book Series="S.W.O.R.D." Number="1" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="S.W.O.R.D." Number="1" Volume="2010" Year="2010">
       <Id>8d116745-ee05-4f45-9334-612f5fd202c5</Id>
     </Book>
-    <Book Series="S.W.O.R.D." Number="2" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="S.W.O.R.D." Number="2" Volume="2010" Year="2010">
       <Id>aa30120a-5ba7-4c1c-adbb-c1e3927a7979</Id>
     </Book>
-    <Book Series="S.W.O.R.D." Number="3" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="S.W.O.R.D." Number="3" Volume="2010" Year="2010">
       <Id>a5e44101-2083-4f47-a221-11556325adef</Id>
     </Book>
-    <Book Series="S.W.O.R.D." Number="4" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="S.W.O.R.D." Number="4" Volume="2010" Year="2010">
       <Id>1c0ad7be-9673-418d-8742-596ee4f6b9d7</Id>
     </Book>
-    <Book Series="S.W.O.R.D." Number="5" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="S.W.O.R.D." Number="5" Volume="2010" Year="2010">
       <Id>944213eb-e2bc-4ccb-8329-33a15ae63bf9</Id>
     </Book>
-    <Book Series="X-Men: Pixie Strikes Back" Number="1" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="X-Men: Pixie Strikes Back" Number="1" Volume="2010" Year="2010">
       <Id>347028df-2d9a-4258-9770-71620d1237a5</Id>
     </Book>
-    <Book Series="X-Men: Pixie Strikes Back" Number="2" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="X-Men: Pixie Strikes Back" Number="2" Volume="2010" Year="2010">
       <Id>56b44de5-12d0-45ce-899d-9b865bbf8868</Id>
     </Book>
-    <Book Series="X-Men: Pixie Strikes Back" Number="3" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="X-Men: Pixie Strikes Back" Number="3" Volume="2010" Year="2010">
       <Id>0f755c41-41ae-4512-b432-f1fb7ad4bacf</Id>
     </Book>
-    <Book Series="X-Men: Pixie Strikes Back" Number="4" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="X-Men: Pixie Strikes Back" Number="4" Volume="2010" Year="2010">
       <Id>28648575-cd09-40d4-bfeb-47667dede065</Id>
     </Book>
   </Books>

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 011 (Messiah Complex).cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 011 (Messiah Complex).cbl
@@ -1,1062 +1,1063 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>X-Men - Part 11 (Messiah Complex)</Name>
+  <Name>X-Men - Part 011 (Messiah Complex)</Name>
+  <NumIssues>352</NumIssues>
   <Books>
     <Book Series="X-Men: Messiah Complex" Number="1" Volume="2007" Year="2007">
-      <Id>2172251d-6a8b-481c-82d9-afb98b29f1c4</Id>
+      <Database Name="cv" Series="19419" Issue="116360" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="492" Volume="1981" Year="2008">
-      <Id>d199ab09-b274-48ee-b1c9-c8f5d5e34edd</Id>
+      <Database Name="cv" Series="3092" Issue="116949" />
     </Book>
     <Book Series="X-Factor" Number="25" Volume="2006" Year="2008">
-      <Id>de7e3f43-5803-430f-b5d4-32209dd0b600</Id>
+      <Database Name="cv" Series="18109" Issue="117825" />
     </Book>
     <Book Series="New X-Men" Number="44" Volume="2004" Year="2008">
-      <Id>bdb76c74-efaa-48d6-a6e7-56f82deb0f53</Id>
+      <Database Name="cv" Series="18078" Issue="118081" />
     </Book>
     <Book Series="X-Men" Number="205" Volume="2004" Year="2008">
-      <Id>22e2fb38-1807-4f15-844a-ab6e2725d9bb</Id>
+      <Database Name="cv" Series="10731" Issue="118499" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="493" Volume="1981" Year="2008">
-      <Id>a04f71e7-ded1-484a-b820-57a60e6d2010</Id>
+      <Database Name="cv" Series="3092" Issue="119231" />
     </Book>
     <Book Series="X-Factor" Number="26" Volume="2006" Year="2008">
-      <Id>daff3a26-52d1-4441-8956-3cf067423d7b</Id>
+      <Database Name="cv" Series="18109" Issue="119874" />
     </Book>
     <Book Series="New X-Men" Number="45" Volume="2004" Year="2008">
-      <Id>b36ff774-dcf5-43ba-b79e-ee1db30833a9</Id>
+      <Database Name="cv" Series="18078" Issue="120242" />
     </Book>
     <Book Series="X-Men" Number="206" Volume="2004" Year="2008">
-      <Id>06670d7a-45fb-4f2b-a1f9-b5d5dab7a395</Id>
+      <Database Name="cv" Series="10731" Issue="120558" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="494" Volume="1981" Year="2008">
-      <Id>619972bf-16e0-4e32-9262-50e2b7fd7671</Id>
+      <Database Name="cv" Series="3092" Issue="120868" />
     </Book>
     <Book Series="X-Factor" Number="27" Volume="2006" Year="2008">
-      <Id>409755d2-722c-4ef7-a140-d0f172687ec3</Id>
+      <Database Name="cv" Series="18109" Issue="121100" />
     </Book>
     <Book Series="New X-Men" Number="46" Volume="2004" Year="2008">
-      <Id>a1baac28-becd-402a-a462-9fe48230fc68</Id>
+      <Database Name="cv" Series="18078" Issue="121611" />
     </Book>
     <Book Series="X-Men" Number="207" Volume="2004" Year="2008">
-      <Id>d8068777-4034-4e5a-8328-98be6022e0d7</Id>
+      <Database Name="cv" Series="10731" Issue="121878" />
     </Book>
     <Book Series="Wolverine" Number="62" Volume="2003" Year="2008">
-      <Id>8de69dca-ab8d-44a6-b498-0b516c03006a</Id>
+      <Database Name="cv" Series="10809" Issue="122818" />
     </Book>
     <Book Series="Wolverine" Number="63" Volume="2003" Year="2008">
-      <Id>4beb324c-8845-411f-8820-fd816a9986e9</Id>
+      <Database Name="cv" Series="10809" Issue="125192" />
     </Book>
     <Book Series="Wolverine" Number="64" Volume="2003" Year="2008">
-      <Id>16a01edf-1a55-4d1d-bbab-3b2f3d51906c</Id>
+      <Database Name="cv" Series="10809" Issue="127107" />
     </Book>
     <Book Series="Wolverine" Number="65" Volume="2003" Year="2008">
-      <Id>3d2f4499-f70c-443b-a8c4-9d0257d77002</Id>
+      <Database Name="cv" Series="10809" Issue="130357" />
     </Book>
     <Book Series="X-Men: Legacy" Number="208" Volume="2008" Year="2008">
-      <Id>20e4ed59-5360-427f-99d9-7d60a6919eae</Id>
+      <Database Name="cv" Series="20691" Issue="124060" />
     </Book>
     <Book Series="X-Men: Legacy" Number="209" Volume="2008" Year="2008">
-      <Id>a147f93f-78e5-468e-996d-98acc7473916</Id>
+      <Database Name="cv" Series="20691" Issue="125971" />
     </Book>
     <Book Series="X-Men: Legacy" Number="210" Volume="2008" Year="2008">
-      <Id>eca532bd-4ec9-4ed0-aef1-e04e5c1e26e5</Id>
+      <Database Name="cv" Series="20691" Issue="128965" />
     </Book>
     <Book Series="X-Men: Legacy" Number="211" Volume="2008" Year="2008">
-      <Id>6013d187-5d5a-435f-a705-d56c0b65b483</Id>
+      <Database Name="cv" Series="20691" Issue="130246" />
     </Book>
     <Book Series="X-Men: Legacy" Number="212" Volume="2008" Year="2008">
-      <Id>6c09a2c9-4cef-4f68-8b8e-76ade8a106eb</Id>
+      <Database Name="cv" Series="20691" Issue="130972" />
     </Book>
     <Book Series="X-Men: Legacy" Number="213" Volume="2008" Year="2008">
-      <Id>cd8fde6c-3fe8-44a1-8323-2a67c385fc19</Id>
+      <Database Name="cv" Series="20691" Issue="131844" />
     </Book>
     <Book Series="X-Men: Legacy" Number="214" Volume="2008" Year="2008">
-      <Id>250e276f-f392-46c2-b2cc-e6070de9eaea</Id>
+      <Database Name="cv" Series="20691" Issue="134100" />
     </Book>
     <Book Series="Young X-Men" Number="1" Volume="2008" Year="2008">
-      <Id>9ca423b6-9785-4a20-9a93-81c9fa323c68</Id>
+      <Database Name="cv" Series="21082" Issue="126423" />
     </Book>
     <Book Series="Young X-Men" Number="2" Volume="2008" Year="2008">
-      <Id>52f8abf9-581f-4b6f-82b4-a7957350c5ca</Id>
+      <Database Name="cv" Series="21082" Issue="129704" />
     </Book>
     <Book Series="Young X-Men" Number="3" Volume="2008" Year="2008">
-      <Id>6f294363-8318-4131-be88-0c6b827f20b2</Id>
+      <Database Name="cv" Series="21082" Issue="131325" />
     </Book>
     <Book Series="Young X-Men" Number="4" Volume="2008" Year="2008">
-      <Id>fa4712f4-6315-47ea-bffc-a2eacd06cda6</Id>
+      <Database Name="cv" Series="21082" Issue="133021" />
     </Book>
     <Book Series="Young X-Men" Number="5" Volume="2008" Year="2008">
-      <Id>3071f57a-0f87-4ce1-8045-496de9fc2f72</Id>
+      <Database Name="cv" Series="21082" Issue="136066" />
     </Book>
     <Book Series="X-Factor" Number="28" Volume="2006" Year="2008">
-      <Id>e7212633-58a0-443e-a982-79d38dcd0382</Id>
+      <Database Name="cv" Series="18109" Issue="122815" />
     </Book>
     <Book Series="X-Factor" Number="29" Volume="2006" Year="2008">
-      <Id>7bd0f496-0c1e-458b-9c46-40eb5d7edce7</Id>
+      <Database Name="cv" Series="18109" Issue="125186" />
     </Book>
     <Book Series="X-Factor" Number="30" Volume="2006" Year="2008">
-      <Id>dec4c03c-6be5-4285-9fc0-1aed1dc59eea</Id>
+      <Database Name="cv" Series="18109" Issue="127498" />
     </Book>
     <Book Series="X-Factor" Number="31" Volume="2006" Year="2008">
-      <Id>7be0d2fa-273e-43a2-b1f3-8bfd6f7b8410</Id>
+      <Database Name="cv" Series="18109" Issue="130657" />
     </Book>
     <Book Series="X-Factor" Number="32" Volume="2006" Year="2008">
-      <Id>50aa30db-efbe-486f-8a6c-e72b5e5738e5</Id>
+      <Database Name="cv" Series="18109" Issue="131538" />
     </Book>
     <Book Series="X-Force" Number="1" Volume="2008" Year="2008">
-      <Id>4239d933-8be5-4a1c-be85-60c821134684</Id>
+      <Database Name="cv" Series="20511" Issue="122783" />
     </Book>
     <Book Series="X-Force" Number="2" Volume="2008" Year="2008">
-      <Id>395beebf-8f7f-4b1a-a72f-8b31933ba0af</Id>
+      <Database Name="cv" Series="20511" Issue="124685" />
     </Book>
     <Book Series="X-Force" Number="3" Volume="2008" Year="2008">
-      <Id>78567c3c-7093-4df3-b92a-85e0d74ace2b</Id>
+      <Database Name="cv" Series="20511" Issue="128191" />
     </Book>
     <Book Series="X-Force" Number="4" Volume="2008" Year="2008">
-      <Id>01b1b0be-46c0-4b77-8f7d-002f4413b347</Id>
+      <Database Name="cv" Series="20511" Issue="130970" />
     </Book>
     <Book Series="X-Force" Number="5" Volume="2008" Year="2008">
-      <Id>22c37441-eebe-45f3-94a9-2e3a866ae577</Id>
+      <Database Name="cv" Series="20511" Issue="133610" />
     </Book>
     <Book Series="X-Force" Number="6" Volume="2008" Year="2008">
-      <Id>e3b0024e-28f8-4f41-9b5a-ad82d46d8c34</Id>
+      <Database Name="cv" Series="20511" Issue="136512" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="495" Volume="1981" Year="2008">
-      <Id>f620083b-c8fc-491f-936b-3d85500e6584</Id>
+      <Database Name="cv" Series="3092" Issue="122405" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="496" Volume="1981" Year="2008">
-      <Id>87b1be42-34db-4055-a4ae-09061ad16991</Id>
+      <Database Name="cv" Series="3092" Issue="124676" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="497" Volume="1981" Year="2008">
-      <Id>a3ab5939-75ca-497f-a590-272c86e4c2df</Id>
+      <Database Name="cv" Series="3092" Issue="128189" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="498" Volume="1981" Year="2008">
-      <Id>c9067f5d-f2f2-4953-b4d0-dbb853430131</Id>
+      <Database Name="cv" Series="3092" Issue="130971" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="499" Volume="1981" Year="2008">
-      <Id>31ad0714-c769-42ec-8c18-c6d936783e95</Id>
+      <Database Name="cv" Series="3092" Issue="131797" />
     </Book>
     <Book Series="X-Men: Divided We Stand" Number="1" Volume="2008" Year="2008">
-      <Id>4df21649-db00-432a-8bbe-e85bf11095bf</Id>
+      <Database Name="cv" Series="21203" Issue="127499" />
     </Book>
     <Book Series="X-Men: Divided We Stand" Number="2" Volume="2008" Year="2008">
-      <Id>231e98a3-5135-418d-9551-92337515bdb8</Id>
+      <Database Name="cv" Series="21203" Issue="130517" />
     </Book>
     <Book Series="Cable" Number="1" Volume="2008" Year="2008">
-      <Id>6a47bbfb-369e-409b-a53e-581c7e36a418</Id>
+      <Database Name="cv" Series="20805" Issue="124690" />
     </Book>
     <Book Series="Cable" Number="2" Volume="2008" Year="2008">
-      <Id>eda0a68a-09ac-4ff9-b6ae-20daef3eff27</Id>
+      <Database Name="cv" Series="20805" Issue="126427" />
     </Book>
     <Book Series="Cable" Number="3" Volume="2008" Year="2008">
-      <Id>162719b8-ccd8-496d-9344-f561b64f831b</Id>
+      <Database Name="cv" Series="20805" Issue="129696" />
     </Book>
     <Book Series="Cable" Number="4" Volume="2008" Year="2008">
-      <Id>8b7d5cfd-9978-421d-b97a-1961d468f32e</Id>
+      <Database Name="cv" Series="20805" Issue="131326" />
     </Book>
     <Book Series="Cable" Number="5" Volume="2008" Year="2008">
-      <Id>52ac93c9-19ac-474e-8d52-edc885f6e735</Id>
+      <Database Name="cv" Series="20805" Issue="132222" />
     </Book>
     <Book Series="X-Force Special: Ain't No Dog" Number="1" Volume="2008" Year="2008">
-      <Id>c69e8593-56b3-4443-9c42-b9048706209e</Id>
+      <Database Name="cv" Series="21817" Issue="131468" />
     </Book>
     <Book Series="Logan" Number="1" Volume="2008" Year="2008">
-      <Id>1f24c0cd-36d3-46c7-a4f5-cf52adef26e4</Id>
+      <Database Name="cv" Series="20837" Issue="124875" />
     </Book>
     <Book Series="Logan" Number="2" Volume="2008" Year="2008">
-      <Id>057f7cdf-94c6-4c82-826e-477bf5f77025</Id>
+      <Database Name="cv" Series="20837" Issue="126504" />
     </Book>
     <Book Series="Logan" Number="3" Volume="2008" Year="2008">
-      <Id>90513fe2-cec1-46cb-a5b0-707681e1a879</Id>
+      <Database Name="cv" Series="20837" Issue="129698" />
     </Book>
     <Book Series="Angel: Revelations" Number="1" Volume="2008" Year="2008">
-      <Id>cc03b6b6-1635-462d-a1ca-dcc28a01c0cc</Id>
+      <Database Name="cv" Series="21709" Issue="130968" />
     </Book>
     <Book Series="Angel: Revelations" Number="2" Volume="2008" Year="2008">
-      <Id>ba928d37-6e79-4cfb-b4c8-2a951a3da59b</Id>
+      <Database Name="cv" Series="21709" Issue="134194" />
     </Book>
     <Book Series="Angel: Revelations" Number="3" Volume="2008" Year="2008">
-      <Id>d433db65-986b-4d00-b46f-71c60ca63325</Id>
+      <Database Name="cv" Series="21709" Issue="134195" />
     </Book>
     <Book Series="Angel: Revelations" Number="4" Volume="2008" Year="2008">
-      <Id>1268164d-d451-482a-b48a-ccedd52bb1ac</Id>
+      <Database Name="cv" Series="21709" Issue="136615" />
     </Book>
     <Book Series="Angel: Revelations" Number="5" Volume="2008" Year="2008">
-      <Id>6999e296-1380-4949-9931-e06904638e2e</Id>
+      <Database Name="cv" Series="21709" Issue="139391" />
     </Book>
     <Book Series="Wolverine: Dangerous Games" Number="1" Volume="2008" Year="2008">
-      <Id>06a3def4-f450-42c8-8feb-f118f6a032eb</Id>
+      <Database Name="cv" Series="21779" Issue="131329" />
     </Book>
     <Book Series="X-Men: Kingbreaker" Number="1" Volume="2009" Year="2009">
-      <Id>4eb12379-ea00-4159-8aab-ed73848076c4</Id>
+      <Database Name="cv" Series="24917" Issue="146966" />
     </Book>
     <Book Series="X-Men: Kingbreaker" Number="2" Volume="2009" Year="2009">
-      <Id>1bd13648-e435-4542-bd6d-9a5f5d30f0e3</Id>
+      <Database Name="cv" Series="24917" Issue="150544" />
     </Book>
     <Book Series="X-Men: Kingbreaker" Number="3" Volume="2009" Year="2009">
-      <Id>d3e726a1-f990-474a-9895-d05c06332f63</Id>
+      <Database Name="cv" Series="24917" Issue="152246" />
     </Book>
     <Book Series="X-Men: Kingbreaker" Number="4" Volume="2009" Year="2009">
-      <Id>7ca5215d-504b-464e-b7a5-34df8c3ad0d0</Id>
+      <Database Name="cv" Series="24917" Issue="154036" />
     </Book>
     <Book Series="X-Men: Manifest Destiny" Number="1" Volume="2008" Year="2008">
-      <Id>c1830ac8-40ff-4188-ab74-153f2d865be0</Id>
+      <Database Name="cv" Series="22867" Issue="137352" />
     </Book>
     <Book Series="X-Men: Manifest Destiny" Number="2" Volume="2008" Year="2008">
-      <Id>b6efd243-2ca9-4be6-8b97-f0933bd3461d</Id>
+      <Database Name="cv" Series="22867" Issue="140124" />
     </Book>
     <Book Series="X-Men: Manifest Destiny" Number="3" Volume="2008" Year="2009">
-      <Id>566b3fe5-3c4c-4912-a930-8b76e7b46860</Id>
+      <Database Name="cv" Series="22867" Issue="141529" />
     </Book>
     <Book Series="X-Men: Manifest Destiny" Number="4" Volume="2008" Year="2009">
-      <Id>86d7592a-96e5-4f87-92c4-2ea681aeb4a6</Id>
+      <Database Name="cv" Series="22867" Issue="144348" />
     </Book>
     <Book Series="X-Men: Manifest Destiny" Number="5" Volume="2008" Year="2009">
-      <Id>977e3595-d2d8-4b4b-8076-010194cbc742</Id>
+      <Database Name="cv" Series="22867" Issue="150496" />
     </Book>
     <Book Series="X-Men: Manifest Destiny: Nightcrawler" Number="1" Volume="2009" Year="2009">
-      <Id>3206a18a-8f96-4b44-8959-f5c3d2feb983</Id>
+      <Database Name="cv" Series="25963" Issue="153449" />
     </Book>
     <Book Series="Wolverine: Manifest Destiny" Number="1" Volume="2008" Year="2008">
-      <Id>883733de-0f9e-4a20-8a30-5d561654f231</Id>
+      <Database Name="cv" Series="23486" Issue="140846" />
     </Book>
     <Book Series="Wolverine: Manifest Destiny" Number="2" Volume="2008" Year="2009">
-      <Id>beef014b-9bc3-4b93-825c-36bbd374a3de</Id>
+      <Database Name="cv" Series="23486" Issue="144424" />
     </Book>
     <Book Series="Wolverine: Manifest Destiny" Number="3" Volume="2008" Year="2009">
-      <Id>f953f585-5004-4d4a-a653-99951cd82caa</Id>
+      <Database Name="cv" Series="23486" Issue="149288" />
     </Book>
     <Book Series="Wolverine: Manifest Destiny" Number="4" Volume="2008" Year="2009">
-      <Id>783cf126-160d-4b1f-b0c8-5406148e147d</Id>
+      <Database Name="cv" Series="23486" Issue="151796" />
     </Book>
     <Book Series="Astonishing X-Men" Number="25" Volume="2004" Year="2008">
-      <Id>bf115c5f-d4ee-4ecd-95e2-1b878d093234</Id>
+      <Database Name="cv" Series="10746" Issue="131985" />
     </Book>
     <Book Series="Astonishing X-Men" Number="26" Volume="2004" Year="2008">
-      <Id>48dbe156-9b45-4cc0-aa1f-c2670fcdf2ef</Id>
+      <Database Name="cv" Series="10746" Issue="135433" />
     </Book>
     <Book Series="Astonishing X-Men" Number="27" Volume="2004" Year="2008">
-      <Id>89e65047-29ca-4981-8188-6917a5a16bac</Id>
+      <Database Name="cv" Series="10746" Issue="140444" />
     </Book>
     <Book Series="Astonishing X-Men: Ghost Boxes" Number="1" Volume="2008" Year="2008">
-      <Id>473d85c6-3f60-4e45-932a-40a387ef56ba</Id>
+      <Database Name="cv" Series="23541" Issue="141259" />
     </Book>
     <Book Series="Astonishing X-Men: Ghost Boxes" Number="2" Volume="2008" Year="2009">
-      <Id>904e3652-b778-41c2-9ff2-be3f8cf138c7</Id>
+      <Database Name="cv" Series="23541" Issue="145532" />
     </Book>
     <Book Series="Astonishing X-Men" Number="28" Volume="2004" Year="2009">
-      <Id>c6334284-d6c4-41fb-9402-071d36e5cbd3</Id>
+      <Database Name="cv" Series="10746" Issue="150497" />
     </Book>
     <Book Series="Astonishing X-Men" Number="29" Volume="2004" Year="2009">
-      <Id>61f71ac9-3750-4f47-a99a-ce3a9bccde84</Id>
+      <Database Name="cv" Series="10746" Issue="155841" />
     </Book>
     <Book Series="Astonishing X-Men" Number="30" Volume="2004" Year="2009">
-      <Id>fe470f48-f945-48b0-a97d-22e574a201b8</Id>
+      <Database Name="cv" Series="10746" Issue="161755" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="500" Volume="1981" Year="2008">
-      <Id>73a5941a-d76a-4f23-98a3-227acf6ebb8d</Id>
+      <Database Name="cv" Series="3092" Issue="134012" />
     </Book>
     <Book Series="X-Men: Legacy" Number="215" Volume="2008" Year="2008">
-      <Id>17403dc5-aa0b-4b33-9799-a3fbf2a008f4</Id>
+      <Database Name="cv" Series="20691" Issue="136584" />
     </Book>
     <Book Series="X-Men: Legacy" Number="216" Volume="2008" Year="2008">
-      <Id>c7c69562-762e-44c2-82d1-f502dfb319e3</Id>
+      <Database Name="cv" Series="20691" Issue="139392" />
     </Book>
     <Book Series="Wolverine: Origins" Number="21" Volume="2006" Year="2008">
-      <Id>28d70dfc-62b6-443d-ba3a-29578fc9d3c2</Id>
+      <Database Name="cv" Series="18130" Issue="121655" />
     </Book>
     <Book Series="Wolverine: Origins" Number="22" Volume="2006" Year="2008">
-      <Id>6ac42aff-b97f-44f3-9942-350c75e620e6</Id>
+      <Database Name="cv" Series="18130" Issue="123442" />
     </Book>
     <Book Series="Wolverine: Origins" Number="23" Volume="2006" Year="2008">
-      <Id>bb338277-3835-43b3-932a-3da38eae011e</Id>
+      <Database Name="cv" Series="18130" Issue="125663" />
     </Book>
     <Book Series="Wolverine: Origins" Number="24" Volume="2006" Year="2008">
-      <Id>af0cf4bb-b59a-44c1-9c32-9560ff5fc2a8</Id>
+      <Database Name="cv" Series="18130" Issue="127563" />
     </Book>
     <Book Series="Wolverine: Origins" Number="25" Volume="2006" Year="2008">
-      <Id>34588b6e-704a-46ed-9269-357e5d35e313</Id>
+      <Database Name="cv" Series="18130" Issue="130775" />
     </Book>
     <Book Series="Wolverine: Origins" Number="26" Volume="2006" Year="2008">
-      <Id>00a5eb5a-e850-4c42-a37a-84051a0421ed</Id>
+      <Database Name="cv" Series="18130" Issue="131851" />
     </Book>
     <Book Series="Wolverine: Origins" Number="27" Volume="2006" Year="2008">
-      <Id>393e51a4-dc8d-4183-862e-d4ea98ab92b5</Id>
+      <Database Name="cv" Series="18130" Issue="134650" />
     </Book>
     <Book Series="Wolverine: Origins" Number="28" Volume="2006" Year="2008">
-      <Id>76045c5e-ed5b-4a20-b2d5-dc3a3b574439</Id>
+      <Database Name="cv" Series="18130" Issue="139330" />
     </Book>
     <Book Series="X-Men: Original Sin" Number="1" Volume="2008" Year="2008">
-      <Id>810949af-4c77-41db-97dc-4fb5c2766f7a</Id>
+      <Database Name="cv" Series="23350" Issue="140141" />
     </Book>
     <Book Series="X-Men: Legacy" Number="217" Volume="2008" Year="2008">
-      <Id>7c3fc32d-03ab-4df0-9d3b-30ed5439518a</Id>
+      <Database Name="cv" Series="20691" Issue="140847" />
     </Book>
     <Book Series="Wolverine: Origins" Number="29" Volume="2006" Year="2008">
-      <Id>4ea80b37-60aa-4efa-be48-8f175eb00c3b</Id>
+      <Database Name="cv" Series="18130" Issue="141684" />
     </Book>
     <Book Series="X-Men: Legacy" Number="218" Volume="2008" Year="2009">
-      <Id>2c23de44-0d9a-45e9-9c45-d7855e9082b9</Id>
+      <Database Name="cv" Series="20691" Issue="142503" />
     </Book>
     <Book Series="Wolverine: Origins" Number="30" Volume="2006" Year="2009">
-      <Id>c302f73b-6a8e-4fbc-8eec-c67297e7886d</Id>
+      <Database Name="cv" Series="18130" Issue="143160" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="501" Volume="1981" Year="2008">
-      <Id>c7c8b538-3275-4dd1-b001-5491e338eb11</Id>
+      <Database Name="cv" Series="3092" Issue="136044" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="502" Volume="1981" Year="2008">
-      <Id>357f4d0f-47a7-4ddd-9aa7-d8cb491cfa03</Id>
+      <Database Name="cv" Series="3092" Issue="139026" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="503" Volume="1981" Year="2008">
-      <Id>431fdf67-c2d8-4ef5-adfe-0169a77d22e3</Id>
+      <Database Name="cv" Series="3092" Issue="140442" />
     </Book>
     <Book Series="NYX: No Way Home" Number="1" Volume="2008" Year="2008">
-      <Id>fde416f6-1d9e-4857-824f-0248ddce3b32</Id>
+      <Database Name="cv" Series="22497" Issue="135071" />
     </Book>
     <Book Series="NYX: No Way Home" Number="2" Volume="2008" Year="2008">
-      <Id>02610dda-d8a0-4a05-85ec-7055f945e3ec</Id>
+      <Database Name="cv" Series="22497" Issue="138256" />
     </Book>
     <Book Series="NYX: No Way Home" Number="3" Volume="2008" Year="2008">
-      <Id>27f5cc59-e32a-46fb-8032-db81cd8e8d61</Id>
+      <Database Name="cv" Series="22497" Issue="140473" />
     </Book>
     <Book Series="NYX: No Way Home" Number="4" Volume="2008" Year="2009">
-      <Id>daefe79c-448a-46c7-9079-883398327031</Id>
+      <Database Name="cv" Series="22497" Issue="144573" />
     </Book>
     <Book Series="NYX: No Way Home" Number="5" Volume="2008" Year="2009">
-      <Id>08948d20-85db-4a12-ab64-c4f3117f0529</Id>
+      <Database Name="cv" Series="22497" Issue="149786" />
     </Book>
     <Book Series="NYX: No Way Home" Number="6" Volume="2008" Year="2009">
-      <Id>d02871f1-3471-45a4-838f-6f20cf171c62</Id>
+      <Database Name="cv" Series="22497" Issue="152418" />
     </Book>
     <Book Series="Cable" Number="6" Volume="2008" Year="2008">
-      <Id>19732c0e-4309-4399-b8ff-1fa923441b33</Id>
+      <Database Name="cv" Series="20805" Issue="135076" />
     </Book>
     <Book Series="Cable" Number="7" Volume="2008" Year="2008">
-      <Id>5d0f367b-52f6-4b28-8110-1da69d4fb06b</Id>
+      <Database Name="cv" Series="20805" Issue="139684" />
     </Book>
     <Book Series="Cable" Number="8" Volume="2008" Year="2009">
-      <Id>f6fe479c-56fa-46f3-bc43-f078f230bc22</Id>
+      <Database Name="cv" Series="20805" Issue="141584" />
     </Book>
     <Book Series="Cable" Number="9" Volume="2008" Year="2009">
-      <Id>8c672fa1-f1ad-4cd9-bea0-45f45aed027a</Id>
+      <Database Name="cv" Series="20805" Issue="144347" />
     </Book>
     <Book Series="Cable" Number="10" Volume="2008" Year="2009">
-      <Id>fdb4c7b1-e4db-4716-8059-d1b261ddde37</Id>
+      <Database Name="cv" Series="20805" Issue="149796" />
     </Book>
     <Book Series="King-Size Cable Spectacular" Number="1" Volume="2008" Year="2008">
-      <Id>d95bc1ad-a214-4aa4-9db1-466ccec9c1ec</Id>
+      <Database Name="cv" Series="22978" Issue="138431" />
     </Book>
     <Book Series="X-Factor" Number="33" Volume="2006" Year="2008">
-      <Id>f51a2ade-78d8-43ae-bc2c-22fcd476824a</Id>
+      <Database Name="cv" Series="18109" Issue="133729" />
     </Book>
     <Book Series="She-Hulk" Number="31" Volume="2005" Year="2008">
-      <Id>54fbe521-6221-4bcd-9444-38e32d486c7d</Id>
+      <Database Name="cv" Series="18293" Issue="134099" />
     </Book>
     <Book Series="X-Factor" Number="34" Volume="2006" Year="2008">
-      <Id>52e5dea3-f4f6-48b3-a067-5b63d9665157</Id>
+      <Database Name="cv" Series="18109" Issue="135993" />
     </Book>
     <Book Series="Secret Invasion: X-Men" Number="1" Volume="2008" Year="2008">
-      <Id>98d94475-f13d-4ade-8554-134a0d221d03</Id>
+      <Database Name="cv" Series="22562" Issue="135404" />
     </Book>
     <Book Series="Secret Invasion: X-Men" Number="2" Volume="2008" Year="2008">
-      <Id>c516b87a-7045-4421-8abc-114e8bb4e182</Id>
+      <Database Name="cv" Series="22562" Issue="138410" />
     </Book>
     <Book Series="Secret Invasion: X-Men" Number="3" Volume="2008" Year="2008">
-      <Id>cce4a0e9-dc4b-4835-9836-ba2b2e73a044</Id>
+      <Database Name="cv" Series="22562" Issue="141242" />
     </Book>
     <Book Series="Secret Invasion: X-Men" Number="4" Volume="2008" Year="2009">
-      <Id>9db86cd5-7280-484f-824b-b4187e8f30c1</Id>
+      <Database Name="cv" Series="22562" Issue="143151" />
     </Book>
     <Book Series="X-Factor: The Quick and the Dead" Number="1" Volume="2008" Year="2008">
-      <Id>ccd81066-e5c4-41b7-a146-abdb337b2b92</Id>
+      <Database Name="cv" Series="21499" Issue="129705" />
     </Book>
     <Book Series="X-Force" Number="7" Volume="2008" Year="2008">
-      <Id>eb43a688-3c0a-4ed4-9311-81435c5e30ae</Id>
+      <Database Name="cv" Series="20511" Issue="139327" />
     </Book>
     <Book Series="X-Force" Number="8" Volume="2008" Year="2008">
-      <Id>56e8ad10-6816-4ce9-9d01-7831b8fac6d2</Id>
+      <Database Name="cv" Series="20511" Issue="141187" />
     </Book>
     <Book Series="X-Force" Number="9" Volume="2008" Year="2009">
-      <Id>50ddacb6-b4bf-4110-b06f-82043be29405</Id>
+      <Database Name="cv" Series="20511" Issue="143269" />
     </Book>
     <Book Series="X-Force" Number="10" Volume="2008" Year="2009">
-      <Id>f2568ec6-74e7-4ac5-a957-6202c6da2d7f</Id>
+      <Database Name="cv" Series="20511" Issue="149311" />
     </Book>
     <Book Series="X-Force" Number="11" Volume="2008" Year="2009">
-      <Id>286e46df-ca5c-472a-9458-241b5de8558d</Id>
+      <Database Name="cv" Series="20511" Issue="150595" />
     </Book>
     <Book Series="X-Force" Number="12" Volume="2008" Year="2009">
-      <Id>a775ac44-956c-447b-8ee7-70064e408bcd</Id>
+      <Database Name="cv" Series="20511" Issue="152605" />
     </Book>
     <Book Series="X-Men: Worlds Apart" Number="1" Volume="2008" Year="2008">
-      <Id>71285c4a-7548-4705-bbd7-29bd8003b8fc</Id>
+      <Database Name="cv" Series="23443" Issue="140555" />
     </Book>
     <Book Series="X-Men: Worlds Apart" Number="2" Volume="2008" Year="2009">
-      <Id>68c81ec6-2f34-4a20-8d58-3e7f94585164</Id>
+      <Database Name="cv" Series="23443" Issue="142743" />
     </Book>
     <Book Series="X-Men: Worlds Apart" Number="3" Volume="2008" Year="2009">
-      <Id>0ce9c510-ee6c-4008-bacb-3f918385daeb</Id>
+      <Database Name="cv" Series="23443" Issue="149297" />
     </Book>
     <Book Series="X-Men: Worlds Apart" Number="4" Volume="2008" Year="2009">
-      <Id>e9fd765d-49a4-4048-bc21-10d1970ca52e</Id>
+      <Database Name="cv" Series="23443" Issue="150654" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="504" Volume="1981" Year="2009">
-      <Id>753e5ec9-868d-4b54-86c9-13c9344f637c</Id>
+      <Database Name="cv" Series="3092" Issue="142534" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="505" Volume="1981" Year="2009">
-      <Id>e442971f-d30a-4d64-969a-6a8a45ed08ee</Id>
+      <Database Name="cv" Series="3092" Issue="146890" />
     </Book>
     <Book Series="Uncanny X-Men Annual" Number="2" Volume="2006" Year="2009">
-      <Id>c2df8d04-d7c4-420c-b031-8355abfcc902</Id>
+      <Database Name="cv" Series="18405" Issue="150498" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="506" Volume="1981" Year="2009">
-      <Id>3a5b4cb8-2d6f-4ef9-89cf-b9c8e5f6f0c3</Id>
+      <Database Name="cv" Series="3092" Issue="152232" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="507" Volume="1981" Year="2009">
-      <Id>df638842-d7d6-4957-b1a3-9a4e3b179353</Id>
+      <Database Name="cv" Series="3092" Issue="105657" />
     </Book>
     <Book Series="Wolverine: Flies to a Spider" Number="1" Volume="2009" Year="2009">
-      <Id>4a2868a2-6667-4d5b-b906-232afacf8eee</Id>
+      <Database Name="cv" Series="24595" Issue="145548" />
     </Book>
     <Book Series="Wolverine: Origins" Number="31" Volume="2006" Year="2009">
-      <Id>38d851ac-70d6-40fe-b7d7-795ac654fa18</Id>
+      <Database Name="cv" Series="18130" Issue="148691" />
     </Book>
     <Book Series="Wolverine: Origins" Number="32" Volume="2006" Year="2009">
-      <Id>43829512-b080-4cdd-a572-4a0baf03c81e</Id>
+      <Database Name="cv" Series="18130" Issue="150541" />
     </Book>
     <Book Series="Wolverine: Origins" Number="33" Volume="2006" Year="2009">
-      <Id>6127acf2-db7e-43c8-8c60-d1a2715fc479</Id>
+      <Database Name="cv" Series="18130" Issue="152716" />
     </Book>
     <Book Series="Wolverine: Origins" Number="34" Volume="2006" Year="2009">
-      <Id>f23ac0f6-b137-4f74-8a29-00400150b86b</Id>
+      <Database Name="cv" Series="18130" Issue="153679" />
     </Book>
     <Book Series="Wolverine: Origins" Number="35" Volume="2006" Year="2009">
-      <Id>45d66f5a-c01d-4250-b476-23f566744095</Id>
+      <Database Name="cv" Series="18130" Issue="155774" />
     </Book>
     <Book Series="Wolverine: Origins" Number="36" Volume="2006" Year="2009">
-      <Id>19765834-0c31-4c75-b163-8855058ff944</Id>
+      <Database Name="cv" Series="18130" Issue="158624" />
     </Book>
     <Book Series="Wolverine: Origins" Number="37" Volume="2006" Year="2009">
-      <Id>35972789-4e75-40a1-bfe3-523295e4df59</Id>
+      <Database Name="cv" Series="18130" Issue="160514" />
     </Book>
     <Book Series="Wolverine: Origins" Number="38" Volume="2006" Year="2009">
-      <Id>74ddd96a-1ae0-44fb-95fd-a7ff2f802663</Id>
+      <Database Name="cv" Series="18130" Issue="164799" />
     </Book>
     <Book Series="Wolverine: Origins" Number="39" Volume="2006" Year="2009">
-      <Id>ab080cde-2427-4149-9a3d-ea2be1aaa767</Id>
+      <Database Name="cv" Series="18130" Issue="168415" />
     </Book>
     <Book Series="Wolverine: Origins" Number="40" Volume="2006" Year="2009">
-      <Id>01d4f461-e4f3-4536-8cc6-5dfe06149d36</Id>
+      <Database Name="cv" Series="18130" Issue="172376" />
     </Book>
     <Book Series="Young X-Men" Number="6" Volume="2008" Year="2008">
-      <Id>898a9def-f86c-496f-896d-ef2f380a51ca</Id>
+      <Database Name="cv" Series="21082" Issue="139001" />
     </Book>
     <Book Series="Young X-Men" Number="7" Volume="2008" Year="2008">
-      <Id>6f6bea9a-ee98-443e-8040-85a31e1a4eab</Id>
+      <Database Name="cv" Series="21082" Issue="140445" />
     </Book>
     <Book Series="Young X-Men" Number="8" Volume="2008" Year="2009">
-      <Id>f55199dc-51af-47f7-8064-7d32d3f9fcda</Id>
+      <Database Name="cv" Series="21082" Issue="142546" />
     </Book>
     <Book Series="Young X-Men" Number="9" Volume="2008" Year="2009">
-      <Id>e7d77258-1634-423d-89ce-db166cb3e28b</Id>
+      <Database Name="cv" Series="21082" Issue="149466" />
     </Book>
     <Book Series="Young X-Men" Number="10" Volume="2008" Year="2009">
-      <Id>4b6b4b08-d458-46a3-b6d2-90a77d6f3222</Id>
+      <Database Name="cv" Series="21082" Issue="150703" />
     </Book>
     <Book Series="Young X-Men" Number="11" Volume="2008" Year="2009">
-      <Id>57a2069c-9de9-4ffc-bade-c18842520887</Id>
+      <Database Name="cv" Series="21082" Issue="152247" />
     </Book>
     <Book Series="Young X-Men" Number="12" Volume="2008" Year="2009">
-      <Id>57bab579-499f-4263-a758-9a7575996af7</Id>
+      <Database Name="cv" Series="21082" Issue="153682" />
     </Book>
     <Book Series="X-Infernus" Number="1" Volume="2009" Year="2009">
-      <Id>a9078d6c-e53d-4039-9ff3-ddde2275a492</Id>
+      <Database Name="cv" Series="24079" Issue="143199" />
     </Book>
     <Book Series="X-Infernus" Number="2" Volume="2009" Year="2009">
-      <Id>8965113e-1927-4632-99cd-7e7a6373f804</Id>
+      <Database Name="cv" Series="24079" Issue="149201" />
     </Book>
     <Book Series="X-Infernus" Number="3" Volume="2009" Year="2009">
-      <Id>671ee091-ca32-4bdb-a744-41ff3effbd87</Id>
+      <Database Name="cv" Series="24079" Issue="151701" />
     </Book>
     <Book Series="X-Infernus" Number="4" Volume="2009" Year="2009">
-      <Id>91b4475f-9988-4581-b22d-f1351423f3af</Id>
+      <Database Name="cv" Series="24079" Issue="153913" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="508" Volume="1981" Year="2009">
-      <Id>d7763cf3-af7d-4f60-bca7-37f55e392f78</Id>
+      <Database Name="cv" Series="3092" Issue="105760" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="509" Volume="1981" Year="2009">
-      <Id>87c0fa05-16eb-4d1e-a0cb-591ef1349728</Id>
+      <Database Name="cv" Series="3092" Issue="156102" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="510" Volume="1981" Year="2009">
-      <Id>e89b403f-e1fc-420a-ad5f-188b37f24b5f</Id>
+      <Database Name="cv" Series="3092" Issue="157781" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="511" Volume="1981" Year="2009">
-      <Id>16b4ee92-b524-40d1-add4-8b905fabf130</Id>
+      <Database Name="cv" Series="3092" Issue="159712" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="512" Volume="1981" Year="2009">
-      <Id>fbb73935-ab26-4929-abba-e482b9b0df13</Id>
+      <Database Name="cv" Series="3092" Issue="161867" />
     </Book>
     <Book Series="Eternals" Number="7" Volume="2008" Year="2009">
-      <Id>593eb97d-88f3-478a-8316-11496f9440ba</Id>
+      <Database Name="cv" Series="21937" Issue="149805" />
     </Book>
     <Book Series="Eternals" Number="8" Volume="2008" Year="2009">
-      <Id>b714e0a8-6454-47eb-b15d-ade0e195ac6d</Id>
+      <Database Name="cv" Series="21937" Issue="151871" />
     </Book>
     <Book Series="Eternals" Number="9" Volume="2008" Year="2009">
-      <Id>df5f8907-308e-48ec-bc21-1c24a681bdab</Id>
+      <Database Name="cv" Series="21937" Issue="153671" />
     </Book>
     <Book Series="Runaways" Number="10" Volume="2008" Year="2009">
-      <Id>81b10103-7d5c-4a55-8814-3460bcd4824d</Id>
+      <Database Name="cv" Series="22775" Issue="158856" />
     </Book>
     <Book Series="X-Factor" Number="35" Volume="2006" Year="2008">
-      <Id>9a2ab0a9-1e05-4a26-ab02-7fe5621b8d91</Id>
+      <Database Name="cv" Series="18109" Issue="139002" />
     </Book>
     <Book Series="X-Factor" Number="36" Volume="2006" Year="2008">
-      <Id>807f920e-1e51-4e77-b6ef-48f30a560639</Id>
+      <Database Name="cv" Series="18109" Issue="140960" />
     </Book>
     <Book Series="X-Factor" Number="37" Volume="2006" Year="2009">
-      <Id>0c26cb50-7777-4560-83e9-ccd256d5b882</Id>
+      <Database Name="cv" Series="18109" Issue="142565" />
     </Book>
     <Book Series="X-Factor" Number="38" Volume="2006" Year="2009">
-      <Id>9d54422c-8034-49d1-b123-e23baef6c5c1</Id>
+      <Database Name="cv" Series="18109" Issue="146978" />
     </Book>
     <Book Series="X-Factor" Number="39" Volume="2006" Year="2009">
-      <Id>95df9ade-8c99-4646-9b43-b496a659f209</Id>
+      <Database Name="cv" Series="18109" Issue="150548" />
     </Book>
     <Book Series="Weapon X: First Class" Number="1" Volume="2009" Year="2009">
-      <Id>08ee0a17-3e32-4a49-a220-47ee3ad1fc8e</Id>
+      <Database Name="cv" Series="23783" Issue="142205" />
     </Book>
     <Book Series="Weapon X: First Class" Number="2" Volume="2009" Year="2009">
-      <Id>5887f398-6377-45dc-97f4-6c90d3707d3b</Id>
+      <Database Name="cv" Series="23783" Issue="145367" />
     </Book>
     <Book Series="Weapon X: First Class" Number="3" Volume="2009" Year="2009">
-      <Id>ba6c4ce2-982c-45f3-a09b-74997fe395bb</Id>
+      <Database Name="cv" Series="23783" Issue="150583" />
     </Book>
     <Book Series="New Mutants" Number="1" Volume="2009" Year="2009">
-      <Id>a0f7d266-38f8-497d-ac2f-a17b787ecc83</Id>
+      <Database Name="cv" Series="26327" Issue="156650" />
     </Book>
     <Book Series="New Mutants" Number="2" Volume="2009" Year="2009">
-      <Id>b49355bf-cf04-4f7b-a52b-39b729e31ed1</Id>
+      <Database Name="cv" Series="26327" Issue="159289" />
     </Book>
     <Book Series="New Mutants" Number="3" Volume="2009" Year="2009">
-      <Id>eccb4edb-ac45-48a5-b991-b4a60f7216b6</Id>
+      <Database Name="cv" Series="26327" Issue="164084" />
     </Book>
     <Book Series="New Mutants" Number="4" Volume="2009" Year="2009">
-      <Id>40cfe9a7-ae5a-4202-ba72-443376629643</Id>
+      <Database Name="cv" Series="26327" Issue="168308" />
     </Book>
     <Book Series="Astonishing X-Men" Number="31" Volume="2004" Year="2009">
-      <Id>8f96c962-f2cb-4262-9364-c88644668dbb</Id>
+      <Database Name="cv" Series="10746" Issue="174976" />
     </Book>
     <Book Series="Astonishing X-Men" Number="32" Volume="2004" Year="2010">
-      <Id>a9924e88-850b-4a7d-b63e-83b64614ff8e</Id>
+      <Database Name="cv" Series="10746" Issue="181101" />
     </Book>
     <Book Series="Astonishing X-Men" Number="33" Volume="2004" Year="2010">
-      <Id>013c4849-0e80-4ad8-88d2-6f6f5773fb62</Id>
+      <Database Name="cv" Series="10746" Issue="187624" />
     </Book>
     <Book Series="Astonishing X-Men" Number="34" Volume="2004" Year="2010">
-      <Id>1f170c86-daa5-4c7f-9911-cda44023bcbd</Id>
+      <Database Name="cv" Series="10746" Issue="221757" />
     </Book>
     <Book Series="Astonishing X-Men" Number="35" Volume="2004" Year="2010">
-      <Id>6bb75e92-ef17-4ade-8781-894396967482</Id>
+      <Database Name="cv" Series="10746" Issue="231666" />
     </Book>
     <Book Series="Astonishing X-Men: Xenogenesis" Number="1" Volume="2010" Year="2010">
-      <Id>bc0a73ce-28d3-4153-8b85-9c59817f3f1b</Id>
+      <Database Name="cv" Series="33085" Issue="213448" />
     </Book>
     <Book Series="Astonishing X-Men: Xenogenesis" Number="2" Volume="2010" Year="2010">
-      <Id>2f9331f3-2c89-45ef-8fe6-8dd15c6e41c9</Id>
+      <Database Name="cv" Series="33085" Issue="218295" />
     </Book>
     <Book Series="Astonishing X-Men: Xenogenesis" Number="3" Volume="2010" Year="2010">
-      <Id>714317c2-7543-428c-b374-4d693a00424f</Id>
+      <Database Name="cv" Series="33085" Issue="235329" />
     </Book>
     <Book Series="Astonishing X-Men: Xenogenesis" Number="4" Volume="2010" Year="2011">
-      <Id>888c8930-156c-4cb4-8067-841df664684f</Id>
+      <Database Name="cv" Series="33085" Issue="252747" />
     </Book>
     <Book Series="Astonishing X-Men: Xenogenesis" Number="5" Volume="2010" Year="2011">
-      <Id>5fc5d117-6a83-412f-8cc1-5481b756c4e1</Id>
+      <Database Name="cv" Series="33085" Issue="262599" />
     </Book>
     <Book Series="Cable" Number="11" Volume="2008" Year="2009">
-      <Id>71381a52-5db0-4683-b60c-714c1eeb8b80</Id>
+      <Database Name="cv" Series="20805" Issue="151130" />
     </Book>
     <Book Series="Cable" Number="12" Volume="2008" Year="2009">
-      <Id>33a8c27d-44da-410a-8c2b-42add049a922</Id>
+      <Database Name="cv" Series="20805" Issue="153060" />
     </Book>
-    <Book Series="X-Men: The Times &amp; Life of Lucas Bishop" Number="1" Volume="2009" Year="2009">
-      <Id>82b784f3-cc03-4d2d-90f7-84f7cafd3b86</Id>
+    <Book Series="X-Men: The Times &#38; Life of Lucas Bishop" Number="1" Volume="2009" Year="2009">
+      <Database Name="cv" Series="25714" Issue="151439" />
     </Book>
-    <Book Series="X-Men: The Times &amp; Life of Lucas Bishop" Number="2" Volume="2009" Year="2009">
-      <Id>65501505-ab6e-4ae6-8fc3-195ba730a83a</Id>
+    <Book Series="X-Men: The Times &#38; Life of Lucas Bishop" Number="2" Volume="2009" Year="2009">
+      <Database Name="cv" Series="25714" Issue="153992" />
     </Book>
-    <Book Series="X-Men: The Times &amp; Life of Lucas Bishop" Number="3" Volume="2009" Year="2009">
-      <Id>17ab0cb9-6bd7-426d-9d9d-92aef3d3348e</Id>
+    <Book Series="X-Men: The Times &#38; Life of Lucas Bishop" Number="3" Volume="2009" Year="2009">
+      <Database Name="cv" Series="25714" Issue="155782" />
     </Book>
     <Book Series="X-Force" Number="13" Volume="2008" Year="2009">
-      <Id>35b72332-5680-45d2-9982-95099a3f33d2</Id>
+      <Database Name="cv" Series="20511" Issue="153653" />
     </Book>
     <Book Series="X-Force/Cable: Messiah War" Number="1" Volume="2009" Year="2009">
-      <Id>7a7d0d55-ce40-48e8-8252-d71f5398185d</Id>
+      <Database Name="cv" Series="26055" Issue="154017" />
     </Book>
     <Book Series="Cable" Number="13" Volume="2008" Year="2009">
-      <Id>44fb1274-73cf-4324-b257-34b254891a97</Id>
+      <Database Name="cv" Series="20805" Issue="154460" />
     </Book>
     <Book Series="X-Force" Number="14" Volume="2008" Year="2009">
-      <Id>b15bd8cf-6b75-4bf8-9310-60178d710683</Id>
+      <Database Name="cv" Series="20511" Issue="155738" />
     </Book>
     <Book Series="Cable" Number="14" Volume="2008" Year="2009">
-      <Id>10fd86ce-9118-4b8c-9946-c1fc580d6d13</Id>
+      <Database Name="cv" Series="20805" Issue="156646" />
     </Book>
     <Book Series="X-Force" Number="15" Volume="2008" Year="2009">
-      <Id>9c200b4b-c220-44f6-8d7b-6151dc8f3527</Id>
+      <Database Name="cv" Series="20511" Issue="158731" />
     </Book>
     <Book Series="Cable" Number="15" Volume="2008" Year="2009">
-      <Id>b05872a5-8a8b-4caa-9906-73e684c574db</Id>
+      <Database Name="cv" Series="20805" Issue="160411" />
     </Book>
     <Book Series="X-Force" Number="16" Volume="2008" Year="2009">
-      <Id>85c86727-99c4-4993-9192-b2517e0cc3db</Id>
+      <Database Name="cv" Series="20511" Issue="161549" />
     </Book>
     <Book Series="X-Men: Future History –– Messiah War Sourcebook" Number="1" Volume="2009" Year="2009">
-      <Id>076f33e7-bbb4-4366-8997-3d4a280be2ef</Id>
+      <Database Name="cv" Series="28492" Issue="175550" />
     </Book>
     <Book Series="X-Force" Number="17" Volume="2008" Year="2009">
-      <Id>118fc8ce-d145-44bb-9010-07db6cd41c1f</Id>
+      <Database Name="cv" Series="20511" Issue="164780" />
     </Book>
     <Book Series="X-Force" Number="18" Volume="2008" Year="2009">
-      <Id>c4cbf5df-43b4-46d5-898a-5d830ef28dc1</Id>
+      <Database Name="cv" Series="20511" Issue="168465" />
     </Book>
     <Book Series="X-Force" Number="19" Volume="2008" Year="2009">
-      <Id>684448e4-f2d4-4d9f-953c-006b87e080fe</Id>
+      <Database Name="cv" Series="20511" Issue="173708" />
     </Book>
     <Book Series="X-Force" Number="20" Volume="2008" Year="2009">
-      <Id>e2ea410d-6bf1-49dc-8e07-7f7360d9f20b</Id>
+      <Database Name="cv" Series="20511" Issue="179171" />
     </Book>
-    <Book Series="X-Force: Sex &amp; Violence" Number="1" Volume="2010" Year="2010">
-      <Id>3dce2015-2bc2-4ad0-be5b-bb18dfebe0b1</Id>
+    <Book Series="X-Force: Sex &#38; Violence" Number="1" Volume="2010" Year="2010">
+      <Database Name="cv" Series="34411" Issue="224583" />
     </Book>
-    <Book Series="X-Force: Sex &amp; Violence" Number="2" Volume="2010" Year="2010">
-      <Id>cf7f2312-afdd-4865-a8d3-619086bb7263</Id>
+    <Book Series="X-Force: Sex &#38; Violence" Number="2" Volume="2010" Year="2010">
+      <Database Name="cv" Series="34411" Issue="228876" />
     </Book>
-    <Book Series="X-Force: Sex &amp; Violence" Number="3" Volume="2010" Year="2010">
-      <Id>83ce59c7-4335-4840-ad07-2dd51983298f</Id>
+    <Book Series="X-Force: Sex &#38; Violence" Number="3" Volume="2010" Year="2010">
+      <Database Name="cv" Series="34411" Issue="233757" />
     </Book>
     <Book Series="Thunderbolts" Number="130" Volume="2006" Year="2009">
-      <Id>2ee5a59c-54b6-412e-a74d-d6519f2ddc48</Id>
+      <Database Name="cv" Series="18128" Issue="153654" />
     </Book>
     <Book Series="Thunderbolts" Number="131" Volume="2006" Year="2009">
-      <Id>1e618900-7f84-4c13-bec8-dbd0680335f5</Id>
+      <Database Name="cv" Series="18128" Issue="156169" />
     </Book>
     <Book Series="Wolverine: First Class" Number="13" Volume="2008" Year="2009">
-      <Id>2511b4b5-aa41-44a3-bbc8-55a2507db313</Id>
+      <Database Name="cv" Series="21049" Issue="153978" />
     </Book>
     <Book Series="Wolverine: First Class" Number="14" Volume="2008" Year="2009">
-      <Id>65b85a02-51d3-4c82-b3d1-7682f5d64c2e</Id>
+      <Database Name="cv" Series="21049" Issue="155848" />
     </Book>
     <Book Series="Wolverine: First Class" Number="15" Volume="2008" Year="2009">
-      <Id>7c6ddbd6-9d70-40e1-95ba-315a5754abba</Id>
+      <Database Name="cv" Series="21049" Issue="158685" />
     </Book>
     <Book Series="Wolverine: First Class" Number="16" Volume="2008" Year="2009">
-      <Id>a37f2238-dce2-441a-9499-0e58aaa7ea3e</Id>
+      <Database Name="cv" Series="21049" Issue="161598" />
     </Book>
     <Book Series="Wolverine: Switchback" Number="1" Volume="2009" Year="2009">
-      <Id>52313542-5935-481d-9d9d-6767479871c8</Id>
+      <Database Name="cv" Series="25385" Issue="149843" />
     </Book>
     <Book Series="Wolverine: The Anniversary" Number="1" Volume="2009" Year="2009">
-      <Id>d59000f2-43f9-4ca3-bff4-0ff2dade9072</Id>
+      <Database Name="cv" Series="26286" Issue="155944" />
     </Book>
     <Book Series="Rampaging Wolverine" Number="1" Volume="2009" Year="2009">
-      <Id>80fa7a4e-124c-46d1-aa20-f1f203566d58</Id>
+      <Database Name="cv" Series="26218" Issue="155520" />
     </Book>
     <Book Series="New Exiles" Number="16" Volume="2008" Year="2009">
-      <Id>05c32ecc-725a-4f5b-b420-54a28b92c6c7</Id>
+      <Database Name="cv" Series="20347" Issue="148694" />
     </Book>
     <Book Series="New Exiles" Number="17" Volume="2008" Year="2009">
-      <Id>4787b2bc-a6aa-4a19-82c6-26be15bced20</Id>
+      <Database Name="cv" Series="20347" Issue="150630" />
     </Book>
     <Book Series="New Exiles" Number="18" Volume="2008" Year="2009">
-      <Id>8fe1356b-5959-4ba1-84de-7087adbd167e</Id>
+      <Database Name="cv" Series="20347" Issue="152355" />
     </Book>
     <Book Series="X-Men: Sword of the Braddocks" Number="1" Volume="2009" Year="2009">
-      <Id>b669253b-b2f0-4554-87c0-d472be9dc127</Id>
+      <Database Name="cv" Series="26051" Issue="153979" />
     </Book>
     <Book Series="Wolverine" Number="73" Volume="2003" Year="2009">
-      <Id>8c179d17-62c9-4571-992c-16051cfa0f11</Id>
+      <Database Name="cv" Series="10809" Issue="157332" />
     </Book>
     <Book Series="Wolverine" Number="74" Volume="2003" Year="2009">
-      <Id>54ca5831-3dea-49dc-97ea-e03096150464</Id>
+      <Database Name="cv" Series="10809" Issue="159720" />
     </Book>
     <Book Series="Dark Wolverine" Number="75" Volume="2009" Year="2009">
-      <Id>9a232e01-f187-4852-9a3f-1a4199fde378</Id>
+      <Database Name="cv" Series="26883" Issue="161496" />
     </Book>
     <Book Series="Dark Wolverine" Number="76" Volume="2009" Year="2009">
-      <Id>e7917c36-d915-4e70-8a23-48ec40c9dacc</Id>
+      <Database Name="cv" Series="26883" Issue="164829" />
     </Book>
     <Book Series="Dark Wolverine" Number="77" Volume="2009" Year="2009">
-      <Id>f1f9ca53-417e-485d-b0b7-263104cfdbb0</Id>
+      <Database Name="cv" Series="26883" Issue="168298" />
     </Book>
     <Book Series="Wolverine: Revolver" Number="1" Volume="2009" Year="2009">
-      <Id>9db86b3e-ffce-4f1a-9211-d7401d1b90cf</Id>
+      <Database Name="cv" Series="26627" Issue="159326" />
     </Book>
     <Book Series="Wolverine: First Class" Number="17" Volume="2008" Year="2009">
-      <Id>13bf78bd-c1ad-41ef-8149-8e18690470ff</Id>
+      <Database Name="cv" Series="21049" Issue="165512" />
     </Book>
     <Book Series="Wolverine: First Class" Number="18" Volume="2008" Year="2009">
-      <Id>5ca47997-e44f-4a0b-bb3c-e425872b9b8e</Id>
+      <Database Name="cv" Series="21049" Issue="168549" />
     </Book>
     <Book Series="Wolverine: First Class" Number="19" Volume="2008" Year="2009">
-      <Id>327f37c7-26ee-49b5-bcbd-465946d1a9d6</Id>
+      <Database Name="cv" Series="21049" Issue="172386" />
     </Book>
     <Book Series="Wolverine: First Class" Number="20" Volume="2008" Year="2009">
-      <Id>90d642b1-52eb-4b68-ae75-90caff30a172</Id>
+      <Database Name="cv" Series="21049" Issue="179196" />
     </Book>
     <Book Series="Wolverine: First Class" Number="21" Volume="2008" Year="2010">
-      <Id>6825e190-e67b-4c42-8a2a-5f4038a8100b</Id>
+      <Database Name="cv" Series="21049" Issue="184988" />
     </Book>
     <Book Series="X-Men: Legacy" Number="219" Volume="2008" Year="2009">
-      <Id>5a82bf42-e7fb-42f3-9e20-9d89e99076e7</Id>
+      <Database Name="cv" Series="20691" Issue="146906" />
     </Book>
     <Book Series="X-Men: Legacy" Number="220" Volume="2008" Year="2009">
-      <Id>c2f983ee-a82e-41a7-a28a-2cbe1d73ee64</Id>
+      <Database Name="cv" Series="20691" Issue="150508" />
     </Book>
     <Book Series="X-Men: Legacy" Number="221" Volume="2008" Year="2009">
-      <Id>e74898ff-ed52-4d4a-adcb-c1241cba851f</Id>
+      <Database Name="cv" Series="20691" Issue="152228" />
     </Book>
     <Book Series="X-Men: Legacy" Number="222" Volume="2008" Year="2009">
-      <Id>f33f2ded-acd2-467f-9f36-505c55e7d416</Id>
+      <Database Name="cv" Series="20691" Issue="153681" />
     </Book>
     <Book Series="X-Men: Legacy" Number="223" Volume="2008" Year="2009">
-      <Id>1c273ebb-0112-41c3-9fcc-f65befad726c</Id>
+      <Database Name="cv" Series="20691" Issue="155479" />
     </Book>
     <Book Series="X-Men: Legacy" Number="224" Volume="2008" Year="2009">
-      <Id>c01e13c1-31ba-4b59-a9bb-1bab79931375</Id>
+      <Database Name="cv" Series="20691" Issue="158643" />
     </Book>
     <Book Series="X-Men: Legacy" Number="225" Volume="2008" Year="2009">
-      <Id>71570c58-1bf9-4197-85d1-f962380f7954</Id>
+      <Database Name="cv" Series="20691" Issue="160536" />
     </Book>
     <Book Series="Dark Avengers/Uncanny X-Men: Utopia" Number="1" Volume="2009" Year="2009">
-      <Id>9f292f92-5382-42dc-bb80-88b04c27c8ff</Id>
+      <Database Name="cv" Series="26888" Issue="161518" />
     </Book>
     <Book Series="Dark X-Men: The Beginning" Number="2" Volume="2009" Year="2009">
-      <Id>83e35db5-0567-4501-9a40-accd9df000ad</Id>
+      <Database Name="cv" Series="27004" Issue="165447" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="513" Volume="1981" Year="2009">
-      <Id>6585ec57-c16e-4230-8105-495fe4982c23</Id>
+      <Database Name="cv" Series="3092" Issue="162522" />
     </Book>
     <Book Series="Dark Avengers" Number="7" Volume="2009" Year="2009">
-      <Id>c67df123-0253-4103-ba3a-6f7ae6622cca</Id>
+      <Database Name="cv" Series="25512" Issue="164008" />
     </Book>
     <Book Series="Dark X-Men: The Beginning" Number="1" Volume="2009" Year="2009">
-      <Id>a0f2e474-ad06-44fd-88f8-2abd840fbafd</Id>
+      <Database Name="cv" Series="27004" Issue="163261" />
     </Book>
     <Book Series="X-Men: Legacy" Number="226" Volume="2008" Year="2009">
-      <Id>554d3f85-3f35-4982-952f-893ca5261ba7</Id>
+      <Database Name="cv" Series="20691" Issue="163253" />
     </Book>
     <Book Series="X-Men: Legacy" Number="227" Volume="2008" Year="2009">
-      <Id>17b7eafc-477b-4d54-a45e-bfdbef36e1c0</Id>
+      <Database Name="cv" Series="20691" Issue="167374" />
     </Book>
     <Book Series="Dark X-Men: The Beginning" Number="3" Volume="2009" Year="2009">
-      <Id>61a5f71e-96d0-4886-ad4d-47a6acaff7d6</Id>
+      <Database Name="cv" Series="27004" Issue="168299" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="514" Volume="1981" Year="2009">
-      <Id>ee587349-4e42-4449-b943-3d9f20101fc0</Id>
+      <Database Name="cv" Series="3092" Issue="166794" />
     </Book>
     <Book Series="Dark Avengers" Number="8" Volume="2009" Year="2009">
-      <Id>c11b4006-dc0b-43bc-914c-c35709b6bac5</Id>
+      <Database Name="cv" Series="25512" Issue="168320" />
     </Book>
     <Book Series="Dark Avengers/Uncanny X-Men: Exodus" Number="1" Volume="2009" Year="2009">
-      <Id>747e3c3a-8e3f-40e2-a8b9-fc8a18e7c5b5</Id>
+      <Database Name="cv" Series="27804" Issue="170312" />
     </Book>
     <Book Series="Dark X-Men: The Confession" Number="1" Volume="2009" Year="2009">
-      <Id>44a5951a-3384-4f26-b588-471e9e8bee24</Id>
+      <Database Name="cv" Series="28085" Issue="172433" />
     </Book>
     <Book Series="Dark Reign: The List - X-Men" Number="1" Volume="2009" Year="2009">
-      <Id>6c7e570d-514c-49c0-99a3-a297cd38d183</Id>
+      <Database Name="cv" Series="28084" Issue="172431" />
     </Book>
     <Book Series="Dark Reign: The List - Wolverine" Number="1" Volume="2009" Year="2009">
-      <Id>e3e32528-7298-4301-9685-44454705a8a3</Id>
+      <Database Name="cv" Series="29102" Issue="179031" />
     </Book>
     <Book Series="New Mutants" Number="5" Volume="2009" Year="2009">
-      <Id>c710c66b-8955-4440-8db4-6178a64c1bce</Id>
+      <Database Name="cv" Series="26327" Issue="174485" />
     </Book>
     <Book Series="Wolverine: Origins" Number="41" Volume="2006" Year="2009">
-      <Id>1a322888-b401-4b4d-92a0-c795f7744c1e</Id>
+      <Database Name="cv" Series="18130" Issue="176850" />
     </Book>
     <Book Series="Wolverine: Origins" Number="42" Volume="2006" Year="2010">
-      <Id>d1e56eec-931e-4076-8371-7a072bf6b9a9</Id>
+      <Database Name="cv" Series="18130" Issue="183715" />
     </Book>
     <Book Series="Wolverine: Origins" Number="43" Volume="2006" Year="2010">
-      <Id>bf6b79f3-3cbd-4c68-a47b-2c7d7c46ea16</Id>
+      <Database Name="cv" Series="18130" Issue="189511" />
     </Book>
     <Book Series="Wolverine: Origins" Number="44" Volume="2006" Year="2010">
-      <Id>c22d9e88-adb4-4c94-b737-730dcb1a0072</Id>
+      <Database Name="cv" Series="18130" Issue="194449" />
     </Book>
     <Book Series="Wolverine: Origins" Number="45" Volume="2006" Year="2010">
-      <Id>5940321b-7588-4681-8bcc-15110ae5f735</Id>
+      <Database Name="cv" Series="18130" Issue="201040" />
     </Book>
     <Book Series="Dark X-Men" Number="1" Volume="2010" Year="2010">
-      <Id>88ce5194-8287-4e46-9997-547324ea0cb4</Id>
+      <Database Name="cv" Series="29623" Issue="182542" />
     </Book>
     <Book Series="Dark X-Men" Number="2" Volume="2010" Year="2010">
-      <Id>73834ae7-27a8-4d7c-a911-ab4cf9bc4239</Id>
+      <Database Name="cv" Series="29623" Issue="186674" />
     </Book>
     <Book Series="Dark X-Men" Number="3" Volume="2010" Year="2010">
-      <Id>f979a6f2-9a9f-4e18-a2ff-9d1934e6b938</Id>
+      <Database Name="cv" Series="29623" Issue="192560" />
     </Book>
     <Book Series="Dark X-Men" Number="4" Volume="2010" Year="2010">
-      <Id>862fc857-ef6c-4e2a-ab58-88fc52d2bace</Id>
+      <Database Name="cv" Series="29623" Issue="196455" />
     </Book>
     <Book Series="Dark X-Men" Number="5" Volume="2010" Year="2010">
-      <Id>36f6728b-30df-4596-ba87-dd7e65794bc0</Id>
+      <Database Name="cv" Series="29623" Issue="200036" />
     </Book>
     <Book Series="Dark Wolverine" Number="78" Volume="2009" Year="2009">
-      <Id>56c8464f-2c3a-4048-a5b5-642f1c6d29e6</Id>
+      <Database Name="cv" Series="26883" Issue="171390" />
     </Book>
     <Book Series="Dark Wolverine" Number="79" Volume="2009" Year="2009">
-      <Id>120fba67-c06e-4c54-aa07-419141bc5bff</Id>
+      <Database Name="cv" Series="26883" Issue="176844" />
     </Book>
     <Book Series="Dark Wolverine" Number="80" Volume="2009" Year="2010">
-      <Id>a8dd58c1-9665-48cb-8c27-aafacca514ac</Id>
+      <Database Name="cv" Series="26883" Issue="184816" />
     </Book>
     <Book Series="Dark Wolverine" Number="81" Volume="2009" Year="2010">
-      <Id>ef47a17e-825e-49e0-9abb-60cd436e2882</Id>
+      <Database Name="cv" Series="26883" Issue="187614" />
     </Book>
     <Book Series="X-Factor" Number="40" Volume="2006" Year="2009">
-      <Id>6a7cd3e0-154d-4935-b79a-be59b257f552</Id>
+      <Database Name="cv" Series="18109" Issue="152245" />
     </Book>
     <Book Series="X-Factor" Number="41" Volume="2006" Year="2009">
-      <Id>8347d48b-e033-4a84-862a-fd1ab63e9fe8</Id>
+      <Database Name="cv" Series="18109" Issue="153680" />
     </Book>
     <Book Series="X-Factor" Number="42" Volume="2006" Year="2009">
-      <Id>d3d3e86d-e047-4d38-9663-fbfcff7e669a</Id>
+      <Database Name="cv" Series="18109" Issue="155519" />
     </Book>
     <Book Series="X-Factor" Number="43" Volume="2006" Year="2009">
-      <Id>6f30da2a-d603-4fc3-a606-d0ad1bed74e3</Id>
+      <Database Name="cv" Series="18109" Issue="157159" />
     </Book>
     <Book Series="X-Factor" Number="44" Volume="2006" Year="2009">
-      <Id>6a3bd1b9-1ac3-4793-b331-ecc0e83d13a7</Id>
+      <Database Name="cv" Series="18109" Issue="159816" />
     </Book>
     <Book Series="X-Factor" Number="45" Volume="2006" Year="2009">
-      <Id>442382a5-1dfa-47c2-86a2-8ecd710686a5</Id>
+      <Database Name="cv" Series="18109" Issue="161887" />
     </Book>
     <Book Series="X-Factor" Number="46" Volume="2006" Year="2009">
-      <Id>80a434d0-2f1b-4654-8184-83ca8b677588</Id>
+      <Database Name="cv" Series="18109" Issue="164146" />
     </Book>
     <Book Series="X-Factor" Number="47" Volume="2006" Year="2009">
-      <Id>a2475c4e-2be3-41fb-8b04-35263e45e9b4</Id>
+      <Database Name="cv" Series="18109" Issue="167373" />
     </Book>
     <Book Series="X-Factor" Number="48" Volume="2006" Year="2009">
-      <Id>175a83cb-88cf-416e-9e5d-78d3c559180a</Id>
+      <Database Name="cv" Series="18109" Issue="171389" />
     </Book>
     <Book Series="X-Factor" Number="49" Volume="2006" Year="2009">
-      <Id>aa392bde-824d-4660-a9f3-6d9f8157177f</Id>
+      <Database Name="cv" Series="18109" Issue="173886" />
     </Book>
     <Book Series="X-Factor" Number="50" Volume="2006" Year="2009">
-      <Id>8cc126b2-2668-43ad-a9bb-7aefa69c2c34</Id>
+      <Database Name="cv" Series="18109" Issue="179202" />
     </Book>
     <Book Series="X-Factor: Layla Miller" Number="1" Volume="2008" Year="2008">
-      <Id>21d52074-540e-4bd6-8d6d-e57389ec2f85</Id>
+      <Database Name="cv" Series="22690" Issue="136064" />
     </Book>
     <Book Series="X-Factor" Number="200" Volume="2006" Year="2010">
-      <Id>6c4d5121-e263-4532-9ca5-2b647c3d0e5f</Id>
+      <Database Name="cv" Series="18109" Issue="187690" />
     </Book>
     <Book Series="X-Factor" Number="201" Volume="2006" Year="2010">
-      <Id>20a15582-147b-474a-a9e9-2527ca25c2d5</Id>
+      <Database Name="cv" Series="18109" Issue="194454" />
     </Book>
     <Book Series="X-Factor" Number="202" Volume="2006" Year="2010">
-      <Id>55972c90-a5e8-4858-b77c-c9f11372f858</Id>
+      <Database Name="cv" Series="18109" Issue="198346" />
     </Book>
     <Book Series="X-Factor" Number="203" Volume="2006" Year="2010">
-      <Id>16cf9599-aebf-4bef-bc43-9ce92ac37304</Id>
+      <Database Name="cv" Series="18109" Issue="201932" />
     </Book>
     <Book Series="X-Factor" Number="204" Volume="2006" Year="2010">
-      <Id>a97915f9-dcd5-4282-9491-9753f11b529b</Id>
+      <Database Name="cv" Series="18109" Issue="208661" />
     </Book>
     <Book Series="X-Factor" Number="205" Volume="2006" Year="2010">
-      <Id>d71d6c1a-6070-488a-94b4-d0bf58518102</Id>
+      <Database Name="cv" Series="18109" Issue="214767" />
     </Book>
     <Book Series="X-Factor" Number="206" Volume="2006" Year="2010">
-      <Id>aac0419b-0b53-4359-b33f-60484127bcdc</Id>
+      <Database Name="cv" Series="18109" Issue="220789" />
     </Book>
     <Book Series="Wolverine: The Best There Is" Number="1" Volume="2011" Year="2011">
-      <Id>95691a2a-2d90-42bf-990b-f483a9b9d0a2</Id>
+      <Database Name="cv" Series="37097" Issue="247372" />
     </Book>
     <Book Series="Wolverine: The Best There Is" Number="2" Volume="2011" Year="2011">
-      <Id>99ddf808-bf05-4f9b-98de-8b06eb506828</Id>
+      <Database Name="cv" Series="37097" Issue="254736" />
     </Book>
     <Book Series="Wolverine: The Best There Is" Number="3" Volume="2011" Year="2011">
-      <Id>1396cc25-180c-4e27-90f5-3c92d715cabe</Id>
+      <Database Name="cv" Series="37097" Issue="260017" />
     </Book>
     <Book Series="Wolverine: The Best There Is" Number="4" Volume="2011" Year="2011">
-      <Id>d806ab2c-347f-4ee8-a77f-0e80f0ce3ce5</Id>
+      <Database Name="cv" Series="37097" Issue="264591" />
     </Book>
     <Book Series="Wolverine: The Best There Is" Number="5" Volume="2011" Year="2011">
-      <Id>c9d2ae1a-6d91-465c-aa99-3315ab94d7c7</Id>
+      <Database Name="cv" Series="37097" Issue="267575" />
     </Book>
     <Book Series="Wolverine: The Best There Is" Number="6" Volume="2011" Year="2011">
-      <Id>8ad0df60-01a6-4cf9-adfa-0f5d00ec5cba</Id>
+      <Database Name="cv" Series="37097" Issue="269481" />
     </Book>
     <Book Series="Wolverine: The Best There Is" Number="7" Volume="2011" Year="2011">
-      <Id>32d4cc10-cf39-455e-8fb7-ca48182819d3</Id>
+      <Database Name="cv" Series="37097" Issue="276703" />
     </Book>
     <Book Series="Wolverine: The Best There Is" Number="8" Volume="2011" Year="2011">
-      <Id>bdf2a305-82c4-41e8-8327-49e5f8309304</Id>
+      <Database Name="cv" Series="37097" Issue="281816" />
     </Book>
     <Book Series="Wolverine: The Best There Is" Number="9" Volume="2011" Year="2011">
-      <Id>d9b1b586-b9dd-484c-a168-8ff81531af76</Id>
+      <Database Name="cv" Series="37097" Issue="288720" />
     </Book>
     <Book Series="Psylocke" Number="2" Volume="2009" Year="2010">
-      <Id>a5cbf969-2542-4474-9ac4-4c299b1999db</Id>
+      <Database Name="cv" Series="29299" Issue="186067" />
     </Book>
     <Book Series="Wolverine: The Best There Is" Number="10" Volume="2011" Year="2011">
-      <Id>34f6d189-635f-4997-beb1-e024070d7173</Id>
+      <Database Name="cv" Series="37097" Issue="293625" />
     </Book>
     <Book Series="Wolverine: The Best There Is" Number="11" Volume="2011" Year="2012">
-      <Id>af9c1020-34c8-41f8-93fa-f3f57a1aa582</Id>
+      <Database Name="cv" Series="37097" Issue="302778" />
     </Book>
     <Book Series="Wolverine: The Best There Is" Number="12" Volume="2011" Year="2012">
-      <Id>b83edfae-02dc-4660-bc56-7daa1997208b</Id>
+      <Database Name="cv" Series="37097" Issue="306568" />
     </Book>
     <Book Series="Psylocke" Number="1" Volume="2009" Year="2010">
-      <Id>384a29b4-fa62-4a1b-94bd-ea02269fbbad</Id>
+      <Database Name="cv" Series="29299" Issue="181096" />
     </Book>
     <Book Series="Psylocke" Number="3" Volume="2009" Year="2010">
-      <Id>a7eb17c4-6a39-4277-9240-2508c53b5003</Id>
+      <Database Name="cv" Series="29299" Issue="192324" />
     </Book>
     <Book Series="Psylocke" Number="4" Volume="2009" Year="2010">
-      <Id>99cc38b8-8727-4e4a-a37a-a1f5f835d0a3</Id>
+      <Database Name="cv" Series="29299" Issue="197470" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="515" Volume="1981" Year="2009">
-      <Id>b5963bbd-8c2a-4c62-984e-fb92b8be99bb</Id>
+      <Database Name="cv" Series="3092" Issue="172382" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="516" Volume="1981" Year="2009">
-      <Id>c7c7fa8e-0df7-42da-87d2-9cbe2096e943</Id>
+      <Database Name="cv" Series="3092" Issue="175925" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="517" Volume="1981" Year="2010">
-      <Id>4609768b-0697-454d-95e1-928acae2edb0</Id>
+      <Database Name="cv" Series="3092" Issue="184818" />
     </Book>
     <Book Series="Nation X" Number="1" Volume="2010" Year="2010">
-      <Id>5344429d-fe6e-4f75-a9b7-c9d3582b4187</Id>
+      <Database Name="cv" Series="30313" Issue="186675" />
     </Book>
     <Book Series="X-Men: Legacy Annual" Number="1" Volume="2009" Year="2009">
-      <Id>2812920f-370a-49a4-9d9f-093f9e2d711e</Id>
+      <Database Name="cv" Series="27952" Issue="171387" />
     </Book>
     <Book Series="X-Men: Legacy" Number="228" Volume="2008" Year="2009">
-      <Id>49e0a795-c76d-4083-a653-e7efa5bf838b</Id>
+      <Database Name="cv" Series="20691" Issue="176851" />
     </Book>
     <Book Series="X-Men: Legacy" Number="229" Volume="2008" Year="2010">
-      <Id>897e57e1-3bc9-4e9d-8a3a-8e5054ddca1f</Id>
+      <Database Name="cv" Series="20691" Issue="183795" />
     </Book>
     <Book Series="X-Men: Legacy" Number="230" Volume="2008" Year="2010">
-      <Id>98fbcc16-b6ab-4f13-b404-ce7d82fc29e7</Id>
+      <Database Name="cv" Series="20691" Issue="187695" />
     </Book>
-    <Book Series="X Necrosha: The Gathering" Number="1" Volume="2010" Year="2010">
-      <Id>42a6f424-1309-4010-90f8-a6bbd69c5046</Id>
+    <Book Series="X Necrosha: The Gathering" Number="1" Volume="2009" Year="2010">
+      <Database Name="cv" Series="30314" Issue="186683" />
     </Book>
     <Book Series="X Necrosha" Number="1" Volume="2009" Year="2009">
-      <Id>2efa26cf-ed87-46b2-8516-58276e58c271</Id>
+      <Database Name="cv" Series="29125" Issue="179203" />
     </Book>
     <Book Series="X-Force" Number="21" Volume="2008" Year="2010">
-      <Id>9b46718d-ce3a-40d0-ac55-0795f2b6bd98</Id>
+      <Database Name="cv" Series="20511" Issue="182545" />
     </Book>
     <Book Series="X-Force" Number="22" Volume="2008" Year="2010">
-      <Id>75a19dbb-0835-456a-9603-9ab13abf9857</Id>
+      <Database Name="cv" Series="20511" Issue="187677" />
     </Book>
     <Book Series="X-Force" Number="23" Volume="2008" Year="2010">
-      <Id>60a23d2e-2fcd-4719-b61c-ac884ac9204c</Id>
+      <Database Name="cv" Series="20511" Issue="194457" />
     </Book>
     <Book Series="X-Force" Number="24" Volume="2008" Year="2010">
-      <Id>0d0da7ad-6986-44b7-a158-494c6bd6cdbd</Id>
+      <Database Name="cv" Series="20511" Issue="198343" />
     </Book>
     <Book Series="New Mutants" Number="6" Volume="2009" Year="2009">
-      <Id>6ca30c76-f33e-429e-9e52-3a0dfb9ea833</Id>
+      <Database Name="cv" Series="26327" Issue="179208" />
     </Book>
     <Book Series="New Mutants" Number="7" Volume="2009" Year="2010">
-      <Id>84fca8ae-3c7b-47c7-9fe7-bdc8ef050318</Id>
+      <Database Name="cv" Series="26327" Issue="184805" />
     </Book>
     <Book Series="New Mutants" Number="8" Volume="2009" Year="2010">
-      <Id>66f14ca7-bc34-407d-ae5a-74b0fd98317a</Id>
+      <Database Name="cv" Series="26327" Issue="189509" />
     </Book>
     <Book Series="X-Men: Legacy" Number="231" Volume="2008" Year="2010">
-      <Id>7c1aa450-14ca-47f1-be24-7904f122865f</Id>
+      <Database Name="cv" Series="20691" Issue="189520" />
     </Book>
     <Book Series="X-Men: Legacy" Number="232" Volume="2008" Year="2010">
-      <Id>ea17ef23-e9c2-4a16-81d5-0786ccfb9612</Id>
+      <Database Name="cv" Series="20691" Issue="194468" />
     </Book>
     <Book Series="X-Men: Legacy" Number="233" Volume="2008" Year="2010">
-      <Id>fd441421-cbbe-4066-b9f6-e2e19fd5752a</Id>
+      <Database Name="cv" Series="20691" Issue="198349" />
     </Book>
     <Book Series="X-Force" Number="25" Volume="2008" Year="2010">
-      <Id>abc30136-d29b-4b61-b6e5-ef9f1749279e</Id>
+      <Database Name="cv" Series="20511" Issue="202489" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="518" Volume="1981" Year="2010">
-      <Id>052dc17e-045e-4d1b-a0fd-8e76f597a214</Id>
+      <Database Name="cv" Series="3092" Issue="185623" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="519" Volume="1981" Year="2010">
-      <Id>c96883b5-6ac4-4027-a4cf-0f9843c46085</Id>
+      <Database Name="cv" Series="3092" Issue="189510" />
     </Book>
     <Book Series="Nation X: X-Factor" Number="1" Volume="2010" Year="2010">
-      <Id>8edf7e2b-fa81-4673-b35a-e064bd337c45</Id>
+      <Database Name="cv" Series="30918" Issue="191271" />
     </Book>
     <Book Series="Nation X" Number="2" Volume="2010" Year="2010">
-      <Id>85aaa17d-587b-4640-9455-f077b264573c</Id>
+      <Database Name="cv" Series="30313" Issue="192469" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="520" Volume="1981" Year="2010">
-      <Id>91b996ce-2e71-4c88-a58c-f5faa9affadc</Id>
+      <Database Name="cv" Series="3092" Issue="193358" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="521" Volume="1981" Year="2010">
-      <Id>7657db0e-1b9f-4414-87b5-b6a6c986976b</Id>
+      <Database Name="cv" Series="3092" Issue="197867" />
     </Book>
     <Book Series="Nation X" Number="3" Volume="2010" Year="2010">
-      <Id>433724fa-297c-48d5-b652-0857deb943a6</Id>
+      <Database Name="cv" Series="30313" Issue="198376" />
     </Book>
     <Book Series="Nation X" Number="4" Volume="2010" Year="2010">
-      <Id>f0cd3af6-fda6-42ae-b3b9-6875f1bd686f</Id>
+      <Database Name="cv" Series="30313" Issue="201000" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="522" Volume="1981" Year="2010">
-      <Id>cb3660a4-b29e-4eda-bd93-f9b0447d9bb4</Id>
+      <Database Name="cv" Series="3092" Issue="201708" />
     </Book>
-    <Book Series="X-Force Annual" Number="1" Volume="2010" Year="2010">
-      <Id>3f380b4c-17fc-47a0-9acf-48b677f3200a</Id>
+    <Book Series="X-Force Annual" Number="1" Volume="2009" Year="2010">
+      <Database Name="cv" Series="30173" Issue="185752" />
     </Book>
     <Book Series="X-Men: Legacy" Number="234" Volume="2008" Year="2010">
-      <Id>72d6bfcf-7950-43f3-b863-8222ba4698a4</Id>
+      <Database Name="cv" Series="20691" Issue="200996" />
     </Book>
     <Book Series="Dazzler" Number="1" Volume="2010" Year="2010">
-      <Id>9f84caac-cc7d-4691-922e-1d851ca06f49</Id>
+      <Database Name="cv" Series="33347" Issue="216175" />
     </Book>
     <Book Series="New Mutants" Number="9" Volume="2009" Year="2010">
-      <Id>7800eae2-6d97-429f-b416-0b26f1b5b3b2</Id>
+      <Database Name="cv" Series="26327" Issue="191456" />
     </Book>
     <Book Series="New Mutants" Number="10" Volume="2009" Year="2010">
-      <Id>1e52bfd6-39b8-4d01-bba0-08c8836289f6</Id>
+      <Database Name="cv" Series="26327" Issue="196078" />
     </Book>
     <Book Series="New Mutants" Number="11" Volume="2009" Year="2010">
-      <Id>ed1e27fa-95d4-4c0f-9686-5ac9e1c39f75</Id>
+      <Database Name="cv" Series="26327" Issue="202486" />
     </Book>
     <Book Series="S.W.O.R.D." Number="1" Volume="2010" Year="2010">
-      <Id>8d116745-ee05-4f45-9334-612f5fd202c5</Id>
+      <Database Name="cv" Series="29619" Issue="182521" />
     </Book>
     <Book Series="S.W.O.R.D." Number="2" Volume="2010" Year="2010">
-      <Id>aa30120a-5ba7-4c1c-adbb-c1e3927a7979</Id>
+      <Database Name="cv" Series="29619" Issue="186687" />
     </Book>
     <Book Series="S.W.O.R.D." Number="3" Volume="2010" Year="2010">
-      <Id>a5e44101-2083-4f47-a221-11556325adef</Id>
+      <Database Name="cv" Series="29619" Issue="192449" />
     </Book>
     <Book Series="S.W.O.R.D." Number="4" Volume="2010" Year="2010">
-      <Id>1c0ad7be-9673-418d-8742-596ee4f6b9d7</Id>
+      <Database Name="cv" Series="29619" Issue="197068" />
     </Book>
     <Book Series="S.W.O.R.D." Number="5" Volume="2010" Year="2010">
-      <Id>944213eb-e2bc-4ccb-8329-33a15ae63bf9</Id>
+      <Database Name="cv" Series="29619" Issue="200190" />
     </Book>
     <Book Series="X-Men: Pixie Strikes Back" Number="1" Volume="2010" Year="2010">
-      <Id>347028df-2d9a-4258-9770-71620d1237a5</Id>
+      <Database Name="cv" Series="31477" Issue="196459" />
     </Book>
     <Book Series="X-Men: Pixie Strikes Back" Number="2" Volume="2010" Year="2010">
-      <Id>56b44de5-12d0-45ce-899d-9b865bbf8868</Id>
+      <Database Name="cv" Series="31477" Issue="200108" />
     </Book>
     <Book Series="X-Men: Pixie Strikes Back" Number="3" Volume="2010" Year="2010">
-      <Id>0f755c41-41ae-4512-b432-f1fb7ad4bacf</Id>
+      <Database Name="cv" Series="31477" Issue="208664" />
     </Book>
     <Book Series="X-Men: Pixie Strikes Back" Number="4" Volume="2010" Year="2010">
-      <Id>28648575-cd09-40d4-bfeb-47667dede065</Id>
+      <Database Name="cv" Series="31477" Issue="214755" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 012.cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 012.cbl
@@ -1,1068 +1,1069 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>X-Men - Part 12</Name>
+  <Name>X-Men - Part 012</Name>
+  <NumIssues>355</NumIssues>
   <Books>
     <Book Series="Wolverine Weapon X" Number="1" Volume="2009" Year="2009">
-      <Id>c4351fa9-7945-44ac-9a19-d3a2c5791eec</Id>
+      <Database Name="cv" Series="26150" Issue="155144" />
     </Book>
     <Book Series="Wolverine Weapon X" Number="2" Volume="2009" Year="2009">
-      <Id>9e513673-1e8f-4255-a9c2-bc37dd7ff79f</Id>
+      <Database Name="cv" Series="26150" Issue="157717" />
     </Book>
     <Book Series="Wolverine Weapon X" Number="3" Volume="2009" Year="2009">
-      <Id>8c27fc10-d8ea-480b-8af3-4f259367997b</Id>
+      <Database Name="cv" Series="26150" Issue="161500" />
     </Book>
     <Book Series="Wolverine Weapon X" Number="4" Volume="2009" Year="2009">
-      <Id>f00a96e6-8912-498b-9bcb-4d35de00973d</Id>
+      <Database Name="cv" Series="26150" Issue="167372" />
     </Book>
     <Book Series="Wolverine Weapon X" Number="5" Volume="2009" Year="2009">
-      <Id>39e2b7f1-279f-4a6d-9142-d43c3a6c3636</Id>
+      <Database Name="cv" Series="26150" Issue="173768" />
     </Book>
     <Book Series="Wolverine Weapon X" Number="6" Volume="2009" Year="2009">
-      <Id>1164863f-9ce8-4104-868b-2966084cb5b3</Id>
+      <Database Name="cv" Series="26150" Issue="179195" />
     </Book>
     <Book Series="Wolverine Weapon X" Number="7" Volume="2009" Year="2010">
-      <Id>a42d09bb-c333-4f40-8a1c-aed51234e01b</Id>
+      <Database Name="cv" Series="26150" Issue="183716" />
     </Book>
     <Book Series="Wolverine Weapon X" Number="8" Volume="2009" Year="2010">
-      <Id>1cd6469d-7956-41c9-bed7-5dca5d627fe8</Id>
+      <Database Name="cv" Series="26150" Issue="189691" />
     </Book>
     <Book Series="Wolverine Weapon X" Number="9" Volume="2009" Year="2010">
-      <Id>d382152a-fd49-4f79-b680-b5f4f7375b86</Id>
+      <Database Name="cv" Series="26150" Issue="193355" />
     </Book>
     <Book Series="Wolverine Weapon X" Number="10" Volume="2009" Year="2010">
-      <Id>ae160a91-380e-4658-ba56-ef620a48c453</Id>
+      <Database Name="cv" Series="26150" Issue="195364" />
     </Book>
     <Book Series="Cable" Number="16" Volume="2008" Year="2009">
-      <Id>4372a8b0-4815-4c7f-a4c0-09c039abdeb3</Id>
+      <Database Name="cv" Series="20805" Issue="162621" />
     </Book>
     <Book Series="Cable" Number="17" Volume="2008" Year="2009">
-      <Id>69cf6629-2c05-466b-8148-03b66fe49b15</Id>
+      <Database Name="cv" Series="20805" Issue="166816" />
     </Book>
     <Book Series="Cable" Number="18" Volume="2008" Year="2009">
-      <Id>7a682aff-abe7-4f7c-ba56-aa6f3253c98a</Id>
+      <Database Name="cv" Series="20805" Issue="169207" />
     </Book>
     <Book Series="Cable" Number="19" Volume="2008" Year="2009">
-      <Id>43ff2235-3e37-4da2-9ed0-8a6adc6d2543</Id>
+      <Database Name="cv" Series="20805" Issue="174971" />
     </Book>
     <Book Series="Cable" Number="20" Volume="2008" Year="2010">
-      <Id>01f3cd14-0689-445a-9dd8-b671ec48561a</Id>
+      <Database Name="cv" Series="20805" Issue="182540" />
     </Book>
     <Book Series="Dark Wolverine" Number="82" Volume="2009" Year="2010">
-      <Id>b5fa2f45-0224-463a-b0b5-09f0ed7bc08e</Id>
+      <Database Name="cv" Series="26883" Issue="193349" />
     </Book>
     <Book Series="Dark Wolverine" Number="83" Volume="2009" Year="2010">
-      <Id>069e3799-85dd-4bc7-9130-3b6efa8f1f9c</Id>
+      <Database Name="cv" Series="26883" Issue="198257" />
     </Book>
     <Book Series="Dark Wolverine" Number="84" Volume="2009" Year="2010">
-      <Id>b0f77f03-c49e-48a3-9cdc-c7a3a864c929</Id>
+      <Database Name="cv" Series="26883" Issue="202485" />
     </Book>
     <Book Series="Wolverine: Savage" Number="1" Volume="2010" Year="2010">
-      <Id>e8965213-97be-4344-aaa3-051539b85a1b</Id>
+      <Database Name="cv" Series="31365" Issue="195365" />
     </Book>
     <Book Series="Wolverine: Mr X" Number="1" Volume="2010" Year="2010">
-      <Id>bb2dac0a-0f3b-4f60-b80a-cd38c29b5108</Id>
+      <Database Name="cv" Series="31907" Issue="200205" />
     </Book>
     <Book Series="Wolverine Weapon X" Number="11" Volume="2009" Year="2010">
-      <Id>21a664e0-4028-486e-821d-e707c05a6cf7</Id>
+      <Database Name="cv" Series="26150" Issue="198817" />
     </Book>
     <Book Series="Wolverine Weapon X" Number="12" Volume="2009" Year="2010">
-      <Id>255d6ce1-f879-4401-bbcd-807c21439385</Id>
+      <Database Name="cv" Series="26150" Issue="204463" />
     </Book>
     <Book Series="Wolverine Weapon X" Number="13" Volume="2009" Year="2010">
-      <Id>518c53bb-c357-461c-a9c6-09241a264153</Id>
+      <Database Name="cv" Series="26150" Issue="216275" />
     </Book>
     <Book Series="Wolverine Weapon X" Number="14" Volume="2009" Year="2010">
-      <Id>af754e35-dff3-4d7f-851f-d3c44bd2925e</Id>
+      <Database Name="cv" Series="26150" Issue="220843" />
     </Book>
     <Book Series="Wolverine Weapon X" Number="15" Volume="2009" Year="2010">
-      <Id>3423da18-a7f5-4fe2-9ff1-4300d519a9e5</Id>
+      <Database Name="cv" Series="26150" Issue="226907" />
     </Book>
     <Book Series="Wolverine: Origins" Number="46" Volume="2006" Year="2010">
-      <Id>23427e1b-2ab1-4882-9001-017f6adc246a</Id>
+      <Database Name="cv" Series="18130" Issue="202488" />
     </Book>
     <Book Series="Dark Wolverine" Number="85" Volume="2009" Year="2010">
-      <Id>b02088ea-86a5-432f-aac7-299a25c7d231</Id>
+      <Database Name="cv" Series="26883" Issue="208485" />
     </Book>
     <Book Series="Wolverine: Origins" Number="47" Volume="2006" Year="2010">
-      <Id>53aeb2c9-edbe-4726-a12a-329f362ed471</Id>
+      <Database Name="cv" Series="18130" Issue="210221" />
     </Book>
     <Book Series="Dark Wolverine" Number="86" Volume="2009" Year="2010">
-      <Id>e94b7a25-8e6a-4ed0-85d3-fd638617ea1c</Id>
+      <Database Name="cv" Series="26883" Issue="216168" />
     </Book>
     <Book Series="Wolverine: Origins" Number="48" Volume="2006" Year="2010">
-      <Id>b05d7c27-6832-4f76-8b4d-464547a09a34</Id>
+      <Database Name="cv" Series="18130" Issue="216336" />
     </Book>
     <Book Series="Dark Wolverine" Number="87" Volume="2009" Year="2010">
-      <Id>0b080dbb-2b9d-4cba-a8ea-9ba8aec3efbb</Id>
+      <Database Name="cv" Series="26883" Issue="219557" />
     </Book>
     <Book Series="Wolverine: Origins" Number="49" Volume="2006" Year="2010">
-      <Id>9ce59c36-8c42-4bf4-b13f-dec2dec78273</Id>
+      <Database Name="cv" Series="18130" Issue="220588" />
     </Book>
     <Book Series="Wolverine: Origins" Number="50" Volume="2006" Year="2010">
-      <Id>548a2d41-1ee5-4a60-bfa0-d39fa818071f</Id>
+      <Database Name="cv" Series="18130" Issue="226973" />
     </Book>
     <Book Series="Dark Wolverine" Number="88" Volume="2009" Year="2010">
-      <Id>0fa245ca-52ac-4014-8d50-8f0112cd88ba</Id>
+      <Database Name="cv" Series="26883" Issue="225781" />
     </Book>
     <Book Series="Franken-Castle" Number="19" Volume="2010" Year="2010">
-      <Id>2cb5977e-e9d2-4327-82f0-8c55a5ed2cb0</Id>
+      <Database Name="cv" Series="33560" Issue="226873" />
     </Book>
     <Book Series="Dark Wolverine" Number="89" Volume="2009" Year="2010">
-      <Id>56e0ad34-1abb-44c3-b5b0-5089e36121b0</Id>
+      <Database Name="cv" Series="26883" Issue="228984" />
     </Book>
     <Book Series="Cable" Number="21" Volume="2008" Year="2010">
-      <Id>eae39093-bfcb-4d14-9859-b05d04d65e87</Id>
+      <Database Name="cv" Series="20805" Issue="187673" />
     </Book>
     <Book Series="Cable" Number="22" Volume="2008" Year="2010">
-      <Id>d1990c90-b8f2-4493-b886-5d1916a4bf7e</Id>
+      <Database Name="cv" Series="20805" Issue="191455" />
     </Book>
     <Book Series="Cable" Number="23" Volume="2008" Year="2010">
-      <Id>7af14ec7-8b6a-4e70-8ef6-ca0718fd2031</Id>
+      <Database Name="cv" Series="20805" Issue="195398" />
     </Book>
     <Book Series="Cable" Number="24" Volume="2008" Year="2010">
-      <Id>8b864080-2873-42ca-b04e-3bab6bf532e9</Id>
+      <Database Name="cv" Series="20805" Issue="199838" />
     </Book>
     <Book Series="Cable" Number="25" Volume="2008" Year="2010">
-      <Id>4050ebed-ba3d-4be7-9260-e2b184f13a19</Id>
+      <Database Name="cv" Series="20805" Issue="204546" />
     </Book>
     <Book Series="Second Coming: Prepare" Number="1" Volume="2010" Year="2010">
-      <Id>f3a455a0-53cd-49c4-8da6-8519c1f50633</Id>
+      <Database Name="cv" Series="31667" Issue="198355" />
     </Book>
     <Book Series="X-Men: Hope" Number="1" Volume="2010" Year="2010">
-      <Id>a7ea660a-80dc-4937-8458-ba53e12ab696</Id>
+      <Database Name="cv" Series="31726" Issue="198820" />
     </Book>
     <Book Series="X-Men: Second Coming" Number="1" Volume="2010" Year="2010">
-      <Id>2acb4d79-44a3-4355-a57d-dae39e774fc4</Id>
+      <Database Name="cv" Series="32271" Issue="202574" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="523" Volume="1981" Year="2010">
-      <Id>527ddbf1-90f4-4467-b9cb-5e1a04f3069b</Id>
+      <Database Name="cv" Series="3092" Issue="204515" />
     </Book>
     <Book Series="New Mutants" Number="12" Volume="2009" Year="2010">
-      <Id>63caf658-5739-4d79-a5a4-bed81cb85513</Id>
+      <Database Name="cv" Series="26327" Issue="206640" />
     </Book>
     <Book Series="X-Men: Legacy" Number="235" Volume="2008" Year="2010">
-      <Id>18fc7b9d-e653-40e5-82d1-03c227955dca</Id>
+      <Database Name="cv" Series="20691" Issue="208533" />
     </Book>
     <Book Series="X-Force" Number="26" Volume="2008" Year="2010">
-      <Id>dd332f15-1736-4864-89c9-74c939fbebcd</Id>
+      <Database Name="cv" Series="20511" Issue="210231" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="524" Volume="1981" Year="2010">
-      <Id>61c098ee-9c27-499b-9549-4cbb0f0272cd</Id>
+      <Database Name="cv" Series="3092" Issue="211929" />
     </Book>
     <Book Series="New Mutants" Number="13" Volume="2009" Year="2010">
-      <Id>0bbd8d8d-7461-40a1-86e9-2f2a6fcadde2</Id>
+      <Database Name="cv" Series="26327" Issue="213447" />
     </Book>
     <Book Series="X-Men: Legacy" Number="236" Volume="2008" Year="2010">
-      <Id>cec02ec3-3526-44c3-872f-8a18cf873946</Id>
+      <Database Name="cv" Series="20691" Issue="214734" />
     </Book>
     <Book Series="X-Force" Number="27" Volume="2008" Year="2010">
-      <Id>3f6cce91-b67a-49d0-99ea-b632d7fae6de</Id>
+      <Database Name="cv" Series="20511" Issue="215972" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="525" Volume="1981" Year="2010">
-      <Id>714a8ce3-ffdd-47b3-a68b-965bf17ac0fa</Id>
+      <Database Name="cv" Series="3092" Issue="218329" />
     </Book>
     <Book Series="New Mutants" Number="14" Volume="2009" Year="2010">
-      <Id>650efe6a-f31d-4b40-b469-6da75f2f5675</Id>
+      <Database Name="cv" Series="26327" Issue="219419" />
     </Book>
     <Book Series="X-Men: Legacy" Number="237" Volume="2008" Year="2010">
-      <Id>3ad4d805-aceb-4196-acdc-f9e568db0bfd</Id>
+      <Database Name="cv" Series="20691" Issue="220732" />
     </Book>
     <Book Series="X-Force" Number="28" Volume="2008" Year="2010">
-      <Id>5c79fd95-393d-436a-b985-65fd66f1fa80</Id>
+      <Database Name="cv" Series="20511" Issue="223173" />
     </Book>
     <Book Series="X-Men: Second Coming" Number="2" Volume="2010" Year="2010">
-      <Id>f57707be-ef7b-44e2-b8de-7511db3d1e8c</Id>
+      <Database Name="cv" Series="32271" Issue="224511" />
     </Book>
     <Book Series="X-Men: Hellbound" Number="1" Volume="2010" Year="2010">
-      <Id>4392360e-f48b-489b-a9a1-7e346f690b21</Id>
+      <Database Name="cv" Series="32928" Issue="211930" />
     </Book>
     <Book Series="X-Men: Blind Science" Number="1" Volume="2010" Year="2010">
-      <Id>d8804511-279a-457d-a8fe-299fdd40cea2</Id>
+      <Database Name="cv" Series="33351" Issue="216185" />
     </Book>
     <Book Series="X-Men: Hellbound" Number="2" Volume="2010" Year="2010">
-      <Id>b7c4e3ff-f759-4dd9-8bc0-ea6786e90891</Id>
+      <Database Name="cv" Series="32928" Issue="218294" />
     </Book>
     <Book Series="X-Men: Hellbound" Number="3" Volume="2010" Year="2010">
-      <Id>eb5065c2-968a-4079-b6b1-0fa6f984aa5a</Id>
+      <Database Name="cv" Series="32928" Issue="224510" />
     </Book>
     <Book Series="X-Men Origins: Colossus" Number="1" Volume="2008" Year="2008">
-      <Id>012c64ab-f32c-4527-a22a-df96e7eb3f54</Id>
+      <Database Name="cv" Series="21591" Issue="130414" />
     </Book>
     <Book Series="X-Men Origins: Jean Grey" Number="1" Volume="2008" Year="2008">
-      <Id>4bbb05ba-5ac1-42c9-ae84-1b53ecc3d393</Id>
+      <Database Name="cv" Series="22629" Issue="135782" />
     </Book>
     <Book Series="X-Men Origins: Beast" Number="1" Volume="2008" Year="2008">
-      <Id>54c7b025-6935-45c2-bad0-88a9fb258965</Id>
+      <Database Name="cv" Series="22875" Issue="137380" />
     </Book>
     <Book Series="X-Men Origins: Sabretooth" Number="1" Volume="2009" Year="2009">
-      <Id>db461968-d41c-4c7f-8628-7baad414e98e</Id>
+      <Database Name="cv" Series="25745" Issue="151794" />
     </Book>
     <Book Series="X-Men Origins: Wolverine" Number="1" Volume="2009" Year="2009">
-      <Id>b8518070-0ea2-4f03-bc78-faab29d75914</Id>
+      <Database Name="cv" Series="26310" Issue="156377" />
     </Book>
     <Book Series="X-Men Origins: Gambit" Number="1" Volume="2009" Year="2009">
-      <Id>60a45a99-f094-4100-bb85-ea2daf4cf972</Id>
+      <Database Name="cv" Series="26755" Issue="160453" />
     </Book>
     <Book Series="X-Men Origins: Iceman" Number="1" Volume="2010" Year="2010">
-      <Id>4b7a468b-32cc-4b53-bb9f-41858af2fe32</Id>
+      <Database Name="cv" Series="29328" Issue="181297" />
     </Book>
     <Book Series="X-Men Origins: Cyclops" Number="1" Volume="2010" Year="2010">
-      <Id>d2a9ac35-0d4b-4636-888f-5ef71872c63b</Id>
+      <Database Name="cv" Series="31052" Issue="192575" />
     </Book>
     <Book Series="X-Men Origins: Nightcrawler" Number="1" Volume="2010" Year="2010">
-      <Id>0eec7a2b-c090-44c9-9751-67155d7b4673</Id>
+      <Database Name="cv" Series="32187" Issue="202002" />
     </Book>
     <Book Series="X-Men Origins: Emma Frost" Number="1" Volume="2010" Year="2010">
-      <Id>f7c8ebdf-5d43-4569-a253-4dfd41ea403b</Id>
+      <Database Name="cv" Series="33383" Issue="216366" />
     </Book>
     <Book Series="Uncanny X-Men: The Heroic Age" Number="1" Volume="2010" Year="2010">
-      <Id>10f3c207-f1de-4c4c-a365-8cc71e2b3482</Id>
+      <Database Name="cv" Series="34412" Issue="224585" />
     </Book>
     <Book Series="Heroic Age: X-Men" Number="1" Volume="2011" Year="2011">
-      <Id>a2548243-1b20-4e93-aee1-0350edac2254</Id>
+      <Database Name="cv" Series="37973" Issue="253004" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="526" Volume="1981" Year="2010">
-      <Id>6229997d-d272-42ba-9566-ad81bda793af</Id>
+      <Database Name="cv" Series="3092" Issue="226786" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="527" Volume="1981" Year="2010">
-      <Id>0461ac27-2d16-4ed6-a576-e69f85678d51</Id>
+      <Database Name="cv" Series="3092" Issue="230305" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="528" Volume="1981" Year="2010">
-      <Id>9db0cc56-00f2-4859-a25a-eb2e416c660a</Id>
+      <Database Name="cv" Series="3092" Issue="235335" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="529" Volume="1981" Year="2010">
-      <Id>d10c3684-8f93-4f42-b75e-cbd847918909</Id>
+      <Database Name="cv" Series="3092" Issue="239798" />
     </Book>
     <Book Series="Wolverine Weapon X" Number="16" Volume="2009" Year="2010">
-      <Id>441312ee-f7e0-4b17-92d9-5e6b06cfa127</Id>
+      <Database Name="cv" Series="26150" Issue="230328" />
     </Book>
     <Book Series="New Mutants" Number="15" Volume="2009" Year="2010">
-      <Id>dd8fc979-506c-45b6-ae0d-79e9badede56</Id>
+      <Database Name="cv" Series="26327" Issue="225698" />
     </Book>
     <Book Series="New Mutants" Number="16" Volume="2009" Year="2010">
-      <Id>1eadb1c0-a684-4cbb-b39f-3ac84e55ed9b</Id>
+      <Database Name="cv" Series="26327" Issue="230323" />
     </Book>
     <Book Series="New Mutants" Number="17" Volume="2009" Year="2010">
-      <Id>144e4e64-825c-4388-964d-8066bc493af5</Id>
+      <Database Name="cv" Series="26327" Issue="234590" />
     </Book>
     <Book Series="New Mutants" Number="18" Volume="2009" Year="2010">
-      <Id>d35f6491-6238-40e3-8e04-ea54d168c89b</Id>
+      <Database Name="cv" Series="26327" Issue="239021" />
     </Book>
     <Book Series="New Mutants" Number="19" Volume="2009" Year="2011">
-      <Id>ab254aa6-0671-4b7c-8ebf-c777c36fc639</Id>
+      <Database Name="cv" Series="26327" Issue="246425" />
     </Book>
     <Book Series="Generation Hope" Number="1" Volume="2011" Year="2011">
-      <Id>2cfde706-5ba7-4e82-8cae-81a4bd7a6bb3</Id>
+      <Database Name="cv" Series="36469" Issue="240744" />
     </Book>
     <Book Series="Generation Hope" Number="2" Volume="2011" Year="2011">
-      <Id>84318523-9b8d-43fc-84ad-cd694137e060</Id>
+      <Database Name="cv" Series="36469" Issue="247310" />
     </Book>
     <Book Series="Generation Hope" Number="3" Volume="2011" Year="2011">
-      <Id>78a93ca4-e34f-43e0-91ac-9af1a6d2b95a</Id>
+      <Database Name="cv" Series="36469" Issue="254912" />
     </Book>
     <Book Series="Generation Hope" Number="4" Volume="2011" Year="2011">
-      <Id>e68e98e2-4bb5-40ae-99eb-e1f7a07c2c25</Id>
+      <Database Name="cv" Series="36469" Issue="262480" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="530" Volume="1981" Year="2011">
-      <Id>5714c141-ea4f-49c5-b8cf-dcd74cc14c07</Id>
+      <Database Name="cv" Series="3092" Issue="246422" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="531" Volume="1981" Year="2011">
-      <Id>9c7c5113-bf5c-46f3-9645-8e17cc1c40ee</Id>
+      <Database Name="cv" Series="3092" Issue="250624" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="532" Volume="1981" Year="2011">
-      <Id>5ff71463-5476-4bee-8604-3104525fa315</Id>
+      <Database Name="cv" Series="3092" Issue="259122" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="533" Volume="1981" Year="2011">
-      <Id>ae980434-6a7d-4cc3-978e-d04bd7ed1abd</Id>
+      <Database Name="cv" Series="3092" Issue="263747" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="534" Volume="1981" Year="2011">
-      <Id>a6f90ff1-2ee1-4f65-8e4e-98f7625dda34</Id>
+      <Database Name="cv" Series="3092" Issue="266488" />
     </Book>
     <Book Series="Generation Hope" Number="5" Volume="2011" Year="2011">
-      <Id>5b56727f-4ce1-41d6-a797-f305f7c989e4</Id>
+      <Database Name="cv" Series="36469" Issue="266004" />
     </Book>
     <Book Series="X-Women" Number="1" Volume="2010" Year="2010">
-      <Id>4b6a57de-167d-4ef5-b58c-e36d12bcd1f8</Id>
+      <Database Name="cv" Series="34233" Issue="223268" />
     </Book>
     <Book Series="Wolverine: The Road to Hell" Number="1" Volume="2010" Year="2010">
-      <Id>525d12d3-0688-454a-8d67-53da8b04ac6b</Id>
+      <Database Name="cv" Series="35279" Issue="232620" />
     </Book>
     <Book Series="Uncanny X-Force" Number="1" Volume="2010" Year="2010">
-      <Id>fd881f1b-2bc0-4019-868c-27e3a87a2e61</Id>
+      <Database Name="cv" Series="35835" Issue="237053" />
     </Book>
     <Book Series="Uncanny X-Force" Number="2" Volume="2010" Year="2011">
-      <Id>c4195183-6f66-455e-86cc-fc9f6141997d</Id>
+      <Database Name="cv" Series="35835" Issue="246424" />
     </Book>
     <Book Series="Uncanny X-Force" Number="3" Volume="2010" Year="2011">
-      <Id>aafedf8c-6a70-4c13-84a9-1b046f6dc614</Id>
+      <Database Name="cv" Series="35835" Issue="249206" />
     </Book>
     <Book Series="Uncanny X-Force" Number="4" Volume="2010" Year="2011">
-      <Id>d1f7430d-bcf9-4570-b09e-a8e6f0899661</Id>
+      <Database Name="cv" Series="35835" Issue="259125" />
     </Book>
-    <Book Series="Death of Dracula" Number="1" Volume="2010" Year="2010">
-      <Id>0a0b3f34-8ad7-4333-bd4e-3b0a377264a2</Id>
+    <Book Series="Death of Dracula" Number="1" Volume="2011" Year="2011">
+      <Database Name="cv" Series="40785" Issue="275026" />
     </Book>
     <Book Series="X-Men: Curse of the Mutants - Blade" Number="1" Volume="2010" Year="2010">
-      <Id>c6998ff9-6ccc-471c-91c4-28b733e980c5</Id>
+      <Database Name="cv" Series="35108" Issue="231672" />
     </Book>
     <Book Series="X-Men: Curse Of The Mutants Saga" Number="1" Volume="2010" Year="2010">
-      <Id>63816873-9c9c-458d-b472-9ee8d8d7d368</Id>
+      <Database Name="cv" Series="34032" Issue="221891" />
     </Book>
     <Book Series="X-Men" Number="1" Volume="2010" Year="2010">
-      <Id>2f0a5be5-7be5-4aa3-86f7-994719411425</Id>
+      <Database Name="cv" Series="34221" Issue="223204" />
     </Book>
     <Book Series="X-Men" Number="2" Volume="2010" Year="2010">
-      <Id>04eefe23-25a7-4322-b30c-7c0aafe4f4d8</Id>
+      <Database Name="cv" Series="34221" Issue="228872" />
     </Book>
-    <Book Series="X-Men: Curse of the Mutants - Storm &amp; Gambit" Number="1" Volume="2010" Year="2010">
-      <Id>6196985b-90b7-46af-8ada-9620292c136a</Id>
+    <Book Series="X-Men: Curse of the Mutants - Storm &#38; Gambit" Number="1" Volume="2010" Year="2010">
+      <Database Name="cv" Series="35104" Issue="231617" />
     </Book>
     <Book Series="X-Men: Curse of the Mutants - Smoke and Blood" Number="1" Volume="2010" Year="2010">
-      <Id>bc1ca97a-856e-45a6-a88b-4bb254f3c94f</Id>
+      <Database Name="cv" Series="35292" Issue="232701" />
     </Book>
     <Book Series="X-Men: Curse of the Mutants - X-Men Vs. Vampires" Number="1" Volume="2010" Year="2010">
-      <Id>f922a0ec-0aed-4644-b6d0-9852366e26a1</Id>
+      <Database Name="cv" Series="35725" Issue="236412" />
     </Book>
     <Book Series="X-Men: Curse of the Mutants - X-Men Vs. Vampires" Number="2" Volume="2010" Year="2010">
-      <Id>01b62cb1-ad38-445b-b485-32e5d27e2df2</Id>
+      <Database Name="cv" Series="35725" Issue="239819" />
     </Book>
     <Book Series="Namor: The First Mutant" Number="1" Volume="2010" Year="2010">
-      <Id>3538ef05-ac93-4096-8255-d0a29e643327</Id>
+      <Database Name="cv" Series="34839" Issue="231613" />
     </Book>
     <Book Series="X-Men" Number="3" Volume="2010" Year="2010">
-      <Id>edc8207d-ef02-41e5-8612-7b0e96446992</Id>
+      <Database Name="cv" Series="34221" Issue="233618" />
     </Book>
     <Book Series="Namor: The First Mutant" Number="2" Volume="2010" Year="2010">
-      <Id>335654d4-3d9a-46c3-ad1d-4fe96d7552d8</Id>
+      <Database Name="cv" Series="34839" Issue="236298" />
     </Book>
     <Book Series="Namor: The First Mutant" Number="3" Volume="2010" Year="2010">
-      <Id>c3ef4b21-9733-4a26-a9d8-9c2f4db9cb59</Id>
+      <Database Name="cv" Series="34839" Issue="240600" />
     </Book>
     <Book Series="X-Men" Number="4" Volume="2010" Year="2010">
-      <Id>76c50b97-c525-435a-b598-a705563ee458</Id>
+      <Database Name="cv" Series="34221" Issue="238074" />
     </Book>
     <Book Series="Namor: The First Mutant" Number="4" Volume="2010" Year="2011">
-      <Id>6eba1136-8406-421f-bc5e-3f5e1ed624cf</Id>
+      <Database Name="cv" Series="34839" Issue="246427" />
     </Book>
     <Book Series="X-Men" Number="5" Volume="2010" Year="2011">
-      <Id>4e11ebe5-8dd3-4d44-9347-8d9da5981a2e</Id>
+      <Database Name="cv" Series="34221" Issue="244786" />
     </Book>
     <Book Series="X-Men" Number="6" Volume="2010" Year="2011">
-      <Id>dcb51350-35f0-4def-8a0d-5bc6028bf49a</Id>
+      <Database Name="cv" Series="34221" Issue="250625" />
     </Book>
     <Book Series="X-Men: To Serve and Protect" Number="1" Volume="2011" Year="2011">
-      <Id>feb8b140-c61a-4164-8dfc-2ade012c993a</Id>
+      <Database Name="cv" Series="36470" Issue="240745" />
     </Book>
     <Book Series="X-Men: To Serve and Protect" Number="2" Volume="2011" Year="2011">
-      <Id>6775c489-9716-4d4e-b4f6-956816c3e565</Id>
+      <Database Name="cv" Series="36470" Issue="252756" />
     </Book>
     <Book Series="X-Men: To Serve and Protect" Number="3" Volume="2011" Year="2011">
-      <Id>e1bfb336-902d-4e6d-8b6b-ed50f9724e3c</Id>
+      <Database Name="cv" Series="36470" Issue="259133" />
     </Book>
     <Book Series="X-Men: To Serve and Protect" Number="4" Volume="2011" Year="2011">
-      <Id>e192b879-3a27-4156-bf8c-f280f0eb0189</Id>
+      <Database Name="cv" Series="36470" Issue="263750" />
     </Book>
     <Book Series="X-Men: Legacy" Number="238" Volume="2008" Year="2010">
-      <Id>1523793f-568a-4f94-b9ec-bf7ee895a2bb</Id>
+      <Database Name="cv" Series="20691" Issue="226787" />
     </Book>
     <Book Series="X-Men: Legacy" Number="239" Volume="2008" Year="2010">
-      <Id>e3f07615-4060-4d64-909d-bb6a9415dbc2</Id>
+      <Database Name="cv" Series="20691" Issue="231571" />
     </Book>
     <Book Series="X-Men: Legacy" Number="240" Volume="2008" Year="2010">
-      <Id>ca282d9e-69a5-4588-a47a-ddd2db8adebe</Id>
+      <Database Name="cv" Series="20691" Issue="236190" />
     </Book>
     <Book Series="X-Men: Legacy" Number="241" Volume="2008" Year="2010">
-      <Id>e8d4ef6d-ff45-480c-b320-0de62627355e</Id>
+      <Database Name="cv" Series="20691" Issue="239817" />
     </Book>
     <Book Series="Wolverine and Jubilee" Number="1" Volume="2011" Year="2011">
-      <Id>60c6bf2b-0549-4864-9673-71f328e1f359</Id>
+      <Database Name="cv" Series="38504" Issue="258469" />
     </Book>
     <Book Series="Wolverine and Jubilee" Number="2" Volume="2011" Year="2011">
-      <Id>7ab6a99e-8415-4b3a-aa0a-1193a388c907</Id>
+      <Database Name="cv" Series="38504" Issue="262642" />
     </Book>
     <Book Series="Wolverine and Jubilee" Number="3" Volume="2011" Year="2011">
-      <Id>420192b1-7041-47a4-94f6-74584988c103</Id>
+      <Database Name="cv" Series="38504" Issue="266609" />
     </Book>
     <Book Series="Wolverine and Jubilee" Number="4" Volume="2011" Year="2011">
-      <Id>7a1ce09a-2636-4cfd-b805-f29dffea45d9</Id>
+      <Database Name="cv" Series="38504" Issue="268751" />
     </Book>
     <Book Series="X-Factor" Number="207" Volume="2006" Year="2010">
-      <Id>7cadc0c0-9586-4c51-b80f-92aca48abded</Id>
+      <Database Name="cv" Series="18109" Issue="225699" />
     </Book>
     <Book Series="X-Factor" Number="208" Volume="2006" Year="2010">
-      <Id>6a6677c3-8bb0-4739-b505-7ff11236a294</Id>
+      <Database Name="cv" Series="18109" Issue="231575" />
     </Book>
     <Book Series="X-Factor" Number="209" Volume="2006" Year="2010">
-      <Id>4903f156-2796-4540-9f16-df3a5d07f647</Id>
+      <Database Name="cv" Series="18109" Issue="234669" />
     </Book>
     <Book Series="X-Factor" Number="210" Volume="2006" Year="2010">
-      <Id>3b529bc4-ea7a-43c7-9d80-c5ab11d1b83e</Id>
+      <Database Name="cv" Series="18109" Issue="239171" />
     </Book>
     <Book Series="X-Factor" Number="211" Volume="2006" Year="2011">
-      <Id>a668ed8a-f377-4342-a92b-275b455b0522</Id>
+      <Database Name="cv" Series="18109" Issue="244787" />
     </Book>
     <Book Series="X-Factor" Number="213" Volume="2006" Year="2011">
-      <Id>0c42c988-0ccd-4eb5-abd1-0c6699ecf8c0</Id>
+      <Database Name="cv" Series="18109" Issue="254787" />
     </Book>
     <Book Series="X-Factor" Number="214" Volume="2006" Year="2011">
-      <Id>6a4407e7-1b8d-400e-bd1e-5268f707cfb3</Id>
+      <Database Name="cv" Series="18109" Issue="258472" />
     </Book>
     <Book Series="X-Factor" Number="215" Volume="2006" Year="2011">
-      <Id>1d214ede-5bc4-4545-a4b2-b839a00ae027</Id>
+      <Database Name="cv" Series="18109" Issue="261245" />
     </Book>
     <Book Series="X-Factor" Number="216" Volume="2006" Year="2011">
-      <Id>f840ce09-7b04-4125-8ab6-7158bb8f4b1d</Id>
+      <Database Name="cv" Series="18109" Issue="264592" />
     </Book>
     <Book Series="X-Factor" Number="217" Volume="2006" Year="2011">
-      <Id>757bd2fa-6464-48e2-9a38-702a30a9cb09</Id>
+      <Database Name="cv" Series="18109" Issue="265997" />
     </Book>
     <Book Series="X-Factor" Number="218" Volume="2006" Year="2011">
-      <Id>758d1718-8076-44eb-af9a-99a762f0b492</Id>
+      <Database Name="cv" Series="18109" Issue="268749" />
     </Book>
     <Book Series="X-Factor" Number="219" Volume="2006" Year="2011">
-      <Id>1c2f5863-be4d-48c5-88f2-8340f771352d</Id>
+      <Database Name="cv" Series="18109" Issue="270431" />
     </Book>
     <Book Series="X-23" Number="1" Volume="2010" Year="2010">
-      <Id>496c7e22-13da-453d-8f54-a91697c74824</Id>
-    </Book>
-    <Book Series="X-23" Number="1" Volume="2010" Year="2010">
-      <Id>6837b991-3a00-48b5-9fb2-7b066eb3ca52</Id>
+      <Database Name="cv" Series="35496" Issue="234641" />
     </Book>
     <Book Series="X-23" Number="2" Volume="2010" Year="2010">
-      <Id>5e9ad1e6-d4b8-437e-aab1-21ea7417909d</Id>
+      <Database Name="cv" Series="35496" Issue="239137" />
     </Book>
     <Book Series="X-23" Number="3" Volume="2010" Year="2011">
-      <Id>bdf6ac88-1c7a-4981-8793-a196c960ce1b</Id>
+      <Database Name="cv" Series="35496" Issue="244789" />
     </Book>
     <Book Series="X-23" Number="4" Volume="2010" Year="2011">
-      <Id>9585f393-b862-40c8-a37b-e53490e24234</Id>
+      <Database Name="cv" Series="35496" Issue="252992" />
     </Book>
     <Book Series="X-23" Number="5" Volume="2010" Year="2011">
-      <Id>f547220f-c795-45f5-b3a6-ee6f29d5375f</Id>
+      <Database Name="cv" Series="35496" Issue="259126" />
     </Book>
     <Book Series="X-23" Number="6" Volume="2010" Year="2011">
-      <Id>45db4d77-7d19-4d6f-b13d-3c4e2bca1f15</Id>
+      <Database Name="cv" Series="35496" Issue="263796" />
     </Book>
     <Book Series="Dark Wolverine" Number="90" Volume="2009" Year="2010">
-      <Id>4e9b2779-eb70-4498-bc63-0247f3617aa5</Id>
+      <Database Name="cv" Series="26883" Issue="231577" />
     </Book>
     <Book Series="Daken: Dark Wolverine" Number="1" Volume="2010" Year="2010">
-      <Id>19919f93-f0a4-40b3-abbe-45d2e5fc5c1f</Id>
+      <Database Name="cv" Series="35409" Issue="233620" />
     </Book>
     <Book Series="Daken: Dark Wolverine" Number="2" Volume="2010" Year="2010">
-      <Id>2ecd9d69-9ee7-4111-81b8-32aee006ee28</Id>
+      <Database Name="cv" Series="35409" Issue="238326" />
     </Book>
     <Book Series="Daken: Dark Wolverine" Number="3" Volume="2010" Year="2011">
-      <Id>5940e9a3-d0e7-4532-b393-9a0a324d40d9</Id>
+      <Database Name="cv" Series="35409" Issue="244790" />
     </Book>
     <Book Series="Wolverine" Number="1" Volume="2010" Year="2010">
-      <Id>b84d4800-87cf-47b2-ab4d-2dad7b462df2</Id>
+      <Database Name="cv" Series="35263" Issue="232524" />
     </Book>
     <Book Series="Wolverine" Number="2" Volume="2010" Year="2010">
-      <Id>4285cc1e-327f-4fce-a64d-1c7b7539061c</Id>
+      <Database Name="cv" Series="35263" Issue="237113" />
     </Book>
     <Book Series="Wolverine" Number="3" Volume="2010" Year="2011">
-      <Id>3b7f050f-c1c0-424e-ac3f-b55fb961a950</Id>
+      <Database Name="cv" Series="35263" Issue="240986" />
     </Book>
     <Book Series="Wolverine" Number="4" Volume="2010" Year="2011">
-      <Id>2acebc2d-0000-4514-aa7b-4c0015669e36</Id>
+      <Database Name="cv" Series="35263" Issue="249226" />
     </Book>
     <Book Series="Wolverine" Number="5" Volume="2010" Year="2011">
-      <Id>d3b48617-480c-4997-a975-4b3aed0be117</Id>
+      <Database Name="cv" Series="35263" Issue="258414" />
     </Book>
     <Book Series="Wolverine" Number="900" Volume="2003" Year="2010">
-      <Id>8ac9f241-8462-46a6-8753-8176c4524fa3</Id>
+      <Database Name="cv" Series="10809" Issue="213629" />
     </Book>
     <Book Series="Wolverine" Number="1000" Volume="2010" Year="2011">
-      <Id>11c8f749-177f-4d80-aa16-7445736dea37</Id>
+      <Database Name="cv" Series="35263" Issue="261348" />
     </Book>
     <Book Series="Wolverine" Number="5.1" Volume="2010" Year="2011">
-      <Id>589dfc4e-c0fa-4d39-9d78-51cbaf0b5470</Id>
+      <Database Name="cv" Series="35263" Issue="261260" />
     </Book>
     <Book Series="Wolverine" Number="6" Volume="2010" Year="2011">
-      <Id>b7441774-917a-41ad-b1dc-4fca9f06ad6f</Id>
+      <Database Name="cv" Series="35263" Issue="262617" />
     </Book>
     <Book Series="Wolverine" Number="7" Volume="2010" Year="2011">
-      <Id>30e6481c-fa29-4e23-ad0b-8e2b92221793</Id>
+      <Database Name="cv" Series="35263" Issue="267089" />
     </Book>
     <Book Series="Wolverine" Number="8" Volume="2010" Year="2011">
-      <Id>faa98978-1732-4292-a7d2-9436dc15e5d8</Id>
+      <Database Name="cv" Series="35263" Issue="268747" />
     </Book>
     <Book Series="Wolverine" Number="9" Volume="2010" Year="2011">
-      <Id>478628d5-33df-46fa-b95a-b40158205b48</Id>
+      <Database Name="cv" Series="35263" Issue="271597" />
     </Book>
     <Book Series="Namor: The First Mutant" Number="5" Volume="2010" Year="2011">
-      <Id>a4e131f0-ebd5-41ed-885a-e48c85571756</Id>
+      <Database Name="cv" Series="34839" Issue="250623" />
     </Book>
     <Book Series="Namor: The First Mutant" Number="6" Volume="2010" Year="2011">
-      <Id>d731e93d-fe1e-4760-814c-db4b68442fb8</Id>
+      <Database Name="cv" Series="34839" Issue="259138" />
     </Book>
     <Book Series="Namor: The First Mutant" Number="7" Volume="2010" Year="2011">
-      <Id>9ad5b6b8-b994-4651-99da-c1869668e566</Id>
+      <Database Name="cv" Series="34839" Issue="263746" />
     </Book>
     <Book Series="Namor: The First Mutant" Number="8" Volume="2010" Year="2011">
-      <Id>453e497e-8c08-4ab0-aca8-2c02c037b83c</Id>
+      <Database Name="cv" Series="34839" Issue="266490" />
     </Book>
     <Book Series="Namor: The First Mutant" Number="9" Volume="2010" Year="2011">
-      <Id>3c9065e3-62c7-4faf-98d5-3d9e6809d985</Id>
+      <Database Name="cv" Series="34839" Issue="268983" />
     </Book>
     <Book Series="Namor: The First Mutant" Number="10" Volume="2010" Year="2011">
-      <Id>1180342e-d035-4e37-b656-10303d6bc6b7</Id>
+      <Database Name="cv" Series="34839" Issue="271431" />
     </Book>
     <Book Series="Namor: The First Mutant" Number="11" Volume="2010" Year="2011">
-      <Id>3b32dfeb-66db-4f65-bd32-a2c753f08539</Id>
+      <Database Name="cv" Series="34839" Issue="275808" />
     </Book>
     <Book Series="X-Men" Number="7" Volume="2010" Year="2011">
-      <Id>aa0a446d-40a0-46e3-9bc8-6fd86855458f</Id>
+      <Database Name="cv" Series="34221" Issue="259141" />
     </Book>
     <Book Series="X-Men" Number="8" Volume="2010" Year="2011">
-      <Id>9c8f61d9-ffdb-4d15-89d1-e8d59b801c99</Id>
+      <Database Name="cv" Series="34221" Issue="263757" />
     </Book>
     <Book Series="X-Men" Number="9" Volume="2010" Year="2011">
-      <Id>55f4e46f-dc60-4e58-8f1c-b6075317049e</Id>
+      <Database Name="cv" Series="34221" Issue="266502" />
     </Book>
     <Book Series="X-Men" Number="10" Volume="2010" Year="2011">
-      <Id>bb71cff4-7804-4a14-b1a0-2176638e71d6</Id>
+      <Database Name="cv" Series="34221" Issue="268932" />
     </Book>
     <Book Series="X-Men" Number="11" Volume="2010" Year="2011">
-      <Id>80378f4f-f7a3-4f54-a52a-1c2126996880</Id>
+      <Database Name="cv" Series="34221" Issue="269818" />
     </Book>
     <Book Series="Chaos War" Number="1" Volume="2010" Year="2010">
-      <Id>07d0001c-29ea-4d59-8952-c0c000e69f3c</Id>
+      <Database Name="cv" Series="35877" Issue="237208" />
     </Book>
     <Book Series="Chaos War" Number="2" Volume="2010" Year="2010">
-      <Id>ada55af9-61ff-42e7-8ce0-7c2b5bcbf751</Id>
+      <Database Name="cv" Series="35877" Issue="239053" />
     </Book>
     <Book Series="Chaos War" Number="3" Volume="2010" Year="2011">
-      <Id>9d42da34-537e-4146-b0ff-a832f9b8399a</Id>
+      <Database Name="cv" Series="35877" Issue="240898" />
     </Book>
     <Book Series="Chaos War: Alpha Flight" Number="1" Volume="2011" Year="2011">
-      <Id>97d61e72-7126-4500-8d69-376e508c7742</Id>
+      <Database Name="cv" Series="36952" Issue="246466" />
     </Book>
     <Book Series="Chaos War: Chaos King" Number="1" Volume="2011" Year="2011">
-      <Id>d6a15590-9685-4c95-a94f-bc68877b01e6</Id>
+      <Database Name="cv" Series="36737" Issue="244976" />
     </Book>
     <Book Series="Chaos War: Dead Avengers" Number="1" Volume="2011" Year="2011">
-      <Id>2caf0396-c911-40bc-9f5d-da2fa96edcb5</Id>
+      <Database Name="cv" Series="36730" Issue="244901" />
     </Book>
     <Book Series="Chaos War: Thor" Number="1" Volume="2011" Year="2011">
-      <Id>d5e87733-f7e9-4793-a608-f62e5116e123</Id>
+      <Database Name="cv" Series="36613" Issue="242917" />
     </Book>
     <Book Series="Chaos War" Number="4" Volume="2010" Year="2011">
-      <Id>860b3c91-c570-4574-87c0-b6a5ca12ab75</Id>
+      <Database Name="cv" Series="35877" Issue="249228" />
     </Book>
     <Book Series="Chaos War: Ares" Number="1" Volume="2011" Year="2011">
-      <Id>97b0d43e-4efd-4a2c-a72d-19c936802e9e</Id>
+      <Database Name="cv" Series="37344" Issue="248495" />
     </Book>
     <Book Series="Chaos War: Dead Avengers" Number="2" Volume="2011" Year="2011">
-      <Id>4114bb47-3204-4fb6-94e9-194f19c517f1</Id>
+      <Database Name="cv" Series="36730" Issue="250619" />
     </Book>
     <Book Series="Chaos War: God Squad" Number="1" Volume="2011" Year="2011">
-      <Id>9a5be231-0cbf-423e-a287-fd9aaee10898</Id>
+      <Database Name="cv" Series="36852" Issue="247525" />
     </Book>
     <Book Series="Chaos War: Thor" Number="2" Volume="2011" Year="2011">
-      <Id>cd17cae6-5ff7-4dd6-b1de-acfe5a319013</Id>
+      <Database Name="cv" Series="36613" Issue="249564" />
     </Book>
     <Book Series="Chaos War: X-Men" Number="1" Volume="2011" Year="2011">
-      <Id>127dccd9-9056-4f08-9587-851c797b31ed</Id>
+      <Database Name="cv" Series="37956" Issue="252737" />
     </Book>
     <Book Series="Incredible Hulks" Number="618" Volume="2010" Year="2011">
-      <Id>db29e233-9b30-4b6f-904d-7540edaa399e</Id>
+      <Database Name="cv" Series="35303" Issue="248499" />
     </Book>
     <Book Series="Incredible Hulks" Number="619" Volume="2010" Year="2011">
-      <Id>6bbda978-9604-4299-bf86-2ce2a0a29b98</Id>
+      <Database Name="cv" Series="35303" Issue="250621" />
     </Book>
     <Book Series="Chaos War: Dead Avengers" Number="3" Volume="2011" Year="2011">
-      <Id>b507e2f1-1cdc-4f38-874d-a2dd11a5b744</Id>
+      <Database Name="cv" Series="36730" Issue="255931" />
     </Book>
     <Book Series="Chaos War: X-Men" Number="2" Volume="2011" Year="2011">
-      <Id>40501a0f-60eb-4579-977e-0a9517560a71</Id>
+      <Database Name="cv" Series="37956" Issue="259132" />
+    </Book>
+    <Book Series="Chaos War" Number="5" Volume="2010" Year="2011">
+      <Database Name="cv" Series="35877" Issue="259135" />
     </Book>
     <Book Series="Uncanny X-Force" Number="5" Volume="2010" Year="2011">
-      <Id>e0a81654-3716-4848-869f-fdfd1534be93</Id>
+      <Database Name="cv" Series="35835" Issue="262615" />
     </Book>
     <Book Series="Uncanny X-Force" Number="5.1" Volume="2010" Year="2011">
-      <Id>52621846-cc65-4472-92f9-d1265dc62b70</Id>
+      <Database Name="cv" Series="35835" Issue="266000" />
     </Book>
     <Book Series="Uncanny X-Force" Number="6" Volume="2010" Year="2011">
-      <Id>f21c0dbb-a066-4319-a3e6-0db5c31525c9</Id>
+      <Database Name="cv" Series="35835" Issue="266505" />
     </Book>
     <Book Series="Uncanny X-Force" Number="7" Volume="2010" Year="2011">
-      <Id>0875ab09-f741-4cbc-9e42-9182813f68d2</Id>
+      <Database Name="cv" Series="35835" Issue="268219" />
     </Book>
-    <Book Series="Astonishing Spider-Man &amp; Wolverine" Number="1" Volume="2010" Year="2010">
-      <Id>336a7917-4e16-4935-83e0-7375d4a7890a</Id>
+    <Book Series="Astonishing Spider-Man &#38; Wolverine" Number="1" Volume="2010" Year="2010">
+      <Database Name="cv" Series="32931" Issue="212014" />
     </Book>
-    <Book Series="Astonishing Spider-Man &amp; Wolverine" Number="2" Volume="2010" Year="2010">
-      <Id>ecd9066b-4ec3-4062-9850-9ad4309f0dda</Id>
+    <Book Series="Astonishing Spider-Man &#38; Wolverine" Number="2" Volume="2010" Year="2010">
+      <Database Name="cv" Series="32931" Issue="224649" />
     </Book>
-    <Book Series="Astonishing Spider-Man &amp; Wolverine" Number="3" Volume="2010" Year="2010">
-      <Id>7dbeed24-44f7-4ddf-ac73-1b41785467e4</Id>
+    <Book Series="Astonishing Spider-Man &#38; Wolverine" Number="3" Volume="2010" Year="2010">
+      <Database Name="cv" Series="32931" Issue="234675" />
     </Book>
-    <Book Series="Astonishing Spider-Man &amp; Wolverine" Number="4" Volume="2010" Year="2011">
-      <Id>dc108e26-ebe0-47fa-aacf-6b5c34241400</Id>
+    <Book Series="Astonishing Spider-Man &#38; Wolverine" Number="4" Volume="2010" Year="2011">
+      <Database Name="cv" Series="32931" Issue="252999" />
     </Book>
-    <Book Series="Astonishing Spider-Man &amp; Wolverine" Number="5" Volume="2010" Year="2011">
-      <Id>36f68ae6-011c-4179-96be-a5500741b964</Id>
+    <Book Series="Astonishing Spider-Man &#38; Wolverine" Number="5" Volume="2010" Year="2011">
+      <Database Name="cv" Series="32931" Issue="266503" />
     </Book>
-    <Book Series="Astonishing Spider-Man &amp; Wolverine" Number="6" Volume="2010" Year="2011">
-      <Id>b7f558bf-d8cc-473c-b6e4-7d4b8d05b631</Id>
+    <Book Series="Astonishing Spider-Man &#38; Wolverine" Number="6" Volume="2010" Year="2011">
+      <Database Name="cv" Series="32931" Issue="271595" />
     </Book>
     <Book Series="X-Factor" Number="220" Volume="2006" Year="2011">
-      <Id>4a6bcf4b-ad31-4874-b6ea-5af2b2877ac4</Id>
+      <Database Name="cv" Series="18109" Issue="272355" />
     </Book>
     <Book Series="X-Factor" Number="221" Volume="2006" Year="2011">
-      <Id>dfa50933-3e3f-4b90-98ea-38f59f5b87e6</Id>
+      <Database Name="cv" Series="18109" Issue="274213" />
     </Book>
     <Book Series="X-Factor" Number="222" Volume="2006" Year="2011">
-      <Id>b20919f8-7b95-4bf2-be76-93218c1b4576</Id>
+      <Database Name="cv" Series="18109" Issue="279944" />
     </Book>
     <Book Series="X-Factor" Number="223" Volume="2006" Year="2011">
-      <Id>635b5381-493f-4464-b675-ee784b9b6a4f</Id>
+      <Database Name="cv" Series="18109" Issue="283197" />
     </Book>
     <Book Series="X-Factor" Number="224" Volume="2006" Year="2011">
-      <Id>8ad0cbe5-fd92-4e2f-8c44-c6726202a9be</Id>
+      <Database Name="cv" Series="18109" Issue="286685" />
     </Book>
     <Book Series="Avengers: The Children's Crusade" Number="1" Volume="2010" Year="2010">
-      <Id>33cf354f-f268-4b41-aef6-b44e183ff594</Id>
+      <Database Name="cv" Series="34241" Issue="223380" />
     </Book>
     <Book Series="Avengers: The Children's Crusade" Number="2" Volume="2010" Year="2010">
-      <Id>c0df33c4-3024-4711-af13-a82e88fd3f46</Id>
+      <Database Name="cv" Series="34241" Issue="232535" />
     </Book>
     <Book Series="Avengers: The Children's Crusade" Number="3" Volume="2010" Year="2011">
-      <Id>8a06f43a-e565-45ea-88a5-3bf77390b717</Id>
+      <Database Name="cv" Series="34241" Issue="242038" />
     </Book>
     <Book Series="Avengers: The Children's Crusade" Number="4" Volume="2010" Year="2011">
-      <Id>49628fb6-d084-42f4-9dc6-f333d0cea89a</Id>
+      <Database Name="cv" Series="34241" Issue="254667" />
     </Book>
     <Book Series="Avengers: The Children's Crusade - Young Avengers" Number="1" Volume="2011" Year="2011">
-      <Id>646f0499-5000-4b45-b09a-01ab291431c8</Id>
+      <Database Name="cv" Series="39371" Issue="266008" />
     </Book>
     <Book Series="Avengers: The Children's Crusade" Number="5" Volume="2010" Year="2011">
-      <Id>98cd53d9-52d4-4931-9e54-0308b75e7c4f</Id>
+      <Database Name="cv" Series="34241" Issue="267533" />
     </Book>
     <Book Series="Avengers: The Children's Crusade" Number="6" Volume="2010" Year="2011">
-      <Id>10915c1d-84ca-4ee9-9f40-7f6c58b0c664</Id>
+      <Database Name="cv" Series="34241" Issue="276706" />
     </Book>
     <Book Series="Avengers: The Children's Crusade" Number="7" Volume="2010" Year="2011">
-      <Id>c763c642-bb92-4e00-8146-a085015c1563</Id>
+      <Database Name="cv" Series="34241" Issue="293355" />
     </Book>
     <Book Series="Avengers: The Children's Crusade" Number="8" Volume="2010" Year="2012">
-      <Id>34ce11e9-ae52-44f1-99b5-bfae10082d99</Id>
+      <Database Name="cv" Series="34241" Issue="308624" />
     </Book>
     <Book Series="Avengers: The Children's Crusade" Number="9" Volume="2010" Year="2012">
-      <Id>70054397-94fb-4232-83e0-32c267cdc619</Id>
+      <Database Name="cv" Series="34241" Issue="319366" />
     </Book>
-    <Book Series="Wolverine &amp; The Black Cat: Claws 2" Number="1" Volume="2011" Year="2011">
-      <Id>cdc48e8d-f0bc-419b-9065-3f02d6a38a19</Id>
+    <Book Series="Wolverine &#38; The Black Cat: Claws 2" Number="1" Volume="2011" Year="2011">
+      <Database Name="cv" Series="41136" Issue="277526" />
     </Book>
-    <Book Series="Wolverine &amp; The Black Cat: Claws 2" Number="2" Volume="2011" Year="2011">
-      <Id>49248fb4-0645-4018-a5e4-36f07df33993</Id>
+    <Book Series="Wolverine &#38; The Black Cat: Claws 2" Number="2" Volume="2011" Year="2011">
+      <Database Name="cv" Series="41136" Issue="286960" />
     </Book>
-    <Book Series="Wolverine &amp; The Black Cat: Claws 2" Number="3" Volume="2011" Year="2011">
-      <Id>39d8adc0-95d0-439b-9a31-b522ee320e24</Id>
+    <Book Series="Wolverine &#38; The Black Cat: Claws 2" Number="3" Volume="2011" Year="2011">
+      <Database Name="cv" Series="41136" Issue="294781" />
     </Book>
     <Book Series="Uncanny X-Men Annual" Number="3" Volume="2006" Year="2011">
-      <Id>66459b80-3f8f-428f-84e6-0b03bee4ec65</Id>
+      <Database Name="cv" Series="18405" Issue="265998" />
     </Book>
     <Book Series="Steve Rogers: Super Soldier Annual" Number="1" Volume="2011" Year="2011">
-      <Id>3f7a120f-756d-4c7b-841e-bb6c7414ba43</Id>
+      <Database Name="cv" Series="39765" Issue="268365" />
     </Book>
     <Book Series="Namor: The First Mutant Annual" Number="1" Volume="2011" Year="2011">
-      <Id>09fd3fe0-0ff4-4400-8efb-70114ff7b245</Id>
+      <Database Name="cv" Series="40215" Issue="270428" />
     </Book>
     <Book Series="X-Men Giant-Size" Number="1" Volume="2011" Year="2011">
-      <Id>0c282d10-fb86-4dfc-bd92-8f7ded16ddb7</Id>
+      <Database Name="cv" Series="40207" Issue="270399" />
     </Book>
     <Book Series="X-Men" Number="12" Volume="2010" Year="2011">
-      <Id>293ff35f-536e-4ab7-8091-a8dde1a92150</Id>
+      <Database Name="cv" Series="34221" Issue="272295" />
     </Book>
     <Book Series="X-Men" Number="13" Volume="2010" Year="2011">
-      <Id>fe9fe3a8-4cf7-4981-9ac5-4b02b0434ea4</Id>
+      <Database Name="cv" Series="34221" Issue="274227" />
     </Book>
     <Book Series="X-Men" Number="14" Volume="2010" Year="2011">
-      <Id>73e680de-be0e-4b46-af4e-9597a2c4dd2b</Id>
+      <Database Name="cv" Series="34221" Issue="277342" />
     </Book>
     <Book Series="X-Men" Number="15" Volume="2010" Year="2011">
-      <Id>38b955a1-c5b8-4d4d-9437-a32991476831</Id>
+      <Database Name="cv" Series="34221" Issue="279954" />
     </Book>
     <Book Series="X-Men" Number="15.1" Volume="2010" Year="2011">
-      <Id>64588afd-c374-4ef2-ac87-c70aae8a562c</Id>
+      <Database Name="cv" Series="34221" Issue="285548" />
     </Book>
     <Book Series="X-Men" Number="16" Volume="2010" Year="2011">
-      <Id>8b40f3b9-da2c-428c-83de-d65d516235e1</Id>
+      <Database Name="cv" Series="34221" Issue="288488" />
     </Book>
     <Book Series="X-Men" Number="17" Volume="2010" Year="2011">
-      <Id>eaf78b28-03a9-48a9-9c32-ca7ef4db27fd</Id>
+      <Database Name="cv" Series="34221" Issue="291176" />
     </Book>
     <Book Series="X-Men" Number="18" Volume="2010" Year="2011">
-      <Id>0845a1e4-daf5-4021-b6e0-2e54948f5d1b</Id>
+      <Database Name="cv" Series="34221" Issue="293351" />
     </Book>
     <Book Series="X-Men" Number="19" Volume="2010" Year="2011">
-      <Id>f23eae28-8591-4952-983d-505d841ad6d1</Id>
+      <Database Name="cv" Series="34221" Issue="294052" />
     </Book>
     <Book Series="Gambit and the Champions: From the Marvel Vault" Number="1" Volume="2011" Year="2011">
-      <Id>b35a6e84-3f77-4fcb-a935-97cfba19cc10</Id>
+      <Database Name="cv" Series="42561" Issue="290949" />
     </Book>
     <Book Series="X-23" Number="7" Volume="2010" Year="2011">
-      <Id>74afabb3-e365-4af5-8340-50dbdbde221b</Id>
+      <Database Name="cv" Series="35496" Issue="265505" />
     </Book>
     <Book Series="Daken: Dark Wolverine" Number="4" Volume="2010" Year="2011">
-      <Id>ae316f31-f6ec-4086-bbfe-397358b223e9</Id>
+      <Database Name="cv" Series="35409" Issue="252740" />
     </Book>
     <Book Series="Daken: Dark Wolverine" Number="5" Volume="2010" Year="2011">
-      <Id>1f0c3f6e-93da-49c3-95a4-8af0c0d31b5a</Id>
+      <Database Name="cv" Series="35409" Issue="259996" />
     </Book>
     <Book Series="Daken: Dark Wolverine" Number="6" Volume="2010" Year="2011">
-      <Id>fdefc515-3aa5-414c-8f4c-ea871b472671</Id>
+      <Database Name="cv" Series="35409" Issue="264588" />
     </Book>
     <Book Series="Daken: Dark Wolverine" Number="7" Volume="2010" Year="2011">
-      <Id>69e1ffa8-f935-4681-b40f-d4d422a9314f</Id>
+      <Database Name="cv" Series="35409" Issue="266489" />
     </Book>
     <Book Series="X-23" Number="8" Volume="2010" Year="2011">
-      <Id>754da0ab-dae1-4daa-acab-f2ee67311dd4</Id>
+      <Database Name="cv" Series="35496" Issue="267088" />
     </Book>
     <Book Series="Daken: Dark Wolverine" Number="8" Volume="2010" Year="2011">
-      <Id>96646361-6ae4-4d89-8e82-41822a4c46b5</Id>
+      <Database Name="cv" Series="35409" Issue="268234" />
     </Book>
     <Book Series="X-23" Number="9" Volume="2010" Year="2011">
-      <Id>475c87b9-eba0-4713-a7c9-2d1ad02eb8b7</Id>
+      <Database Name="cv" Series="35496" Issue="268984" />
     </Book>
     <Book Series="Daken: Dark Wolverine" Number="9" Volume="2010" Year="2011">
-      <Id>a35447f8-d938-410e-80f3-81ec32e97f1f</Id>
+      <Database Name="cv" Series="35409" Issue="269962" />
     </Book>
     <Book Series="X-Men: Legacy" Number="242" Volume="2008" Year="2011">
-      <Id>a295034c-0ae5-484c-89e3-5a93d1a8b17f</Id>
+      <Database Name="cv" Series="20691" Issue="246421" />
     </Book>
     <Book Series="X-Men: Legacy" Number="243" Volume="2008" Year="2011">
-      <Id>e6b9b183-8163-4127-aada-34995d27f7da</Id>
+      <Database Name="cv" Series="20691" Issue="250666" />
     </Book>
     <Book Series="X-Men: Legacy" Number="244" Volume="2008" Year="2011">
-      <Id>f6a45098-42dd-40e2-976e-b57c44199a2d</Id>
+      <Database Name="cv" Series="20691" Issue="258326" />
     </Book>
     <Book Series="Magneto" Number="1" Volume="2011" Year="2011">
-      <Id>d8be559b-0c10-4181-8727-217c819fdfa2</Id>
+      <Database Name="cv" Series="38622" Issue="259182" />
     </Book>
     <Book Series="Marvel Girl" Number="1" Volume="2011" Year="2011">
-      <Id>978d89ae-22f9-42d8-94ba-5a1af32c414c</Id>
+      <Database Name="cv" Series="39064" Issue="263103" />
     </Book>
     <Book Series="Iceman and Angel" Number="1" Volume="2011" Year="2011">
-      <Id>38bf1979-c160-43d5-b64d-8e1056a9946a</Id>
+      <Database Name="cv" Series="39370" Issue="266005" />
     </Book>
     <Book Series="Cyclops" Number="1" Volume="2011" Year="2011">
-      <Id>29ff87ce-d066-49c8-bbf8-01268fd2ac2f</Id>
+      <Database Name="cv" Series="75650" Issue="459447" />
     </Book>
     <Book Series="New Mutants" Number="20" Volume="2009" Year="2011">
-      <Id>ebc39d63-8839-469e-add4-c5875fd0c518</Id>
+      <Database Name="cv" Series="26327" Issue="252753" />
     </Book>
     <Book Series="New Mutants" Number="21" Volume="2009" Year="2011">
-      <Id>24f8702a-deb6-4a98-95a3-e64f24bd4bc5</Id>
+      <Database Name="cv" Series="26327" Issue="259130" />
     </Book>
     <Book Series="Age of X: Alpha" Number="1" Volume="2011" Year="2011">
-      <Id>ba45baa5-c7a3-470a-b42f-448ea13cf901</Id>
+      <Database Name="cv" Series="38611" Issue="259113" />
     </Book>
     <Book Series="X-Men: Legacy" Number="245" Volume="2008" Year="2011">
-      <Id>aff80106-3135-4bac-99a9-0923465aa4b0</Id>
+      <Database Name="cv" Series="20691" Issue="263714" />
     </Book>
     <Book Series="New Mutants" Number="22" Volume="2009" Year="2011">
-      <Id>19f0b5f4-1ec3-4448-8568-5e7d7253373c</Id>
+      <Database Name="cv" Series="26327" Issue="263713" />
     </Book>
     <Book Series="X-Men: Legacy" Number="246" Volume="2008" Year="2011">
-      <Id>78d2ec5a-7985-4d81-90b9-93baa2387eb1</Id>
+      <Database Name="cv" Series="20691" Issue="265506" />
     </Book>
     <Book Series="New Mutants" Number="23" Volume="2009" Year="2011">
-      <Id>577921a0-b985-4640-8884-ea80d295c32d</Id>
+      <Database Name="cv" Series="26327" Issue="266508" />
     </Book>
     <Book Series="Age of X: Universe" Number="1" Volume="2011" Year="2011">
-      <Id>990bf152-a212-4133-9530-af02f5c0fb1c</Id>
+      <Database Name="cv" Series="39513" Issue="267087" />
     </Book>
     <Book Series="X-Men: Legacy" Number="247" Volume="2008" Year="2011">
-      <Id>f604c559-881b-4051-8fc2-680149e3272f</Id>
+      <Database Name="cv" Series="20691" Issue="268218" />
     </Book>
     <Book Series="New Mutants" Number="24" Volume="2009" Year="2011">
-      <Id>8a33e202-bb5b-481d-981e-5758e73de575</Id>
+      <Database Name="cv" Series="26327" Issue="268985" />
     </Book>
     <Book Series="Age of X: Universe" Number="2" Volume="2011" Year="2011">
-      <Id>dff031b5-6f78-4d03-a68d-ee25b62beb9e</Id>
+      <Database Name="cv" Series="39513" Issue="268981" />
     </Book>
     <Book Series="X-Men: Legacy" Number="248" Volume="2008" Year="2011">
-      <Id>ae4e23ba-bb21-412c-8636-584861860dc4</Id>
+      <Database Name="cv" Series="20691" Issue="269781" />
     </Book>
     <Book Series="X-Men: Legacy" Number="249" Volume="2008" Year="2011">
-      <Id>7b5c6a07-cfff-4e4f-8bbd-c5370e98a110</Id>
+      <Database Name="cv" Series="20691" Issue="271298" />
     </Book>
     <Book Series="X-Men: Legacy" Number="250" Volume="2008" Year="2011">
-      <Id>068e3474-df8d-4e93-9305-4b6f6f8445a5</Id>
+      <Database Name="cv" Series="20691" Issue="273056" />
     </Book>
     <Book Series="X-Men: Legacy" Number="251" Volume="2008" Year="2011">
-      <Id>020aa3b5-c7d8-4d22-8704-8af45632c2fb</Id>
+      <Database Name="cv" Series="20691" Issue="275410" />
     </Book>
     <Book Series="X-Men: Legacy" Number="252" Volume="2008" Year="2011">
-      <Id>9d8969cf-14bb-423e-a55c-2ed33b69c9d1</Id>
+      <Database Name="cv" Series="20691" Issue="281716" />
     </Book>
     <Book Series="X-Men: Legacy" Number="253" Volume="2008" Year="2011">
-      <Id>2036b904-024e-4d94-8149-036e6a5fcb5f</Id>
+      <Database Name="cv" Series="20691" Issue="285350" />
     </Book>
     <Book Series="X-Men: Legacy" Number="254" Volume="2008" Year="2011">
-      <Id>fd4a288d-baf4-487f-8957-cdd3b46208bc</Id>
+      <Database Name="cv" Series="20691" Issue="288498" />
     </Book>
     <Book Series="X-Men: Legacy" Number="255" Volume="2008" Year="2011">
-      <Id>e7ad826b-fde0-4608-b45d-c80a1d479ffd</Id>
+      <Database Name="cv" Series="20691" Issue="292594" />
     </Book>
     <Book Series="X-Men: Legacy" Number="256" Volume="2008" Year="2011">
-      <Id>9dfa9584-00f8-4a3c-825e-d1710a90d667</Id>
+      <Database Name="cv" Series="20691" Issue="293591" />
     </Book>
     <Book Series="X-Men: Legacy" Number="257" Volume="2008" Year="2011">
-      <Id>61baf622-0d85-4ecc-8a13-10208925ea56</Id>
+      <Database Name="cv" Series="20691" Issue="294854" />
     </Book>
     <Book Series="X-Men: Legacy" Number="258" Volume="2008" Year="2012">
-      <Id>c438a8e6-d865-4aaf-becf-952e0adfd455</Id>
+      <Database Name="cv" Series="20691" Issue="301660" />
     </Book>
     <Book Series="New Mutants" Number="25" Volume="2009" Year="2011">
-      <Id>5c99b79a-b280-4b12-8d4b-65973ca6aa2a</Id>
+      <Database Name="cv" Series="26327" Issue="269819" />
     </Book>
     <Book Series="New Mutants" Number="26" Volume="2009" Year="2011">
-      <Id>21a6702a-70f0-4535-9529-03cf8f4dcc2c</Id>
+      <Database Name="cv" Series="26327" Issue="275412" />
     </Book>
     <Book Series="New Mutants" Number="27" Volume="2009" Year="2011">
-      <Id>5d3170e0-7b90-4234-befe-67ade0d31e5b</Id>
+      <Database Name="cv" Series="26327" Issue="278805" />
     </Book>
     <Book Series="New Mutants" Number="28" Volume="2009" Year="2011">
-      <Id>54bda66c-76e1-4d37-b70a-00480a86e5f5</Id>
+      <Database Name="cv" Series="26327" Issue="281714" />
     </Book>
     <Book Series="Generation Hope" Number="6" Volume="2011" Year="2011">
-      <Id>fc310259-a9d0-46bf-995c-fcf84089c293</Id>
+      <Database Name="cv" Series="36469" Issue="268663" />
     </Book>
     <Book Series="Generation Hope" Number="7" Volume="2011" Year="2011">
-      <Id>3ca4452c-e21e-4629-a1ad-675851627c5c</Id>
+      <Database Name="cv" Series="36469" Issue="270427" />
     </Book>
     <Book Series="Generation Hope" Number="8" Volume="2011" Year="2011">
-      <Id>00656d01-c0ac-417d-bd6d-6dbf813ddabb</Id>
+      <Database Name="cv" Series="36469" Issue="274229" />
     </Book>
     <Book Series="Generation Hope" Number="9" Volume="2011" Year="2011">
-      <Id>4f349aed-e4d6-402f-a632-8737c9a0ff6a</Id>
+      <Database Name="cv" Series="36469" Issue="279973" />
     </Book>
     <Book Series="Astonishing X-Men" Number="36" Volume="2004" Year="2011">
-      <Id>fad0bd49-944b-4bda-8c13-0bb5d2b13040</Id>
+      <Database Name="cv" Series="10746" Issue="263709" />
     </Book>
     <Book Series="Astonishing X-Men" Number="37" Volume="2004" Year="2011">
-      <Id>b8ce043f-3c15-4024-af93-1dab91d3286c</Id>
+      <Database Name="cv" Series="10746" Issue="269779" />
     </Book>
     <Book Series="Astonishing X-Men" Number="38" Volume="2004" Year="2011">
-      <Id>7690fb78-8cc5-4801-8811-edabd6b547ff</Id>
+      <Database Name="cv" Series="10746" Issue="270426" />
     </Book>
     <Book Series="Astonishing X-Men" Number="39" Volume="2004" Year="2011">
-      <Id>44d979fe-f05e-44e4-92e8-07ca7d17aac3</Id>
+      <Database Name="cv" Series="10746" Issue="272293" />
     </Book>
     <Book Series="Astonishing X-Men" Number="40" Volume="2004" Year="2011">
-      <Id>0ce17d5a-571d-40b2-ab82-16ee1a3f6c18</Id>
+      <Database Name="cv" Series="10746" Issue="281718" />
     </Book>
     <Book Series="Astonishing X-Men" Number="41" Volume="2004" Year="2011">
-      <Id>9b051de1-2943-4e2e-9e73-36e6b8fd9cf3</Id>
+      <Database Name="cv" Series="10746" Issue="288516" />
     </Book>
     <Book Series="Astonishing X-Men" Number="42" Volume="2004" Year="2011">
-      <Id>79b75353-29e2-4e23-bfa7-6620a5a09d8d</Id>
+      <Database Name="cv" Series="10746" Issue="293595" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="534.1" Volume="1981" Year="2011">
-      <Id>f1c2d1ae-25ee-46a4-bb95-5ea014fc268b</Id>
+      <Database Name="cv" Series="3092" Issue="267573" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="535" Volume="1981" Year="2011">
-      <Id>db3921ca-cea1-47e6-bcf1-add03812c0be</Id>
+      <Database Name="cv" Series="3092" Issue="268156" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="536" Volume="1981" Year="2011">
-      <Id>952b8cba-bdc2-459a-8c39-4cf01bbe521d</Id>
+      <Database Name="cv" Series="3092" Issue="268930" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="537" Volume="1981" Year="2011">
-      <Id>4ee8185f-fc11-436c-9e16-98ec32945d36</Id>
+      <Database Name="cv" Series="3092" Issue="271292" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="538" Volume="1981" Year="2011">
-      <Id>5638e475-2053-42b8-9e21-0b0de6bce09c</Id>
+      <Database Name="cv" Series="3092" Issue="274230" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="539" Volume="1981" Year="2011">
-      <Id>e09b1e91-1280-4bb3-80e8-5642874041cd</Id>
+      <Database Name="cv" Series="3092" Issue="276672" />
     </Book>
     <Book Series="Daken: Dark Wolverine" Number="9.1" Volume="2010" Year="2011">
-      <Id>0db51bed-22bc-4ee2-9b5d-3ef7c28853d1</Id>
+      <Database Name="cv" Series="35409" Issue="271596" />
     </Book>
     <Book Series="Daken: Dark Wolverine" Number="10" Volume="2010" Year="2011">
-      <Id>38287a1d-9b89-4579-8ea6-a610dca96def</Id>
+      <Database Name="cv" Series="35409" Issue="274602" />
     </Book>
     <Book Series="Daken: Dark Wolverine" Number="11" Volume="2010" Year="2011">
-      <Id>1d2c72d9-9a23-4449-8fb9-bc5f7eafa6b0</Id>
+      <Database Name="cv" Series="35409" Issue="279025" />
     </Book>
     <Book Series="Daken: Dark Wolverine" Number="12" Volume="2010" Year="2011">
-      <Id>c74cb209-cc87-4e24-b9c4-19d3ec53d33d</Id>
+      <Database Name="cv" Series="35409" Issue="286949" />
     </Book>
     <Book Series="Daken: Dark Wolverine" Number="13" Volume="2010" Year="2011">
-      <Id>0ceb4be4-135c-448c-8101-dc9a615b9756</Id>
+      <Database Name="cv" Series="35409" Issue="288886" />
     </Book>
     <Book Series="Daken: Dark Wolverine" Number="14" Volume="2010" Year="2011">
-      <Id>b46de065-f288-44fd-91db-9252207b36ed</Id>
+      <Database Name="cv" Series="35409" Issue="292614" />
     </Book>
     <Book Series="Daken: Dark Wolverine" Number="15" Volume="2010" Year="2011">
-      <Id>e22bb796-48f5-4284-b63b-5a1608634878</Id>
+      <Database Name="cv" Series="35409" Issue="296134" />
     </Book>
     <Book Series="Daken: Dark Wolverine" Number="16" Volume="2010" Year="2011">
-      <Id>c1eef4cd-2be1-45c4-b7c2-f8001168d372</Id>
+      <Database Name="cv" Series="35409" Issue="299747" />
     </Book>
     <Book Series="Daken: Dark Wolverine" Number="17" Volume="2010" Year="2012">
-      <Id>1e6509db-f988-4cb2-85ae-0a42aab381c5</Id>
+      <Database Name="cv" Series="35409" Issue="303617" />
     </Book>
     <Book Series="Daken: Dark Wolverine" Number="18" Volume="2010" Year="2012">
-      <Id>6c7f77e9-74dc-4ead-89d2-cc18aff7c7e5</Id>
+      <Database Name="cv" Series="35409" Issue="307874" />
     </Book>
     <Book Series="Daken: Dark Wolverine" Number="19" Volume="2010" Year="2012">
-      <Id>34b60b9d-520a-49a2-a9c9-1f3597f85606</Id>
+      <Database Name="cv" Series="35409" Issue="311018" />
     </Book>
     <Book Series="X-23" Number="10" Volume="2010" Year="2011">
-      <Id>4e2b677f-3a68-4f46-aa7a-a03b88601a09</Id>
+      <Database Name="cv" Series="35496" Issue="270430" />
     </Book>
     <Book Series="X-23" Number="11" Volume="2010" Year="2011">
-      <Id>1bb1b8da-aa9e-41cd-af7b-627e0ffac842</Id>
+      <Database Name="cv" Series="35496" Issue="272305" />
     </Book>
     <Book Series="X-23" Number="12" Volume="2010" Year="2011">
-      <Id>8154fbb7-f5d0-40db-97ec-5d82470858c6</Id>
+      <Database Name="cv" Series="35496" Issue="277464" />
     </Book>
     <Book Series="X-23" Number="13" Volume="2010" Year="2011">
-      <Id>89f206ee-8377-4a72-bc5d-40e2e120982d</Id>
+      <Database Name="cv" Series="35496" Issue="283916" />
     </Book>
     <Book Series="X-23" Number="14" Volume="2010" Year="2011">
-      <Id>3a992cce-dfb0-4bf7-a57a-71b1e93128c9</Id>
+      <Database Name="cv" Series="35496" Issue="291179" />
     </Book>
     <Book Series="X-23" Number="15" Volume="2010" Year="2011">
-      <Id>702c5a28-8ab5-4957-b76b-83f1216c77bf</Id>
+      <Database Name="cv" Series="35496" Issue="294198" />
     </Book>
     <Book Series="X-23" Number="16" Volume="2010" Year="2012">
-      <Id>da7a5469-75b1-47b0-a187-5352e5ba338b</Id>
+      <Database Name="cv" Series="35496" Issue="301079" />
     </Book>
     <Book Series="X-Men: Prelude to Schism" Number="1" Volume="2011" Year="2011">
-      <Id>0a06e988-0b72-47e5-bf65-de157fb88220</Id>
+      <Database Name="cv" Series="39952" Issue="269469" />
     </Book>
     <Book Series="X-Men: Prelude to Schism" Number="2" Volume="2011" Year="2011">
-      <Id>5d6cfad4-0189-4b94-a952-2e2f217a691a</Id>
+      <Database Name="cv" Series="39952" Issue="270432" />
     </Book>
     <Book Series="X-Men: Prelude to Schism" Number="3" Volume="2011" Year="2011">
-      <Id>035fcd65-3bea-4c8e-aecb-5c3257e2e887</Id>
+      <Database Name="cv" Series="39952" Issue="274226" />
     </Book>
     <Book Series="X-Men: Prelude to Schism" Number="4" Volume="2011" Year="2011">
-      <Id>87c22a17-afcb-4d33-8f54-d6bed07cc9d9</Id>
+      <Database Name="cv" Series="39952" Issue="276447" />
     </Book>
     <Book Series="Fear Itself: Sin's Past" Number="1" Volume="2011" Year="2011">
-      <Id>7d4092ee-d068-43c0-9cfd-26bd164b08ae</Id>
+      <Database Name="cv" Series="39847" Issue="268763" />
     </Book>
     <Book Series="Fear Itself: Book of the Skull" Number="1" Volume="2011" Year="2011">
-      <Id>26d6cf57-8804-4342-90ff-cf48489c5038</Id>
+      <Database Name="cv" Series="39363" Issue="265959" />
     </Book>
     <Book Series="Fear Itself" Number="1" Volume="2011" Year="2011">
-      <Id>f7b6b461-3686-46e9-a5c8-faaa26abe61f</Id>
+      <Database Name="cv" Series="39611" Issue="267534" />
     </Book>
     <Book Series="Fear Itself" Number="2" Volume="2011" Year="2011">
-      <Id>657ea318-89cc-4107-959a-18dbeaef810c</Id>
+      <Database Name="cv" Series="39611" Issue="269476" />
     </Book>
     <Book Series="Fear Itself: Wolverine" Number="1" Volume="2011" Year="2011">
-      <Id>5cfd1b3f-7f91-4a1e-b95a-255335d5b03e</Id>
+      <Database Name="cv" Series="41144" Issue="277546" />
     </Book>
     <Book Series="Fear Itself: Wolverine" Number="2" Volume="2011" Year="2011">
-      <Id>02742319-aa24-4d5f-9caa-fb79bdaf82a5</Id>
+      <Database Name="cv" Series="41144" Issue="283176" />
     </Book>
     <Book Series="Fear Itself" Number="3" Volume="2011" Year="2011">
-      <Id>fee3109e-a456-4ca7-884a-bb54c3ad7880</Id>
+      <Database Name="cv" Series="39611" Issue="272330" />
     </Book>
     <Book Series="Alpha Flight" Number="0.1" Volume="2011" Year="2011">
-      <Id>437fea0c-cc16-4a0f-ba00-f28fe9b3b9be</Id>
+      <Database Name="cv" Series="40216" Issue="270433" />
     </Book>
     <Book Series="Alpha Flight" Number="1" Volume="2011" Year="2011">
-      <Id>d1cc0305-8f5e-4d74-b6ea-6f4d2743a8c7</Id>
+      <Database Name="cv" Series="40216" Issue="274228" />
     </Book>
     <Book Series="Fear Itself: Wolverine" Number="3" Volume="2011" Year="2011">
-      <Id>f0221623-0d5e-46c6-9e48-0c29f1f2bdf5</Id>
+      <Database Name="cv" Series="41144" Issue="291145" />
     </Book>
     <Book Series="Fear Itself: Uncanny X-Force" Number="1" Volume="2011" Year="2011">
-      <Id>05819f77-47b1-4cc0-a888-549f796e90da</Id>
+      <Database Name="cv" Series="41143" Issue="277627" />
     </Book>
     <Book Series="Fear Itself" Number="4" Volume="2011" Year="2011">
-      <Id>fe09a64f-eda8-4633-8f95-0ec6e3f08323</Id>
+      <Database Name="cv" Series="39611" Issue="277536" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="540" Volume="1981" Year="2011">
-      <Id>3ff81e59-367e-4260-afa6-866853d7b2e2</Id>
+      <Database Name="cv" Series="3092" Issue="277343" />
     </Book>
     <Book Series="Fear Itself: Uncanny X-Force" Number="2" Volume="2011" Year="2011">
-      <Id>8f6cab9f-71d4-4cdc-b201-92763db5c62d</Id>
+      <Database Name="cv" Series="41143" Issue="285336" />
     </Book>
     <Book Series="Fear Itself: Uncanny X-Force" Number="3" Volume="2011" Year="2011">
-      <Id>10367a11-54e0-4a66-9736-8aedc73274ea</Id>
+      <Database Name="cv" Series="41143" Issue="293317" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="541" Volume="1981" Year="2011">
-      <Id>072047f0-17a1-424d-90ea-60d28ca898c3</Id>
+      <Database Name="cv" Series="3092" Issue="279974" />
     </Book>
     <Book Series="Alpha Flight" Number="2" Volume="2011" Year="2011">
-      <Id>ee99124e-68b9-4958-8c17-76b0c7d2448b</Id>
+      <Database Name="cv" Series="40216" Issue="278776" />
     </Book>
     <Book Series="Alpha Flight" Number="3" Volume="2011" Year="2011">
-      <Id>aaec1154-eab9-4032-bdb7-b8ad8aa742a3</Id>
+      <Database Name="cv" Series="40216" Issue="285357" />
     </Book>
     <Book Series="New Mutants" Number="29" Volume="2009" Year="2011">
-      <Id>4dc8caee-580a-4acf-a5d5-4fb0aa88dd78</Id>
+      <Database Name="cv" Series="26327" Issue="286576" />
     </Book>
     <Book Series="New Mutants" Number="30" Volume="2009" Year="2011">
-      <Id>7107afa8-1451-47d0-a7b4-47e7e2c4d0a5</Id>
+      <Database Name="cv" Series="26327" Issue="288679" />
     </Book>
     <Book Series="New Mutants" Number="31" Volume="2009" Year="2011">
-      <Id>fcafc5a6-e941-4523-b13d-abaf22663d80</Id>
+      <Database Name="cv" Series="26327" Issue="293626" />
     </Book>
     <Book Series="New Mutants" Number="32" Volume="2009" Year="2011">
-      <Id>f5372552-24c4-4f13-9c6c-dc81a27b02b5</Id>
+      <Database Name="cv" Series="26327" Issue="299751" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="542" Volume="1981" Year="2011">
-      <Id>978dbadc-a19c-4931-bfdc-04c6382ba132</Id>
+      <Database Name="cv" Series="3092" Issue="286886" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="543" Volume="1981" Year="2011">
-      <Id>42f31a08-b95c-470d-bcdf-756326ff18d2</Id>
+      <Database Name="cv" Series="3092" Issue="293320" />
     </Book>
     <Book Series="Alpha Flight" Number="4" Volume="2011" Year="2011">
-      <Id>2f3f692a-a818-45dd-b9f1-29df6b4971fa</Id>
+      <Database Name="cv" Series="40216" Issue="293356" />
     </Book>
     <Book Series="Fear Itself" Number="5" Volume="2011" Year="2011">
-      <Id>f9a10c83-e35e-4786-8579-ae2f9801a80b</Id>
+      <Database Name="cv" Series="39611" Issue="285335" />
     </Book>
     <Book Series="Fear Itself: The Deep" Number="1" Volume="2011" Year="2011">
-      <Id>f0d17751-f55a-4f66-b0ed-cad512473a89</Id>
+      <Database Name="cv" Series="40418" Issue="272302" />
     </Book>
     <Book Series="Fear Itself: The Deep" Number="2" Volume="2011" Year="2011">
-      <Id>316e8d1d-9ae0-4587-a133-503060337140</Id>
+      <Database Name="cv" Series="40418" Issue="281966" />
     </Book>
     <Book Series="Fear Itself: The Deep" Number="3" Volume="2011" Year="2011">
-      <Id>dc6aaa49-a135-4b4f-b492-a01ed2341231</Id>
+      <Database Name="cv" Series="40418" Issue="290623" />
     </Book>
     <Book Series="Fear Itself: The Deep" Number="4" Volume="2011" Year="2011">
-      <Id>8f8c2bec-d604-4c62-a1c1-3b6639d4569f</Id>
+      <Database Name="cv" Series="40418" Issue="293791" />
     </Book>
     <Book Series="Fear Itself" Number="6" Volume="2011" Year="2011">
-      <Id>43146781-8a88-44d2-9751-5e862bc22b16</Id>
+      <Database Name="cv" Series="39611" Issue="292590" />
     </Book>
     <Book Series="Fear Itself" Number="7" Volume="2011" Year="2011">
-      <Id>cfe1aac4-1232-494e-8a06-d6e18d2339be</Id>
+      <Database Name="cv" Series="39611" Issue="297217" />
     </Book>
     <Book Series="Wolverine" Number="10" Volume="2010" Year="2011">
-      <Id>7528420e-9700-4c54-913d-511435da91b5</Id>
+      <Database Name="cv" Series="35263" Issue="273093" />
     </Book>
     <Book Series="Wolverine" Number="11" Volume="2010" Year="2011">
-      <Id>bcfd0711-22d6-42dc-b8ea-8dcc98d1a1fb</Id>
+      <Database Name="cv" Series="35263" Issue="275663" />
     </Book>
     <Book Series="Wolverine" Number="12" Volume="2010" Year="2011">
-      <Id>992686dd-e04b-46fd-a9ec-29a90a96c1c6</Id>
+      <Database Name="cv" Series="35263" Issue="278565" />
     </Book>
     <Book Series="Wolverine" Number="13" Volume="2010" Year="2011">
-      <Id>c8a5c861-a0b2-4d68-a340-3d7a0410e088</Id>
+      <Database Name="cv" Series="35263" Issue="282838" />
     </Book>
     <Book Series="Wolverine" Number="14" Volume="2010" Year="2011">
-      <Id>2b343369-d418-471b-8ac2-aaa673c8d4d1</Id>
+      <Database Name="cv" Series="35263" Issue="288479" />
     </Book>
     <Book Series="Wolverine" Number="15" Volume="2010" Year="2011">
-      <Id>80a194ec-7ace-4a0a-8853-2650747a167e</Id>
+      <Database Name="cv" Series="35263" Issue="291177" />
     </Book>
     <Book Series="Wolverine" Number="16" Volume="2010" Year="2011">
-      <Id>77d6660c-f14a-41e1-a856-b0b749be4071</Id>
+      <Database Name="cv" Series="35263" Issue="293594" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 012.cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 012.cbl
@@ -2,1066 +2,1066 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>X-Men - Part 12</Name>
   <Books>
-    <Book Series="Wolverine Weapon X" Number="1" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Wolverine Weapon X" Number="1" Volume="2009" Year="2009">
       <Id>c4351fa9-7945-44ac-9a19-d3a2c5791eec</Id>
     </Book>
-    <Book Series="Wolverine Weapon X" Number="2" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Wolverine Weapon X" Number="2" Volume="2009" Year="2009">
       <Id>9e513673-1e8f-4255-a9c2-bc37dd7ff79f</Id>
     </Book>
-    <Book Series="Wolverine Weapon X" Number="3" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Wolverine Weapon X" Number="3" Volume="2009" Year="2009">
       <Id>8c27fc10-d8ea-480b-8af3-4f259367997b</Id>
     </Book>
-    <Book Series="Wolverine Weapon X" Number="4" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Wolverine Weapon X" Number="4" Volume="2009" Year="2009">
       <Id>f00a96e6-8912-498b-9bcb-4d35de00973d</Id>
     </Book>
-    <Book Series="Wolverine Weapon X" Number="5" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Wolverine Weapon X" Number="5" Volume="2009" Year="2009">
       <Id>39e2b7f1-279f-4a6d-9142-d43c3a6c3636</Id>
     </Book>
-    <Book Series="Wolverine Weapon X" Number="6" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Wolverine Weapon X" Number="6" Volume="2009" Year="2009">
       <Id>1164863f-9ce8-4104-868b-2966084cb5b3</Id>
     </Book>
-    <Book Series="Wolverine Weapon X" Number="7" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Wolverine Weapon X" Number="7" Volume="2009" Year="2010">
       <Id>a42d09bb-c333-4f40-8a1c-aed51234e01b</Id>
     </Book>
-    <Book Series="Wolverine Weapon X" Number="8" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Wolverine Weapon X" Number="8" Volume="2009" Year="2010">
       <Id>1cd6469d-7956-41c9-bed7-5dca5d627fe8</Id>
     </Book>
-    <Book Series="Wolverine Weapon X" Number="9" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Wolverine Weapon X" Number="9" Volume="2009" Year="2010">
       <Id>d382152a-fd49-4f79-b680-b5f4f7375b86</Id>
     </Book>
-    <Book Series="Wolverine Weapon X" Number="10" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Wolverine Weapon X" Number="10" Volume="2009" Year="2010">
       <Id>ae160a91-380e-4658-ba56-ef620a48c453</Id>
     </Book>
-    <Book Series="Cable" Number="16" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Cable" Number="16" Volume="2008" Year="2009">
       <Id>4372a8b0-4815-4c7f-a4c0-09c039abdeb3</Id>
     </Book>
-    <Book Series="Cable" Number="17" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Cable" Number="17" Volume="2008" Year="2009">
       <Id>69cf6629-2c05-466b-8148-03b66fe49b15</Id>
     </Book>
-    <Book Series="Cable" Number="18" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Cable" Number="18" Volume="2008" Year="2009">
       <Id>7a682aff-abe7-4f7c-ba56-aa6f3253c98a</Id>
     </Book>
-    <Book Series="Cable" Number="19" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Cable" Number="19" Volume="2008" Year="2009">
       <Id>43ff2235-3e37-4da2-9ed0-8a6adc6d2543</Id>
     </Book>
-    <Book Series="Cable" Number="20" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="Cable" Number="20" Volume="2008" Year="2010">
       <Id>01f3cd14-0689-445a-9dd8-b671ec48561a</Id>
     </Book>
-    <Book Series="Dark Wolverine" Number="82" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Dark Wolverine" Number="82" Volume="2009" Year="2010">
       <Id>b5fa2f45-0224-463a-b0b5-09f0ed7bc08e</Id>
     </Book>
-    <Book Series="Dark Wolverine" Number="83" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Dark Wolverine" Number="83" Volume="2009" Year="2010">
       <Id>069e3799-85dd-4bc7-9130-3b6efa8f1f9c</Id>
     </Book>
-    <Book Series="Dark Wolverine" Number="84" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Dark Wolverine" Number="84" Volume="2009" Year="2010">
       <Id>b0f77f03-c49e-48a3-9cdc-c7a3a864c929</Id>
     </Book>
-    <Book Series="Wolverine: Savage" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="Wolverine: Savage" Number="1" Volume="2010" Year="2010">
       <Id>e8965213-97be-4344-aaa3-051539b85a1b</Id>
     </Book>
-    <Book Series="Wolverine: Mr X" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="Wolverine: Mr X" Number="1" Volume="2010" Year="2010">
       <Id>bb2dac0a-0f3b-4f60-b80a-cd38c29b5108</Id>
     </Book>
-    <Book Series="Wolverine Weapon X" Number="11" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Wolverine Weapon X" Number="11" Volume="2009" Year="2010">
       <Id>21a664e0-4028-486e-821d-e707c05a6cf7</Id>
     </Book>
-    <Book Series="Wolverine Weapon X" Number="12" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Wolverine Weapon X" Number="12" Volume="2009" Year="2010">
       <Id>255d6ce1-f879-4401-bbcd-807c21439385</Id>
     </Book>
-    <Book Series="Wolverine Weapon X" Number="13" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Wolverine Weapon X" Number="13" Volume="2009" Year="2010">
       <Id>518c53bb-c357-461c-a9c6-09241a264153</Id>
     </Book>
-    <Book Series="Wolverine Weapon X" Number="14" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Wolverine Weapon X" Number="14" Volume="2009" Year="2010">
       <Id>af754e35-dff3-4d7f-851f-d3c44bd2925e</Id>
     </Book>
-    <Book Series="Wolverine Weapon X" Number="15" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Wolverine Weapon X" Number="15" Volume="2009" Year="2010">
       <Id>3423da18-a7f5-4fe2-9ff1-4300d519a9e5</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="46" Volume="2006" Year="2010" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="46" Volume="2006" Year="2010">
       <Id>23427e1b-2ab1-4882-9001-017f6adc246a</Id>
     </Book>
-    <Book Series="Dark Wolverine" Number="85" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Dark Wolverine" Number="85" Volume="2009" Year="2010">
       <Id>b02088ea-86a5-432f-aac7-299a25c7d231</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="47" Volume="2006" Year="2010" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="47" Volume="2006" Year="2010">
       <Id>53aeb2c9-edbe-4726-a12a-329f362ed471</Id>
     </Book>
-    <Book Series="Dark Wolverine" Number="86" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Dark Wolverine" Number="86" Volume="2009" Year="2010">
       <Id>e94b7a25-8e6a-4ed0-85d3-fd638617ea1c</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="48" Volume="2006" Year="2010" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="48" Volume="2006" Year="2010">
       <Id>b05d7c27-6832-4f76-8b4d-464547a09a34</Id>
     </Book>
-    <Book Series="Dark Wolverine" Number="87" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Dark Wolverine" Number="87" Volume="2009" Year="2010">
       <Id>0b080dbb-2b9d-4cba-a8ea-9ba8aec3efbb</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="49" Volume="2006" Year="2010" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="49" Volume="2006" Year="2010">
       <Id>9ce59c36-8c42-4bf4-b13f-dec2dec78273</Id>
     </Book>
-    <Book Series="Wolverine: Origins" Number="50" Volume="2006" Year="2010" Format="Main Series">
+    <Book Series="Wolverine: Origins" Number="50" Volume="2006" Year="2010">
       <Id>548a2d41-1ee5-4a60-bfa0-d39fa818071f</Id>
     </Book>
-    <Book Series="Dark Wolverine" Number="88" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Dark Wolverine" Number="88" Volume="2009" Year="2010">
       <Id>0fa245ca-52ac-4014-8d50-8f0112cd88ba</Id>
     </Book>
-    <Book Series="Franken-Castle" Number="19" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="Franken-Castle" Number="19" Volume="2010" Year="2010">
       <Id>2cb5977e-e9d2-4327-82f0-8c55a5ed2cb0</Id>
     </Book>
-    <Book Series="Dark Wolverine" Number="89" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Dark Wolverine" Number="89" Volume="2009" Year="2010">
       <Id>56e0ad34-1abb-44c3-b5b0-5089e36121b0</Id>
     </Book>
-    <Book Series="Cable" Number="21" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="Cable" Number="21" Volume="2008" Year="2010">
       <Id>eae39093-bfcb-4d14-9859-b05d04d65e87</Id>
     </Book>
-    <Book Series="Cable" Number="22" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="Cable" Number="22" Volume="2008" Year="2010">
       <Id>d1990c90-b8f2-4493-b886-5d1916a4bf7e</Id>
     </Book>
-    <Book Series="Cable" Number="23" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="Cable" Number="23" Volume="2008" Year="2010">
       <Id>7af14ec7-8b6a-4e70-8ef6-ca0718fd2031</Id>
     </Book>
-    <Book Series="Cable" Number="24" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="Cable" Number="24" Volume="2008" Year="2010">
       <Id>8b864080-2873-42ca-b04e-3bab6bf532e9</Id>
     </Book>
-    <Book Series="Cable" Number="25" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="Cable" Number="25" Volume="2008" Year="2010">
       <Id>4050ebed-ba3d-4be7-9260-e2b184f13a19</Id>
     </Book>
-    <Book Series="Second Coming: Prepare" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="Second Coming: Prepare" Number="1" Volume="2010" Year="2010">
       <Id>f3a455a0-53cd-49c4-8da6-8519c1f50633</Id>
     </Book>
-    <Book Series="X-Men: Hope" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="X-Men: Hope" Number="1" Volume="2010" Year="2010">
       <Id>a7ea660a-80dc-4937-8458-ba53e12ab696</Id>
     </Book>
-    <Book Series="X-Men: Second Coming" Number="1" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="X-Men: Second Coming" Number="1" Volume="2010" Year="2010">
       <Id>2acb4d79-44a3-4355-a57d-dae39e774fc4</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="523" Volume="1981" Year="2010" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="523" Volume="1981" Year="2010">
       <Id>527ddbf1-90f4-4467-b9cb-5e1a04f3069b</Id>
     </Book>
-    <Book Series="New Mutants" Number="12" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="New Mutants" Number="12" Volume="2009" Year="2010">
       <Id>63caf658-5739-4d79-a5a4-bed81cb85513</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="235" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="235" Volume="2008" Year="2010">
       <Id>18fc7b9d-e653-40e5-82d1-03c227955dca</Id>
     </Book>
-    <Book Series="X-Force" Number="26" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="X-Force" Number="26" Volume="2008" Year="2010">
       <Id>dd332f15-1736-4864-89c9-74c939fbebcd</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="524" Volume="1981" Year="2010" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="524" Volume="1981" Year="2010">
       <Id>61c098ee-9c27-499b-9549-4cbb0f0272cd</Id>
     </Book>
-    <Book Series="New Mutants" Number="13" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="New Mutants" Number="13" Volume="2009" Year="2010">
       <Id>0bbd8d8d-7461-40a1-86e9-2f2a6fcadde2</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="236" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="236" Volume="2008" Year="2010">
       <Id>cec02ec3-3526-44c3-872f-8a18cf873946</Id>
     </Book>
-    <Book Series="X-Force" Number="27" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="X-Force" Number="27" Volume="2008" Year="2010">
       <Id>3f6cce91-b67a-49d0-99ea-b632d7fae6de</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="525" Volume="1981" Year="2010" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="525" Volume="1981" Year="2010">
       <Id>714a8ce3-ffdd-47b3-a68b-965bf17ac0fa</Id>
     </Book>
-    <Book Series="New Mutants" Number="14" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="New Mutants" Number="14" Volume="2009" Year="2010">
       <Id>650efe6a-f31d-4b40-b469-6da75f2f5675</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="237" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="237" Volume="2008" Year="2010">
       <Id>3ad4d805-aceb-4196-acdc-f9e568db0bfd</Id>
     </Book>
-    <Book Series="X-Force" Number="28" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="X-Force" Number="28" Volume="2008" Year="2010">
       <Id>5c79fd95-393d-436a-b985-65fd66f1fa80</Id>
     </Book>
-    <Book Series="X-Men: Second Coming" Number="2" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="X-Men: Second Coming" Number="2" Volume="2010" Year="2010">
       <Id>f57707be-ef7b-44e2-b8de-7511db3d1e8c</Id>
     </Book>
-    <Book Series="X-Men: Hellbound" Number="1" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="X-Men: Hellbound" Number="1" Volume="2010" Year="2010">
       <Id>4392360e-f48b-489b-a9a1-7e346f690b21</Id>
     </Book>
-    <Book Series="X-Men: Blind Science" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="X-Men: Blind Science" Number="1" Volume="2010" Year="2010">
       <Id>d8804511-279a-457d-a8fe-299fdd40cea2</Id>
     </Book>
-    <Book Series="X-Men: Hellbound" Number="2" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="X-Men: Hellbound" Number="2" Volume="2010" Year="2010">
       <Id>b7c4e3ff-f759-4dd9-8bc0-ea6786e90891</Id>
     </Book>
-    <Book Series="X-Men: Hellbound" Number="3" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="X-Men: Hellbound" Number="3" Volume="2010" Year="2010">
       <Id>eb5065c2-968a-4079-b6b1-0fa6f984aa5a</Id>
     </Book>
-    <Book Series="X-Men Origins: Colossus" Number="1" Volume="2008" Year="2008" Format="One-Shot">
+    <Book Series="X-Men Origins: Colossus" Number="1" Volume="2008" Year="2008">
       <Id>012c64ab-f32c-4527-a22a-df96e7eb3f54</Id>
     </Book>
-    <Book Series="X-Men Origins: Jean Grey" Number="1" Volume="2008" Year="2008" Format="One-Shot">
+    <Book Series="X-Men Origins: Jean Grey" Number="1" Volume="2008" Year="2008">
       <Id>4bbb05ba-5ac1-42c9-ae84-1b53ecc3d393</Id>
     </Book>
-    <Book Series="X-Men Origins: Beast" Number="1" Volume="2008" Year="2008" Format="One-Shot">
+    <Book Series="X-Men Origins: Beast" Number="1" Volume="2008" Year="2008">
       <Id>54c7b025-6935-45c2-bad0-88a9fb258965</Id>
     </Book>
-    <Book Series="X-Men Origins: Sabretooth" Number="1" Volume="2009" Year="2009" Format="One-Shot">
+    <Book Series="X-Men Origins: Sabretooth" Number="1" Volume="2009" Year="2009">
       <Id>db461968-d41c-4c7f-8628-7baad414e98e</Id>
     </Book>
-    <Book Series="X-Men Origins: Wolverine" Number="1" Volume="2009" Year="2009" Format="One-Shot">
+    <Book Series="X-Men Origins: Wolverine" Number="1" Volume="2009" Year="2009">
       <Id>b8518070-0ea2-4f03-bc78-faab29d75914</Id>
     </Book>
-    <Book Series="X-Men Origins: Gambit" Number="1" Volume="2009" Year="2009" Format="One-Shot">
+    <Book Series="X-Men Origins: Gambit" Number="1" Volume="2009" Year="2009">
       <Id>60a45a99-f094-4100-bb85-ea2daf4cf972</Id>
     </Book>
-    <Book Series="X-Men Origins: Iceman" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="X-Men Origins: Iceman" Number="1" Volume="2010" Year="2010">
       <Id>4b7a468b-32cc-4b53-bb9f-41858af2fe32</Id>
     </Book>
-    <Book Series="X-Men Origins: Cyclops" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="X-Men Origins: Cyclops" Number="1" Volume="2010" Year="2010">
       <Id>d2a9ac35-0d4b-4636-888f-5ef71872c63b</Id>
     </Book>
-    <Book Series="X-Men Origins: Nightcrawler" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="X-Men Origins: Nightcrawler" Number="1" Volume="2010" Year="2010">
       <Id>0eec7a2b-c090-44c9-9751-67155d7b4673</Id>
     </Book>
-    <Book Series="X-Men Origins: Emma Frost" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="X-Men Origins: Emma Frost" Number="1" Volume="2010" Year="2010">
       <Id>f7c8ebdf-5d43-4569-a253-4dfd41ea403b</Id>
     </Book>
-    <Book Series="Uncanny X-Men: The Heroic Age" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="Uncanny X-Men: The Heroic Age" Number="1" Volume="2010" Year="2010">
       <Id>10f3c207-f1de-4c4c-a365-8cc71e2b3482</Id>
     </Book>
-    <Book Series="Heroic Age: X-Men" Number="1" Volume="2011" Year="2011" Format="One-Shot">
+    <Book Series="Heroic Age: X-Men" Number="1" Volume="2011" Year="2011">
       <Id>a2548243-1b20-4e93-aee1-0350edac2254</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="526" Volume="1981" Year="2010" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="526" Volume="1981" Year="2010">
       <Id>6229997d-d272-42ba-9566-ad81bda793af</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="527" Volume="1981" Year="2010" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="527" Volume="1981" Year="2010">
       <Id>0461ac27-2d16-4ed6-a576-e69f85678d51</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="528" Volume="1981" Year="2010" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="528" Volume="1981" Year="2010">
       <Id>9db0cc56-00f2-4859-a25a-eb2e416c660a</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="529" Volume="1981" Year="2010" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="529" Volume="1981" Year="2010">
       <Id>d10c3684-8f93-4f42-b75e-cbd847918909</Id>
     </Book>
-    <Book Series="Wolverine Weapon X" Number="16" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Wolverine Weapon X" Number="16" Volume="2009" Year="2010">
       <Id>441312ee-f7e0-4b17-92d9-5e6b06cfa127</Id>
     </Book>
-    <Book Series="New Mutants" Number="15" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="New Mutants" Number="15" Volume="2009" Year="2010">
       <Id>dd8fc979-506c-45b6-ae0d-79e9badede56</Id>
     </Book>
-    <Book Series="New Mutants" Number="16" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="New Mutants" Number="16" Volume="2009" Year="2010">
       <Id>1eadb1c0-a684-4cbb-b39f-3ac84e55ed9b</Id>
     </Book>
-    <Book Series="New Mutants" Number="17" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="New Mutants" Number="17" Volume="2009" Year="2010">
       <Id>144e4e64-825c-4388-964d-8066bc493af5</Id>
     </Book>
-    <Book Series="New Mutants" Number="18" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="New Mutants" Number="18" Volume="2009" Year="2010">
       <Id>d35f6491-6238-40e3-8e04-ea54d168c89b</Id>
     </Book>
-    <Book Series="New Mutants" Number="19" Volume="2009" Year="2011" Format="Main Series">
+    <Book Series="New Mutants" Number="19" Volume="2009" Year="2011">
       <Id>ab254aa6-0671-4b7c-8ebf-c777c36fc639</Id>
     </Book>
-    <Book Series="Generation Hope" Number="1" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Generation Hope" Number="1" Volume="2011" Year="2011">
       <Id>2cfde706-5ba7-4e82-8cae-81a4bd7a6bb3</Id>
     </Book>
-    <Book Series="Generation Hope" Number="2" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Generation Hope" Number="2" Volume="2011" Year="2011">
       <Id>84318523-9b8d-43fc-84ad-cd694137e060</Id>
     </Book>
-    <Book Series="Generation Hope" Number="3" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Generation Hope" Number="3" Volume="2011" Year="2011">
       <Id>78a93ca4-e34f-43e0-91ac-9af1a6d2b95a</Id>
     </Book>
-    <Book Series="Generation Hope" Number="4" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Generation Hope" Number="4" Volume="2011" Year="2011">
       <Id>e68e98e2-4bb5-40ae-99eb-e1f7a07c2c25</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="530" Volume="1981" Year="2011" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="530" Volume="1981" Year="2011">
       <Id>5714c141-ea4f-49c5-b8cf-dcd74cc14c07</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="531" Volume="1981" Year="2011" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="531" Volume="1981" Year="2011">
       <Id>9c7c5113-bf5c-46f3-9645-8e17cc1c40ee</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="532" Volume="1981" Year="2011" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="532" Volume="1981" Year="2011">
       <Id>5ff71463-5476-4bee-8604-3104525fa315</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="533" Volume="1981" Year="2011" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="533" Volume="1981" Year="2011">
       <Id>ae980434-6a7d-4cc3-978e-d04bd7ed1abd</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="534" Volume="1981" Year="2011" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="534" Volume="1981" Year="2011">
       <Id>a6f90ff1-2ee1-4f65-8e4e-98f7625dda34</Id>
     </Book>
-    <Book Series="Generation Hope" Number="5" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Generation Hope" Number="5" Volume="2011" Year="2011">
       <Id>5b56727f-4ce1-41d6-a797-f305f7c989e4</Id>
     </Book>
-    <Book Series="X-Women" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="X-Women" Number="1" Volume="2010" Year="2010">
       <Id>4b6a57de-167d-4ef5-b58c-e36d12bcd1f8</Id>
     </Book>
-    <Book Series="Wolverine: The Road to Hell" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="Wolverine: The Road to Hell" Number="1" Volume="2010" Year="2010">
       <Id>525d12d3-0688-454a-8d67-53da8b04ac6b</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="1" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="1" Volume="2010" Year="2010">
       <Id>fd881f1b-2bc0-4019-868c-27e3a87a2e61</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="2" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="2" Volume="2010" Year="2011">
       <Id>c4195183-6f66-455e-86cc-fc9f6141997d</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="3" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="3" Volume="2010" Year="2011">
       <Id>aafedf8c-6a70-4c13-84a9-1b046f6dc614</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="4" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="4" Volume="2010" Year="2011">
       <Id>d1f7430d-bcf9-4570-b09e-a8e6f0899661</Id>
     </Book>
-    <Book Series="Death of Dracula" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="Death of Dracula" Number="1" Volume="2010" Year="2010">
       <Id>0a0b3f34-8ad7-4333-bd4e-3b0a377264a2</Id>
     </Book>
-    <Book Series="X-Men: Curse of the Mutants - Blade" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="X-Men: Curse of the Mutants - Blade" Number="1" Volume="2010" Year="2010">
       <Id>c6998ff9-6ccc-471c-91c4-28b733e980c5</Id>
     </Book>
-    <Book Series="X-Men: Curse Of The Mutants Saga" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="X-Men: Curse Of The Mutants Saga" Number="1" Volume="2010" Year="2010">
       <Id>63816873-9c9c-458d-b472-9ee8d8d7d368</Id>
     </Book>
-    <Book Series="X-Men" Number="1" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="X-Men" Number="1" Volume="2010" Year="2010">
       <Id>2f0a5be5-7be5-4aa3-86f7-994719411425</Id>
     </Book>
-    <Book Series="X-Men" Number="2" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="X-Men" Number="2" Volume="2010" Year="2010">
       <Id>04eefe23-25a7-4322-b30c-7c0aafe4f4d8</Id>
     </Book>
-    <Book Series="X-Men: Curse of the Mutants - Storm &amp; Gambit" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="X-Men: Curse of the Mutants - Storm &amp; Gambit" Number="1" Volume="2010" Year="2010">
       <Id>6196985b-90b7-46af-8ada-9620292c136a</Id>
     </Book>
-    <Book Series="X-Men: Curse of the Mutants - Smoke and Blood" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="X-Men: Curse of the Mutants - Smoke and Blood" Number="1" Volume="2010" Year="2010">
       <Id>bc1ca97a-856e-45a6-a88b-4bb254f3c94f</Id>
     </Book>
-    <Book Series="X-Men: Curse of the Mutants - X-Men Vs. Vampires" Number="1" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="X-Men: Curse of the Mutants - X-Men Vs. Vampires" Number="1" Volume="2010" Year="2010">
       <Id>f922a0ec-0aed-4644-b6d0-9852366e26a1</Id>
     </Book>
-    <Book Series="X-Men: Curse of the Mutants - X-Men Vs. Vampires" Number="2" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="X-Men: Curse of the Mutants - X-Men Vs. Vampires" Number="2" Volume="2010" Year="2010">
       <Id>01b62cb1-ad38-445b-b485-32e5d27e2df2</Id>
     </Book>
-    <Book Series="Namor: The First Mutant" Number="1" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="Namor: The First Mutant" Number="1" Volume="2010" Year="2010">
       <Id>3538ef05-ac93-4096-8255-d0a29e643327</Id>
     </Book>
-    <Book Series="X-Men" Number="3" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="X-Men" Number="3" Volume="2010" Year="2010">
       <Id>edc8207d-ef02-41e5-8612-7b0e96446992</Id>
     </Book>
-    <Book Series="Namor: The First Mutant" Number="2" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="Namor: The First Mutant" Number="2" Volume="2010" Year="2010">
       <Id>335654d4-3d9a-46c3-ad1d-4fe96d7552d8</Id>
     </Book>
-    <Book Series="Namor: The First Mutant" Number="3" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="Namor: The First Mutant" Number="3" Volume="2010" Year="2010">
       <Id>c3ef4b21-9733-4a26-a9d8-9c2f4db9cb59</Id>
     </Book>
-    <Book Series="X-Men" Number="4" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="X-Men" Number="4" Volume="2010" Year="2010">
       <Id>76c50b97-c525-435a-b598-a705563ee458</Id>
     </Book>
-    <Book Series="Namor: The First Mutant" Number="4" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Namor: The First Mutant" Number="4" Volume="2010" Year="2011">
       <Id>6eba1136-8406-421f-bc5e-3f5e1ed624cf</Id>
     </Book>
-    <Book Series="X-Men" Number="5" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-Men" Number="5" Volume="2010" Year="2011">
       <Id>4e11ebe5-8dd3-4d44-9347-8d9da5981a2e</Id>
     </Book>
-    <Book Series="X-Men" Number="6" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-Men" Number="6" Volume="2010" Year="2011">
       <Id>dcb51350-35f0-4def-8a0d-5bc6028bf49a</Id>
     </Book>
-    <Book Series="X-Men: To Serve and Protect" Number="1" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="X-Men: To Serve and Protect" Number="1" Volume="2011" Year="2011">
       <Id>feb8b140-c61a-4164-8dfc-2ade012c993a</Id>
     </Book>
-    <Book Series="X-Men: To Serve and Protect" Number="2" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="X-Men: To Serve and Protect" Number="2" Volume="2011" Year="2011">
       <Id>6775c489-9716-4d4e-b4f6-956816c3e565</Id>
     </Book>
-    <Book Series="X-Men: To Serve and Protect" Number="3" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="X-Men: To Serve and Protect" Number="3" Volume="2011" Year="2011">
       <Id>e1bfb336-902d-4e6d-8b6b-ed50f9724e3c</Id>
     </Book>
-    <Book Series="X-Men: To Serve and Protect" Number="4" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="X-Men: To Serve and Protect" Number="4" Volume="2011" Year="2011">
       <Id>e192b879-3a27-4156-bf8c-f280f0eb0189</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="238" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="238" Volume="2008" Year="2010">
       <Id>1523793f-568a-4f94-b9ec-bf7ee895a2bb</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="239" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="239" Volume="2008" Year="2010">
       <Id>e3f07615-4060-4d64-909d-bb6a9415dbc2</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="240" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="240" Volume="2008" Year="2010">
       <Id>ca282d9e-69a5-4588-a47a-ddd2db8adebe</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="241" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="241" Volume="2008" Year="2010">
       <Id>e8d4ef6d-ff45-480c-b320-0de62627355e</Id>
     </Book>
-    <Book Series="Wolverine and Jubilee" Number="1" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Wolverine and Jubilee" Number="1" Volume="2011" Year="2011">
       <Id>60c6bf2b-0549-4864-9673-71f328e1f359</Id>
     </Book>
-    <Book Series="Wolverine and Jubilee" Number="2" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Wolverine and Jubilee" Number="2" Volume="2011" Year="2011">
       <Id>7ab6a99e-8415-4b3a-aa0a-1193a388c907</Id>
     </Book>
-    <Book Series="Wolverine and Jubilee" Number="3" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Wolverine and Jubilee" Number="3" Volume="2011" Year="2011">
       <Id>420192b1-7041-47a4-94f6-74584988c103</Id>
     </Book>
-    <Book Series="Wolverine and Jubilee" Number="4" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Wolverine and Jubilee" Number="4" Volume="2011" Year="2011">
       <Id>7a1ce09a-2636-4cfd-b805-f29dffea45d9</Id>
     </Book>
-    <Book Series="X-Factor" Number="207" Volume="2006" Year="2010" Format="Main Series">
+    <Book Series="X-Factor" Number="207" Volume="2006" Year="2010">
       <Id>7cadc0c0-9586-4c51-b80f-92aca48abded</Id>
     </Book>
-    <Book Series="X-Factor" Number="208" Volume="2006" Year="2010" Format="Main Series">
+    <Book Series="X-Factor" Number="208" Volume="2006" Year="2010">
       <Id>6a6677c3-8bb0-4739-b505-7ff11236a294</Id>
     </Book>
-    <Book Series="X-Factor" Number="209" Volume="2006" Year="2010" Format="Main Series">
+    <Book Series="X-Factor" Number="209" Volume="2006" Year="2010">
       <Id>4903f156-2796-4540-9f16-df3a5d07f647</Id>
     </Book>
-    <Book Series="X-Factor" Number="210" Volume="2006" Year="2010" Format="Main Series">
+    <Book Series="X-Factor" Number="210" Volume="2006" Year="2010">
       <Id>3b529bc4-ea7a-43c7-9d80-c5ab11d1b83e</Id>
     </Book>
-    <Book Series="X-Factor" Number="211" Volume="2006" Year="2011" Format="Main Series">
+    <Book Series="X-Factor" Number="211" Volume="2006" Year="2011">
       <Id>a668ed8a-f377-4342-a92b-275b455b0522</Id>
     </Book>
-    <Book Series="X-Factor" Number="213" Volume="2006" Year="2011" Format="Main Series">
+    <Book Series="X-Factor" Number="213" Volume="2006" Year="2011">
       <Id>0c42c988-0ccd-4eb5-abd1-0c6699ecf8c0</Id>
     </Book>
-    <Book Series="X-Factor" Number="214" Volume="2006" Year="2011" Format="Main Series">
+    <Book Series="X-Factor" Number="214" Volume="2006" Year="2011">
       <Id>6a4407e7-1b8d-400e-bd1e-5268f707cfb3</Id>
     </Book>
-    <Book Series="X-Factor" Number="215" Volume="2006" Year="2011" Format="Main Series">
+    <Book Series="X-Factor" Number="215" Volume="2006" Year="2011">
       <Id>1d214ede-5bc4-4545-a4b2-b839a00ae027</Id>
     </Book>
-    <Book Series="X-Factor" Number="216" Volume="2006" Year="2011" Format="Main Series">
+    <Book Series="X-Factor" Number="216" Volume="2006" Year="2011">
       <Id>f840ce09-7b04-4125-8ab6-7158bb8f4b1d</Id>
     </Book>
-    <Book Series="X-Factor" Number="217" Volume="2006" Year="2011" Format="Main Series">
+    <Book Series="X-Factor" Number="217" Volume="2006" Year="2011">
       <Id>757bd2fa-6464-48e2-9a38-702a30a9cb09</Id>
     </Book>
-    <Book Series="X-Factor" Number="218" Volume="2006" Year="2011" Format="Main Series">
+    <Book Series="X-Factor" Number="218" Volume="2006" Year="2011">
       <Id>758d1718-8076-44eb-af9a-99a762f0b492</Id>
     </Book>
-    <Book Series="X-Factor" Number="219" Volume="2006" Year="2011" Format="Main Series">
+    <Book Series="X-Factor" Number="219" Volume="2006" Year="2011">
       <Id>1c2f5863-be4d-48c5-88f2-8340f771352d</Id>
     </Book>
-    <Book Series="X-23" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="X-23" Number="1" Volume="2010" Year="2010">
       <Id>496c7e22-13da-453d-8f54-a91697c74824</Id>
     </Book>
-    <Book Series="X-23" Number="1" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="X-23" Number="1" Volume="2010" Year="2010">
       <Id>6837b991-3a00-48b5-9fb2-7b066eb3ca52</Id>
     </Book>
-    <Book Series="X-23" Number="2" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="X-23" Number="2" Volume="2010" Year="2010">
       <Id>5e9ad1e6-d4b8-437e-aab1-21ea7417909d</Id>
     </Book>
-    <Book Series="X-23" Number="3" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-23" Number="3" Volume="2010" Year="2011">
       <Id>bdf6ac88-1c7a-4981-8793-a196c960ce1b</Id>
     </Book>
-    <Book Series="X-23" Number="4" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-23" Number="4" Volume="2010" Year="2011">
       <Id>9585f393-b862-40c8-a37b-e53490e24234</Id>
     </Book>
-    <Book Series="X-23" Number="5" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-23" Number="5" Volume="2010" Year="2011">
       <Id>f547220f-c795-45f5-b3a6-ee6f29d5375f</Id>
     </Book>
-    <Book Series="X-23" Number="6" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-23" Number="6" Volume="2010" Year="2011">
       <Id>45db4d77-7d19-4d6f-b13d-3c4e2bca1f15</Id>
     </Book>
-    <Book Series="Dark Wolverine" Number="90" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Dark Wolverine" Number="90" Volume="2009" Year="2010">
       <Id>4e9b2779-eb70-4498-bc63-0247f3617aa5</Id>
     </Book>
-    <Book Series="Daken: Dark Wolverine" Number="1" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="Daken: Dark Wolverine" Number="1" Volume="2010" Year="2010">
       <Id>19919f93-f0a4-40b3-abbe-45d2e5fc5c1f</Id>
     </Book>
-    <Book Series="Daken: Dark Wolverine" Number="2" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="Daken: Dark Wolverine" Number="2" Volume="2010" Year="2010">
       <Id>2ecd9d69-9ee7-4111-81b8-32aee006ee28</Id>
     </Book>
-    <Book Series="Daken: Dark Wolverine" Number="3" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Daken: Dark Wolverine" Number="3" Volume="2010" Year="2011">
       <Id>5940e9a3-d0e7-4532-b393-9a0a324d40d9</Id>
     </Book>
-    <Book Series="Wolverine" Number="1" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="Wolverine" Number="1" Volume="2010" Year="2010">
       <Id>b84d4800-87cf-47b2-ab4d-2dad7b462df2</Id>
     </Book>
-    <Book Series="Wolverine" Number="2" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="Wolverine" Number="2" Volume="2010" Year="2010">
       <Id>4285cc1e-327f-4fce-a64d-1c7b7539061c</Id>
     </Book>
-    <Book Series="Wolverine" Number="3" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Wolverine" Number="3" Volume="2010" Year="2011">
       <Id>3b7f050f-c1c0-424e-ac3f-b55fb961a950</Id>
     </Book>
-    <Book Series="Wolverine" Number="4" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Wolverine" Number="4" Volume="2010" Year="2011">
       <Id>2acebc2d-0000-4514-aa7b-4c0015669e36</Id>
     </Book>
-    <Book Series="Wolverine" Number="5" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Wolverine" Number="5" Volume="2010" Year="2011">
       <Id>d3b48617-480c-4997-a975-4b3aed0be117</Id>
     </Book>
-    <Book Series="Wolverine" Number="900" Volume="2003" Year="2010" Format="Main Series">
+    <Book Series="Wolverine" Number="900" Volume="2003" Year="2010">
       <Id>8ac9f241-8462-46a6-8753-8176c4524fa3</Id>
     </Book>
-    <Book Series="Wolverine" Number="1000" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Wolverine" Number="1000" Volume="2010" Year="2011">
       <Id>11c8f749-177f-4d80-aa16-7445736dea37</Id>
     </Book>
-    <Book Series="Wolverine" Number="5.1" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Wolverine" Number="5.1" Volume="2010" Year="2011">
       <Id>589dfc4e-c0fa-4d39-9d78-51cbaf0b5470</Id>
     </Book>
-    <Book Series="Wolverine" Number="6" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Wolverine" Number="6" Volume="2010" Year="2011">
       <Id>b7441774-917a-41ad-b1dc-4fca9f06ad6f</Id>
     </Book>
-    <Book Series="Wolverine" Number="7" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Wolverine" Number="7" Volume="2010" Year="2011">
       <Id>30e6481c-fa29-4e23-ad0b-8e2b92221793</Id>
     </Book>
-    <Book Series="Wolverine" Number="8" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Wolverine" Number="8" Volume="2010" Year="2011">
       <Id>faa98978-1732-4292-a7d2-9436dc15e5d8</Id>
     </Book>
-    <Book Series="Wolverine" Number="9" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Wolverine" Number="9" Volume="2010" Year="2011">
       <Id>478628d5-33df-46fa-b95a-b40158205b48</Id>
     </Book>
-    <Book Series="Namor: The First Mutant" Number="5" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Namor: The First Mutant" Number="5" Volume="2010" Year="2011">
       <Id>a4e131f0-ebd5-41ed-885a-e48c85571756</Id>
     </Book>
-    <Book Series="Namor: The First Mutant" Number="6" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Namor: The First Mutant" Number="6" Volume="2010" Year="2011">
       <Id>d731e93d-fe1e-4760-814c-db4b68442fb8</Id>
     </Book>
-    <Book Series="Namor: The First Mutant" Number="7" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Namor: The First Mutant" Number="7" Volume="2010" Year="2011">
       <Id>9ad5b6b8-b994-4651-99da-c1869668e566</Id>
     </Book>
-    <Book Series="Namor: The First Mutant" Number="8" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Namor: The First Mutant" Number="8" Volume="2010" Year="2011">
       <Id>453e497e-8c08-4ab0-aca8-2c02c037b83c</Id>
     </Book>
-    <Book Series="Namor: The First Mutant" Number="9" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Namor: The First Mutant" Number="9" Volume="2010" Year="2011">
       <Id>3c9065e3-62c7-4faf-98d5-3d9e6809d985</Id>
     </Book>
-    <Book Series="Namor: The First Mutant" Number="10" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Namor: The First Mutant" Number="10" Volume="2010" Year="2011">
       <Id>1180342e-d035-4e37-b656-10303d6bc6b7</Id>
     </Book>
-    <Book Series="Namor: The First Mutant" Number="11" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Namor: The First Mutant" Number="11" Volume="2010" Year="2011">
       <Id>3b32dfeb-66db-4f65-bd32-a2c753f08539</Id>
     </Book>
-    <Book Series="X-Men" Number="7" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-Men" Number="7" Volume="2010" Year="2011">
       <Id>aa0a446d-40a0-46e3-9bc8-6fd86855458f</Id>
     </Book>
-    <Book Series="X-Men" Number="8" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-Men" Number="8" Volume="2010" Year="2011">
       <Id>9c8f61d9-ffdb-4d15-89d1-e8d59b801c99</Id>
     </Book>
-    <Book Series="X-Men" Number="9" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-Men" Number="9" Volume="2010" Year="2011">
       <Id>55f4e46f-dc60-4e58-8f1c-b6075317049e</Id>
     </Book>
-    <Book Series="X-Men" Number="10" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-Men" Number="10" Volume="2010" Year="2011">
       <Id>bb71cff4-7804-4a14-b1a0-2176638e71d6</Id>
     </Book>
-    <Book Series="X-Men" Number="11" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-Men" Number="11" Volume="2010" Year="2011">
       <Id>80378f4f-f7a3-4f54-a52a-1c2126996880</Id>
     </Book>
-    <Book Series="Chaos War" Number="1" Volume="2010" Year="2010" Format="Crossover">
+    <Book Series="Chaos War" Number="1" Volume="2010" Year="2010">
       <Id>07d0001c-29ea-4d59-8952-c0c000e69f3c</Id>
     </Book>
-    <Book Series="Chaos War" Number="2" Volume="2010" Year="2010" Format="Crossover">
+    <Book Series="Chaos War" Number="2" Volume="2010" Year="2010">
       <Id>ada55af9-61ff-42e7-8ce0-7c2b5bcbf751</Id>
     </Book>
-    <Book Series="Chaos War" Number="3" Volume="2010" Year="2011" Format="Crossover">
+    <Book Series="Chaos War" Number="3" Volume="2010" Year="2011">
       <Id>9d42da34-537e-4146-b0ff-a832f9b8399a</Id>
     </Book>
-    <Book Series="Chaos War: Alpha Flight" Number="1" Volume="2011" Year="2011" Format="One-Shot">
+    <Book Series="Chaos War: Alpha Flight" Number="1" Volume="2011" Year="2011">
       <Id>97d61e72-7126-4500-8d69-376e508c7742</Id>
     </Book>
-    <Book Series="Chaos War: Chaos King" Number="1" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Chaos War: Chaos King" Number="1" Volume="2011" Year="2011">
       <Id>d6a15590-9685-4c95-a94f-bc68877b01e6</Id>
     </Book>
-    <Book Series="Chaos War: Dead Avengers" Number="1" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Chaos War: Dead Avengers" Number="1" Volume="2011" Year="2011">
       <Id>2caf0396-c911-40bc-9f5d-da2fa96edcb5</Id>
     </Book>
-    <Book Series="Chaos War: Thor" Number="1" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Chaos War: Thor" Number="1" Volume="2011" Year="2011">
       <Id>d5e87733-f7e9-4793-a608-f62e5116e123</Id>
     </Book>
-    <Book Series="Chaos War" Number="4" Volume="2010" Year="2011" Format="Crossover">
+    <Book Series="Chaos War" Number="4" Volume="2010" Year="2011">
       <Id>860b3c91-c570-4574-87c0-b6a5ca12ab75</Id>
     </Book>
-    <Book Series="Chaos War: Ares" Number="1" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Chaos War: Ares" Number="1" Volume="2011" Year="2011">
       <Id>97b0d43e-4efd-4a2c-a72d-19c936802e9e</Id>
     </Book>
-    <Book Series="Chaos War: Dead Avengers" Number="2" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Chaos War: Dead Avengers" Number="2" Volume="2011" Year="2011">
       <Id>4114bb47-3204-4fb6-94e9-194f19c517f1</Id>
     </Book>
-    <Book Series="Chaos War: God Squad" Number="1" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Chaos War: God Squad" Number="1" Volume="2011" Year="2011">
       <Id>9a5be231-0cbf-423e-a287-fd9aaee10898</Id>
     </Book>
-    <Book Series="Chaos War: Thor" Number="2" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Chaos War: Thor" Number="2" Volume="2011" Year="2011">
       <Id>cd17cae6-5ff7-4dd6-b1de-acfe5a319013</Id>
     </Book>
-    <Book Series="Chaos War: X-Men" Number="1" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Chaos War: X-Men" Number="1" Volume="2011" Year="2011">
       <Id>127dccd9-9056-4f08-9587-851c797b31ed</Id>
     </Book>
-    <Book Series="Incredible Hulks" Number="618" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Incredible Hulks" Number="618" Volume="2010" Year="2011">
       <Id>db29e233-9b30-4b6f-904d-7540edaa399e</Id>
     </Book>
-    <Book Series="Incredible Hulks" Number="619" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Incredible Hulks" Number="619" Volume="2010" Year="2011">
       <Id>6bbda978-9604-4299-bf86-2ce2a0a29b98</Id>
     </Book>
-    <Book Series="Chaos War: Dead Avengers" Number="3" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Chaos War: Dead Avengers" Number="3" Volume="2011" Year="2011">
       <Id>b507e2f1-1cdc-4f38-874d-a2dd11a5b744</Id>
     </Book>
-    <Book Series="Chaos War: X-Men" Number="2" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Chaos War: X-Men" Number="2" Volume="2011" Year="2011">
       <Id>40501a0f-60eb-4579-977e-0a9517560a71</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="5" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="5" Volume="2010" Year="2011">
       <Id>e0a81654-3716-4848-869f-fdfd1534be93</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="5.1" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="5.1" Volume="2010" Year="2011">
       <Id>52621846-cc65-4472-92f9-d1265dc62b70</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="6" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="6" Volume="2010" Year="2011">
       <Id>f21c0dbb-a066-4319-a3e6-0db5c31525c9</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="7" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="7" Volume="2010" Year="2011">
       <Id>0875ab09-f741-4cbc-9e42-9182813f68d2</Id>
     </Book>
-    <Book Series="Astonishing Spider-Man &amp; Wolverine" Number="1" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Astonishing Spider-Man &amp; Wolverine" Number="1" Volume="2010" Year="2010">
       <Id>336a7917-4e16-4935-83e0-7375d4a7890a</Id>
     </Book>
-    <Book Series="Astonishing Spider-Man &amp; Wolverine" Number="2" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Astonishing Spider-Man &amp; Wolverine" Number="2" Volume="2010" Year="2010">
       <Id>ecd9066b-4ec3-4062-9850-9ad4309f0dda</Id>
     </Book>
-    <Book Series="Astonishing Spider-Man &amp; Wolverine" Number="3" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Astonishing Spider-Man &amp; Wolverine" Number="3" Volume="2010" Year="2010">
       <Id>7dbeed24-44f7-4ddf-ac73-1b41785467e4</Id>
     </Book>
-    <Book Series="Astonishing Spider-Man &amp; Wolverine" Number="4" Volume="2010" Year="2011" Format="Limited Series">
+    <Book Series="Astonishing Spider-Man &amp; Wolverine" Number="4" Volume="2010" Year="2011">
       <Id>dc108e26-ebe0-47fa-aacf-6b5c34241400</Id>
     </Book>
-    <Book Series="Astonishing Spider-Man &amp; Wolverine" Number="5" Volume="2010" Year="2011" Format="Limited Series">
+    <Book Series="Astonishing Spider-Man &amp; Wolverine" Number="5" Volume="2010" Year="2011">
       <Id>36f68ae6-011c-4179-96be-a5500741b964</Id>
     </Book>
-    <Book Series="Astonishing Spider-Man &amp; Wolverine" Number="6" Volume="2010" Year="2011" Format="Limited Series">
+    <Book Series="Astonishing Spider-Man &amp; Wolverine" Number="6" Volume="2010" Year="2011">
       <Id>b7f558bf-d8cc-473c-b6e4-7d4b8d05b631</Id>
     </Book>
-    <Book Series="X-Factor" Number="220" Volume="2006" Year="2011" Format="Main Series">
+    <Book Series="X-Factor" Number="220" Volume="2006" Year="2011">
       <Id>4a6bcf4b-ad31-4874-b6ea-5af2b2877ac4</Id>
     </Book>
-    <Book Series="X-Factor" Number="221" Volume="2006" Year="2011" Format="Main Series">
+    <Book Series="X-Factor" Number="221" Volume="2006" Year="2011">
       <Id>dfa50933-3e3f-4b90-98ea-38f59f5b87e6</Id>
     </Book>
-    <Book Series="X-Factor" Number="222" Volume="2006" Year="2011" Format="Main Series">
+    <Book Series="X-Factor" Number="222" Volume="2006" Year="2011">
       <Id>b20919f8-7b95-4bf2-be76-93218c1b4576</Id>
     </Book>
-    <Book Series="X-Factor" Number="223" Volume="2006" Year="2011" Format="Main Series">
+    <Book Series="X-Factor" Number="223" Volume="2006" Year="2011">
       <Id>635b5381-493f-4464-b675-ee784b9b6a4f</Id>
     </Book>
-    <Book Series="X-Factor" Number="224" Volume="2006" Year="2011" Format="Main Series">
+    <Book Series="X-Factor" Number="224" Volume="2006" Year="2011">
       <Id>8ad0cbe5-fd92-4e2f-8c44-c6726202a9be</Id>
     </Book>
-    <Book Series="Avengers: The Children's Crusade" Number="1" Volume="2010" Year="2010" Format="Crossover">
+    <Book Series="Avengers: The Children's Crusade" Number="1" Volume="2010" Year="2010">
       <Id>33cf354f-f268-4b41-aef6-b44e183ff594</Id>
     </Book>
-    <Book Series="Avengers: The Children's Crusade" Number="2" Volume="2010" Year="2010" Format="Crossover">
+    <Book Series="Avengers: The Children's Crusade" Number="2" Volume="2010" Year="2010">
       <Id>c0df33c4-3024-4711-af13-a82e88fd3f46</Id>
     </Book>
-    <Book Series="Avengers: The Children's Crusade" Number="3" Volume="2010" Year="2011" Format="Crossover">
+    <Book Series="Avengers: The Children's Crusade" Number="3" Volume="2010" Year="2011">
       <Id>8a06f43a-e565-45ea-88a5-3bf77390b717</Id>
     </Book>
-    <Book Series="Avengers: The Children's Crusade" Number="4" Volume="2010" Year="2011" Format="Crossover">
+    <Book Series="Avengers: The Children's Crusade" Number="4" Volume="2010" Year="2011">
       <Id>49628fb6-d084-42f4-9dc6-f333d0cea89a</Id>
     </Book>
-    <Book Series="Avengers: The Children's Crusade - Young Avengers" Number="1" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Avengers: The Children's Crusade - Young Avengers" Number="1" Volume="2011" Year="2011">
       <Id>646f0499-5000-4b45-b09a-01ab291431c8</Id>
     </Book>
-    <Book Series="Avengers: The Children's Crusade" Number="5" Volume="2010" Year="2011" Format="Crossover">
+    <Book Series="Avengers: The Children's Crusade" Number="5" Volume="2010" Year="2011">
       <Id>98cd53d9-52d4-4931-9e54-0308b75e7c4f</Id>
     </Book>
-    <Book Series="Avengers: The Children's Crusade" Number="6" Volume="2010" Year="2011" Format="Crossover">
+    <Book Series="Avengers: The Children's Crusade" Number="6" Volume="2010" Year="2011">
       <Id>10915c1d-84ca-4ee9-9f40-7f6c58b0c664</Id>
     </Book>
-    <Book Series="Avengers: The Children's Crusade" Number="7" Volume="2010" Year="2011" Format="Crossover">
+    <Book Series="Avengers: The Children's Crusade" Number="7" Volume="2010" Year="2011">
       <Id>c763c642-bb92-4e00-8146-a085015c1563</Id>
     </Book>
-    <Book Series="Avengers: The Children's Crusade" Number="8" Volume="2010" Year="2012" Format="Crossover">
+    <Book Series="Avengers: The Children's Crusade" Number="8" Volume="2010" Year="2012">
       <Id>34ce11e9-ae52-44f1-99b5-bfae10082d99</Id>
     </Book>
-    <Book Series="Avengers: The Children's Crusade" Number="9" Volume="2010" Year="2012" Format="Crossover">
+    <Book Series="Avengers: The Children's Crusade" Number="9" Volume="2010" Year="2012">
       <Id>70054397-94fb-4232-83e0-32c267cdc619</Id>
     </Book>
-    <Book Series="Wolverine &amp; The Black Cat: Claws 2" Number="1" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Wolverine &amp; The Black Cat: Claws 2" Number="1" Volume="2011" Year="2011">
       <Id>cdc48e8d-f0bc-419b-9065-3f02d6a38a19</Id>
     </Book>
-    <Book Series="Wolverine &amp; The Black Cat: Claws 2" Number="2" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Wolverine &amp; The Black Cat: Claws 2" Number="2" Volume="2011" Year="2011">
       <Id>49248fb4-0645-4018-a5e4-36f07df33993</Id>
     </Book>
-    <Book Series="Wolverine &amp; The Black Cat: Claws 2" Number="3" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Wolverine &amp; The Black Cat: Claws 2" Number="3" Volume="2011" Year="2011">
       <Id>39d8adc0-95d0-439b-9a31-b522ee320e24</Id>
     </Book>
-    <Book Series="Uncanny X-Men Annual" Number="3" Volume="2006" Year="2011" Format="Annual">
+    <Book Series="Uncanny X-Men Annual" Number="3" Volume="2006" Year="2011">
       <Id>66459b80-3f8f-428f-84e6-0b03bee4ec65</Id>
     </Book>
-    <Book Series="Steve Rogers: Super Soldier Annual" Number="1" Volume="2011" Year="2011" Format="Annual">
+    <Book Series="Steve Rogers: Super Soldier Annual" Number="1" Volume="2011" Year="2011">
       <Id>3f7a120f-756d-4c7b-841e-bb6c7414ba43</Id>
     </Book>
-    <Book Series="Namor: The First Mutant Annual" Number="1" Volume="2011" Year="2011" Format="Annual">
+    <Book Series="Namor: The First Mutant Annual" Number="1" Volume="2011" Year="2011">
       <Id>09fd3fe0-0ff4-4400-8efb-70114ff7b245</Id>
     </Book>
-    <Book Series="X-Men Giant-Size" Number="1" Volume="2011" Year="2011" Format="Giant Size">
+    <Book Series="X-Men Giant-Size" Number="1" Volume="2011" Year="2011">
       <Id>0c282d10-fb86-4dfc-bd92-8f7ded16ddb7</Id>
     </Book>
-    <Book Series="X-Men" Number="12" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-Men" Number="12" Volume="2010" Year="2011">
       <Id>293ff35f-536e-4ab7-8091-a8dde1a92150</Id>
     </Book>
-    <Book Series="X-Men" Number="13" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-Men" Number="13" Volume="2010" Year="2011">
       <Id>fe9fe3a8-4cf7-4981-9ac5-4b02b0434ea4</Id>
     </Book>
-    <Book Series="X-Men" Number="14" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-Men" Number="14" Volume="2010" Year="2011">
       <Id>73e680de-be0e-4b46-af4e-9597a2c4dd2b</Id>
     </Book>
-    <Book Series="X-Men" Number="15" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-Men" Number="15" Volume="2010" Year="2011">
       <Id>38b955a1-c5b8-4d4d-9437-a32991476831</Id>
     </Book>
-    <Book Series="X-Men" Number="15.1" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-Men" Number="15.1" Volume="2010" Year="2011">
       <Id>64588afd-c374-4ef2-ac87-c70aae8a562c</Id>
     </Book>
-    <Book Series="X-Men" Number="16" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-Men" Number="16" Volume="2010" Year="2011">
       <Id>8b40f3b9-da2c-428c-83de-d65d516235e1</Id>
     </Book>
-    <Book Series="X-Men" Number="17" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-Men" Number="17" Volume="2010" Year="2011">
       <Id>eaf78b28-03a9-48a9-9c32-ca7ef4db27fd</Id>
     </Book>
-    <Book Series="X-Men" Number="18" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-Men" Number="18" Volume="2010" Year="2011">
       <Id>0845a1e4-daf5-4021-b6e0-2e54948f5d1b</Id>
     </Book>
-    <Book Series="X-Men" Number="19" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-Men" Number="19" Volume="2010" Year="2011">
       <Id>f23eae28-8591-4952-983d-505d841ad6d1</Id>
     </Book>
-    <Book Series="Gambit and the Champions: From the Marvel Vault" Number="1" Volume="2011" Year="2011" Format="One-Shot">
+    <Book Series="Gambit and the Champions: From the Marvel Vault" Number="1" Volume="2011" Year="2011">
       <Id>b35a6e84-3f77-4fcb-a935-97cfba19cc10</Id>
     </Book>
-    <Book Series="X-23" Number="7" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-23" Number="7" Volume="2010" Year="2011">
       <Id>74afabb3-e365-4af5-8340-50dbdbde221b</Id>
     </Book>
-    <Book Series="Daken: Dark Wolverine" Number="4" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Daken: Dark Wolverine" Number="4" Volume="2010" Year="2011">
       <Id>ae316f31-f6ec-4086-bbfe-397358b223e9</Id>
     </Book>
-    <Book Series="Daken: Dark Wolverine" Number="5" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Daken: Dark Wolverine" Number="5" Volume="2010" Year="2011">
       <Id>1f0c3f6e-93da-49c3-95a4-8af0c0d31b5a</Id>
     </Book>
-    <Book Series="Daken: Dark Wolverine" Number="6" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Daken: Dark Wolverine" Number="6" Volume="2010" Year="2011">
       <Id>fdefc515-3aa5-414c-8f4c-ea871b472671</Id>
     </Book>
-    <Book Series="Daken: Dark Wolverine" Number="7" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Daken: Dark Wolverine" Number="7" Volume="2010" Year="2011">
       <Id>69e1ffa8-f935-4681-b40f-d4d422a9314f</Id>
     </Book>
-    <Book Series="X-23" Number="8" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-23" Number="8" Volume="2010" Year="2011">
       <Id>754da0ab-dae1-4daa-acab-f2ee67311dd4</Id>
     </Book>
-    <Book Series="Daken: Dark Wolverine" Number="8" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Daken: Dark Wolverine" Number="8" Volume="2010" Year="2011">
       <Id>96646361-6ae4-4d89-8e82-41822a4c46b5</Id>
     </Book>
-    <Book Series="X-23" Number="9" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-23" Number="9" Volume="2010" Year="2011">
       <Id>475c87b9-eba0-4713-a7c9-2d1ad02eb8b7</Id>
     </Book>
-    <Book Series="Daken: Dark Wolverine" Number="9" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Daken: Dark Wolverine" Number="9" Volume="2010" Year="2011">
       <Id>a35447f8-d938-410e-80f3-81ec32e97f1f</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="242" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="242" Volume="2008" Year="2011">
       <Id>a295034c-0ae5-484c-89e3-5a93d1a8b17f</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="243" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="243" Volume="2008" Year="2011">
       <Id>e6b9b183-8163-4127-aada-34995d27f7da</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="244" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="244" Volume="2008" Year="2011">
       <Id>f6a45098-42dd-40e2-976e-b57c44199a2d</Id>
     </Book>
-    <Book Series="Magneto" Number="1" Volume="2011" Year="2011" Format="One-Shot">
+    <Book Series="Magneto" Number="1" Volume="2011" Year="2011">
       <Id>d8be559b-0c10-4181-8727-217c819fdfa2</Id>
     </Book>
-    <Book Series="Marvel Girl" Number="1" Volume="2011" Year="2011" Format="One-Shot">
+    <Book Series="Marvel Girl" Number="1" Volume="2011" Year="2011">
       <Id>978d89ae-22f9-42d8-94ba-5a1af32c414c</Id>
     </Book>
-    <Book Series="Iceman and Angel" Number="1" Volume="2011" Year="2011" Format="One-Shot">
+    <Book Series="Iceman and Angel" Number="1" Volume="2011" Year="2011">
       <Id>38bf1979-c160-43d5-b64d-8e1056a9946a</Id>
     </Book>
-    <Book Series="Cyclops" Number="1" Volume="2011" Year="2011" Format="One-Shot">
+    <Book Series="Cyclops" Number="1" Volume="2011" Year="2011">
       <Id>29ff87ce-d066-49c8-bbf8-01268fd2ac2f</Id>
     </Book>
-    <Book Series="New Mutants" Number="20" Volume="2009" Year="2011" Format="Main Series">
+    <Book Series="New Mutants" Number="20" Volume="2009" Year="2011">
       <Id>ebc39d63-8839-469e-add4-c5875fd0c518</Id>
     </Book>
-    <Book Series="New Mutants" Number="21" Volume="2009" Year="2011" Format="Main Series">
+    <Book Series="New Mutants" Number="21" Volume="2009" Year="2011">
       <Id>24f8702a-deb6-4a98-95a3-e64f24bd4bc5</Id>
     </Book>
-    <Book Series="Age of X: Alpha" Number="1" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Age of X: Alpha" Number="1" Volume="2011" Year="2011">
       <Id>ba45baa5-c7a3-470a-b42f-448ea13cf901</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="245" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="245" Volume="2008" Year="2011">
       <Id>aff80106-3135-4bac-99a9-0923465aa4b0</Id>
     </Book>
-    <Book Series="New Mutants" Number="22" Volume="2009" Year="2011" Format="Main Series">
+    <Book Series="New Mutants" Number="22" Volume="2009" Year="2011">
       <Id>19f0b5f4-1ec3-4448-8568-5e7d7253373c</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="246" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="246" Volume="2008" Year="2011">
       <Id>78d2ec5a-7985-4d81-90b9-93baa2387eb1</Id>
     </Book>
-    <Book Series="New Mutants" Number="23" Volume="2009" Year="2011" Format="Main Series">
+    <Book Series="New Mutants" Number="23" Volume="2009" Year="2011">
       <Id>577921a0-b985-4640-8884-ea80d295c32d</Id>
     </Book>
-    <Book Series="Age of X: Universe" Number="1" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Age of X: Universe" Number="1" Volume="2011" Year="2011">
       <Id>990bf152-a212-4133-9530-af02f5c0fb1c</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="247" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="247" Volume="2008" Year="2011">
       <Id>f604c559-881b-4051-8fc2-680149e3272f</Id>
     </Book>
-    <Book Series="New Mutants" Number="24" Volume="2009" Year="2011" Format="Main Series">
+    <Book Series="New Mutants" Number="24" Volume="2009" Year="2011">
       <Id>8a33e202-bb5b-481d-981e-5758e73de575</Id>
     </Book>
-    <Book Series="Age of X: Universe" Number="2" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Age of X: Universe" Number="2" Volume="2011" Year="2011">
       <Id>dff031b5-6f78-4d03-a68d-ee25b62beb9e</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="248" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="248" Volume="2008" Year="2011">
       <Id>ae4e23ba-bb21-412c-8636-584861860dc4</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="249" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="249" Volume="2008" Year="2011">
       <Id>7b5c6a07-cfff-4e4f-8bbd-c5370e98a110</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="250" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="250" Volume="2008" Year="2011">
       <Id>068e3474-df8d-4e93-9305-4b6f6f8445a5</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="251" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="251" Volume="2008" Year="2011">
       <Id>020aa3b5-c7d8-4d22-8704-8af45632c2fb</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="252" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="252" Volume="2008" Year="2011">
       <Id>9d8969cf-14bb-423e-a55c-2ed33b69c9d1</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="253" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="253" Volume="2008" Year="2011">
       <Id>2036b904-024e-4d94-8149-036e6a5fcb5f</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="254" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="254" Volume="2008" Year="2011">
       <Id>fd4a288d-baf4-487f-8957-cdd3b46208bc</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="255" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="255" Volume="2008" Year="2011">
       <Id>e7ad826b-fde0-4608-b45d-c80a1d479ffd</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="256" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="256" Volume="2008" Year="2011">
       <Id>9dfa9584-00f8-4a3c-825e-d1710a90d667</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="257" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="257" Volume="2008" Year="2011">
       <Id>61baf622-0d85-4ecc-8a13-10208925ea56</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="258" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="258" Volume="2008" Year="2012">
       <Id>c438a8e6-d865-4aaf-becf-952e0adfd455</Id>
     </Book>
-    <Book Series="New Mutants" Number="25" Volume="2009" Year="2011" Format="Main Series">
+    <Book Series="New Mutants" Number="25" Volume="2009" Year="2011">
       <Id>5c99b79a-b280-4b12-8d4b-65973ca6aa2a</Id>
     </Book>
-    <Book Series="New Mutants" Number="26" Volume="2009" Year="2011" Format="Main Series">
+    <Book Series="New Mutants" Number="26" Volume="2009" Year="2011">
       <Id>21a6702a-70f0-4535-9529-03cf8f4dcc2c</Id>
     </Book>
-    <Book Series="New Mutants" Number="27" Volume="2009" Year="2011" Format="Main Series">
+    <Book Series="New Mutants" Number="27" Volume="2009" Year="2011">
       <Id>5d3170e0-7b90-4234-befe-67ade0d31e5b</Id>
     </Book>
-    <Book Series="New Mutants" Number="28" Volume="2009" Year="2011" Format="Main Series">
+    <Book Series="New Mutants" Number="28" Volume="2009" Year="2011">
       <Id>54bda66c-76e1-4d37-b70a-00480a86e5f5</Id>
     </Book>
-    <Book Series="Generation Hope" Number="6" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Generation Hope" Number="6" Volume="2011" Year="2011">
       <Id>fc310259-a9d0-46bf-995c-fcf84089c293</Id>
     </Book>
-    <Book Series="Generation Hope" Number="7" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Generation Hope" Number="7" Volume="2011" Year="2011">
       <Id>3ca4452c-e21e-4629-a1ad-675851627c5c</Id>
     </Book>
-    <Book Series="Generation Hope" Number="8" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Generation Hope" Number="8" Volume="2011" Year="2011">
       <Id>00656d01-c0ac-417d-bd6d-6dbf813ddabb</Id>
     </Book>
-    <Book Series="Generation Hope" Number="9" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Generation Hope" Number="9" Volume="2011" Year="2011">
       <Id>4f349aed-e4d6-402f-a632-8737c9a0ff6a</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="36" Volume="2004" Year="2011" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="36" Volume="2004" Year="2011">
       <Id>fad0bd49-944b-4bda-8c13-0bb5d2b13040</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="37" Volume="2004" Year="2011" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="37" Volume="2004" Year="2011">
       <Id>b8ce043f-3c15-4024-af93-1dab91d3286c</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="38" Volume="2004" Year="2011" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="38" Volume="2004" Year="2011">
       <Id>7690fb78-8cc5-4801-8811-edabd6b547ff</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="39" Volume="2004" Year="2011" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="39" Volume="2004" Year="2011">
       <Id>44d979fe-f05e-44e4-92e8-07ca7d17aac3</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="40" Volume="2004" Year="2011" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="40" Volume="2004" Year="2011">
       <Id>0ce17d5a-571d-40b2-ab82-16ee1a3f6c18</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="41" Volume="2004" Year="2011" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="41" Volume="2004" Year="2011">
       <Id>9b051de1-2943-4e2e-9e73-36e6b8fd9cf3</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="42" Volume="2004" Year="2011" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="42" Volume="2004" Year="2011">
       <Id>79b75353-29e2-4e23-bfa7-6620a5a09d8d</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="534.1" Volume="1981" Year="2011" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="534.1" Volume="1981" Year="2011">
       <Id>f1c2d1ae-25ee-46a4-bb95-5ea014fc268b</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="535" Volume="1981" Year="2011" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="535" Volume="1981" Year="2011">
       <Id>db3921ca-cea1-47e6-bcf1-add03812c0be</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="536" Volume="1981" Year="2011" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="536" Volume="1981" Year="2011">
       <Id>952b8cba-bdc2-459a-8c39-4cf01bbe521d</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="537" Volume="1981" Year="2011" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="537" Volume="1981" Year="2011">
       <Id>4ee8185f-fc11-436c-9e16-98ec32945d36</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="538" Volume="1981" Year="2011" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="538" Volume="1981" Year="2011">
       <Id>5638e475-2053-42b8-9e21-0b0de6bce09c</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="539" Volume="1981" Year="2011" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="539" Volume="1981" Year="2011">
       <Id>e09b1e91-1280-4bb3-80e8-5642874041cd</Id>
     </Book>
-    <Book Series="Daken: Dark Wolverine" Number="9.1" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Daken: Dark Wolverine" Number="9.1" Volume="2010" Year="2011">
       <Id>0db51bed-22bc-4ee2-9b5d-3ef7c28853d1</Id>
     </Book>
-    <Book Series="Daken: Dark Wolverine" Number="10" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Daken: Dark Wolverine" Number="10" Volume="2010" Year="2011">
       <Id>38287a1d-9b89-4579-8ea6-a610dca96def</Id>
     </Book>
-    <Book Series="Daken: Dark Wolverine" Number="11" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Daken: Dark Wolverine" Number="11" Volume="2010" Year="2011">
       <Id>1d2c72d9-9a23-4449-8fb9-bc5f7eafa6b0</Id>
     </Book>
-    <Book Series="Daken: Dark Wolverine" Number="12" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Daken: Dark Wolverine" Number="12" Volume="2010" Year="2011">
       <Id>c74cb209-cc87-4e24-b9c4-19d3ec53d33d</Id>
     </Book>
-    <Book Series="Daken: Dark Wolverine" Number="13" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Daken: Dark Wolverine" Number="13" Volume="2010" Year="2011">
       <Id>0ceb4be4-135c-448c-8101-dc9a615b9756</Id>
     </Book>
-    <Book Series="Daken: Dark Wolverine" Number="14" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Daken: Dark Wolverine" Number="14" Volume="2010" Year="2011">
       <Id>b46de065-f288-44fd-91db-9252207b36ed</Id>
     </Book>
-    <Book Series="Daken: Dark Wolverine" Number="15" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Daken: Dark Wolverine" Number="15" Volume="2010" Year="2011">
       <Id>e22bb796-48f5-4284-b63b-5a1608634878</Id>
     </Book>
-    <Book Series="Daken: Dark Wolverine" Number="16" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Daken: Dark Wolverine" Number="16" Volume="2010" Year="2011">
       <Id>c1eef4cd-2be1-45c4-b7c2-f8001168d372</Id>
     </Book>
-    <Book Series="Daken: Dark Wolverine" Number="17" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Daken: Dark Wolverine" Number="17" Volume="2010" Year="2012">
       <Id>1e6509db-f988-4cb2-85ae-0a42aab381c5</Id>
     </Book>
-    <Book Series="Daken: Dark Wolverine" Number="18" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Daken: Dark Wolverine" Number="18" Volume="2010" Year="2012">
       <Id>6c7f77e9-74dc-4ead-89d2-cc18aff7c7e5</Id>
     </Book>
-    <Book Series="Daken: Dark Wolverine" Number="19" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Daken: Dark Wolverine" Number="19" Volume="2010" Year="2012">
       <Id>34b60b9d-520a-49a2-a9c9-1f3597f85606</Id>
     </Book>
-    <Book Series="X-23" Number="10" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-23" Number="10" Volume="2010" Year="2011">
       <Id>4e2b677f-3a68-4f46-aa7a-a03b88601a09</Id>
     </Book>
-    <Book Series="X-23" Number="11" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-23" Number="11" Volume="2010" Year="2011">
       <Id>1bb1b8da-aa9e-41cd-af7b-627e0ffac842</Id>
     </Book>
-    <Book Series="X-23" Number="12" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-23" Number="12" Volume="2010" Year="2011">
       <Id>8154fbb7-f5d0-40db-97ec-5d82470858c6</Id>
     </Book>
-    <Book Series="X-23" Number="13" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-23" Number="13" Volume="2010" Year="2011">
       <Id>89f206ee-8377-4a72-bc5d-40e2e120982d</Id>
     </Book>
-    <Book Series="X-23" Number="14" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-23" Number="14" Volume="2010" Year="2011">
       <Id>3a992cce-dfb0-4bf7-a57a-71b1e93128c9</Id>
     </Book>
-    <Book Series="X-23" Number="15" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="X-23" Number="15" Volume="2010" Year="2011">
       <Id>702c5a28-8ab5-4957-b76b-83f1216c77bf</Id>
     </Book>
-    <Book Series="X-23" Number="16" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="X-23" Number="16" Volume="2010" Year="2012">
       <Id>da7a5469-75b1-47b0-a187-5352e5ba338b</Id>
     </Book>
-    <Book Series="X-Men: Prelude to Schism" Number="1" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="X-Men: Prelude to Schism" Number="1" Volume="2011" Year="2011">
       <Id>0a06e988-0b72-47e5-bf65-de157fb88220</Id>
     </Book>
-    <Book Series="X-Men: Prelude to Schism" Number="2" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="X-Men: Prelude to Schism" Number="2" Volume="2011" Year="2011">
       <Id>5d6cfad4-0189-4b94-a952-2e2f217a691a</Id>
     </Book>
-    <Book Series="X-Men: Prelude to Schism" Number="3" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="X-Men: Prelude to Schism" Number="3" Volume="2011" Year="2011">
       <Id>035fcd65-3bea-4c8e-aecb-5c3257e2e887</Id>
     </Book>
-    <Book Series="X-Men: Prelude to Schism" Number="4" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="X-Men: Prelude to Schism" Number="4" Volume="2011" Year="2011">
       <Id>87c22a17-afcb-4d33-8f54-d6bed07cc9d9</Id>
     </Book>
-    <Book Series="Fear Itself: Sin's Past" Number="1" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Fear Itself: Sin's Past" Number="1" Volume="2011" Year="2011">
       <Id>7d4092ee-d068-43c0-9cfd-26bd164b08ae</Id>
     </Book>
-    <Book Series="Fear Itself: Book of the Skull" Number="1" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Fear Itself: Book of the Skull" Number="1" Volume="2011" Year="2011">
       <Id>26d6cf57-8804-4342-90ff-cf48489c5038</Id>
     </Book>
-    <Book Series="Fear Itself" Number="1" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Fear Itself" Number="1" Volume="2011" Year="2011">
       <Id>f7b6b461-3686-46e9-a5c8-faaa26abe61f</Id>
     </Book>
-    <Book Series="Fear Itself" Number="2" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Fear Itself" Number="2" Volume="2011" Year="2011">
       <Id>657ea318-89cc-4107-959a-18dbeaef810c</Id>
     </Book>
-    <Book Series="Fear Itself: Wolverine" Number="1" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Fear Itself: Wolverine" Number="1" Volume="2011" Year="2011">
       <Id>5cfd1b3f-7f91-4a1e-b95a-255335d5b03e</Id>
     </Book>
-    <Book Series="Fear Itself: Wolverine" Number="2" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Fear Itself: Wolverine" Number="2" Volume="2011" Year="2011">
       <Id>02742319-aa24-4d5f-9caa-fb79bdaf82a5</Id>
     </Book>
-    <Book Series="Fear Itself" Number="3" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Fear Itself" Number="3" Volume="2011" Year="2011">
       <Id>fee3109e-a456-4ca7-884a-bb54c3ad7880</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="0.1" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Alpha Flight" Number="0.1" Volume="2011" Year="2011">
       <Id>437fea0c-cc16-4a0f-ba00-f28fe9b3b9be</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="1" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Alpha Flight" Number="1" Volume="2011" Year="2011">
       <Id>d1cc0305-8f5e-4d74-b6ea-6f4d2743a8c7</Id>
     </Book>
-    <Book Series="Fear Itself: Wolverine" Number="3" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Fear Itself: Wolverine" Number="3" Volume="2011" Year="2011">
       <Id>f0221623-0d5e-46c6-9e48-0c29f1f2bdf5</Id>
     </Book>
-    <Book Series="Fear Itself: Uncanny X-Force" Number="1" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Fear Itself: Uncanny X-Force" Number="1" Volume="2011" Year="2011">
       <Id>05819f77-47b1-4cc0-a888-549f796e90da</Id>
     </Book>
-    <Book Series="Fear Itself" Number="4" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Fear Itself" Number="4" Volume="2011" Year="2011">
       <Id>fe09a64f-eda8-4633-8f95-0ec6e3f08323</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="540" Volume="1981" Year="2011" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="540" Volume="1981" Year="2011">
       <Id>3ff81e59-367e-4260-afa6-866853d7b2e2</Id>
     </Book>
-    <Book Series="Fear Itself: Uncanny X-Force" Number="2" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Fear Itself: Uncanny X-Force" Number="2" Volume="2011" Year="2011">
       <Id>8f6cab9f-71d4-4cdc-b201-92763db5c62d</Id>
     </Book>
-    <Book Series="Fear Itself: Uncanny X-Force" Number="3" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Fear Itself: Uncanny X-Force" Number="3" Volume="2011" Year="2011">
       <Id>10367a11-54e0-4a66-9736-8aedc73274ea</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="541" Volume="1981" Year="2011" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="541" Volume="1981" Year="2011">
       <Id>072047f0-17a1-424d-90ea-60d28ca898c3</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="2" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Alpha Flight" Number="2" Volume="2011" Year="2011">
       <Id>ee99124e-68b9-4958-8c17-76b0c7d2448b</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="3" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Alpha Flight" Number="3" Volume="2011" Year="2011">
       <Id>aaec1154-eab9-4032-bdb7-b8ad8aa742a3</Id>
     </Book>
-    <Book Series="New Mutants" Number="29" Volume="2009" Year="2011" Format="Main Series">
+    <Book Series="New Mutants" Number="29" Volume="2009" Year="2011">
       <Id>4dc8caee-580a-4acf-a5d5-4fb0aa88dd78</Id>
     </Book>
-    <Book Series="New Mutants" Number="30" Volume="2009" Year="2011" Format="Main Series">
+    <Book Series="New Mutants" Number="30" Volume="2009" Year="2011">
       <Id>7107afa8-1451-47d0-a7b4-47e7e2c4d0a5</Id>
     </Book>
-    <Book Series="New Mutants" Number="31" Volume="2009" Year="2011" Format="Main Series">
+    <Book Series="New Mutants" Number="31" Volume="2009" Year="2011">
       <Id>fcafc5a6-e941-4523-b13d-abaf22663d80</Id>
     </Book>
-    <Book Series="New Mutants" Number="32" Volume="2009" Year="2011" Format="Main Series">
+    <Book Series="New Mutants" Number="32" Volume="2009" Year="2011">
       <Id>f5372552-24c4-4f13-9c6c-dc81a27b02b5</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="542" Volume="1981" Year="2011" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="542" Volume="1981" Year="2011">
       <Id>978dbadc-a19c-4931-bfdc-04c6382ba132</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="543" Volume="1981" Year="2011" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="543" Volume="1981" Year="2011">
       <Id>42f31a08-b95c-470d-bcdf-756326ff18d2</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="4" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Alpha Flight" Number="4" Volume="2011" Year="2011">
       <Id>2f3f692a-a818-45dd-b9f1-29df6b4971fa</Id>
     </Book>
-    <Book Series="Fear Itself" Number="5" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Fear Itself" Number="5" Volume="2011" Year="2011">
       <Id>f9a10c83-e35e-4786-8579-ae2f9801a80b</Id>
     </Book>
-    <Book Series="Fear Itself: The Deep" Number="1" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Fear Itself: The Deep" Number="1" Volume="2011" Year="2011">
       <Id>f0d17751-f55a-4f66-b0ed-cad512473a89</Id>
     </Book>
-    <Book Series="Fear Itself: The Deep" Number="2" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Fear Itself: The Deep" Number="2" Volume="2011" Year="2011">
       <Id>316e8d1d-9ae0-4587-a133-503060337140</Id>
     </Book>
-    <Book Series="Fear Itself: The Deep" Number="3" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Fear Itself: The Deep" Number="3" Volume="2011" Year="2011">
       <Id>dc6aaa49-a135-4b4f-b492-a01ed2341231</Id>
     </Book>
-    <Book Series="Fear Itself: The Deep" Number="4" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Fear Itself: The Deep" Number="4" Volume="2011" Year="2011">
       <Id>8f8c2bec-d604-4c62-a1c1-3b6639d4569f</Id>
     </Book>
-    <Book Series="Fear Itself" Number="6" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Fear Itself" Number="6" Volume="2011" Year="2011">
       <Id>43146781-8a88-44d2-9751-5e862bc22b16</Id>
     </Book>
-    <Book Series="Fear Itself" Number="7" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Fear Itself" Number="7" Volume="2011" Year="2011">
       <Id>cfe1aac4-1232-494e-8a06-d6e18d2339be</Id>
     </Book>
-    <Book Series="Wolverine" Number="10" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Wolverine" Number="10" Volume="2010" Year="2011">
       <Id>7528420e-9700-4c54-913d-511435da91b5</Id>
     </Book>
-    <Book Series="Wolverine" Number="11" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Wolverine" Number="11" Volume="2010" Year="2011">
       <Id>bcfd0711-22d6-42dc-b8ea-8dcc98d1a1fb</Id>
     </Book>
-    <Book Series="Wolverine" Number="12" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Wolverine" Number="12" Volume="2010" Year="2011">
       <Id>992686dd-e04b-46fd-a9ec-29a90a96c1c6</Id>
     </Book>
-    <Book Series="Wolverine" Number="13" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Wolverine" Number="13" Volume="2010" Year="2011">
       <Id>c8a5c861-a0b2-4d68-a340-3d7a0410e088</Id>
     </Book>
-    <Book Series="Wolverine" Number="14" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Wolverine" Number="14" Volume="2010" Year="2011">
       <Id>2b343369-d418-471b-8ac2-aaa673c8d4d1</Id>
     </Book>
-    <Book Series="Wolverine" Number="15" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Wolverine" Number="15" Volume="2010" Year="2011">
       <Id>80a194ec-7ace-4a0a-8853-2650747a167e</Id>
     </Book>
-    <Book Series="Wolverine" Number="16" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Wolverine" Number="16" Volume="2010" Year="2011">
       <Id>77d6660c-f14a-41e1-a856-b0b749be4071</Id>
     </Book>
   </Books>

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 013 - (Regenesis).cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 013 - (Regenesis).cbl
@@ -2,1051 +2,1051 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>X-Men - Part 13 - (Regenesis)</Name>
   <Books>
-    <Book Series="X-Men: Schism" Number="1" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="X-Men: Schism" Number="1" Volume="2011" Year="2011">
       <Id>a9e95a16-497d-42bd-b4bd-269b31eee1ef</Id>
     </Book>
-    <Book Series="X-Men: Schism" Number="2" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="X-Men: Schism" Number="2" Volume="2011" Year="2011">
       <Id>29df7ed5-925f-4110-ab56-bc3ed83330d9</Id>
     </Book>
-    <Book Series="X-Men: Schism" Number="3" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="X-Men: Schism" Number="3" Volume="2011" Year="2011">
       <Id>ceca5705-ac96-4faf-915c-d55eb52f455f</Id>
     </Book>
-    <Book Series="Generation Hope" Number="10" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Generation Hope" Number="10" Volume="2011" Year="2011">
       <Id>f7569c60-4d5f-4709-a9d9-5dfed699bfd9</Id>
     </Book>
-    <Book Series="X-Men: Schism" Number="4" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="X-Men: Schism" Number="4" Volume="2011" Year="2011">
       <Id>94c6429a-17b9-4c38-b0b8-9e79bf25e508</Id>
     </Book>
-    <Book Series="Generation Hope" Number="11" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Generation Hope" Number="11" Volume="2011" Year="2011">
       <Id>bc0553d8-fde8-4573-946c-1c44c6781a3a</Id>
     </Book>
-    <Book Series="X-Men: Schism" Number="5" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="X-Men: Schism" Number="5" Volume="2011" Year="2011">
       <Id>02121850-8f71-475e-8d91-aebd1fa9ede8</Id>
     </Book>
-    <Book Series="The Uncanny X-Men" Number="544" Volume="1981" Year="2011" Format="Main Series">
+    <Book Series="The Uncanny X-Men" Number="544" Volume="1981" Year="2011">
       <Id>1185dbd7-45b6-45a1-89a1-437db40b6fed</Id>
     </Book>
-    <Book Series="Generation Hope" Number="12" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Generation Hope" Number="12" Volume="2011" Year="2011">
       <Id>74b795a3-3188-4d55-a8a7-99e976754f81</Id>
     </Book>
-    <Book Series="X-Men: Regenesis" Number="1" Volume="2011" Year="2011" Format="One-Shot">
+    <Book Series="X-Men: Regenesis" Number="1" Volume="2011" Year="2011">
       <Id>8452e7f6-eae8-4929-b1a6-316bbf2a76e5</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="8" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="8" Volume="2010" Year="2011">
       <Id>ab7fdf72-8f77-490d-bb07-5c9c0ec49b8b</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="9" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="9" Volume="2010" Year="2011">
       <Id>9735be17-3067-42bb-af07-fdb71571fdeb</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="10" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="10" Volume="2010" Year="2011">
       <Id>471b422b-c4b4-42a5-a367-01c7621c5fc1</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="11" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="11" Volume="2010" Year="2011">
       <Id>b60b39a3-de9a-45c7-977a-6f1bfb783a1c</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="12" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="12" Volume="2010" Year="2011">
       <Id>3f5530c9-b3aa-4512-9312-d2c0d70facd5</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="13" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="13" Volume="2010" Year="2011">
       <Id>2d4497e9-3567-4669-a53f-044ed61fa10b</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="14" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="14" Volume="2010" Year="2011">
       <Id>5f7f4bf3-d165-48a3-849d-81710486bb24</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="15" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="15" Volume="2010" Year="2011">
       <Id>391c8da3-683a-4967-8dc7-a85b1889c877</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="16" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="16" Volume="2010" Year="2011">
       <Id>3506c217-70d2-490f-80f0-af13959b2a62</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="17" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="17" Volume="2010" Year="2012">
       <Id>d27a5b6f-0f52-42f7-92f6-57337088a3cb</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="18" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="18" Volume="2010" Year="2012">
       <Id>28c0b637-4a23-46c8-b67b-2c73a154e978</Id>
     </Book>
-    <Book Series="X-Factor" Number="224.1" Volume="2006" Year="2011" Format="Main Series">
+    <Book Series="X-Factor" Number="224.1" Volume="2006" Year="2011">
       <Id>9635711e-3e5e-4a54-84a5-adce37d79497</Id>
     </Book>
-    <Book Series="X-Factor" Number="225" Volume="2006" Year="2011" Format="Main Series">
+    <Book Series="X-Factor" Number="225" Volume="2006" Year="2011">
       <Id>f12028c4-1230-41de-81ea-5acd981be485</Id>
     </Book>
-    <Book Series="X-Factor" Number="226" Volume="2006" Year="2011" Format="Main Series">
+    <Book Series="X-Factor" Number="226" Volume="2006" Year="2011">
       <Id>8e128f75-9777-4deb-af28-288da7e1847c</Id>
     </Book>
-    <Book Series="X-Factor" Number="227" Volume="2006" Year="2012" Format="Main Series">
+    <Book Series="X-Factor" Number="227" Volume="2006" Year="2012">
       <Id>77508e12-2166-4d28-a17a-ca333700c611</Id>
     </Book>
-    <Book Series="X-Factor" Number="228" Volume="2006" Year="2012" Format="Main Series">
+    <Book Series="X-Factor" Number="228" Volume="2006" Year="2012">
       <Id>8672cc67-4543-4730-b9db-b5b17a660b2d</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="5" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Alpha Flight" Number="5" Volume="2011" Year="2011">
       <Id>d7a76ba1-81a4-4aea-a06f-7c1c799f8829</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="6" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Alpha Flight" Number="6" Volume="2011" Year="2012">
       <Id>c1e428f0-0a04-4f4a-bace-cb17b17f022a</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="7" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Alpha Flight" Number="7" Volume="2011" Year="2012">
       <Id>c1d39d63-fe62-4f56-ba15-207e68b4f3cf</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="8" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Alpha Flight" Number="8" Volume="2011" Year="2012">
       <Id>a0b1fb0e-35a7-4642-9538-f8bd18f05210</Id>
     </Book>
-    <Book Series="X-23" Number="17" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="X-23" Number="17" Volume="2010" Year="2012">
       <Id>2fee8da0-3f89-4d48-9278-cfe88be6edcb</Id>
     </Book>
-    <Book Series="X-23" Number="18" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="X-23" Number="18" Volume="2010" Year="2012">
       <Id>01d75287-f124-47ba-8bc4-849d51c97b60</Id>
     </Book>
-    <Book Series="X-23" Number="19" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="X-23" Number="19" Volume="2010" Year="2012">
       <Id>8d52c4bb-642c-48cd-b961-35466e72ad04</Id>
     </Book>
-    <Book Series="Wolverine" Number="17" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Wolverine" Number="17" Volume="2010" Year="2011">
       <Id>3fbccec5-e4d3-4003-bf3d-777a751e34d5</Id>
     </Book>
-    <Book Series="Wolverine" Number="18" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Wolverine" Number="18" Volume="2010" Year="2012">
       <Id>a948c9be-4618-4d0c-a6c5-cae8029a9b3a</Id>
     </Book>
-    <Book Series="Wolverine" Number="19" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Wolverine" Number="19" Volume="2010" Year="2012">
       <Id>861d4284-a7b2-4ef1-af47-5569e731362d</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="1" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="1" Volume="2012" Year="2012">
       <Id>bb579e6e-a3ae-4a6e-89ea-5d56a8a1b7e8</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="2" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="2" Volume="2012" Year="2012">
       <Id>89392cb5-d5ce-409f-b7e5-52b2e77abe86</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="3" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="3" Volume="2012" Year="2012">
       <Id>152764fb-2f6c-4466-acc9-1058e98dfc95</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="4" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="4" Volume="2012" Year="2012">
       <Id>0a0b344f-cf0b-4af3-acfb-344e158afa6b</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="1" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="1" Volume="2011" Year="2011">
       <Id>29fa3ffb-fde6-4ef2-bfb7-3405904ed723</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="2" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="2" Volume="2011" Year="2012">
       <Id>66d0d8d8-bb74-4f22-92e3-d5d388eae11c</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="3" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="3" Volume="2011" Year="2012">
       <Id>f59af4cb-0b09-4993-9ade-33f57dff9804</Id>
     </Book>
-    <Book Series="X-Men" Number="20" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="X-Men" Number="20" Volume="2010" Year="2012">
       <Id>291c1b4b-8583-45c4-85f1-168864d8a43b</Id>
     </Book>
-    <Book Series="X-Men" Number="21" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="X-Men" Number="21" Volume="2010" Year="2012">
       <Id>a0cbca8a-4112-4447-88d2-175a44ae728d</Id>
     </Book>
-    <Book Series="X-Men" Number="22" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="X-Men" Number="22" Volume="2010" Year="2012">
       <Id>7fe32a2b-9747-4b87-989f-5959fe7b905d</Id>
     </Book>
-    <Book Series="X-Men" Number="23" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="X-Men" Number="23" Volume="2010" Year="2012">
       <Id>48987e1c-80fd-423e-8ad0-142e408baa94</Id>
     </Book>
-    <Book Series="New Mutants" Number="33" Volume="2009" Year="2012" Format="Main Series">
+    <Book Series="New Mutants" Number="33" Volume="2009" Year="2012">
       <Id>f58b37be-e0d4-447e-b175-a0083f72c95b</Id>
     </Book>
-    <Book Series="New Mutants" Number="34" Volume="2009" Year="2012" Format="Main Series">
+    <Book Series="New Mutants" Number="34" Volume="2009" Year="2012">
       <Id>2a00cb95-2284-414e-8194-b11d36d1b1db</Id>
     </Book>
-    <Book Series="New Mutants" Number="35" Volume="2009" Year="2012" Format="Main Series">
+    <Book Series="New Mutants" Number="35" Volume="2009" Year="2012">
       <Id>0c1798bd-0f77-4871-9a84-942896336afa</Id>
     </Book>
-    <Book Series="New Mutants" Number="36" Volume="2009" Year="2012" Format="Main Series">
+    <Book Series="New Mutants" Number="36" Volume="2009" Year="2012">
       <Id>c0765dec-db73-4bfc-95fd-ed2d413a7a3f</Id>
     </Book>
-    <Book Series="New Mutants" Number="37" Volume="2009" Year="2012" Format="Main Series">
+    <Book Series="New Mutants" Number="37" Volume="2009" Year="2012">
       <Id>670d2898-f7e2-4427-a0d1-7d542edaaa55</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="259" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="259" Volume="2008" Year="2012">
       <Id>ae196749-66c5-4380-94a8-bb424f703cc9</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="260" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="260" Volume="2008" Year="2012">
       <Id>a8136fc7-2338-45ac-ac93-7ca04ce8f2f2</Id>
     </Book>
-    <Book Series="X-Factor" Number="229" Volume="2006" Year="2012" Format="Main Series">
+    <Book Series="X-Factor" Number="229" Volume="2006" Year="2012">
       <Id>70b4b0c1-f586-4c69-8fc6-134106135d02</Id>
     </Book>
-    <Book Series="X-Factor" Number="230" Volume="2006" Year="2012" Format="Main Series">
+    <Book Series="X-Factor" Number="230" Volume="2006" Year="2012">
       <Id>ebcea5c4-c479-47bf-9051-8de9892e61dd</Id>
     </Book>
-    <Book Series="X-Factor" Number="231" Volume="2006" Year="2012" Format="Main Series">
+    <Book Series="X-Factor" Number="231" Volume="2006" Year="2012">
       <Id>cb61fa88-3f0d-4634-9403-d2e83c2f72f8</Id>
     </Book>
-    <Book Series="X-Factor" Number="232" Volume="2006" Year="2012" Format="Main Series">
+    <Book Series="X-Factor" Number="232" Volume="2006" Year="2012">
       <Id>d1b218c4-6839-4446-a722-a7d8ed41e832</Id>
     </Book>
-    <Book Series="Generation Hope" Number="13" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Generation Hope" Number="13" Volume="2011" Year="2012">
       <Id>c999f3f8-4807-4c7b-a796-8b8dc1cf8a86</Id>
     </Book>
-    <Book Series="Generation Hope" Number="14" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Generation Hope" Number="14" Volume="2011" Year="2012">
       <Id>273f1999-8cbd-432c-9b3b-8fbe6cf95d61</Id>
     </Book>
-    <Book Series="Generation Hope" Number="15" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Generation Hope" Number="15" Volume="2011" Year="2012">
       <Id>33453e7b-1de0-4a6b-b5dd-96d588b98104</Id>
     </Book>
-    <Book Series="Generation Hope" Number="16" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Generation Hope" Number="16" Volume="2011" Year="2012">
       <Id>01f5f7c4-e01c-42ec-843d-fc2242862cff</Id>
     </Book>
-    <Book Series="Generation Hope" Number="17" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Generation Hope" Number="17" Volume="2011" Year="2012">
       <Id>662c9ca9-9937-440d-9c2c-d3e56ec769d5</Id>
     </Book>
-    <Book Series="Magneto: Not A Hero" Number="1" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Magneto: Not A Hero" Number="1" Volume="2012" Year="2012">
       <Id>77239656-6763-4e73-9e41-cf6149dd4f62</Id>
     </Book>
-    <Book Series="Magneto: Not A Hero" Number="2" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Magneto: Not A Hero" Number="2" Volume="2012" Year="2012">
       <Id>d43a0b6a-08a5-4564-8a26-c3e45af69cdf</Id>
     </Book>
-    <Book Series="Magneto: Not A Hero" Number="3" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Magneto: Not A Hero" Number="3" Volume="2012" Year="2012">
       <Id>e7d2ce0a-0662-450d-b030-4ce1740c3692</Id>
     </Book>
-    <Book Series="Magneto: Not A Hero" Number="4" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Magneto: Not A Hero" Number="4" Volume="2012" Year="2012">
       <Id>0180744d-0973-45f0-ad22-b1baece217a0</Id>
     </Book>
-    <Book Series="X-Club" Number="1" Volume="2011" Year="2012" Format="Limited Series">
+    <Book Series="X-Club" Number="1" Volume="2011" Year="2012">
       <Id>ae814b36-147d-4d29-8eec-fda39548de02</Id>
     </Book>
-    <Book Series="X-Club" Number="2" Volume="2011" Year="2012" Format="Limited Series">
+    <Book Series="X-Club" Number="2" Volume="2011" Year="2012">
       <Id>b98067f0-bc9b-4b71-b592-7cd681e5b308</Id>
     </Book>
-    <Book Series="X-Club" Number="3" Volume="2011" Year="2012" Format="Limited Series">
+    <Book Series="X-Club" Number="3" Volume="2011" Year="2012">
       <Id>53931315-636d-4794-a491-f738f03b3dd7</Id>
     </Book>
-    <Book Series="X-Club" Number="4" Volume="2011" Year="2012" Format="Limited Series">
+    <Book Series="X-Club" Number="4" Volume="2011" Year="2012">
       <Id>b753b9cb-e399-4bf3-ae22-917617d328a9</Id>
     </Book>
-    <Book Series="X-Club" Number="5" Volume="2011" Year="2012" Format="Limited Series">
+    <Book Series="X-Club" Number="5" Volume="2011" Year="2012">
       <Id>3e604998-1c5b-475a-b836-1ffcd779c3a5</Id>
     </Book>
-    <Book Series="Avengers: X-Sanction" Number="1" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Avengers: X-Sanction" Number="1" Volume="2012" Year="2012">
       <Id>c83bc85f-783c-4e16-b7b9-f3d91e435bb9</Id>
     </Book>
-    <Book Series="Avengers: X-Sanction" Number="2" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Avengers: X-Sanction" Number="2" Volume="2012" Year="2012">
       <Id>4d4a684b-c77d-4adf-b93e-5d5c55adc17b</Id>
     </Book>
-    <Book Series="Avengers: X-Sanction" Number="3" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Avengers: X-Sanction" Number="3" Volume="2012" Year="2012">
       <Id>0550b34e-e235-45b3-81d2-368d0ccd9601</Id>
     </Book>
-    <Book Series="Avengers: X-Sanction" Number="4" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Avengers: X-Sanction" Number="4" Volume="2012" Year="2012">
       <Id>04a79481-a1da-4ee9-94f1-c3956688eb01</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="43" Volume="2004" Year="2011" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="43" Volume="2004" Year="2011">
       <Id>e4ec3b5b-aed0-4104-901a-5a31c06ae589</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="44" Volume="2004" Year="2012" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="44" Volume="2004" Year="2012">
       <Id>cd589efc-b742-47cc-b504-92b8bf8035f3</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="45" Volume="2004" Year="2012" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="45" Volume="2004" Year="2012">
       <Id>e39729f3-5560-4ee6-bb98-06b4124c3abd</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="47" Volume="2004" Year="2012" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="47" Volume="2004" Year="2012">
       <Id>de3fcf2b-c102-48b5-b52d-16edbfac30e3</Id>
     </Book>
-    <Book Series="Wolverine and the X-Men: Alpha &amp; Omega" Number="1" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Wolverine and the X-Men: Alpha &amp; Omega" Number="1" Volume="2012" Year="2012">
       <Id>141b7015-1a3c-4d05-b52e-791a4fa353ac</Id>
     </Book>
-    <Book Series="Wolverine and the X-Men: Alpha &amp; Omega" Number="2" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Wolverine and the X-Men: Alpha &amp; Omega" Number="2" Volume="2012" Year="2012">
       <Id>2a848ea3-f4d4-45aa-a851-b782042a5b14</Id>
     </Book>
-    <Book Series="Wolverine and the X-Men: Alpha &amp; Omega" Number="3" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Wolverine and the X-Men: Alpha &amp; Omega" Number="3" Volume="2012" Year="2012">
       <Id>68281d63-64e1-4cad-bb90-0e2f56df6e66</Id>
     </Book>
-    <Book Series="Wolverine and the X-Men: Alpha &amp; Omega" Number="4" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Wolverine and the X-Men: Alpha &amp; Omega" Number="4" Volume="2012" Year="2012">
       <Id>d4224504-60c4-4265-afac-5f3c48d2915f</Id>
     </Book>
-    <Book Series="Wolverine and the X-Men: Alpha &amp; Omega" Number="5" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Wolverine and the X-Men: Alpha &amp; Omega" Number="5" Volume="2012" Year="2012">
       <Id>3678db98-a224-4890-9d88-9a4859fffa59</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="5" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="5" Volume="2012" Year="2012">
       <Id>a1f82865-8d2d-4df6-99a6-71775aed13e7</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="6" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="6" Volume="2012" Year="2012">
       <Id>89fecc15-a36d-480d-b06e-9cce907f57d6</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="7" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="7" Volume="2012" Year="2012">
       <Id>e5f5e8e6-b1b0-4932-8030-747e6f70ad9b</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="8" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="8" Volume="2012" Year="2012">
       <Id>621690f1-0bf5-4b70-8b30-53254bf70442</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="19" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="19" Volume="2010" Year="2012">
       <Id>6f32537a-08a1-40cd-9dde-8cf5edb5d757</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="19.1" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="19.1" Volume="2010" Year="2012">
       <Id>86dcb5f9-0f3b-4c9a-a3d5-a2da8a59d257</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="20" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="20" Volume="2010" Year="2012">
       <Id>26f9137e-21a6-40de-b2bc-d1c49b975c03</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="21" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="21" Volume="2010" Year="2012">
       <Id>a1d4ac54-104c-4266-920e-6829158300d1</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="22" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="22" Volume="2010" Year="2012">
       <Id>99ad9d15-e883-46b4-9eac-9005279c14f7</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="23" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="23" Volume="2010" Year="2012">
       <Id>dc9d6ee6-23ae-4841-8fa9-fdf157ec9209</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="4" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="4" Volume="2011" Year="2012">
       <Id>7430cc06-6f00-4085-9fca-78095fcbbd10</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="5" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="5" Volume="2011" Year="2012">
       <Id>69f75219-8d83-48f5-940c-e23415e46815</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="6" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="6" Volume="2011" Year="2012">
       <Id>6e82f362-cdd6-4c52-a097-c20db222cade</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="7" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="7" Volume="2011" Year="2012">
       <Id>ea24f7c0-697a-4aa0-aeba-a218151c2ebd</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="8" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="8" Volume="2011" Year="2012">
       <Id>4d2892aa-21db-4a93-8615-ca12280daf9d</Id>
     </Book>
-    <Book Series="Daken: Dark Wolverine" Number="20" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Daken: Dark Wolverine" Number="20" Volume="2010" Year="2012">
       <Id>0322e690-5604-477a-ae25-cbb71f3ecd97</Id>
     </Book>
-    <Book Series="Daken: Dark Wolverine" Number="21" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Daken: Dark Wolverine" Number="21" Volume="2010" Year="2012">
       <Id>cdc67e6b-0768-42d7-ba69-52825472e35c</Id>
     </Book>
-    <Book Series="Daken: Dark Wolverine" Number="22" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Daken: Dark Wolverine" Number="22" Volume="2010" Year="2012">
       <Id>d8983916-d447-47b7-984d-3374ae81ab33</Id>
     </Book>
-    <Book Series="Daken: Dark Wolverine" Number="23" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Daken: Dark Wolverine" Number="23" Volume="2010" Year="2012">
       <Id>a20f3d06-5088-4d3a-9df2-6cdb076c1414</Id>
     </Book>
-    <Book Series="X-23" Number="20" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="X-23" Number="20" Volume="2010" Year="2012">
       <Id>57947a41-774f-420f-b430-797269a9b4a5</Id>
     </Book>
-    <Book Series="X-23" Number="21" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="X-23" Number="21" Volume="2010" Year="2012">
       <Id>f2f69537-148c-4053-842c-5b89a7b000d7</Id>
     </Book>
-    <Book Series="Wolverine" Number="20" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Wolverine" Number="20" Volume="2010" Year="2012">
       <Id>0f7c4ac0-fa89-4c09-8c3c-3d13f45854ff</Id>
     </Book>
-    <Book Series="Wolverine" Number="300" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Wolverine" Number="300" Volume="2010" Year="2012">
       <Id>2f0ff4ef-99df-47b3-b332-a0f80422593d</Id>
     </Book>
-    <Book Series="Wolverine" Number="301" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Wolverine" Number="301" Volume="2010" Year="2012">
       <Id>d877de58-6fb1-4029-ab35-e34bf3292ef5</Id>
     </Book>
-    <Book Series="Wolverine" Number="302" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Wolverine" Number="302" Volume="2010" Year="2012">
       <Id>080d9944-76de-4070-af2e-620fca945256</Id>
     </Book>
-    <Book Series="Wolverine" Number="303" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Wolverine" Number="303" Volume="2010" Year="2012">
       <Id>91d37d61-edfd-425e-b8bf-cd137ba6b883</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="260.1" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="260.1" Volume="2008" Year="2012">
       <Id>7bc0bfa2-05e2-425f-8138-1c2e2811de58</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="261" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="261" Volume="2008" Year="2012">
       <Id>cf4eaa33-72a5-4923-8d36-13bb7f1633b4</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="262" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="262" Volume="2008" Year="2012">
       <Id>3f7e6fc9-b6d1-4bb3-bcb6-6a1fdbb76e13</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="263" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="263" Volume="2008" Year="2012">
       <Id>31a0a242-89d3-4422-8517-8fb7a443e905</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="264" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="264" Volume="2008" Year="2012">
       <Id>5d1458f6-5d51-48df-8f89-0fc390f96139</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="265" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="265" Volume="2008" Year="2012">
       <Id>fa1f9c3c-d7e8-4c72-b09d-3e9b11c939e9</Id>
     </Book>
-    <Book Series="X-Men" Number="24" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="X-Men" Number="24" Volume="2010" Year="2012">
       <Id>6d36346f-4752-4008-8ca0-11ba1226a9a0</Id>
     </Book>
-    <Book Series="X-Men" Number="25" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="X-Men" Number="25" Volume="2010" Year="2012">
       <Id>519c13ea-0277-4a1d-94bc-02a3f662370a</Id>
     </Book>
-    <Book Series="X-Men" Number="26" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="X-Men" Number="26" Volume="2010" Year="2012">
       <Id>51b11a2b-8493-478d-85fc-727f20d9a309</Id>
     </Book>
-    <Book Series="X-Men" Number="27" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="X-Men" Number="27" Volume="2010" Year="2012">
       <Id>74c85d79-d4a7-4612-99e1-0c87e52cfcbd</Id>
     </Book>
-    <Book Series="New Mutants" Number="38" Volume="2009" Year="2012" Format="Main Series">
+    <Book Series="New Mutants" Number="38" Volume="2009" Year="2012">
       <Id>5a9c6141-ebf4-4849-aeaf-9272a6ecb59a</Id>
     </Book>
-    <Book Series="New Mutants" Number="39" Volume="2009" Year="2012" Format="Main Series">
+    <Book Series="New Mutants" Number="39" Volume="2009" Year="2012">
       <Id>dd8171fc-613b-4217-9b08-fb4018af238a</Id>
     </Book>
-    <Book Series="New Mutants" Number="40" Volume="2009" Year="2012" Format="Main Series">
+    <Book Series="New Mutants" Number="40" Volume="2009" Year="2012">
       <Id>de704756-25b7-44f2-a9b9-8bf4b952729c</Id>
     </Book>
-    <Book Series="New Mutants" Number="41" Volume="2009" Year="2012" Format="Main Series">
+    <Book Series="New Mutants" Number="41" Volume="2009" Year="2012">
       <Id>f85b74d6-7382-4ebd-afa7-54be8182206d</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="9" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="9" Volume="2012" Year="2012">
       <Id>4cc96d45-80f4-4a8f-a157-c000973caef0</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="10" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="10" Volume="2012" Year="2012">
       <Id>298e4f9c-0c9d-4548-a791-53a21ad04459</Id>
     </Book>
-    <Book Series="X-Factor" Number="233" Volume="2006" Year="2012" Format="Main Series">
+    <Book Series="X-Factor" Number="233" Volume="2006" Year="2012">
       <Id>882b611d-9d05-477e-809d-bd0e8184a791</Id>
     </Book>
-    <Book Series="X-Factor" Number="234" Volume="2006" Year="2012" Format="Main Series">
+    <Book Series="X-Factor" Number="234" Volume="2006" Year="2012">
       <Id>d6168db5-e081-4716-b1bb-99021adb585c</Id>
     </Book>
-    <Book Series="X-Factor" Number="235" Volume="2006" Year="2012" Format="Main Series">
+    <Book Series="X-Factor" Number="235" Volume="2006" Year="2012">
       <Id>002ed441-1378-4fe4-b421-debe020d6085</Id>
     </Book>
-    <Book Series="X-Factor" Number="236" Volume="2006" Year="2012" Format="Main Series">
+    <Book Series="X-Factor" Number="236" Volume="2006" Year="2012">
       <Id>b0212ba1-ceb8-4d4c-a14a-a7e584267962</Id>
     </Book>
-    <Book Series="X-Factor" Number="237" Volume="2006" Year="2012" Format="Main Series">
+    <Book Series="X-Factor" Number="237" Volume="2006" Year="2012">
       <Id>fe9b99ae-de34-4b57-9435-296680f8282c</Id>
     </Book>
-    <Book Series="Exiled" Number="1" Volume="2012" Year="2012" Format="One-Shot">
+    <Book Series="Exiled" Number="1" Volume="2012" Year="2012">
       <Id>0f970768-b413-41c4-a673-8d5479ebe087</Id>
     </Book>
-    <Book Series="Journey into Mystery" Number="637" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Journey into Mystery" Number="637" Volume="2011" Year="2012">
       <Id>da3078b0-a380-450a-9dc2-67729949ad92</Id>
     </Book>
-    <Book Series="New Mutants" Number="42" Volume="2009" Year="2012" Format="Main Series">
+    <Book Series="New Mutants" Number="42" Volume="2009" Year="2012">
       <Id>2ddb7cb6-d83c-439e-a936-a5620f74c5a0</Id>
     </Book>
-    <Book Series="Journey into Mystery" Number="638" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Journey into Mystery" Number="638" Volume="2011" Year="2012">
       <Id>d4af5392-99ed-47f8-920e-cc2e8dc2a549</Id>
     </Book>
-    <Book Series="New Mutants" Number="43" Volume="2009" Year="2012" Format="Main Series">
+    <Book Series="New Mutants" Number="43" Volume="2009" Year="2012">
       <Id>f9ac1ef7-2a6f-4cae-b8eb-94073c51edf5</Id>
     </Book>
-    <Book Series="X-Men" Number="28" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="X-Men" Number="28" Volume="2010" Year="2012">
       <Id>5198c9a8-d667-44c2-84da-43668a8923c1</Id>
     </Book>
-    <Book Series="X-Men" Number="29" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="X-Men" Number="29" Volume="2010" Year="2012">
       <Id>97f99c56-3618-4870-b8a9-bfd24ec5735b</Id>
     </Book>
-    <Book Series="Age of Apocalypse" Number="1" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Age of Apocalypse" Number="1" Volume="2012" Year="2012">
       <Id>61fb06fc-48b6-4a17-b9e5-898a864757c5</Id>
     </Book>
-    <Book Series="Age of Apocalypse" Number="2" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Age of Apocalypse" Number="2" Volume="2012" Year="2012">
       <Id>c0e06f55-5057-48d0-95c3-f2b8739c0645</Id>
     </Book>
-    <Book Series="Age of Apocalypse" Number="3" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Age of Apocalypse" Number="3" Volume="2012" Year="2012">
       <Id>8d096535-701b-4b43-b2ad-f8b39c7940f2</Id>
     </Book>
-    <Book Series="Age of Apocalypse" Number="4" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Age of Apocalypse" Number="4" Volume="2012" Year="2012">
       <Id>2dbf3f3f-069e-461a-8ee2-d52cf327ad98</Id>
     </Book>
-    <Book Series="Age of Apocalypse" Number="5" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Age of Apocalypse" Number="5" Volume="2012" Year="2012">
       <Id>12524fe3-8804-4f7d-ae98-648e1ebb835b</Id>
     </Book>
-    <Book Series="Age of Apocalypse" Number="6" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Age of Apocalypse" Number="6" Volume="2012" Year="2012">
       <Id>38c49588-a823-448e-9c7d-7aa1b456c703</Id>
     </Book>
-    <Book Series="Wolverine" Number="304" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Wolverine" Number="304" Volume="2010" Year="2012">
       <Id>2d26fc3b-6768-4bb4-8439-31b757eabe73</Id>
     </Book>
-    <Book Series="Wolverine" Number="305" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Wolverine" Number="305" Volume="2010" Year="2012">
       <Id>89326ab3-bbe3-4f57-adc5-611b292b452a</Id>
     </Book>
-    <Book Series="Wolverine" Number="306" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Wolverine" Number="306" Volume="2010" Year="2012">
       <Id>841df45a-bd25-4fb0-b068-3934be58ad3b</Id>
     </Book>
-    <Book Series="Wolverine" Number="307" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Wolverine" Number="307" Volume="2010" Year="2012">
       <Id>c9dfc24e-8eca-4cf3-89f2-9fbc9d9c4f9a</Id>
     </Book>
-    <Book Series="Wolverine" Number="308" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Wolverine" Number="308" Volume="2010" Year="2012">
       <Id>fbb0564a-54d2-4faa-a3f0-fbed70b8fe97</Id>
     </Book>
-    <Book Series="New Mutants" Number="44" Volume="2009" Year="2012" Format="Main Series">
+    <Book Series="New Mutants" Number="44" Volume="2009" Year="2012">
       <Id>47dd8d86-d35e-48fc-8384-6547652a6bab</Id>
     </Book>
-    <Book Series="New Mutants" Number="45" Volume="2009" Year="2012" Format="Main Series">
+    <Book Series="New Mutants" Number="45" Volume="2009" Year="2012">
       <Id>38c9e321-8f09-4f5a-b247-708539e60423</Id>
     </Book>
-    <Book Series="New Mutants" Number="46" Volume="2009" Year="2012" Format="Main Series">
+    <Book Series="New Mutants" Number="46" Volume="2009" Year="2012">
       <Id>c6421d1b-3207-4895-bc4a-04579d6f3673</Id>
     </Book>
-    <Book Series="X-Men" Number="30" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="X-Men" Number="30" Volume="2010" Year="2012">
       <Id>1bf703a6-791b-4813-b773-fda204064dee</Id>
     </Book>
-    <Book Series="X-Men" Number="31" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="X-Men" Number="31" Volume="2010" Year="2012">
       <Id>76c59937-8f1e-4e05-ad11-7b41afbba517</Id>
     </Book>
-    <Book Series="X-Men" Number="32" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="X-Men" Number="32" Volume="2010" Year="2012">
       <Id>22f33e12-cdaa-40f1-99f5-642dde3eb235</Id>
     </Book>
-    <Book Series="X-Men" Number="33" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="X-Men" Number="33" Volume="2010" Year="2012">
       <Id>45ebff6a-38fc-4cbb-a833-861fd7667034</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="48" Volume="2004" Year="2012" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="48" Volume="2004" Year="2012">
       <Id>635580d7-0a72-4ad0-8e39-4b5f53d8e2be</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="49" Volume="2004" Year="2012" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="49" Volume="2004" Year="2012">
       <Id>0cdca09b-ea45-4008-89ff-fcde716f9de6</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="50" Volume="2004" Year="2012" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="50" Volume="2004" Year="2012">
       <Id>bc6df6ec-a730-4eca-99b2-c43323ee36fb</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="51" Volume="2004" Year="2012" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="51" Volume="2004" Year="2012">
       <Id>0a02adfe-de63-4f5d-bed0-a2b339079283</Id>
     </Book>
-    <Book Series="X-Factor" Number="238" Volume="2006" Year="2012" Format="Main Series">
+    <Book Series="X-Factor" Number="238" Volume="2006" Year="2012">
       <Id>6ccdfa71-3d0e-48b7-bf1a-c1ea5119f652</Id>
     </Book>
-    <Book Series="X-Factor" Number="239" Volume="2006" Year="2012" Format="Main Series">
+    <Book Series="X-Factor" Number="239" Volume="2006" Year="2012">
       <Id>fcf03c06-3f2c-4794-98aa-fc05bcb11d54</Id>
     </Book>
-    <Book Series="X-Factor" Number="240" Volume="2006" Year="2012" Format="Main Series">
+    <Book Series="X-Factor" Number="240" Volume="2006" Year="2012">
       <Id>1c217888-f358-4825-81f7-e6de2cbb9722</Id>
     </Book>
-    <Book Series="Avengers" Number="24.1" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Avengers" Number="24.1" Volume="2010" Year="2012">
       <Id>1b1e23d6-91fc-4227-9581-cd184923c039</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men" Number="0" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men" Number="0" Volume="2012" Year="2012">
       <Id>8c90eea4-ff80-41e0-964c-bb76b8cc39dd</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men: Infinite" Number="1" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men: Infinite" Number="1" Volume="2012" Year="2012">
       <Id>36be309e-31bd-46ef-8fd9-b26a44cc5612</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men" Number="1" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men" Number="1" Volume="2012" Year="2012">
       <Id>3ee055b9-6dc9-408e-84ab-4be34f7bd85a</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="9" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="9" Volume="2011" Year="2012">
       <Id>454d110a-ee27-44e9-acc8-ba28b02a9cfd</Id>
     </Book>
-    <Book Series="New Avengers" Number="24" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="New Avengers" Number="24" Volume="2010" Year="2012">
       <Id>20958fcc-9403-4197-9b41-3661142ce21e</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men" Number="2" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men" Number="2" Volume="2012" Year="2012">
       <Id>a1921a7d-8ab0-48e9-82fb-c6d8f75dd507</Id>
     </Book>
-    <Book Series="AVX: VS" Number="1" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="AVX: VS" Number="1" Volume="2012" Year="2012">
       <Id>852be60f-c2b3-4902-adab-9990dadef15b</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="11" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="11" Volume="2012" Year="2012">
       <Id>164caa74-41ee-4365-86de-b0126c726d23</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men" Number="3" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men" Number="3" Volume="2012" Year="2012">
       <Id>80e84dad-9553-4ebb-a739-d90636e3ee79</Id>
     </Book>
-    <Book Series="Avengers Academy" Number="29" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Avengers Academy" Number="29" Volume="2010" Year="2012">
       <Id>ae06f438-948a-4cf6-813b-8b0960fecda1</Id>
     </Book>
-    <Book Series="Avengers Academy" Number="30" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Avengers Academy" Number="30" Volume="2010" Year="2012">
       <Id>037842be-be48-41b3-aa58-f7c8edf022a8</Id>
     </Book>
-    <Book Series="Avengers Academy" Number="31" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Avengers Academy" Number="31" Volume="2010" Year="2012">
       <Id>0708a180-8dae-41d6-878f-6c04540e7db3</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="10" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="10" Volume="2011" Year="2012">
       <Id>99c1a28a-ade0-4778-8d58-898b670d197f</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="266" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="266" Volume="2008" Year="2012">
       <Id>2bc5a807-c6f4-4acf-b014-ce8fcc4f4973</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="267" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="267" Volume="2008" Year="2012">
       <Id>1e5ddb65-efb1-468f-bde1-4a8af200357a</Id>
     </Book>
-    <Book Series="Avengers" Number="25" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Avengers" Number="25" Volume="2010" Year="2012">
       <Id>ab98876e-d260-4d76-a610-69aa48585d20</Id>
     </Book>
-    <Book Series="Secret Avengers" Number="26" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Secret Avengers" Number="26" Volume="2010" Year="2012">
       <Id>0b3d10dd-77e2-4824-abcc-8a86cf9292ea</Id>
     </Book>
-    <Book Series="Secret Avengers" Number="27" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Secret Avengers" Number="27" Volume="2010" Year="2012">
       <Id>8187f37b-67a9-451a-a4a7-2f1472b24d0e</Id>
     </Book>
-    <Book Series="Secret Avengers" Number="28" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Secret Avengers" Number="28" Volume="2010" Year="2012">
       <Id>375b7c55-e1ac-49f4-9187-482793fea007</Id>
     </Book>
-    <Book Series="Avengers" Number="26" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Avengers" Number="26" Volume="2010" Year="2012">
       <Id>2d2a6b3a-0ee5-44a8-943b-7e210d54c6e5</Id>
     </Book>
-    <Book Series="Avengers" Number="27" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Avengers" Number="27" Volume="2010" Year="2012">
       <Id>66e69f6d-b4bf-4c7b-95dc-af1c15a97302</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men" Number="4" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men" Number="4" Volume="2012" Year="2012">
       <Id>c9f324ce-f4d1-4d0f-93bb-f49cf8d2e12e</Id>
     </Book>
-    <Book Series="AVX: VS" Number="2" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="AVX: VS" Number="2" Volume="2012" Year="2012">
       <Id>d5383d71-9604-47b8-9880-00a20d750598</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="11" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="11" Volume="2011" Year="2012">
       <Id>14657e5d-ea38-41f9-8400-096722bf5aa7</Id>
     </Book>
-    <Book Series="AVX: VS" Number="5" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="AVX: VS" Number="5" Volume="2012" Year="2012">
       <Id>ce9d97b7-df0d-431b-ad57-8dab2167946f</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="12" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="12" Volume="2012" Year="2012">
       <Id>8dcb86c7-0353-4094-a734-292238d4a86f</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men" Number="5" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men" Number="5" Volume="2012" Year="2012">
       <Id>d5e04532-7bd0-43f8-b4b6-838fca87c17b</Id>
     </Book>
-    <Book Series="AVX: VS" Number="3" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="AVX: VS" Number="3" Volume="2012" Year="2012">
       <Id>a2f16a70-7587-47aa-a7a6-00f6e5490bfa</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="13" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="13" Volume="2012" Year="2012">
       <Id>5825d9e6-f0b6-4c06-8426-496ecab7cf6e</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="14" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="14" Volume="2012" Year="2012">
       <Id>cb0435bc-ace6-47cc-b05e-62ae97456d70</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men" Number="6" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men" Number="6" Volume="2012" Year="2012">
       <Id>5f489e6e-8353-4ce0-9c27-f2aec9c0c3d5</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men: Infinite" Number="6" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men: Infinite" Number="6" Volume="2012" Year="2012">
       <Id>f9a4c9f7-96e9-4d90-bd94-a594985c5120</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="268" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="268" Volume="2008" Year="2012">
       <Id>1f0a35ec-e501-40a9-b624-1d5a86ded718</Id>
     </Book>
-    <Book Series="Avengers Academy" Number="32" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Avengers Academy" Number="32" Volume="2010" Year="2012">
       <Id>af50d147-d3df-4cf7-aed9-dd08abf313c3</Id>
     </Book>
-    <Book Series="Avengers Academy" Number="33" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Avengers Academy" Number="33" Volume="2010" Year="2012">
       <Id>cf965975-4898-46cd-a101-5e6dabccf1f7</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="16" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="16" Volume="2011" Year="2012">
       <Id>b68b0fa7-d16b-4cce-852c-15bf57b2ba8d</Id>
     </Book>
-    <Book Series="Avengers" Number="28" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Avengers" Number="28" Volume="2010" Year="2012">
       <Id>75bc807e-112c-40ce-b915-c241b87edaeb</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="15" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="15" Volume="2012" Year="2012">
       <Id>fedb99e1-2a4b-4b01-9ac7-db7b7ef27a4a</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="16" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="16" Volume="2012" Year="2012">
       <Id>001f88b5-9a34-4923-b638-8b8b22d8f050</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="17" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="17" Volume="2012" Year="2012">
       <Id>dc4799cc-b3cc-4c51-a6be-4991ca971d28</Id>
     </Book>
-    <Book Series="New Avengers" Number="29" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="New Avengers" Number="29" Volume="2010" Year="2012">
       <Id>00d47060-8834-444f-9bdc-3920e65ae18d</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men" Number="7" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men" Number="7" Volume="2012" Year="2012">
       <Id>db2de910-ad78-4d73-af4c-e846d9ad52f6</Id>
     </Book>
-    <Book Series="AVX: VS" Number="4" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="AVX: VS" Number="4" Volume="2012" Year="2012">
       <Id>3edb3248-3f08-449c-b2a7-90a330e2cc19</Id>
     </Book>
-    <Book Series="Avengers" Number="29" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Avengers" Number="29" Volume="2010" Year="2012">
       <Id>050cb84b-27bd-4ca2-a01c-c03f222c30a8</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="12" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="12" Volume="2011" Year="2012">
       <Id>85c38c76-5922-4086-9969-81b646aa4ce5</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="13" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="13" Volume="2011" Year="2012">
       <Id>99885785-1a89-4ae7-a661-dac83440f1b5</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men" Number="8" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men" Number="8" Volume="2012" Year="2012">
       <Id>4890b435-8d2d-4169-be96-748ee320601e</Id>
     </Book>
-    <Book Series="New Avengers" Number="25" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="New Avengers" Number="25" Volume="2010" Year="2012">
       <Id>a8ac332c-63fe-45de-9149-9f06f81fb21b</Id>
     </Book>
-    <Book Series="New Avengers" Number="26" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="New Avengers" Number="26" Volume="2010" Year="2012">
       <Id>a6e89747-9e68-40c7-9064-d21de051b628</Id>
     </Book>
-    <Book Series="New Avengers" Number="27" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="New Avengers" Number="27" Volume="2010" Year="2012">
       <Id>5f02b221-ee8d-49b3-bb16-fc412583feaa</Id>
     </Book>
-    <Book Series="New Avengers" Number="28" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="New Avengers" Number="28" Volume="2010" Year="2012">
       <Id>6ccce8a4-24ce-41fb-922f-d7ee876db2d6</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="269" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="269" Volume="2008" Year="2012">
       <Id>61d43fee-78ef-48d5-9f4e-9fe7b33add9c</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="270" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="270" Volume="2008" Year="2012">
       <Id>5d6db1ed-dab0-4a01-a9d9-47ebc05fcc38</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="14" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="14" Volume="2011" Year="2012">
       <Id>d2410b34-3d77-4060-b21b-081a54fc45b5</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men" Number="9" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men" Number="9" Volume="2012" Year="2012">
       <Id>c8c9640a-790b-4dee-a6fa-9256278457d4</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men: Infinite" Number="10" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men: Infinite" Number="10" Volume="2012" Year="2012">
       <Id>8d7c64c1-2a82-4864-9400-0a9b0075f5e6</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men" Number="10" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men" Number="10" Volume="2012" Year="2012">
       <Id>2b7cfa2a-bf09-4a88-82d9-ca28d40103b9</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="15" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="15" Volume="2011" Year="2012">
       <Id>046d2569-9af8-41db-bc2b-5580a4a6a0ca</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men" Number="11" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men" Number="11" Volume="2012" Year="2012">
       <Id>c389edff-e3ad-42d7-92b0-864483403a8c</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="18" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="18" Volume="2012" Year="2012">
       <Id>fee5eed8-87f5-499d-aef8-a60ac18fc9e3</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men" Number="12" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men" Number="12" Volume="2012" Year="2012">
       <Id>28a5a897-c409-48bb-8ac7-910c8b769a0a</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="19" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="19" Volume="2012" Year="2012">
       <Id>4043928a-aba8-40e8-b353-250b49eeffab</Id>
     </Book>
-    <Book Series="AVX: VS" Number="6" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="AVX: VS" Number="6" Volume="2012" Year="2012">
       <Id>2cad5742-b241-40b0-8d68-ba74909fd72e</Id>
     </Book>
-    <Book Series="New Avengers" Number="30" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="New Avengers" Number="30" Volume="2010" Year="2012">
       <Id>a212dc25-9367-451f-8bc4-6945a9a75e52</Id>
     </Book>
-    <Book Series="Avengers" Number="30" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Avengers" Number="30" Volume="2010" Year="2012">
       <Id>753e5980-c72e-4574-8236-62a220b0f577</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="20" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="20" Volume="2012" Year="2012">
       <Id>717d4443-4d1f-4f7a-9d37-a55f4bab494b</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="17" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="17" Volume="2011" Year="2012">
       <Id>b2954686-f6ec-4b03-9054-d443bd6cf821</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="18" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="18" Volume="2011" Year="2012">
       <Id>40bf5c00-5a92-481e-891f-cf42c38fba56</Id>
     </Book>
-    <Book Series="Wolverine" Number="310" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Wolverine" Number="310" Volume="2010" Year="2012">
       <Id>7d79df98-f973-48bb-84b2-e0d5b5d67126</Id>
     </Book>
-    <Book Series="Wolverine" Number="311" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Wolverine" Number="311" Volume="2010" Year="2012">
       <Id>ef46b583-9927-464f-9582-58f66ea362b1</Id>
     </Book>
-    <Book Series="Wolverine" Number="312" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Wolverine" Number="312" Volume="2010" Year="2012">
       <Id>719b9fde-3f38-4fae-9ce5-456d3d26ad4d</Id>
     </Book>
-    <Book Series="Wolverine" Number="313" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Wolverine" Number="313" Volume="2010" Year="2012">
       <Id>3de63068-33af-4285-aeea-ded2f998601a</Id>
     </Book>
-    <Book Series="Fantastic Four Annual" Number="33" Volume="1963" Year="2012" Format="Annual">
+    <Book Series="Fantastic Four Annual" Number="33" Volume="1963" Year="2012">
       <Id>b79d2c3f-7b78-4136-b10f-2d8b44dbcfb5</Id>
     </Book>
-    <Book Series="Daredevil Annual" Number="1" Volume="2012" Year="2012" Format="Annual">
+    <Book Series="Daredevil Annual" Number="1" Volume="2012" Year="2012">
       <Id>7ce3fbde-0a24-4516-bbc0-7c200f7d3df0</Id>
     </Book>
-    <Book Series="Wolverine Annual" Number="1" Volume="2012" Year="2012" Format="Annual">
+    <Book Series="Wolverine Annual" Number="1" Volume="2012" Year="2012">
       <Id>13ffa23f-665f-4e83-8df5-c178bccc5ffc</Id>
     </Book>
-    <Book Series="X-Men" Number="34" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="X-Men" Number="34" Volume="2010" Year="2012">
       <Id>d0fd66b4-079b-43c4-979e-68bcfdd9c839</Id>
     </Book>
-    <Book Series="X-Men" Number="35" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="X-Men" Number="35" Volume="2010" Year="2012">
       <Id>cc96e440-91b2-4d49-84c3-6d37033c1caa</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="271" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="271" Volume="2008" Year="2012">
       <Id>72b8d4df-aa7c-4c3b-9be2-be687d8581c2</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="272" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="272" Volume="2008" Year="2012">
       <Id>6a0fcbb8-95a0-4dba-8285-50e7c7d8a3ad</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="273" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="273" Volume="2008" Year="2012">
       <Id>a84286a8-f9ee-462a-8f49-88af7b4704b4</Id>
     </Book>
-    <Book Series="X-Factor" Number="241" Volume="2006" Year="2012" Format="Main Series">
+    <Book Series="X-Factor" Number="241" Volume="2006" Year="2012">
       <Id>73148dbe-56f8-42b9-aa70-d391fb3fd65a</Id>
     </Book>
-    <Book Series="X-Factor" Number="242" Volume="2006" Year="2012" Format="Main Series">
+    <Book Series="X-Factor" Number="242" Volume="2006" Year="2012">
       <Id>c0becab3-1826-460f-9be4-9f6c3f59e8d4</Id>
     </Book>
-    <Book Series="X-Factor" Number="243" Volume="2006" Year="2012" Format="Main Series">
+    <Book Series="X-Factor" Number="243" Volume="2006" Year="2012">
       <Id>8c3302a8-a174-411d-bc99-720ff1038769</Id>
     </Book>
-    <Book Series="X-Factor" Number="244" Volume="2006" Year="2012" Format="Main Series">
+    <Book Series="X-Factor" Number="244" Volume="2006" Year="2012">
       <Id>1064fee3-0aa9-45a8-90d2-db1cf3f28396</Id>
     </Book>
-    <Book Series="X-Factor" Number="245" Volume="2006" Year="2012" Format="Main Series">
+    <Book Series="X-Factor" Number="245" Volume="2006" Year="2012">
       <Id>6ba42e41-1d22-4369-8cda-88a5dc6535a1</Id>
     </Book>
-    <Book Series="X-Men" Number="36" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="X-Men" Number="36" Volume="2010" Year="2012">
       <Id>be70e826-ecc6-40ea-929b-26a758744672</Id>
     </Book>
-    <Book Series="X-Men" Number="37" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="X-Men" Number="37" Volume="2010" Year="2012">
       <Id>728eace1-2687-4551-9ee8-c9cb6163db80</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="274" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="274" Volume="2008" Year="2012">
       <Id>7b3ce6c2-ca75-449f-9323-6cc3db6b976a</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="275" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="275" Volume="2008" Year="2012">
       <Id>eb99f725-af6e-4841-83e5-932d4df34f49</Id>
     </Book>
-    <Book Series="New Mutants" Number="47" Volume="2009" Year="2012" Format="Main Series">
+    <Book Series="New Mutants" Number="47" Volume="2009" Year="2012">
       <Id>53a3bca5-d712-4e6e-8c26-1c5940f70148</Id>
     </Book>
-    <Book Series="New Mutants" Number="48" Volume="2009" Year="2012" Format="Main Series">
+    <Book Series="New Mutants" Number="48" Volume="2009" Year="2012">
       <Id>009d1308-6fe8-40b0-9c52-4a3e4ee337a3</Id>
     </Book>
-    <Book Series="New Mutants" Number="49" Volume="2009" Year="2012" Format="Main Series">
+    <Book Series="New Mutants" Number="49" Volume="2009" Year="2012">
       <Id>f53155cc-f7db-4349-92e1-0794a065743d</Id>
     </Book>
-    <Book Series="New Mutants" Number="50" Volume="2009" Year="2012" Format="Main Series">
+    <Book Series="New Mutants" Number="50" Volume="2009" Year="2012">
       <Id>03c45268-5903-4d1c-9794-44e3f814e432</Id>
     </Book>
-    <Book Series="AVX: Consequences" Number="1" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="AVX: Consequences" Number="1" Volume="2012" Year="2012">
       <Id>80007ccc-f077-4e48-9609-2c7644da178b</Id>
     </Book>
-    <Book Series="AVX: Consequences" Number="2" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="AVX: Consequences" Number="2" Volume="2012" Year="2012">
       <Id>34c04f3e-b843-434d-9f66-195fb366fded</Id>
     </Book>
-    <Book Series="AVX: Consequences" Number="3" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="AVX: Consequences" Number="3" Volume="2012" Year="2012">
       <Id>fa088423-5cdf-4eae-abd0-aa035e5e116f</Id>
     </Book>
-    <Book Series="AVX: Consequences" Number="4" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="AVX: Consequences" Number="4" Volume="2012" Year="2012">
       <Id>4a273330-8cc9-4b12-86a7-492a41152c30</Id>
     </Book>
-    <Book Series="AVX: Consequences" Number="5" Volume="2012" Year="2013" Format="Crossover">
+    <Book Series="AVX: Consequences" Number="5" Volume="2012" Year="2013">
       <Id>d2002c5e-ada1-468d-a769-8d3b24d933e5</Id>
     </Book>
-    <Book Series="Savage Wolverine" Number="1" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Savage Wolverine" Number="1" Volume="2013" Year="2013">
       <Id>7cef0cd4-29ce-4980-9e75-d9723ab857ba</Id>
     </Book>
-    <Book Series="Savage Wolverine" Number="2" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Savage Wolverine" Number="2" Volume="2013" Year="2013">
       <Id>1ebffb33-d0ce-4d18-af6f-cb6da2aa108d</Id>
     </Book>
-    <Book Series="Savage Wolverine" Number="3" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Savage Wolverine" Number="3" Volume="2013" Year="2013">
       <Id>9ddc9bbc-f315-4621-8822-03c89ad5b61f</Id>
     </Book>
-    <Book Series="Savage Wolverine" Number="4" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Savage Wolverine" Number="4" Volume="2013" Year="2013">
       <Id>bb64ba3f-e9bc-4c57-82ab-977b0ba6de24</Id>
     </Book>
-    <Book Series="Savage Wolverine" Number="5" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Savage Wolverine" Number="5" Volume="2013" Year="2013">
       <Id>0c1a4e79-0ff6-40b0-b598-57462c46399f</Id>
     </Book>
-    <Book Series="X-Factor" Number="246" Volume="2006" Year="2013" Format="Main Series">
+    <Book Series="X-Factor" Number="246" Volume="2006" Year="2013">
       <Id>b1506eff-6f4d-4946-bd4c-8f7e0b25dc86</Id>
     </Book>
-    <Book Series="X-Factor" Number="247" Volume="2006" Year="2013" Format="Main Series">
+    <Book Series="X-Factor" Number="247" Volume="2006" Year="2013">
       <Id>fd0faf1f-04b3-402b-8218-57cfff53e407</Id>
     </Book>
-    <Book Series="X-Factor" Number="248" Volume="2006" Year="2013" Format="Main Series">
+    <Book Series="X-Factor" Number="248" Volume="2006" Year="2013">
       <Id>9e3f37b4-b6cf-4ff2-9cb2-196100faf855</Id>
     </Book>
-    <Book Series="X-Factor" Number="249" Volume="2006" Year="2013" Format="Main Series">
+    <Book Series="X-Factor" Number="249" Volume="2006" Year="2013">
       <Id>ef4fab32-f6e9-446b-b10c-38d9c9fe6218</Id>
     </Book>
-    <Book Series="Savage Wolverine" Number="6" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Savage Wolverine" Number="6" Volume="2013" Year="2013">
       <Id>ac44dcf5-618f-4e73-b6b0-28c27ba7c702</Id>
     </Book>
-    <Book Series="Savage Wolverine" Number="7" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Savage Wolverine" Number="7" Volume="2013" Year="2013">
       <Id>7b82fde3-614c-4011-b105-78fe8246158b</Id>
     </Book>
-    <Book Series="Savage Wolverine" Number="8" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Savage Wolverine" Number="8" Volume="2013" Year="2013">
       <Id>1f721b13-6d57-4613-a555-f41dede19a9b</Id>
     </Book>
-    <Book Series="Deadpool" Number="1" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Deadpool" Number="1" Volume="2013" Year="2013">
       <Id>082ed43d-695d-4aa4-8b72-7bc05113cd11</Id>
     </Book>
-    <Book Series="Deadpool" Number="2" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Deadpool" Number="2" Volume="2013" Year="2013">
       <Id>00d4559c-f04c-439f-9990-f53121974d38</Id>
     </Book>
-    <Book Series="Deadpool" Number="3" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Deadpool" Number="3" Volume="2013" Year="2013">
       <Id>dee83ccf-06b3-47c2-beff-a3425f23c77b</Id>
     </Book>
-    <Book Series="Deadpool" Number="4" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Deadpool" Number="4" Volume="2013" Year="2013">
       <Id>1f139581-dcbf-4219-9e24-af058aa7158f</Id>
     </Book>
-    <Book Series="Deadpool" Number="5" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Deadpool" Number="5" Volume="2013" Year="2013">
       <Id>53895552-2fc4-480b-825b-3e3a93d1a402</Id>
     </Book>
-    <Book Series="Deadpool" Number="6" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Deadpool" Number="6" Volume="2013" Year="2013">
       <Id>4886e86e-1c0f-4634-b6db-4e5329f58962</Id>
     </Book>
-    <Book Series="X-Factor" Number="250" Volume="2006" Year="2013" Format="Main Series">
+    <Book Series="X-Factor" Number="250" Volume="2006" Year="2013">
       <Id>01434001-f3e4-4808-b892-2604bd376e3a</Id>
     </Book>
-    <Book Series="X-Factor" Number="251" Volume="2006" Year="2013" Format="Main Series">
+    <Book Series="X-Factor" Number="251" Volume="2006" Year="2013">
       <Id>2d0a7cf2-84dd-417c-af95-a9d532a01b21</Id>
     </Book>
-    <Book Series="X-Factor" Number="252" Volume="2006" Year="2013" Format="Main Series">
+    <Book Series="X-Factor" Number="252" Volume="2006" Year="2013">
       <Id>5e9ead2d-708b-49ac-a0ee-1e81f1a1b732</Id>
     </Book>
-    <Book Series="X-Factor" Number="253" Volume="2006" Year="2013" Format="Main Series">
+    <Book Series="X-Factor" Number="253" Volume="2006" Year="2013">
       <Id>9a5e3e80-124a-4da5-9f2d-d9a4c0a09f90</Id>
     </Book>
-    <Book Series="X-Factor" Number="254" Volume="2006" Year="2013" Format="Main Series">
+    <Book Series="X-Factor" Number="254" Volume="2006" Year="2013">
       <Id>b4db182f-c352-4481-a2cb-689a60728673</Id>
     </Book>
-    <Book Series="X-Factor" Number="255" Volume="2006" Year="2013" Format="Main Series">
+    <Book Series="X-Factor" Number="255" Volume="2006" Year="2013">
       <Id>07be473c-1ae8-458e-ae84-d4b3aaa5343f</Id>
     </Book>
-    <Book Series="X-Factor" Number="256" Volume="2006" Year="2013" Format="Main Series">
+    <Book Series="X-Factor" Number="256" Volume="2006" Year="2013">
       <Id>4ca4e409-8d76-450c-a26b-cb3fbf0d4317</Id>
     </Book>
-    <Book Series="X-Factor" Number="257" Volume="2006" Year="2013" Format="Main Series">
+    <Book Series="X-Factor" Number="257" Volume="2006" Year="2013">
       <Id>d65b07e8-7c07-4ca0-86a9-ca01daa78d2e</Id>
     </Book>
-    <Book Series="X-Factor" Number="258" Volume="2006" Year="2013" Format="Main Series">
+    <Book Series="X-Factor" Number="258" Volume="2006" Year="2013">
       <Id>fdde437f-6ec8-4482-a510-4c125c3f85c2</Id>
     </Book>
-    <Book Series="X-Factor" Number="259" Volume="2006" Year="2013" Format="Main Series">
+    <Book Series="X-Factor" Number="259" Volume="2006" Year="2013">
       <Id>46b9d7b6-6c2c-478d-9402-42c8764659f6</Id>
     </Book>
-    <Book Series="X-Factor" Number="260" Volume="2006" Year="2013" Format="Main Series">
+    <Book Series="X-Factor" Number="260" Volume="2006" Year="2013">
       <Id>6fa20a90-1548-48be-b1a0-adbb4b91000c</Id>
     </Book>
-    <Book Series="X-Factor" Number="261" Volume="2006" Year="2013" Format="Main Series">
+    <Book Series="X-Factor" Number="261" Volume="2006" Year="2013">
       <Id>71a06641-8a0c-4166-b371-433271e014bc</Id>
     </Book>
-    <Book Series="X-Factor" Number="262" Volume="2006" Year="2013" Format="Main Series">
+    <Book Series="X-Factor" Number="262" Volume="2006" Year="2013">
       <Id>ea114eed-3362-4e9b-b020-e33d9be3e157</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="24" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="24" Volume="2010" Year="2012">
       <Id>24a52347-3c85-4cc5-976a-43044acb2c1a</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="25" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="25" Volume="2010" Year="2012">
       <Id>5f0cefdd-ebf3-4950-82ab-cfcaa8e12d15</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="26" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="26" Volume="2010" Year="2012">
       <Id>3d8f6ef9-5f8d-445c-be1f-ccda8a48436f</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="27" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="27" Volume="2010" Year="2012">
       <Id>0e439067-8f9e-41d6-b4dd-21da13a9e8f2</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="28" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="28" Volume="2010" Year="2012">
       <Id>4261c217-51a1-4ce6-ad16-fd1bc9c73843</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="29" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="29" Volume="2010" Year="2012">
       <Id>8c6aefd8-6dfc-4dee-8c9f-772caeae6ee5</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="30" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="30" Volume="2010" Year="2012">
       <Id>8446f7f1-b6f8-41dc-b0be-5f9eed4f9a6e</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="31" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="31" Volume="2010" Year="2012">
       <Id>099aa704-99e5-4fa6-a99d-fbee4d925e94</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="32" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="32" Volume="2010" Year="2012">
       <Id>efe2f2a1-c733-4efb-ab38-f6368d685e58</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="33" Volume="2010" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="33" Volume="2010" Year="2013">
       <Id>cbc68070-d97e-4e90-8f02-7017d193ef33</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="34" Volume="2010" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="34" Volume="2010" Year="2013">
       <Id>f668e38e-5977-41ab-8a6e-07caeefaae19</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="35" Volume="2010" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="35" Volume="2010" Year="2013">
       <Id>b5cc4ba8-9e81-4a49-93f1-457e388e4bd7</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="19" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="19" Volume="2011" Year="2012">
       <Id>c7957820-f0a1-44ea-b6b0-db7a5b2edec8</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="20" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="20" Volume="2011" Year="2013">
       <Id>ab509176-d2e8-4a62-a652-a11c7cae0620</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="21" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="21" Volume="2011" Year="2013">
       <Id>99e96d76-3064-4359-b8a7-a6f1ff4f65a9</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="22" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="22" Volume="2011" Year="2013">
       <Id>e46ef56f-3d7d-4699-9262-7d26f771e3a4</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="23" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="23" Volume="2011" Year="2013">
       <Id>ac35dc27-ae18-4c7b-ab24-08c2e9617df7</Id>
     </Book>
-    <Book Series="Gambit" Number="1" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Gambit" Number="1" Volume="2012" Year="2012">
       <Id>f270498e-ddca-417e-9cf9-632f35fab8ac</Id>
     </Book>
-    <Book Series="Gambit" Number="2" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Gambit" Number="2" Volume="2012" Year="2012">
       <Id>05022b88-942b-4c65-a83b-e904faefce1c</Id>
     </Book>
-    <Book Series="Gambit" Number="3" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Gambit" Number="3" Volume="2012" Year="2012">
       <Id>f23bf940-4d1c-4572-a22d-bb7bb9d1a5b5</Id>
     </Book>
-    <Book Series="Gambit" Number="4" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Gambit" Number="4" Volume="2012" Year="2012">
       <Id>5006ef50-1f66-4895-b9c5-73cdc9388308</Id>
     </Book>
-    <Book Series="Gambit" Number="5" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Gambit" Number="5" Volume="2012" Year="2013">
       <Id>259984ba-bce7-441e-bff3-df6541acc10d</Id>
     </Book>
-    <Book Series="Gambit" Number="6" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Gambit" Number="6" Volume="2012" Year="2013">
       <Id>591bd806-ccf2-49fd-bd79-1455488780aa</Id>
     </Book>
-    <Book Series="Gambit" Number="7" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Gambit" Number="7" Volume="2012" Year="2013">
       <Id>bd37b78c-cfea-4392-a5db-b00c2656d70c</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="52" Volume="2004" Year="2012" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="52" Volume="2004" Year="2012">
       <Id>fcd6265d-44d6-4da4-8c64-ece636d704be</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="53" Volume="2004" Year="2012" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="53" Volume="2004" Year="2012">
       <Id>96d51374-b2d7-42e4-8acc-10ef2667b85d</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="54" Volume="2004" Year="2012" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="54" Volume="2004" Year="2012">
       <Id>e9d2508b-1ac2-40bc-b3c9-5e7e6e71db0f</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="55" Volume="2004" Year="2012" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="55" Volume="2004" Year="2012">
       <Id>bb7802bf-a012-4e37-a136-87bf6ae234d8</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="56" Volume="2004" Year="2013" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="56" Volume="2004" Year="2013">
       <Id>fc4d70c6-6438-4d58-9068-2871dbcc82c9</Id>
     </Book>
-    <Book Series="Astonishing X-Men Annual" Number="1" Volume="2012" Year="2013" Format="Annual">
+    <Book Series="Astonishing X-Men Annual" Number="1" Volume="2012" Year="2013">
       <Id>54608fa5-d42d-4914-b16d-e3bc622f6240</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="57" Volume="2004" Year="2013" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="57" Volume="2004" Year="2013">
       <Id>51bfd1cb-7193-4296-8943-18dd7beaec74</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="58" Volume="2004" Year="2013" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="58" Volume="2004" Year="2013">
       <Id>13e5a0a1-d608-47fd-87c8-cadca147981d</Id>
     </Book>
-    <Book Series="X-Men" Number="38" Volume="2010" Year="2013" Format="Main Series">
+    <Book Series="X-Men" Number="38" Volume="2010" Year="2013">
       <Id>ea75d87a-7acc-4225-a363-9deb52fb3e6e</Id>
     </Book>
-    <Book Series="X-Men" Number="39" Volume="2010" Year="2013" Format="Main Series">
+    <Book Series="X-Men" Number="39" Volume="2010" Year="2013">
       <Id>e545e49d-9757-4490-8395-1e5dc4c9af52</Id>
     </Book>
-    <Book Series="X-Men" Number="40" Volume="2010" Year="2013" Format="Main Series">
+    <Book Series="X-Men" Number="40" Volume="2010" Year="2013">
       <Id>4b829dad-a704-4cd8-a533-03113d9bed6a</Id>
     </Book>
-    <Book Series="X-Men" Number="41" Volume="2010" Year="2013" Format="Main Series">
+    <Book Series="X-Men" Number="41" Volume="2010" Year="2013">
       <Id>405b8f15-3e01-4de7-bd88-dbe94fa1801f</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="1" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="1" Volume="2013" Year="2013">
       <Id>77b9c2cb-7e2d-40b8-88a0-f6ece5b08175</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="2" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="2" Volume="2013" Year="2013">
       <Id>ccb2c82a-2469-45dc-91e9-704c7dab9bea</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="3" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="3" Volume="2013" Year="2013">
       <Id>b219e679-f544-4449-bd4a-0d3223679977</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="4" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="4" Volume="2013" Year="2013">
       <Id>f1f97bdc-3483-4251-8859-875f19ccf55a</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="5" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="5" Volume="2013" Year="2013">
       <Id>10c3c19d-f839-447f-9755-49a61ea90501</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="6" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="6" Volume="2013" Year="2013">
       <Id>9b042d2b-44e8-45f6-ad3f-814d70b069b0</Id>
     </Book>
-    <Book Series="Cable and X-Force" Number="1" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Cable and X-Force" Number="1" Volume="2013" Year="2013">
       <Id>11ab9a51-308b-48af-96fd-ae21d24411dd</Id>
     </Book>
-    <Book Series="Cable and X-Force" Number="2" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Cable and X-Force" Number="2" Volume="2013" Year="2013">
       <Id>5f568ab9-3ecd-4709-83e1-58708d15da1d</Id>
     </Book>
-    <Book Series="Cable and X-Force" Number="3" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Cable and X-Force" Number="3" Volume="2013" Year="2013">
       <Id>f0125f74-2c38-4702-9a44-93d4c0a8bad8</Id>
     </Book>
-    <Book Series="Cable and X-Force" Number="4" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Cable and X-Force" Number="4" Volume="2013" Year="2013">
       <Id>4df9e64a-2940-440b-9e06-4e6a8807b15b</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="59" Volume="2004" Year="2013" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="59" Volume="2004" Year="2013">
       <Id>d9b6f12e-76af-47db-8cf6-a5b9ff78f331</Id>
     </Book>
-    <Book Series="Age of Apocalypse" Number="13" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Age of Apocalypse" Number="13" Volume="2012" Year="2013">
       <Id>a5f42fb0-6d38-4615-ae77-fb593798a575</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="12" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="12" Volume="2012" Year="2013">
       <Id>d6b9b272-0af8-4cbc-ad2e-8259f089165d</Id>
     </Book>
-    <Book Series="X-Termination" Number="1" Volume="2013" Year="2013" Format="Limited Series">
+    <Book Series="X-Termination" Number="1" Volume="2013" Year="2013">
       <Id>44b555ab-156b-4faa-adcb-581b1cb9f9bf</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="60" Volume="2004" Year="2013" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="60" Volume="2004" Year="2013">
       <Id>7ba7c19e-72cd-4a30-9483-5f96b9ed8130</Id>
     </Book>
-    <Book Series="Age of Apocalypse" Number="14" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Age of Apocalypse" Number="14" Volume="2012" Year="2013">
       <Id>6a5e0a88-4265-40cc-9edd-dcc390711c82</Id>
     </Book>
-    <Book Series="X-Treme X-Men" Number="13" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="X-Treme X-Men" Number="13" Volume="2012" Year="2013">
       <Id>94bafb9b-b68f-4bb0-8b83-73c01fd1c8a5</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="61" Volume="2004" Year="2013" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="61" Volume="2004" Year="2013">
       <Id>7cf1804e-0edc-49f2-94e2-12c859364846</Id>
     </Book>
-    <Book Series="X-Termination" Number="2" Volume="2013" Year="2013" Format="Limited Series">
+    <Book Series="X-Termination" Number="2" Volume="2013" Year="2013">
       <Id>81c327db-9140-435f-83af-8af83b1f2035</Id>
     </Book>
   </Books>

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 013 - (Regenesis).cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 013 - (Regenesis).cbl
@@ -1,1053 +1,1054 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>X-Men - Part 13 - (Regenesis)</Name>
+  <Name>X-Men - Part 013 - (Regenesis)</Name>
+  <NumIssues>349</NumIssues>
   <Books>
     <Book Series="X-Men: Schism" Number="1" Volume="2011" Year="2011">
-      <Id>a9e95a16-497d-42bd-b4bd-269b31eee1ef</Id>
+      <Database Name="cv" Series="41281" Issue="278744" />
     </Book>
     <Book Series="X-Men: Schism" Number="2" Volume="2011" Year="2011">
-      <Id>29df7ed5-925f-4110-ab56-bc3ed83330d9</Id>
+      <Database Name="cv" Series="41281" Issue="281713" />
     </Book>
     <Book Series="X-Men: Schism" Number="3" Volume="2011" Year="2011">
-      <Id>ceca5705-ac96-4faf-915c-d55eb52f455f</Id>
+      <Database Name="cv" Series="41281" Issue="286947" />
     </Book>
     <Book Series="Generation Hope" Number="10" Volume="2011" Year="2011">
-      <Id>f7569c60-4d5f-4709-a9d9-5dfed699bfd9</Id>
+      <Database Name="cv" Series="36469" Issue="286948" />
     </Book>
     <Book Series="X-Men: Schism" Number="4" Volume="2011" Year="2011">
-      <Id>94c6429a-17b9-4c38-b0b8-9e79bf25e508</Id>
+      <Database Name="cv" Series="41281" Issue="293380" />
     </Book>
     <Book Series="Generation Hope" Number="11" Volume="2011" Year="2011">
-      <Id>bc0553d8-fde8-4573-946c-1c44c6781a3a</Id>
+      <Database Name="cv" Series="36469" Issue="293389" />
     </Book>
     <Book Series="X-Men: Schism" Number="5" Volume="2011" Year="2011">
-      <Id>02121850-8f71-475e-8d91-aebd1fa9ede8</Id>
+      <Database Name="cv" Series="41281" Issue="294049" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="544" Volume="1981" Year="2011">
-      <Id>1185dbd7-45b6-45a1-89a1-437db40b6fed</Id>
+      <Database Name="cv" Series="3092" Issue="297216" />
     </Book>
     <Book Series="Generation Hope" Number="12" Volume="2011" Year="2011">
-      <Id>74b795a3-3188-4d55-a8a7-99e976754f81</Id>
+      <Database Name="cv" Series="36469" Issue="295072" />
     </Book>
     <Book Series="X-Men: Regenesis" Number="1" Volume="2011" Year="2011">
-      <Id>8452e7f6-eae8-4929-b1a6-316bbf2a76e5</Id>
+      <Database Name="cv" Series="43223" Issue="294888" />
     </Book>
     <Book Series="Uncanny X-Force" Number="8" Volume="2010" Year="2011">
-      <Id>ab7fdf72-8f77-490d-bb07-5c9c0ec49b8b</Id>
+      <Database Name="cv" Series="35835" Issue="268750" />
     </Book>
     <Book Series="Uncanny X-Force" Number="9" Volume="2010" Year="2011">
-      <Id>9735be17-3067-42bb-af07-fdb71571fdeb</Id>
+      <Database Name="cv" Series="35835" Issue="269471" />
     </Book>
     <Book Series="Uncanny X-Force" Number="10" Volume="2010" Year="2011">
-      <Id>471b422b-c4b4-42a5-a367-01c7621c5fc1</Id>
+      <Database Name="cv" Series="35835" Issue="270429" />
     </Book>
     <Book Series="Uncanny X-Force" Number="11" Volume="2010" Year="2011">
-      <Id>b60b39a3-de9a-45c7-977a-6f1bfb783a1c</Id>
+      <Database Name="cv" Series="35835" Issue="272304" />
     </Book>
     <Book Series="Uncanny X-Force" Number="12" Volume="2010" Year="2011">
-      <Id>3f5530c9-b3aa-4512-9312-d2c0d70facd5</Id>
+      <Database Name="cv" Series="35835" Issue="281715" />
     </Book>
     <Book Series="Uncanny X-Force" Number="13" Volume="2010" Year="2011">
-      <Id>2d4497e9-3567-4669-a53f-044ed61fa10b</Id>
+      <Database Name="cv" Series="35835" Issue="288489" />
     </Book>
     <Book Series="Uncanny X-Force" Number="14" Volume="2010" Year="2011">
-      <Id>5f7f4bf3-d165-48a3-849d-81710486bb24</Id>
+      <Database Name="cv" Series="35835" Issue="290416" />
     </Book>
     <Book Series="Uncanny X-Force" Number="15" Volume="2010" Year="2011">
-      <Id>391c8da3-683a-4967-8dc7-a85b1889c877</Id>
+      <Database Name="cv" Series="35835" Issue="292576" />
     </Book>
     <Book Series="Uncanny X-Force" Number="16" Volume="2010" Year="2011">
-      <Id>3506c217-70d2-490f-80f0-af13959b2a62</Id>
+      <Database Name="cv" Series="35835" Issue="294857" />
     </Book>
     <Book Series="Uncanny X-Force" Number="17" Volume="2010" Year="2012">
-      <Id>d27a5b6f-0f52-42f7-92f6-57337088a3cb</Id>
+      <Database Name="cv" Series="35835" Issue="301656" />
     </Book>
     <Book Series="Uncanny X-Force" Number="18" Volume="2010" Year="2012">
-      <Id>28c0b637-4a23-46c8-b67b-2c73a154e978</Id>
+      <Database Name="cv" Series="35835" Issue="306477" />
     </Book>
     <Book Series="X-Factor" Number="224.1" Volume="2006" Year="2011">
-      <Id>9635711e-3e5e-4a54-84a5-adce37d79497</Id>
+      <Database Name="cv" Series="18109" Issue="292537" />
     </Book>
     <Book Series="X-Factor" Number="225" Volume="2006" Year="2011">
-      <Id>f12028c4-1230-41de-81ea-5acd981be485</Id>
+      <Database Name="cv" Series="18109" Issue="293468" />
     </Book>
     <Book Series="X-Factor" Number="226" Volume="2006" Year="2011">
-      <Id>8e128f75-9777-4deb-af28-288da7e1847c</Id>
+      <Database Name="cv" Series="18109" Issue="297402" />
     </Book>
     <Book Series="X-Factor" Number="227" Volume="2006" Year="2012">
-      <Id>77508e12-2166-4d28-a17a-ca333700c611</Id>
+      <Database Name="cv" Series="18109" Issue="302516" />
     </Book>
     <Book Series="X-Factor" Number="228" Volume="2006" Year="2012">
-      <Id>8672cc67-4543-4730-b9db-b5b17a660b2d</Id>
+      <Database Name="cv" Series="18109" Issue="305826" />
     </Book>
     <Book Series="Alpha Flight" Number="5" Volume="2011" Year="2011">
-      <Id>d7a76ba1-81a4-4aea-a06f-7c1c799f8829</Id>
+      <Database Name="cv" Series="40216" Issue="295201" />
     </Book>
     <Book Series="Alpha Flight" Number="6" Volume="2011" Year="2012">
-      <Id>c1e428f0-0a04-4f4a-bace-cb17b17f022a</Id>
+      <Database Name="cv" Series="40216" Issue="303616" />
     </Book>
     <Book Series="Alpha Flight" Number="7" Volume="2011" Year="2012">
-      <Id>c1d39d63-fe62-4f56-ba15-207e68b4f3cf</Id>
+      <Database Name="cv" Series="40216" Issue="308477" />
     </Book>
     <Book Series="Alpha Flight" Number="8" Volume="2011" Year="2012">
-      <Id>a0b1fb0e-35a7-4642-9538-f8bd18f05210</Id>
+      <Database Name="cv" Series="40216" Issue="312789" />
     </Book>
     <Book Series="X-23" Number="17" Volume="2010" Year="2012">
-      <Id>2fee8da0-3f89-4d48-9278-cfe88be6edcb</Id>
+      <Database Name="cv" Series="35496" Issue="302673" />
     </Book>
     <Book Series="X-23" Number="18" Volume="2010" Year="2012">
-      <Id>01d75287-f124-47ba-8bc4-849d51c97b60</Id>
+      <Database Name="cv" Series="35496" Issue="305778" />
     </Book>
     <Book Series="X-23" Number="19" Volume="2010" Year="2012">
-      <Id>8d52c4bb-642c-48cd-b961-35466e72ad04</Id>
+      <Database Name="cv" Series="35496" Issue="307727" />
     </Book>
     <Book Series="Wolverine" Number="17" Volume="2010" Year="2011">
-      <Id>3fbccec5-e4d3-4003-bf3d-777a751e34d5</Id>
+      <Database Name="cv" Series="35263" Issue="297215" />
     </Book>
     <Book Series="Wolverine" Number="18" Volume="2010" Year="2012">
-      <Id>a948c9be-4618-4d0c-a6c5-cae8029a9b3a</Id>
+      <Database Name="cv" Series="35263" Issue="301655" />
     </Book>
     <Book Series="Wolverine" Number="19" Volume="2010" Year="2012">
-      <Id>861d4284-a7b2-4ef1-af47-5569e731362d</Id>
+      <Database Name="cv" Series="35263" Issue="304470" />
     </Book>
-    <Book Series="Uncanny X-Men" Number="1" Volume="2012" Year="2012">
-      <Id>bb579e6e-a3ae-4a6e-89ea-5d56a8a1b7e8</Id>
+    <Book Series="Uncanny X-Men" Number="1" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43785" Issue="301011" />
     </Book>
-    <Book Series="Uncanny X-Men" Number="2" Volume="2012" Year="2012">
-      <Id>89392cb5-d5ce-409f-b7e5-52b2e77abe86</Id>
+    <Book Series="Uncanny X-Men" Number="2" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43785" Issue="304473" />
     </Book>
-    <Book Series="Uncanny X-Men" Number="3" Volume="2012" Year="2012">
-      <Id>152764fb-2f6c-4466-acc9-1058e98dfc95</Id>
+    <Book Series="Uncanny X-Men" Number="3" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43785" Issue="308437" />
     </Book>
-    <Book Series="Uncanny X-Men" Number="4" Volume="2012" Year="2012">
-      <Id>0a0b344f-cf0b-4af3-acfb-344e158afa6b</Id>
+    <Book Series="Uncanny X-Men" Number="4" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43785" Issue="309467" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="1" Volume="2011" Year="2011">
-      <Id>29fa3ffb-fde6-4ef2-bfb7-3405904ed723</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="1" Volume="2011" Year="2011">
+      <Database Name="cv" Series="43539" Issue="299471" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="2" Volume="2011" Year="2012">
-      <Id>66d0d8d8-bb74-4f22-92e3-d5d388eae11c</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="2" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43539" Issue="303379" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="3" Volume="2011" Year="2012">
-      <Id>f59af4cb-0b09-4993-9ade-33f57dff9804</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="3" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43539" Issue="307452" />
     </Book>
     <Book Series="X-Men" Number="20" Volume="2010" Year="2012">
-      <Id>291c1b4b-8583-45c4-85f1-168864d8a43b</Id>
+      <Database Name="cv" Series="34221" Issue="300972" />
     </Book>
     <Book Series="X-Men" Number="21" Volume="2010" Year="2012">
-      <Id>a0cbca8a-4112-4447-88d2-175a44ae728d</Id>
+      <Database Name="cv" Series="34221" Issue="302517" />
     </Book>
     <Book Series="X-Men" Number="22" Volume="2010" Year="2012">
-      <Id>7fe32a2b-9747-4b87-989f-5959fe7b905d</Id>
+      <Database Name="cv" Series="34221" Issue="305672" />
     </Book>
     <Book Series="X-Men" Number="23" Volume="2010" Year="2012">
-      <Id>48987e1c-80fd-423e-8ad0-142e408baa94</Id>
+      <Database Name="cv" Series="34221" Issue="309394" />
     </Book>
     <Book Series="New Mutants" Number="33" Volume="2009" Year="2012">
-      <Id>f58b37be-e0d4-447e-b175-a0083f72c95b</Id>
+      <Database Name="cv" Series="26327" Issue="301071" />
     </Book>
     <Book Series="New Mutants" Number="34" Volume="2009" Year="2012">
-      <Id>2a00cb95-2284-414e-8194-b11d36d1b1db</Id>
+      <Database Name="cv" Series="26327" Issue="302664" />
     </Book>
     <Book Series="New Mutants" Number="35" Volume="2009" Year="2012">
-      <Id>0c1798bd-0f77-4871-9a84-942896336afa</Id>
+      <Database Name="cv" Series="26327" Issue="307478" />
     </Book>
     <Book Series="New Mutants" Number="36" Volume="2009" Year="2012">
-      <Id>c0765dec-db73-4bfc-95fd-ed2d413a7a3f</Id>
+      <Database Name="cv" Series="26327" Issue="311800" />
     </Book>
     <Book Series="New Mutants" Number="37" Volume="2009" Year="2012">
-      <Id>670d2898-f7e2-4427-a0d1-7d542edaaa55</Id>
+      <Database Name="cv" Series="26327" Issue="315085" />
     </Book>
     <Book Series="X-Men: Legacy" Number="259" Volume="2008" Year="2012">
-      <Id>ae196749-66c5-4380-94a8-bb424f703cc9</Id>
+      <Database Name="cv" Series="20691" Issue="304477" />
     </Book>
     <Book Series="X-Men: Legacy" Number="260" Volume="2008" Year="2012">
-      <Id>a8136fc7-2338-45ac-ac93-7ca04ce8f2f2</Id>
+      <Database Name="cv" Series="20691" Issue="308418" />
     </Book>
     <Book Series="X-Factor" Number="229" Volume="2006" Year="2012">
-      <Id>70b4b0c1-f586-4c69-8fc6-134106135d02</Id>
+      <Database Name="cv" Series="18109" Issue="307481" />
     </Book>
     <Book Series="X-Factor" Number="230" Volume="2006" Year="2012">
-      <Id>ebcea5c4-c479-47bf-9051-8de9892e61dd</Id>
+      <Database Name="cv" Series="18109" Issue="310833" />
     </Book>
     <Book Series="X-Factor" Number="231" Volume="2006" Year="2012">
-      <Id>cb61fa88-3f0d-4634-9403-d2e83c2f72f8</Id>
+      <Database Name="cv" Series="18109" Issue="313902" />
     </Book>
     <Book Series="X-Factor" Number="232" Volume="2006" Year="2012">
-      <Id>d1b218c4-6839-4446-a722-a7d8ed41e832</Id>
+      <Database Name="cv" Series="18109" Issue="315729" />
     </Book>
     <Book Series="Generation Hope" Number="13" Volume="2011" Year="2012">
-      <Id>c999f3f8-4807-4c7b-a796-8b8dc1cf8a86</Id>
+      <Database Name="cv" Series="36469" Issue="302663" />
     </Book>
     <Book Series="Generation Hope" Number="14" Volume="2011" Year="2012">
-      <Id>273f1999-8cbd-432c-9b3b-8fbe6cf95d61</Id>
+      <Database Name="cv" Series="36469" Issue="307573" />
     </Book>
     <Book Series="Generation Hope" Number="15" Volume="2011" Year="2012">
-      <Id>33453e7b-1de0-4a6b-b5dd-96d588b98104</Id>
+      <Database Name="cv" Series="36469" Issue="311798" />
     </Book>
     <Book Series="Generation Hope" Number="16" Volume="2011" Year="2012">
-      <Id>01f5f7c4-e01c-42ec-843d-fc2242862cff</Id>
+      <Database Name="cv" Series="36469" Issue="315752" />
     </Book>
     <Book Series="Generation Hope" Number="17" Volume="2011" Year="2012">
-      <Id>662c9ca9-9937-440d-9c2c-d3e56ec769d5</Id>
+      <Database Name="cv" Series="36469" Issue="322771" />
     </Book>
     <Book Series="Magneto: Not A Hero" Number="1" Volume="2012" Year="2012">
-      <Id>77239656-6763-4e73-9e41-cf6149dd4f62</Id>
+      <Database Name="cv" Series="43891" Issue="301653" />
     </Book>
     <Book Series="Magneto: Not A Hero" Number="2" Volume="2012" Year="2012">
-      <Id>d43a0b6a-08a5-4564-8a26-c3e45af69cdf</Id>
+      <Database Name="cv" Series="43891" Issue="306476" />
     </Book>
     <Book Series="Magneto: Not A Hero" Number="3" Volume="2012" Year="2012">
-      <Id>e7d2ce0a-0662-450d-b030-4ce1740c3692</Id>
+      <Database Name="cv" Series="43891" Issue="310806" />
     </Book>
     <Book Series="Magneto: Not A Hero" Number="4" Volume="2012" Year="2012">
-      <Id>0180744d-0973-45f0-ad22-b1baece217a0</Id>
+      <Database Name="cv" Series="43891" Issue="316681" />
     </Book>
     <Book Series="X-Club" Number="1" Volume="2011" Year="2012">
-      <Id>ae814b36-147d-4d29-8eec-fda39548de02</Id>
+      <Database Name="cv" Series="44386" Issue="305786" />
     </Book>
     <Book Series="X-Club" Number="2" Volume="2011" Year="2012">
-      <Id>b98067f0-bc9b-4b71-b592-7cd681e5b308</Id>
+      <Database Name="cv" Series="44386" Issue="309474" />
     </Book>
     <Book Series="X-Club" Number="3" Volume="2011" Year="2012">
-      <Id>53931315-636d-4794-a491-f738f03b3dd7</Id>
+      <Database Name="cv" Series="44386" Issue="313896" />
     </Book>
     <Book Series="X-Club" Number="4" Volume="2011" Year="2012">
-      <Id>b753b9cb-e399-4bf3-ae22-917617d328a9</Id>
+      <Database Name="cv" Series="44386" Issue="319376" />
     </Book>
     <Book Series="X-Club" Number="5" Volume="2011" Year="2012">
-      <Id>3e604998-1c5b-475a-b836-1ffcd779c3a5</Id>
+      <Database Name="cv" Series="44386" Issue="326873" />
     </Book>
     <Book Series="Avengers: X-Sanction" Number="1" Volume="2012" Year="2012">
-      <Id>c83bc85f-783c-4e16-b7b9-f3d91e435bb9</Id>
+      <Database Name="cv" Series="44477" Issue="306478" />
     </Book>
     <Book Series="Avengers: X-Sanction" Number="2" Volume="2012" Year="2012">
-      <Id>4d4a684b-c77d-4adf-b93e-5d5c55adc17b</Id>
+      <Database Name="cv" Series="44477" Issue="309396" />
     </Book>
     <Book Series="Avengers: X-Sanction" Number="3" Volume="2012" Year="2012">
-      <Id>0550b34e-e235-45b3-81d2-368d0ccd9601</Id>
+      <Database Name="cv" Series="44477" Issue="313883" />
     </Book>
     <Book Series="Avengers: X-Sanction" Number="4" Volume="2012" Year="2012">
-      <Id>04a79481-a1da-4ee9-94f1-c3956688eb01</Id>
+      <Database Name="cv" Series="44477" Issue="322751" />
     </Book>
     <Book Series="Astonishing X-Men" Number="43" Volume="2004" Year="2011">
-      <Id>e4ec3b5b-aed0-4104-901a-5a31c06ae589</Id>
+      <Database Name="cv" Series="10746" Issue="299579" />
     </Book>
     <Book Series="Astonishing X-Men" Number="44" Volume="2004" Year="2012">
-      <Id>cd589efc-b742-47cc-b504-92b8bf8035f3</Id>
+      <Database Name="cv" Series="10746" Issue="303452" />
     </Book>
     <Book Series="Astonishing X-Men" Number="45" Volume="2004" Year="2012">
-      <Id>e39729f3-5560-4ee6-bb98-06b4124c3abd</Id>
+      <Database Name="cv" Series="10746" Issue="308448" />
     </Book>
     <Book Series="Astonishing X-Men" Number="47" Volume="2004" Year="2012">
-      <Id>de3fcf2b-c102-48b5-b52d-16edbfac30e3</Id>
+      <Database Name="cv" Series="10746" Issue="318006" />
     </Book>
-    <Book Series="Wolverine and the X-Men: Alpha &amp; Omega" Number="1" Volume="2012" Year="2012">
-      <Id>141b7015-1a3c-4d05-b52e-791a4fa353ac</Id>
+    <Book Series="Wolverine and the X-Men: Alpha &#38; Omega" Number="1" Volume="2012" Year="2012">
+      <Database Name="cv" Series="44964" Issue="309473" />
     </Book>
-    <Book Series="Wolverine and the X-Men: Alpha &amp; Omega" Number="2" Volume="2012" Year="2012">
-      <Id>2a848ea3-f4d4-45aa-a851-b782042a5b14</Id>
+    <Book Series="Wolverine and the X-Men: Alpha &#38; Omega" Number="2" Volume="2012" Year="2012">
+      <Database Name="cv" Series="44964" Issue="315084" />
     </Book>
-    <Book Series="Wolverine and the X-Men: Alpha &amp; Omega" Number="3" Volume="2012" Year="2012">
-      <Id>68281d63-64e1-4cad-bb90-0e2f56df6e66</Id>
+    <Book Series="Wolverine and the X-Men: Alpha &#38; Omega" Number="3" Volume="2012" Year="2012">
+      <Database Name="cv" Series="44964" Issue="319369" />
     </Book>
-    <Book Series="Wolverine and the X-Men: Alpha &amp; Omega" Number="4" Volume="2012" Year="2012">
-      <Id>d4224504-60c4-4265-afac-5f3c48d2915f</Id>
+    <Book Series="Wolverine and the X-Men: Alpha &#38; Omega" Number="4" Volume="2012" Year="2012">
+      <Database Name="cv" Series="44964" Issue="326868" />
     </Book>
-    <Book Series="Wolverine and the X-Men: Alpha &amp; Omega" Number="5" Volume="2012" Year="2012">
-      <Id>3678db98-a224-4890-9d88-9a4859fffa59</Id>
+    <Book Series="Wolverine and the X-Men: Alpha &#38; Omega" Number="5" Volume="2012" Year="2012">
+      <Database Name="cv" Series="44964" Issue="334165" />
     </Book>
-    <Book Series="Uncanny X-Men" Number="5" Volume="2012" Year="2012">
-      <Id>a1f82865-8d2d-4df6-99a6-71775aed13e7</Id>
+    <Book Series="Uncanny X-Men" Number="5" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43785" Issue="311756" />
     </Book>
-    <Book Series="Uncanny X-Men" Number="6" Volume="2012" Year="2012">
-      <Id>89fecc15-a36d-480d-b06e-9cce907f57d6</Id>
+    <Book Series="Uncanny X-Men" Number="6" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43785" Issue="313845" />
     </Book>
-    <Book Series="Uncanny X-Men" Number="7" Volume="2012" Year="2012">
-      <Id>e5f5e8e6-b1b0-4932-8030-747e6f70ad9b</Id>
+    <Book Series="Uncanny X-Men" Number="7" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43785" Issue="315783" />
     </Book>
-    <Book Series="Uncanny X-Men" Number="8" Volume="2012" Year="2012">
-      <Id>621690f1-0bf5-4b70-8b30-53254bf70442</Id>
+    <Book Series="Uncanny X-Men" Number="8" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43785" Issue="319363" />
     </Book>
     <Book Series="Uncanny X-Force" Number="19" Volume="2010" Year="2012">
-      <Id>6f32537a-08a1-40cd-9dde-8cf5edb5d757</Id>
+      <Database Name="cv" Series="35835" Issue="307451" />
     </Book>
     <Book Series="Uncanny X-Force" Number="19.1" Volume="2010" Year="2012">
-      <Id>86dcb5f9-0f3b-4c9a-a3d5-a2da8a59d257</Id>
+      <Database Name="cv" Series="35835" Issue="309399" />
     </Book>
     <Book Series="Uncanny X-Force" Number="20" Volume="2010" Year="2012">
-      <Id>26f9137e-21a6-40de-b2bc-d1c49b975c03</Id>
+      <Database Name="cv" Series="35835" Issue="311672" />
     </Book>
     <Book Series="Uncanny X-Force" Number="21" Volume="2010" Year="2012">
-      <Id>a1d4ac54-104c-4266-920e-6829158300d1</Id>
+      <Database Name="cv" Series="35835" Issue="313715" />
     </Book>
     <Book Series="Uncanny X-Force" Number="22" Volume="2010" Year="2012">
-      <Id>99ad9d15-e883-46b4-9eac-9005279c14f7</Id>
+      <Database Name="cv" Series="35835" Issue="316683" />
     </Book>
     <Book Series="Uncanny X-Force" Number="23" Volume="2010" Year="2012">
-      <Id>dc9d6ee6-23ae-4841-8fa9-fdf157ec9209</Id>
+      <Database Name="cv" Series="35835" Issue="324701" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="4" Volume="2011" Year="2012">
-      <Id>7430cc06-6f00-4085-9fca-78095fcbbd10</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="4" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43539" Issue="310892" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="5" Volume="2011" Year="2012">
-      <Id>69f75219-8d83-48f5-940c-e23415e46815</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="5" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43539" Issue="315083" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="6" Volume="2011" Year="2012">
-      <Id>6e82f362-cdd6-4c52-a097-c20db222cade</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="6" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43539" Issue="316711" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="7" Volume="2011" Year="2012">
-      <Id>ea24f7c0-697a-4aa0-aeba-a218151c2ebd</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="7" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43539" Issue="321295" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="8" Volume="2011" Year="2012">
-      <Id>4d2892aa-21db-4a93-8615-ca12280daf9d</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="8" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43539" Issue="326863" />
     </Book>
     <Book Series="Daken: Dark Wolverine" Number="20" Volume="2010" Year="2012">
-      <Id>0322e690-5604-477a-ae25-cbb71f3ecd97</Id>
+      <Database Name="cv" Series="35409" Issue="312791" />
     </Book>
     <Book Series="Daken: Dark Wolverine" Number="21" Volume="2010" Year="2012">
-      <Id>cdc67e6b-0768-42d7-ba69-52825472e35c</Id>
+      <Database Name="cv" Series="35409" Issue="315093" />
     </Book>
     <Book Series="Daken: Dark Wolverine" Number="22" Volume="2010" Year="2012">
-      <Id>d8983916-d447-47b7-984d-3374ae81ab33</Id>
+      <Database Name="cv" Series="35409" Issue="321348" />
     </Book>
     <Book Series="Daken: Dark Wolverine" Number="23" Volume="2010" Year="2012">
-      <Id>a20f3d06-5088-4d3a-9df2-6cdb076c1414</Id>
+      <Database Name="cv" Series="35409" Issue="324947" />
     </Book>
     <Book Series="X-23" Number="20" Volume="2010" Year="2012">
-      <Id>57947a41-774f-420f-b430-797269a9b4a5</Id>
+      <Database Name="cv" Series="35496" Issue="309598" />
     </Book>
     <Book Series="X-23" Number="21" Volume="2010" Year="2012">
-      <Id>f2f69537-148c-4053-842c-5b89a7b000d7</Id>
+      <Database Name="cv" Series="35496" Issue="321362" />
     </Book>
     <Book Series="Wolverine" Number="20" Volume="2010" Year="2012">
-      <Id>0f7c4ac0-fa89-4c09-8c3c-3d13f45854ff</Id>
+      <Database Name="cv" Series="35263" Issue="307450" />
     </Book>
     <Book Series="Wolverine" Number="300" Volume="2010" Year="2012">
-      <Id>2f0ff4ef-99df-47b3-b332-a0f80422593d</Id>
+      <Database Name="cv" Series="35263" Issue="310807" />
     </Book>
     <Book Series="Wolverine" Number="301" Volume="2010" Year="2012">
-      <Id>d877de58-6fb1-4029-ab35-e34bf3292ef5</Id>
+      <Database Name="cv" Series="35263" Issue="315753" />
     </Book>
     <Book Series="Wolverine" Number="302" Volume="2010" Year="2012">
-      <Id>080d9944-76de-4070-af2e-620fca945256</Id>
+      <Database Name="cv" Series="35263" Issue="319367" />
     </Book>
     <Book Series="Wolverine" Number="303" Volume="2010" Year="2012">
-      <Id>91d37d61-edfd-425e-b8bf-cd137ba6b883</Id>
+      <Database Name="cv" Series="35263" Issue="322748" />
     </Book>
     <Book Series="X-Men: Legacy" Number="260.1" Volume="2008" Year="2012">
-      <Id>7bc0bfa2-05e2-425f-8138-1c2e2811de58</Id>
+      <Database Name="cv" Series="20691" Issue="310912" />
     </Book>
     <Book Series="X-Men: Legacy" Number="261" Volume="2008" Year="2012">
-      <Id>cf4eaa33-72a5-4923-8d36-13bb7f1633b4</Id>
+      <Database Name="cv" Series="20691" Issue="312715" />
     </Book>
     <Book Series="X-Men: Legacy" Number="262" Volume="2008" Year="2012">
-      <Id>3f7e6fc9-b6d1-4bb3-bcb6-6a1fdbb76e13</Id>
+      <Database Name="cv" Series="20691" Issue="316709" />
     </Book>
     <Book Series="X-Men: Legacy" Number="263" Volume="2008" Year="2012">
-      <Id>31a0a242-89d3-4422-8517-8fb7a443e905</Id>
+      <Database Name="cv" Series="20691" Issue="321330" />
     </Book>
     <Book Series="X-Men: Legacy" Number="264" Volume="2008" Year="2012">
-      <Id>5d1458f6-5d51-48df-8f89-0fc390f96139</Id>
+      <Database Name="cv" Series="20691" Issue="324898" />
     </Book>
     <Book Series="X-Men: Legacy" Number="265" Volume="2008" Year="2012">
-      <Id>fa1f9c3c-d7e8-4c72-b09d-3e9b11c939e9</Id>
+      <Database Name="cv" Series="20691" Issue="333427" />
     </Book>
     <Book Series="X-Men" Number="24" Volume="2010" Year="2012">
-      <Id>6d36346f-4752-4008-8ca0-11ba1226a9a0</Id>
+      <Database Name="cv" Series="34221" Issue="315092" />
     </Book>
     <Book Series="X-Men" Number="25" Volume="2010" Year="2012">
-      <Id>519c13ea-0277-4a1d-94bc-02a3f662370a</Id>
+      <Database Name="cv" Series="34221" Issue="316710" />
     </Book>
     <Book Series="X-Men" Number="26" Volume="2010" Year="2012">
-      <Id>51b11a2b-8493-478d-85fc-727f20d9a309</Id>
+      <Database Name="cv" Series="34221" Issue="319374" />
     </Book>
     <Book Series="X-Men" Number="27" Volume="2010" Year="2012">
-      <Id>74c85d79-d4a7-4612-99e1-0c87e52cfcbd</Id>
+      <Database Name="cv" Series="34221" Issue="331910" />
     </Book>
     <Book Series="New Mutants" Number="38" Volume="2009" Year="2012">
-      <Id>5a9c6141-ebf4-4849-aeaf-9272a6ecb59a</Id>
+      <Database Name="cv" Series="26327" Issue="316789" />
     </Book>
     <Book Series="New Mutants" Number="39" Volume="2009" Year="2012">
-      <Id>dd8171fc-613b-4217-9b08-fb4018af238a</Id>
+      <Database Name="cv" Series="26327" Issue="323109" />
     </Book>
     <Book Series="New Mutants" Number="40" Volume="2009" Year="2012">
-      <Id>de704756-25b7-44f2-a9b9-8bf4b952729c</Id>
+      <Database Name="cv" Series="26327" Issue="326872" />
     </Book>
     <Book Series="New Mutants" Number="41" Volume="2009" Year="2012">
-      <Id>f85b74d6-7382-4ebd-afa7-54be8182206d</Id>
+      <Database Name="cv" Series="26327" Issue="331914" />
     </Book>
-    <Book Series="Uncanny X-Men" Number="9" Volume="2012" Year="2012">
-      <Id>4cc96d45-80f4-4a8f-a157-c000973caef0</Id>
+    <Book Series="Uncanny X-Men" Number="9" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43785" Issue="322747" />
     </Book>
-    <Book Series="Uncanny X-Men" Number="10" Volume="2012" Year="2012">
-      <Id>298e4f9c-0c9d-4548-a791-53a21ad04459</Id>
+    <Book Series="Uncanny X-Men" Number="10" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43785" Issue="329216" />
     </Book>
     <Book Series="X-Factor" Number="233" Volume="2006" Year="2012">
-      <Id>882b611d-9d05-477e-809d-bd0e8184a791</Id>
+      <Database Name="cv" Series="18109" Issue="322724" />
     </Book>
     <Book Series="X-Factor" Number="234" Volume="2006" Year="2012">
-      <Id>d6168db5-e081-4716-b1bb-99021adb585c</Id>
+      <Database Name="cv" Series="18109" Issue="331871" />
     </Book>
     <Book Series="X-Factor" Number="235" Volume="2006" Year="2012">
-      <Id>002ed441-1378-4fe4-b421-debe020d6085</Id>
+      <Database Name="cv" Series="18109" Issue="334191" />
     </Book>
     <Book Series="X-Factor" Number="236" Volume="2006" Year="2012">
-      <Id>b0212ba1-ceb8-4d4c-a14a-a7e584267962</Id>
+      <Database Name="cv" Series="18109" Issue="335947" />
     </Book>
     <Book Series="X-Factor" Number="237" Volume="2006" Year="2012">
-      <Id>fe9b99ae-de34-4b57-9435-296680f8282c</Id>
+      <Database Name="cv" Series="18109" Issue="338453" />
     </Book>
     <Book Series="Exiled" Number="1" Volume="2012" Year="2012">
-      <Id>0f970768-b413-41c4-a673-8d5479ebe087</Id>
+      <Database Name="cv" Series="48555" Issue="334329" />
     </Book>
     <Book Series="Journey into Mystery" Number="637" Volume="2011" Year="2012">
-      <Id>da3078b0-a380-450a-9dc2-67729949ad92</Id>
+      <Database Name="cv" Series="39761" Issue="335282" />
     </Book>
     <Book Series="New Mutants" Number="42" Volume="2009" Year="2012">
-      <Id>2ddb7cb6-d83c-439e-a936-a5620f74c5a0</Id>
+      <Database Name="cv" Series="26327" Issue="335927" />
     </Book>
     <Book Series="Journey into Mystery" Number="638" Volume="2011" Year="2012">
-      <Id>d4af5392-99ed-47f8-920e-cc2e8dc2a549</Id>
+      <Database Name="cv" Series="39761" Issue="336595" />
     </Book>
     <Book Series="New Mutants" Number="43" Volume="2009" Year="2012">
-      <Id>f9ac1ef7-2a6f-4cae-b8eb-94073c51edf5</Id>
+      <Database Name="cv" Series="26327" Issue="337506" />
     </Book>
     <Book Series="X-Men" Number="28" Volume="2010" Year="2012">
-      <Id>5198c9a8-d667-44c2-84da-43668a8923c1</Id>
+      <Database Name="cv" Series="34221" Issue="334167" />
     </Book>
     <Book Series="X-Men" Number="29" Volume="2010" Year="2012">
-      <Id>97f99c56-3618-4870-b8a9-bfd24ec5735b</Id>
+      <Database Name="cv" Series="34221" Issue="337500" />
     </Book>
     <Book Series="Age of Apocalypse" Number="1" Volume="2012" Year="2012">
-      <Id>61fb06fc-48b6-4a17-b9e5-898a864757c5</Id>
+      <Database Name="cv" Series="46347" Issue="319368" />
     </Book>
     <Book Series="Age of Apocalypse" Number="2" Volume="2012" Year="2012">
-      <Id>c0e06f55-5057-48d0-95c3-f2b8739c0645</Id>
+      <Database Name="cv" Series="46347" Issue="326870" />
     </Book>
     <Book Series="Age of Apocalypse" Number="3" Volume="2012" Year="2012">
-      <Id>8d096535-701b-4b43-b2ad-f8b39c7940f2</Id>
+      <Database Name="cv" Series="46347" Issue="334324" />
     </Book>
     <Book Series="Age of Apocalypse" Number="4" Volume="2012" Year="2012">
-      <Id>2dbf3f3f-069e-461a-8ee2-d52cf327ad98</Id>
+      <Database Name="cv" Series="46347" Issue="338547" />
     </Book>
     <Book Series="Age of Apocalypse" Number="5" Volume="2012" Year="2012">
-      <Id>12524fe3-8804-4f7d-ae98-648e1ebb835b</Id>
+      <Database Name="cv" Series="46347" Issue="344090" />
     </Book>
     <Book Series="Age of Apocalypse" Number="6" Volume="2012" Year="2012">
-      <Id>38c49588-a823-448e-9c7d-7aa1b456c703</Id>
+      <Database Name="cv" Series="46347" Issue="348066" />
     </Book>
     <Book Series="Wolverine" Number="304" Volume="2010" Year="2012">
-      <Id>2d26fc3b-6768-4bb4-8439-31b757eabe73</Id>
+      <Database Name="cv" Series="35263" Issue="329214" />
     </Book>
     <Book Series="Wolverine" Number="305" Volume="2010" Year="2012">
-      <Id>89326ab3-bbe3-4f57-adc5-611b292b452a</Id>
+      <Database Name="cv" Series="35263" Issue="333397" />
     </Book>
     <Book Series="Wolverine" Number="306" Volume="2010" Year="2012">
-      <Id>841df45a-bd25-4fb0-b068-3934be58ad3b</Id>
+      <Database Name="cv" Series="35263" Issue="335267" />
     </Book>
     <Book Series="Wolverine" Number="307" Volume="2010" Year="2012">
-      <Id>c9dfc24e-8eca-4cf3-89f2-9fbc9d9c4f9a</Id>
+      <Database Name="cv" Series="35263" Issue="337498" />
     </Book>
     <Book Series="Wolverine" Number="308" Volume="2010" Year="2012">
-      <Id>fbb0564a-54d2-4faa-a3f0-fbed70b8fe97</Id>
+      <Database Name="cv" Series="35263" Issue="341715" />
     </Book>
     <Book Series="New Mutants" Number="44" Volume="2009" Year="2012">
-      <Id>47dd8d86-d35e-48fc-8384-6547652a6bab</Id>
+      <Database Name="cv" Series="26327" Issue="341708" />
     </Book>
     <Book Series="New Mutants" Number="45" Volume="2009" Year="2012">
-      <Id>38c9e321-8f09-4f5a-b247-708539e60423</Id>
+      <Database Name="cv" Series="26327" Issue="345403" />
     </Book>
     <Book Series="New Mutants" Number="46" Volume="2009" Year="2012">
-      <Id>c6421d1b-3207-4895-bc4a-04579d6f3673</Id>
+      <Database Name="cv" Series="26327" Issue="346265" />
     </Book>
     <Book Series="X-Men" Number="30" Volume="2010" Year="2012">
-      <Id>1bf703a6-791b-4813-b773-fda204064dee</Id>
+      <Database Name="cv" Series="34221" Issue="340396" />
     </Book>
     <Book Series="X-Men" Number="31" Volume="2010" Year="2012">
-      <Id>76c59937-8f1e-4e05-ad11-7b41afbba517</Id>
+      <Database Name="cv" Series="34221" Issue="342843" />
     </Book>
     <Book Series="X-Men" Number="32" Volume="2010" Year="2012">
-      <Id>22f33e12-cdaa-40f1-99f5-642dde3eb235</Id>
+      <Database Name="cv" Series="34221" Issue="346264" />
     </Book>
     <Book Series="X-Men" Number="33" Volume="2010" Year="2012">
-      <Id>45ebff6a-38fc-4cbb-a833-861fd7667034</Id>
+      <Database Name="cv" Series="34221" Issue="348068" />
     </Book>
     <Book Series="Astonishing X-Men" Number="48" Volume="2004" Year="2012">
-      <Id>635580d7-0a72-4ad0-8e39-4b5f53d8e2be</Id>
+      <Database Name="cv" Series="10746" Issue="324899" />
     </Book>
     <Book Series="Astonishing X-Men" Number="49" Volume="2004" Year="2012">
-      <Id>0cdca09b-ea45-4008-89ff-fcde716f9de6</Id>
+      <Database Name="cv" Series="10746" Issue="333430" />
     </Book>
     <Book Series="Astonishing X-Men" Number="50" Volume="2004" Year="2012">
-      <Id>bc6df6ec-a730-4eca-99b2-c43323ee36fb</Id>
+      <Database Name="cv" Series="10746" Issue="336664" />
     </Book>
     <Book Series="Astonishing X-Men" Number="51" Volume="2004" Year="2012">
-      <Id>0a02adfe-de63-4f5d-bed0-a2b339079283</Id>
+      <Database Name="cv" Series="10746" Issue="341838" />
     </Book>
     <Book Series="X-Factor" Number="238" Volume="2006" Year="2012">
-      <Id>6ccdfa71-3d0e-48b7-bf1a-c1ea5119f652</Id>
+      <Database Name="cv" Series="18109" Issue="341652" />
     </Book>
     <Book Series="X-Factor" Number="239" Volume="2006" Year="2012">
-      <Id>fcf03c06-3f2c-4794-98aa-fc05bcb11d54</Id>
+      <Database Name="cv" Series="18109" Issue="344047" />
     </Book>
     <Book Series="X-Factor" Number="240" Volume="2006" Year="2012">
-      <Id>1c217888-f358-4825-81f7-e6de2cbb9722</Id>
+      <Database Name="cv" Series="18109" Issue="346426" />
     </Book>
     <Book Series="Avengers" Number="24.1" Volume="2010" Year="2012">
-      <Id>1b1e23d6-91fc-4227-9581-cd184923c039</Id>
+      <Database Name="cv" Series="33227" Issue="324946" />
     </Book>
     <Book Series="Avengers Vs. X-Men" Number="0" Volume="2012" Year="2012">
-      <Id>8c90eea4-ff80-41e0-964c-bb76b8cc39dd</Id>
+      <Database Name="cv" Series="47331" Issue="324839" />
     </Book>
     <Book Series="Avengers Vs. X-Men: Infinite" Number="1" Volume="2012" Year="2012">
-      <Id>36be309e-31bd-46ef-8fd9-b26a44cc5612</Id>
+      <Database Name="cv" Series="47625" Issue="327550" />
     </Book>
     <Book Series="Avengers Vs. X-Men" Number="1" Volume="2012" Year="2012">
-      <Id>3ee055b9-6dc9-408e-84ab-4be34f7bd85a</Id>
+      <Database Name="cv" Series="47331" Issue="326860" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="9" Volume="2011" Year="2012">
-      <Id>454d110a-ee27-44e9-acc8-ba28b02a9cfd</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="9" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43539" Issue="332029" />
     </Book>
     <Book Series="New Avengers" Number="24" Volume="2010" Year="2012">
-      <Id>20958fcc-9403-4197-9b41-3661142ce21e</Id>
+      <Database Name="cv" Series="33777" Issue="329220" />
     </Book>
     <Book Series="Avengers Vs. X-Men" Number="2" Volume="2012" Year="2012">
-      <Id>a1921a7d-8ab0-48e9-82fb-c6d8f75dd507</Id>
+      <Database Name="cv" Series="47331" Issue="331952" />
     </Book>
     <Book Series="AVX: VS" Number="1" Volume="2012" Year="2012">
-      <Id>852be60f-c2b3-4902-adab-9990dadef15b</Id>
+      <Database Name="cv" Series="48342" Issue="333447" />
     </Book>
-    <Book Series="Uncanny X-Men" Number="11" Volume="2012" Year="2012">
-      <Id>164caa74-41ee-4365-86de-b0126c726d23</Id>
+    <Book Series="Uncanny X-Men" Number="11" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43785" Issue="333449" />
     </Book>
     <Book Series="Avengers Vs. X-Men" Number="3" Volume="2012" Year="2012">
-      <Id>80e84dad-9553-4ebb-a739-d90636e3ee79</Id>
+      <Database Name="cv" Series="47331" Issue="334169" />
     </Book>
     <Book Series="Avengers Academy" Number="29" Volume="2010" Year="2012">
-      <Id>ae06f438-948a-4cf6-813b-8b0960fecda1</Id>
+      <Database Name="cv" Series="33633" Issue="334211" />
     </Book>
     <Book Series="Avengers Academy" Number="30" Volume="2010" Year="2012">
-      <Id>037842be-be48-41b3-aa58-f7c8edf022a8</Id>
+      <Database Name="cv" Series="33633" Issue="335928" />
     </Book>
     <Book Series="Avengers Academy" Number="31" Volume="2010" Year="2012">
-      <Id>0708a180-8dae-41d6-878f-6c04540e7db3</Id>
+      <Database Name="cv" Series="33633" Issue="338524" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="10" Volume="2011" Year="2012">
-      <Id>99c1a28a-ade0-4778-8d58-898b670d197f</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="10" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43539" Issue="335236" />
     </Book>
     <Book Series="X-Men: Legacy" Number="266" Volume="2008" Year="2012">
-      <Id>2bc5a807-c6f4-4acf-b014-ce8fcc4f4973</Id>
+      <Database Name="cv" Series="20691" Issue="335232" />
     </Book>
     <Book Series="X-Men: Legacy" Number="267" Volume="2008" Year="2012">
-      <Id>1e5ddb65-efb1-468f-bde1-4a8af200357a</Id>
+      <Database Name="cv" Series="20691" Issue="337502" />
     </Book>
     <Book Series="Avengers" Number="25" Volume="2010" Year="2012">
-      <Id>ab98876e-d260-4d76-a610-69aa48585d20</Id>
+      <Database Name="cv" Series="33227" Issue="331948" />
     </Book>
     <Book Series="Secret Avengers" Number="26" Volume="2010" Year="2012">
-      <Id>0b3d10dd-77e2-4824-abcc-8a86cf9292ea</Id>
+      <Database Name="cv" Series="33350" Issue="333444" />
     </Book>
     <Book Series="Secret Avengers" Number="27" Volume="2010" Year="2012">
-      <Id>8187f37b-67a9-451a-a4a7-2f1472b24d0e</Id>
+      <Database Name="cv" Series="33350" Issue="336585" />
     </Book>
     <Book Series="Secret Avengers" Number="28" Volume="2010" Year="2012">
-      <Id>375b7c55-e1ac-49f4-9187-482793fea007</Id>
+      <Database Name="cv" Series="33350" Issue="341693" />
     </Book>
     <Book Series="Avengers" Number="26" Volume="2010" Year="2012">
-      <Id>2d2a6b3a-0ee5-44a8-943b-7e210d54c6e5</Id>
+      <Database Name="cv" Series="33227" Issue="335925" />
     </Book>
     <Book Series="Avengers" Number="27" Volume="2010" Year="2012">
-      <Id>66e69f6d-b4bf-4c7b-95dc-af1c15a97302</Id>
+      <Database Name="cv" Series="33227" Issue="340392" />
     </Book>
     <Book Series="Avengers Vs. X-Men" Number="4" Volume="2012" Year="2012">
-      <Id>c9f324ce-f4d1-4d0f-93bb-f49cf8d2e12e</Id>
+      <Database Name="cv" Series="47331" Issue="336045" />
     </Book>
     <Book Series="AVX: VS" Number="2" Volume="2012" Year="2012">
-      <Id>d5383d71-9604-47b8-9880-00a20d750598</Id>
+      <Database Name="cv" Series="48342" Issue="335954" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="11" Volume="2011" Year="2012">
-      <Id>14657e5d-ea38-41f9-8400-096722bf5aa7</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="11" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43539" Issue="337499" />
     </Book>
     <Book Series="AVX: VS" Number="5" Volume="2012" Year="2012">
-      <Id>ce9d97b7-df0d-431b-ad57-8dab2167946f</Id>
+      <Database Name="cv" Series="48342" Issue="354184" />
     </Book>
-    <Book Series="Uncanny X-Men" Number="12" Volume="2012" Year="2012">
-      <Id>8dcb86c7-0353-4094-a734-292238d4a86f</Id>
+    <Book Series="Uncanny X-Men" Number="12" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43785" Issue="336047" />
     </Book>
     <Book Series="Avengers Vs. X-Men" Number="5" Volume="2012" Year="2012">
-      <Id>d5e04532-7bd0-43f8-b4b6-838fca87c17b</Id>
+      <Database Name="cv" Series="47331" Issue="338525" />
     </Book>
     <Book Series="AVX: VS" Number="3" Volume="2012" Year="2012">
-      <Id>a2f16a70-7587-47aa-a7a6-00f6e5490bfa</Id>
+      <Database Name="cv" Series="48342" Issue="340399" />
     </Book>
-    <Book Series="Uncanny X-Men" Number="13" Volume="2012" Year="2012">
-      <Id>5825d9e6-f0b6-4c06-8426-496ecab7cf6e</Id>
+    <Book Series="Uncanny X-Men" Number="13" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43785" Issue="338486" />
     </Book>
-    <Book Series="Uncanny X-Men" Number="14" Volume="2012" Year="2012">
-      <Id>cb0435bc-ace6-47cc-b05e-62ae97456d70</Id>
+    <Book Series="Uncanny X-Men" Number="14" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43785" Issue="341738" />
     </Book>
     <Book Series="Avengers Vs. X-Men" Number="6" Volume="2012" Year="2012">
-      <Id>5f489e6e-8353-4ce0-9c27-f2aec9c0c3d5</Id>
+      <Database Name="cv" Series="47331" Issue="341749" />
     </Book>
     <Book Series="Avengers Vs. X-Men: Infinite" Number="6" Volume="2012" Year="2012">
-      <Id>f9a4c9f7-96e9-4d90-bd94-a594985c5120</Id>
+      <Database Name="cv" Series="47625" Issue="341924" />
     </Book>
     <Book Series="X-Men: Legacy" Number="268" Volume="2008" Year="2012">
-      <Id>1f0a35ec-e501-40a9-b624-1d5a86ded718</Id>
+      <Database Name="cv" Series="20691" Issue="340395" />
     </Book>
     <Book Series="Avengers Academy" Number="32" Volume="2010" Year="2012">
-      <Id>af50d147-d3df-4cf7-aed9-dd08abf313c3</Id>
+      <Database Name="cv" Series="33633" Issue="341837" />
     </Book>
     <Book Series="Avengers Academy" Number="33" Volume="2010" Year="2012">
-      <Id>cf965975-4898-46cd-a101-5e6dabccf1f7</Id>
+      <Database Name="cv" Series="33633" Issue="346269" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="16" Volume="2011" Year="2012">
-      <Id>b68b0fa7-d16b-4cce-852c-15bf57b2ba8d</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="16" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43539" Issue="356779" />
     </Book>
     <Book Series="Avengers" Number="28" Volume="2010" Year="2012">
-      <Id>75bc807e-112c-40ce-b915-c241b87edaeb</Id>
+      <Database Name="cv" Series="33227" Issue="347231" />
     </Book>
-    <Book Series="Uncanny X-Men" Number="15" Volume="2012" Year="2012">
-      <Id>fedb99e1-2a4b-4b01-9ac7-db7b7ef27a4a</Id>
+    <Book Series="Uncanny X-Men" Number="15" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43785" Issue="344115" />
     </Book>
-    <Book Series="Uncanny X-Men" Number="16" Volume="2012" Year="2012">
-      <Id>001f88b5-9a34-4923-b638-8b8b22d8f050</Id>
+    <Book Series="Uncanny X-Men" Number="16" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43785" Issue="346273" />
     </Book>
-    <Book Series="Uncanny X-Men" Number="17" Volume="2012" Year="2012">
-      <Id>dc4799cc-b3cc-4c51-a6be-4991ca971d28</Id>
+    <Book Series="Uncanny X-Men" Number="17" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43785" Issue="352641" />
     </Book>
     <Book Series="New Avengers" Number="29" Volume="2010" Year="2012">
-      <Id>00d47060-8834-444f-9bdc-3920e65ae18d</Id>
+      <Database Name="cv" Series="33777" Issue="349640" />
     </Book>
     <Book Series="Avengers Vs. X-Men" Number="7" Volume="2012" Year="2012">
-      <Id>db2de910-ad78-4d73-af4c-e846d9ad52f6</Id>
+      <Database Name="cv" Series="47331" Issue="344114" />
     </Book>
     <Book Series="AVX: VS" Number="4" Volume="2012" Year="2012">
-      <Id>3edb3248-3f08-449c-b2a7-90a330e2cc19</Id>
+      <Database Name="cv" Series="48342" Issue="345445" />
     </Book>
     <Book Series="Avengers" Number="29" Volume="2010" Year="2012">
-      <Id>050cb84b-27bd-4ca2-a01c-c03f222c30a8</Id>
+      <Database Name="cv" Series="33227" Issue="351071" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="12" Volume="2011" Year="2012">
-      <Id>85c38c76-5922-4086-9969-81b646aa4ce5</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="12" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43539" Issue="342841" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="13" Volume="2011" Year="2012">
-      <Id>99885785-1a89-4ae7-a661-dac83440f1b5</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="13" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43539" Issue="345398" />
     </Book>
     <Book Series="Avengers Vs. X-Men" Number="8" Volume="2012" Year="2012">
-      <Id>4890b435-8d2d-4169-be96-748ee320601e</Id>
+      <Database Name="cv" Series="47331" Issue="346240" />
     </Book>
     <Book Series="New Avengers" Number="25" Volume="2010" Year="2012">
-      <Id>a8ac332c-63fe-45de-9149-9f06f81fb21b</Id>
+      <Database Name="cv" Series="33777" Issue="333450" />
     </Book>
     <Book Series="New Avengers" Number="26" Volume="2010" Year="2012">
-      <Id>a6e89747-9e68-40c7-9064-d21de051b628</Id>
+      <Database Name="cv" Series="33777" Issue="335284" />
     </Book>
     <Book Series="New Avengers" Number="27" Volume="2010" Year="2012">
-      <Id>5f02b221-ee8d-49b3-bb16-fc412583feaa</Id>
+      <Database Name="cv" Series="33777" Issue="341733" />
     </Book>
     <Book Series="New Avengers" Number="28" Volume="2010" Year="2012">
-      <Id>6ccce8a4-24ce-41fb-922f-d7ee876db2d6</Id>
+      <Database Name="cv" Series="33777" Issue="345393" />
     </Book>
     <Book Series="X-Men: Legacy" Number="269" Volume="2008" Year="2012">
-      <Id>61d43fee-78ef-48d5-9f4e-9fe7b33add9c</Id>
+      <Database Name="cv" Series="20691" Issue="342842" />
     </Book>
     <Book Series="X-Men: Legacy" Number="270" Volume="2008" Year="2012">
-      <Id>5d6db1ed-dab0-4a01-a9d9-47ebc05fcc38</Id>
+      <Database Name="cv" Series="20691" Issue="347229" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="14" Volume="2011" Year="2012">
-      <Id>d2410b34-3d77-4060-b21b-081a54fc45b5</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="14" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43539" Issue="347208" />
     </Book>
     <Book Series="Avengers Vs. X-Men" Number="9" Volume="2012" Year="2012">
-      <Id>c8c9640a-790b-4dee-a6fa-9256278457d4</Id>
+      <Database Name="cv" Series="47331" Issue="348054" />
     </Book>
     <Book Series="Avengers Vs. X-Men: Infinite" Number="10" Volume="2012" Year="2012">
-      <Id>8d7c64c1-2a82-4864-9400-0a9b0075f5e6</Id>
+      <Database Name="cv" Series="47625" Issue="351270" />
     </Book>
     <Book Series="Avengers Vs. X-Men" Number="10" Volume="2012" Year="2012">
-      <Id>2b7cfa2a-bf09-4a88-82d9-ca28d40103b9</Id>
+      <Database Name="cv" Series="47331" Issue="351068" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="15" Volume="2011" Year="2012">
-      <Id>046d2569-9af8-41db-bc2b-5580a4a6a0ca</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="15" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43539" Issue="354103" />
     </Book>
     <Book Series="Avengers Vs. X-Men" Number="11" Volume="2012" Year="2012">
-      <Id>c389edff-e3ad-42d7-92b0-864483403a8c</Id>
+      <Database Name="cv" Series="47331" Issue="356764" />
     </Book>
-    <Book Series="Uncanny X-Men" Number="18" Volume="2012" Year="2012">
-      <Id>fee5eed8-87f5-499d-aef8-a60ac18fc9e3</Id>
+    <Book Series="Uncanny X-Men" Number="18" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43785" Issue="356777" />
     </Book>
     <Book Series="Avengers Vs. X-Men" Number="12" Volume="2012" Year="2012">
-      <Id>28a5a897-c409-48bb-8ac7-910c8b769a0a</Id>
+      <Database Name="cv" Series="47331" Issue="359916" />
     </Book>
-    <Book Series="Uncanny X-Men" Number="19" Volume="2012" Year="2012">
-      <Id>4043928a-aba8-40e8-b353-250b49eeffab</Id>
+    <Book Series="Uncanny X-Men" Number="19" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43785" Issue="360032" />
     </Book>
     <Book Series="AVX: VS" Number="6" Volume="2012" Year="2012">
-      <Id>2cad5742-b241-40b0-8d68-ba74909fd72e</Id>
+      <Database Name="cv" Series="48342" Issue="360037" />
     </Book>
     <Book Series="New Avengers" Number="30" Volume="2010" Year="2012">
-      <Id>a212dc25-9367-451f-8bc4-6945a9a75e52</Id>
+      <Database Name="cv" Series="33777" Issue="356773" />
     </Book>
     <Book Series="Avengers" Number="30" Volume="2010" Year="2012">
-      <Id>753e5980-c72e-4574-8236-62a220b0f577</Id>
+      <Database Name="cv" Series="33227" Issue="357707" />
     </Book>
-    <Book Series="Uncanny X-Men" Number="20" Volume="2012" Year="2012">
-      <Id>717d4443-4d1f-4f7a-9d37-a55f4bab494b</Id>
+    <Book Series="Uncanny X-Men" Number="20" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43785" Issue="362220" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="17" Volume="2011" Year="2012">
-      <Id>b2954686-f6ec-4b03-9054-d443bd6cf821</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="17" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43539" Issue="358926" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="18" Volume="2011" Year="2012">
-      <Id>40bf5c00-5a92-481e-891f-cf42c38fba56</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="18" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43539" Issue="360916" />
     </Book>
     <Book Series="Wolverine" Number="310" Volume="2010" Year="2012">
-      <Id>7d79df98-f973-48bb-84b2-e0d5b5d67126</Id>
+      <Database Name="cv" Series="35263" Issue="344051" />
     </Book>
     <Book Series="Wolverine" Number="311" Volume="2010" Year="2012">
-      <Id>ef46b583-9927-464f-9582-58f66ea362b1</Id>
+      <Database Name="cv" Series="35263" Issue="348384" />
     </Book>
     <Book Series="Wolverine" Number="312" Volume="2010" Year="2012">
-      <Id>719b9fde-3f38-4fae-9ce5-456d3d26ad4d</Id>
+      <Database Name="cv" Series="35263" Issue="352670" />
     </Book>
     <Book Series="Wolverine" Number="313" Volume="2010" Year="2012">
-      <Id>3de63068-33af-4285-aeea-ded2f998601a</Id>
+      <Database Name="cv" Series="35263" Issue="358977" />
     </Book>
     <Book Series="Fantastic Four Annual" Number="33" Volume="1963" Year="2012">
-      <Id>b79d2c3f-7b78-4136-b10f-2d8b44dbcfb5</Id>
+      <Database Name="cv" Series="2129" Issue="345406" />
     </Book>
     <Book Series="Daredevil Annual" Number="1" Volume="2012" Year="2012">
-      <Id>7ce3fbde-0a24-4516-bbc0-7c200f7d3df0</Id>
+      <Database Name="cv" Series="51109" Issue="349681" />
     </Book>
     <Book Series="Wolverine Annual" Number="1" Volume="2012" Year="2012">
-      <Id>13ffa23f-665f-4e83-8df5-c178bccc5ffc</Id>
+      <Database Name="cv" Series="51435" Issue="352699" />
     </Book>
     <Book Series="X-Men" Number="34" Volume="2010" Year="2012">
-      <Id>d0fd66b4-079b-43c4-979e-68bcfdd9c839</Id>
+      <Database Name="cv" Series="34221" Issue="351054" />
     </Book>
     <Book Series="X-Men" Number="35" Volume="2010" Year="2012">
-      <Id>cc96e440-91b2-4d49-84c3-6d37033c1caa</Id>
+      <Database Name="cv" Series="34221" Issue="356778" />
     </Book>
     <Book Series="X-Men: Legacy" Number="271" Volume="2008" Year="2012">
-      <Id>72b8d4df-aa7c-4c3b-9be2-be687d8581c2</Id>
+      <Database Name="cv" Series="20691" Issue="349676" />
     </Book>
     <Book Series="X-Men: Legacy" Number="272" Volume="2008" Year="2012">
-      <Id>6a0fcbb8-95a0-4dba-8285-50e7c7d8a3ad</Id>
+      <Database Name="cv" Series="20691" Issue="352694" />
     </Book>
     <Book Series="X-Men: Legacy" Number="273" Volume="2008" Year="2012">
-      <Id>a84286a8-f9ee-462a-8f49-88af7b4704b4</Id>
+      <Database Name="cv" Series="20691" Issue="356780" />
     </Book>
     <Book Series="X-Factor" Number="241" Volume="2006" Year="2012">
-      <Id>73148dbe-56f8-42b9-aa70-d391fb3fd65a</Id>
+      <Database Name="cv" Series="18109" Issue="348126" />
     </Book>
     <Book Series="X-Factor" Number="242" Volume="2006" Year="2012">
-      <Id>c0becab3-1826-460f-9be4-9f6c3f59e8d4</Id>
+      <Database Name="cv" Series="18109" Issue="351080" />
     </Book>
     <Book Series="X-Factor" Number="243" Volume="2006" Year="2012">
-      <Id>8c3302a8-a174-411d-bc99-720ff1038769</Id>
+      <Database Name="cv" Series="18109" Issue="355877" />
     </Book>
     <Book Series="X-Factor" Number="244" Volume="2006" Year="2012">
-      <Id>1064fee3-0aa9-45a8-90d2-db1cf3f28396</Id>
+      <Database Name="cv" Series="18109" Issue="357644" />
     </Book>
     <Book Series="X-Factor" Number="245" Volume="2006" Year="2012">
-      <Id>6ba42e41-1d22-4369-8cda-88a5dc6535a1</Id>
+      <Database Name="cv" Series="18109" Issue="362203" />
     </Book>
     <Book Series="X-Men" Number="36" Volume="2010" Year="2012">
-      <Id>be70e826-ecc6-40ea-929b-26a758744672</Id>
+      <Database Name="cv" Series="34221" Issue="358924" />
     </Book>
     <Book Series="X-Men" Number="37" Volume="2010" Year="2012">
-      <Id>728eace1-2687-4551-9ee8-c9cb6163db80</Id>
+      <Database Name="cv" Series="34221" Issue="360906" />
     </Book>
     <Book Series="X-Men: Legacy" Number="274" Volume="2008" Year="2012">
-      <Id>7b3ce6c2-ca75-449f-9323-6cc3db6b976a</Id>
+      <Database Name="cv" Series="20691" Issue="358972" />
     </Book>
     <Book Series="X-Men: Legacy" Number="275" Volume="2008" Year="2012">
-      <Id>eb99f725-af6e-4841-83e5-932d4df34f49</Id>
+      <Database Name="cv" Series="20691" Issue="364155" />
     </Book>
     <Book Series="New Mutants" Number="47" Volume="2009" Year="2012">
-      <Id>53a3bca5-d712-4e6e-8c26-1c5940f70148</Id>
+      <Database Name="cv" Series="26327" Issue="351089" />
     </Book>
     <Book Series="New Mutants" Number="48" Volume="2009" Year="2012">
-      <Id>009d1308-6fe8-40b0-9c52-4a3e4ee337a3</Id>
+      <Database Name="cv" Series="26327" Issue="354129" />
     </Book>
     <Book Series="New Mutants" Number="49" Volume="2009" Year="2012">
-      <Id>f53155cc-f7db-4349-92e1-0794a065743d</Id>
+      <Database Name="cv" Series="26327" Issue="357710" />
     </Book>
     <Book Series="New Mutants" Number="50" Volume="2009" Year="2012">
-      <Id>03c45268-5903-4d1c-9794-44e3f814e432</Id>
+      <Database Name="cv" Series="26327" Issue="364161" />
     </Book>
     <Book Series="AVX: Consequences" Number="1" Volume="2012" Year="2012">
-      <Id>80007ccc-f077-4e48-9609-2c7644da178b</Id>
+      <Database Name="cv" Series="52885" Issue="360904" />
     </Book>
     <Book Series="AVX: Consequences" Number="2" Volume="2012" Year="2012">
-      <Id>34c04f3e-b843-434d-9f66-195fb366fded</Id>
+      <Database Name="cv" Series="52885" Issue="362180" />
     </Book>
     <Book Series="AVX: Consequences" Number="3" Volume="2012" Year="2012">
-      <Id>fa088423-5cdf-4eae-abd0-aa035e5e116f</Id>
+      <Database Name="cv" Series="52885" Issue="363152" />
     </Book>
     <Book Series="AVX: Consequences" Number="4" Volume="2012" Year="2012">
-      <Id>4a273330-8cc9-4b12-86a7-492a41152c30</Id>
+      <Database Name="cv" Series="52885" Issue="364151" />
     </Book>
     <Book Series="AVX: Consequences" Number="5" Volume="2012" Year="2013">
-      <Id>d2002c5e-ada1-468d-a769-8d3b24d933e5</Id>
+      <Database Name="cv" Series="52885" Issue="366173" />
     </Book>
     <Book Series="Savage Wolverine" Number="1" Volume="2013" Year="2013">
-      <Id>7cef0cd4-29ce-4980-9e75-d9723ab857ba</Id>
+      <Database Name="cv" Series="55802" Issue="380278" />
     </Book>
     <Book Series="Savage Wolverine" Number="2" Volume="2013" Year="2013">
-      <Id>1ebffb33-d0ce-4d18-af6f-cb6da2aa108d</Id>
+      <Database Name="cv" Series="55802" Issue="387261" />
     </Book>
     <Book Series="Savage Wolverine" Number="3" Volume="2013" Year="2013">
-      <Id>9ddc9bbc-f315-4621-8822-03c89ad5b61f</Id>
+      <Database Name="cv" Series="55802" Issue="394711" />
     </Book>
     <Book Series="Savage Wolverine" Number="4" Volume="2013" Year="2013">
-      <Id>bb64ba3f-e9bc-4c57-82ab-977b0ba6de24</Id>
+      <Database Name="cv" Series="55802" Issue="397549" />
     </Book>
     <Book Series="Savage Wolverine" Number="5" Volume="2013" Year="2013">
-      <Id>0c1a4e79-0ff6-40b0-b598-57462c46399f</Id>
+      <Database Name="cv" Series="55802" Issue="406979" />
     </Book>
     <Book Series="X-Factor" Number="246" Volume="2006" Year="2013">
-      <Id>b1506eff-6f4d-4946-bd4c-8f7e0b25dc86</Id>
+      <Database Name="cv" Series="18109" Issue="366185" />
     </Book>
     <Book Series="X-Factor" Number="247" Volume="2006" Year="2013">
-      <Id>fd0faf1f-04b3-402b-8218-57cfff53e407</Id>
+      <Database Name="cv" Series="18109" Issue="369106" />
     </Book>
     <Book Series="X-Factor" Number="248" Volume="2006" Year="2013">
-      <Id>9e3f37b4-b6cf-4ff2-9cb2-196100faf855</Id>
+      <Database Name="cv" Series="18109" Issue="371164" />
     </Book>
     <Book Series="X-Factor" Number="249" Volume="2006" Year="2013">
-      <Id>ef4fab32-f6e9-446b-b10c-38d9c9fe6218</Id>
+      <Database Name="cv" Series="18109" Issue="373314" />
     </Book>
     <Book Series="Savage Wolverine" Number="6" Volume="2013" Year="2013">
-      <Id>ac44dcf5-618f-4e73-b6b0-28c27ba7c702</Id>
+      <Database Name="cv" Series="55802" Issue="410321" />
     </Book>
     <Book Series="Savage Wolverine" Number="7" Volume="2013" Year="2013">
-      <Id>7b82fde3-614c-4011-b105-78fe8246158b</Id>
+      <Database Name="cv" Series="55802" Issue="417841" />
     </Book>
     <Book Series="Savage Wolverine" Number="8" Volume="2013" Year="2013">
-      <Id>1f721b13-6d57-4613-a555-f41dede19a9b</Id>
+      <Database Name="cv" Series="55802" Issue="425937" />
     </Book>
-    <Book Series="Deadpool" Number="1" Volume="2013" Year="2013">
-      <Id>082ed43d-695d-4aa4-8b72-7bc05113cd11</Id>
+    <Book Series="Deadpool" Number="1" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53726" Issue="365760" />
     </Book>
-    <Book Series="Deadpool" Number="2" Volume="2013" Year="2013">
-      <Id>00d4559c-f04c-439f-9990-f53121974d38</Id>
+    <Book Series="Deadpool" Number="2" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53726" Issue="369057" />
     </Book>
-    <Book Series="Deadpool" Number="3" Volume="2013" Year="2013">
-      <Id>dee83ccf-06b3-47c2-beff-a3425f23c77b</Id>
+    <Book Series="Deadpool" Number="3" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53726" Issue="371106" />
     </Book>
-    <Book Series="Deadpool" Number="4" Volume="2013" Year="2013">
-      <Id>1f139581-dcbf-4219-9e24-af058aa7158f</Id>
+    <Book Series="Deadpool" Number="4" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53726" Issue="381412" />
     </Book>
-    <Book Series="Deadpool" Number="5" Volume="2013" Year="2013">
-      <Id>53895552-2fc4-480b-825b-3e3a93d1a402</Id>
+    <Book Series="Deadpool" Number="5" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53726" Issue="387257" />
     </Book>
-    <Book Series="Deadpool" Number="6" Volume="2013" Year="2013">
-      <Id>4886e86e-1c0f-4634-b6db-4e5329f58962</Id>
+    <Book Series="Deadpool" Number="6" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53726" Issue="394707" />
     </Book>
     <Book Series="X-Factor" Number="250" Volume="2006" Year="2013">
-      <Id>01434001-f3e4-4808-b892-2604bd376e3a</Id>
+      <Database Name="cv" Series="18109" Issue="380359" />
     </Book>
     <Book Series="X-Factor" Number="251" Volume="2006" Year="2013">
-      <Id>2d0a7cf2-84dd-417c-af95-a9d532a01b21</Id>
+      <Database Name="cv" Series="18109" Issue="384969" />
     </Book>
     <Book Series="X-Factor" Number="252" Volume="2006" Year="2013">
-      <Id>5e9ead2d-708b-49ac-a0ee-1e81f1a1b732</Id>
+      <Database Name="cv" Series="18109" Issue="387265" />
     </Book>
     <Book Series="X-Factor" Number="253" Volume="2006" Year="2013">
-      <Id>9a5e3e80-124a-4da5-9f2d-d9a4c0a09f90</Id>
+      <Database Name="cv" Series="18109" Issue="394714" />
     </Book>
     <Book Series="X-Factor" Number="254" Volume="2006" Year="2013">
-      <Id>b4db182f-c352-4481-a2cb-689a60728673</Id>
+      <Database Name="cv" Series="18109" Issue="397555" />
     </Book>
     <Book Series="X-Factor" Number="255" Volume="2006" Year="2013">
-      <Id>07be473c-1ae8-458e-ae84-d4b3aaa5343f</Id>
+      <Database Name="cv" Series="18109" Issue="400156" />
     </Book>
     <Book Series="X-Factor" Number="256" Volume="2006" Year="2013">
-      <Id>4ca4e409-8d76-450c-a26b-cb3fbf0d4317</Id>
+      <Database Name="cv" Series="18109" Issue="402294" />
     </Book>
     <Book Series="X-Factor" Number="257" Volume="2006" Year="2013">
-      <Id>d65b07e8-7c07-4ca0-86a9-ca01daa78d2e</Id>
+      <Database Name="cv" Series="18109" Issue="409004" />
     </Book>
     <Book Series="X-Factor" Number="258" Volume="2006" Year="2013">
-      <Id>fdde437f-6ec8-4482-a510-4c125c3f85c2</Id>
+      <Database Name="cv" Series="18109" Issue="411837" />
     </Book>
     <Book Series="X-Factor" Number="259" Volume="2006" Year="2013">
-      <Id>46b9d7b6-6c2c-478d-9402-42c8764659f6</Id>
+      <Database Name="cv" Series="18109" Issue="417850" />
     </Book>
     <Book Series="X-Factor" Number="260" Volume="2006" Year="2013">
-      <Id>6fa20a90-1548-48be-b1a0-adbb4b91000c</Id>
+      <Database Name="cv" Series="18109" Issue="420648" />
     </Book>
     <Book Series="X-Factor" Number="261" Volume="2006" Year="2013">
-      <Id>71a06641-8a0c-4166-b371-433271e014bc</Id>
+      <Database Name="cv" Series="18109" Issue="422505" />
     </Book>
     <Book Series="X-Factor" Number="262" Volume="2006" Year="2013">
-      <Id>ea114eed-3362-4e9b-b020-e33d9be3e157</Id>
+      <Database Name="cv" Series="18109" Issue="424542" />
     </Book>
     <Book Series="Uncanny X-Force" Number="24" Volume="2010" Year="2012">
-      <Id>24a52347-3c85-4cc5-976a-43044acb2c1a</Id>
+      <Database Name="cv" Series="35835" Issue="331917" />
     </Book>
     <Book Series="Uncanny X-Force" Number="25" Volume="2010" Year="2012">
-      <Id>5f0cefdd-ebf3-4950-82ab-cfcaa8e12d15</Id>
+      <Database Name="cv" Series="35835" Issue="335059" />
     </Book>
     <Book Series="Uncanny X-Force" Number="26" Volume="2010" Year="2012">
-      <Id>3d8f6ef9-5f8d-445c-be1f-ccda8a48436f</Id>
+      <Database Name="cv" Series="35835" Issue="340176" />
     </Book>
     <Book Series="Uncanny X-Force" Number="27" Volume="2010" Year="2012">
-      <Id>0e439067-8f9e-41d6-b4dd-21da13a9e8f2</Id>
+      <Database Name="cv" Series="35835" Issue="345327" />
     </Book>
     <Book Series="Uncanny X-Force" Number="28" Volume="2010" Year="2012">
-      <Id>4261c217-51a1-4ce6-ad16-fd1bc9c73843</Id>
+      <Database Name="cv" Series="35835" Issue="347199" />
     </Book>
     <Book Series="Uncanny X-Force" Number="29" Volume="2010" Year="2012">
-      <Id>8c6aefd8-6dfc-4dee-8c9f-772caeae6ee5</Id>
+      <Database Name="cv" Series="35835" Issue="351056" />
     </Book>
     <Book Series="Uncanny X-Force" Number="30" Volume="2010" Year="2012">
-      <Id>8446f7f1-b6f8-41dc-b0be-5f9eed4f9a6e</Id>
+      <Database Name="cv" Series="35835" Issue="354097" />
     </Book>
     <Book Series="Uncanny X-Force" Number="31" Volume="2010" Year="2012">
-      <Id>099aa704-99e5-4fa6-a99d-fbee4d925e94</Id>
+      <Database Name="cv" Series="35835" Issue="356772" />
     </Book>
     <Book Series="Uncanny X-Force" Number="32" Volume="2010" Year="2012">
-      <Id>efe2f2a1-c733-4efb-ab38-f6368d685e58</Id>
+      <Database Name="cv" Series="35835" Issue="360030" />
     </Book>
     <Book Series="Uncanny X-Force" Number="33" Volume="2010" Year="2013">
-      <Id>cbc68070-d97e-4e90-8f02-7017d193ef33</Id>
+      <Database Name="cv" Series="35835" Issue="366181" />
     </Book>
     <Book Series="Uncanny X-Force" Number="34" Volume="2010" Year="2013">
-      <Id>f668e38e-5977-41ab-8a6e-07caeefaae19</Id>
+      <Database Name="cv" Series="35835" Issue="369095" />
     </Book>
     <Book Series="Uncanny X-Force" Number="35" Volume="2010" Year="2013">
-      <Id>b5cc4ba8-9e81-4a49-93f1-457e388e4bd7</Id>
+      <Database Name="cv" Series="35835" Issue="373316" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="19" Volume="2011" Year="2012">
-      <Id>c7957820-f0a1-44ea-b6b0-db7a5b2edec8</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="19" Volume="2011" Year="2012">
+      <Database Name="cv" Series="43539" Issue="364133" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="20" Volume="2011" Year="2013">
-      <Id>ab509176-d2e8-4a62-a652-a11c7cae0620</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="20" Volume="2011" Year="2013">
+      <Database Name="cv" Series="43539" Issue="367699" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="21" Volume="2011" Year="2013">
-      <Id>99e96d76-3064-4359-b8a7-a6f1ff4f65a9</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="21" Volume="2011" Year="2013">
+      <Database Name="cv" Series="43539" Issue="369058" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="22" Volume="2011" Year="2013">
-      <Id>e46ef56f-3d7d-4699-9262-7d26f771e3a4</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="22" Volume="2011" Year="2013">
+      <Database Name="cv" Series="43539" Issue="373313" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="23" Volume="2011" Year="2013">
-      <Id>ac35dc27-ae18-4c7b-ab24-08c2e9617df7</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="23" Volume="2011" Year="2013">
+      <Database Name="cv" Series="43539" Issue="378900" />
     </Book>
     <Book Series="Gambit" Number="1" Volume="2012" Year="2012">
-      <Id>f270498e-ddca-417e-9cf9-632f35fab8ac</Id>
+      <Database Name="cv" Series="51107" Issue="349643" />
     </Book>
     <Book Series="Gambit" Number="2" Volume="2012" Year="2012">
-      <Id>05022b88-942b-4c65-a83b-e904faefce1c</Id>
+      <Database Name="cv" Series="51107" Issue="354144" />
     </Book>
     <Book Series="Gambit" Number="3" Volume="2012" Year="2012">
-      <Id>f23bf940-4d1c-4572-a22d-bb7bb9d1a5b5</Id>
+      <Database Name="cv" Series="51107" Issue="358930" />
     </Book>
     <Book Series="Gambit" Number="4" Volume="2012" Year="2012">
-      <Id>5006ef50-1f66-4895-b9c5-73cdc9388308</Id>
+      <Database Name="cv" Series="51107" Issue="363157" />
     </Book>
     <Book Series="Gambit" Number="5" Volume="2012" Year="2013">
-      <Id>259984ba-bce7-441e-bff3-df6541acc10d</Id>
+      <Database Name="cv" Series="51107" Issue="367779" />
     </Book>
     <Book Series="Gambit" Number="6" Volume="2012" Year="2013">
-      <Id>591bd806-ccf2-49fd-bd79-1455488780aa</Id>
+      <Database Name="cv" Series="51107" Issue="370563" />
     </Book>
     <Book Series="Gambit" Number="7" Volume="2012" Year="2013">
-      <Id>bd37b78c-cfea-4392-a5db-b00c2656d70c</Id>
+      <Database Name="cv" Series="51107" Issue="373302" />
     </Book>
     <Book Series="Astonishing X-Men" Number="52" Volume="2004" Year="2012">
-      <Id>fcd6265d-44d6-4da4-8c64-ece636d704be</Id>
+      <Database Name="cv" Series="10746" Issue="347211" />
     </Book>
     <Book Series="Astonishing X-Men" Number="53" Volume="2004" Year="2012">
-      <Id>96d51374-b2d7-42e4-8acc-10ef2667b85d</Id>
+      <Database Name="cv" Series="10746" Issue="352581" />
     </Book>
     <Book Series="Astonishing X-Men" Number="54" Volume="2004" Year="2012">
-      <Id>e9d2508b-1ac2-40bc-b3c9-5e7e6e71db0f</Id>
+      <Database Name="cv" Series="10746" Issue="358956" />
     </Book>
     <Book Series="Astonishing X-Men" Number="55" Volume="2004" Year="2012">
-      <Id>bb7802bf-a012-4e37-a136-87bf6ae234d8</Id>
+      <Database Name="cv" Series="10746" Issue="363150" />
     </Book>
     <Book Series="Astonishing X-Men" Number="56" Volume="2004" Year="2013">
-      <Id>fc4d70c6-6438-4d58-9068-2871dbcc82c9</Id>
+      <Database Name="cv" Series="10746" Issue="369079" />
     </Book>
     <Book Series="Astonishing X-Men Annual" Number="1" Volume="2012" Year="2013">
-      <Id>54608fa5-d42d-4914-b16d-e3bc622f6240</Id>
+      <Database Name="cv" Series="54341" Issue="370561" />
     </Book>
     <Book Series="Astonishing X-Men" Number="57" Volume="2004" Year="2013">
-      <Id>51bfd1cb-7193-4296-8943-18dd7beaec74</Id>
+      <Database Name="cv" Series="10746" Issue="373295" />
     </Book>
     <Book Series="Astonishing X-Men" Number="58" Volume="2004" Year="2013">
-      <Id>13e5a0a1-d608-47fd-87c8-cadca147981d</Id>
+      <Database Name="cv" Series="10746" Issue="381410" />
     </Book>
     <Book Series="X-Men" Number="38" Volume="2010" Year="2013">
-      <Id>ea75d87a-7acc-4225-a363-9deb52fb3e6e</Id>
+      <Database Name="cv" Series="34221" Issue="366182" />
     </Book>
     <Book Series="X-Men" Number="39" Volume="2010" Year="2013">
-      <Id>e545e49d-9757-4490-8395-1e5dc4c9af52</Id>
+      <Database Name="cv" Series="34221" Issue="371261" />
     </Book>
     <Book Series="X-Men" Number="40" Volume="2010" Year="2013">
-      <Id>4b829dad-a704-4cd8-a533-03113d9bed6a</Id>
+      <Database Name="cv" Series="34221" Issue="380360" />
     </Book>
     <Book Series="X-Men" Number="41" Volume="2010" Year="2013">
-      <Id>405b8f15-3e01-4de7-bd88-dbe94fa1801f</Id>
+      <Database Name="cv" Series="34221" Issue="386143" />
     </Book>
     <Book Series="X-Men: Legacy" Number="1" Volume="2013" Year="2013">
-      <Id>77b9c2cb-7e2d-40b8-88a0-f6ece5b08175</Id>
+      <Database Name="cv" Series="53922" Issue="367697" />
     </Book>
     <Book Series="X-Men: Legacy" Number="2" Volume="2013" Year="2013">
-      <Id>ccb2c82a-2469-45dc-91e9-704c7dab9bea</Id>
+      <Database Name="cv" Series="53922" Issue="370369" />
     </Book>
     <Book Series="X-Men: Legacy" Number="3" Volume="2013" Year="2013">
-      <Id>b219e679-f544-4449-bd4a-0d3223679977</Id>
+      <Database Name="cv" Series="53922" Issue="373315" />
     </Book>
     <Book Series="X-Men: Legacy" Number="4" Volume="2013" Year="2013">
-      <Id>f1f97bdc-3483-4251-8859-875f19ccf55a</Id>
+      <Database Name="cv" Series="53922" Issue="378901" />
     </Book>
     <Book Series="X-Men: Legacy" Number="5" Volume="2013" Year="2013">
-      <Id>10c3c19d-f839-447f-9755-49a61ea90501</Id>
+      <Database Name="cv" Series="53922" Issue="381620" />
     </Book>
     <Book Series="X-Men: Legacy" Number="6" Volume="2013" Year="2013">
-      <Id>9b042d2b-44e8-45f6-ad3f-814d70b069b0</Id>
+      <Database Name="cv" Series="53922" Issue="388567" />
     </Book>
     <Book Series="Cable and X-Force" Number="1" Volume="2013" Year="2013">
-      <Id>11ab9a51-308b-48af-96fd-ae21d24411dd</Id>
+      <Database Name="cv" Series="54644" Issue="372342" />
     </Book>
     <Book Series="Cable and X-Force" Number="2" Volume="2013" Year="2013">
-      <Id>5f568ab9-3ecd-4709-83e1-58708d15da1d</Id>
+      <Database Name="cv" Series="54644" Issue="373296" />
     </Book>
     <Book Series="Cable and X-Force" Number="3" Volume="2013" Year="2013">
-      <Id>f0125f74-2c38-4702-9a44-93d4c0a8bad8</Id>
+      <Database Name="cv" Series="54644" Issue="378884" />
     </Book>
     <Book Series="Cable and X-Force" Number="4" Volume="2013" Year="2013">
-      <Id>4df9e64a-2940-440b-9e06-4e6a8807b15b</Id>
+      <Database Name="cv" Series="54644" Issue="386134" />
     </Book>
     <Book Series="Astonishing X-Men" Number="59" Volume="2004" Year="2013">
-      <Id>d9b6f12e-76af-47db-8cf6-a5b9ff78f331</Id>
+      <Database Name="cv" Series="10746" Issue="388551" />
     </Book>
     <Book Series="Age of Apocalypse" Number="13" Volume="2012" Year="2013">
-      <Id>a5f42fb0-6d38-4615-ae77-fb593798a575</Id>
+      <Database Name="cv" Series="46347" Issue="390441" />
     </Book>
     <Book Series="X-Treme X-Men" Number="12" Volume="2012" Year="2013">
-      <Id>d6b9b272-0af8-4cbc-ad2e-8259f089165d</Id>
+      <Database Name="cv" Series="50754" Issue="392365" />
     </Book>
     <Book Series="X-Termination" Number="1" Volume="2013" Year="2013">
-      <Id>44b555ab-156b-4faa-adcb-581b1cb9f9bf</Id>
+      <Database Name="cv" Series="59188" Issue="394715" />
     </Book>
     <Book Series="Astonishing X-Men" Number="60" Volume="2004" Year="2013">
-      <Id>7ba7c19e-72cd-4a30-9483-5f96b9ed8130</Id>
+      <Database Name="cv" Series="10746" Issue="395245" />
     </Book>
     <Book Series="Age of Apocalypse" Number="14" Volume="2012" Year="2013">
-      <Id>6a5e0a88-4265-40cc-9edd-dcc390711c82</Id>
+      <Database Name="cv" Series="46347" Issue="395698" />
     </Book>
     <Book Series="X-Treme X-Men" Number="13" Volume="2012" Year="2013">
-      <Id>94bafb9b-b68f-4bb0-8b83-73c01fd1c8a5</Id>
+      <Database Name="cv" Series="50754" Issue="396438" />
     </Book>
     <Book Series="Astonishing X-Men" Number="61" Volume="2004" Year="2013">
-      <Id>7cf1804e-0edc-49f2-94e2-12c859364846</Id>
+      <Database Name="cv" Series="10746" Issue="397540" />
     </Book>
     <Book Series="X-Termination" Number="2" Volume="2013" Year="2013">
-      <Id>81c327db-9140-435f-83af-8af83b1f2035</Id>
+      <Database Name="cv" Series="59188" Issue="398996" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 014 - (Marvel NOW!).cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 014 - (Marvel NOW!).cbl
@@ -1,918 +1,919 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>X-Men - Part 14 - (Marvel NOW!)</Name>
+  <Name>X-Men - Part 014 - (Marvel NOW!)</Name>
+  <NumIssues>304</NumIssues>
   <Books>
-    <Book Series="All-New X-Men" Number="1" Volume="2013" Year="2013">
-      <Id>10452916-45ec-446f-a2e3-c391cb28240b</Id>
+    <Book Series="All-New X-Men" Number="1" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53919" Issue="367691" />
     </Book>
-    <Book Series="All-New X-Men" Number="2" Volume="2013" Year="2013">
-      <Id>22966396-a9cc-46ee-bd3f-2f3d03116daf</Id>
+    <Book Series="All-New X-Men" Number="2" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53919" Issue="370245" />
     </Book>
-    <Book Series="All-New X-Men" Number="3" Volume="2013" Year="2013">
-      <Id>4b133d8d-1851-4971-8096-564a1406b260</Id>
+    <Book Series="All-New X-Men" Number="3" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53919" Issue="371105" />
     </Book>
-    <Book Series="All-New X-Men" Number="4" Volume="2013" Year="2013">
-      <Id>71d56a58-a843-43e5-9190-ad41215b68ba</Id>
+    <Book Series="All-New X-Men" Number="4" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53919" Issue="373215" />
     </Book>
-    <Book Series="All-New X-Men" Number="5" Volume="2013" Year="2013">
-      <Id>8df26baa-f533-4e0c-8e68-150098bec283</Id>
+    <Book Series="All-New X-Men" Number="5" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53919" Issue="376661" />
     </Book>
-    <Book Series="All-New X-Men" Number="6" Volume="2013" Year="2013">
-      <Id>59d211a3-e458-48cc-880c-7235774115ff</Id>
+    <Book Series="All-New X-Men" Number="6" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53919" Issue="380348" />
     </Book>
-    <Book Series="All-New X-Men" Number="7" Volume="2013" Year="2013">
-      <Id>68428270-0971-40f8-a986-f60ab0351b01</Id>
+    <Book Series="All-New X-Men" Number="7" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53919" Issue="384952" />
     </Book>
-    <Book Series="All-New X-Men" Number="8" Volume="2013" Year="2013">
-      <Id>4dc08b2e-1a97-4550-9c66-25b94764b558</Id>
+    <Book Series="All-New X-Men" Number="8" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53919" Issue="390443" />
     </Book>
     <Book Series="Uncanny Avengers" Number="1" Volume="2012" Year="2012">
-      <Id>2cbbae33-9fdd-41a1-a9ed-ac28b43b776e</Id>
+      <Database Name="cv" Series="52880" Issue="360884" />
     </Book>
     <Book Series="Uncanny Avengers" Number="2" Volume="2012" Year="2013">
-      <Id>807c2878-68df-422a-9666-210653e20e1f</Id>
+      <Database Name="cv" Series="52880" Issue="370249" />
     </Book>
     <Book Series="Uncanny Avengers" Number="3" Volume="2012" Year="2013">
-      <Id>27c386db-c888-4afc-a54e-a5c01bd39cc8</Id>
+      <Database Name="cv" Series="52880" Issue="381419" />
     </Book>
     <Book Series="Uncanny Avengers" Number="4" Volume="2012" Year="2013">
-      <Id>00c9df39-83b3-4660-81a5-e14988dcae45</Id>
+      <Database Name="cv" Series="52880" Issue="388564" />
     </Book>
     <Book Series="A+X" Number="1" Volume="2012" Year="2012">
-      <Id>5cdada2c-01e2-4fc8-a87c-a7b944b9be43</Id>
+      <Database Name="cv" Series="53535" Issue="364153" />
     </Book>
     <Book Series="A+X" Number="2" Volume="2012" Year="2013">
-      <Id>bb920991-8eac-404b-88fe-68a489a4d5af</Id>
+      <Database Name="cv" Series="53535" Issue="370250" />
     </Book>
     <Book Series="A+X" Number="3" Volume="2012" Year="2013">
-      <Id>d5b893b7-476b-4e29-99be-eef13f04d1f2</Id>
+      <Database Name="cv" Series="53535" Issue="373219" />
     </Book>
     <Book Series="A+X" Number="4" Volume="2012" Year="2013">
-      <Id>e5421f0c-6c51-435c-8edf-9ec541e7e105</Id>
+      <Database Name="cv" Series="53535" Issue="381409" />
     </Book>
     <Book Series="A+X" Number="5" Volume="2012" Year="2013">
-      <Id>10d8a635-d460-45cd-a6e1-add6853780e4</Id>
+      <Database Name="cv" Series="53535" Issue="390440" />
     </Book>
     <Book Series="A+X" Number="6" Volume="2012" Year="2013">
-      <Id>30157b14-f536-4553-8763-bca55d38e5b0</Id>
+      <Database Name="cv" Series="53535" Issue="395243" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="24" Volume="2011" Year="2013">
-      <Id>1b001262-3d36-4ca5-98ab-de3149120b9e</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="24" Volume="2011" Year="2013">
+      <Database Name="cv" Series="43539" Issue="381421" />
     </Book>
     <Book Series="Uncanny X-Force" Number="1" Volume="2013" Year="2013">
-      <Id>1b16f63d-74f7-4839-89c5-6c0762653665</Id>
+      <Database Name="cv" Series="56119" Issue="381408" />
     </Book>
     <Book Series="Uncanny X-Force" Number="2" Volume="2013" Year="2013">
-      <Id>fd0a5105-7641-47d4-9993-e6a5f251c728</Id>
+      <Database Name="cv" Series="56119" Issue="388565" />
     </Book>
     <Book Series="Uncanny X-Force" Number="3" Volume="2013" Year="2013">
-      <Id>3902e559-4f39-41de-a13a-6a56f726dbb8</Id>
+      <Database Name="cv" Series="56119" Issue="395259" />
     </Book>
     <Book Series="Uncanny X-Force" Number="4" Volume="2013" Year="2013">
-      <Id>b6f8a026-dbd1-4a64-b8bb-c182ef7c1978</Id>
+      <Database Name="cv" Series="56119" Issue="401213" />
     </Book>
     <Book Series="Uncanny X-Force" Number="5" Volume="2013" Year="2013">
-      <Id>92acb89a-4146-426f-92a3-acc7719f50ef</Id>
+      <Database Name="cv" Series="56119" Issue="406980" />
     </Book>
     <Book Series="Uncanny X-Force" Number="6" Volume="2013" Year="2013">
-      <Id>1fe9dd8d-ec35-4930-935a-7101fae128d1</Id>
+      <Database Name="cv" Series="56119" Issue="410324" />
     </Book>
     <Book Series="Savage Wolverine" Number="9" Volume="2013" Year="2013">
-      <Id>7ec9f0e1-c198-4909-bf28-91a9bbecdd44</Id>
+      <Database Name="cv" Series="55802" Issue="427693" />
     </Book>
     <Book Series="Savage Wolverine" Number="10" Volume="2013" Year="2013">
-      <Id>f8b5dca9-07e2-496d-8ed8-29db3d9208d6</Id>
+      <Database Name="cv" Series="55802" Issue="430760" />
     </Book>
     <Book Series="Savage Wolverine" Number="11" Volume="2013" Year="2014">
-      <Id>823d480d-2c9f-4e85-aa7e-147715e8f8f8</Id>
+      <Database Name="cv" Series="55802" Issue="433175" />
     </Book>
     <Book Series="Savage Wolverine" Number="12" Volume="2013" Year="2014">
-      <Id>c8573fac-52d1-4092-ac27-dd29da360da8</Id>
+      <Database Name="cv" Series="55802" Issue="435063" />
     </Book>
     <Book Series="Savage Wolverine" Number="13" Volume="2013" Year="2014">
-      <Id>716f115b-7831-41b9-8991-93fde1cfe382</Id>
+      <Database Name="cv" Series="55802" Issue="440251" />
     </Book>
     <Book Series="Astonishing X-Men" Number="62" Volume="2004" Year="2013">
-      <Id>402e2685-032c-4595-ba61-4e64cb116e32</Id>
+      <Database Name="cv" Series="10746" Issue="401201" />
     </Book>
     <Book Series="Astonishing X-Men" Number="63" Volume="2004" Year="2013">
-      <Id>503c4816-9f7e-45b0-a1b7-8aad7c7af2d3</Id>
+      <Database Name="cv" Series="10746" Issue="410317" />
     </Book>
     <Book Series="Astonishing X-Men" Number="64" Volume="2004" Year="2013">
-      <Id>4b84e8a9-9cd9-440e-84f0-185a2c8d408a</Id>
+      <Database Name="cv" Series="10746" Issue="416941" />
     </Book>
     <Book Series="Astonishing X-Men" Number="65" Volume="2004" Year="2013">
-      <Id>1c1e38d5-c7f2-4bb4-8413-de4ae13d776a</Id>
+      <Database Name="cv" Series="10746" Issue="421686" />
     </Book>
     <Book Series="Uncanny X-Men" Number="1" Volume="2013" Year="2013">
-      <Id>821b35e1-8301-4c1f-a4c1-67e773d85b90</Id>
+      <Database Name="cv" Series="57181" Issue="386141" />
     </Book>
     <Book Series="Uncanny X-Men" Number="2" Volume="2013" Year="2013">
-      <Id>a6b4b5ed-0aae-453c-b790-0c7e25c69347</Id>
+      <Database Name="cv" Series="57181" Issue="388566" />
     </Book>
     <Book Series="Uncanny X-Men" Number="3" Volume="2013" Year="2013">
-      <Id>3cfc498a-5e37-4ddc-9e30-bcbb5f82fd70</Id>
+      <Database Name="cv" Series="57181" Issue="392362" />
     </Book>
-    <Book Series="All-New X-Men" Number="9" Volume="2013" Year="2013">
-      <Id>cdb0345e-fe75-4566-a477-0b6a38b02b1f</Id>
+    <Book Series="All-New X-Men" Number="9" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53919" Issue="394700" />
     </Book>
     <Book Series="Uncanny Avengers" Number="5" Volume="2012" Year="2013">
-      <Id>5bde829c-f845-4feb-a2ef-51a20034ddae</Id>
+      <Database Name="cv" Series="52880" Issue="395258" />
     </Book>
-    <Book Series="All-New X-Men" Number="10" Volume="2013" Year="2013">
-      <Id>6eb7493e-7de5-4cf0-bc90-0e193c161a4e</Id>
+    <Book Series="All-New X-Men" Number="10" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53919" Issue="395700" />
     </Book>
-    <Book Series="All-New X-Men" Number="11" Volume="2013" Year="2013">
-      <Id>a7895752-0244-4c36-be6e-abdc4a045f5d</Id>
+    <Book Series="All-New X-Men" Number="11" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53919" Issue="400145" />
     </Book>
-    <Book Series="All-New X-Men" Number="12" Volume="2013" Year="2013">
-      <Id>5f8bda44-9073-4dff-baed-06be43436795</Id>
+    <Book Series="All-New X-Men" Number="12" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53919" Issue="408989" />
     </Book>
-    <Book Series="All-New X-Men" Number="13" Volume="2013" Year="2013">
-      <Id>607f83e1-261b-47a8-ae97-462e6818efea</Id>
+    <Book Series="All-New X-Men" Number="13" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53919" Issue="413652" />
     </Book>
     <Book Series="Uncanny X-Men" Number="4" Volume="2013" Year="2013">
-      <Id>baa393fb-c03d-44e3-90a7-b29438d8b5b5</Id>
+      <Database Name="cv" Series="57181" Issue="396436" />
     </Book>
     <Book Series="Uncanny X-Men" Number="5" Volume="2013" Year="2013">
-      <Id>c5252066-6dad-46fe-84b4-4d646d1daec7</Id>
+      <Database Name="cv" Series="57181" Issue="398994" />
     </Book>
     <Book Series="Uncanny X-Men" Number="6" Volume="2013" Year="2013">
-      <Id>2bfefd58-e542-4d3b-ace9-9e87e265b88a</Id>
+      <Database Name="cv" Series="57181" Issue="404705" />
     </Book>
     <Book Series="Uncanny X-Men" Number="7" Volume="2013" Year="2013">
-      <Id>a55ee469-3f6a-4821-bbee-73850036ebd4</Id>
+      <Database Name="cv" Series="57181" Issue="413669" />
     </Book>
     <Book Series="Cable and X-Force" Number="5" Volume="2013" Year="2013">
-      <Id>d6c3f81d-37db-4828-8fa9-6bae9317a62e</Id>
+      <Database Name="cv" Series="54644" Issue="390445" />
     </Book>
     <Book Series="Cable and X-Force" Number="6" Volume="2013" Year="2013">
-      <Id>ef4dc665-edfd-4fdb-b0a9-02fee9ad7883</Id>
+      <Database Name="cv" Series="54644" Issue="394702" />
     </Book>
     <Book Series="Cable and X-Force" Number="7" Volume="2013" Year="2013">
-      <Id>9cbe4a62-9f1f-4ae6-91e5-065dad08b093</Id>
+      <Database Name="cv" Series="54644" Issue="397541" />
     </Book>
     <Book Series="Cable and X-Force" Number="8" Volume="2013" Year="2013">
-      <Id>9f51d3a1-b256-44d1-beab-ecc62463ed4d</Id>
+      <Database Name="cv" Series="54644" Issue="402285" />
     </Book>
     <Book Series="X-Men" Number="1" Volume="2013" Year="2013">
-      <Id>ad5ed4f8-eddc-421d-9a46-5e44036b0346</Id>
+      <Database Name="cv" Series="62383" Issue="406983" />
     </Book>
     <Book Series="X-Men" Number="2" Volume="2013" Year="2013">
-      <Id>01e5cd4d-2f1c-473c-98f0-b61d80601809</Id>
+      <Database Name="cv" Series="62383" Issue="413672" />
     </Book>
     <Book Series="X-Men" Number="3" Volume="2013" Year="2013">
-      <Id>928af964-f515-4240-a690-c17e2d34dd96</Id>
+      <Database Name="cv" Series="62383" Issue="419977" />
     </Book>
     <Book Series="X-Men: Legacy" Number="7" Volume="2013" Year="2013">
-      <Id>1a335ef7-4923-4962-bf3d-301caf971db5</Id>
+      <Database Name="cv" Series="53922" Issue="392364" />
     </Book>
     <Book Series="X-Men: Legacy" Number="8" Volume="2013" Year="2013">
-      <Id>5d154dc6-4551-4331-a17e-84b7a12ee418</Id>
+      <Database Name="cv" Series="53922" Issue="395261" />
     </Book>
     <Book Series="X-Men: Legacy" Number="9" Volume="2013" Year="2013">
-      <Id>b0467dac-dc06-4176-a919-fb804bb42707</Id>
+      <Database Name="cv" Series="53922" Issue="397556" />
     </Book>
     <Book Series="X-Men: Legacy" Number="10" Volume="2013" Year="2013">
-      <Id>c2946246-b061-403f-ac6c-05362d0b8af4</Id>
+      <Database Name="cv" Series="53922" Issue="400157" />
     </Book>
     <Book Series="X-Men: Legacy" Number="11" Volume="2013" Year="2013">
-      <Id>50805178-e124-40f7-a999-60d423396959</Id>
+      <Database Name="cv" Series="53922" Issue="404706" />
     </Book>
-    <Book Series="Deadpool" Number="7" Volume="2013" Year="2013">
-      <Id>db94ff54-cd13-48fc-819c-351842edb88a</Id>
+    <Book Series="Deadpool" Number="7" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53726" Issue="395701" />
     </Book>
-    <Book Series="Deadpool" Number="8" Volume="2013" Year="2013">
-      <Id>4ff838e4-1d65-430e-a403-5a3201d929bd</Id>
+    <Book Series="Deadpool" Number="8" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53726" Issue="398981" />
     </Book>
-    <Book Series="Deadpool" Number="9" Volume="2013" Year="2013">
-      <Id>ae8facd2-b2ac-4d2f-8859-8e3ab51438d5</Id>
+    <Book Series="Deadpool" Number="9" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53726" Issue="401205" />
     </Book>
-    <Book Series="Deadpool" Number="10" Volume="2013" Year="2013">
-      <Id>ca8d2a65-9abe-479d-aee4-5ae3774f6db8</Id>
+    <Book Series="Deadpool" Number="10" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53726" Issue="404695" />
     </Book>
-    <Book Series="Deadpool" Number="11" Volume="2013" Year="2013">
-      <Id>d69b0f54-83fc-43a6-9e49-848c06f0ab8b</Id>
+    <Book Series="Deadpool" Number="11" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53726" Issue="410319" />
     </Book>
-    <Book Series="Deadpool" Number="12" Volume="2013" Year="2013">
-      <Id>57203d38-d636-4aec-90e0-515f968bcad2</Id>
+    <Book Series="Deadpool" Number="12" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53726" Issue="413656" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="25" Volume="2011" Year="2013">
-      <Id>0821e799-136f-42a0-983e-e1bfe5c7bc5b</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="25" Volume="2011" Year="2013">
+      <Database Name="cv" Series="43539" Issue="386142" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="26" Volume="2011" Year="2013">
-      <Id>37a07afd-1730-4cdc-830f-a362a7a652fc</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="26" Volume="2011" Year="2013">
+      <Database Name="cv" Series="43539" Issue="392363" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="27" Volume="2011" Year="2013">
-      <Id>9513d2ee-d6af-4e94-bb0e-9a425bb7f279</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="27" Volume="2011" Year="2013">
+      <Database Name="cv" Series="43539" Issue="395260" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="28" Volume="2011" Year="2013">
-      <Id>760e1b09-2fa9-42fe-a575-b1d309693b87</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="28" Volume="2011" Year="2013">
+      <Database Name="cv" Series="43539" Issue="398995" />
     </Book>
     <Book Series="Gambit" Number="8" Volume="2012" Year="2013">
-      <Id>075214de-0767-4dd3-b545-2d7a2c6a28c6</Id>
+      <Database Name="cv" Series="51107" Issue="381415" />
     </Book>
     <Book Series="Gambit" Number="9" Volume="2012" Year="2013">
-      <Id>50de811d-9662-4c09-839a-2c4dcbfdeec8</Id>
+      <Database Name="cv" Series="51107" Issue="388556" />
     </Book>
     <Book Series="Gambit" Number="10" Volume="2012" Year="2013">
-      <Id>32be9030-4243-46e4-9e01-78c01f5ae8fc</Id>
+      <Database Name="cv" Series="51107" Issue="395249" />
     </Book>
     <Book Series="Gambit" Number="11" Volume="2012" Year="2013">
-      <Id>d07db992-c969-49ab-9e2d-89b0a756eeae</Id>
+      <Database Name="cv" Series="51107" Issue="398985" />
     </Book>
     <Book Series="Gambit" Number="12" Volume="2012" Year="2013">
-      <Id>6722281d-fc1c-46e7-9297-be2f7a3fdf45</Id>
+      <Database Name="cv" Series="51107" Issue="402287" />
     </Book>
     <Book Series="Gambit" Number="13" Volume="2012" Year="2013">
-      <Id>e2166b82-1215-4bf9-8903-a226710181b4</Id>
+      <Database Name="cv" Series="51107" Issue="406974" />
     </Book>
     <Book Series="Uncanny Avengers" Number="6" Volume="2012" Year="2013">
-      <Id>e8f54b45-7057-428a-b7cc-67d54978cc32</Id>
+      <Database Name="cv" Series="52880" Issue="396435" />
     </Book>
     <Book Series="Uncanny Avengers" Number="7" Volume="2012" Year="2013">
-      <Id>3fbf3a7d-557d-4ba8-b6ef-49e4a367e570</Id>
+      <Database Name="cv" Series="52880" Issue="398993" />
     </Book>
     <Book Series="Uncanny Avengers" Number="8" Volume="2012" Year="2013">
-      <Id>51551667-4d44-41ac-b219-23a6b9a7e205</Id>
+      <Database Name="cv" Series="52880" Issue="401212" />
     </Book>
     <Book Series="Uncanny Avengers" Number="9" Volume="2012" Year="2013">
-      <Id>a848a4df-0f35-485e-ad0a-e15350312a61</Id>
+      <Database Name="cv" Series="52880" Issue="411836" />
     </Book>
     <Book Series="Uncanny Avengers" Number="10" Volume="2012" Year="2013">
-      <Id>90b49a01-b912-434a-a0b9-321d97700ef2</Id>
+      <Database Name="cv" Series="52880" Issue="418825" />
     </Book>
     <Book Series="Uncanny Avengers" Number="11" Volume="2012" Year="2013">
-      <Id>de881a59-ecc0-4edf-ab9c-51f9841ec207</Id>
+      <Database Name="cv" Series="52880" Issue="423683" />
     </Book>
     <Book Series="Uncanny Avengers" Number="8AU" Volume="2012" Year="2013">
-      <Id>14c3d29b-25fc-4341-bee9-322e8a8b0add</Id>
+      <Database Name="cv" Series="52880" Issue="404704" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="27AU" Volume="2011" Year="2013">
-      <Id>cd3983e8-f6d5-44c6-a34d-ab16923eda89</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="27AU" Volume="2011" Year="2013">
+      <Database Name="cv" Series="43539" Issue="397554" />
     </Book>
     <Book Series="Cable and X-Force" Number="9" Volume="2013" Year="2013">
-      <Id>cbbfdc0a-a383-4f84-9abe-39475b2f2821</Id>
+      <Database Name="cv" Series="54644" Issue="408992" />
     </Book>
     <Book Series="Cable and X-Force" Number="10" Volume="2013" Year="2013">
-      <Id>6e7b9d42-913a-4442-ba6f-b5d0d2ee9bae</Id>
+      <Database Name="cv" Series="54644" Issue="411826" />
     </Book>
     <Book Series="Cable and X-Force" Number="11" Volume="2013" Year="2013">
-      <Id>80fc8d03-57dc-4042-af8b-6600c0d8d78f</Id>
+      <Database Name="cv" Series="54644" Issue="417833" />
     </Book>
     <Book Series="Wolverine" Number="1" Volume="2013" Year="2013">
-      <Id>7db8df59-e1da-42f0-a37c-1e7b0261a34f</Id>
+      <Database Name="cv" Series="58822" Issue="392213" />
     </Book>
     <Book Series="Wolverine" Number="2" Volume="2013" Year="2013">
-      <Id>0802ce6d-3e95-4640-ae9b-523fac5b77d3</Id>
+      <Database Name="cv" Series="58822" Issue="396437" />
     </Book>
     <Book Series="Wolverine" Number="3" Volume="2013" Year="2013">
-      <Id>3253e530-5a7d-4dcd-b360-c619d228d2fc</Id>
+      <Database Name="cv" Series="58822" Issue="401214" />
     </Book>
     <Book Series="Wolverine" Number="4" Volume="2013" Year="2013">
-      <Id>f0e062c2-c5f1-4e0e-8a55-94e6e623bf12</Id>
+      <Database Name="cv" Series="58822" Issue="410326" />
     </Book>
     <Book Series="Wolverine" Number="314" Volume="2010" Year="2012">
-      <Id>d161403f-9030-4d39-9a21-2662b5146d02</Id>
+      <Database Name="cv" Series="35263" Issue="360920" />
     </Book>
     <Book Series="Wolverine" Number="315" Volume="2010" Year="2012">
-      <Id>f3389726-118c-42e8-8465-007fb81b4c68</Id>
+      <Database Name="cv" Series="35263" Issue="363164" />
     </Book>
     <Book Series="Wolverine" Number="316" Volume="2010" Year="2013">
-      <Id>8ba25d1f-5ec6-4cbb-9660-ffe2c94d6e0b</Id>
+      <Database Name="cv" Series="35263" Issue="369072" />
     </Book>
     <Book Series="Wolverine" Number="317" Volume="2010" Year="2013">
-      <Id>cd7033a3-8ac0-4c16-95c6-182eeae36cb5</Id>
+      <Database Name="cv" Series="35263" Issue="372457" />
     </Book>
     <Book Series="Gambit" Number="14" Volume="2012" Year="2013">
-      <Id>a6bf4f0b-ad9d-43a7-8cfd-2560ee774af8</Id>
+      <Database Name="cv" Series="51107" Issue="413658" />
     </Book>
     <Book Series="Gambit" Number="15" Volume="2012" Year="2013">
-      <Id>1fdcc5fe-2d05-43a1-9f7a-b93fa177fd80</Id>
+      <Database Name="cv" Series="51107" Issue="418816" />
     </Book>
     <Book Series="Gambit" Number="16" Volume="2012" Year="2013">
-      <Id>f56c33b8-685e-48e6-a89c-75dce36926c7</Id>
+      <Database Name="cv" Series="51107" Issue="423675" />
     </Book>
     <Book Series="Gambit" Number="17" Volume="2012" Year="2013">
-      <Id>a77342e3-1cd3-4446-9367-28bc3e995a52</Id>
+      <Database Name="cv" Series="51107" Issue="426875" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="29" Volume="2011" Year="2013">
-      <Id>53638a48-c4fc-49ab-83ab-802197f14ac9</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="29" Volume="2011" Year="2013">
+      <Database Name="cv" Series="43539" Issue="402293" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="30" Volume="2011" Year="2013">
-      <Id>305f427d-9f3d-42ff-9ba8-72f3d4b4650b</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="30" Volume="2011" Year="2013">
+      <Database Name="cv" Series="43539" Issue="406982" />
     </Book>
     <Book Series="A+X" Number="7" Volume="2012" Year="2013">
-      <Id>81a6ef2a-1533-45ec-ae0e-85623e94b330</Id>
+      <Database Name="cv" Series="53535" Issue="398978" />
     </Book>
     <Book Series="A+X" Number="8" Volume="2012" Year="2013">
-      <Id>c3c1d075-fbed-4e44-ab1c-c4c31b138772</Id>
+      <Database Name="cv" Series="53535" Issue="404692" />
     </Book>
     <Book Series="A+X" Number="9" Volume="2012" Year="2013">
-      <Id>3114da11-7b18-4f05-b15b-828cbdc490fc</Id>
+      <Database Name="cv" Series="53535" Issue="411823" />
     </Book>
     <Book Series="A+X" Number="10" Volume="2012" Year="2013">
-      <Id>63cf076a-3f5a-4ce6-8c30-44ef52d07fcb</Id>
+      <Database Name="cv" Series="53535" Issue="417829" />
     </Book>
     <Book Series="A+X" Number="11" Volume="2012" Year="2013">
-      <Id>1c6f6f52-eaab-45bc-8ba0-3a04e4708f91</Id>
+      <Database Name="cv" Series="53535" Issue="423668" />
     </Book>
     <Book Series="A+X" Number="12" Volume="2012" Year="2013">
-      <Id>1c9a22a6-3728-4064-8724-55e1b208e9b7</Id>
+      <Database Name="cv" Series="53535" Issue="426870" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men Annual" Number="1" Volume="2013" Year="2014">
-      <Id>dcdc2090-2b09-42a9-adf7-f752a7dc1580</Id>
+    <Book Series="Wolverine &#38; the X-Men Annual" Number="1" Volume="2013" Year="2014">
+      <Database Name="cv" Series="69573" Issue="435070" />
     </Book>
     <Book Series="Uncanny X-Force" Number="7" Volume="2013" Year="2013">
-      <Id>4ca9bf08-cbb5-4ce6-998d-2ce18a7443fe</Id>
+      <Database Name="cv" Series="56119" Issue="413668" />
     </Book>
     <Book Series="Uncanny X-Force" Number="8" Volume="2013" Year="2013">
-      <Id>16b5e79e-b114-4221-a4e6-e6373d94c77e</Id>
+      <Database Name="cv" Series="56119" Issue="417848" />
     </Book>
     <Book Series="Uncanny X-Force" Number="9" Volume="2013" Year="2013">
-      <Id>f792383b-f8a1-43ff-9dd9-a4eecc953f4b</Id>
+      <Database Name="cv" Series="56119" Issue="419972" />
     </Book>
     <Book Series="Uncanny X-Force" Number="10" Volume="2013" Year="2013">
-      <Id>6ac54826-2104-4a0d-b05f-772f3ec13b62</Id>
+      <Database Name="cv" Series="56119" Issue="421698" />
     </Book>
     <Book Series="Uncanny X-Force" Number="11" Volume="2013" Year="2013">
-      <Id>2191e474-6bed-4605-88c2-561a5dd3e8e6</Id>
+      <Database Name="cv" Series="56119" Issue="425034" />
     </Book>
     <Book Series="Uncanny X-Force" Number="12" Volume="2013" Year="2013">
-      <Id>89de6f17-4a0a-4800-b490-cae80f75293b</Id>
+      <Database Name="cv" Series="56119" Issue="428302" />
     </Book>
     <Book Series="Uncanny X-Force" Number="13" Volume="2013" Year="2013">
-      <Id>4b74cf64-bddb-43df-9ed2-4c94691414df</Id>
+      <Database Name="cv" Series="56119" Issue="431448" />
     </Book>
     <Book Series="Uncanny X-Force" Number="14" Volume="2013" Year="2014">
-      <Id>ac59a9c4-7c14-4a79-8716-587d8517798b</Id>
+      <Database Name="cv" Series="56119" Issue="435068" />
     </Book>
     <Book Series="Uncanny X-Force" Number="15" Volume="2013" Year="2014">
-      <Id>717ce8a4-bc7e-479c-96db-90102a8b22c0</Id>
+      <Database Name="cv" Series="56119" Issue="437500" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="31" Volume="2011" Year="2013">
-      <Id>278d04b5-5e6a-4f28-a6ba-db58c195a9e7</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="31" Volume="2011" Year="2013">
+      <Database Name="cv" Series="43539" Issue="410327" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="32" Volume="2011" Year="2013">
-      <Id>943039e4-1b91-4a6d-87ea-ea276ae3578a</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="32" Volume="2011" Year="2013">
+      <Database Name="cv" Series="43539" Issue="413671" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="33" Volume="2011" Year="2013">
-      <Id>408b002b-ead9-4272-bc24-def38c3763bf</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="33" Volume="2011" Year="2013">
+      <Database Name="cv" Series="43539" Issue="418978" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="34" Volume="2011" Year="2013">
-      <Id>b204323b-02c4-4891-bfd1-091b5e5f6946</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="34" Volume="2011" Year="2013">
+      <Database Name="cv" Series="43539" Issue="421701" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="35" Volume="2011" Year="2013">
-      <Id>d8e86ad6-8529-4be9-ae0c-fb0f12117585</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="35" Volume="2011" Year="2013">
+      <Database Name="cv" Series="43539" Issue="423685" />
     </Book>
     <Book Series="Astonishing X-Men" Number="66" Volume="2004" Year="2013">
-      <Id>3f52c509-a3d4-4851-9be0-b1858f78d1dd</Id>
+      <Database Name="cv" Series="10746" Issue="423669" />
     </Book>
     <Book Series="Astonishing X-Men" Number="67" Volume="2004" Year="2013">
-      <Id>440439aa-936e-4d2b-8f55-3d0807ec96b2</Id>
+      <Database Name="cv" Series="10746" Issue="425021" />
     </Book>
     <Book Series="Astonishing X-Men" Number="68" Volume="2004" Year="2013">
-      <Id>d9dda74a-456a-4d81-8550-b37a339082fa</Id>
+      <Database Name="cv" Series="10746" Issue="428291" />
     </Book>
     <Book Series="Uncanny Avengers" Number="12" Volume="2012" Year="2013">
-      <Id>dba16362-851f-428b-97db-c300f712eab9</Id>
+      <Database Name="cv" Series="52880" Issue="426885" />
     </Book>
     <Book Series="Uncanny Avengers" Number="13" Volume="2012" Year="2013">
-      <Id>4ba3c94c-34a8-4910-a9e8-4ed990f68309</Id>
+      <Database Name="cv" Series="52880" Issue="430766" />
     </Book>
     <Book Series="Uncanny Avengers" Number="14" Volume="2012" Year="2014">
-      <Id>1ed9bb76-9eff-43e1-a0fb-3bd7f98f2a06</Id>
+      <Database Name="cv" Series="52880" Issue="435067" />
     </Book>
     <Book Series="Uncanny Avengers" Number="15" Volume="2012" Year="2014">
-      <Id>2fd94959-877b-433c-b109-0b7ba79e5c4c</Id>
+      <Database Name="cv" Series="52880" Issue="437499" />
     </Book>
     <Book Series="Uncanny Avengers" Number="16" Volume="2012" Year="2014">
-      <Id>99cce352-11c1-4ef2-b6d2-ddd823502734</Id>
+      <Database Name="cv" Series="52880" Issue="443990" />
     </Book>
     <Book Series="Uncanny Avengers" Number="17" Volume="2012" Year="2014">
-      <Id>4112eec1-3439-4857-ac51-320585f62af9</Id>
+      <Database Name="cv" Series="52880" Issue="446492" />
     </Book>
-    <Book Series="Deadpool" Number="13" Volume="2013" Year="2013">
-      <Id>623e704d-9823-4cb2-8da1-c882cae92fe8</Id>
+    <Book Series="Deadpool" Number="13" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53726" Issue="417834" />
     </Book>
-    <Book Series="Deadpool" Number="14" Volume="2013" Year="2013">
-      <Id>82fdd768-9ac4-431c-8374-ec27ca1cd431</Id>
+    <Book Series="Deadpool" Number="14" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53726" Issue="421688" />
     </Book>
-    <Book Series="Deadpool" Number="15" Volume="2013" Year="2013">
-      <Id>27d8de72-5ca4-423f-b782-a62b498355dd</Id>
+    <Book Series="Deadpool" Number="15" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53726" Issue="423673" />
     </Book>
-    <Book Series="Deadpool" Number="16" Volume="2013" Year="2013">
-      <Id>41089bfd-8157-420a-a169-71f5b25faac7</Id>
+    <Book Series="Deadpool" Number="16" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53726" Issue="425025" />
     </Book>
-    <Book Series="Deadpool" Number="17" Volume="2013" Year="2013">
-      <Id>b0231fb8-b365-4b24-89e1-4b7c9eddfbd5</Id>
+    <Book Series="Deadpool" Number="17" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53726" Issue="426873" />
     </Book>
-    <Book Series="Deadpool" Number="18" Volume="2013" Year="2013">
-      <Id>f2973342-1910-463c-8976-e52a4aefc0f9</Id>
+    <Book Series="Deadpool" Number="18" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53726" Issue="428295" />
     </Book>
-    <Book Series="Deadpool" Number="19" Volume="2013" Year="2014">
-      <Id>ef280a6e-657d-4836-8686-6374ebf92634</Id>
+    <Book Series="Deadpool" Number="19" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53726" Issue="433171" />
     </Book>
     <Book Series="Deadpool Annual" Number="1" Volume="2013" Year="2014">
-      <Id>278c1a5d-f806-413b-ac1c-145722e2d9b2</Id>
+      <Database Name="cv" Series="69572" Issue="435051" />
     </Book>
     <Book Series="X-Men: Legacy" Number="12" Volume="2013" Year="2013">
-      <Id>08845b24-4844-48ae-928d-f8c616c4ba8b</Id>
+      <Database Name="cv" Series="53922" Issue="411838" />
     </Book>
     <Book Series="X-Men: Legacy" Number="13" Volume="2013" Year="2013">
-      <Id>f8ffb983-6467-432b-a793-5edfc0434a7e</Id>
+      <Database Name="cv" Series="53922" Issue="415245" />
     </Book>
     <Book Series="X-Men: Legacy" Number="14" Volume="2013" Year="2013">
-      <Id>5bbc33ed-f59b-4b04-b5c8-972c2c3ac2ca</Id>
+      <Database Name="cv" Series="53922" Issue="419978" />
     </Book>
     <Book Series="X-Men: Legacy" Number="15" Volume="2013" Year="2013">
-      <Id>42ca63a8-dd5b-410c-8f81-2618445598fd</Id>
+      <Database Name="cv" Series="53922" Issue="422507" />
     </Book>
     <Book Series="X-Men: Legacy" Number="16" Volume="2013" Year="2013">
-      <Id>1faffaf8-6c93-4e90-8810-008d9225b61e</Id>
+      <Database Name="cv" Series="53922" Issue="424544" />
     </Book>
     <Book Series="X-Men: Legacy" Number="17" Volume="2013" Year="2013">
-      <Id>19a00ec2-815d-45eb-85f1-a049f4a771bf</Id>
+      <Database Name="cv" Series="53922" Issue="425946" />
     </Book>
     <Book Series="X-Men: Legacy" Number="18" Volume="2013" Year="2013">
-      <Id>e219a03a-1d7e-474a-a128-f208832f16b5</Id>
+      <Database Name="cv" Series="53922" Issue="428868" />
     </Book>
     <Book Series="Wolverine" Number="5" Volume="2013" Year="2013">
-      <Id>9bfdd376-5f72-422a-ac24-05b9fce6a98a</Id>
+      <Database Name="cv" Series="58822" Issue="413670" />
     </Book>
     <Book Series="Wolverine" Number="6" Volume="2013" Year="2013">
-      <Id>3b63031d-360b-4b19-bc3b-7038e712d20f</Id>
+      <Database Name="cv" Series="58822" Issue="416948" />
     </Book>
     <Book Series="Wolverine" Number="7" Volume="2013" Year="2013">
-      <Id>86966a0a-adfc-42bb-8c3f-84505bd8ec4f</Id>
+      <Database Name="cv" Series="58822" Issue="418826" />
     </Book>
-    <Book Series="All-New X-Men" Number="14" Volume="2013" Year="2013">
-      <Id>08247481-683c-4693-93aa-6a87f6f4e770</Id>
+    <Book Series="All-New X-Men" Number="14" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53919" Issue="417830" />
     </Book>
-    <Book Series="All-New X-Men" Number="15" Volume="2013" Year="2013">
-      <Id>a9a1e9ab-dead-4f39-a3d0-150278058d44</Id>
+    <Book Series="All-New X-Men" Number="15" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53919" Issue="420633" />
     </Book>
     <Book Series="All-New X-Men Special" Number="1" Volume="2013" Year="2013">
-      <Id>db40a7d4-0ab5-4cfa-8313-11c5c01fdc34</Id>
+      <Database Name="cv" Series="67916" Issue="427683" />
     </Book>
     <Book Series="Indestructible Hulk Special" Number="1" Volume="2013" Year="2013">
-      <Id>eb738a1d-ad79-42db-b9d1-1d15d8bfab91</Id>
+      <Database Name="cv" Series="68320" Issue="428862" />
     </Book>
     <Book Series="Superior Spider-Man Team-Up Special" Number="1" Volume="2013" Year="2013">
-      <Id>acfe03ea-b44d-441f-8218-3103227b69c6</Id>
+      <Database Name="cv" Series="68721" Issue="431445" />
     </Book>
     <Book Series="X-Men" Number="4" Volume="2013" Year="2013">
-      <Id>5e151630-35fe-4b9a-ab97-6189ea806b38</Id>
+      <Database Name="cv" Series="62383" Issue="422506" />
     </Book>
     <Book Series="Uncanny X-Men" Number="8" Volume="2013" Year="2013">
-      <Id>ced9f1a9-75fa-49c3-afc0-0d15143da501</Id>
+      <Database Name="cv" Series="57181" Issue="416917" />
     </Book>
     <Book Series="Uncanny X-Men" Number="9" Volume="2013" Year="2013">
-      <Id>aa93b343-86e9-4bc9-98e0-b60bed0f67b9</Id>
+      <Database Name="cv" Series="57181" Issue="419973" />
     </Book>
     <Book Series="Uncanny X-Men" Number="10" Volume="2013" Year="2013">
-      <Id>f28df617-ff19-4983-be89-3eedab2c5646</Id>
+      <Database Name="cv" Series="57181" Issue="421699" />
     </Book>
     <Book Series="Uncanny X-Men" Number="11" Volume="2013" Year="2013">
-      <Id>b3bf000f-652f-4ed8-8f96-61b12ff1d9ae</Id>
+      <Database Name="cv" Series="57181" Issue="423684" />
     </Book>
     <Book Series="Wolverine" Number="8" Volume="2013" Year="2013">
-      <Id>a83374e2-09d3-4692-b499-f51ed6e3b98b</Id>
+      <Database Name="cv" Series="58822" Issue="421700" />
     </Book>
     <Book Series="Wolverine" Number="9" Volume="2013" Year="2013">
-      <Id>c152b4d8-853b-4c70-8e9d-7bfd1878a1a7</Id>
+      <Database Name="cv" Series="58822" Issue="425035" />
     </Book>
     <Book Series="Wolverine" Number="10" Volume="2013" Year="2013">
-      <Id>49eb4803-54b9-48db-9264-dabd21aad98c</Id>
+      <Database Name="cv" Series="58822" Issue="428303" />
     </Book>
     <Book Series="Wolverine" Number="11" Volume="2013" Year="2014">
-      <Id>b41b1a7d-3012-4181-9214-a4c024e0ba38</Id>
+      <Database Name="cv" Series="58822" Issue="433179" />
     </Book>
     <Book Series="Wolverine" Number="12" Volume="2013" Year="2014">
-      <Id>3f12768d-fb3d-4a8e-87e2-e3d0fbbfdae1</Id>
+      <Database Name="cv" Series="58822" Issue="436209" />
     </Book>
     <Book Series="Wolverine" Number="13" Volume="2013" Year="2014">
-      <Id>b5130e7b-930e-4f84-8c1d-f2f3f9e6a09d</Id>
+      <Database Name="cv" Series="58822" Issue="441421" />
     </Book>
     <Book Series="X-Men: Battle of the Atom" Number="1" Volume="2013" Year="2013">
-      <Id>cc9a5d89-1e93-407e-9956-3a63ba295b7d</Id>
+      <Database Name="cv" Series="67028" Issue="424543" />
     </Book>
-    <Book Series="All-New X-Men" Number="16" Volume="2013" Year="2013">
-      <Id>761dcb32-0ce0-4cca-9276-99b59523577d</Id>
+    <Book Series="All-New X-Men" Number="16" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53919" Issue="424528" />
     </Book>
     <Book Series="X-Men" Number="5" Volume="2013" Year="2013">
-      <Id>e1b33985-973b-4bf8-a253-8b469a1cc06b</Id>
+      <Database Name="cv" Series="62383" Issue="425036" />
     </Book>
     <Book Series="Uncanny X-Men" Number="12" Volume="2013" Year="2013">
-      <Id>f41c1983-69a8-4e3b-9f4e-3c2d05ba4af3</Id>
+      <Database Name="cv" Series="57181" Issue="425944" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="36" Volume="2011" Year="2013">
-      <Id>d5230721-19a4-4c0f-b2af-a469b00b55d4</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="36" Volume="2011" Year="2013">
+      <Database Name="cv" Series="43539" Issue="426886" />
     </Book>
-    <Book Series="All-New X-Men" Number="17" Volume="2013" Year="2013">
-      <Id>a8a75547-1e32-4c12-95e2-642fe05806ac</Id>
+    <Book Series="All-New X-Men" Number="17" Volume="2012" Year="2013">
+      <Database Name="cv" Series="53919" Issue="427682" />
     </Book>
     <Book Series="X-Men" Number="6" Volume="2013" Year="2013">
-      <Id>65ff2991-7aa6-4bb3-b723-f4696bd5d6c6</Id>
+      <Database Name="cv" Series="62383" Issue="428304" />
     </Book>
     <Book Series="Uncanny X-Men" Number="13" Volume="2013" Year="2013">
-      <Id>a7e425bc-68fb-448e-9cc2-cf090beb093f</Id>
+      <Database Name="cv" Series="57181" Issue="428867" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="37" Volume="2011" Year="2013">
-      <Id>23d7f2a9-0774-4f2c-913c-14855e950d6e</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="37" Volume="2011" Year="2013">
+      <Database Name="cv" Series="43539" Issue="430768" />
     </Book>
     <Book Series="X-Men: Battle of the Atom" Number="2" Volume="2013" Year="2013">
-      <Id>a71e53ff-3273-4205-85d7-edd24b392874</Id>
+      <Database Name="cv" Series="67028" Issue="431449" />
     </Book>
     <Book Series="A+X" Number="13" Volume="2012" Year="2013">
-      <Id>c7d7c6c9-da28-4e9a-a902-dcf62207e3ce</Id>
+      <Database Name="cv" Series="53535" Issue="428854" />
     </Book>
     <Book Series="A+X" Number="14" Volume="2012" Year="2014">
-      <Id>9ca54e4a-83c5-41c8-9258-b8818adefb8e</Id>
+      <Database Name="cv" Series="53535" Issue="433839" />
     </Book>
     <Book Series="A+X" Number="15" Volume="2012" Year="2014">
-      <Id>73b7e20b-4768-4acf-aaa3-025569f049b2</Id>
+      <Database Name="cv" Series="53535" Issue="436189" />
     </Book>
     <Book Series="A+X" Number="16" Volume="2012" Year="2014">
-      <Id>a39d5f33-21b5-4a9b-8b0b-41e0b691d0c8</Id>
+      <Database Name="cv" Series="53535" Issue="441423" />
     </Book>
     <Book Series="A+X" Number="17" Volume="2012" Year="2014">
-      <Id>99b49301-c8a6-44a7-bfa5-e99103365a1d</Id>
+      <Database Name="cv" Series="53535" Issue="445807" />
     </Book>
     <Book Series="A+X" Number="18" Volume="2012" Year="2014">
-      <Id>5820d6ed-6d7c-402a-87c2-aae588a660b2</Id>
+      <Database Name="cv" Series="53535" Issue="448958" />
     </Book>
     <Book Series="X-Men: Legacy" Number="19" Volume="2013" Year="2014">
-      <Id>847f4024-a255-477a-9cf8-2012f5a10bbb</Id>
+      <Database Name="cv" Series="53922" Issue="432337" />
     </Book>
     <Book Series="X-Men: Legacy" Number="20" Volume="2013" Year="2014">
-      <Id>ce06ac8e-6dcc-4e8a-be12-968ca060e319</Id>
+      <Database Name="cv" Series="53922" Issue="433855" />
     </Book>
     <Book Series="X-Men: Legacy" Number="21" Volume="2013" Year="2014">
-      <Id>05e8635b-e7be-4dc9-9c6b-6571cfb9034e</Id>
+      <Database Name="cv" Series="53922" Issue="435592" />
     </Book>
     <Book Series="X-Men: Legacy" Number="22" Volume="2013" Year="2014">
-      <Id>552f1057-3fe0-4230-8b63-4a008d3aac09</Id>
+      <Database Name="cv" Series="53922" Issue="442181" />
     </Book>
     <Book Series="X-Men: Legacy" Number="23" Volume="2013" Year="2014">
-      <Id>39f90ddc-9ef3-44af-815c-c682f10b4743</Id>
+      <Database Name="cv" Series="53922" Issue="443992" />
     </Book>
     <Book Series="X-Men: Legacy" Number="24" Volume="2013" Year="2014">
-      <Id>33dc0599-9fd3-46cd-ba46-a73f8a84dffb</Id>
+      <Database Name="cv" Series="53922" Issue="445189" />
     </Book>
     <Book Series="X-Men: Legacy" Number="300" Volume="2013" Year="2014">
-      <Id>2d1b9ad4-cfe9-49f6-a8bc-748a3cbee31b</Id>
+      <Database Name="cv" Series="53922" Issue="447519" />
     </Book>
     <Book Series="Uncanny X-Men" Number="14" Volume="2013" Year="2014">
-      <Id>4f6d8931-c56d-496d-85f7-bf6728a0fcba</Id>
+      <Database Name="cv" Series="57181" Issue="433852" />
     </Book>
-    <Book Series="All-New X-Men" Number="18" Volume="2013" Year="2014">
-      <Id>0267b1cd-5062-4a3a-83b3-8eeadce76311</Id>
+    <Book Series="All-New X-Men" Number="18" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53919" Issue="433167" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="38" Volume="2011" Year="2014">
-      <Id>a36697b0-f46c-4af4-b8ec-34f5c5f657be</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="38" Volume="2011" Year="2014">
+      <Database Name="cv" Series="43539" Issue="435069" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="39" Volume="2011" Year="2014">
-      <Id>0780076a-a090-4dfa-8609-a8a481bd423a</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="39" Volume="2011" Year="2014">
+      <Database Name="cv" Series="43539" Issue="436210" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="40" Volume="2011" Year="2014">
-      <Id>7b37eba1-5c58-4f12-bbc0-cd0c077d07a0</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="40" Volume="2011" Year="2014">
+      <Database Name="cv" Series="43539" Issue="442929" />
     </Book>
-    <Book Series="Amazing X-Men" Number="1" Volume="2013" Year="2014">
-      <Id>f8ed765d-6fb6-4d49-a8b1-7c0e5009e6eb</Id>
+    <Book Series="Amazing X-Men" Number="1" Volume="2014" Year="2014">
+      <Database Name="cv" Series="68919" Issue="432322" />
     </Book>
-    <Book Series="Amazing X-Men" Number="2" Volume="2013" Year="2014">
-      <Id>caff3978-38cf-4765-aed5-5b6e1735069d</Id>
+    <Book Series="Amazing X-Men" Number="2" Volume="2014" Year="2014">
+      <Database Name="cv" Series="68919" Issue="435574" />
     </Book>
-    <Book Series="Amazing X-Men" Number="3" Volume="2013" Year="2014">
-      <Id>83d080fd-4f60-4096-b301-6aacabe966e5</Id>
+    <Book Series="Amazing X-Men" Number="3" Volume="2014" Year="2014">
+      <Database Name="cv" Series="68919" Issue="442162" />
     </Book>
-    <Book Series="Amazing X-Men" Number="4" Volume="2013" Year="2014">
-      <Id>cffbfd6f-81ab-4d5f-9915-cac31808911f</Id>
+    <Book Series="Amazing X-Men" Number="4" Volume="2014" Year="2014">
+      <Database Name="cv" Series="68919" Issue="445808" />
     </Book>
-    <Book Series="Amazing X-Men" Number="5" Volume="2013" Year="2014">
-      <Id>57d63239-4aeb-436c-adc3-edeaa8645768</Id>
+    <Book Series="Amazing X-Men" Number="5" Volume="2014" Year="2014">
+      <Database Name="cv" Series="68919" Issue="448961" />
     </Book>
-    <Book Series="Amazing X-Men" Number="6" Volume="2013" Year="2014">
-      <Id>bd981fbe-8523-4915-a887-674a2f7ec576</Id>
+    <Book Series="Amazing X-Men" Number="6" Volume="2014" Year="2014">
+      <Database Name="cv" Series="68919" Issue="450549" />
     </Book>
-    <Book Series="All-New X-Men" Number="19" Volume="2013" Year="2014">
-      <Id>fd9ddea1-040a-40a8-8d6b-ee70968f7994</Id>
+    <Book Series="All-New X-Men" Number="19" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53919" Issue="435047" />
     </Book>
-    <Book Series="All-New X-Men" Number="20" Volume="2013" Year="2014">
-      <Id>28cdcfe8-ed21-4e12-be91-3aecef837da1</Id>
+    <Book Series="All-New X-Men" Number="20" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53919" Issue="437482" />
     </Book>
-    <Book Series="All-New X-Men" Number="21" Volume="2013" Year="2014">
-      <Id>80417fa3-0505-4781-8d15-757b269a9dc2</Id>
+    <Book Series="All-New X-Men" Number="21" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53919" Issue="442161" />
     </Book>
-    <Book Series="Deadpool" Number="20" Volume="2013" Year="2014">
-      <Id>f88533ba-0e7f-4865-bd64-4f0766d2e2c4</Id>
+    <Book Series="Deadpool" Number="20" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53726" Issue="435578" />
     </Book>
-    <Book Series="Deadpool" Number="21" Volume="2013" Year="2014">
-      <Id>2be11137-c686-4734-868f-2a26647de6c1</Id>
+    <Book Series="Deadpool" Number="21" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53726" Issue="437488" />
     </Book>
-    <Book Series="Deadpool" Number="22" Volume="2013" Year="2014">
-      <Id>52159d50-cf01-4906-b662-750971f1fe0d</Id>
+    <Book Series="Deadpool" Number="22" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53726" Issue="441412" />
     </Book>
-    <Book Series="Deadpool" Number="23" Volume="2013" Year="2014">
-      <Id>820de166-eaeb-4b8d-8735-147cd24ab444</Id>
+    <Book Series="Deadpool" Number="23" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53726" Issue="445177" />
     </Book>
-    <Book Series="Deadpool" Number="24" Volume="2013" Year="2014">
-      <Id>c0eff143-d318-45f6-aa64-1b7f24fd5443</Id>
+    <Book Series="Deadpool" Number="24" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53726" Issue="446479" />
     </Book>
     <Book Series="Uncanny X-Men" Number="15" Volume="2013" Year="2014">
-      <Id>a60cbaf6-de20-4d55-b78f-af7028bc3b9e</Id>
+      <Database Name="cv" Series="57181" Issue="436208" />
     </Book>
     <Book Series="Inhumanity: The Awakening" Number="1" Volume="2013" Year="2014">
-      <Id>a1abe811-4371-4ba2-9287-5510760fd41d</Id>
+      <Database Name="cv" Series="69866" Issue="436199" />
     </Book>
     <Book Series="Inhumanity: The Awakening" Number="2" Volume="2013" Year="2014">
-      <Id>20c07b28-fb4e-4dae-ab20-f21b8e671f59</Id>
+      <Database Name="cv" Series="69866" Issue="441415" />
     </Book>
     <Book Series="Uncanny X-Men" Number="16" Volume="2013" Year="2014">
-      <Id>c796d696-90bf-46d4-a385-b0b0b5cede1e</Id>
+      <Database Name="cv" Series="57181" Issue="442179" />
     </Book>
     <Book Series="Uncanny X-Men" Number="17" Volume="2013" Year="2014">
-      <Id>9ff63a93-3f1f-46a8-88f6-95cad5799402</Id>
+      <Database Name="cv" Series="57181" Issue="445823" />
     </Book>
     <Book Series="Uncanny X-Men" Number="18" Volume="2013" Year="2014">
-      <Id>0b401270-302e-4837-86e9-36703eb0feb9</Id>
+      <Database Name="cv" Series="57181" Issue="446998" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="41" Volume="2011" Year="2014">
-      <Id>82648dc3-ba2f-4921-8d1f-325acb91cf69</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="41" Volume="2011" Year="2014">
+      <Database Name="cv" Series="43539" Issue="445187" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="42" Volume="2011" Year="2014">
-      <Id>56a26b74-cc2d-4769-89ec-9d9b4ae5c918</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="42" Volume="2011" Year="2014">
+      <Database Name="cv" Series="43539" Issue="446494" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="1" Volume="2014" Year="2014">
-      <Id>3a693d12-a94b-434c-95f8-5bbb4f56a796</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="1" Volume="2014" Year="2014">
+      <Database Name="cv" Series="72113" Issue="446927" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="2" Volume="2014" Year="2014">
-      <Id>c01ff8f4-b3d1-4f24-8a0f-b47f160d8e9c</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="2" Volume="2014" Year="2014">
+      <Database Name="cv" Series="72113" Issue="448008" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="3" Volume="2014" Year="2014">
-      <Id>8ceacd01-9a98-40c2-8de1-e30042128cbc</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="3" Volume="2014" Year="2014">
+      <Database Name="cv" Series="72113" Issue="450561" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="4" Volume="2014" Year="2014">
-      <Id>bf4da200-447e-4a58-bec3-ffe0a3edcd6f</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="4" Volume="2014" Year="2014">
+      <Database Name="cv" Series="72113" Issue="453423" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="5" Volume="2014" Year="2014">
-      <Id>7a91b322-d801-4360-a8be-7ccad7c897de</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="5" Volume="2014" Year="2014">
+      <Database Name="cv" Series="72113" Issue="456559" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="6" Volume="2014" Year="2014">
-      <Id>b39a7f83-d46a-46f2-bcaf-5998d776b587</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="6" Volume="2014" Year="2014">
+      <Database Name="cv" Series="72113" Issue="460319" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="7" Volume="2014" Year="2014">
-      <Id>c3e6a3ba-8603-4611-aee6-76b2a83270b7</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="7" Volume="2014" Year="2014">
+      <Database Name="cv" Series="72113" Issue="462262" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="8" Volume="2014" Year="2014">
-      <Id>97094aed-d189-44f0-a778-e98eac9f2d74</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="8" Volume="2014" Year="2014">
+      <Database Name="cv" Series="72113" Issue="463491" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="9" Volume="2014" Year="2014">
-      <Id>835fd808-6712-4b2a-a166-7bba1a0f4c39</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="9" Volume="2014" Year="2014">
+      <Database Name="cv" Series="72113" Issue="465854" />
     </Book>
     <Book Series="Wolverine" Number="1" Volume="2014" Year="2014">
-      <Id>b567be6b-91ad-42cf-a8ea-175adae33b28</Id>
+      <Database Name="cv" Series="71431" Issue="444437" />
     </Book>
     <Book Series="Wolverine" Number="2" Volume="2014" Year="2014">
-      <Id>1e94c6aa-a434-4f12-94f1-9d6775413247</Id>
+      <Database Name="cv" Series="71431" Issue="446493" />
     </Book>
     <Book Series="Wolverine" Number="3" Volume="2014" Year="2014">
-      <Id>dca1dba3-b5ba-42e1-9ae3-f29badfc9cfb</Id>
+      <Database Name="cv" Series="71431" Issue="447517" />
     </Book>
     <Book Series="Wolverine" Number="4" Volume="2014" Year="2014">
-      <Id>6164f61a-dcb6-4db0-8bb6-7f53ff917083</Id>
+      <Database Name="cv" Series="71431" Issue="450560" />
     </Book>
     <Book Series="Wolverine" Number="5" Volume="2014" Year="2014">
-      <Id>a63b6fda-522b-45c1-8a9f-e0a438011aa4</Id>
+      <Database Name="cv" Series="71431" Issue="451775" />
     </Book>
     <Book Series="Savage Wolverine" Number="14" Volume="2013" Year="2014">
-      <Id>42a49827-4d5e-47c6-86fc-965a157bdaa5</Id>
+      <Database Name="cv" Series="55802" Issue="441420" />
     </Book>
     <Book Series="Savage Wolverine" Number="15" Volume="2013" Year="2014">
-      <Id>8a660fab-3c0f-48de-893d-9325305c75b7</Id>
+      <Database Name="cv" Series="55802" Issue="445821" />
     </Book>
     <Book Series="Savage Wolverine" Number="16" Volume="2013" Year="2014">
-      <Id>884fbcff-e1b1-4989-89a3-1d136335561b</Id>
+      <Database Name="cv" Series="55802" Issue="448976" />
     </Book>
     <Book Series="Savage Wolverine" Number="17" Volume="2013" Year="2014">
-      <Id>280d81fc-113a-4dea-9ba4-808f8e8b2d01</Id>
+      <Database Name="cv" Series="55802" Issue="451090" />
     </Book>
     <Book Series="Wolverine" Number="6" Volume="2014" Year="2014">
-      <Id>717d115f-349c-464a-a27a-6ed8968288dc</Id>
+      <Database Name="cv" Series="71431" Issue="452859" />
     </Book>
     <Book Series="Wolverine" Number="7" Volume="2014" Year="2014">
-      <Id>3d2eeb5e-5244-41b0-90d3-17ac80fa223c</Id>
+      <Database Name="cv" Series="71431" Issue="454111" />
     </Book>
     <Book Series="X-Men" Number="7" Volume="2013" Year="2014">
-      <Id>fe81cba8-00fb-41aa-aa62-4fb8d9c774c6</Id>
+      <Database Name="cv" Series="62383" Issue="433854" />
     </Book>
     <Book Series="X-Men" Number="8" Volume="2013" Year="2014">
-      <Id>d5b54999-0208-4ce1-a2d9-f486f0423fd3</Id>
+      <Database Name="cv" Series="62383" Issue="437501" />
     </Book>
     <Book Series="X-Men" Number="9" Volume="2013" Year="2014">
-      <Id>00a68609-84b4-41fd-a3d2-a01883918925</Id>
+      <Database Name="cv" Series="62383" Issue="442930" />
     </Book>
     <Book Series="X-Men" Number="10" Volume="2013" Year="2014">
-      <Id>764a3bfd-b3ea-454e-8b68-a9fbe631169d</Id>
+      <Database Name="cv" Series="62383" Issue="444540" />
     </Book>
     <Book Series="X-Men" Number="11" Volume="2013" Year="2014">
-      <Id>3e11a158-6af7-47c3-94ff-416722e946f1</Id>
+      <Database Name="cv" Series="62383" Issue="445824" />
     </Book>
     <Book Series="X-Men" Number="12" Volume="2013" Year="2014">
-      <Id>a8dfbe56-d46d-4ba8-8def-d83accb93e5d</Id>
+      <Database Name="cv" Series="62383" Issue="448009" />
     </Book>
     <Book Series="All-New Marvel Now! Point One" Number="1" Volume="2014" Year="2014">
-      <Id>c2cc8f1a-2d7a-46ea-928f-895ee83745db</Id>
+      <Database Name="cv" Series="70702" Issue="441403" />
     </Book>
-    <Book Series="All-New X-Men" Number="22" Volume="2013" Year="2014">
-      <Id>f188ba06-9f3b-46c7-8327-af440614b01b</Id>
+    <Book Series="All-New X-Men" Number="22" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53919" Issue="442912" />
     </Book>
     <Book Series="Guardians of the Galaxy" Number="11" Volume="2013" Year="2014">
-      <Id>45279447-a624-4ca8-9bea-b030bcde4ae3</Id>
+      <Database Name="cv" Series="57960" Issue="443982" />
     </Book>
-    <Book Series="All-New X-Men" Number="23" Volume="2013" Year="2014">
-      <Id>8c34eec5-4ee5-45d3-8ccb-ef658b352722</Id>
+    <Book Series="All-New X-Men" Number="23" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53919" Issue="445174" />
     </Book>
     <Book Series="Guardians of the Galaxy" Number="12" Volume="2013" Year="2014">
-      <Id>450f0cd0-66f6-428c-9c42-498bc6a09f3d</Id>
+      <Database Name="cv" Series="57960" Issue="446482" />
     </Book>
-    <Book Series="All-New X-Men" Number="24" Volume="2013" Year="2014">
-      <Id>a5e14438-8dd8-452f-b248-e5bcf13cfe5c</Id>
+    <Book Series="All-New X-Men" Number="24" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53919" Issue="447504" />
     </Book>
     <Book Series="Guardians of the Galaxy" Number="13" Volume="2013" Year="2014">
-      <Id>d71a1e27-789b-4911-aeb5-25f24bb0447a</Id>
+      <Database Name="cv" Series="57960" Issue="448967" />
     </Book>
     <Book Series="Cable and X-Force" Number="12" Volume="2013" Year="2013">
-      <Id>ec67030a-e6a6-459f-acb2-35626fdb28b0</Id>
+      <Database Name="cv" Series="54644" Issue="420636" />
     </Book>
     <Book Series="Cable and X-Force" Number="13" Volume="2013" Year="2013">
-      <Id>a4a1829a-1bc8-45f9-a62f-4cabf9979cea</Id>
+      <Database Name="cv" Series="54644" Issue="422495" />
     </Book>
     <Book Series="Cable and X-Force" Number="14" Volume="2013" Year="2013">
-      <Id>a0ad3f9e-cf77-4efa-9cb1-369f23683cef</Id>
+      <Database Name="cv" Series="54644" Issue="425930" />
     </Book>
     <Book Series="Cable and X-Force" Number="15" Volume="2013" Year="2013">
-      <Id>92dca633-967b-4bde-b307-9f708e047d82</Id>
+      <Database Name="cv" Series="54644" Issue="428857" />
     </Book>
     <Book Series="Cable and X-Force" Number="16" Volume="2013" Year="2014">
-      <Id>e705b6d8-ac6e-4c99-84f7-75d0a7a47022</Id>
+      <Database Name="cv" Series="54644" Issue="433842" />
     </Book>
     <Book Series="Cable and X-Force" Number="17" Volume="2013" Year="2014">
-      <Id>3ce95a29-1e40-4049-aa20-d950de7ef892</Id>
+      <Database Name="cv" Series="54644" Issue="436193" />
     </Book>
     <Book Series="Cable and X-Force" Number="18" Volume="2013" Year="2014">
-      <Id>1d8ac729-f3e5-4f90-b47e-1f712c31dd53</Id>
+      <Database Name="cv" Series="54644" Issue="441408" />
     </Book>
     <Book Series="Uncanny X-Force" Number="16" Volume="2013" Year="2014">
-      <Id>8858a1ed-87f6-4623-9f98-8b421a0ceb98</Id>
+      <Database Name="cv" Series="56119" Issue="442178" />
     </Book>
     <Book Series="Cable and X-Force" Number="19" Volume="2013" Year="2014">
-      <Id>e1b79301-70fc-4af6-a2c0-420f76e1ef11</Id>
+      <Database Name="cv" Series="54644" Issue="442916" />
     </Book>
     <Book Series="Uncanny X-Force" Number="17" Volume="2013" Year="2014">
-      <Id>97695939-7e49-4dbc-a1cd-203a0216ef2b</Id>
+      <Database Name="cv" Series="56119" Issue="443991" />
     </Book>
     <Book Series="All-New X-Factor" Number="1" Volume="2014" Year="2014">
-      <Id>d3981a5f-fd02-427b-adc8-ed5ca29e5493</Id>
+      <Database Name="cv" Series="70703" Issue="441404" />
     </Book>
     <Book Series="All-New X-Factor" Number="2" Volume="2014" Year="2014">
-      <Id>77eb0b2c-72bb-4ba9-a980-d5ed654842a1</Id>
+      <Database Name="cv" Series="70703" Issue="442911" />
     </Book>
     <Book Series="All-New X-Factor" Number="3" Volume="2014" Year="2014">
-      <Id>0149dec5-4c3c-4622-be37-ce4032bdc94d</Id>
+      <Database Name="cv" Series="70703" Issue="445173" />
     </Book>
     <Book Series="All-New X-Factor" Number="4" Volume="2014" Year="2014">
-      <Id>9c31f070-e64c-4961-abdf-df35f08cbfe9</Id>
+      <Database Name="cv" Series="70703" Issue="447503" />
     </Book>
     <Book Series="All-New X-Factor" Number="5" Volume="2014" Year="2014">
-      <Id>28ea6f75-8e9d-42d5-8145-0f0cf6711f27</Id>
+      <Database Name="cv" Series="70703" Issue="448959" />
     </Book>
     <Book Series="All-New X-Factor" Number="6" Volume="2014" Year="2014">
-      <Id>8074ff31-430b-4792-9869-f5a154a72964</Id>
+      <Database Name="cv" Series="70703" Issue="450067" />
     </Book>
     <Book Series="All-New X-Factor" Number="7" Volume="2014" Year="2014">
-      <Id>4ab92953-91d6-4932-9e39-c995f410a050</Id>
+      <Database Name="cv" Series="70703" Issue="452305" />
     </Book>
     <Book Series="All-New X-Factor" Number="8" Volume="2014" Year="2014">
-      <Id>07fca32f-7851-4a9b-a5b4-c4f12b229231</Id>
+      <Database Name="cv" Series="70703" Issue="453407" />
     </Book>
     <Book Series="All-New X-Factor" Number="9" Volume="2014" Year="2014">
-      <Id>a97616b5-f4b2-459b-b55a-9d8358f562c8</Id>
+      <Database Name="cv" Series="70703" Issue="455480" />
     </Book>
     <Book Series="All-New X-Factor" Number="10" Volume="2014" Year="2014">
-      <Id>53a7eade-17a0-4d66-b5b4-51956d2d716d</Id>
+      <Database Name="cv" Series="70703" Issue="458611" />
     </Book>
     <Book Series="All-New X-Factor" Number="11" Volume="2014" Year="2014">
-      <Id>f8e7538d-ff7e-4ac7-ba89-8689a9b0a59b</Id>
+      <Database Name="cv" Series="70703" Issue="459669" />
     </Book>
     <Book Series="All-New X-Factor" Number="12" Volume="2014" Year="2014">
-      <Id>d76f2df5-5994-47ae-ae1f-da4db7196466</Id>
+      <Database Name="cv" Series="70703" Issue="462886" />
     </Book>
     <Book Series="All-New X-Factor" Number="13" Volume="2014" Year="2014">
-      <Id>36d6165e-98da-42b7-9f94-7a779ac5cd46</Id>
+      <Database Name="cv" Series="70703" Issue="463979" />
     </Book>
     <Book Series="All-New X-Factor" Number="14" Volume="2014" Year="2014">
-      <Id>6df2ad65-7ead-4ef7-9698-b3ff64074fe6</Id>
+      <Database Name="cv" Series="70703" Issue="465835" />
     </Book>
     <Book Series="X-Force" Number="1" Volume="2014" Year="2014">
-      <Id>ba1415c0-7853-4414-aecc-be5a1956298a</Id>
+      <Database Name="cv" Series="71614" Issue="445188" />
     </Book>
     <Book Series="X-Force" Number="2" Volume="2014" Year="2014">
-      <Id>f3e53027-27ac-4715-b64c-990114438e6c</Id>
+      <Database Name="cv" Series="71614" Issue="447518" />
     </Book>
     <Book Series="X-Force" Number="3" Volume="2014" Year="2014">
-      <Id>5940f08a-7102-46e6-a1f7-ea54d0a09cdc</Id>
+      <Database Name="cv" Series="71614" Issue="450562" />
     </Book>
     <Book Series="X-Force" Number="4" Volume="2014" Year="2014">
-      <Id>7e9b488c-0bf7-4689-a008-35a2ddf80ea4</Id>
+      <Database Name="cv" Series="71614" Issue="451776" />
     </Book>
     <Book Series="X-Force" Number="5" Volume="2014" Year="2014">
-      <Id>71469a1e-4e96-4ed4-8b70-49fb171157b4</Id>
+      <Database Name="cv" Series="71614" Issue="452860" />
     </Book>
     <Book Series="X-Force" Number="6" Volume="2014" Year="2014">
-      <Id>62b17d68-b293-4bc2-9001-f4beef85e0d5</Id>
+      <Database Name="cv" Series="71614" Issue="457654" />
     </Book>
     <Book Series="X-Force" Number="7" Volume="2014" Year="2014">
-      <Id>dfa40b4a-678b-460e-8041-f3cd34b74fb5</Id>
+      <Database Name="cv" Series="71614" Issue="459181" />
     </Book>
     <Book Series="X-Force" Number="8" Volume="2014" Year="2014">
-      <Id>c1530216-5840-418f-86b8-0ea736fae60b</Id>
+      <Database Name="cv" Series="71614" Issue="462263" />
     </Book>
     <Book Series="X-Force" Number="9" Volume="2014" Year="2014">
-      <Id>2e57c9b3-6ece-4621-9a8d-d6b050da949f</Id>
+      <Database Name="cv" Series="71614" Issue="464991" />
     </Book>
     <Book Series="X-Force" Number="10" Volume="2014" Year="2014">
-      <Id>9261fa3b-6d8f-4422-a572-9e6ea7b59cdb</Id>
+      <Database Name="cv" Series="71614" Issue="467658" />
     </Book>
     <Book Series="X-Force" Number="11" Volume="2014" Year="2014">
-      <Id>a5ac81cd-aa65-4b46-8ab1-fc1e50961bba</Id>
+      <Database Name="cv" Series="71614" Issue="468467" />
     </Book>
     <Book Series="X-Force" Number="12" Volume="2014" Year="2015">
-      <Id>d7e4369c-4a68-457a-9143-609001b2c0cd</Id>
+      <Database Name="cv" Series="71614" Issue="470437" />
     </Book>
     <Book Series="X-Force" Number="13" Volume="2014" Year="2015">
-      <Id>58f3c38c-1ca8-47a0-91d6-46383f3bffce</Id>
+      <Database Name="cv" Series="71614" Issue="472915" />
     </Book>
     <Book Series="X-Force" Number="14" Volume="2014" Year="2015">
-      <Id>87e4f2bf-2d4a-4ca8-b0af-5d074eaa4804</Id>
+      <Database Name="cv" Series="71614" Issue="475948" />
     </Book>
     <Book Series="X-Force" Number="15" Volume="2014" Year="2015">
-      <Id>96c0655e-cd02-473e-94ab-bf57a3f36b1c</Id>
+      <Database Name="cv" Series="71614" Issue="479267" />
     </Book>
-    <Book Series="Deadpool" Number="25" Volume="2013" Year="2014">
-      <Id>b6d0d4fe-69f1-4c3e-bcaa-a0d484257e08</Id>
+    <Book Series="Deadpool" Number="25" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53726" Issue="447508" />
     </Book>
-    <Book Series="Deadpool" Number="26" Volume="2013" Year="2014">
-      <Id>5b7c5bca-b07f-4e4d-8a60-59e05b736405</Id>
+    <Book Series="Deadpool" Number="26" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53726" Issue="448965" />
     </Book>
-    <Book Series="Deadpool" Number="27" Volume="2013" Year="2014">
-      <Id>018f7595-507c-4296-889d-42aa682a2164</Id>
+    <Book Series="Deadpool" Number="27" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53726" Issue="450073" />
     </Book>
     <Book Series="Deadpool vs. Carnage" Number="1" Volume="2014" Year="2014">
-      <Id>82be6400-4bd8-4c3f-9899-49e92e51bb21</Id>
+      <Database Name="cv" Series="72790" Issue="449591" />
     </Book>
     <Book Series="Deadpool vs. Carnage" Number="2" Volume="2014" Year="2014">
-      <Id>1c8b4c7a-49a4-447e-8940-f26359ef1b04</Id>
+      <Database Name="cv" Series="72790" Issue="450550" />
     </Book>
     <Book Series="Deadpool vs. Carnage" Number="3" Volume="2014" Year="2014">
-      <Id>480da703-3d88-408b-a7c8-e3a1bc9b6632</Id>
+      <Database Name="cv" Series="72790" Issue="452310" />
     </Book>
     <Book Series="Deadpool vs. Carnage" Number="4" Volume="2014" Year="2014">
-      <Id>af06dd17-e772-46e0-a693-45869cd18042</Id>
+      <Database Name="cv" Series="72790" Issue="457639" />
     </Book>
     <Book Series="Deadpool Annual" Number="2" Volume="2013" Year="2014">
-      <Id>57bcec5f-c3b9-49d7-800b-12ff1f673fbb</Id>
+      <Database Name="cv" Series="69572" Issue="453412" />
     </Book>
-    <Book Series="Deadpool" Number="28" Volume="2013" Year="2014">
-      <Id>9457e06c-e638-4356-b7f2-55dd57636cbd</Id>
+    <Book Series="Deadpool" Number="28" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53726" Issue="452851" />
     </Book>
-    <Book Series="Deadpool" Number="29" Volume="2013" Year="2014">
-      <Id>832625f8-d810-4098-a7da-3c26dff567a4</Id>
+    <Book Series="Deadpool" Number="29" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53726" Issue="454095" />
     </Book>
     <Book Series="Magneto" Number="1" Volume="2014" Year="2014">
-      <Id>6b66ed0e-7f3f-4cf0-97ff-40b81af80d4f</Id>
+      <Database Name="cv" Series="72111" Issue="446925" />
     </Book>
     <Book Series="Magneto" Number="2" Volume="2014" Year="2014">
-      <Id>7b4158e5-47eb-4632-b968-f35fa138ffd5</Id>
+      <Database Name="cv" Series="72111" Issue="449594" />
     </Book>
     <Book Series="Magneto" Number="3" Volume="2014" Year="2014">
-      <Id>061697b1-9f8e-4e5a-a44b-d29fccdbd22a</Id>
+      <Database Name="cv" Series="72111" Issue="452313" />
     </Book>
     <Book Series="Magneto" Number="4" Volume="2014" Year="2014">
-      <Id>f11b6c1d-7ba3-4149-acd0-019aeaf2cd1d</Id>
+      <Database Name="cv" Series="72111" Issue="453415" />
     </Book>
     <Book Series="Magneto" Number="5" Volume="2014" Year="2014">
-      <Id>6a18f138-1648-4261-b4f7-06918a2dff75</Id>
+      <Database Name="cv" Series="72111" Issue="455490" />
     </Book>
     <Book Series="Magneto" Number="6" Volume="2014" Year="2014">
-      <Id>71614085-525f-4848-a33f-67501272c3ee</Id>
+      <Database Name="cv" Series="72111" Issue="458619" />
     </Book>
     <Book Series="Magneto" Number="7" Volume="2014" Year="2014">
-      <Id>17c5b61f-6ebe-4983-a142-c5d39b278c7c</Id>
+      <Database Name="cv" Series="72111" Issue="459673" />
     </Book>
     <Book Series="Magneto" Number="8" Volume="2014" Year="2014">
-      <Id>24ffdb96-fee7-48c9-b2ac-6aebbc813940</Id>
+      <Database Name="cv" Series="72111" Issue="462893" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 014 - (Marvel NOW!).cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 014 - (Marvel NOW!).cbl
@@ -2,916 +2,916 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>X-Men - Part 14 - (Marvel NOW!)</Name>
   <Books>
-    <Book Series="All-New X-Men" Number="1" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="All-New X-Men" Number="1" Volume="2013" Year="2013">
       <Id>10452916-45ec-446f-a2e3-c391cb28240b</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="2" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="All-New X-Men" Number="2" Volume="2013" Year="2013">
       <Id>22966396-a9cc-46ee-bd3f-2f3d03116daf</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="3" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="All-New X-Men" Number="3" Volume="2013" Year="2013">
       <Id>4b133d8d-1851-4971-8096-564a1406b260</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="4" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="All-New X-Men" Number="4" Volume="2013" Year="2013">
       <Id>71d56a58-a843-43e5-9190-ad41215b68ba</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="5" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="All-New X-Men" Number="5" Volume="2013" Year="2013">
       <Id>8df26baa-f533-4e0c-8e68-150098bec283</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="6" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="All-New X-Men" Number="6" Volume="2013" Year="2013">
       <Id>59d211a3-e458-48cc-880c-7235774115ff</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="7" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="All-New X-Men" Number="7" Volume="2013" Year="2013">
       <Id>68428270-0971-40f8-a986-f60ab0351b01</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="8" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="All-New X-Men" Number="8" Volume="2013" Year="2013">
       <Id>4dc08b2e-1a97-4550-9c66-25b94764b558</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="1" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="1" Volume="2012" Year="2012">
       <Id>2cbbae33-9fdd-41a1-a9ed-ac28b43b776e</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="2" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="2" Volume="2012" Year="2013">
       <Id>807c2878-68df-422a-9666-210653e20e1f</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="3" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="3" Volume="2012" Year="2013">
       <Id>27c386db-c888-4afc-a54e-a5c01bd39cc8</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="4" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="4" Volume="2012" Year="2013">
       <Id>00c9df39-83b3-4660-81a5-e14988dcae45</Id>
     </Book>
-    <Book Series="A+X" Number="1" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="A+X" Number="1" Volume="2012" Year="2012">
       <Id>5cdada2c-01e2-4fc8-a87c-a7b944b9be43</Id>
     </Book>
-    <Book Series="A+X" Number="2" Volume="2012" Year="2013" Format="Crossover">
+    <Book Series="A+X" Number="2" Volume="2012" Year="2013">
       <Id>bb920991-8eac-404b-88fe-68a489a4d5af</Id>
     </Book>
-    <Book Series="A+X" Number="3" Volume="2012" Year="2013" Format="Crossover">
+    <Book Series="A+X" Number="3" Volume="2012" Year="2013">
       <Id>d5b893b7-476b-4e29-99be-eef13f04d1f2</Id>
     </Book>
-    <Book Series="A+X" Number="4" Volume="2012" Year="2013" Format="Crossover">
+    <Book Series="A+X" Number="4" Volume="2012" Year="2013">
       <Id>e5421f0c-6c51-435c-8edf-9ec541e7e105</Id>
     </Book>
-    <Book Series="A+X" Number="5" Volume="2012" Year="2013" Format="Crossover">
+    <Book Series="A+X" Number="5" Volume="2012" Year="2013">
       <Id>10d8a635-d460-45cd-a6e1-add6853780e4</Id>
     </Book>
-    <Book Series="A+X" Number="6" Volume="2012" Year="2013" Format="Crossover">
+    <Book Series="A+X" Number="6" Volume="2012" Year="2013">
       <Id>30157b14-f536-4553-8763-bca55d38e5b0</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="24" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="24" Volume="2011" Year="2013">
       <Id>1b001262-3d36-4ca5-98ab-de3149120b9e</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="1" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="1" Volume="2013" Year="2013">
       <Id>1b16f63d-74f7-4839-89c5-6c0762653665</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="2" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="2" Volume="2013" Year="2013">
       <Id>fd0a5105-7641-47d4-9993-e6a5f251c728</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="3" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="3" Volume="2013" Year="2013">
       <Id>3902e559-4f39-41de-a13a-6a56f726dbb8</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="4" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="4" Volume="2013" Year="2013">
       <Id>b6f8a026-dbd1-4a64-b8bb-c182ef7c1978</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="5" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="5" Volume="2013" Year="2013">
       <Id>92acb89a-4146-426f-92a3-acc7719f50ef</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="6" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="6" Volume="2013" Year="2013">
       <Id>1fe9dd8d-ec35-4930-935a-7101fae128d1</Id>
     </Book>
-    <Book Series="Savage Wolverine" Number="9" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Savage Wolverine" Number="9" Volume="2013" Year="2013">
       <Id>7ec9f0e1-c198-4909-bf28-91a9bbecdd44</Id>
     </Book>
-    <Book Series="Savage Wolverine" Number="10" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Savage Wolverine" Number="10" Volume="2013" Year="2013">
       <Id>f8b5dca9-07e2-496d-8ed8-29db3d9208d6</Id>
     </Book>
-    <Book Series="Savage Wolverine" Number="11" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Savage Wolverine" Number="11" Volume="2013" Year="2014">
       <Id>823d480d-2c9f-4e85-aa7e-147715e8f8f8</Id>
     </Book>
-    <Book Series="Savage Wolverine" Number="12" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Savage Wolverine" Number="12" Volume="2013" Year="2014">
       <Id>c8573fac-52d1-4092-ac27-dd29da360da8</Id>
     </Book>
-    <Book Series="Savage Wolverine" Number="13" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Savage Wolverine" Number="13" Volume="2013" Year="2014">
       <Id>716f115b-7831-41b9-8991-93fde1cfe382</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="62" Volume="2004" Year="2013" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="62" Volume="2004" Year="2013">
       <Id>402e2685-032c-4595-ba61-4e64cb116e32</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="63" Volume="2004" Year="2013" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="63" Volume="2004" Year="2013">
       <Id>503c4816-9f7e-45b0-a1b7-8aad7c7af2d3</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="64" Volume="2004" Year="2013" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="64" Volume="2004" Year="2013">
       <Id>4b84e8a9-9cd9-440e-84f0-185a2c8d408a</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="65" Volume="2004" Year="2013" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="65" Volume="2004" Year="2013">
       <Id>1c1e38d5-c7f2-4bb4-8413-de4ae13d776a</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="1" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="1" Volume="2013" Year="2013">
       <Id>821b35e1-8301-4c1f-a4c1-67e773d85b90</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="2" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="2" Volume="2013" Year="2013">
       <Id>a6b4b5ed-0aae-453c-b790-0c7e25c69347</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="3" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="3" Volume="2013" Year="2013">
       <Id>3cfc498a-5e37-4ddc-9e30-bcbb5f82fd70</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="9" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="All-New X-Men" Number="9" Volume="2013" Year="2013">
       <Id>cdb0345e-fe75-4566-a477-0b6a38b02b1f</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="5" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="5" Volume="2012" Year="2013">
       <Id>5bde829c-f845-4feb-a2ef-51a20034ddae</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="10" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="All-New X-Men" Number="10" Volume="2013" Year="2013">
       <Id>6eb7493e-7de5-4cf0-bc90-0e193c161a4e</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="11" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="All-New X-Men" Number="11" Volume="2013" Year="2013">
       <Id>a7895752-0244-4c36-be6e-abdc4a045f5d</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="12" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="All-New X-Men" Number="12" Volume="2013" Year="2013">
       <Id>5f8bda44-9073-4dff-baed-06be43436795</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="13" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="All-New X-Men" Number="13" Volume="2013" Year="2013">
       <Id>607f83e1-261b-47a8-ae97-462e6818efea</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="4" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="4" Volume="2013" Year="2013">
       <Id>baa393fb-c03d-44e3-90a7-b29438d8b5b5</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="5" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="5" Volume="2013" Year="2013">
       <Id>c5252066-6dad-46fe-84b4-4d646d1daec7</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="6" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="6" Volume="2013" Year="2013">
       <Id>2bfefd58-e542-4d3b-ace9-9e87e265b88a</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="7" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="7" Volume="2013" Year="2013">
       <Id>a55ee469-3f6a-4821-bbee-73850036ebd4</Id>
     </Book>
-    <Book Series="Cable and X-Force" Number="5" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Cable and X-Force" Number="5" Volume="2013" Year="2013">
       <Id>d6c3f81d-37db-4828-8fa9-6bae9317a62e</Id>
     </Book>
-    <Book Series="Cable and X-Force" Number="6" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Cable and X-Force" Number="6" Volume="2013" Year="2013">
       <Id>ef4dc665-edfd-4fdb-b0a9-02fee9ad7883</Id>
     </Book>
-    <Book Series="Cable and X-Force" Number="7" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Cable and X-Force" Number="7" Volume="2013" Year="2013">
       <Id>9cbe4a62-9f1f-4ae6-91e5-065dad08b093</Id>
     </Book>
-    <Book Series="Cable and X-Force" Number="8" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Cable and X-Force" Number="8" Volume="2013" Year="2013">
       <Id>9f51d3a1-b256-44d1-beab-ecc62463ed4d</Id>
     </Book>
-    <Book Series="X-Men" Number="1" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="X-Men" Number="1" Volume="2013" Year="2013">
       <Id>ad5ed4f8-eddc-421d-9a46-5e44036b0346</Id>
     </Book>
-    <Book Series="X-Men" Number="2" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="X-Men" Number="2" Volume="2013" Year="2013">
       <Id>01e5cd4d-2f1c-473c-98f0-b61d80601809</Id>
     </Book>
-    <Book Series="X-Men" Number="3" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="X-Men" Number="3" Volume="2013" Year="2013">
       <Id>928af964-f515-4240-a690-c17e2d34dd96</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="7" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="7" Volume="2013" Year="2013">
       <Id>1a335ef7-4923-4962-bf3d-301caf971db5</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="8" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="8" Volume="2013" Year="2013">
       <Id>5d154dc6-4551-4331-a17e-84b7a12ee418</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="9" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="9" Volume="2013" Year="2013">
       <Id>b0467dac-dc06-4176-a919-fb804bb42707</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="10" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="10" Volume="2013" Year="2013">
       <Id>c2946246-b061-403f-ac6c-05362d0b8af4</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="11" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="11" Volume="2013" Year="2013">
       <Id>50805178-e124-40f7-a999-60d423396959</Id>
     </Book>
-    <Book Series="Deadpool" Number="7" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Deadpool" Number="7" Volume="2013" Year="2013">
       <Id>db94ff54-cd13-48fc-819c-351842edb88a</Id>
     </Book>
-    <Book Series="Deadpool" Number="8" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Deadpool" Number="8" Volume="2013" Year="2013">
       <Id>4ff838e4-1d65-430e-a403-5a3201d929bd</Id>
     </Book>
-    <Book Series="Deadpool" Number="9" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Deadpool" Number="9" Volume="2013" Year="2013">
       <Id>ae8facd2-b2ac-4d2f-8859-8e3ab51438d5</Id>
     </Book>
-    <Book Series="Deadpool" Number="10" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Deadpool" Number="10" Volume="2013" Year="2013">
       <Id>ca8d2a65-9abe-479d-aee4-5ae3774f6db8</Id>
     </Book>
-    <Book Series="Deadpool" Number="11" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Deadpool" Number="11" Volume="2013" Year="2013">
       <Id>d69b0f54-83fc-43a6-9e49-848c06f0ab8b</Id>
     </Book>
-    <Book Series="Deadpool" Number="12" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Deadpool" Number="12" Volume="2013" Year="2013">
       <Id>57203d38-d636-4aec-90e0-515f968bcad2</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="25" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="25" Volume="2011" Year="2013">
       <Id>0821e799-136f-42a0-983e-e1bfe5c7bc5b</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="26" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="26" Volume="2011" Year="2013">
       <Id>37a07afd-1730-4cdc-830f-a362a7a652fc</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="27" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="27" Volume="2011" Year="2013">
       <Id>9513d2ee-d6af-4e94-bb0e-9a425bb7f279</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="28" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="28" Volume="2011" Year="2013">
       <Id>760e1b09-2fa9-42fe-a575-b1d309693b87</Id>
     </Book>
-    <Book Series="Gambit" Number="8" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Gambit" Number="8" Volume="2012" Year="2013">
       <Id>075214de-0767-4dd3-b545-2d7a2c6a28c6</Id>
     </Book>
-    <Book Series="Gambit" Number="9" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Gambit" Number="9" Volume="2012" Year="2013">
       <Id>50de811d-9662-4c09-839a-2c4dcbfdeec8</Id>
     </Book>
-    <Book Series="Gambit" Number="10" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Gambit" Number="10" Volume="2012" Year="2013">
       <Id>32be9030-4243-46e4-9e01-78c01f5ae8fc</Id>
     </Book>
-    <Book Series="Gambit" Number="11" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Gambit" Number="11" Volume="2012" Year="2013">
       <Id>d07db992-c969-49ab-9e2d-89b0a756eeae</Id>
     </Book>
-    <Book Series="Gambit" Number="12" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Gambit" Number="12" Volume="2012" Year="2013">
       <Id>6722281d-fc1c-46e7-9297-be2f7a3fdf45</Id>
     </Book>
-    <Book Series="Gambit" Number="13" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Gambit" Number="13" Volume="2012" Year="2013">
       <Id>e2166b82-1215-4bf9-8903-a226710181b4</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="6" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="6" Volume="2012" Year="2013">
       <Id>e8f54b45-7057-428a-b7cc-67d54978cc32</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="7" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="7" Volume="2012" Year="2013">
       <Id>3fbf3a7d-557d-4ba8-b6ef-49e4a367e570</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="8" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="8" Volume="2012" Year="2013">
       <Id>51551667-4d44-41ac-b219-23a6b9a7e205</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="9" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="9" Volume="2012" Year="2013">
       <Id>a848a4df-0f35-485e-ad0a-e15350312a61</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="10" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="10" Volume="2012" Year="2013">
       <Id>90b49a01-b912-434a-a0b9-321d97700ef2</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="11" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="11" Volume="2012" Year="2013">
       <Id>de881a59-ecc0-4edf-ab9c-51f9841ec207</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="8AU" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="8AU" Volume="2012" Year="2013">
       <Id>14c3d29b-25fc-4341-bee9-322e8a8b0add</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="27AU" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="27AU" Volume="2011" Year="2013">
       <Id>cd3983e8-f6d5-44c6-a34d-ab16923eda89</Id>
     </Book>
-    <Book Series="Cable and X-Force" Number="9" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Cable and X-Force" Number="9" Volume="2013" Year="2013">
       <Id>cbbfdc0a-a383-4f84-9abe-39475b2f2821</Id>
     </Book>
-    <Book Series="Cable and X-Force" Number="10" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Cable and X-Force" Number="10" Volume="2013" Year="2013">
       <Id>6e7b9d42-913a-4442-ba6f-b5d0d2ee9bae</Id>
     </Book>
-    <Book Series="Cable and X-Force" Number="11" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Cable and X-Force" Number="11" Volume="2013" Year="2013">
       <Id>80fc8d03-57dc-4042-af8b-6600c0d8d78f</Id>
     </Book>
-    <Book Series="Wolverine" Number="1" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Wolverine" Number="1" Volume="2013" Year="2013">
       <Id>7db8df59-e1da-42f0-a37c-1e7b0261a34f</Id>
     </Book>
-    <Book Series="Wolverine" Number="2" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Wolverine" Number="2" Volume="2013" Year="2013">
       <Id>0802ce6d-3e95-4640-ae9b-523fac5b77d3</Id>
     </Book>
-    <Book Series="Wolverine" Number="3" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Wolverine" Number="3" Volume="2013" Year="2013">
       <Id>3253e530-5a7d-4dcd-b360-c619d228d2fc</Id>
     </Book>
-    <Book Series="Wolverine" Number="4" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Wolverine" Number="4" Volume="2013" Year="2013">
       <Id>f0e062c2-c5f1-4e0e-8a55-94e6e623bf12</Id>
     </Book>
-    <Book Series="Wolverine" Number="314" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Wolverine" Number="314" Volume="2010" Year="2012">
       <Id>d161403f-9030-4d39-9a21-2662b5146d02</Id>
     </Book>
-    <Book Series="Wolverine" Number="315" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="Wolverine" Number="315" Volume="2010" Year="2012">
       <Id>f3389726-118c-42e8-8465-007fb81b4c68</Id>
     </Book>
-    <Book Series="Wolverine" Number="316" Volume="2010" Year="2013" Format="Main Series">
+    <Book Series="Wolverine" Number="316" Volume="2010" Year="2013">
       <Id>8ba25d1f-5ec6-4cbb-9660-ffe2c94d6e0b</Id>
     </Book>
-    <Book Series="Wolverine" Number="317" Volume="2010" Year="2013" Format="Main Series">
+    <Book Series="Wolverine" Number="317" Volume="2010" Year="2013">
       <Id>cd7033a3-8ac0-4c16-95c6-182eeae36cb5</Id>
     </Book>
-    <Book Series="Gambit" Number="14" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Gambit" Number="14" Volume="2012" Year="2013">
       <Id>a6bf4f0b-ad9d-43a7-8cfd-2560ee774af8</Id>
     </Book>
-    <Book Series="Gambit" Number="15" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Gambit" Number="15" Volume="2012" Year="2013">
       <Id>1fdcc5fe-2d05-43a1-9f7a-b93fa177fd80</Id>
     </Book>
-    <Book Series="Gambit" Number="16" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Gambit" Number="16" Volume="2012" Year="2013">
       <Id>f56c33b8-685e-48e6-a89c-75dce36926c7</Id>
     </Book>
-    <Book Series="Gambit" Number="17" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Gambit" Number="17" Volume="2012" Year="2013">
       <Id>a77342e3-1cd3-4446-9367-28bc3e995a52</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="29" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="29" Volume="2011" Year="2013">
       <Id>53638a48-c4fc-49ab-83ab-802197f14ac9</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="30" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="30" Volume="2011" Year="2013">
       <Id>305f427d-9f3d-42ff-9ba8-72f3d4b4650b</Id>
     </Book>
-    <Book Series="A+X" Number="7" Volume="2012" Year="2013" Format="Crossover">
+    <Book Series="A+X" Number="7" Volume="2012" Year="2013">
       <Id>81a6ef2a-1533-45ec-ae0e-85623e94b330</Id>
     </Book>
-    <Book Series="A+X" Number="8" Volume="2012" Year="2013" Format="Crossover">
+    <Book Series="A+X" Number="8" Volume="2012" Year="2013">
       <Id>c3c1d075-fbed-4e44-ab1c-c4c31b138772</Id>
     </Book>
-    <Book Series="A+X" Number="9" Volume="2012" Year="2013" Format="Crossover">
+    <Book Series="A+X" Number="9" Volume="2012" Year="2013">
       <Id>3114da11-7b18-4f05-b15b-828cbdc490fc</Id>
     </Book>
-    <Book Series="A+X" Number="10" Volume="2012" Year="2013" Format="Crossover">
+    <Book Series="A+X" Number="10" Volume="2012" Year="2013">
       <Id>63cf076a-3f5a-4ce6-8c30-44ef52d07fcb</Id>
     </Book>
-    <Book Series="A+X" Number="11" Volume="2012" Year="2013" Format="Crossover">
+    <Book Series="A+X" Number="11" Volume="2012" Year="2013">
       <Id>1c6f6f52-eaab-45bc-8ba0-3a04e4708f91</Id>
     </Book>
-    <Book Series="A+X" Number="12" Volume="2012" Year="2013" Format="Crossover">
+    <Book Series="A+X" Number="12" Volume="2012" Year="2013">
       <Id>1c9a22a6-3728-4064-8724-55e1b208e9b7</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men Annual" Number="1" Volume="2013" Year="2014" Format="Annual">
+    <Book Series="Wolverine &amp; the X-Men Annual" Number="1" Volume="2013" Year="2014">
       <Id>dcdc2090-2b09-42a9-adf7-f752a7dc1580</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="7" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="7" Volume="2013" Year="2013">
       <Id>4ca9bf08-cbb5-4ce6-998d-2ce18a7443fe</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="8" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="8" Volume="2013" Year="2013">
       <Id>16b5e79e-b114-4221-a4e6-e6373d94c77e</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="9" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="9" Volume="2013" Year="2013">
       <Id>f792383b-f8a1-43ff-9dd9-a4eecc953f4b</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="10" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="10" Volume="2013" Year="2013">
       <Id>6ac54826-2104-4a0d-b05f-772f3ec13b62</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="11" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="11" Volume="2013" Year="2013">
       <Id>2191e474-6bed-4605-88c2-561a5dd3e8e6</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="12" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="12" Volume="2013" Year="2013">
       <Id>89de6f17-4a0a-4800-b490-cae80f75293b</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="13" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="13" Volume="2013" Year="2013">
       <Id>4b74cf64-bddb-43df-9ed2-4c94691414df</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="14" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="14" Volume="2013" Year="2014">
       <Id>ac59a9c4-7c14-4a79-8716-587d8517798b</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="15" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="15" Volume="2013" Year="2014">
       <Id>717ce8a4-bc7e-479c-96db-90102a8b22c0</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="31" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="31" Volume="2011" Year="2013">
       <Id>278d04b5-5e6a-4f28-a6ba-db58c195a9e7</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="32" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="32" Volume="2011" Year="2013">
       <Id>943039e4-1b91-4a6d-87ea-ea276ae3578a</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="33" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="33" Volume="2011" Year="2013">
       <Id>408b002b-ead9-4272-bc24-def38c3763bf</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="34" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="34" Volume="2011" Year="2013">
       <Id>b204323b-02c4-4891-bfd1-091b5e5f6946</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="35" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="35" Volume="2011" Year="2013">
       <Id>d8e86ad6-8529-4be9-ae0c-fb0f12117585</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="66" Volume="2004" Year="2013" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="66" Volume="2004" Year="2013">
       <Id>3f52c509-a3d4-4851-9be0-b1858f78d1dd</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="67" Volume="2004" Year="2013" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="67" Volume="2004" Year="2013">
       <Id>440439aa-936e-4d2b-8f55-3d0807ec96b2</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="68" Volume="2004" Year="2013" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="68" Volume="2004" Year="2013">
       <Id>d9dda74a-456a-4d81-8550-b37a339082fa</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="12" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="12" Volume="2012" Year="2013">
       <Id>dba16362-851f-428b-97db-c300f712eab9</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="13" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="13" Volume="2012" Year="2013">
       <Id>4ba3c94c-34a8-4910-a9e8-4ed990f68309</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="14" Volume="2012" Year="2014" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="14" Volume="2012" Year="2014">
       <Id>1ed9bb76-9eff-43e1-a0fb-3bd7f98f2a06</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="15" Volume="2012" Year="2014" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="15" Volume="2012" Year="2014">
       <Id>2fd94959-877b-433c-b109-0b7ba79e5c4c</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="16" Volume="2012" Year="2014" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="16" Volume="2012" Year="2014">
       <Id>99cce352-11c1-4ef2-b6d2-ddd823502734</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="17" Volume="2012" Year="2014" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="17" Volume="2012" Year="2014">
       <Id>4112eec1-3439-4857-ac51-320585f62af9</Id>
     </Book>
-    <Book Series="Deadpool" Number="13" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Deadpool" Number="13" Volume="2013" Year="2013">
       <Id>623e704d-9823-4cb2-8da1-c882cae92fe8</Id>
     </Book>
-    <Book Series="Deadpool" Number="14" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Deadpool" Number="14" Volume="2013" Year="2013">
       <Id>82fdd768-9ac4-431c-8374-ec27ca1cd431</Id>
     </Book>
-    <Book Series="Deadpool" Number="15" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Deadpool" Number="15" Volume="2013" Year="2013">
       <Id>27d8de72-5ca4-423f-b782-a62b498355dd</Id>
     </Book>
-    <Book Series="Deadpool" Number="16" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Deadpool" Number="16" Volume="2013" Year="2013">
       <Id>41089bfd-8157-420a-a169-71f5b25faac7</Id>
     </Book>
-    <Book Series="Deadpool" Number="17" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Deadpool" Number="17" Volume="2013" Year="2013">
       <Id>b0231fb8-b365-4b24-89e1-4b7c9eddfbd5</Id>
     </Book>
-    <Book Series="Deadpool" Number="18" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Deadpool" Number="18" Volume="2013" Year="2013">
       <Id>f2973342-1910-463c-8976-e52a4aefc0f9</Id>
     </Book>
-    <Book Series="Deadpool" Number="19" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Deadpool" Number="19" Volume="2013" Year="2014">
       <Id>ef280a6e-657d-4836-8686-6374ebf92634</Id>
     </Book>
-    <Book Series="Deadpool Annual" Number="1" Volume="2013" Year="2014" Format="Annual">
+    <Book Series="Deadpool Annual" Number="1" Volume="2013" Year="2014">
       <Id>278c1a5d-f806-413b-ac1c-145722e2d9b2</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="12" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="12" Volume="2013" Year="2013">
       <Id>08845b24-4844-48ae-928d-f8c616c4ba8b</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="13" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="13" Volume="2013" Year="2013">
       <Id>f8ffb983-6467-432b-a793-5edfc0434a7e</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="14" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="14" Volume="2013" Year="2013">
       <Id>5bbc33ed-f59b-4b04-b5c8-972c2c3ac2ca</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="15" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="15" Volume="2013" Year="2013">
       <Id>42ca63a8-dd5b-410c-8f81-2618445598fd</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="16" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="16" Volume="2013" Year="2013">
       <Id>1faffaf8-6c93-4e90-8810-008d9225b61e</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="17" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="17" Volume="2013" Year="2013">
       <Id>19a00ec2-815d-45eb-85f1-a049f4a771bf</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="18" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="18" Volume="2013" Year="2013">
       <Id>e219a03a-1d7e-474a-a128-f208832f16b5</Id>
     </Book>
-    <Book Series="Wolverine" Number="5" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Wolverine" Number="5" Volume="2013" Year="2013">
       <Id>9bfdd376-5f72-422a-ac24-05b9fce6a98a</Id>
     </Book>
-    <Book Series="Wolverine" Number="6" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Wolverine" Number="6" Volume="2013" Year="2013">
       <Id>3b63031d-360b-4b19-bc3b-7038e712d20f</Id>
     </Book>
-    <Book Series="Wolverine" Number="7" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Wolverine" Number="7" Volume="2013" Year="2013">
       <Id>86966a0a-adfc-42bb-8c3f-84505bd8ec4f</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="14" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="All-New X-Men" Number="14" Volume="2013" Year="2013">
       <Id>08247481-683c-4693-93aa-6a87f6f4e770</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="15" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="All-New X-Men" Number="15" Volume="2013" Year="2013">
       <Id>a9a1e9ab-dead-4f39-a3d0-150278058d44</Id>
     </Book>
-    <Book Series="All-New X-Men Special" Number="1" Volume="2013" Year="2013" Format="One-Shot">
+    <Book Series="All-New X-Men Special" Number="1" Volume="2013" Year="2013">
       <Id>db40a7d4-0ab5-4cfa-8313-11c5c01fdc34</Id>
     </Book>
-    <Book Series="Indestructible Hulk Special" Number="1" Volume="2013" Year="2013" Format="One-Shot">
+    <Book Series="Indestructible Hulk Special" Number="1" Volume="2013" Year="2013">
       <Id>eb738a1d-ad79-42db-b9d1-1d15d8bfab91</Id>
     </Book>
-    <Book Series="Superior Spider-Man Team-Up Special" Number="1" Volume="2013" Year="2013" Format="One-Shot">
+    <Book Series="Superior Spider-Man Team-Up Special" Number="1" Volume="2013" Year="2013">
       <Id>acfe03ea-b44d-441f-8218-3103227b69c6</Id>
     </Book>
-    <Book Series="X-Men" Number="4" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="X-Men" Number="4" Volume="2013" Year="2013">
       <Id>5e151630-35fe-4b9a-ab97-6189ea806b38</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="8" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="8" Volume="2013" Year="2013">
       <Id>ced9f1a9-75fa-49c3-afc0-0d15143da501</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="9" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="9" Volume="2013" Year="2013">
       <Id>aa93b343-86e9-4bc9-98e0-b60bed0f67b9</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="10" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="10" Volume="2013" Year="2013">
       <Id>f28df617-ff19-4983-be89-3eedab2c5646</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="11" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="11" Volume="2013" Year="2013">
       <Id>b3bf000f-652f-4ed8-8f96-61b12ff1d9ae</Id>
     </Book>
-    <Book Series="Wolverine" Number="8" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Wolverine" Number="8" Volume="2013" Year="2013">
       <Id>a83374e2-09d3-4692-b499-f51ed6e3b98b</Id>
     </Book>
-    <Book Series="Wolverine" Number="9" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Wolverine" Number="9" Volume="2013" Year="2013">
       <Id>c152b4d8-853b-4c70-8e9d-7bfd1878a1a7</Id>
     </Book>
-    <Book Series="Wolverine" Number="10" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Wolverine" Number="10" Volume="2013" Year="2013">
       <Id>49eb4803-54b9-48db-9264-dabd21aad98c</Id>
     </Book>
-    <Book Series="Wolverine" Number="11" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Wolverine" Number="11" Volume="2013" Year="2014">
       <Id>b41b1a7d-3012-4181-9214-a4c024e0ba38</Id>
     </Book>
-    <Book Series="Wolverine" Number="12" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Wolverine" Number="12" Volume="2013" Year="2014">
       <Id>3f12768d-fb3d-4a8e-87e2-e3d0fbbfdae1</Id>
     </Book>
-    <Book Series="Wolverine" Number="13" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Wolverine" Number="13" Volume="2013" Year="2014">
       <Id>b5130e7b-930e-4f84-8c1d-f2f3f9e6a09d</Id>
     </Book>
-    <Book Series="X-Men: Battle of the Atom" Number="1" Volume="2013" Year="2013" Format="Limited Series">
+    <Book Series="X-Men: Battle of the Atom" Number="1" Volume="2013" Year="2013">
       <Id>cc9a5d89-1e93-407e-9956-3a63ba295b7d</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="16" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="All-New X-Men" Number="16" Volume="2013" Year="2013">
       <Id>761dcb32-0ce0-4cca-9276-99b59523577d</Id>
     </Book>
-    <Book Series="X-Men" Number="5" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="X-Men" Number="5" Volume="2013" Year="2013">
       <Id>e1b33985-973b-4bf8-a253-8b469a1cc06b</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="12" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="12" Volume="2013" Year="2013">
       <Id>f41c1983-69a8-4e3b-9f4e-3c2d05ba4af3</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="36" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="36" Volume="2011" Year="2013">
       <Id>d5230721-19a4-4c0f-b2af-a469b00b55d4</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="17" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="All-New X-Men" Number="17" Volume="2013" Year="2013">
       <Id>a8a75547-1e32-4c12-95e2-642fe05806ac</Id>
     </Book>
-    <Book Series="X-Men" Number="6" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="X-Men" Number="6" Volume="2013" Year="2013">
       <Id>65ff2991-7aa6-4bb3-b723-f4696bd5d6c6</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="13" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="13" Volume="2013" Year="2013">
       <Id>a7e425bc-68fb-448e-9cc2-cf090beb093f</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="37" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="37" Volume="2011" Year="2013">
       <Id>23d7f2a9-0774-4f2c-913c-14855e950d6e</Id>
     </Book>
-    <Book Series="X-Men: Battle of the Atom" Number="2" Volume="2013" Year="2013" Format="Limited Series">
+    <Book Series="X-Men: Battle of the Atom" Number="2" Volume="2013" Year="2013">
       <Id>a71e53ff-3273-4205-85d7-edd24b392874</Id>
     </Book>
-    <Book Series="A+X" Number="13" Volume="2012" Year="2013" Format="Crossover">
+    <Book Series="A+X" Number="13" Volume="2012" Year="2013">
       <Id>c7d7c6c9-da28-4e9a-a902-dcf62207e3ce</Id>
     </Book>
-    <Book Series="A+X" Number="14" Volume="2012" Year="2014" Format="Crossover">
+    <Book Series="A+X" Number="14" Volume="2012" Year="2014">
       <Id>9ca54e4a-83c5-41c8-9258-b8818adefb8e</Id>
     </Book>
-    <Book Series="A+X" Number="15" Volume="2012" Year="2014" Format="Crossover">
+    <Book Series="A+X" Number="15" Volume="2012" Year="2014">
       <Id>73b7e20b-4768-4acf-aaa3-025569f049b2</Id>
     </Book>
-    <Book Series="A+X" Number="16" Volume="2012" Year="2014" Format="Crossover">
+    <Book Series="A+X" Number="16" Volume="2012" Year="2014">
       <Id>a39d5f33-21b5-4a9b-8b0b-41e0b691d0c8</Id>
     </Book>
-    <Book Series="A+X" Number="17" Volume="2012" Year="2014" Format="Crossover">
+    <Book Series="A+X" Number="17" Volume="2012" Year="2014">
       <Id>99b49301-c8a6-44a7-bfa5-e99103365a1d</Id>
     </Book>
-    <Book Series="A+X" Number="18" Volume="2012" Year="2014" Format="Crossover">
+    <Book Series="A+X" Number="18" Volume="2012" Year="2014">
       <Id>5820d6ed-6d7c-402a-87c2-aae588a660b2</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="19" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="19" Volume="2013" Year="2014">
       <Id>847f4024-a255-477a-9cf8-2012f5a10bbb</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="20" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="20" Volume="2013" Year="2014">
       <Id>ce06ac8e-6dcc-4e8a-be12-968ca060e319</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="21" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="21" Volume="2013" Year="2014">
       <Id>05e8635b-e7be-4dc9-9c6b-6571cfb9034e</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="22" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="22" Volume="2013" Year="2014">
       <Id>552f1057-3fe0-4230-8b63-4a008d3aac09</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="23" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="23" Volume="2013" Year="2014">
       <Id>39f90ddc-9ef3-44af-815c-c682f10b4743</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="24" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="24" Volume="2013" Year="2014">
       <Id>33dc0599-9fd3-46cd-ba46-a73f8a84dffb</Id>
     </Book>
-    <Book Series="X-Men: Legacy" Number="300" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="X-Men: Legacy" Number="300" Volume="2013" Year="2014">
       <Id>2d1b9ad4-cfe9-49f6-a8bc-748a3cbee31b</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="14" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="14" Volume="2013" Year="2014">
       <Id>4f6d8931-c56d-496d-85f7-bf6728a0fcba</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="18" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Men" Number="18" Volume="2013" Year="2014">
       <Id>0267b1cd-5062-4a3a-83b3-8eeadce76311</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="38" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="38" Volume="2011" Year="2014">
       <Id>a36697b0-f46c-4af4-b8ec-34f5c5f657be</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="39" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="39" Volume="2011" Year="2014">
       <Id>0780076a-a090-4dfa-8609-a8a481bd423a</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="40" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="40" Volume="2011" Year="2014">
       <Id>7b37eba1-5c58-4f12-bbc0-cd0c077d07a0</Id>
     </Book>
-    <Book Series="Amazing X-Men" Number="1" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Amazing X-Men" Number="1" Volume="2013" Year="2014">
       <Id>f8ed765d-6fb6-4d49-a8b1-7c0e5009e6eb</Id>
     </Book>
-    <Book Series="Amazing X-Men" Number="2" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Amazing X-Men" Number="2" Volume="2013" Year="2014">
       <Id>caff3978-38cf-4765-aed5-5b6e1735069d</Id>
     </Book>
-    <Book Series="Amazing X-Men" Number="3" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Amazing X-Men" Number="3" Volume="2013" Year="2014">
       <Id>83d080fd-4f60-4096-b301-6aacabe966e5</Id>
     </Book>
-    <Book Series="Amazing X-Men" Number="4" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Amazing X-Men" Number="4" Volume="2013" Year="2014">
       <Id>cffbfd6f-81ab-4d5f-9915-cac31808911f</Id>
     </Book>
-    <Book Series="Amazing X-Men" Number="5" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Amazing X-Men" Number="5" Volume="2013" Year="2014">
       <Id>57d63239-4aeb-436c-adc3-edeaa8645768</Id>
     </Book>
-    <Book Series="Amazing X-Men" Number="6" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Amazing X-Men" Number="6" Volume="2013" Year="2014">
       <Id>bd981fbe-8523-4915-a887-674a2f7ec576</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="19" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Men" Number="19" Volume="2013" Year="2014">
       <Id>fd9ddea1-040a-40a8-8d6b-ee70968f7994</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="20" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Men" Number="20" Volume="2013" Year="2014">
       <Id>28cdcfe8-ed21-4e12-be91-3aecef837da1</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="21" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Men" Number="21" Volume="2013" Year="2014">
       <Id>80417fa3-0505-4781-8d15-757b269a9dc2</Id>
     </Book>
-    <Book Series="Deadpool" Number="20" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Deadpool" Number="20" Volume="2013" Year="2014">
       <Id>f88533ba-0e7f-4865-bd64-4f0766d2e2c4</Id>
     </Book>
-    <Book Series="Deadpool" Number="21" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Deadpool" Number="21" Volume="2013" Year="2014">
       <Id>2be11137-c686-4734-868f-2a26647de6c1</Id>
     </Book>
-    <Book Series="Deadpool" Number="22" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Deadpool" Number="22" Volume="2013" Year="2014">
       <Id>52159d50-cf01-4906-b662-750971f1fe0d</Id>
     </Book>
-    <Book Series="Deadpool" Number="23" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Deadpool" Number="23" Volume="2013" Year="2014">
       <Id>820de166-eaeb-4b8d-8735-147cd24ab444</Id>
     </Book>
-    <Book Series="Deadpool" Number="24" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Deadpool" Number="24" Volume="2013" Year="2014">
       <Id>c0eff143-d318-45f6-aa64-1b7f24fd5443</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="15" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="15" Volume="2013" Year="2014">
       <Id>a60cbaf6-de20-4d55-b78f-af7028bc3b9e</Id>
     </Book>
-    <Book Series="Inhumanity: The Awakening" Number="1" Volume="2013" Year="2014" Format="Limited Series">
+    <Book Series="Inhumanity: The Awakening" Number="1" Volume="2013" Year="2014">
       <Id>a1abe811-4371-4ba2-9287-5510760fd41d</Id>
     </Book>
-    <Book Series="Inhumanity: The Awakening" Number="2" Volume="2013" Year="2014" Format="Limited Series">
+    <Book Series="Inhumanity: The Awakening" Number="2" Volume="2013" Year="2014">
       <Id>20c07b28-fb4e-4dae-ab20-f21b8e671f59</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="16" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="16" Volume="2013" Year="2014">
       <Id>c796d696-90bf-46d4-a385-b0b0b5cede1e</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="17" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="17" Volume="2013" Year="2014">
       <Id>9ff63a93-3f1f-46a8-88f6-95cad5799402</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="18" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="18" Volume="2013" Year="2014">
       <Id>0b401270-302e-4837-86e9-36703eb0feb9</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="41" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="41" Volume="2011" Year="2014">
       <Id>82648dc3-ba2f-4921-8d1f-325acb91cf69</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="42" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="42" Volume="2011" Year="2014">
       <Id>56a26b74-cc2d-4769-89ec-9d9b4ae5c918</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="1" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="1" Volume="2014" Year="2014">
       <Id>3a693d12-a94b-434c-95f8-5bbb4f56a796</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="2" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="2" Volume="2014" Year="2014">
       <Id>c01ff8f4-b3d1-4f24-8a0f-b47f160d8e9c</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="3" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="3" Volume="2014" Year="2014">
       <Id>8ceacd01-9a98-40c2-8de1-e30042128cbc</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="4" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="4" Volume="2014" Year="2014">
       <Id>bf4da200-447e-4a58-bec3-ffe0a3edcd6f</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="5" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="5" Volume="2014" Year="2014">
       <Id>7a91b322-d801-4360-a8be-7ccad7c897de</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="6" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="6" Volume="2014" Year="2014">
       <Id>b39a7f83-d46a-46f2-bcaf-5998d776b587</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="7" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="7" Volume="2014" Year="2014">
       <Id>c3e6a3ba-8603-4611-aee6-76b2a83270b7</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="8" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="8" Volume="2014" Year="2014">
       <Id>97094aed-d189-44f0-a778-e98eac9f2d74</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="9" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="9" Volume="2014" Year="2014">
       <Id>835fd808-6712-4b2a-a166-7bba1a0f4c39</Id>
     </Book>
-    <Book Series="Wolverine" Number="1" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Wolverine" Number="1" Volume="2014" Year="2014">
       <Id>b567be6b-91ad-42cf-a8ea-175adae33b28</Id>
     </Book>
-    <Book Series="Wolverine" Number="2" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Wolverine" Number="2" Volume="2014" Year="2014">
       <Id>1e94c6aa-a434-4f12-94f1-9d6775413247</Id>
     </Book>
-    <Book Series="Wolverine" Number="3" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Wolverine" Number="3" Volume="2014" Year="2014">
       <Id>dca1dba3-b5ba-42e1-9ae3-f29badfc9cfb</Id>
     </Book>
-    <Book Series="Wolverine" Number="4" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Wolverine" Number="4" Volume="2014" Year="2014">
       <Id>6164f61a-dcb6-4db0-8bb6-7f53ff917083</Id>
     </Book>
-    <Book Series="Wolverine" Number="5" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Wolverine" Number="5" Volume="2014" Year="2014">
       <Id>a63b6fda-522b-45c1-8a9f-e0a438011aa4</Id>
     </Book>
-    <Book Series="Savage Wolverine" Number="14" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Savage Wolverine" Number="14" Volume="2013" Year="2014">
       <Id>42a49827-4d5e-47c6-86fc-965a157bdaa5</Id>
     </Book>
-    <Book Series="Savage Wolverine" Number="15" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Savage Wolverine" Number="15" Volume="2013" Year="2014">
       <Id>8a660fab-3c0f-48de-893d-9325305c75b7</Id>
     </Book>
-    <Book Series="Savage Wolverine" Number="16" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Savage Wolverine" Number="16" Volume="2013" Year="2014">
       <Id>884fbcff-e1b1-4989-89a3-1d136335561b</Id>
     </Book>
-    <Book Series="Savage Wolverine" Number="17" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Savage Wolverine" Number="17" Volume="2013" Year="2014">
       <Id>280d81fc-113a-4dea-9ba4-808f8e8b2d01</Id>
     </Book>
-    <Book Series="Wolverine" Number="6" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Wolverine" Number="6" Volume="2014" Year="2014">
       <Id>717d115f-349c-464a-a27a-6ed8968288dc</Id>
     </Book>
-    <Book Series="Wolverine" Number="7" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Wolverine" Number="7" Volume="2014" Year="2014">
       <Id>3d2eeb5e-5244-41b0-90d3-17ac80fa223c</Id>
     </Book>
-    <Book Series="X-Men" Number="7" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="X-Men" Number="7" Volume="2013" Year="2014">
       <Id>fe81cba8-00fb-41aa-aa62-4fb8d9c774c6</Id>
     </Book>
-    <Book Series="X-Men" Number="8" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="X-Men" Number="8" Volume="2013" Year="2014">
       <Id>d5b54999-0208-4ce1-a2d9-f486f0423fd3</Id>
     </Book>
-    <Book Series="X-Men" Number="9" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="X-Men" Number="9" Volume="2013" Year="2014">
       <Id>00a68609-84b4-41fd-a3d2-a01883918925</Id>
     </Book>
-    <Book Series="X-Men" Number="10" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="X-Men" Number="10" Volume="2013" Year="2014">
       <Id>764a3bfd-b3ea-454e-8b68-a9fbe631169d</Id>
     </Book>
-    <Book Series="X-Men" Number="11" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="X-Men" Number="11" Volume="2013" Year="2014">
       <Id>3e11a158-6af7-47c3-94ff-416722e946f1</Id>
     </Book>
-    <Book Series="X-Men" Number="12" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="X-Men" Number="12" Volume="2013" Year="2014">
       <Id>a8dfbe56-d46d-4ba8-8def-d83accb93e5d</Id>
     </Book>
-    <Book Series="All-New Marvel Now! Point One" Number="1" Volume="2014" Year="2014" Format="One-Shot">
+    <Book Series="All-New Marvel Now! Point One" Number="1" Volume="2014" Year="2014">
       <Id>c2cc8f1a-2d7a-46ea-928f-895ee83745db</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="22" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Men" Number="22" Volume="2013" Year="2014">
       <Id>f188ba06-9f3b-46c7-8327-af440614b01b</Id>
     </Book>
-    <Book Series="Guardians of the Galaxy" Number="11" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Guardians of the Galaxy" Number="11" Volume="2013" Year="2014">
       <Id>45279447-a624-4ca8-9bea-b030bcde4ae3</Id>
     </Book>
     <Book Series="All-New X-Men" Number="23" Volume="2013" Year="2014">
       <Id>8c34eec5-4ee5-45d3-8ccb-ef658b352722</Id>
     </Book>
-    <Book Series="Guardians of the Galaxy" Number="12" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Guardians of the Galaxy" Number="12" Volume="2013" Year="2014">
       <Id>450f0cd0-66f6-428c-9c42-498bc6a09f3d</Id>
     </Book>
     <Book Series="All-New X-Men" Number="24" Volume="2013" Year="2014">
       <Id>a5e14438-8dd8-452f-b248-e5bcf13cfe5c</Id>
     </Book>
-    <Book Series="Guardians of the Galaxy" Number="13" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Guardians of the Galaxy" Number="13" Volume="2013" Year="2014">
       <Id>d71a1e27-789b-4911-aeb5-25f24bb0447a</Id>
     </Book>
-    <Book Series="Cable and X-Force" Number="12" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Cable and X-Force" Number="12" Volume="2013" Year="2013">
       <Id>ec67030a-e6a6-459f-acb2-35626fdb28b0</Id>
     </Book>
-    <Book Series="Cable and X-Force" Number="13" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Cable and X-Force" Number="13" Volume="2013" Year="2013">
       <Id>a4a1829a-1bc8-45f9-a62f-4cabf9979cea</Id>
     </Book>
-    <Book Series="Cable and X-Force" Number="14" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Cable and X-Force" Number="14" Volume="2013" Year="2013">
       <Id>a0ad3f9e-cf77-4efa-9cb1-369f23683cef</Id>
     </Book>
-    <Book Series="Cable and X-Force" Number="15" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Cable and X-Force" Number="15" Volume="2013" Year="2013">
       <Id>92dca633-967b-4bde-b307-9f708e047d82</Id>
     </Book>
-    <Book Series="Cable and X-Force" Number="16" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Cable and X-Force" Number="16" Volume="2013" Year="2014">
       <Id>e705b6d8-ac6e-4c99-84f7-75d0a7a47022</Id>
     </Book>
-    <Book Series="Cable and X-Force" Number="17" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Cable and X-Force" Number="17" Volume="2013" Year="2014">
       <Id>3ce95a29-1e40-4049-aa20-d950de7ef892</Id>
     </Book>
-    <Book Series="Cable and X-Force" Number="18" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Cable and X-Force" Number="18" Volume="2013" Year="2014">
       <Id>1d8ac729-f3e5-4f90-b47e-1f712c31dd53</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="16" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="16" Volume="2013" Year="2014">
       <Id>8858a1ed-87f6-4623-9f98-8b421a0ceb98</Id>
     </Book>
-    <Book Series="Cable and X-Force" Number="19" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Cable and X-Force" Number="19" Volume="2013" Year="2014">
       <Id>e1b79301-70fc-4af6-a2c0-420f76e1ef11</Id>
     </Book>
-    <Book Series="Uncanny X-Force" Number="17" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Uncanny X-Force" Number="17" Volume="2013" Year="2014">
       <Id>97695939-7e49-4dbc-a1cd-203a0216ef2b</Id>
     </Book>
-    <Book Series="All-New X-Factor" Number="1" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Factor" Number="1" Volume="2014" Year="2014">
       <Id>d3981a5f-fd02-427b-adc8-ed5ca29e5493</Id>
     </Book>
-    <Book Series="All-New X-Factor" Number="2" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Factor" Number="2" Volume="2014" Year="2014">
       <Id>77eb0b2c-72bb-4ba9-a980-d5ed654842a1</Id>
     </Book>
-    <Book Series="All-New X-Factor" Number="3" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Factor" Number="3" Volume="2014" Year="2014">
       <Id>0149dec5-4c3c-4622-be37-ce4032bdc94d</Id>
     </Book>
-    <Book Series="All-New X-Factor" Number="4" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Factor" Number="4" Volume="2014" Year="2014">
       <Id>9c31f070-e64c-4961-abdf-df35f08cbfe9</Id>
     </Book>
-    <Book Series="All-New X-Factor" Number="5" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Factor" Number="5" Volume="2014" Year="2014">
       <Id>28ea6f75-8e9d-42d5-8145-0f0cf6711f27</Id>
     </Book>
-    <Book Series="All-New X-Factor" Number="6" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Factor" Number="6" Volume="2014" Year="2014">
       <Id>8074ff31-430b-4792-9869-f5a154a72964</Id>
     </Book>
-    <Book Series="All-New X-Factor" Number="7" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Factor" Number="7" Volume="2014" Year="2014">
       <Id>4ab92953-91d6-4932-9e39-c995f410a050</Id>
     </Book>
-    <Book Series="All-New X-Factor" Number="8" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Factor" Number="8" Volume="2014" Year="2014">
       <Id>07fca32f-7851-4a9b-a5b4-c4f12b229231</Id>
     </Book>
-    <Book Series="All-New X-Factor" Number="9" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Factor" Number="9" Volume="2014" Year="2014">
       <Id>a97616b5-f4b2-459b-b55a-9d8358f562c8</Id>
     </Book>
-    <Book Series="All-New X-Factor" Number="10" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Factor" Number="10" Volume="2014" Year="2014">
       <Id>53a7eade-17a0-4d66-b5b4-51956d2d716d</Id>
     </Book>
-    <Book Series="All-New X-Factor" Number="11" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Factor" Number="11" Volume="2014" Year="2014">
       <Id>f8e7538d-ff7e-4ac7-ba89-8689a9b0a59b</Id>
     </Book>
-    <Book Series="All-New X-Factor" Number="12" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Factor" Number="12" Volume="2014" Year="2014">
       <Id>d76f2df5-5994-47ae-ae1f-da4db7196466</Id>
     </Book>
-    <Book Series="All-New X-Factor" Number="13" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Factor" Number="13" Volume="2014" Year="2014">
       <Id>36d6165e-98da-42b7-9f94-7a779ac5cd46</Id>
     </Book>
-    <Book Series="All-New X-Factor" Number="14" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Factor" Number="14" Volume="2014" Year="2014">
       <Id>6df2ad65-7ead-4ef7-9698-b3ff64074fe6</Id>
     </Book>
-    <Book Series="X-Force" Number="1" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="X-Force" Number="1" Volume="2014" Year="2014">
       <Id>ba1415c0-7853-4414-aecc-be5a1956298a</Id>
     </Book>
-    <Book Series="X-Force" Number="2" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="X-Force" Number="2" Volume="2014" Year="2014">
       <Id>f3e53027-27ac-4715-b64c-990114438e6c</Id>
     </Book>
-    <Book Series="X-Force" Number="3" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="X-Force" Number="3" Volume="2014" Year="2014">
       <Id>5940f08a-7102-46e6-a1f7-ea54d0a09cdc</Id>
     </Book>
-    <Book Series="X-Force" Number="4" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="X-Force" Number="4" Volume="2014" Year="2014">
       <Id>7e9b488c-0bf7-4689-a008-35a2ddf80ea4</Id>
     </Book>
-    <Book Series="X-Force" Number="5" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="X-Force" Number="5" Volume="2014" Year="2014">
       <Id>71469a1e-4e96-4ed4-8b70-49fb171157b4</Id>
     </Book>
-    <Book Series="X-Force" Number="6" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="X-Force" Number="6" Volume="2014" Year="2014">
       <Id>62b17d68-b293-4bc2-9001-f4beef85e0d5</Id>
     </Book>
-    <Book Series="X-Force" Number="7" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="X-Force" Number="7" Volume="2014" Year="2014">
       <Id>dfa40b4a-678b-460e-8041-f3cd34b74fb5</Id>
     </Book>
-    <Book Series="X-Force" Number="8" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="X-Force" Number="8" Volume="2014" Year="2014">
       <Id>c1530216-5840-418f-86b8-0ea736fae60b</Id>
     </Book>
-    <Book Series="X-Force" Number="9" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="X-Force" Number="9" Volume="2014" Year="2014">
       <Id>2e57c9b3-6ece-4621-9a8d-d6b050da949f</Id>
     </Book>
-    <Book Series="X-Force" Number="10" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="X-Force" Number="10" Volume="2014" Year="2014">
       <Id>9261fa3b-6d8f-4422-a572-9e6ea7b59cdb</Id>
     </Book>
-    <Book Series="X-Force" Number="11" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="X-Force" Number="11" Volume="2014" Year="2014">
       <Id>a5ac81cd-aa65-4b46-8ab1-fc1e50961bba</Id>
     </Book>
-    <Book Series="X-Force" Number="12" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="X-Force" Number="12" Volume="2014" Year="2015">
       <Id>d7e4369c-4a68-457a-9143-609001b2c0cd</Id>
     </Book>
-    <Book Series="X-Force" Number="13" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="X-Force" Number="13" Volume="2014" Year="2015">
       <Id>58f3c38c-1ca8-47a0-91d6-46383f3bffce</Id>
     </Book>
-    <Book Series="X-Force" Number="14" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="X-Force" Number="14" Volume="2014" Year="2015">
       <Id>87e4f2bf-2d4a-4ca8-b0af-5d074eaa4804</Id>
     </Book>
-    <Book Series="X-Force" Number="15" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="X-Force" Number="15" Volume="2014" Year="2015">
       <Id>96c0655e-cd02-473e-94ab-bf57a3f36b1c</Id>
     </Book>
-    <Book Series="Deadpool" Number="25" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Deadpool" Number="25" Volume="2013" Year="2014">
       <Id>b6d0d4fe-69f1-4c3e-bcaa-a0d484257e08</Id>
     </Book>
-    <Book Series="Deadpool" Number="26" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Deadpool" Number="26" Volume="2013" Year="2014">
       <Id>5b7c5bca-b07f-4e4d-8a60-59e05b736405</Id>
     </Book>
-    <Book Series="Deadpool" Number="27" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Deadpool" Number="27" Volume="2013" Year="2014">
       <Id>018f7595-507c-4296-889d-42aa682a2164</Id>
     </Book>
-    <Book Series="Deadpool vs. Carnage" Number="1" Volume="2014" Year="2014" Format="Limited Series">
+    <Book Series="Deadpool vs. Carnage" Number="1" Volume="2014" Year="2014">
       <Id>82be6400-4bd8-4c3f-9899-49e92e51bb21</Id>
     </Book>
-    <Book Series="Deadpool vs. Carnage" Number="2" Volume="2014" Year="2014" Format="Limited Series">
+    <Book Series="Deadpool vs. Carnage" Number="2" Volume="2014" Year="2014">
       <Id>1c8b4c7a-49a4-447e-8940-f26359ef1b04</Id>
     </Book>
-    <Book Series="Deadpool vs. Carnage" Number="3" Volume="2014" Year="2014" Format="Limited Series">
+    <Book Series="Deadpool vs. Carnage" Number="3" Volume="2014" Year="2014">
       <Id>480da703-3d88-408b-a7c8-e3a1bc9b6632</Id>
     </Book>
-    <Book Series="Deadpool vs. Carnage" Number="4" Volume="2014" Year="2014" Format="Limited Series">
+    <Book Series="Deadpool vs. Carnage" Number="4" Volume="2014" Year="2014">
       <Id>af06dd17-e772-46e0-a693-45869cd18042</Id>
     </Book>
-    <Book Series="Deadpool Annual" Number="2" Volume="2013" Year="2014" Format="Annual">
+    <Book Series="Deadpool Annual" Number="2" Volume="2013" Year="2014">
       <Id>57bcec5f-c3b9-49d7-800b-12ff1f673fbb</Id>
     </Book>
-    <Book Series="Deadpool" Number="28" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Deadpool" Number="28" Volume="2013" Year="2014">
       <Id>9457e06c-e638-4356-b7f2-55dd57636cbd</Id>
     </Book>
-    <Book Series="Deadpool" Number="29" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Deadpool" Number="29" Volume="2013" Year="2014">
       <Id>832625f8-d810-4098-a7da-3c26dff567a4</Id>
     </Book>
-    <Book Series="Magneto" Number="1" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Magneto" Number="1" Volume="2014" Year="2014">
       <Id>6b66ed0e-7f3f-4cf0-97ff-40b81af80d4f</Id>
     </Book>
-    <Book Series="Magneto" Number="2" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Magneto" Number="2" Volume="2014" Year="2014">
       <Id>7b4158e5-47eb-4632-b968-f35fa138ffd5</Id>
     </Book>
-    <Book Series="Magneto" Number="3" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Magneto" Number="3" Volume="2014" Year="2014">
       <Id>061697b1-9f8e-4e5a-a44b-d29fccdbd22a</Id>
     </Book>
-    <Book Series="Magneto" Number="4" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Magneto" Number="4" Volume="2014" Year="2014">
       <Id>f11b6c1d-7ba3-4149-acd0-019aeaf2cd1d</Id>
     </Book>
-    <Book Series="Magneto" Number="5" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Magneto" Number="5" Volume="2014" Year="2014">
       <Id>6a18f138-1648-4261-b4f7-06918a2dff75</Id>
     </Book>
-    <Book Series="Magneto" Number="6" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Magneto" Number="6" Volume="2014" Year="2014">
       <Id>71614085-525f-4848-a33f-67501272c3ee</Id>
     </Book>
-    <Book Series="Magneto" Number="7" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Magneto" Number="7" Volume="2014" Year="2014">
       <Id>17c5b61f-6ebe-4983-a142-c5d39b278c7c</Id>
     </Book>
-    <Book Series="Magneto" Number="8" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Magneto" Number="8" Volume="2014" Year="2014">
       <Id>24ffdb96-fee7-48c9-b2ac-6aebbc813940</Id>
     </Book>
   </Books>

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 015.cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 015.cbl
@@ -1,831 +1,832 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>X-Men - Part 15</Name>
+  <Name>X-Men - Part 015</Name>
+  <NumIssues>275</NumIssues>
   <Books>
     <Book Series="Nightcrawler" Number="1" Volume="2014" Year="2014">
-      <Id>42c503c7-9be9-4ff2-b63f-b5322127b81a</Id>
+      <Database Name="cv" Series="72934" Issue="450079" />
     </Book>
     <Book Series="Nightcrawler" Number="2" Volume="2014" Year="2014">
-      <Id>7d4a741c-bbeb-46a7-afb3-a516ed789bbc</Id>
+      <Database Name="cv" Series="72934" Issue="452856" />
     </Book>
     <Book Series="Nightcrawler" Number="3" Volume="2014" Year="2014">
-      <Id>5b0d1b5a-dd4c-4699-bf9a-160a2aca272d</Id>
+      <Database Name="cv" Series="72934" Issue="456027" />
     </Book>
     <Book Series="Nightcrawler" Number="4" Volume="2014" Year="2014">
-      <Id>0b1c6ce8-43b3-4b62-8820-41f343efe29d</Id>
+      <Database Name="cv" Series="72934" Issue="459173" />
     </Book>
     <Book Series="Nightcrawler" Number="5" Volume="2014" Year="2014">
-      <Id>56ea59bd-03ea-4b48-9898-109100496a3b</Id>
+      <Database Name="cv" Series="72934" Issue="462254" />
     </Book>
     <Book Series="Nightcrawler" Number="6" Volume="2014" Year="2014">
-      <Id>e9d4ffab-d7c6-4dfe-a821-4bc0b55bd003</Id>
+      <Database Name="cv" Series="72934" Issue="464988" />
     </Book>
     <Book Series="X-Men" Number="13" Volume="2013" Year="2014">
-      <Id>8552ccc5-7e36-4bee-a80c-1817e836682b</Id>
+      <Database Name="cv" Series="62383" Issue="450563" />
     </Book>
     <Book Series="X-Men" Number="14" Volume="2013" Year="2014">
-      <Id>b1e76492-d438-48e8-abca-421c4c8af2ee</Id>
+      <Database Name="cv" Series="62383" Issue="453424" />
     </Book>
     <Book Series="X-Men" Number="15" Volume="2013" Year="2014">
-      <Id>bf9f4c08-d554-4733-9c78-b692d9ee28da</Id>
+      <Database Name="cv" Series="62383" Issue="456560" />
     </Book>
     <Book Series="X-Men" Number="16" Volume="2013" Year="2014">
-      <Id>46ed49b3-2a5b-4b15-bc25-b8ecfda94160</Id>
+      <Database Name="cv" Series="62383" Issue="459686" />
     </Book>
     <Book Series="X-Men" Number="17" Volume="2013" Year="2014">
-      <Id>8968680b-04c7-403e-b320-8db81fcbd76f</Id>
+      <Database Name="cv" Series="62383" Issue="460975" />
     </Book>
-    <Book Series="Amazing X-Men" Number="7" Volume="2013" Year="2014">
-      <Id>a1c9b27a-3b12-43d9-9aa8-4813600cfed7</Id>
+    <Book Series="Amazing X-Men" Number="7" Volume="2014" Year="2014">
+      <Database Name="cv" Series="68919" Issue="453409" />
     </Book>
     <Book Series="Uncanny X-Men" Number="19" Volume="2013" Year="2014">
-      <Id>f5073000-af2f-43ac-aa85-8828d0d7f157</Id>
+      <Database Name="cv" Series="57181" Issue="448006" />
     </Book>
     <Book Series="Uncanny X-Men" Number="20" Volume="2013" Year="2014">
-      <Id>b0b5a9da-cd22-4cc9-bbaf-670217598c3b</Id>
+      <Database Name="cv" Series="57181" Issue="450557" />
     </Book>
     <Book Series="Uncanny X-Men" Number="21" Volume="2013" Year="2014">
-      <Id>074f10d5-f4d2-48c7-841b-7496f31bf5cb</Id>
+      <Database Name="cv" Series="57181" Issue="453422" />
     </Book>
     <Book Series="Uncanny X-Men" Number="22" Volume="2013" Year="2014">
-      <Id>eaee406f-0fc3-4688-b732-20e5ac660b7b</Id>
+      <Database Name="cv" Series="57181" Issue="456558" />
     </Book>
     <Book Series="Storm" Number="1" Volume="2014" Year="2014">
-      <Id>d9d9a60f-5c5e-4968-8064-9cf29c0211d0</Id>
+      <Database Name="cv" Series="75874" Issue="460317" />
     </Book>
     <Book Series="Storm" Number="2" Volume="2014" Year="2014">
-      <Id>db6502c4-1d20-4552-8e16-e55e22036ebd</Id>
+      <Database Name="cv" Series="75874" Issue="462902" />
     </Book>
     <Book Series="Storm" Number="3" Volume="2014" Year="2014">
-      <Id>57c7328b-b83d-408d-9321-f9430cc18ad7</Id>
+      <Database Name="cv" Series="75874" Issue="466336" />
     </Book>
     <Book Series="Amazing X-Men Annual" Number="1" Volume="2014" Year="2014">
-      <Id>3bff280d-a030-4c2d-85d0-1bdedffb02db</Id>
+      <Database Name="cv" Series="74520" Issue="455482" />
     </Book>
-    <Book Series="Amazing X-Men" Number="8" Volume="2013" Year="2014">
-      <Id>fd879dd8-9b21-4a8f-ae7b-3c52ada60b3f</Id>
+    <Book Series="Amazing X-Men" Number="8" Volume="2014" Year="2014">
+      <Database Name="cv" Series="68919" Issue="455481" />
     </Book>
-    <Book Series="Amazing X-Men" Number="9" Volume="2013" Year="2014">
-      <Id>a3e6a2f5-b803-4256-b4d0-fb81cd3dba70</Id>
+    <Book Series="Amazing X-Men" Number="9" Volume="2014" Year="2014">
+      <Database Name="cv" Series="68919" Issue="459163" />
     </Book>
-    <Book Series="Amazing X-Men" Number="10" Volume="2013" Year="2014">
-      <Id>a0c1f1cf-0e2e-4bb1-9672-100139c8527a</Id>
+    <Book Series="Amazing X-Men" Number="10" Volume="2014" Year="2014">
+      <Database Name="cv" Series="68919" Issue="462243" />
     </Book>
-    <Book Series="Amazing X-Men" Number="11" Volume="2013" Year="2014">
-      <Id>4ff162e4-eb77-4e54-acdc-75177cd6129e</Id>
+    <Book Series="Amazing X-Men" Number="11" Volume="2014" Year="2014">
+      <Database Name="cv" Series="68919" Issue="466323" />
     </Book>
-    <Book Series="Amazing X-Men" Number="12" Volume="2013" Year="2014">
-      <Id>aa24e5ed-6510-4592-b639-5be1bd187b07</Id>
+    <Book Series="Amazing X-Men" Number="12" Volume="2014" Year="2014">
+      <Database Name="cv" Series="68919" Issue="468456" />
     </Book>
     <Book Series="Wolverine" Number="8" Volume="2014" Year="2014">
-      <Id>bf5b1e89-8e52-47c5-84b0-580e147a3637</Id>
+      <Database Name="cv" Series="71431" Issue="456034" />
     </Book>
     <Book Series="Wolverine" Number="9" Volume="2014" Year="2014">
-      <Id>595093dc-c8a0-4fa6-97d2-8ebffb12ad91</Id>
+      <Database Name="cv" Series="71431" Issue="457653" />
     </Book>
     <Book Series="Wolverine" Number="10" Volume="2014" Year="2014">
-      <Id>40038cf3-8bdb-4fb2-b33a-069773cdfc51</Id>
+      <Database Name="cv" Series="71431" Issue="459180" />
     </Book>
     <Book Series="Wolverine" Number="11" Volume="2014" Year="2014">
-      <Id>e1ba05c5-8547-4a38-bbd8-6003ddf75992</Id>
+      <Database Name="cv" Series="71431" Issue="462261" />
     </Book>
     <Book Series="Wolverine" Number="12" Volume="2014" Year="2014">
-      <Id>f915d40b-1433-4389-a039-083366a6237c</Id>
+      <Database Name="cv" Series="71431" Issue="463490" />
     </Book>
     <Book Series="Uncanny X-Men Special" Number="1" Volume="2014" Year="2014">
-      <Id>162dfc74-0906-404b-ba45-9cf72c5e1779</Id>
+      <Database Name="cv" Series="74730" Issue="456032" />
     </Book>
     <Book Series="Iron Man Special" Number="1" Volume="2014" Year="2014">
-      <Id>1b18577f-dd2f-4e1e-8941-a3c05a1cf2e6</Id>
+      <Database Name="cv" Series="76085" Issue="460967" />
     </Book>
     <Book Series="Nova Special" Number="1" Volume="2014" Year="2014">
-      <Id>b8608ffa-653c-425e-8172-52eb1d6353be</Id>
+      <Database Name="cv" Series="76387" Issue="462255" />
     </Book>
-    <Book Series="All-New X-Men" Number="25" Volume="2013" Year="2014">
-      <Id>e9308029-0727-4e52-bd90-614ca401b631</Id>
+    <Book Series="All-New X-Men" Number="25" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53919" Issue="450068" />
     </Book>
-    <Book Series="Deadpool" Number="30" Volume="2013" Year="2014">
-      <Id>4b896913-6246-41e8-b2be-826394b338a6</Id>
+    <Book Series="Deadpool" Number="30" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53726" Issue="456022" />
     </Book>
-    <Book Series="Deadpool" Number="31" Volume="2013" Year="2014">
-      <Id>03a9c0c8-9143-41bc-bb21-d63d33e80732</Id>
+    <Book Series="Deadpool" Number="31" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53726" Issue="459169" />
     </Book>
-    <Book Series="Deadpool" Number="32" Volume="2013" Year="2014">
-      <Id>ee9e085d-4726-4fe4-9ee3-91215c6f67ef</Id>
+    <Book Series="Deadpool" Number="32" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53726" Issue="460311" />
     </Book>
-    <Book Series="Deadpool" Number="33" Volume="2013" Year="2014">
-      <Id>438750fe-4a5f-4620-b69a-4c00c60d5bd2</Id>
+    <Book Series="Deadpool" Number="33" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53726" Issue="462248" />
     </Book>
-    <Book Series="All-New X-Men" Number="26" Volume="2013" Year="2014">
-      <Id>68b0efdc-39e3-4679-b0f4-a13f4894e9dc</Id>
+    <Book Series="All-New X-Men" Number="26" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53919" Issue="451763" />
     </Book>
-    <Book Series="All-New X-Men" Number="27" Volume="2013" Year="2014">
-      <Id>39c87891-5fc0-4134-8cdc-0c4b0bdb51a9</Id>
+    <Book Series="All-New X-Men" Number="27" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53919" Issue="452845" />
     </Book>
-    <Book Series="All-New X-Men" Number="28" Volume="2013" Year="2014">
-      <Id>cdf108eb-7394-4513-9ad3-1249f9078982</Id>
+    <Book Series="All-New X-Men" Number="28" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53919" Issue="456017" />
     </Book>
-    <Book Series="All-New X-Men" Number="29" Volume="2013" Year="2014">
-      <Id>dc311ed2-c68d-4f9f-88b1-7955ce7db601</Id>
+    <Book Series="All-New X-Men" Number="29" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53919" Issue="459161" />
     </Book>
     <Book Series="Uncanny X-Men Annual" Number="1" Volume="2014" Year="2015">
-      <Id>b8a393b8-bdec-4c61-a73d-8da304b2c0d8</Id>
+      <Database Name="cv" Series="78718" Issue="472914" />
     </Book>
     <Book Series="All-New X-Men Annual" Number="1" Volume="2014" Year="2015">
-      <Id>2c1c902c-1d8a-4633-86ca-fb9dfdf1c5e4</Id>
+      <Database Name="cv" Series="79024" Issue="474620" />
     </Book>
     <Book Series="Uncanny X-Men" Number="23" Volume="2013" Year="2014">
-      <Id>5c04efd8-d2fc-4484-8cf5-afbf993de5fd</Id>
+      <Database Name="cv" Series="57181" Issue="459685" />
     </Book>
-    <Book Series="All-New X-Men" Number="30" Volume="2013" Year="2014">
-      <Id>329e3ebe-8b00-4bd4-80b7-e2b124f437bf</Id>
+    <Book Series="All-New X-Men" Number="30" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53919" Issue="462241" />
     </Book>
     <Book Series="Uncanny X-Men" Number="24" Volume="2013" Year="2014">
-      <Id>9054cd08-bc61-4493-8c6e-e6ca67c78562</Id>
+      <Database Name="cv" Series="57181" Issue="460974" />
     </Book>
     <Book Series="Uncanny X-Men" Number="25" Volume="2013" Year="2014">
-      <Id>40853a95-6925-4fad-80c4-b0f4eb707cc8</Id>
+      <Database Name="cv" Series="57181" Issue="463998" />
     </Book>
-    <Book Series="All-New X-Men" Number="31" Volume="2013" Year="2014">
-      <Id>d750a344-fd74-469f-9d24-6c28e1a2803b</Id>
+    <Book Series="All-New X-Men" Number="31" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53919" Issue="463476" />
     </Book>
-    <Book Series="All-New X-Men" Number="32" Volume="2013" Year="2014">
-      <Id>39e0c9af-22ac-47a9-ad81-6efa038f6960</Id>
+    <Book Series="All-New X-Men" Number="32" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53919" Issue="465836" />
     </Book>
-    <Book Series="All-New X-Men" Number="33" Volume="2013" Year="2014">
-      <Id>eafbd74c-10ef-44bb-b451-86c6736dd163</Id>
+    <Book Series="All-New X-Men" Number="33" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53919" Issue="468900" />
     </Book>
-    <Book Series="All-New X-Men" Number="34" Volume="2013" Year="2015">
-      <Id>72cd6c70-87a5-4a98-b428-95d6ae4f9a86</Id>
+    <Book Series="All-New X-Men" Number="34" Volume="2012" Year="2015">
+      <Database Name="cv" Series="53919" Issue="473638" />
     </Book>
-    <Book Series="All-New X-Men" Number="36" Volume="2013" Year="2015">
-      <Id>e6451593-0357-4a40-9837-092a99a7a794</Id>
+    <Book Series="All-New X-Men" Number="36" Volume="2012" Year="2015">
+      <Database Name="cv" Series="53919" Issue="479253" />
     </Book>
-    <Book Series="All-New X-Men" Number="35" Volume="2013" Year="2015">
-      <Id>d0223661-fe5e-4ff3-9bc4-bd7c261c995d</Id>
+    <Book Series="All-New X-Men" Number="35" Volume="2012" Year="2015">
+      <Database Name="cv" Series="53919" Issue="476778" />
     </Book>
     <Book Series="Uncanny X-Men" Number="26" Volume="2013" Year="2014">
-      <Id>b5ece96b-43e3-4d38-b7e5-355989d7ee32</Id>
+      <Database Name="cv" Series="57181" Issue="465853" />
     </Book>
     <Book Series="Uncanny X-Men" Number="27" Volume="2013" Year="2014">
-      <Id>1940adf0-a4a8-4ecb-8c27-9b646d461880</Id>
+      <Database Name="cv" Series="57181" Issue="468091" />
     </Book>
     <Book Series="Uncanny X-Men" Number="28" Volume="2013" Year="2015">
-      <Id>fe8c9a1d-48fd-447e-b2dd-edc52eef531a</Id>
+      <Database Name="cv" Series="57181" Issue="470436" />
     </Book>
     <Book Series="Uncanny X-Men" Number="29" Volume="2013" Year="2015">
-      <Id>0d67f38c-a9ed-4c5d-9d45-fde20026582e</Id>
+      <Database Name="cv" Series="57181" Issue="474637" />
     </Book>
     <Book Series="Uncanny X-Men" Number="30" Volume="2013" Year="2015">
-      <Id>d7cf2958-9d3f-46d9-8f0c-0ca9e82b4b38</Id>
+      <Database Name="cv" Series="57181" Issue="477858" />
     </Book>
     <Book Series="Uncanny X-Men" Number="31" Volume="2013" Year="2015">
-      <Id>9b9b8da0-9ea6-4d1a-83e7-956fbfff90cb</Id>
+      <Database Name="cv" Series="57181" Issue="479985" />
     </Book>
-    <Book Series="All-New X-Men" Number="37" Volume="2013" Year="2015">
-      <Id>7d9558fb-04b2-40d7-94f1-c6d9131ce349</Id>
+    <Book Series="All-New X-Men" Number="37" Volume="2012" Year="2015">
+      <Database Name="cv" Series="53919" Issue="482149" />
     </Book>
     <Book Series="X-Men" Number="18" Volume="2013" Year="2014">
-      <Id>8ad499d5-a542-4bfa-9be3-42f2534e4e53</Id>
+      <Database Name="cv" Series="62383" Issue="462264" />
     </Book>
     <Book Series="X-Men" Number="19" Volume="2013" Year="2014">
-      <Id>24e28014-373b-400e-802b-3aadad80870e</Id>
+      <Database Name="cv" Series="62383" Issue="463999" />
     </Book>
     <Book Series="X-Men" Number="20" Volume="2013" Year="2014">
-      <Id>61db32ee-18f9-432a-bd59-4252d221b209</Id>
+      <Database Name="cv" Series="62383" Issue="467044" />
     </Book>
     <Book Series="X-Men" Number="21" Volume="2013" Year="2015">
-      <Id>7060ed56-9603-4ad0-9d17-c452755cb454</Id>
+      <Database Name="cv" Series="62383" Issue="469498" />
     </Book>
     <Book Series="X-Men" Number="22" Volume="2013" Year="2015">
-      <Id>f884c034-1250-4a45-9bce-79c4e823df3e</Id>
+      <Database Name="cv" Series="62383" Issue="472916" />
     </Book>
-    <Book Series="Amazing X-Men" Number="13" Volume="2013" Year="2015">
-      <Id>6c201c30-7afe-46f8-a410-21937df701f0</Id>
+    <Book Series="Amazing X-Men" Number="13" Volume="2014" Year="2015">
+      <Database Name="cv" Series="68919" Issue="471312" />
     </Book>
     <Book Series="Deadpool Bi-Annual" Number="1" Volume="2014" Year="2014">
-      <Id>0acbaa0b-5106-436a-9914-c795a12bb643</Id>
+      <Database Name="cv" Series="76981" Issue="465841" />
     </Book>
-    <Book Series="Deadpool" Number="34" Volume="2013" Year="2014">
-      <Id>0d8a992c-28e5-4c07-a293-f90a23b6b412</Id>
+    <Book Series="Deadpool" Number="34" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53726" Issue="464977" />
     </Book>
-    <Book Series="Deadpool" Number="35" Volume="2013" Year="2014">
-      <Id>f4b83a40-d011-4498-a641-953f4640c740</Id>
+    <Book Series="Deadpool" Number="35" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53726" Issue="466325" />
     </Book>
     <Book Series="Death of Wolverine" Number="1" Volume="2014" Year="2014">
-      <Id>fc4c8149-a4c8-4ff9-a5ae-97867ae813b2</Id>
+      <Database Name="cv" Series="76710" Issue="463886" />
     </Book>
     <Book Series="Death of Wolverine" Number="2" Volume="2014" Year="2014">
-      <Id>ef238abb-beea-4941-be77-0208adc87ec0</Id>
+      <Database Name="cv" Series="76710" Issue="464978" />
     </Book>
     <Book Series="Death of Wolverine" Number="3" Volume="2014" Year="2014">
-      <Id>fece51fd-a47f-4afa-8531-d33939dc9a20</Id>
+      <Database Name="cv" Series="76710" Issue="467034" />
     </Book>
     <Book Series="Death of Wolverine" Number="4" Volume="2014" Year="2014">
-      <Id>a6c6a23f-3acc-45b0-ab98-f367c022918a</Id>
+      <Database Name="cv" Series="76710" Issue="468075" />
     </Book>
     <Book Series="Death of Wolverine: The Weapon X Program" Number="1" Volume="2014" Year="2015">
-      <Id>12f9d748-4550-43c6-ba76-b91f8367ea7c</Id>
+      <Database Name="cv" Series="77940" Issue="469492" />
     </Book>
     <Book Series="Death of Wolverine: The Weapon X Program" Number="2" Volume="2014" Year="2015">
-      <Id>626d70f8-8bf9-4720-8d75-4dfd3025cea5</Id>
+      <Database Name="cv" Series="77940" Issue="470425" />
     </Book>
     <Book Series="Death of Wolverine: Life After Logan" Number="1" Volume="2014" Year="2015">
-      <Id>ba57ad0a-2ced-403e-95bc-47a056d810d0</Id>
+      <Database Name="cv" Series="77939" Issue="469491" />
     </Book>
-    <Book Series="Death of Wolverine: Deadpool &amp; Captain America" Number="1" Volume="2014" Year="2014">
-      <Id>417723bf-5136-4e89-8014-2afc716ef284</Id>
+    <Book Series="Death of Wolverine: Deadpool &#38; Captain America" Number="1" Volume="2014" Year="2014">
+      <Database Name="cv" Series="77807" Issue="468903" />
     </Book>
     <Book Series="Nightcrawler" Number="7" Volume="2014" Year="2014">
-      <Id>544a68cf-c4cb-4300-83a8-0cfa0a332ed4</Id>
+      <Database Name="cv" Series="72934" Issue="467653" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="10" Volume="2014" Year="2014">
-      <Id>96f3bb82-4a55-4ff3-b331-9e09a734a439</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="10" Volume="2014" Year="2014">
+      <Database Name="cv" Series="72113" Issue="468092" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="11" Volume="2014" Year="2014">
-      <Id>24466e14-de5f-435c-ad70-f0f488de3bad</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="11" Volume="2014" Year="2014">
+      <Database Name="cv" Series="72113" Issue="468916" />
     </Book>
     <Book Series="Storm" Number="4" Volume="2014" Year="2014">
-      <Id>b86899f5-3df7-4f86-8ead-ee139f6c58c8</Id>
+      <Database Name="cv" Series="75874" Issue="468088" />
     </Book>
-    <Book Series="Death of Wolverine: The Weapon X Program" Number="3" Volume="2014" Year="2015">
-      <Id>b935e3aa-617a-4ad3-ad31-49ab4aa6dcdf</Id>
+    <Book Series="Death of Wolverine: The Weapon X Program" Number="3" Volume="2015" Year="2015">
+      <Database Name="cv" Series="77940" Issue="471963" />
     </Book>
-    <Book Series="Death of Wolverine: The Weapon X Program" Number="4" Volume="2014" Year="2015">
-      <Id>0933cd52-521d-4af1-abd8-dad497a9345f</Id>
+    <Book Series="Death of Wolverine: The Weapon X Program" Number="4" Volume="2015" Year="2015">
+      <Database Name="cv" Series="77940" Issue="473645" />
     </Book>
-    <Book Series="Death of Wolverine: The Weapon X Program" Number="5" Volume="2014" Year="2015">
-      <Id>1cc58d51-15d1-4f3c-9c99-c39e56d63d9d</Id>
+    <Book Series="Death of Wolverine: The Weapon X Program" Number="5" Volume="2015" Year="2015">
+      <Database Name="cv" Series="77940" Issue="475454" />
     </Book>
     <Book Series="Death of Wolverine: The Logan Legacy" Number="1" Volume="2014" Year="2014">
-      <Id>1ce79e74-eaf5-448f-9d95-f71268ca34c7</Id>
+      <Database Name="cv" Series="77576" Issue="468076" />
     </Book>
     <Book Series="Death of Wolverine: The Logan Legacy" Number="2" Volume="2014" Year="2014">
-      <Id>b84d70b4-10a1-47c7-a6fe-f316e35c63c6</Id>
+      <Database Name="cv" Series="77576" Issue="468462" />
     </Book>
     <Book Series="Death of Wolverine: The Logan Legacy" Number="3" Volume="2014" Year="2014">
-      <Id>e5314d4a-208e-48a3-a785-4d1f9c5ec759</Id>
+      <Database Name="cv" Series="77576" Issue="468904" />
     </Book>
     <Book Series="Death of Wolverine: The Logan Legacy" Number="4" Volume="2014" Year="2015">
-      <Id>924d3faa-d0b2-412f-af6c-445621e48457</Id>
+      <Database Name="cv" Series="77576" Issue="469831" />
     </Book>
     <Book Series="Death of Wolverine: The Logan Legacy" Number="5" Volume="2014" Year="2015">
-      <Id>444c2f17-c7d8-47e8-b9d2-1e9e1cf64fea</Id>
+      <Database Name="cv" Series="77576" Issue="471315" />
     </Book>
     <Book Series="Death of Wolverine: The Logan Legacy" Number="6" Volume="2014" Year="2015">
-      <Id>a63c681a-0681-4ae9-9a45-060ae6ba1735</Id>
+      <Database Name="cv" Series="77576" Issue="472905" />
     </Book>
     <Book Series="Death of Wolverine: The Logan Legacy" Number="7" Volume="2014" Year="2015">
-      <Id>47419760-2d4c-4180-813e-461c017b637d</Id>
+      <Database Name="cv" Series="77576" Issue="474627" />
     </Book>
     <Book Series="Wolverines" Number="1" Volume="2015" Year="2015">
-      <Id>47f2467e-2601-424b-97f6-ba5f85f9cf4a</Id>
+      <Database Name="cv" Series="79270" Issue="475465" />
     </Book>
     <Book Series="Wolverines" Number="2" Volume="2015" Year="2015">
-      <Id>82dbf7a2-58d9-4412-8593-9f9aec2b4e07</Id>
+      <Database Name="cv" Series="79270" Issue="475947" />
     </Book>
     <Book Series="Wolverines" Number="3" Volume="2015" Year="2015">
-      <Id>baf61b30-9e47-4a84-b340-88d088569519</Id>
+      <Database Name="cv" Series="79270" Issue="476797" />
     </Book>
     <Book Series="Wolverines" Number="4" Volume="2015" Year="2015">
-      <Id>1d5936af-9fb1-44d8-b499-6e579bea9e76</Id>
+      <Database Name="cv" Series="79270" Issue="477859" />
     </Book>
     <Book Series="Wolverines" Number="5" Volume="2015" Year="2015">
-      <Id>a1530f9e-751b-4ff7-bcdb-e9d0b3be0ba6</Id>
+      <Database Name="cv" Series="79270" Issue="478618" />
     </Book>
     <Book Series="Wolverines" Number="6" Volume="2015" Year="2015">
-      <Id>4073f848-2bea-4284-b190-da6170686a05</Id>
+      <Database Name="cv" Series="79270" Issue="479266" />
     </Book>
     <Book Series="Wolverines" Number="7" Volume="2015" Year="2015">
-      <Id>5eff416d-ddda-4e69-9423-df979525362c</Id>
+      <Database Name="cv" Series="79270" Issue="479986" />
     </Book>
     <Book Series="Wolverines" Number="8" Volume="2015" Year="2015">
-      <Id>b4bf6745-236d-4f8e-93c4-e438d178d01a</Id>
+      <Database Name="cv" Series="79270" Issue="480686" />
     </Book>
     <Book Series="Wolverines" Number="9" Volume="2015" Year="2015">
-      <Id>c261560f-920f-4391-a68b-e80086833d18</Id>
+      <Database Name="cv" Series="79270" Issue="481616" />
     </Book>
     <Book Series="Wolverines" Number="10" Volume="2015" Year="2015">
-      <Id>e31bd264-36a9-4cb4-b95e-81d221eadfef</Id>
+      <Database Name="cv" Series="79270" Issue="482169" />
     </Book>
     <Book Series="Wolverines" Number="11" Volume="2015" Year="2015">
-      <Id>834254ab-65a2-4bf6-be7c-2006035afad9</Id>
+      <Database Name="cv" Series="79270" Issue="482696" />
     </Book>
     <Book Series="Wolverines" Number="12" Volume="2015" Year="2015">
-      <Id>3a1e51a3-2165-4463-91b7-75fc9729fb08</Id>
+      <Database Name="cv" Series="79270" Issue="483362" />
     </Book>
     <Book Series="Wolverines" Number="13" Volume="2015" Year="2015">
-      <Id>a972a350-cb27-441a-9b0f-0ff2442d2e6e</Id>
+      <Database Name="cv" Series="79270" Issue="484910" />
     </Book>
     <Book Series="Wolverines" Number="14" Volume="2015" Year="2015">
-      <Id>bf91d7d9-6f33-440e-ad60-a83867906181</Id>
+      <Database Name="cv" Series="79270" Issue="486159" />
     </Book>
     <Book Series="Wolverines" Number="15" Volume="2015" Year="2015">
-      <Id>5aa436b0-b21c-4c55-915c-2e3f1ea79c46</Id>
+      <Database Name="cv" Series="79270" Issue="486731" />
     </Book>
     <Book Series="Wolverines" Number="16" Volume="2015" Year="2015">
-      <Id>bf9b7fa9-1c70-45ff-8a72-ccec245de3ea</Id>
+      <Database Name="cv" Series="79270" Issue="487221" />
     </Book>
     <Book Series="Wolverines" Number="17" Volume="2015" Year="2015">
-      <Id>b3e3de01-cb33-4183-b83a-1946a947a876</Id>
+      <Database Name="cv" Series="79270" Issue="487849" />
     </Book>
     <Book Series="Wolverines" Number="18" Volume="2015" Year="2015">
-      <Id>9e1a9fcb-ae78-492d-8e14-dd242b56e852</Id>
+      <Database Name="cv" Series="79270" Issue="488664" />
     </Book>
     <Book Series="Wolverines" Number="19" Volume="2015" Year="2015">
-      <Id>f9ce2ad8-0e6c-4352-bb57-8357230f66b7</Id>
+      <Database Name="cv" Series="79270" Issue="489331" />
     </Book>
     <Book Series="Wolverines" Number="20" Volume="2015" Year="2015">
-      <Id>cc519fc1-23b0-4d73-a997-e803bb47e898</Id>
+      <Database Name="cv" Series="79270" Issue="490896" />
     </Book>
     <Book Series="Storm" Number="5" Volume="2014" Year="2015">
-      <Id>67aaa0ee-4ff2-4e57-805a-0715a667260a</Id>
+      <Database Name="cv" Series="75874" Issue="470435" />
     </Book>
     <Book Series="Storm" Number="6" Volume="2014" Year="2015">
-      <Id>34c50d81-1f01-4dfb-88b9-5684f1dcf70a</Id>
+      <Database Name="cv" Series="75874" Issue="473655" />
     </Book>
     <Book Series="Storm" Number="7" Volume="2014" Year="2015">
-      <Id>f0fb4d14-760e-4120-8419-3294e9a6a33c</Id>
+      <Database Name="cv" Series="75874" Issue="475463" />
     </Book>
     <Book Series="Storm" Number="8" Volume="2014" Year="2015">
-      <Id>383e69bd-f30f-4f35-8375-237aa99390cb</Id>
+      <Database Name="cv" Series="75874" Issue="479984" />
     </Book>
     <Book Series="Magneto" Number="9" Volume="2014" Year="2014">
-      <Id>279e8ef9-5c43-431c-83c7-90904532c596</Id>
+      <Database Name="cv" Series="72111" Issue="464984" />
     </Book>
     <Book Series="Magneto" Number="10" Volume="2014" Year="2014">
-      <Id>18f6d80e-a708-46fe-9ff8-d763b689c219</Id>
+      <Database Name="cv" Series="72111" Issue="466330" />
     </Book>
     <Book Series="Uncanny Avengers" Number="24" Volume="2012" Year="2014">
-      <Id>9577af9d-6230-499b-b942-6d5533d0a7cc</Id>
+      <Database Name="cv" Series="52880" Issue="465852" />
     </Book>
     <Book Series="Uncanny Avengers" Number="25" Volume="2012" Year="2014">
-      <Id>6a2d6856-6bc5-4f4b-98e9-b6ca08d44fea</Id>
+      <Database Name="cv" Series="52880" Issue="467043" />
     </Book>
-    <Book Series="Avengers &amp; X-Men: Axis" Number="1" Volume="2014" Year="2014">
-      <Id>7cc3caee-a190-4fe3-8777-421ffe52ce20</Id>
+    <Book Series="Avengers &#38; X-Men: Axis" Number="1" Volume="2014" Year="2014">
+      <Database Name="cv" Series="77424" Issue="467648" />
     </Book>
     <Book Series="Axis: Revolutions" Number="1" Volume="2014" Year="2014">
-      <Id>71207ff6-2e5c-4cae-be65-f5080b859cbf</Id>
+      <Database Name="cv" Series="77806" Issue="468902" />
     </Book>
-    <Book Series="Avengers &amp; X-Men: Axis" Number="2" Volume="2014" Year="2014">
-      <Id>1dcf44f5-e194-408b-bc3d-146173cd332d</Id>
+    <Book Series="Avengers &#38; X-Men: Axis" Number="2" Volume="2014" Year="2014">
+      <Database Name="cv" Series="77424" Issue="468072" />
     </Book>
     <Book Series="Magneto" Number="11" Volume="2014" Year="2014">
-      <Id>f38c90c1-b5e9-4b9f-b3f7-1217057d69fe</Id>
+      <Database Name="cv" Series="72111" Issue="468081" />
     </Book>
-    <Book Series="Avengers &amp; X-Men: Axis" Number="3" Volume="2014" Year="2014">
-      <Id>b5129bbb-b14e-4ebe-b680-1042619a3090</Id>
+    <Book Series="Avengers &#38; X-Men: Axis" Number="3" Volume="2014" Year="2014">
+      <Database Name="cv" Series="77424" Issue="468458" />
     </Book>
     <Book Series="Magneto" Number="12" Volume="2014" Year="2015">
-      <Id>81b69d22-30e8-4911-8a75-8f3c0482825a</Id>
+      <Database Name="cv" Series="72111" Issue="470431" />
     </Book>
-    <Book Series="Deadpool" Number="36" Volume="2013" Year="2014">
-      <Id>ca166fb3-8567-491d-b696-01c3c3bea17c</Id>
+    <Book Series="Deadpool" Number="36" Volume="2012" Year="2014">
+      <Database Name="cv" Series="53726" Issue="468461" />
     </Book>
     <Book Series="All-New X-Factor" Number="15" Volume="2014" Year="2014">
-      <Id>52b99647-ea3c-41ac-835f-611f68b4bfaf</Id>
+      <Database Name="cv" Series="70703" Issue="468454" />
     </Book>
     <Book Series="All-New X-Factor" Number="16" Volume="2014" Year="2015">
-      <Id>544928f3-1cf3-4dee-a770-20dd2d7475ea</Id>
+      <Database Name="cv" Series="70703" Issue="469486" />
     </Book>
-    <Book Series="Avengers &amp; X-Men: Axis" Number="4" Volume="2014" Year="2015">
-      <Id>3f817a41-54aa-4fcb-8b7b-a78ef0ffe401</Id>
+    <Book Series="Avengers &#38; X-Men: Axis" Number="4" Volume="2014" Year="2015">
+      <Database Name="cv" Series="77424" Issue="469488" />
     </Book>
-    <Book Series="Deadpool" Number="37" Volume="2013" Year="2015">
-      <Id>a6a793c8-972f-4e56-ac63-134c5fc4252a</Id>
+    <Book Series="Deadpool" Number="37" Volume="2012" Year="2015">
+      <Database Name="cv" Series="53726" Issue="470424" />
     </Book>
     <Book Series="All-New X-Factor" Number="17" Volume="2014" Year="2015">
-      <Id>9b0f1c18-bb9a-4ce6-be55-09f74a08c77d</Id>
+      <Database Name="cv" Series="70703" Issue="471958" />
     </Book>
-    <Book Series="Avengers &amp; X-Men: Axis" Number="5" Volume="2014" Year="2015">
-      <Id>398fdb4d-9618-40f5-aae4-4b045b6b06e6</Id>
+    <Book Series="Avengers &#38; X-Men: Axis" Number="5" Volume="2014" Year="2015">
+      <Database Name="cv" Series="77424" Issue="469826" />
     </Book>
     <Book Series="Axis: Revolutions" Number="2" Volume="2014" Year="2015">
-      <Id>4d7a8349-61ee-4126-8975-223c365a3239</Id>
+      <Database Name="cv" Series="77806" Issue="470421" />
     </Book>
     <Book Series="Axis: Revolutions" Number="3" Volume="2014" Year="2015">
-      <Id>72cb40b3-09d2-494a-96a9-f301060c884b</Id>
+      <Database Name="cv" Series="77806" Issue="471960" />
     </Book>
     <Book Series="Axis: Revolutions" Number="4" Volume="2014" Year="2015">
-      <Id>e211e310-7c14-4850-b115-4da1848b034d</Id>
+      <Database Name="cv" Series="77806" Issue="473641" />
     </Book>
-    <Book Series="Avengers &amp; X-Men: Axis" Number="6" Volume="2014" Year="2015">
-      <Id>1aa020bd-3cc7-4294-a877-09520c3c57d7</Id>
+    <Book Series="Avengers &#38; X-Men: Axis" Number="6" Volume="2014" Year="2015">
+      <Database Name="cv" Series="77424" Issue="470419" />
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="12" Volume="2014" Year="2015">
-      <Id>28fc407a-2ae8-40e6-b307-1a7cda0efd94</Id>
+    <Book Series="Wolverine &#38; the X-Men" Number="12" Volume="2014" Year="2015">
+      <Database Name="cv" Series="72113" Issue="471326" />
     </Book>
-    <Book Series="Deadpool" Number="38" Volume="2013" Year="2015">
-      <Id>429ce863-7f3f-447f-b314-3a812b1ae35e</Id>
+    <Book Series="Deadpool" Number="38" Volume="2012" Year="2015">
+      <Database Name="cv" Series="53726" Issue="471962" />
     </Book>
-    <Book Series="Avengers &amp; X-Men: Axis" Number="7" Volume="2014" Year="2015">
-      <Id>13c5d3dc-a10f-4e8b-b89e-42975f304c66</Id>
+    <Book Series="Avengers &#38; X-Men: Axis" Number="7" Volume="2014" Year="2015">
+      <Database Name="cv" Series="77424" Issue="472901" />
     </Book>
-    <Book Series="Avengers &amp; X-Men: Axis" Number="8" Volume="2014" Year="2015">
-      <Id>047600e4-7787-4aff-9d2e-43816c4e8b04</Id>
+    <Book Series="Avengers &#38; X-Men: Axis" Number="8" Volume="2014" Year="2015">
+      <Database Name="cv" Series="77424" Issue="473639" />
     </Book>
-    <Book Series="Avengers &amp; X-Men: Axis" Number="9" Volume="2014" Year="2015">
-      <Id>a3afb1bc-693d-4df6-b7d5-e8c35a3b7d97</Id>
+    <Book Series="Avengers &#38; X-Men: Axis" Number="9" Volume="2014" Year="2015">
+      <Database Name="cv" Series="77424" Issue="474621" />
     </Book>
-    <Book Series="Deadpool" Number="39" Volume="2013" Year="2015">
-      <Id>e5dc9bf3-2e92-488d-9de5-ce056c9de5c2</Id>
+    <Book Series="Deadpool" Number="39" Volume="2012" Year="2015">
+      <Database Name="cv" Series="53726" Issue="474626" />
     </Book>
     <Book Series="Guardians of the Galaxy: Best Story Ever" Number="1" Volume="2015" Year="2015">
-      <Id>2b7bffa5-caa1-466f-ba49-0416bd92ef66</Id>
+      <Database Name="cv" Series="81087" Issue="484896" />
     </Book>
     <Book Series="Legendary Star-Lord" Number="1" Volume="2014" Year="2014">
-      <Id>28073f55-1564-4c3a-949e-0379431a96e7</Id>
+      <Database Name="cv" Series="75335" Issue="458532" />
     </Book>
     <Book Series="Legendary Star-Lord" Number="2" Volume="2014" Year="2014">
-      <Id>612e784f-1682-4e49-af30-592247102cbf</Id>
+      <Database Name="cv" Series="75335" Issue="461728" />
     </Book>
     <Book Series="Legendary Star-Lord" Number="3" Volume="2014" Year="2014">
-      <Id>ad3f8b0f-bf9d-4e29-847b-3578920de18d</Id>
+      <Database Name="cv" Series="75335" Issue="463988" />
     </Book>
     <Book Series="Legendary Star-Lord" Number="4" Volume="2014" Year="2014">
-      <Id>2186ce8a-11e4-4d38-aaa7-fb064dd74d89</Id>
+      <Database Name="cv" Series="75335" Issue="467038" />
     </Book>
     <Book Series="Legendary Star-Lord" Number="5" Volume="2014" Year="2015">
-      <Id>a91d812b-0299-48a4-bfd0-941014cd2b34</Id>
+      <Database Name="cv" Series="75335" Issue="469494" />
     </Book>
     <Book Series="Guardians of the Galaxy" Number="21" Volume="2013" Year="2015">
-      <Id>84b1d993-5d32-48fb-ae35-8760f82d886a</Id>
+      <Database Name="cv" Series="57960" Issue="470428" />
     </Book>
     <Book Series="Guardians of the Galaxy" Number="22" Volume="2013" Year="2015">
-      <Id>b0201890-6538-4aa8-a0b7-b0a1c196a455</Id>
+      <Database Name="cv" Series="57960" Issue="473648" />
     </Book>
     <Book Series="Guardians of the Galaxy" Number="23" Volume="2013" Year="2015">
-      <Id>a1e5e6c3-aef7-4ee1-81f1-81864551dd4c</Id>
+      <Database Name="cv" Series="57960" Issue="476786" />
     </Book>
     <Book Series="Legendary Star-Lord" Number="6" Volume="2014" Year="2015">
-      <Id>2bce621e-1eb0-4734-a27f-43e0f753a305</Id>
+      <Database Name="cv" Series="75335" Issue="471968" />
     </Book>
     <Book Series="Legendary Star-Lord" Number="7" Volume="2014" Year="2015">
-      <Id>77f291ad-cc42-4c60-9244-0ee221317ddf</Id>
+      <Database Name="cv" Series="75335" Issue="475458" />
     </Book>
     <Book Series="Legendary Star-Lord" Number="8" Volume="2014" Year="2015">
-      <Id>b18f4914-1bbc-4b44-9644-c7d9912e416a</Id>
+      <Database Name="cv" Series="75335" Issue="476787" />
     </Book>
     <Book Series="Uncanny X-Men" Number="32" Volume="2013" Year="2015">
-      <Id>16b00e63-5787-493f-9d6e-f9e5c65711fc</Id>
+      <Database Name="cv" Series="57181" Issue="483361" />
     </Book>
     <Book Series="Uncanny X-Men" Number="33" Volume="2013" Year="2015">
-      <Id>16da33e7-eb20-44e5-a119-52c54dc4c40f</Id>
+      <Database Name="cv" Series="57181" Issue="486158" />
     </Book>
     <Book Series="Cyclops" Number="1" Volume="2014" Year="2014">
-      <Id>6fc75925-f44c-4e5f-a4c8-b28069269b4b</Id>
+      <Database Name="cv" Series="73677" Issue="452309" />
     </Book>
     <Book Series="Cyclops" Number="2" Volume="2014" Year="2014">
-      <Id>12357d7b-0157-4e10-93a2-c9460d8ef40a</Id>
+      <Database Name="cv" Series="73677" Issue="455486" />
     </Book>
     <Book Series="Cyclops" Number="3" Volume="2014" Year="2014">
-      <Id>1531b3cf-0ed8-456a-a3be-30135de3d99f</Id>
+      <Database Name="cv" Series="73677" Issue="460964" />
     </Book>
     <Book Series="Cyclops" Number="4" Volume="2014" Year="2014">
-      <Id>594ab424-d4ba-4686-b204-93adf2d66deb</Id>
+      <Database Name="cv" Series="73677" Issue="463480" />
     </Book>
     <Book Series="Cyclops" Number="5" Volume="2014" Year="2014">
-      <Id>7c8c891d-129d-422a-b76f-6078b5b8e60b</Id>
+      <Database Name="cv" Series="73677" Issue="466324" />
     </Book>
     <Book Series="Cyclops" Number="6" Volume="2014" Year="2014">
-      <Id>f94e3cf2-da87-4671-94bb-acf8e0fb4273</Id>
+      <Database Name="cv" Series="73677" Issue="468460" />
     </Book>
     <Book Series="Cyclops" Number="7" Volume="2014" Year="2015">
-      <Id>0c68cc60-82f3-4dbc-9437-24826e0127f3</Id>
+      <Database Name="cv" Series="73677" Issue="471314" />
     </Book>
     <Book Series="Cyclops" Number="8" Volume="2014" Year="2015">
-      <Id>e88d8530-40bc-4a09-b3a1-8ec10bee1420</Id>
+      <Database Name="cv" Series="73677" Issue="474623" />
     </Book>
     <Book Series="Cyclops" Number="9" Volume="2014" Year="2015">
-      <Id>6ede995c-1ce4-4ba7-8dc2-e23e3298247a</Id>
+      <Database Name="cv" Series="73677" Issue="475934" />
     </Book>
     <Book Series="Cyclops" Number="10" Volume="2014" Year="2015">
-      <Id>38373a59-4f09-4cea-93d0-064073414353</Id>
+      <Database Name="cv" Series="73677" Issue="479257" />
     </Book>
     <Book Series="Cyclops" Number="11" Volume="2014" Year="2015">
-      <Id>452b189b-49f3-49c5-94c1-da780a5e7258</Id>
+      <Database Name="cv" Series="73677" Issue="482683" />
     </Book>
-    <Book Series="Guardians of the Galaxy &amp; X-Men: The Black Vortex Alpha" Number="1" Volume="2015" Year="2015">
-      <Id>ae669f9b-8768-480e-aa83-d10e0ff6421c</Id>
+    <Book Series="Guardians of the Galaxy &#38; X-Men: The Black Vortex Alpha" Number="1" Volume="2015" Year="2015">
+      <Database Name="cv" Series="79860" Issue="478607" />
     </Book>
     <Book Series="Guardians of the Galaxy" Number="24" Volume="2013" Year="2015">
-      <Id>158496c8-2b2f-4e48-855b-330911eedb06</Id>
+      <Database Name="cv" Series="57960" Issue="479260" />
     </Book>
     <Book Series="Legendary Star-Lord" Number="9" Volume="2014" Year="2015">
-      <Id>290c955d-31b0-41a0-b969-2ab08d4347d9</Id>
+      <Database Name="cv" Series="75335" Issue="479972" />
     </Book>
-    <Book Series="All-New X-Men" Number="38" Volume="2013" Year="2015">
-      <Id>dc2a3dff-7d43-4b1d-aae9-aa254a81663c</Id>
+    <Book Series="All-New X-Men" Number="38" Volume="2012" Year="2015">
+      <Database Name="cv" Series="53919" Issue="480667" />
     </Book>
     <Book Series="Guardians Team-Up" Number="3" Volume="2015" Year="2015">
-      <Id>c08ac4ac-c5f4-4ec5-8cfa-e5cfb3aa7b93</Id>
+      <Database Name="cv" Series="80454" Issue="482684" />
     </Book>
-    <Book Series="All-New X-Men" Number="39" Volume="2013" Year="2015">
-      <Id>f8dfd878-211d-41da-9400-1947aaeb1cc1</Id>
+    <Book Series="All-New X-Men" Number="39" Volume="2012" Year="2015">
+      <Database Name="cv" Series="53919" Issue="482678" />
     </Book>
     <Book Series="Guardians of the Galaxy" Number="25" Volume="2013" Year="2015">
-      <Id>3ec56c52-9902-470f-99df-cf08360c2108</Id>
+      <Database Name="cv" Series="57960" Issue="483351" />
     </Book>
     <Book Series="Nova" Number="28" Volume="2013" Year="2015">
-      <Id>bbd9e7cd-0764-46fa-88db-0dd1d8113fe5</Id>
+      <Database Name="cv" Series="57535" Issue="483357" />
     </Book>
     <Book Series="Legendary Star-Lord" Number="10" Volume="2014" Year="2015">
-      <Id>b2496dd8-1bb8-4752-98b1-db8f22b8fd5a</Id>
+      <Database Name="cv" Series="75335" Issue="483353" />
     </Book>
     <Book Series="Cyclops" Number="12" Volume="2014" Year="2015">
-      <Id>ee080736-5632-4759-9f7a-7be31c8c3322</Id>
+      <Database Name="cv" Series="73677" Issue="484893" />
     </Book>
     <Book Series="Captain Marvel" Number="14" Volume="2014" Year="2015">
-      <Id>041ed1a3-eed4-45d4-a61d-a879bf0ab6fd</Id>
+      <Database Name="cv" Series="72272" Issue="485509" />
     </Book>
     <Book Series="Legendary Star-Lord" Number="11" Volume="2014" Year="2015">
-      <Id>80e01901-6707-4b34-ac76-a0a3b2c79225</Id>
+      <Database Name="cv" Series="75335" Issue="486148" />
     </Book>
-    <Book Series="Guardians of the Galaxy &amp; X-Men: The Black Vortex Omega" Number="1" Volume="2015" Year="2015">
-      <Id>316f908a-42c7-4074-b30f-d46f89661ca9</Id>
+    <Book Series="Guardians of the Galaxy &#38; X-Men: The Black Vortex Omega" Number="1" Volume="2015" Year="2015">
+      <Database Name="cv" Series="81482" Issue="486723" />
     </Book>
     <Book Series="All-New X-Factor" Number="18" Volume="2014" Year="2015">
-      <Id>4f6af9db-b144-45d2-b747-68ab2e048a98</Id>
+      <Database Name="cv" Series="70703" Issue="474619" />
     </Book>
     <Book Series="All-New X-Factor" Number="19" Volume="2014" Year="2015">
-      <Id>b22b7d09-2204-4786-8ae7-74b41988cfbc</Id>
+      <Database Name="cv" Series="70703" Issue="475449" />
     </Book>
     <Book Series="All-New X-Factor" Number="20" Volume="2014" Year="2015">
-      <Id>d2bce3da-e997-4d85-af81-e809776fa222</Id>
+      <Database Name="cv" Series="70703" Issue="476777" />
     </Book>
     <Book Series="Uncanny Avengers" Number="1" Volume="2015" Year="2015">
-      <Id>4dc61054-afe9-40c8-8012-2433f076bf10</Id>
+      <Database Name="cv" Series="85318" Issue="502874" />
     </Book>
-    <Book Series="Uncanny Avengers" Number="2" Volume="2015" Year="2015">
-      <Id>f906d8bf-edae-4f24-857a-9d32e159fc75</Id>
+    <Book Series="Uncanny Avengers" Number="2" Volume="2015" Year="2016">
+      <Database Name="cv" Series="85318" Issue="505530" />
     </Book>
-    <Book Series="Uncanny Avengers" Number="3" Volume="2015" Year="2015">
-      <Id>7b682693-dc2c-47ae-8354-fe58c64bf314</Id>
+    <Book Series="Uncanny Avengers" Number="3" Volume="2015" Year="2016">
+      <Database Name="cv" Series="85318" Issue="507786" />
     </Book>
-    <Book Series="Uncanny Avengers" Number="4" Volume="2015" Year="2015">
-      <Id>2444fe3e-acdb-4164-8e9e-38f0326ca0b5</Id>
+    <Book Series="Uncanny Avengers" Number="4" Volume="2015" Year="2016">
+      <Database Name="cv" Series="85318" Issue="510957" />
     </Book>
-    <Book Series="Uncanny Avengers" Number="5" Volume="2015" Year="2015">
-      <Id>2bff0f5c-0291-4a36-9986-5c258dbf44c7</Id>
+    <Book Series="Uncanny Avengers" Number="5" Volume="2015" Year="2016">
+      <Database Name="cv" Series="85318" Issue="513659" />
     </Book>
-    <Book Series="Spider-Man &amp; the X-Men" Number="1" Volume="2014" Year="2015">
-      <Id>4e648eae-7adb-47c4-bf04-a18ac9d5092a</Id>
+    <Book Series="Spider-Man &#38; the X-Men" Number="1" Volume="2014" Year="2015">
+      <Database Name="cv" Series="78717" Issue="472911" />
     </Book>
-    <Book Series="Spider-Man &amp; the X-Men" Number="2" Volume="2014" Year="2015">
-      <Id>ccb5a65b-c521-4d0e-99ee-e9230998f91c</Id>
+    <Book Series="Spider-Man &#38; the X-Men" Number="2" Volume="2014" Year="2015">
+      <Database Name="cv" Series="78717" Issue="477855" />
     </Book>
-    <Book Series="Spider-Man &amp; the X-Men" Number="3" Volume="2014" Year="2015">
-      <Id>490d0783-87d0-4055-8c58-2930fa358525</Id>
+    <Book Series="Spider-Man &#38; the X-Men" Number="3" Volume="2014" Year="2015">
+      <Database Name="cv" Series="78717" Issue="480681" />
     </Book>
-    <Book Series="Spider-Man &amp; the X-Men" Number="4" Volume="2014" Year="2015">
-      <Id>dcd89d50-5a4a-4f16-a811-444ce81e2043</Id>
+    <Book Series="Spider-Man &#38; the X-Men" Number="4" Volume="2014" Year="2015">
+      <Database Name="cv" Series="78717" Issue="482165" />
     </Book>
-    <Book Series="Spider-Man &amp; the X-Men" Number="5" Volume="2014" Year="2015">
-      <Id>377546d0-11d9-4ec6-a3fb-0aca9eef6f35</Id>
+    <Book Series="Spider-Man &#38; the X-Men" Number="5" Volume="2014" Year="2015">
+      <Database Name="cv" Series="78717" Issue="486153" />
     </Book>
-    <Book Series="Spider-Man &amp; the X-Men" Number="6" Volume="2014" Year="2015">
-      <Id>7b46f829-33a8-4c4b-9abd-03d5d0f5d532</Id>
+    <Book Series="Spider-Man &#38; the X-Men" Number="6" Volume="2014" Year="2015">
+      <Database Name="cv" Series="78717" Issue="487217" />
     </Book>
-    <Book Series="All-New X-Men" Number="40" Volume="2013" Year="2015">
-      <Id>95f566ab-4b28-4063-ac97-d1537017962c</Id>
+    <Book Series="All-New X-Men" Number="40" Volume="2012" Year="2015">
+      <Database Name="cv" Series="53919" Issue="486715" />
     </Book>
-    <Book Series="All-New X-Men" Number="41" Volume="2013" Year="2015">
-      <Id>83745d76-c7e6-45c4-944c-3a821b18fc1e</Id>
+    <Book Series="All-New X-Men" Number="41" Volume="2012" Year="2015">
+      <Database Name="cv" Series="53919" Issue="490874" />
     </Book>
     <Book Series="Uncanny X-Men" Number="34" Volume="2013" Year="2015">
-      <Id>6f60a6bf-ee1f-45ea-afec-91f367a092e3</Id>
+      <Database Name="cv" Series="57181" Issue="489330" />
     </Book>
     <Book Series="Uncanny X-Men" Number="35" Volume="2013" Year="2015">
-      <Id>7f56f58a-b21d-4921-b9f6-8f1ea1e4b959</Id>
+      <Database Name="cv" Series="57181" Issue="495810" />
     </Book>
     <Book Series="Magneto" Number="13" Volume="2014" Year="2015">
-      <Id>5a00c411-7c2b-4477-a23e-332a056a4f60</Id>
+      <Database Name="cv" Series="72111" Issue="474680" />
     </Book>
     <Book Series="Magneto" Number="14" Volume="2014" Year="2015">
-      <Id>c884c4a1-706a-4cf1-8f64-1a74bafd8527</Id>
+      <Database Name="cv" Series="72111" Issue="476789" />
     </Book>
     <Book Series="Magneto" Number="15" Volume="2014" Year="2015">
-      <Id>a932e9e1-6478-460e-8382-9453cb2e5e71</Id>
+      <Database Name="cv" Series="72111" Issue="479974" />
     </Book>
     <Book Series="Magneto" Number="16" Volume="2014" Year="2015">
-      <Id>18c4bf39-1bae-4dfd-a3f5-251337e9840e</Id>
+      <Database Name="cv" Series="72111" Issue="482687" />
     </Book>
     <Book Series="Magneto" Number="17" Volume="2014" Year="2015">
-      <Id>6e41f1fb-603f-4efd-94e5-c2a6d8122220</Id>
+      <Database Name="cv" Series="72111" Issue="486150" />
     </Book>
-    <Book Series="Deadpool" Number="40" Volume="2013" Year="2015">
-      <Id>fefd1a8d-5d73-46bb-9f6c-f97d942d6f16</Id>
+    <Book Series="Deadpool" Number="40" Volume="2012" Year="2015">
+      <Database Name="cv" Series="53726" Issue="475937" />
     </Book>
-    <Book Series="Deadpool" Number="41" Volume="2013" Year="2015">
-      <Id>66956ec6-31ba-4b28-88fc-f145f32d470b</Id>
+    <Book Series="Deadpool" Number="41" Volume="2012" Year="2015">
+      <Database Name="cv" Series="53726" Issue="477848" />
     </Book>
-    <Book Series="Deadpool" Number="42" Volume="2013" Year="2015">
-      <Id>a4db450b-385e-466a-9a85-d1222df5bd64</Id>
+    <Book Series="Deadpool" Number="42" Volume="2012" Year="2015">
+      <Database Name="cv" Series="53726" Issue="480671" />
     </Book>
-    <Book Series="Deadpool" Number="43" Volume="2013" Year="2015">
-      <Id>8ce61f8b-61a6-49ce-a859-1aa552010bc7</Id>
+    <Book Series="Deadpool" Number="43" Volume="2012" Year="2015">
+      <Database Name="cv" Series="53726" Issue="482154" />
     </Book>
-    <Book Series="Deadpool" Number="44" Volume="2013" Year="2015">
-      <Id>ff5314a0-65c1-4f38-839b-1c2e8342a53b</Id>
+    <Book Series="Deadpool" Number="44" Volume="2012" Year="2015">
+      <Database Name="cv" Series="53726" Issue="483347" />
     </Book>
-    <Book Series="Deadpool" Number="45" Volume="2013" Year="2015">
-      <Id>c3ff352b-d89b-4ca2-910c-c9105aafd5e1</Id>
+    <Book Series="Deadpool" Number="45" Volume="2012" Year="2015">
+      <Database Name="cv" Series="53726" Issue="485511" />
     </Book>
     <Book Series="Nightcrawler" Number="8" Volume="2014" Year="2015">
-      <Id>7820fd0a-df6f-46a0-941a-6efcb0d92912</Id>
+      <Database Name="cv" Series="72934" Issue="469837" />
     </Book>
     <Book Series="Nightcrawler" Number="9" Volume="2014" Year="2015">
-      <Id>272340d6-8709-4ab9-bae3-0cf1e5498ac1</Id>
+      <Database Name="cv" Series="72934" Issue="472908" />
     </Book>
     <Book Series="Nightcrawler" Number="10" Volume="2014" Year="2015">
-      <Id>bfdd8a86-45cf-44b9-a92c-bcff45c00dad</Id>
+      <Database Name="cv" Series="72934" Issue="475942" />
     </Book>
     <Book Series="Nightcrawler" Number="11" Volume="2014" Year="2015">
-      <Id>81ccbde2-6bac-48c4-a272-b587316d3561</Id>
+      <Database Name="cv" Series="72934" Issue="479262" />
     </Book>
     <Book Series="Nightcrawler" Number="12" Volume="2014" Year="2015">
-      <Id>b6d7f953-da40-4b54-a9e1-c18c97b5a517</Id>
+      <Database Name="cv" Series="72934" Issue="483356" />
     </Book>
     <Book Series="Storm" Number="9" Volume="2014" Year="2015">
-      <Id>a7efb688-439b-44a9-8bff-7f5c9c817550</Id>
+      <Database Name="cv" Series="75874" Issue="482694" />
     </Book>
     <Book Series="Storm" Number="10" Volume="2014" Year="2015">
-      <Id>1bc4998e-2612-447a-abef-3547da2d8afb</Id>
+      <Database Name="cv" Series="75874" Issue="485521" />
     </Book>
     <Book Series="Storm" Number="11" Volume="2014" Year="2015">
-      <Id>5a51bd43-9056-4369-a9ce-aa19005f2d04</Id>
+      <Database Name="cv" Series="75874" Issue="488660" />
     </Book>
     <Book Series="X-Men" Number="23" Volume="2013" Year="2015">
-      <Id>bc4ff7ea-bd99-4ce2-a5d2-f944f32663f2</Id>
+      <Database Name="cv" Series="62383" Issue="475466" />
     </Book>
     <Book Series="X-Men" Number="24" Volume="2013" Year="2015">
-      <Id>1a82eebf-d51c-4c1a-83f1-9b7301f60e69</Id>
+      <Database Name="cv" Series="62383" Issue="479268" />
     </Book>
     <Book Series="X-Men" Number="25" Volume="2013" Year="2015">
-      <Id>b425935c-a9ea-4db0-b153-5c67b0c170c0</Id>
+      <Database Name="cv" Series="62383" Issue="481617" />
     </Book>
     <Book Series="X-Men" Number="26" Volume="2013" Year="2015">
-      <Id>2291d5c0-805a-4150-807b-5b3ec76cb745</Id>
+      <Database Name="cv" Series="62383" Issue="487222" />
     </Book>
-    <Book Series="Amazing X-Men" Number="15" Volume="2013" Year="2015">
-      <Id>00ca23f0-a8bc-45e3-8e78-d2da3938e36f</Id>
+    <Book Series="Amazing X-Men" Number="15" Volume="2014" Year="2015">
+      <Database Name="cv" Series="68919" Issue="475930" />
     </Book>
-    <Book Series="Amazing X-Men" Number="16" Volume="2013" Year="2015">
-      <Id>25fac883-89cf-4ea5-bdbe-14a456009b95</Id>
+    <Book Series="Amazing X-Men" Number="16" Volume="2014" Year="2015">
+      <Database Name="cv" Series="68919" Issue="477847" />
     </Book>
-    <Book Series="Amazing X-Men" Number="17" Volume="2013" Year="2015">
-      <Id>46b70acb-fcff-4b84-bf97-41ecc747afab</Id>
+    <Book Series="Amazing X-Men" Number="17" Volume="2014" Year="2015">
+      <Database Name="cv" Series="68919" Issue="480669" />
     </Book>
-    <Book Series="Amazing X-Men" Number="18" Volume="2013" Year="2015">
-      <Id>10fdcb20-f8f7-4b47-8f7d-0714336bfbc6</Id>
+    <Book Series="Amazing X-Men" Number="18" Volume="2014" Year="2015">
+      <Database Name="cv" Series="68919" Issue="483342" />
     </Book>
-    <Book Series="Amazing X-Men" Number="19" Volume="2013" Year="2015">
-      <Id>53fcb991-48fc-4cae-a7cd-2e7b1faff667</Id>
+    <Book Series="Amazing X-Men" Number="19" Volume="2014" Year="2015">
+      <Database Name="cv" Series="68919" Issue="486717" />
     </Book>
     <Book Series="Uncanny X-Men" Number="600" Volume="2013" Year="2016">
-      <Id>30f34560-53fc-4a97-a5b7-b745470259c7</Id>
+      <Database Name="cv" Series="57181" Issue="504952" />
     </Book>
     <Book Series="Deadpool's Secret Secret Wars" Number="1" Volume="2015" Year="2015">
-      <Id>9679994a-d35c-4ee1-ab53-20f143fe6c8f</Id>
+      <Database Name="cv" Series="82102" Issue="489316" />
     </Book>
     <Book Series="Deadpool's Secret Secret Wars" Number="2" Volume="2015" Year="2015">
-      <Id>fad4b653-2a61-4b28-93d1-a2204000cc47</Id>
+      <Database Name="cv" Series="82102" Issue="492216" />
     </Book>
     <Book Series="Deadpool's Secret Secret Wars" Number="3" Volume="2015" Year="2015">
-      <Id>49e432ab-a0ff-4223-a3ac-913c4bdda89e</Id>
+      <Database Name="cv" Series="82102" Issue="496388" />
     </Book>
     <Book Series="Deadpool's Secret Secret Wars" Number="4" Volume="2015" Year="2015">
-      <Id>f42252ac-4762-4691-b3ff-887acb076e15</Id>
+      <Database Name="cv" Series="82102" Issue="498385" />
     </Book>
     <Book Series="Secret Wars" Number="1" Volume="2015" Year="2015">
-      <Id>3244b4aa-3741-4c19-8ecb-07117f46e2a5</Id>
+      <Database Name="cv" Series="81833" Issue="487843" />
     </Book>
     <Book Series="Magneto" Number="18" Volume="2014" Year="2015">
-      <Id>7292f651-48c2-4b17-91be-3ec308c05164</Id>
+      <Database Name="cv" Series="72111" Issue="488650" />
     </Book>
     <Book Series="Magneto" Number="19" Volume="2014" Year="2015">
-      <Id>b0c7b625-2e2d-482e-855a-3e4bee3ce48b</Id>
+      <Database Name="cv" Series="72111" Issue="492219" />
     </Book>
     <Book Series="Magneto" Number="20" Volume="2014" Year="2015">
-      <Id>00f47611-0e75-4d86-8ded-7cf4ac88a74e</Id>
+      <Database Name="cv" Series="72111" Issue="495802" />
     </Book>
     <Book Series="Magneto" Number="21" Volume="2014" Year="2015">
-      <Id>808685ac-8fa4-4331-ac9c-63d17426681e</Id>
+      <Database Name="cv" Series="72111" Issue="498390" />
     </Book>
     <Book Series="Secret Wars" Number="2" Volume="2015" Year="2015">
-      <Id>4f4855ba-7a3d-4051-9336-8c200e577f71</Id>
+      <Database Name="cv" Series="81833" Issue="488656" />
     </Book>
     <Book Series="Inferno" Number="1" Volume="2015" Year="2015">
-      <Id>d6ad9a17-abf6-457d-b1b8-02c9a23f0a88</Id>
+      <Database Name="cv" Series="82202" Issue="489901" />
     </Book>
     <Book Series="Inferno" Number="2" Volume="2015" Year="2015">
-      <Id>5167df99-5c9f-492f-8ed9-c1f216081e1e</Id>
+      <Database Name="cv" Series="82202" Issue="491514" />
     </Book>
     <Book Series="Inferno" Number="3" Volume="2015" Year="2015">
-      <Id>0ecc2213-7265-4b7a-84ac-7d36b37a398f</Id>
+      <Database Name="cv" Series="82202" Issue="494319" />
     </Book>
     <Book Series="Inferno" Number="4" Volume="2015" Year="2015">
-      <Id>d614edf9-2fde-40f1-9cf0-8ba04b268b96</Id>
+      <Database Name="cv" Series="82202" Issue="497946" />
     </Book>
     <Book Series="Inferno" Number="5" Volume="2015" Year="2015">
-      <Id>73436e2d-72df-4d2e-aebf-d7722dd258da</Id>
+      <Database Name="cv" Series="82202" Issue="501614" />
     </Book>
     <Book Series="Age of Apocalypse: Warzones" Number="1" Volume="2015" Year="2015">
-      <Id>6ff8c8d0-1b00-4252-9f0a-4a4d1701f00e</Id>
+      <Database Name="cv" Series="85735" Issue="504928" />
     </Book>
     <Book Series="E Is For Extinction" Number="1" Volume="2015" Year="2015">
-      <Id>7c1133fa-4ca3-48b8-a678-aba62927c47c</Id>
+      <Database Name="cv" Series="82833" Issue="493040" />
     </Book>
     <Book Series="E Is For Extinction" Number="2" Volume="2015" Year="2015">
-      <Id>98e3d48b-50f2-447a-a502-b1bc27b2d579</Id>
+      <Database Name="cv" Series="82833" Issue="495797" />
     </Book>
     <Book Series="E Is For Extinction" Number="3" Volume="2015" Year="2015">
-      <Id>01972b54-8066-4f67-8f8b-407ae609d772</Id>
+      <Database Name="cv" Series="82833" Issue="498386" />
     </Book>
     <Book Series="E Is For Extinction" Number="4" Volume="2015" Year="2015">
-      <Id>555266d9-88ca-4d83-8a07-156ba42548f3</Id>
+      <Database Name="cv" Series="82833" Issue="501609" />
     </Book>
     <Book Series="X-Tinction Agenda" Number="1" Volume="2015" Year="2015">
-      <Id>195a716b-f52c-48f5-88cd-7fd8347dd420</Id>
+      <Database Name="cv" Series="82381" Issue="490897" />
     </Book>
     <Book Series="X-Tinction Agenda" Number="2" Volume="2015" Year="2015">
-      <Id>24b3f293-b0db-4779-bd51-133ba191b953</Id>
+      <Database Name="cv" Series="82381" Issue="493805" />
     </Book>
     <Book Series="X-Tinction Agenda" Number="3" Volume="2015" Year="2015">
-      <Id>32fa3a2d-b547-4eb0-a103-862988843e5d</Id>
+      <Database Name="cv" Series="82381" Issue="497966" />
     </Book>
     <Book Series="X-Tinction Agenda" Number="4" Volume="2015" Year="2015">
-      <Id>31600bfc-5b04-404e-94b6-909104403527</Id>
+      <Database Name="cv" Series="82381" Issue="501032" />
     </Book>
     <Book Series="Years of Future Past" Number="1" Volume="2015" Year="2015">
-      <Id>3cae2fa1-86b1-4527-bbcd-acf117feba88</Id>
+      <Database Name="cv" Series="82382" Issue="490898" />
     </Book>
     <Book Series="Years of Future Past" Number="2" Volume="2015" Year="2015">
-      <Id>205dba32-707b-4c40-b331-62b7b9de8533</Id>
+      <Database Name="cv" Series="82382" Issue="493806" />
     </Book>
     <Book Series="Years of Future Past" Number="3" Volume="2015" Year="2015">
-      <Id>5c6e95df-a99f-44fa-b7f1-4d7781cc4ad3</Id>
+      <Database Name="cv" Series="82382" Issue="495283" />
     </Book>
     <Book Series="Years of Future Past" Number="4" Volume="2015" Year="2015">
-      <Id>75ca6cc6-2897-412a-88ad-1dbbd2fde331</Id>
+      <Database Name="cv" Series="82382" Issue="497403" />
     </Book>
     <Book Series="Years of Future Past" Number="5" Volume="2015" Year="2015">
-      <Id>7e15d288-8b75-46a8-a6ab-966f2bde8548</Id>
+      <Database Name="cv" Series="82382" Issue="501033" />
     </Book>
     <Book Series="House of M" Number="1" Volume="2015" Year="2015">
-      <Id>d9e9a6df-bc5c-4e56-a8b0-6a7763d38f0b</Id>
+      <Database Name="cv" Series="83959" Issue="497944" />
     </Book>
     <Book Series="House of M" Number="2" Volume="2015" Year="2015">
-      <Id>28203646-ba85-4d73-af49-1fd04939dcbe</Id>
+      <Database Name="cv" Series="83959" Issue="499040" />
     </Book>
     <Book Series="House of M" Number="3" Volume="2015" Year="2015">
-      <Id>e4e737b8-a870-43ce-8a47-ea2eb50fdd50</Id>
+      <Database Name="cv" Series="83959" Issue="500302" />
     </Book>
     <Book Series="House of M" Number="4" Volume="2015" Year="2015">
-      <Id>58a5af28-fe3c-4688-9bc4-df28c3231874</Id>
+      <Database Name="cv" Series="83959" Issue="504340" />
     </Book>
     <Book Series="Mrs. Deadpool and the Howling Commandos: Warzones!" Number="1" Volume="2016" Year="2016">
-      <Id>8da38e41-05c7-4575-959d-0664bbc33da0</Id>
+      <Database Name="cv" Series="89615" Issue="525033" />
     </Book>
     <Book Series="X-Men '92: Warzones!" Number="1" Volume="2016" Year="2016">
-      <Id>2325c1ac-35e1-49d7-b198-d4897ec9ccb1</Id>
+      <Database Name="cv" Series="88816" Issue="519169" />
     </Book>
     <Book Series="Secret Wars" Number="3" Volume="2015" Year="2015">
-      <Id>855b8600-84dd-4b5d-b56f-d7aac338c9f9</Id>
+      <Database Name="cv" Series="81833" Issue="490887" />
     </Book>
     <Book Series="Secret Wars" Number="4" Volume="2015" Year="2015">
-      <Id>48830bae-ed26-4c6a-8a53-692aa68d96ea</Id>
+      <Database Name="cv" Series="81833" Issue="493798" />
     </Book>
     <Book Series="Secret Wars" Number="5" Volume="2015" Year="2015">
-      <Id>f77b6ab1-a052-4ed0-9ec4-daa98d467829</Id>
+      <Database Name="cv" Series="81833" Issue="497397" />
     </Book>
     <Book Series="Old Man Logan" Number="1" Volume="2015" Year="2015">
-      <Id>fc8e786f-620e-4205-a635-0919a7daa695</Id>
+      <Database Name="cv" Series="82208" Issue="489910" />
     </Book>
     <Book Series="Old Man Logan" Number="2" Volume="2015" Year="2015">
-      <Id>0e7aca85-cdd4-4285-8ac8-82790e1701f5</Id>
+      <Database Name="cv" Series="82208" Issue="492222" />
     </Book>
     <Book Series="Old Man Logan" Number="3" Volume="2015" Year="2015">
-      <Id>8815f675-35e3-4668-adf4-aff3ff21ef59</Id>
+      <Database Name="cv" Series="82208" Issue="495804" />
     </Book>
     <Book Series="Old Man Logan" Number="4" Volume="2015" Year="2015">
-      <Id>a73eb878-fb73-4788-92ea-cc05df3b07c9</Id>
+      <Database Name="cv" Series="82208" Issue="498395" />
     </Book>
     <Book Series="Secret Wars" Number="6" Volume="2015" Year="2015">
-      <Id>ca805e46-41b6-425f-9b47-3d4f1d70dc52</Id>
+      <Database Name="cv" Series="81833" Issue="502130" />
     </Book>
     <Book Series="Secret Wars" Number="7" Volume="2015" Year="2016">
-      <Id>26e7f22a-4566-4d7e-b5fe-f9866cb1cbb4</Id>
+      <Database Name="cv" Series="81833" Issue="505522" />
     </Book>
     <Book Series="Secret Wars" Number="8" Volume="2015" Year="2016">
-      <Id>a86052c5-b509-4986-b105-b914ba79b09f</Id>
+      <Database Name="cv" Series="81833" Issue="507780" />
     </Book>
     <Book Series="Secret Wars" Number="9" Volume="2015" Year="2016">
-      <Id>7f2eecca-d885-4705-9ec0-97fdac82fe27</Id>
+      <Database Name="cv" Series="81833" Issue="510951" />
     </Book>
     <Book Series="Old Man Logan" Number="5" Volume="2015" Year="2015">
-      <Id>641fddde-c4fd-4226-9280-7b89f802da4e</Id>
+      <Database Name="cv" Series="82208" Issue="502127" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 015.cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 015.cbl
@@ -2,829 +2,829 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>X-Men - Part 15</Name>
   <Books>
-    <Book Series="Nightcrawler" Number="1" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Nightcrawler" Number="1" Volume="2014" Year="2014">
       <Id>42c503c7-9be9-4ff2-b63f-b5322127b81a</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="2" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Nightcrawler" Number="2" Volume="2014" Year="2014">
       <Id>7d4a741c-bbeb-46a7-afb3-a516ed789bbc</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="3" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Nightcrawler" Number="3" Volume="2014" Year="2014">
       <Id>5b0d1b5a-dd4c-4699-bf9a-160a2aca272d</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="4" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Nightcrawler" Number="4" Volume="2014" Year="2014">
       <Id>0b1c6ce8-43b3-4b62-8820-41f343efe29d</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="5" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Nightcrawler" Number="5" Volume="2014" Year="2014">
       <Id>56ea59bd-03ea-4b48-9898-109100496a3b</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="6" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Nightcrawler" Number="6" Volume="2014" Year="2014">
       <Id>e9d4ffab-d7c6-4dfe-a821-4bc0b55bd003</Id>
     </Book>
-    <Book Series="X-Men" Number="13" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="X-Men" Number="13" Volume="2013" Year="2014">
       <Id>8552ccc5-7e36-4bee-a80c-1817e836682b</Id>
     </Book>
-    <Book Series="X-Men" Number="14" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="X-Men" Number="14" Volume="2013" Year="2014">
       <Id>b1e76492-d438-48e8-abca-421c4c8af2ee</Id>
     </Book>
-    <Book Series="X-Men" Number="15" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="X-Men" Number="15" Volume="2013" Year="2014">
       <Id>bf9f4c08-d554-4733-9c78-b692d9ee28da</Id>
     </Book>
-    <Book Series="X-Men" Number="16" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="X-Men" Number="16" Volume="2013" Year="2014">
       <Id>46ed49b3-2a5b-4b15-bc25-b8ecfda94160</Id>
     </Book>
-    <Book Series="X-Men" Number="17" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="X-Men" Number="17" Volume="2013" Year="2014">
       <Id>8968680b-04c7-403e-b320-8db81fcbd76f</Id>
     </Book>
-    <Book Series="Amazing X-Men" Number="7" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Amazing X-Men" Number="7" Volume="2013" Year="2014">
       <Id>a1c9b27a-3b12-43d9-9aa8-4813600cfed7</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="19" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="19" Volume="2013" Year="2014">
       <Id>f5073000-af2f-43ac-aa85-8828d0d7f157</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="20" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="20" Volume="2013" Year="2014">
       <Id>b0b5a9da-cd22-4cc9-bbaf-670217598c3b</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="21" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="21" Volume="2013" Year="2014">
       <Id>074f10d5-f4d2-48c7-841b-7496f31bf5cb</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="22" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="22" Volume="2013" Year="2014">
       <Id>eaee406f-0fc3-4688-b732-20e5ac660b7b</Id>
     </Book>
-    <Book Series="Storm" Number="1" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Storm" Number="1" Volume="2014" Year="2014">
       <Id>d9d9a60f-5c5e-4968-8064-9cf29c0211d0</Id>
     </Book>
-    <Book Series="Storm" Number="2" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Storm" Number="2" Volume="2014" Year="2014">
       <Id>db6502c4-1d20-4552-8e16-e55e22036ebd</Id>
     </Book>
-    <Book Series="Storm" Number="3" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Storm" Number="3" Volume="2014" Year="2014">
       <Id>57c7328b-b83d-408d-9321-f9430cc18ad7</Id>
     </Book>
-    <Book Series="Amazing X-Men Annual" Number="1" Volume="2014" Year="2014" Format="Annual">
+    <Book Series="Amazing X-Men Annual" Number="1" Volume="2014" Year="2014">
       <Id>3bff280d-a030-4c2d-85d0-1bdedffb02db</Id>
     </Book>
-    <Book Series="Amazing X-Men" Number="8" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Amazing X-Men" Number="8" Volume="2013" Year="2014">
       <Id>fd879dd8-9b21-4a8f-ae7b-3c52ada60b3f</Id>
     </Book>
-    <Book Series="Amazing X-Men" Number="9" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Amazing X-Men" Number="9" Volume="2013" Year="2014">
       <Id>a3e6a2f5-b803-4256-b4d0-fb81cd3dba70</Id>
     </Book>
-    <Book Series="Amazing X-Men" Number="10" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Amazing X-Men" Number="10" Volume="2013" Year="2014">
       <Id>a0c1f1cf-0e2e-4bb1-9672-100139c8527a</Id>
     </Book>
-    <Book Series="Amazing X-Men" Number="11" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Amazing X-Men" Number="11" Volume="2013" Year="2014">
       <Id>4ff162e4-eb77-4e54-acdc-75177cd6129e</Id>
     </Book>
-    <Book Series="Amazing X-Men" Number="12" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Amazing X-Men" Number="12" Volume="2013" Year="2014">
       <Id>aa24e5ed-6510-4592-b639-5be1bd187b07</Id>
     </Book>
-    <Book Series="Wolverine" Number="8" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Wolverine" Number="8" Volume="2014" Year="2014">
       <Id>bf5b1e89-8e52-47c5-84b0-580e147a3637</Id>
     </Book>
-    <Book Series="Wolverine" Number="9" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Wolverine" Number="9" Volume="2014" Year="2014">
       <Id>595093dc-c8a0-4fa6-97d2-8ebffb12ad91</Id>
     </Book>
-    <Book Series="Wolverine" Number="10" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Wolverine" Number="10" Volume="2014" Year="2014">
       <Id>40038cf3-8bdb-4fb2-b33a-069773cdfc51</Id>
     </Book>
-    <Book Series="Wolverine" Number="11" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Wolverine" Number="11" Volume="2014" Year="2014">
       <Id>e1ba05c5-8547-4a38-bbd8-6003ddf75992</Id>
     </Book>
-    <Book Series="Wolverine" Number="12" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Wolverine" Number="12" Volume="2014" Year="2014">
       <Id>f915d40b-1433-4389-a039-083366a6237c</Id>
     </Book>
-    <Book Series="Uncanny X-Men Special" Number="1" Volume="2014" Year="2014" Format="One-Shot">
+    <Book Series="Uncanny X-Men Special" Number="1" Volume="2014" Year="2014">
       <Id>162dfc74-0906-404b-ba45-9cf72c5e1779</Id>
     </Book>
-    <Book Series="Iron Man Special" Number="1" Volume="2014" Year="2014" Format="One-Shot">
+    <Book Series="Iron Man Special" Number="1" Volume="2014" Year="2014">
       <Id>1b18577f-dd2f-4e1e-8941-a3c05a1cf2e6</Id>
     </Book>
-    <Book Series="Nova Special" Number="1" Volume="2014" Year="2014" Format="One-Shot">
+    <Book Series="Nova Special" Number="1" Volume="2014" Year="2014">
       <Id>b8608ffa-653c-425e-8172-52eb1d6353be</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="25" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Men" Number="25" Volume="2013" Year="2014">
       <Id>e9308029-0727-4e52-bd90-614ca401b631</Id>
     </Book>
-    <Book Series="Deadpool" Number="30" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Deadpool" Number="30" Volume="2013" Year="2014">
       <Id>4b896913-6246-41e8-b2be-826394b338a6</Id>
     </Book>
-    <Book Series="Deadpool" Number="31" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Deadpool" Number="31" Volume="2013" Year="2014">
       <Id>03a9c0c8-9143-41bc-bb21-d63d33e80732</Id>
     </Book>
-    <Book Series="Deadpool" Number="32" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Deadpool" Number="32" Volume="2013" Year="2014">
       <Id>ee9e085d-4726-4fe4-9ee3-91215c6f67ef</Id>
     </Book>
-    <Book Series="Deadpool" Number="33" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Deadpool" Number="33" Volume="2013" Year="2014">
       <Id>438750fe-4a5f-4620-b69a-4c00c60d5bd2</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="26" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Men" Number="26" Volume="2013" Year="2014">
       <Id>68b0efdc-39e3-4679-b0f4-a13f4894e9dc</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="27" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Men" Number="27" Volume="2013" Year="2014">
       <Id>39c87891-5fc0-4134-8cdc-0c4b0bdb51a9</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="28" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Men" Number="28" Volume="2013" Year="2014">
       <Id>cdf108eb-7394-4513-9ad3-1249f9078982</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="29" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Men" Number="29" Volume="2013" Year="2014">
       <Id>dc311ed2-c68d-4f9f-88b1-7955ce7db601</Id>
     </Book>
-    <Book Series="Uncanny X-Men Annual" Number="1" Volume="2014" Year="2015" Format="Annual">
+    <Book Series="Uncanny X-Men Annual" Number="1" Volume="2014" Year="2015">
       <Id>b8a393b8-bdec-4c61-a73d-8da304b2c0d8</Id>
     </Book>
-    <Book Series="All-New X-Men Annual" Number="1" Volume="2014" Year="2015" Format="Annual">
+    <Book Series="All-New X-Men Annual" Number="1" Volume="2014" Year="2015">
       <Id>2c1c902c-1d8a-4633-86ca-fb9dfdf1c5e4</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="23" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="23" Volume="2013" Year="2014">
       <Id>5c04efd8-d2fc-4484-8cf5-afbf993de5fd</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="30" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Men" Number="30" Volume="2013" Year="2014">
       <Id>329e3ebe-8b00-4bd4-80b7-e2b124f437bf</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="24" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="24" Volume="2013" Year="2014">
       <Id>9054cd08-bc61-4493-8c6e-e6ca67c78562</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="25" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="25" Volume="2013" Year="2014">
       <Id>40853a95-6925-4fad-80c4-b0f4eb707cc8</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="31" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Men" Number="31" Volume="2013" Year="2014">
       <Id>d750a344-fd74-469f-9d24-6c28e1a2803b</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="32" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Men" Number="32" Volume="2013" Year="2014">
       <Id>39e0c9af-22ac-47a9-ad81-6efa038f6960</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="33" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Men" Number="33" Volume="2013" Year="2014">
       <Id>eafbd74c-10ef-44bb-b451-86c6736dd163</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="34" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="All-New X-Men" Number="34" Volume="2013" Year="2015">
       <Id>72cd6c70-87a5-4a98-b428-95d6ae4f9a86</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="36" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="All-New X-Men" Number="36" Volume="2013" Year="2015">
       <Id>e6451593-0357-4a40-9837-092a99a7a794</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="35" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="All-New X-Men" Number="35" Volume="2013" Year="2015">
       <Id>d0223661-fe5e-4ff3-9bc4-bd7c261c995d</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="26" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="26" Volume="2013" Year="2014">
       <Id>b5ece96b-43e3-4d38-b7e5-355989d7ee32</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="27" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="27" Volume="2013" Year="2014">
       <Id>1940adf0-a4a8-4ecb-8c27-9b646d461880</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="28" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="28" Volume="2013" Year="2015">
       <Id>fe8c9a1d-48fd-447e-b2dd-edc52eef531a</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="29" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="29" Volume="2013" Year="2015">
       <Id>0d67f38c-a9ed-4c5d-9d45-fde20026582e</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="30" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="30" Volume="2013" Year="2015">
       <Id>d7cf2958-9d3f-46d9-8f0c-0ca9e82b4b38</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="31" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="31" Volume="2013" Year="2015">
       <Id>9b9b8da0-9ea6-4d1a-83e7-956fbfff90cb</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="37" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="All-New X-Men" Number="37" Volume="2013" Year="2015">
       <Id>7d9558fb-04b2-40d7-94f1-c6d9131ce349</Id>
     </Book>
-    <Book Series="X-Men" Number="18" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="X-Men" Number="18" Volume="2013" Year="2014">
       <Id>8ad499d5-a542-4bfa-9be3-42f2534e4e53</Id>
     </Book>
-    <Book Series="X-Men" Number="19" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="X-Men" Number="19" Volume="2013" Year="2014">
       <Id>24e28014-373b-400e-802b-3aadad80870e</Id>
     </Book>
-    <Book Series="X-Men" Number="20" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="X-Men" Number="20" Volume="2013" Year="2014">
       <Id>61db32ee-18f9-432a-bd59-4252d221b209</Id>
     </Book>
-    <Book Series="X-Men" Number="21" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="X-Men" Number="21" Volume="2013" Year="2015">
       <Id>7060ed56-9603-4ad0-9d17-c452755cb454</Id>
     </Book>
-    <Book Series="X-Men" Number="22" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="X-Men" Number="22" Volume="2013" Year="2015">
       <Id>f884c034-1250-4a45-9bce-79c4e823df3e</Id>
     </Book>
-    <Book Series="Amazing X-Men" Number="13" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Amazing X-Men" Number="13" Volume="2013" Year="2015">
       <Id>6c201c30-7afe-46f8-a410-21937df701f0</Id>
     </Book>
-    <Book Series="Deadpool Bi-Annual" Number="1" Volume="2014" Year="2014" Format="Annual">
+    <Book Series="Deadpool Bi-Annual" Number="1" Volume="2014" Year="2014">
       <Id>0acbaa0b-5106-436a-9914-c795a12bb643</Id>
     </Book>
-    <Book Series="Deadpool" Number="34" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Deadpool" Number="34" Volume="2013" Year="2014">
       <Id>0d8a992c-28e5-4c07-a293-f90a23b6b412</Id>
     </Book>
-    <Book Series="Deadpool" Number="35" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Deadpool" Number="35" Volume="2013" Year="2014">
       <Id>f4b83a40-d011-4498-a641-953f4640c740</Id>
     </Book>
-    <Book Series="Death of Wolverine" Number="1" Volume="2014" Year="2014" Format="Limited Series">
+    <Book Series="Death of Wolverine" Number="1" Volume="2014" Year="2014">
       <Id>fc4c8149-a4c8-4ff9-a5ae-97867ae813b2</Id>
     </Book>
-    <Book Series="Death of Wolverine" Number="2" Volume="2014" Year="2014" Format="Limited Series">
+    <Book Series="Death of Wolverine" Number="2" Volume="2014" Year="2014">
       <Id>ef238abb-beea-4941-be77-0208adc87ec0</Id>
     </Book>
-    <Book Series="Death of Wolverine" Number="3" Volume="2014" Year="2014" Format="Limited Series">
+    <Book Series="Death of Wolverine" Number="3" Volume="2014" Year="2014">
       <Id>fece51fd-a47f-4afa-8531-d33939dc9a20</Id>
     </Book>
-    <Book Series="Death of Wolverine" Number="4" Volume="2014" Year="2014" Format="Limited Series">
+    <Book Series="Death of Wolverine" Number="4" Volume="2014" Year="2014">
       <Id>a6c6a23f-3acc-45b0-ab98-f367c022918a</Id>
     </Book>
-    <Book Series="Death of Wolverine: The Weapon X Program" Number="1" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Death of Wolverine: The Weapon X Program" Number="1" Volume="2014" Year="2015">
       <Id>12f9d748-4550-43c6-ba76-b91f8367ea7c</Id>
     </Book>
-    <Book Series="Death of Wolverine: The Weapon X Program" Number="2" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Death of Wolverine: The Weapon X Program" Number="2" Volume="2014" Year="2015">
       <Id>626d70f8-8bf9-4720-8d75-4dfd3025cea5</Id>
     </Book>
-    <Book Series="Death of Wolverine: Life After Logan" Number="1" Volume="2014" Year="2015" Format="One-Shot">
+    <Book Series="Death of Wolverine: Life After Logan" Number="1" Volume="2014" Year="2015">
       <Id>ba57ad0a-2ced-403e-95bc-47a056d810d0</Id>
     </Book>
-    <Book Series="Death of Wolverine: Deadpool &amp; Captain America" Number="1" Volume="2014" Year="2014" Format="One-Shot">
+    <Book Series="Death of Wolverine: Deadpool &amp; Captain America" Number="1" Volume="2014" Year="2014">
       <Id>417723bf-5136-4e89-8014-2afc716ef284</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="7" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Nightcrawler" Number="7" Volume="2014" Year="2014">
       <Id>544a68cf-c4cb-4300-83a8-0cfa0a332ed4</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="10" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="10" Volume="2014" Year="2014">
       <Id>96f3bb82-4a55-4ff3-b331-9e09a734a439</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="11" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="11" Volume="2014" Year="2014">
       <Id>24466e14-de5f-435c-ad70-f0f488de3bad</Id>
     </Book>
-    <Book Series="Storm" Number="4" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Storm" Number="4" Volume="2014" Year="2014">
       <Id>b86899f5-3df7-4f86-8ead-ee139f6c58c8</Id>
     </Book>
-    <Book Series="Death of Wolverine: The Weapon X Program" Number="3" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Death of Wolverine: The Weapon X Program" Number="3" Volume="2014" Year="2015">
       <Id>b935e3aa-617a-4ad3-ad31-49ab4aa6dcdf</Id>
     </Book>
-    <Book Series="Death of Wolverine: The Weapon X Program" Number="4" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Death of Wolverine: The Weapon X Program" Number="4" Volume="2014" Year="2015">
       <Id>0933cd52-521d-4af1-abd8-dad497a9345f</Id>
     </Book>
-    <Book Series="Death of Wolverine: The Weapon X Program" Number="5" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Death of Wolverine: The Weapon X Program" Number="5" Volume="2014" Year="2015">
       <Id>1cc58d51-15d1-4f3c-9c99-c39e56d63d9d</Id>
     </Book>
-    <Book Series="Death of Wolverine: The Logan Legacy" Number="1" Volume="2014" Year="2014" Format="Limited Series">
+    <Book Series="Death of Wolverine: The Logan Legacy" Number="1" Volume="2014" Year="2014">
       <Id>1ce79e74-eaf5-448f-9d95-f71268ca34c7</Id>
     </Book>
-    <Book Series="Death of Wolverine: The Logan Legacy" Number="2" Volume="2014" Year="2014" Format="Limited Series">
+    <Book Series="Death of Wolverine: The Logan Legacy" Number="2" Volume="2014" Year="2014">
       <Id>b84d70b4-10a1-47c7-a6fe-f316e35c63c6</Id>
     </Book>
-    <Book Series="Death of Wolverine: The Logan Legacy" Number="3" Volume="2014" Year="2014" Format="Limited Series">
+    <Book Series="Death of Wolverine: The Logan Legacy" Number="3" Volume="2014" Year="2014">
       <Id>e5314d4a-208e-48a3-a785-4d1f9c5ec759</Id>
     </Book>
-    <Book Series="Death of Wolverine: The Logan Legacy" Number="4" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Death of Wolverine: The Logan Legacy" Number="4" Volume="2014" Year="2015">
       <Id>924d3faa-d0b2-412f-af6c-445621e48457</Id>
     </Book>
-    <Book Series="Death of Wolverine: The Logan Legacy" Number="5" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Death of Wolverine: The Logan Legacy" Number="5" Volume="2014" Year="2015">
       <Id>444c2f17-c7d8-47e8-b9d2-1e9e1cf64fea</Id>
     </Book>
-    <Book Series="Death of Wolverine: The Logan Legacy" Number="6" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Death of Wolverine: The Logan Legacy" Number="6" Volume="2014" Year="2015">
       <Id>a63c681a-0681-4ae9-9a45-060ae6ba1735</Id>
     </Book>
-    <Book Series="Death of Wolverine: The Logan Legacy" Number="7" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Death of Wolverine: The Logan Legacy" Number="7" Volume="2014" Year="2015">
       <Id>47419760-2d4c-4180-813e-461c017b637d</Id>
     </Book>
-    <Book Series="Wolverines" Number="1" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Wolverines" Number="1" Volume="2015" Year="2015">
       <Id>47f2467e-2601-424b-97f6-ba5f85f9cf4a</Id>
     </Book>
-    <Book Series="Wolverines" Number="2" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Wolverines" Number="2" Volume="2015" Year="2015">
       <Id>82dbf7a2-58d9-4412-8593-9f9aec2b4e07</Id>
     </Book>
-    <Book Series="Wolverines" Number="3" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Wolverines" Number="3" Volume="2015" Year="2015">
       <Id>baf61b30-9e47-4a84-b340-88d088569519</Id>
     </Book>
-    <Book Series="Wolverines" Number="4" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Wolverines" Number="4" Volume="2015" Year="2015">
       <Id>1d5936af-9fb1-44d8-b499-6e579bea9e76</Id>
     </Book>
-    <Book Series="Wolverines" Number="5" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Wolverines" Number="5" Volume="2015" Year="2015">
       <Id>a1530f9e-751b-4ff7-bcdb-e9d0b3be0ba6</Id>
     </Book>
-    <Book Series="Wolverines" Number="6" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Wolverines" Number="6" Volume="2015" Year="2015">
       <Id>4073f848-2bea-4284-b190-da6170686a05</Id>
     </Book>
-    <Book Series="Wolverines" Number="7" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Wolverines" Number="7" Volume="2015" Year="2015">
       <Id>5eff416d-ddda-4e69-9423-df979525362c</Id>
     </Book>
-    <Book Series="Wolverines" Number="8" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Wolverines" Number="8" Volume="2015" Year="2015">
       <Id>b4bf6745-236d-4f8e-93c4-e438d178d01a</Id>
     </Book>
-    <Book Series="Wolverines" Number="9" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Wolverines" Number="9" Volume="2015" Year="2015">
       <Id>c261560f-920f-4391-a68b-e80086833d18</Id>
     </Book>
-    <Book Series="Wolverines" Number="10" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Wolverines" Number="10" Volume="2015" Year="2015">
       <Id>e31bd264-36a9-4cb4-b95e-81d221eadfef</Id>
     </Book>
-    <Book Series="Wolverines" Number="11" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Wolverines" Number="11" Volume="2015" Year="2015">
       <Id>834254ab-65a2-4bf6-be7c-2006035afad9</Id>
     </Book>
-    <Book Series="Wolverines" Number="12" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Wolverines" Number="12" Volume="2015" Year="2015">
       <Id>3a1e51a3-2165-4463-91b7-75fc9729fb08</Id>
     </Book>
-    <Book Series="Wolverines" Number="13" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Wolverines" Number="13" Volume="2015" Year="2015">
       <Id>a972a350-cb27-441a-9b0f-0ff2442d2e6e</Id>
     </Book>
-    <Book Series="Wolverines" Number="14" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Wolverines" Number="14" Volume="2015" Year="2015">
       <Id>bf91d7d9-6f33-440e-ad60-a83867906181</Id>
     </Book>
-    <Book Series="Wolverines" Number="15" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Wolverines" Number="15" Volume="2015" Year="2015">
       <Id>5aa436b0-b21c-4c55-915c-2e3f1ea79c46</Id>
     </Book>
-    <Book Series="Wolverines" Number="16" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Wolverines" Number="16" Volume="2015" Year="2015">
       <Id>bf9b7fa9-1c70-45ff-8a72-ccec245de3ea</Id>
     </Book>
-    <Book Series="Wolverines" Number="17" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Wolverines" Number="17" Volume="2015" Year="2015">
       <Id>b3e3de01-cb33-4183-b83a-1946a947a876</Id>
     </Book>
-    <Book Series="Wolverines" Number="18" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Wolverines" Number="18" Volume="2015" Year="2015">
       <Id>9e1a9fcb-ae78-492d-8e14-dd242b56e852</Id>
     </Book>
-    <Book Series="Wolverines" Number="19" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Wolverines" Number="19" Volume="2015" Year="2015">
       <Id>f9ce2ad8-0e6c-4352-bb57-8357230f66b7</Id>
     </Book>
-    <Book Series="Wolverines" Number="20" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Wolverines" Number="20" Volume="2015" Year="2015">
       <Id>cc519fc1-23b0-4d73-a997-e803bb47e898</Id>
     </Book>
-    <Book Series="Storm" Number="5" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Storm" Number="5" Volume="2014" Year="2015">
       <Id>67aaa0ee-4ff2-4e57-805a-0715a667260a</Id>
     </Book>
-    <Book Series="Storm" Number="6" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Storm" Number="6" Volume="2014" Year="2015">
       <Id>34c50d81-1f01-4dfb-88b9-5684f1dcf70a</Id>
     </Book>
-    <Book Series="Storm" Number="7" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Storm" Number="7" Volume="2014" Year="2015">
       <Id>f0fb4d14-760e-4120-8419-3294e9a6a33c</Id>
     </Book>
-    <Book Series="Storm" Number="8" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Storm" Number="8" Volume="2014" Year="2015">
       <Id>383e69bd-f30f-4f35-8375-237aa99390cb</Id>
     </Book>
-    <Book Series="Magneto" Number="9" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Magneto" Number="9" Volume="2014" Year="2014">
       <Id>279e8ef9-5c43-431c-83c7-90904532c596</Id>
     </Book>
-    <Book Series="Magneto" Number="10" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Magneto" Number="10" Volume="2014" Year="2014">
       <Id>18f6d80e-a708-46fe-9ff8-d763b689c219</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="24" Volume="2012" Year="2014" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="24" Volume="2012" Year="2014">
       <Id>9577af9d-6230-499b-b942-6d5533d0a7cc</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="25" Volume="2012" Year="2014" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="25" Volume="2012" Year="2014">
       <Id>6a2d6856-6bc5-4f4b-98e9-b6ca08d44fea</Id>
     </Book>
-    <Book Series="Avengers &amp; X-Men: Axis" Number="1" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="Avengers &amp; X-Men: Axis" Number="1" Volume="2014" Year="2014">
       <Id>7cc3caee-a190-4fe3-8777-421ffe52ce20</Id>
     </Book>
-    <Book Series="Axis: Revolutions" Number="1" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="Axis: Revolutions" Number="1" Volume="2014" Year="2014">
       <Id>71207ff6-2e5c-4cae-be65-f5080b859cbf</Id>
     </Book>
-    <Book Series="Avengers &amp; X-Men: Axis" Number="2" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="Avengers &amp; X-Men: Axis" Number="2" Volume="2014" Year="2014">
       <Id>1dcf44f5-e194-408b-bc3d-146173cd332d</Id>
     </Book>
-    <Book Series="Magneto" Number="11" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Magneto" Number="11" Volume="2014" Year="2014">
       <Id>f38c90c1-b5e9-4b9f-b3f7-1217057d69fe</Id>
     </Book>
-    <Book Series="Avengers &amp; X-Men: Axis" Number="3" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="Avengers &amp; X-Men: Axis" Number="3" Volume="2014" Year="2014">
       <Id>b5129bbb-b14e-4ebe-b680-1042619a3090</Id>
     </Book>
-    <Book Series="Magneto" Number="12" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Magneto" Number="12" Volume="2014" Year="2015">
       <Id>81b69d22-30e8-4911-8a75-8f3c0482825a</Id>
     </Book>
-    <Book Series="Deadpool" Number="36" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Deadpool" Number="36" Volume="2013" Year="2014">
       <Id>ca166fb3-8567-491d-b696-01c3c3bea17c</Id>
     </Book>
-    <Book Series="All-New X-Factor" Number="15" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="All-New X-Factor" Number="15" Volume="2014" Year="2014">
       <Id>52b99647-ea3c-41ac-835f-611f68b4bfaf</Id>
     </Book>
-    <Book Series="All-New X-Factor" Number="16" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="All-New X-Factor" Number="16" Volume="2014" Year="2015">
       <Id>544928f3-1cf3-4dee-a770-20dd2d7475ea</Id>
     </Book>
-    <Book Series="Avengers &amp; X-Men: Axis" Number="4" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="Avengers &amp; X-Men: Axis" Number="4" Volume="2014" Year="2015">
       <Id>3f817a41-54aa-4fcb-8b7b-a78ef0ffe401</Id>
     </Book>
-    <Book Series="Deadpool" Number="37" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Deadpool" Number="37" Volume="2013" Year="2015">
       <Id>a6a793c8-972f-4e56-ac63-134c5fc4252a</Id>
     </Book>
-    <Book Series="All-New X-Factor" Number="17" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="All-New X-Factor" Number="17" Volume="2014" Year="2015">
       <Id>9b0f1c18-bb9a-4ce6-be55-09f74a08c77d</Id>
     </Book>
-    <Book Series="Avengers &amp; X-Men: Axis" Number="5" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="Avengers &amp; X-Men: Axis" Number="5" Volume="2014" Year="2015">
       <Id>398fdb4d-9618-40f5-aae4-4b045b6b06e6</Id>
     </Book>
-    <Book Series="Axis: Revolutions" Number="2" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="Axis: Revolutions" Number="2" Volume="2014" Year="2015">
       <Id>4d7a8349-61ee-4126-8975-223c365a3239</Id>
     </Book>
-    <Book Series="Axis: Revolutions" Number="3" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="Axis: Revolutions" Number="3" Volume="2014" Year="2015">
       <Id>72cb40b3-09d2-494a-96a9-f301060c884b</Id>
     </Book>
-    <Book Series="Axis: Revolutions" Number="4" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="Axis: Revolutions" Number="4" Volume="2014" Year="2015">
       <Id>e211e310-7c14-4850-b115-4da1848b034d</Id>
     </Book>
-    <Book Series="Avengers &amp; X-Men: Axis" Number="6" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="Avengers &amp; X-Men: Axis" Number="6" Volume="2014" Year="2015">
       <Id>1aa020bd-3cc7-4294-a877-09520c3c57d7</Id>
     </Book>
-    <Book Series="Wolverine &amp; the X-Men" Number="12" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Wolverine &amp; the X-Men" Number="12" Volume="2014" Year="2015">
       <Id>28fc407a-2ae8-40e6-b307-1a7cda0efd94</Id>
     </Book>
-    <Book Series="Deadpool" Number="38" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Deadpool" Number="38" Volume="2013" Year="2015">
       <Id>429ce863-7f3f-447f-b314-3a812b1ae35e</Id>
     </Book>
-    <Book Series="Avengers &amp; X-Men: Axis" Number="7" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="Avengers &amp; X-Men: Axis" Number="7" Volume="2014" Year="2015">
       <Id>13c5d3dc-a10f-4e8b-b89e-42975f304c66</Id>
     </Book>
-    <Book Series="Avengers &amp; X-Men: Axis" Number="8" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="Avengers &amp; X-Men: Axis" Number="8" Volume="2014" Year="2015">
       <Id>047600e4-7787-4aff-9d2e-43816c4e8b04</Id>
     </Book>
-    <Book Series="Avengers &amp; X-Men: Axis" Number="9" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="Avengers &amp; X-Men: Axis" Number="9" Volume="2014" Year="2015">
       <Id>a3afb1bc-693d-4df6-b7d5-e8c35a3b7d97</Id>
     </Book>
-    <Book Series="Deadpool" Number="39" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Deadpool" Number="39" Volume="2013" Year="2015">
       <Id>e5dc9bf3-2e92-488d-9de5-ce056c9de5c2</Id>
     </Book>
-    <Book Series="Guardians of the Galaxy: Best Story Ever" Number="1" Volume="2015" Year="2015" Format="Graphic Novel">
+    <Book Series="Guardians of the Galaxy: Best Story Ever" Number="1" Volume="2015" Year="2015">
       <Id>2b7bffa5-caa1-466f-ba49-0416bd92ef66</Id>
     </Book>
-    <Book Series="Legendary Star-Lord" Number="1" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Legendary Star-Lord" Number="1" Volume="2014" Year="2014">
       <Id>28073f55-1564-4c3a-949e-0379431a96e7</Id>
     </Book>
-    <Book Series="Legendary Star-Lord" Number="2" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Legendary Star-Lord" Number="2" Volume="2014" Year="2014">
       <Id>612e784f-1682-4e49-af30-592247102cbf</Id>
     </Book>
-    <Book Series="Legendary Star-Lord" Number="3" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Legendary Star-Lord" Number="3" Volume="2014" Year="2014">
       <Id>ad3f8b0f-bf9d-4e29-847b-3578920de18d</Id>
     </Book>
-    <Book Series="Legendary Star-Lord" Number="4" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Legendary Star-Lord" Number="4" Volume="2014" Year="2014">
       <Id>2186ce8a-11e4-4d38-aaa7-fb064dd74d89</Id>
     </Book>
-    <Book Series="Legendary Star-Lord" Number="5" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Legendary Star-Lord" Number="5" Volume="2014" Year="2015">
       <Id>a91d812b-0299-48a4-bfd0-941014cd2b34</Id>
     </Book>
-    <Book Series="Guardians of the Galaxy" Number="21" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Guardians of the Galaxy" Number="21" Volume="2013" Year="2015">
       <Id>84b1d993-5d32-48fb-ae35-8760f82d886a</Id>
     </Book>
-    <Book Series="Guardians of the Galaxy" Number="22" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Guardians of the Galaxy" Number="22" Volume="2013" Year="2015">
       <Id>b0201890-6538-4aa8-a0b7-b0a1c196a455</Id>
     </Book>
-    <Book Series="Guardians of the Galaxy" Number="23" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Guardians of the Galaxy" Number="23" Volume="2013" Year="2015">
       <Id>a1e5e6c3-aef7-4ee1-81f1-81864551dd4c</Id>
     </Book>
-    <Book Series="Legendary Star-Lord" Number="6" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Legendary Star-Lord" Number="6" Volume="2014" Year="2015">
       <Id>2bce621e-1eb0-4734-a27f-43e0f753a305</Id>
     </Book>
-    <Book Series="Legendary Star-Lord" Number="7" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Legendary Star-Lord" Number="7" Volume="2014" Year="2015">
       <Id>77f291ad-cc42-4c60-9244-0ee221317ddf</Id>
     </Book>
-    <Book Series="Legendary Star-Lord" Number="8" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Legendary Star-Lord" Number="8" Volume="2014" Year="2015">
       <Id>b18f4914-1bbc-4b44-9644-c7d9912e416a</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="32" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="32" Volume="2013" Year="2015">
       <Id>16b00e63-5787-493f-9d6e-f9e5c65711fc</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="33" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="33" Volume="2013" Year="2015">
       <Id>16da33e7-eb20-44e5-a119-52c54dc4c40f</Id>
     </Book>
-    <Book Series="Cyclops" Number="1" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Cyclops" Number="1" Volume="2014" Year="2014">
       <Id>6fc75925-f44c-4e5f-a4c8-b28069269b4b</Id>
     </Book>
-    <Book Series="Cyclops" Number="2" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Cyclops" Number="2" Volume="2014" Year="2014">
       <Id>12357d7b-0157-4e10-93a2-c9460d8ef40a</Id>
     </Book>
-    <Book Series="Cyclops" Number="3" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Cyclops" Number="3" Volume="2014" Year="2014">
       <Id>1531b3cf-0ed8-456a-a3be-30135de3d99f</Id>
     </Book>
-    <Book Series="Cyclops" Number="4" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Cyclops" Number="4" Volume="2014" Year="2014">
       <Id>594ab424-d4ba-4686-b204-93adf2d66deb</Id>
     </Book>
-    <Book Series="Cyclops" Number="5" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Cyclops" Number="5" Volume="2014" Year="2014">
       <Id>7c8c891d-129d-422a-b76f-6078b5b8e60b</Id>
     </Book>
-    <Book Series="Cyclops" Number="6" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Cyclops" Number="6" Volume="2014" Year="2014">
       <Id>f94e3cf2-da87-4671-94bb-acf8e0fb4273</Id>
     </Book>
-    <Book Series="Cyclops" Number="7" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Cyclops" Number="7" Volume="2014" Year="2015">
       <Id>0c68cc60-82f3-4dbc-9437-24826e0127f3</Id>
     </Book>
-    <Book Series="Cyclops" Number="8" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Cyclops" Number="8" Volume="2014" Year="2015">
       <Id>e88d8530-40bc-4a09-b3a1-8ec10bee1420</Id>
     </Book>
-    <Book Series="Cyclops" Number="9" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Cyclops" Number="9" Volume="2014" Year="2015">
       <Id>6ede995c-1ce4-4ba7-8dc2-e23e3298247a</Id>
     </Book>
-    <Book Series="Cyclops" Number="10" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Cyclops" Number="10" Volume="2014" Year="2015">
       <Id>38373a59-4f09-4cea-93d0-064073414353</Id>
     </Book>
-    <Book Series="Cyclops" Number="11" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Cyclops" Number="11" Volume="2014" Year="2015">
       <Id>452b189b-49f3-49c5-94c1-da780a5e7258</Id>
     </Book>
-    <Book Series="Guardians of the Galaxy &amp; X-Men: The Black Vortex Alpha" Number="1" Volume="2015" Year="2015" Format="One-Shot">
+    <Book Series="Guardians of the Galaxy &amp; X-Men: The Black Vortex Alpha" Number="1" Volume="2015" Year="2015">
       <Id>ae669f9b-8768-480e-aa83-d10e0ff6421c</Id>
     </Book>
-    <Book Series="Guardians of the Galaxy" Number="24" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Guardians of the Galaxy" Number="24" Volume="2013" Year="2015">
       <Id>158496c8-2b2f-4e48-855b-330911eedb06</Id>
     </Book>
-    <Book Series="Legendary Star-Lord" Number="9" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Legendary Star-Lord" Number="9" Volume="2014" Year="2015">
       <Id>290c955d-31b0-41a0-b969-2ab08d4347d9</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="38" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="All-New X-Men" Number="38" Volume="2013" Year="2015">
       <Id>dc2a3dff-7d43-4b1d-aae9-aa254a81663c</Id>
     </Book>
-    <Book Series="Guardians Team-Up" Number="3" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Guardians Team-Up" Number="3" Volume="2015" Year="2015">
       <Id>c08ac4ac-c5f4-4ec5-8cfa-e5cfb3aa7b93</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="39" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="All-New X-Men" Number="39" Volume="2013" Year="2015">
       <Id>f8dfd878-211d-41da-9400-1947aaeb1cc1</Id>
     </Book>
-    <Book Series="Guardians of the Galaxy" Number="25" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Guardians of the Galaxy" Number="25" Volume="2013" Year="2015">
       <Id>3ec56c52-9902-470f-99df-cf08360c2108</Id>
     </Book>
-    <Book Series="Nova" Number="28" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Nova" Number="28" Volume="2013" Year="2015">
       <Id>bbd9e7cd-0764-46fa-88db-0dd1d8113fe5</Id>
     </Book>
-    <Book Series="Legendary Star-Lord" Number="10" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Legendary Star-Lord" Number="10" Volume="2014" Year="2015">
       <Id>b2496dd8-1bb8-4752-98b1-db8f22b8fd5a</Id>
     </Book>
-    <Book Series="Cyclops" Number="12" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Cyclops" Number="12" Volume="2014" Year="2015">
       <Id>ee080736-5632-4759-9f7a-7be31c8c3322</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="14" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Captain Marvel" Number="14" Volume="2014" Year="2015">
       <Id>041ed1a3-eed4-45d4-a61d-a879bf0ab6fd</Id>
     </Book>
-    <Book Series="Legendary Star-Lord" Number="11" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Legendary Star-Lord" Number="11" Volume="2014" Year="2015">
       <Id>80e01901-6707-4b34-ac76-a0a3b2c79225</Id>
     </Book>
-    <Book Series="Guardians of the Galaxy &amp; X-Men: The Black Vortex Omega" Number="1" Volume="2015" Year="2015" Format="One-Shot">
+    <Book Series="Guardians of the Galaxy &amp; X-Men: The Black Vortex Omega" Number="1" Volume="2015" Year="2015">
       <Id>316f908a-42c7-4074-b30f-d46f89661ca9</Id>
     </Book>
-    <Book Series="All-New X-Factor" Number="18" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="All-New X-Factor" Number="18" Volume="2014" Year="2015">
       <Id>4f6af9db-b144-45d2-b747-68ab2e048a98</Id>
     </Book>
-    <Book Series="All-New X-Factor" Number="19" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="All-New X-Factor" Number="19" Volume="2014" Year="2015">
       <Id>b22b7d09-2204-4786-8ae7-74b41988cfbc</Id>
     </Book>
-    <Book Series="All-New X-Factor" Number="20" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="All-New X-Factor" Number="20" Volume="2014" Year="2015">
       <Id>d2bce3da-e997-4d85-af81-e809776fa222</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="1" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Uncanny Avengers" Number="1" Volume="2015" Year="2015">
       <Id>4dc61054-afe9-40c8-8012-2433f076bf10</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="2" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Uncanny Avengers" Number="2" Volume="2015" Year="2015">
       <Id>f906d8bf-edae-4f24-857a-9d32e159fc75</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="3" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Uncanny Avengers" Number="3" Volume="2015" Year="2015">
       <Id>7b682693-dc2c-47ae-8354-fe58c64bf314</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="4" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Uncanny Avengers" Number="4" Volume="2015" Year="2015">
       <Id>2444fe3e-acdb-4164-8e9e-38f0326ca0b5</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="5" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Uncanny Avengers" Number="5" Volume="2015" Year="2015">
       <Id>2bff0f5c-0291-4a36-9986-5c258dbf44c7</Id>
     </Book>
-    <Book Series="Spider-Man &amp; the X-Men" Number="1" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Man &amp; the X-Men" Number="1" Volume="2014" Year="2015">
       <Id>4e648eae-7adb-47c4-bf04-a18ac9d5092a</Id>
     </Book>
-    <Book Series="Spider-Man &amp; the X-Men" Number="2" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Man &amp; the X-Men" Number="2" Volume="2014" Year="2015">
       <Id>ccb5a65b-c521-4d0e-99ee-e9230998f91c</Id>
     </Book>
-    <Book Series="Spider-Man &amp; the X-Men" Number="3" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Man &amp; the X-Men" Number="3" Volume="2014" Year="2015">
       <Id>490d0783-87d0-4055-8c58-2930fa358525</Id>
     </Book>
-    <Book Series="Spider-Man &amp; the X-Men" Number="4" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Man &amp; the X-Men" Number="4" Volume="2014" Year="2015">
       <Id>dcd89d50-5a4a-4f16-a811-444ce81e2043</Id>
     </Book>
-    <Book Series="Spider-Man &amp; the X-Men" Number="5" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Man &amp; the X-Men" Number="5" Volume="2014" Year="2015">
       <Id>377546d0-11d9-4ec6-a3fb-0aca9eef6f35</Id>
     </Book>
-    <Book Series="Spider-Man &amp; the X-Men" Number="6" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Man &amp; the X-Men" Number="6" Volume="2014" Year="2015">
       <Id>7b46f829-33a8-4c4b-9abd-03d5d0f5d532</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="40" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="All-New X-Men" Number="40" Volume="2013" Year="2015">
       <Id>95f566ab-4b28-4063-ac97-d1537017962c</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="41" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="All-New X-Men" Number="41" Volume="2013" Year="2015">
       <Id>83745d76-c7e6-45c4-944c-3a821b18fc1e</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="34" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="34" Volume="2013" Year="2015">
       <Id>6f60a6bf-ee1f-45ea-afec-91f367a092e3</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="35" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="35" Volume="2013" Year="2015">
       <Id>7f56f58a-b21d-4921-b9f6-8f1ea1e4b959</Id>
     </Book>
-    <Book Series="Magneto" Number="13" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Magneto" Number="13" Volume="2014" Year="2015">
       <Id>5a00c411-7c2b-4477-a23e-332a056a4f60</Id>
     </Book>
-    <Book Series="Magneto" Number="14" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Magneto" Number="14" Volume="2014" Year="2015">
       <Id>c884c4a1-706a-4cf1-8f64-1a74bafd8527</Id>
     </Book>
-    <Book Series="Magneto" Number="15" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Magneto" Number="15" Volume="2014" Year="2015">
       <Id>a932e9e1-6478-460e-8382-9453cb2e5e71</Id>
     </Book>
-    <Book Series="Magneto" Number="16" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Magneto" Number="16" Volume="2014" Year="2015">
       <Id>18c4bf39-1bae-4dfd-a3f5-251337e9840e</Id>
     </Book>
-    <Book Series="Magneto" Number="17" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Magneto" Number="17" Volume="2014" Year="2015">
       <Id>6e41f1fb-603f-4efd-94e5-c2a6d8122220</Id>
     </Book>
-    <Book Series="Deadpool" Number="40" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Deadpool" Number="40" Volume="2013" Year="2015">
       <Id>fefd1a8d-5d73-46bb-9f6c-f97d942d6f16</Id>
     </Book>
-    <Book Series="Deadpool" Number="41" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Deadpool" Number="41" Volume="2013" Year="2015">
       <Id>66956ec6-31ba-4b28-88fc-f145f32d470b</Id>
     </Book>
-    <Book Series="Deadpool" Number="42" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Deadpool" Number="42" Volume="2013" Year="2015">
       <Id>a4db450b-385e-466a-9a85-d1222df5bd64</Id>
     </Book>
-    <Book Series="Deadpool" Number="43" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Deadpool" Number="43" Volume="2013" Year="2015">
       <Id>8ce61f8b-61a6-49ce-a859-1aa552010bc7</Id>
     </Book>
-    <Book Series="Deadpool" Number="44" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Deadpool" Number="44" Volume="2013" Year="2015">
       <Id>ff5314a0-65c1-4f38-839b-1c2e8342a53b</Id>
     </Book>
-    <Book Series="Deadpool" Number="45" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Deadpool" Number="45" Volume="2013" Year="2015">
       <Id>c3ff352b-d89b-4ca2-910c-c9105aafd5e1</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="8" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Nightcrawler" Number="8" Volume="2014" Year="2015">
       <Id>7820fd0a-df6f-46a0-941a-6efcb0d92912</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="9" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Nightcrawler" Number="9" Volume="2014" Year="2015">
       <Id>272340d6-8709-4ab9-bae3-0cf1e5498ac1</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="10" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Nightcrawler" Number="10" Volume="2014" Year="2015">
       <Id>bfdd8a86-45cf-44b9-a92c-bcff45c00dad</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="11" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Nightcrawler" Number="11" Volume="2014" Year="2015">
       <Id>81ccbde2-6bac-48c4-a272-b587316d3561</Id>
     </Book>
-    <Book Series="Nightcrawler" Number="12" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Nightcrawler" Number="12" Volume="2014" Year="2015">
       <Id>b6d7f953-da40-4b54-a9e1-c18c97b5a517</Id>
     </Book>
-    <Book Series="Storm" Number="9" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Storm" Number="9" Volume="2014" Year="2015">
       <Id>a7efb688-439b-44a9-8bff-7f5c9c817550</Id>
     </Book>
-    <Book Series="Storm" Number="10" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Storm" Number="10" Volume="2014" Year="2015">
       <Id>1bc4998e-2612-447a-abef-3547da2d8afb</Id>
     </Book>
-    <Book Series="Storm" Number="11" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Storm" Number="11" Volume="2014" Year="2015">
       <Id>5a51bd43-9056-4369-a9ce-aa19005f2d04</Id>
     </Book>
-    <Book Series="X-Men" Number="23" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="X-Men" Number="23" Volume="2013" Year="2015">
       <Id>bc4ff7ea-bd99-4ce2-a5d2-f944f32663f2</Id>
     </Book>
-    <Book Series="X-Men" Number="24" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="X-Men" Number="24" Volume="2013" Year="2015">
       <Id>1a82eebf-d51c-4c1a-83f1-9b7301f60e69</Id>
     </Book>
-    <Book Series="X-Men" Number="25" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="X-Men" Number="25" Volume="2013" Year="2015">
       <Id>b425935c-a9ea-4db0-b153-5c67b0c170c0</Id>
     </Book>
-    <Book Series="X-Men" Number="26" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="X-Men" Number="26" Volume="2013" Year="2015">
       <Id>2291d5c0-805a-4150-807b-5b3ec76cb745</Id>
     </Book>
-    <Book Series="Amazing X-Men" Number="15" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Amazing X-Men" Number="15" Volume="2013" Year="2015">
       <Id>00ca23f0-a8bc-45e3-8e78-d2da3938e36f</Id>
     </Book>
-    <Book Series="Amazing X-Men" Number="16" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Amazing X-Men" Number="16" Volume="2013" Year="2015">
       <Id>25fac883-89cf-4ea5-bdbe-14a456009b95</Id>
     </Book>
-    <Book Series="Amazing X-Men" Number="17" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Amazing X-Men" Number="17" Volume="2013" Year="2015">
       <Id>46b70acb-fcff-4b84-bf97-41ecc747afab</Id>
     </Book>
-    <Book Series="Amazing X-Men" Number="18" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Amazing X-Men" Number="18" Volume="2013" Year="2015">
       <Id>10fdcb20-f8f7-4b47-8f7d-0714336bfbc6</Id>
     </Book>
-    <Book Series="Amazing X-Men" Number="19" Volume="2013" Year="2015" Format="Main Series">
+    <Book Series="Amazing X-Men" Number="19" Volume="2013" Year="2015">
       <Id>53fcb991-48fc-4cae-a7cd-2e7b1faff667</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="600" Volume="2013" Year="2016" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="600" Volume="2013" Year="2016">
       <Id>30f34560-53fc-4a97-a5b7-b745470259c7</Id>
     </Book>
-    <Book Series="Deadpool's Secret Secret Wars" Number="1" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Deadpool's Secret Secret Wars" Number="1" Volume="2015" Year="2015">
       <Id>9679994a-d35c-4ee1-ab53-20f143fe6c8f</Id>
     </Book>
-    <Book Series="Deadpool's Secret Secret Wars" Number="2" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Deadpool's Secret Secret Wars" Number="2" Volume="2015" Year="2015">
       <Id>fad4b653-2a61-4b28-93d1-a2204000cc47</Id>
     </Book>
-    <Book Series="Deadpool's Secret Secret Wars" Number="3" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Deadpool's Secret Secret Wars" Number="3" Volume="2015" Year="2015">
       <Id>49e432ab-a0ff-4223-a3ac-913c4bdda89e</Id>
     </Book>
-    <Book Series="Deadpool's Secret Secret Wars" Number="4" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Deadpool's Secret Secret Wars" Number="4" Volume="2015" Year="2015">
       <Id>f42252ac-4762-4691-b3ff-887acb076e15</Id>
     </Book>
-    <Book Series="Secret Wars" Number="1" Volume="2015" Year="2015" Format="Crossover">
+    <Book Series="Secret Wars" Number="1" Volume="2015" Year="2015">
       <Id>3244b4aa-3741-4c19-8ecb-07117f46e2a5</Id>
     </Book>
-    <Book Series="Magneto" Number="18" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Magneto" Number="18" Volume="2014" Year="2015">
       <Id>7292f651-48c2-4b17-91be-3ec308c05164</Id>
     </Book>
-    <Book Series="Magneto" Number="19" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Magneto" Number="19" Volume="2014" Year="2015">
       <Id>b0c7b625-2e2d-482e-855a-3e4bee3ce48b</Id>
     </Book>
-    <Book Series="Magneto" Number="20" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Magneto" Number="20" Volume="2014" Year="2015">
       <Id>00f47611-0e75-4d86-8ded-7cf4ac88a74e</Id>
     </Book>
-    <Book Series="Magneto" Number="21" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Magneto" Number="21" Volume="2014" Year="2015">
       <Id>808685ac-8fa4-4331-ac9c-63d17426681e</Id>
     </Book>
-    <Book Series="Secret Wars" Number="2" Volume="2015" Year="2015" Format="Crossover">
+    <Book Series="Secret Wars" Number="2" Volume="2015" Year="2015">
       <Id>4f4855ba-7a3d-4051-9336-8c200e577f71</Id>
     </Book>
-    <Book Series="Inferno" Number="1" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Inferno" Number="1" Volume="2015" Year="2015">
       <Id>d6ad9a17-abf6-457d-b1b8-02c9a23f0a88</Id>
     </Book>
-    <Book Series="Inferno" Number="2" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Inferno" Number="2" Volume="2015" Year="2015">
       <Id>5167df99-5c9f-492f-8ed9-c1f216081e1e</Id>
     </Book>
-    <Book Series="Inferno" Number="3" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Inferno" Number="3" Volume="2015" Year="2015">
       <Id>0ecc2213-7265-4b7a-84ac-7d36b37a398f</Id>
     </Book>
-    <Book Series="Inferno" Number="4" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Inferno" Number="4" Volume="2015" Year="2015">
       <Id>d614edf9-2fde-40f1-9cf0-8ba04b268b96</Id>
     </Book>
-    <Book Series="Inferno" Number="5" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Inferno" Number="5" Volume="2015" Year="2015">
       <Id>73436e2d-72df-4d2e-aebf-d7722dd258da</Id>
     </Book>
-    <Book Series="Age of Apocalypse: Warzones" Number="1" Volume="2015" Year="2015" Format="Crossover">
+    <Book Series="Age of Apocalypse: Warzones" Number="1" Volume="2015" Year="2015">
       <Id>6ff8c8d0-1b00-4252-9f0a-4a4d1701f00e</Id>
     </Book>
-    <Book Series="E Is For Extinction" Number="1" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="E Is For Extinction" Number="1" Volume="2015" Year="2015">
       <Id>7c1133fa-4ca3-48b8-a678-aba62927c47c</Id>
     </Book>
-    <Book Series="E Is For Extinction" Number="2" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="E Is For Extinction" Number="2" Volume="2015" Year="2015">
       <Id>98e3d48b-50f2-447a-a502-b1bc27b2d579</Id>
     </Book>
-    <Book Series="E Is For Extinction" Number="3" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="E Is For Extinction" Number="3" Volume="2015" Year="2015">
       <Id>01972b54-8066-4f67-8f8b-407ae609d772</Id>
     </Book>
-    <Book Series="E Is For Extinction" Number="4" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="E Is For Extinction" Number="4" Volume="2015" Year="2015">
       <Id>555266d9-88ca-4d83-8a07-156ba42548f3</Id>
     </Book>
-    <Book Series="X-Tinction Agenda" Number="1" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="X-Tinction Agenda" Number="1" Volume="2015" Year="2015">
       <Id>195a716b-f52c-48f5-88cd-7fd8347dd420</Id>
     </Book>
-    <Book Series="X-Tinction Agenda" Number="2" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="X-Tinction Agenda" Number="2" Volume="2015" Year="2015">
       <Id>24b3f293-b0db-4779-bd51-133ba191b953</Id>
     </Book>
-    <Book Series="X-Tinction Agenda" Number="3" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="X-Tinction Agenda" Number="3" Volume="2015" Year="2015">
       <Id>32fa3a2d-b547-4eb0-a103-862988843e5d</Id>
     </Book>
-    <Book Series="X-Tinction Agenda" Number="4" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="X-Tinction Agenda" Number="4" Volume="2015" Year="2015">
       <Id>31600bfc-5b04-404e-94b6-909104403527</Id>
     </Book>
-    <Book Series="Years of Future Past" Number="1" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Years of Future Past" Number="1" Volume="2015" Year="2015">
       <Id>3cae2fa1-86b1-4527-bbcd-acf117feba88</Id>
     </Book>
-    <Book Series="Years of Future Past" Number="2" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Years of Future Past" Number="2" Volume="2015" Year="2015">
       <Id>205dba32-707b-4c40-b331-62b7b9de8533</Id>
     </Book>
-    <Book Series="Years of Future Past" Number="3" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Years of Future Past" Number="3" Volume="2015" Year="2015">
       <Id>5c6e95df-a99f-44fa-b7f1-4d7781cc4ad3</Id>
     </Book>
-    <Book Series="Years of Future Past" Number="4" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Years of Future Past" Number="4" Volume="2015" Year="2015">
       <Id>75ca6cc6-2897-412a-88ad-1dbbd2fde331</Id>
     </Book>
-    <Book Series="Years of Future Past" Number="5" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Years of Future Past" Number="5" Volume="2015" Year="2015">
       <Id>7e15d288-8b75-46a8-a6ab-966f2bde8548</Id>
     </Book>
-    <Book Series="House of M" Number="1" Volume="2015" Year="2015" Format="Crossover">
+    <Book Series="House of M" Number="1" Volume="2015" Year="2015">
       <Id>d9e9a6df-bc5c-4e56-a8b0-6a7763d38f0b</Id>
     </Book>
-    <Book Series="House of M" Number="2" Volume="2015" Year="2015" Format="Crossover">
+    <Book Series="House of M" Number="2" Volume="2015" Year="2015">
       <Id>28203646-ba85-4d73-af49-1fd04939dcbe</Id>
     </Book>
-    <Book Series="House of M" Number="3" Volume="2015" Year="2015" Format="Crossover">
+    <Book Series="House of M" Number="3" Volume="2015" Year="2015">
       <Id>e4e737b8-a870-43ce-8a47-ea2eb50fdd50</Id>
     </Book>
-    <Book Series="House of M" Number="4" Volume="2015" Year="2015" Format="Crossover">
+    <Book Series="House of M" Number="4" Volume="2015" Year="2015">
       <Id>58a5af28-fe3c-4688-9bc4-df28c3231874</Id>
     </Book>
-    <Book Series="Mrs. Deadpool and the Howling Commandos: Warzones!" Number="1" Volume="2016" Year="2016" Format="Crossover">
+    <Book Series="Mrs. Deadpool and the Howling Commandos: Warzones!" Number="1" Volume="2016" Year="2016">
       <Id>8da38e41-05c7-4575-959d-0664bbc33da0</Id>
     </Book>
-    <Book Series="X-Men '92: Warzones!" Number="1" Volume="2016" Year="2016" Format="Crossover">
+    <Book Series="X-Men '92: Warzones!" Number="1" Volume="2016" Year="2016">
       <Id>2325c1ac-35e1-49d7-b198-d4897ec9ccb1</Id>
     </Book>
-    <Book Series="Secret Wars" Number="3" Volume="2015" Year="2015" Format="Crossover">
+    <Book Series="Secret Wars" Number="3" Volume="2015" Year="2015">
       <Id>855b8600-84dd-4b5d-b56f-d7aac338c9f9</Id>
     </Book>
-    <Book Series="Secret Wars" Number="4" Volume="2015" Year="2015" Format="Crossover">
+    <Book Series="Secret Wars" Number="4" Volume="2015" Year="2015">
       <Id>48830bae-ed26-4c6a-8a53-692aa68d96ea</Id>
     </Book>
-    <Book Series="Secret Wars" Number="5" Volume="2015" Year="2015" Format="Crossover">
+    <Book Series="Secret Wars" Number="5" Volume="2015" Year="2015">
       <Id>f77b6ab1-a052-4ed0-9ec4-daa98d467829</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="1" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Old Man Logan" Number="1" Volume="2015" Year="2015">
       <Id>fc8e786f-620e-4205-a635-0919a7daa695</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="2" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Old Man Logan" Number="2" Volume="2015" Year="2015">
       <Id>0e7aca85-cdd4-4285-8ac8-82790e1701f5</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="3" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Old Man Logan" Number="3" Volume="2015" Year="2015">
       <Id>8815f675-35e3-4668-adf4-aff3ff21ef59</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="4" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Old Man Logan" Number="4" Volume="2015" Year="2015">
       <Id>a73eb878-fb73-4788-92ea-cc05df3b07c9</Id>
     </Book>
-    <Book Series="Secret Wars" Number="6" Volume="2015" Year="2015" Format="Crossover">
+    <Book Series="Secret Wars" Number="6" Volume="2015" Year="2015">
       <Id>ca805e46-41b6-425f-9b47-3d4f1d70dc52</Id>
     </Book>
-    <Book Series="Secret Wars" Number="7" Volume="2015" Year="2016" Format="Crossover">
+    <Book Series="Secret Wars" Number="7" Volume="2015" Year="2016">
       <Id>26e7f22a-4566-4d7e-b5fe-f9866cb1cbb4</Id>
     </Book>
-    <Book Series="Secret Wars" Number="8" Volume="2015" Year="2016" Format="Crossover">
+    <Book Series="Secret Wars" Number="8" Volume="2015" Year="2016">
       <Id>a86052c5-b509-4986-b105-b914ba79b09f</Id>
     </Book>
-    <Book Series="Secret Wars" Number="9" Volume="2015" Year="2016" Format="Crossover">
+    <Book Series="Secret Wars" Number="9" Volume="2015" Year="2016">
       <Id>7f2eecca-d885-4705-9ec0-97fdac82fe27</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="5" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Old Man Logan" Number="5" Volume="2015" Year="2015">
       <Id>641fddde-c4fd-4226-9280-7b89f802da4e</Id>
     </Book>
   </Books>

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 016 (All New, All Different).cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 016 (All New, All Different).cbl
@@ -1,690 +1,691 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>X-Men - Part 16 (All New, All Different)</Name>
+  <Name>X-Men - Part 016 (All New, All Different)</Name>
+  <NumIssues>228</NumIssues>
   <Books>
     <Book Series="Uncanny Avengers" Number="1" Volume="2015" Year="2015">
-      <Id>847cb3f2-a2c9-4e5d-8860-c6747e960e86</Id>
+      <Database Name="cv" Series="85318" Issue="502874" />
     </Book>
     <Book Series="Uncanny Avengers" Number="2" Volume="2015" Year="2016">
-      <Id>32751086-bbfb-48d2-b7f0-2769bc3b1407</Id>
+      <Database Name="cv" Series="85318" Issue="505530" />
     </Book>
     <Book Series="Uncanny Avengers" Number="3" Volume="2015" Year="2016">
-      <Id>91f01a9d-7cb2-46ff-af68-736f3f38efb7</Id>
+      <Database Name="cv" Series="85318" Issue="507786" />
     </Book>
     <Book Series="Uncanny Avengers" Number="4" Volume="2015" Year="2016">
-      <Id>299055df-8f87-44fa-ac89-7be9482c8ac6</Id>
+      <Database Name="cv" Series="85318" Issue="510957" />
     </Book>
     <Book Series="Uncanny Avengers" Number="5" Volume="2015" Year="2016">
-      <Id>7c5bb256-18b3-40eb-b489-71ee972d3764</Id>
+      <Database Name="cv" Series="85318" Issue="513659" />
     </Book>
     <Book Series="Uncanny Avengers" Number="6" Volume="2015" Year="2016">
-      <Id>270a8243-48eb-476a-bd26-b1c59b5a8b27</Id>
+      <Database Name="cv" Series="85318" Issue="517836" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="1" Volume="2016" Year="2016">
-      <Id>f51be8fe-9243-403b-89d3-9645aaed2ef1</Id>
+      <Database Name="cv" Series="87182" Issue="510503" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="2" Volume="2016" Year="2016">
-      <Id>a8eb5a19-7961-4f00-93d7-2063009c551a</Id>
+      <Database Name="cv" Series="87182" Issue="514452" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="3" Volume="2016" Year="2016">
-      <Id>deee85d3-62c9-49b7-ae0c-dd2c4ff83516</Id>
+      <Database Name="cv" Series="87182" Issue="518867" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="4" Volume="2016" Year="2016">
-      <Id>2efb2170-f680-4207-9534-5f04232b5e8f</Id>
+      <Database Name="cv" Series="87182" Issue="526067" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="5" Volume="2016" Year="2016">
-      <Id>3cff998b-1163-4e90-a74a-b293b8c42132</Id>
+      <Database Name="cv" Series="87182" Issue="531899" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="6" Volume="2016" Year="2016">
-      <Id>3e757424-195b-46d7-9bbd-1e1f86d6c3cd</Id>
+      <Database Name="cv" Series="87182" Issue="537946" />
     </Book>
     <Book Series="Deadpool" Number="1" Volume="2015" Year="2016">
-      <Id>13b2a5d5-0044-48b1-8770-13958a126aae</Id>
+      <Database Name="cv" Series="85750" Issue="504934" />
     </Book>
     <Book Series="Deadpool" Number="2" Volume="2015" Year="2016">
-      <Id>46154334-5193-4bf9-bfb3-3a84a49b0b82</Id>
+      <Database Name="cv" Series="85750" Issue="506167" />
     </Book>
     <Book Series="Deadpool" Number="3" Volume="2015" Year="2016">
-      <Id>21c52efe-92d6-4eef-8d69-715b7ba7db29</Id>
+      <Database Name="cv" Series="85750" Issue="507770" />
     </Book>
     <Book Series="Deadpool" Number="4" Volume="2015" Year="2016">
-      <Id>95b6a5f7-eaf3-4f97-8d5f-2a4a1ec5aa4e</Id>
+      <Database Name="cv" Series="85750" Issue="508889" />
     </Book>
     <Book Series="Deadpool" Number="5" Volume="2015" Year="2016">
-      <Id>f71571f4-3a97-47a6-aecf-12122c8de202</Id>
+      <Database Name="cv" Series="85750" Issue="510493" />
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="1" Volume="2016" Year="2016">
-      <Id>72849c95-adb9-412c-bcad-04e8434a219b</Id>
+    <Book Series="Deadpool &#38; The Mercs For Money" Number="1" Volume="2016" Year="2016">
+      <Database Name="cv" Series="87793" Issue="513645" />
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="2" Volume="2016" Year="2016">
-      <Id>5caf6fe1-3799-485d-9ff0-a16396680531</Id>
+    <Book Series="Deadpool &#38; The Mercs For Money" Number="2" Volume="2016" Year="2016">
+      <Database Name="cv" Series="87793" Issue="520200" />
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="3" Volume="2016" Year="2016">
-      <Id>67f368e6-c2a6-448b-a496-30318556d58c</Id>
+    <Book Series="Deadpool &#38; The Mercs For Money" Number="3" Volume="2016" Year="2016">
+      <Database Name="cv" Series="87793" Issue="526049" />
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="4" Volume="2016" Year="2016">
-      <Id>4888961c-e72e-4c66-a7ee-df088ca70de8</Id>
+    <Book Series="Deadpool &#38; The Mercs For Money" Number="4" Volume="2016" Year="2016">
+      <Database Name="cv" Series="87793" Issue="530727" />
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="5" Volume="2016" Year="2016">
-      <Id>5c994245-d579-44f1-8da8-74e6a31607d2</Id>
+    <Book Series="Deadpool &#38; The Mercs For Money" Number="5" Volume="2016" Year="2016">
+      <Database Name="cv" Series="87793" Issue="534285" />
     </Book>
-    <Book Series="Deadpool &amp; Cable: Split Second Infinite Comic" Number="1" Volume="2015" Year="2015">
-      <Id>e5959f09-3e81-4967-a0b7-8bb06a58517d</Id>
+    <Book Series="Deadpool &#38; Cable: Split Second Infinite Comic" Number="1" Volume="2015" Year="2015">
+      <Database Name="cv" Series="85402" Issue="503451" />
     </Book>
-    <Book Series="Deadpool &amp; Cable: Split Second Infinite Comic" Number="2" Volume="2015" Year="2015">
-      <Id>79500862-89ca-4356-a18d-1636bd28ec28</Id>
+    <Book Series="Deadpool &#38; Cable: Split Second Infinite Comic" Number="2" Volume="2015" Year="2015">
+      <Database Name="cv" Series="85402" Issue="505153" />
     </Book>
-    <Book Series="Deadpool &amp; Cable: Split Second Infinite Comic" Number="3" Volume="2015" Year="2015">
-      <Id>8429217f-4faf-4bac-94bc-b8bb6a27485d</Id>
+    <Book Series="Deadpool &#38; Cable: Split Second Infinite Comic" Number="3" Volume="2015" Year="2015">
+      <Database Name="cv" Series="85402" Issue="506345" />
     </Book>
-    <Book Series="Deadpool &amp; Cable: Split Second Infinite Comic" Number="4" Volume="2015" Year="2015">
-      <Id>70286bf4-bc5f-41a6-abee-12c69b4c87e5</Id>
+    <Book Series="Deadpool &#38; Cable: Split Second Infinite Comic" Number="4" Volume="2015" Year="2015">
+      <Database Name="cv" Series="85402" Issue="507414" />
     </Book>
-    <Book Series="Deadpool &amp; Cable: Split Second Infinite Comic" Number="5" Volume="2015" Year="2015">
-      <Id>dc4e775a-a141-4f75-97cf-0809cfe5ddfa</Id>
+    <Book Series="Deadpool &#38; Cable: Split Second Infinite Comic" Number="5" Volume="2015" Year="2015">
+      <Database Name="cv" Series="85402" Issue="508607" />
     </Book>
-    <Book Series="Deadpool &amp; Cable: Split Second Infinite Comic" Number="6" Volume="2015" Year="2016">
-      <Id>e3ce6b6e-0480-4e41-8083-3b96e62e504f</Id>
+    <Book Series="Deadpool &#38; Cable: Split Second Infinite Comic" Number="6" Volume="2015" Year="2016">
+      <Database Name="cv" Series="85402" Issue="510631" />
     </Book>
     <Book Series="Old Man Logan" Number="1" Volume="2016" Year="2016">
-      <Id>2a72f82a-6f4d-4e1d-903b-a09a1a96df0b</Id>
+      <Database Name="cv" Series="87624" Issue="512432" />
     </Book>
     <Book Series="Old Man Logan" Number="2" Volume="2016" Year="2016">
-      <Id>e37bcbef-f761-46ec-8f42-4e45c75b5590</Id>
+      <Database Name="cv" Series="87624" Issue="514445" />
     </Book>
     <Book Series="Old Man Logan" Number="3" Volume="2016" Year="2016">
-      <Id>ac8fc7e0-5829-40d1-a934-8f1332a426a8</Id>
+      <Database Name="cv" Series="87624" Issue="517834" />
     </Book>
     <Book Series="Old Man Logan" Number="4" Volume="2016" Year="2016">
-      <Id>9030059c-24c3-4137-91cf-44143eb936fd</Id>
+      <Database Name="cv" Series="87624" Issue="523262" />
     </Book>
     <Book Series="Extraordinary X-Men" Number="1" Volume="2015" Year="2016">
-      <Id>8206b3fc-5540-4dd2-843d-b67113df7435</Id>
+      <Database Name="cv" Series="85756" Issue="504937" />
     </Book>
     <Book Series="Extraordinary X-Men" Number="2" Volume="2015" Year="2016">
-      <Id>db31828a-7ed4-49cb-b60e-0d918ec07c4f</Id>
+      <Database Name="cv" Series="85756" Issue="506168" />
     </Book>
     <Book Series="Extraordinary X-Men" Number="3" Volume="2015" Year="2016">
-      <Id>8d9d9b9a-71f2-457d-8cc2-bcdb946c68ce</Id>
+      <Database Name="cv" Series="85756" Issue="507180" />
     </Book>
     <Book Series="Extraordinary X-Men" Number="4" Volume="2015" Year="2016">
-      <Id>bd7351b3-a80b-4427-8fda-50498ff8dbaf</Id>
+      <Database Name="cv" Series="85756" Issue="508890" />
     </Book>
     <Book Series="Extraordinary X-Men" Number="5" Volume="2015" Year="2016">
-      <Id>a8dbbab0-b65e-44cd-bdca-45cdad563f05</Id>
+      <Database Name="cv" Series="85756" Issue="510940" />
     </Book>
     <Book Series="Uncanny X-Men" Number="1" Volume="2016" Year="2016">
-      <Id>d3fc6ab6-c92d-444d-b268-8e20a70be29f</Id>
+      <Database Name="cv" Series="87190" Issue="510510" />
     </Book>
     <Book Series="Uncanny X-Men" Number="2" Volume="2016" Year="2016">
-      <Id>2895223e-f67c-47f1-af1e-880da2815d74</Id>
+      <Database Name="cv" Series="87190" Issue="511529" />
     </Book>
     <Book Series="Uncanny X-Men" Number="3" Volume="2016" Year="2016">
-      <Id>b66fe91b-477d-4974-a079-0b64b55fbcd7</Id>
+      <Database Name="cv" Series="87190" Issue="513660" />
     </Book>
     <Book Series="Uncanny X-Men" Number="4" Volume="2016" Year="2016">
-      <Id>02dbc454-09c0-404a-954d-59de38c4c18b</Id>
+      <Database Name="cv" Series="87190" Issue="517837" />
     </Book>
     <Book Series="Uncanny X-Men" Number="5" Volume="2016" Year="2016">
-      <Id>603ba46d-7c1c-49a1-af91-c8e89c116f38</Id>
+      <Database Name="cv" Series="87190" Issue="521347" />
     </Book>
     <Book Series="All-New X-Men" Number="1" Volume="2015" Year="2016">
-      <Id>a0dd1ad1-5ceb-427b-bc93-75cc821b70f2</Id>
+      <Database Name="cv" Series="86334" Issue="507175" />
     </Book>
     <Book Series="All-New X-Men" Number="2" Volume="2015" Year="2016">
-      <Id>6673441c-4f4b-4893-afeb-ffca8846cfe0</Id>
+      <Database Name="cv" Series="86334" Issue="508422" />
     </Book>
     <Book Series="All-New X-Men" Number="3" Volume="2015" Year="2016">
-      <Id>ed77379d-df14-4b72-a57e-675b52effc86</Id>
+      <Database Name="cv" Series="86334" Issue="510935" />
     </Book>
     <Book Series="All-New Wolverine" Number="1" Volume="2015" Year="2016">
-      <Id>335c2f44-46a4-4dfc-a329-a9b0e2d335d2</Id>
+      <Database Name="cv" Series="85930" Issue="505513" />
     </Book>
     <Book Series="All-New Wolverine" Number="2" Volume="2015" Year="2016">
-      <Id>d16c4f31-f2f0-45c4-872b-214386c1b700</Id>
+      <Database Name="cv" Series="85930" Issue="506646" />
     </Book>
     <Book Series="All-New Wolverine" Number="3" Volume="2015" Year="2016">
-      <Id>3dc08010-1254-498b-9220-7c24dd2226ed</Id>
+      <Database Name="cv" Series="85930" Issue="509695" />
     </Book>
     <Book Series="All-New Wolverine" Number="4" Volume="2015" Year="2016">
-      <Id>b1c949f6-27ba-496f-9546-574c38a6f3b3</Id>
+      <Database Name="cv" Series="85930" Issue="510934" />
     </Book>
     <Book Series="All-New Wolverine" Number="5" Volume="2015" Year="2016">
-      <Id>6b51de20-e79a-4646-bdaf-8dd25b83901e</Id>
+      <Database Name="cv" Series="85930" Issue="514430" />
     </Book>
     <Book Series="All-New Wolverine" Number="6" Volume="2015" Year="2016">
-      <Id>531cab4a-6f56-4ac4-b3fc-ef2ebe868022</Id>
+      <Database Name="cv" Series="85930" Issue="518850" />
     </Book>
     <Book Series="All-New Wolverine" Number="7" Volume="2015" Year="2016">
-      <Id>f66fbc3d-78db-491f-912d-72454e850389</Id>
+      <Database Name="cv" Series="85930" Issue="527130" />
     </Book>
     <Book Series="Extraordinary X-Men" Number="6" Volume="2015" Year="2016">
-      <Id>3ddec9dd-1b62-4658-ad5b-c5eb92e1efba</Id>
+      <Database Name="cv" Series="85756" Issue="512423" />
     </Book>
     <Book Series="Extraordinary X-Men" Number="7" Volume="2015" Year="2016">
-      <Id>d525d055-6caa-4e70-8627-94ca05dfb5bf</Id>
+      <Database Name="cv" Series="85756" Issue="516083" />
     </Book>
     <Book Series="All-New X-Men" Number="4" Volume="2015" Year="2016">
-      <Id>394be398-6a9d-4f38-98bf-4a29bf0079cb</Id>
+      <Database Name="cv" Series="86334" Issue="514431" />
     </Book>
     <Book Series="All-New X-Men" Number="5" Volume="2015" Year="2016">
-      <Id>494c25ed-51a3-4f68-9417-9ef0555b4269</Id>
+      <Database Name="cv" Series="86334" Issue="516946" />
     </Book>
     <Book Series="All-New X-Men" Number="6" Volume="2015" Year="2016">
-      <Id>e2eddf5e-9e26-44e3-b956-1bb9992247dc</Id>
+      <Database Name="cv" Series="86334" Issue="520195" />
     </Book>
     <Book Series="All-New X-Men" Number="7" Volume="2015" Year="2016">
-      <Id>a390c6b2-2484-41e6-8f36-0e49d3f45c21</Id>
+      <Database Name="cv" Series="86334" Issue="522423" />
     </Book>
     <Book Series="All-New X-Men" Number="8" Volume="2015" Year="2016">
-      <Id>ecdc8f29-e369-4b16-9aef-a595c02d2a86</Id>
+      <Database Name="cv" Series="86334" Issue="525018" />
     </Book>
     <Book Series="Uncanny Avengers" Number="7" Volume="2015" Year="2016">
-      <Id>9b775e08-41b3-4b9c-a19a-8f64ffa7e18a</Id>
+      <Database Name="cv" Series="85318" Issue="518870" />
     </Book>
     <Book Series="Uncanny Avengers" Number="8" Volume="2015" Year="2016">
-      <Id>be6fcb91-bb49-4f36-8498-bfec4ff49a09</Id>
+      <Database Name="cv" Series="85318" Issue="523268" />
     </Book>
     <Book Series="Uncanny Avengers" Number="9" Volume="2015" Year="2016">
-      <Id>bab3d44a-cd8c-4d4d-b524-ebf900a0308c</Id>
+      <Database Name="cv" Series="85318" Issue="530745" />
     </Book>
     <Book Series="Uncanny Avengers" Number="10" Volume="2015" Year="2016">
-      <Id>4ad11ea6-772f-438f-8711-510ade669574</Id>
+      <Database Name="cv" Series="85318" Issue="537252" />
     </Book>
     <Book Series="Uncanny Avengers" Number="11" Volume="2015" Year="2016">
-      <Id>d5d25586-5136-4750-a4a1-be914285395f</Id>
+      <Database Name="cv" Series="85318" Issue="541225" />
     </Book>
     <Book Series="Uncanny Avengers" Number="12" Volume="2015" Year="2016">
-      <Id>5989cb4f-13ef-44a8-a423-a8ba47818442</Id>
+      <Database Name="cv" Series="85318" Issue="544998" />
     </Book>
     <Book Series="Extraordinary X-Men" Number="8" Volume="2015" Year="2016">
-      <Id>d097487c-74b0-470a-97ab-d1e0c27758cd</Id>
+      <Database Name="cv" Series="85756" Issue="520201" />
     </Book>
     <Book Series="Extraordinary X-Men" Number="9" Volume="2015" Year="2016">
-      <Id>c7146472-857e-42e5-b536-d6c0be5978e3</Id>
+      <Database Name="cv" Series="85756" Issue="526051" />
     </Book>
     <Book Series="Extraordinary X-Men" Number="10" Volume="2015" Year="2016">
-      <Id>88d01db8-c87d-4043-aec7-b8fcf1104318</Id>
+      <Database Name="cv" Series="85756" Issue="531882" />
     </Book>
     <Book Series="Extraordinary X-Men" Number="11" Volume="2015" Year="2016">
-      <Id>041d5b29-aad3-4711-b340-979127368117</Id>
+      <Database Name="cv" Series="85756" Issue="537938" />
     </Book>
     <Book Series="Extraordinary X-Men" Number="12" Volume="2015" Year="2016">
-      <Id>8d877a17-5ff5-4c90-8314-d2619f58c3c8</Id>
+      <Database Name="cv" Series="85756" Issue="541202" />
     </Book>
     <Book Series="Uncanny X-Men" Number="6" Volume="2016" Year="2016">
-      <Id>53e3d0b2-d2d8-422a-b993-0d86c8659ec7</Id>
+      <Database Name="cv" Series="87190" Issue="523269" />
     </Book>
     <Book Series="Uncanny X-Men" Number="7" Volume="2016" Year="2016">
-      <Id>39e91a78-2bc1-4486-85aa-911ac4d09ef5</Id>
+      <Database Name="cv" Series="87190" Issue="528525" />
     </Book>
     <Book Series="Uncanny X-Men" Number="8" Volume="2016" Year="2016">
-      <Id>544383b3-9767-4f99-82b2-719033bd2844</Id>
+      <Database Name="cv" Series="87190" Issue="535372" />
     </Book>
     <Book Series="Uncanny X-Men" Number="9" Volume="2016" Year="2016">
-      <Id>9f07e32b-759a-413c-a562-4344c6da1da9</Id>
+      <Database Name="cv" Series="87190" Issue="537956" />
     </Book>
     <Book Series="Uncanny X-Men" Number="10" Volume="2016" Year="2016">
-      <Id>343c5bcc-703c-43c9-a312-341786ca2c4b</Id>
+      <Database Name="cv" Series="87190" Issue="540092" />
     </Book>
     <Book Series="All-New X-Men" Number="9" Volume="2015" Year="2016">
-      <Id>3086a969-30cb-453f-84c5-1739eedb2233</Id>
+      <Database Name="cv" Series="86334" Issue="529649" />
     </Book>
     <Book Series="All-New X-Men" Number="10" Volume="2015" Year="2016">
-      <Id>5d81630d-7f4d-42d5-aafb-cf4ce51fadb8</Id>
+      <Database Name="cv" Series="86334" Issue="534277" />
     </Book>
     <Book Series="All-New X-Men" Number="11" Volume="2015" Year="2016">
-      <Id>43f2100b-8f81-42bd-80ce-6dc78784f0bf</Id>
+      <Database Name="cv" Series="86334" Issue="539233" />
     </Book>
     <Book Series="Old Man Logan" Number="5" Volume="2016" Year="2016">
-      <Id>cac698f3-da06-4405-91c9-d717fb94f0b3</Id>
+      <Database Name="cv" Series="87624" Issue="527149" />
     </Book>
     <Book Series="Old Man Logan" Number="6" Volume="2016" Year="2016">
-      <Id>cd726e06-8e1e-4969-a4cc-d6a95758ed46</Id>
+      <Database Name="cv" Series="87624" Issue="530733" />
     </Book>
     <Book Series="Old Man Logan" Number="7" Volume="2016" Year="2016">
-      <Id>a94572c3-db71-4ccc-9863-23ebf49dca2f</Id>
+      <Database Name="cv" Series="87624" Issue="533033" />
     </Book>
     <Book Series="Old Man Logan" Number="8" Volume="2016" Year="2016">
-      <Id>1e3ad2e7-23bf-4317-88d9-cb6ec66d4931</Id>
+      <Database Name="cv" Series="87624" Issue="539248" />
     </Book>
     <Book Series="Old Man Logan" Number="9" Volume="2016" Year="2016">
-      <Id>f74cb549-09a7-4169-845a-92af76b831c2</Id>
+      <Database Name="cv" Series="87624" Issue="541216" />
     </Book>
     <Book Series="Old Man Logan" Number="10" Volume="2016" Year="2016">
-      <Id>7f7abf51-d163-4fa7-b341-63a180aabb4e</Id>
+      <Database Name="cv" Series="87624" Issue="543754" />
     </Book>
     <Book Series="Old Man Logan" Number="11" Volume="2016" Year="2016">
-      <Id>e963b6a6-bf7e-4f87-9b11-1aabe893cf1a</Id>
+      <Database Name="cv" Series="87624" Issue="549520" />
     </Book>
     <Book Series="Old Man Logan" Number="12" Volume="2016" Year="2016">
-      <Id>5db04824-e767-47e9-a3bf-086f303cdb99</Id>
+      <Database Name="cv" Series="87624" Issue="553017" />
     </Book>
     <Book Series="Old Man Logan" Number="13" Volume="2016" Year="2017">
-      <Id>f15ed69b-2391-42e4-8272-8fe8d21b9bf3</Id>
+      <Database Name="cv" Series="87624" Issue="558419" />
     </Book>
     <Book Series="Deadpool" Number="3.1" Volume="2015" Year="2016">
-      <Id>fa165c09-8087-4a42-84e4-99ea16c2ba80</Id>
+      <Database Name="cv" Series="85750" Issue="508427" />
     </Book>
     <Book Series="Deadpool" Number="6" Volume="2015" Year="2016">
-      <Id>c615a1e1-6745-45d8-9cfa-a0760459aa27</Id>
+      <Database Name="cv" Series="85750" Issue="511510" />
     </Book>
     <Book Series="Deadpool" Number="7" Volume="2015" Year="2016">
-      <Id>0b997c7d-df33-46ad-b6ca-7da5097ccb80</Id>
+      <Database Name="cv" Series="85750" Issue="514435" />
     </Book>
     <Book Series="Deadpool" Number="8" Volume="2015" Year="2016">
-      <Id>c88d3fe6-77fa-4344-be77-7dd20f260af2</Id>
+      <Database Name="cv" Series="85750" Issue="517827" />
     </Book>
     <Book Series="Deadpool" Number="9" Volume="2015" Year="2016">
-      <Id>2037fb23-03f0-4abb-afbc-53b4676da45b</Id>
+      <Database Name="cv" Series="85750" Issue="523253" />
     </Book>
     <Book Series="Deadpool" Number="10" Volume="2015" Year="2016">
-      <Id>b2ef5640-9d43-4d68-9912-723c3d4d18a5</Id>
+      <Database Name="cv" Series="85750" Issue="526047" />
     </Book>
     <Book Series="Deadpool" Number="11" Volume="2015" Year="2016">
-      <Id>436521e4-7a1f-47bf-bd7d-8ce072d585a6</Id>
+      <Database Name="cv" Series="85750" Issue="529655" />
     </Book>
     <Book Series="Deadpool" Number="12" Volume="2015" Year="2016">
-      <Id>22e38844-9d2c-4775-a090-6ead5000062b</Id>
+      <Database Name="cv" Series="85750" Issue="531878" />
     </Book>
     <Book Series="Deadpool" Number="13" Volume="2015" Year="2016">
-      <Id>a16b743f-47f1-4f90-bb76-1e3d52cd9827</Id>
+      <Database Name="cv" Series="85750" Issue="533029" />
     </Book>
     <Book Series="Deadpool: Last Days of Magic" Number="1" Volume="2016" Year="2016">
-      <Id>5867d2a6-778c-4847-8a23-d4f3ebbcf58f</Id>
+      <Database Name="cv" Series="90523" Issue="530726" />
     </Book>
     <Book Series="All-New Wolverine" Number="8" Volume="2015" Year="2016">
-      <Id>3f76f8c5-d740-4779-9726-542889a960f6</Id>
+      <Database Name="cv" Series="85930" Issue="530722" />
     </Book>
     <Book Series="All-New Wolverine" Number="9" Volume="2015" Year="2016">
-      <Id>0c073db9-342a-474e-b453-8ae242db0edc</Id>
+      <Database Name="cv" Series="85930" Issue="533025" />
     </Book>
     <Book Series="The Totally Awesome Hulk" Number="8" Volume="2015" Year="2016">
-      <Id>d8b92e43-8821-4924-b86d-ef693b4ac68e</Id>
+      <Database Name="cv" Series="86408" Issue="538523" />
     </Book>
     <Book Series="Civil War II" Number="1" Volume="2016" Year="2016">
-      <Id>1e1faaa3-336f-4103-85b0-41cc78f95a69</Id>
+      <Database Name="cv" Series="90521" Issue="533027" />
     </Book>
     <Book Series="Deadpool" Number="14" Volume="2015" Year="2016">
-      <Id>333c751d-2dae-4cad-bcf8-978b4dbe074e</Id>
+      <Database Name="cv" Series="85750" Issue="535352" />
     </Book>
     <Book Series="Deadpool" Number="15" Volume="2015" Year="2016">
-      <Id>7a962298-5b07-4ac7-9138-b838adaa5ad5</Id>
+      <Database Name="cv" Series="85750" Issue="539241" />
     </Book>
     <Book Series="Deadpool" Number="16" Volume="2015" Year="2016">
-      <Id>cdcc22bd-1ed6-4f1e-b34a-02ed41d191c0</Id>
+      <Database Name="cv" Series="85750" Issue="542618" />
     </Book>
     <Book Series="Deadpool" Number="17" Volume="2015" Year="2016">
-      <Id>2074bfc2-5f9a-46cc-a860-b38fc11e4894</Id>
+      <Database Name="cv" Series="85750" Issue="546054" />
     </Book>
     <Book Series="Civil War II" Number="2" Volume="2016" Year="2016">
-      <Id>f8ce50d4-0280-4cfc-863e-f935e8888348</Id>
+      <Database Name="cv" Series="90521" Issue="535350" />
     </Book>
     <Book Series="All-New Wolverine" Number="10" Volume="2015" Year="2016">
-      <Id>c2b36531-5aec-4403-b2b2-41ea76f877ec</Id>
+      <Database Name="cv" Series="85930" Issue="540068" />
     </Book>
     <Book Series="All-New Wolverine" Number="11" Volume="2015" Year="2016">
-      <Id>8d30f0a0-d6d8-4aa2-b607-c00637b4e07e</Id>
+      <Database Name="cv" Series="85930" Issue="544978" />
     </Book>
     <Book Series="All-New Wolverine" Number="12" Volume="2015" Year="2016">
-      <Id>1edb8fbc-b176-4755-839b-480265fbedca</Id>
+      <Database Name="cv" Series="85930" Issue="550343" />
     </Book>
     <Book Series="Civil War II" Number="3" Volume="2016" Year="2016">
-      <Id>e531c6c6-93b1-429a-b3e2-1a3179c984ce</Id>
+      <Database Name="cv" Series="90521" Issue="539234" />
     </Book>
     <Book Series="Uncanny Avengers" Number="13" Volume="2015" Year="2016">
-      <Id>b4ce8201-722f-496b-bdc5-eaad2e83b428</Id>
+      <Database Name="cv" Series="85318" Issue="547297" />
     </Book>
     <Book Series="Civil War II" Number="4" Volume="2016" Year="2016">
-      <Id>d7244968-f7d7-4246-bad5-447dd1cfb37b</Id>
+      <Database Name="cv" Series="90521" Issue="541199" />
     </Book>
     <Book Series="Civil War II: X-Men" Number="1" Volume="2016" Year="2016">
-      <Id>f46bf797-65e0-464c-a526-841673da3729</Id>
+      <Database Name="cv" Series="91275" Issue="535351" />
     </Book>
     <Book Series="Civil War II: X-Men" Number="2" Volume="2016" Year="2016">
-      <Id>75098f64-2206-43c4-8049-bca4cf32dda9</Id>
+      <Database Name="cv" Series="91275" Issue="538504" />
     </Book>
     <Book Series="Civil War II: X-Men" Number="3" Volume="2016" Year="2016">
-      <Id>9cc8efba-4a98-46ae-b150-61d76e16be4e</Id>
+      <Database Name="cv" Series="91275" Issue="544984" />
     </Book>
     <Book Series="Civil War II: X-Men" Number="4" Volume="2016" Year="2016">
-      <Id>268db7a8-4492-4187-99a7-ecb634446569</Id>
+      <Database Name="cv" Series="91275" Issue="550353" />
     </Book>
     <Book Series="Uncanny Avengers" Number="14" Volume="2015" Year="2016">
-      <Id>f74108e6-eb28-457d-afe9-e6a262dffc28</Id>
+      <Database Name="cv" Series="85318" Issue="549528" />
     </Book>
     <Book Series="Deadpool" Number="18" Volume="2015" Year="2016">
-      <Id>d6eb55db-1246-43ae-827d-3837fd819999</Id>
+      <Database Name="cv" Series="85750" Issue="549516" />
     </Book>
     <Book Series="Civil War II" Number="5" Volume="2016" Year="2016">
-      <Id>1a26881e-97e1-4e2b-8cd4-8b5d3ca97295</Id>
+      <Database Name="cv" Series="90521" Issue="550351" />
     </Book>
     <Book Series="Civil War II" Number="6" Volume="2016" Year="2016">
-      <Id>99389268-e40a-419d-b320-730a218f285f</Id>
+      <Database Name="cv" Series="90521" Issue="555515" />
     </Book>
     <Book Series="Civil War II" Number="7" Volume="2016" Year="2017">
-      <Id>5e2043b9-d846-4a9b-ae0a-9a17fe6c233e</Id>
+      <Database Name="cv" Series="90521" Issue="558959" />
     </Book>
     <Book Series="Civil War II" Number="8" Volume="2016" Year="2017">
-      <Id>6634f12a-96e5-4552-b0f0-08a89186be8a</Id>
+      <Database Name="cv" Series="90521" Issue="571661" />
     </Book>
     <Book Series="Uncanny Avengers" Number="15" Volume="2015" Year="2016">
-      <Id>ea057646-7bb2-42d2-a8bc-87f77a5b29d4</Id>
+      <Database Name="cv" Series="85318" Issue="553025" />
     </Book>
     <Book Series="Uncanny Avengers" Number="16" Volume="2015" Year="2017">
-      <Id>9cb6e4b6-9eb2-4951-9655-ea51dfc03307</Id>
+      <Database Name="cv" Series="85318" Issue="557380" />
     </Book>
     <Book Series="Uncanny Avengers" Number="17" Volume="2015" Year="2017">
-      <Id>79100cd8-61c7-4c72-83b8-a68e0edc104b</Id>
+      <Database Name="cv" Series="85318" Issue="566727" />
     </Book>
     <Book Series="Deadpool" Number="19" Volume="2015" Year="2016">
-      <Id>e160cf20-daa1-4e09-9165-c44c230dc466</Id>
+      <Database Name="cv" Series="85750" Issue="551301" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="7" Volume="2016" Year="2016">
-      <Id>2f3e708a-6e26-48aa-a234-81a01b716b75</Id>
+      <Database Name="cv" Series="87182" Issue="540083" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="8" Volume="2016" Year="2016">
-      <Id>0487ffd2-3b26-41a1-a674-30f3ca21159a</Id>
+      <Database Name="cv" Series="87182" Issue="543757" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="9" Volume="2016" Year="2016">
-      <Id>55eccc15-4105-40f9-abba-5416f03a4594</Id>
+      <Database Name="cv" Series="87182" Issue="551317" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="10" Volume="2016" Year="2016">
-      <Id>5d7495b4-941e-4677-a770-75fae3e0d447</Id>
+      <Database Name="cv" Series="87182" Issue="555539" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="11" Volume="2016" Year="2017">
-      <Id>f701b7a7-ee5e-454a-8463-a384a0c80b71</Id>
+      <Database Name="cv" Series="87182" Issue="557376" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="12" Volume="2016" Year="2017">
-      <Id>1e76fddf-dbcb-4e84-aa3f-6d911b0f8bfb</Id>
+      <Database Name="cv" Series="87182" Issue="571683" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="13" Volume="2016" Year="2017">
-      <Id>5c494806-1cc8-417a-ab4e-e4aebc41f089</Id>
+      <Database Name="cv" Series="87182" Issue="575883" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="14" Volume="2016" Year="2017">
-      <Id>ac88dcd9-5a46-4d90-91a0-1104e758da79</Id>
+      <Database Name="cv" Series="87182" Issue="582545" />
     </Book>
     <Book Series="Extraordinary X-Men Annual" Number="1" Volume="2016" Year="2016">
-      <Id>51691418-58a9-4fdc-aa1f-102974c287fb</Id>
+      <Database Name="cv" Series="94271" Issue="550357" />
     </Book>
     <Book Series="Extraordinary X-Men" Number="13" Volume="2015" Year="2016">
-      <Id>08fd0f82-29da-4538-9a63-da9687b9c93f</Id>
+      <Database Name="cv" Series="85756" Issue="546057" />
     </Book>
     <Book Series="Extraordinary X-Men" Number="14" Volume="2015" Year="2016">
-      <Id>508dfe51-ef8c-4385-829f-78610722b786</Id>
+      <Database Name="cv" Series="85756" Issue="551305" />
     </Book>
     <Book Series="Extraordinary X-Men" Number="15" Volume="2015" Year="2016">
-      <Id>26e877a7-cc09-4cc6-a6ad-78654b177b0b</Id>
+      <Database Name="cv" Series="85756" Issue="555521" />
     </Book>
     <Book Series="Extraordinary X-Men" Number="16" Volume="2015" Year="2017">
-      <Id>c19ec373-b66d-4860-aa82-44c91464888f</Id>
+      <Database Name="cv" Series="85756" Issue="562593" />
     </Book>
     <Book Series="All-New X-Men" Number="12" Volume="2015" Year="2016">
-      <Id>b009f763-03b1-4a72-93c8-f8b212fc86cf</Id>
+      <Database Name="cv" Series="86334" Issue="543744" />
     </Book>
     <Book Series="All-New X-Men" Number="13" Volume="2015" Year="2016">
-      <Id>1ee8e21a-ab6f-4cab-9b15-da9e1d593a7b</Id>
+      <Database Name="cv" Series="86334" Issue="549510" />
     </Book>
     <Book Series="All-New X-Men" Number="14" Volume="2015" Year="2016">
-      <Id>c7b77933-66a5-442a-954f-a21f8e5d6b4e</Id>
+      <Database Name="cv" Series="86334" Issue="553944" />
     </Book>
     <Book Series="All-New X-Men" Number="15" Volume="2015" Year="2017">
-      <Id>8ca9a4d9-07f2-4bbf-8a12-b4223fe46286</Id>
+      <Database Name="cv" Series="86334" Issue="557353" />
     </Book>
     <Book Series="All-New X-Men" Number="16" Volume="2015" Year="2017">
-      <Id>fbe3fd2f-a4e2-42b4-b9c5-aa46da99af79</Id>
+      <Database Name="cv" Series="86334" Issue="566702" />
     </Book>
     <Book Series="All-New X-Men Annual" Number="1" Volume="2016" Year="2017">
-      <Id>31793aae-6372-4a32-8f84-c1679be32cfd</Id>
+      <Database Name="cv" Series="95807" Issue="558952" />
     </Book>
     <Book Series="Uncanny X-Men" Number="11" Volume="2016" Year="2016">
-      <Id>692ff962-c165-4f68-9f95-8ff38437e753</Id>
+      <Database Name="cv" Series="87190" Issue="542634" />
     </Book>
     <Book Series="Uncanny X-Men" Number="12" Volume="2016" Year="2016">
-      <Id>209239ae-380a-4d51-b3f2-f9a4cc7383ca</Id>
+      <Database Name="cv" Series="87190" Issue="548588" />
     </Book>
     <Book Series="Uncanny X-Men" Number="13" Volume="2016" Year="2016">
-      <Id>562349b0-7f5b-4a08-a836-48725270fe3d</Id>
+      <Database Name="cv" Series="87190" Issue="550370" />
     </Book>
     <Book Series="Uncanny X-Men" Number="14" Volume="2016" Year="2016">
-      <Id>bfbdbcc4-3c9d-4a7d-894f-3a820d840524</Id>
+      <Database Name="cv" Series="87190" Issue="552174" />
     </Book>
     <Book Series="Uncanny X-Men" Number="15" Volume="2016" Year="2017">
-      <Id>3580afb5-e947-4ec0-b63e-f01a0a20ed46</Id>
+      <Database Name="cv" Series="87190" Issue="557381" />
     </Book>
     <Book Series="Uncanny X-Men Annual" Number="1" Volume="2016" Year="2017">
-      <Id>abcb6d7e-15bf-4f7d-9ed6-c6c687c31bd0</Id>
+      <Database Name="cv" Series="95754" Issue="558428" />
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="1" Volume="2016" Year="2016">
-      <Id>3a27f24b-7032-4436-9593-84cae63f0a85</Id>
+    <Book Series="Deadpool &#38; The Mercs For Money" Number="1" Volume="2016" Year="2016">
+      <Database Name="cv" Series="92360" Issue="540074" />
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="2" Volume="2016" Year="2016">
-      <Id>c379a511-91b0-4ea0-9471-00ea2b1479ce</Id>
+    <Book Series="Deadpool &#38; The Mercs For Money" Number="2" Volume="2016" Year="2016">
+      <Database Name="cv" Series="92360" Issue="543751" />
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="3" Volume="2016" Year="2016">
-      <Id>b013c149-3d9b-4417-99b1-44802faed9bf</Id>
+    <Book Series="Deadpool &#38; The Mercs For Money" Number="3" Volume="2016" Year="2016">
+      <Database Name="cv" Series="92360" Issue="548574" />
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="4" Volume="2016" Year="2016">
-      <Id>131d9cc6-7f20-4653-9bb4-081cfbacfa8d</Id>
+    <Book Series="Deadpool &#38; The Mercs For Money" Number="4" Volume="2016" Year="2016">
+      <Database Name="cv" Series="92360" Issue="552156" />
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="5" Volume="2016" Year="2017">
-      <Id>65ff5a3f-25ab-49e5-83ce-662c19b69af2</Id>
+    <Book Series="Deadpool &#38; The Mercs For Money" Number="5" Volume="2016" Year="2017">
+      <Database Name="cv" Series="92360" Issue="556470" />
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="6" Volume="2016" Year="2017">
-      <Id>3541f223-4421-4240-9136-3231931e9bfa</Id>
+    <Book Series="Deadpool &#38; The Mercs For Money" Number="6" Volume="2016" Year="2017">
+      <Database Name="cv" Series="92360" Issue="569328" />
     </Book>
     <Book Series="All-New Wolverine Annual" Number="1" Volume="2016" Year="2016">
-      <Id>8902210a-974c-4b50-96be-1bed53a77232</Id>
+      <Database Name="cv" Series="93642" Issue="547267" />
     </Book>
     <Book Series="All-New Wolverine" Number="13" Volume="2015" Year="2016">
-      <Id>b63ef5f7-c888-499b-9748-9b32f603945b</Id>
+      <Database Name="cv" Series="85930" Issue="552151" />
     </Book>
     <Book Series="All-New Wolverine" Number="14" Volume="2015" Year="2017">
-      <Id>95d044e9-7c70-4308-9d2b-5d55d2f98888</Id>
+      <Database Name="cv" Series="85930" Issue="558407" />
     </Book>
     <Book Series="All-New Wolverine" Number="15" Volume="2015" Year="2017">
-      <Id>90646286-ea00-4b7d-bb83-65862b314d1c</Id>
+      <Database Name="cv" Series="85930" Issue="563715" />
     </Book>
     <Book Series="All-New Wolverine" Number="16" Volume="2015" Year="2017">
-      <Id>eccd2aa5-1826-4509-9545-a3aae58d6989</Id>
+      <Database Name="cv" Series="85930" Issue="575855" />
     </Book>
     <Book Series="All-New Wolverine" Number="17" Volume="2015" Year="2017">
-      <Id>86dfada8-fd24-4f11-8743-42dc77c2fdcb</Id>
+      <Database Name="cv" Series="85930" Issue="580739" />
     </Book>
     <Book Series="All-New Wolverine" Number="18" Volume="2015" Year="2017">
-      <Id>69a3b4ed-133e-4d8e-a27c-407b28295f3f</Id>
+      <Database Name="cv" Series="85930" Issue="585074" />
     </Book>
     <Book Series="Old Man Logan" Number="14" Volume="2016" Year="2017">
-      <Id>516e66a9-24e4-4ce7-ba3c-427b5c1ff10f</Id>
+      <Database Name="cv" Series="87624" Issue="562602" />
     </Book>
     <Book Series="Old Man Logan" Number="15" Volume="2016" Year="2017">
-      <Id>9f132300-8920-478d-b6ad-16065ebf9003</Id>
+      <Database Name="cv" Series="87624" Issue="566719" />
     </Book>
     <Book Series="Old Man Logan" Number="16" Volume="2016" Year="2017">
-      <Id>6dd7c809-75ab-4670-83e7-2075a5b4295b</Id>
+      <Database Name="cv" Series="87624" Issue="574873" />
     </Book>
     <Book Series="Old Man Logan" Number="17" Volume="2016" Year="2017">
-      <Id>be55e612-5e72-4fac-80d5-104408a5744f</Id>
+      <Database Name="cv" Series="87624" Issue="579321" />
     </Book>
     <Book Series="Old Man Logan" Number="18" Volume="2016" Year="2017">
-      <Id>eae2be90-689e-4189-9aa8-a4c086f11a79</Id>
+      <Database Name="cv" Series="87624" Issue="581563" />
     </Book>
     <Book Series="Old Man Logan" Number="19" Volume="2016" Year="2017">
-      <Id>d494709b-7974-4268-bd83-af772b3bc917</Id>
+      <Database Name="cv" Series="87624" Issue="585089" />
     </Book>
     <Book Series="Old Man Logan" Number="20" Volume="2016" Year="2017">
-      <Id>96295009-be90-4b57-9c9b-0be19702197f</Id>
+      <Database Name="cv" Series="87624" Issue="589835" />
     </Book>
     <Book Series="Old Man Logan" Number="21" Volume="2016" Year="2017">
-      <Id>5c299e66-b443-465e-aee3-4fcf60f89770</Id>
+      <Database Name="cv" Series="87624" Issue="591764" />
     </Book>
     <Book Series="Old Man Logan" Number="22" Volume="2016" Year="2017">
-      <Id>f8640cdd-5ed2-404e-ac54-7316ace835d7</Id>
+      <Database Name="cv" Series="87624" Issue="593269" />
     </Book>
     <Book Series="Old Man Logan" Number="23" Volume="2016" Year="2017">
-      <Id>e3507e2c-050b-48db-b1d8-b88c3b8349c9</Id>
+      <Database Name="cv" Series="87624" Issue="594969" />
     </Book>
     <Book Series="Old Man Logan" Number="24" Volume="2016" Year="2017">
-      <Id>1a0e423e-1cc8-448c-85c0-7a9dcb81819e</Id>
+      <Database Name="cv" Series="87624" Issue="598382" />
     </Book>
     <Book Series="Death of X" Number="1" Volume="2016" Year="2016">
-      <Id>2a2e99d2-e8c7-4c97-942f-279d4b16ada9</Id>
+      <Database Name="cv" Series="94620" Issue="552158" />
     </Book>
     <Book Series="Death of X" Number="2" Volume="2016" Year="2016">
-      <Id>c7f2bf69-7011-4e83-93cd-f8d7983bca09</Id>
+      <Database Name="cv" Series="94620" Issue="553955" />
     </Book>
     <Book Series="Death of X" Number="3" Volume="2016" Year="2017">
-      <Id>85c3bcc0-29dd-4f64-8062-4b0d378e2dcf</Id>
+      <Database Name="cv" Series="94620" Issue="556471" />
     </Book>
     <Book Series="Death of X" Number="4" Volume="2016" Year="2017">
-      <Id>ef61d9b1-bee3-4990-8474-e7c75962ef7e</Id>
+      <Database Name="cv" Series="94620" Issue="558962" />
     </Book>
     <Book Series="IvX" Number="0" Volume="2016" Year="2017">
-      <Id>948da7a8-f7db-4a2b-8b35-25bdcec43b7d</Id>
+      <Database Name="cv" Series="96144" Issue="562597" />
     </Book>
     <Book Series="IvX" Number="1" Volume="2016" Year="2017">
-      <Id>160da639-153a-4ad8-b4d7-1556a7118ced</Id>
+      <Database Name="cv" Series="96144" Issue="566713" />
     </Book>
     <Book Series="Uncanny X-Men" Number="16" Volume="2016" Year="2017">
-      <Id>3c23e41f-8937-4c2c-9866-19d293450e90</Id>
+      <Database Name="cv" Series="87190" Issue="569354" />
     </Book>
     <Book Series="Extraordinary X-Men" Number="17" Volume="2015" Year="2017">
-      <Id>33b7ac85-4fba-4a8c-b86b-8a6dabd01614</Id>
+      <Database Name="cv" Series="85756" Issue="571665" />
     </Book>
     <Book Series="IvX" Number="2" Volume="2016" Year="2017">
-      <Id>58cd78e6-5988-4943-8136-7d4f53644613</Id>
+      <Database Name="cv" Series="96144" Issue="575870" />
     </Book>
     <Book Series="Uncanny X-Men" Number="17" Volume="2016" Year="2017">
-      <Id>ce8da992-8061-432f-9f37-4c9e3b4c7824</Id>
+      <Database Name="cv" Series="87190" Issue="575887" />
     </Book>
     <Book Series="Uncanny Inhumans" Number="18" Volume="2015" Year="2017">
-      <Id>6b47e7d1-e4ba-4183-a46c-df5186924c3e</Id>
+      <Database Name="cv" Series="81092" Issue="576641" />
     </Book>
     <Book Series="All-New X-Men" Number="17" Volume="2015" Year="2017">
-      <Id>2d70ad25-f792-4651-a625-196ad4734ace</Id>
+      <Database Name="cv" Series="86334" Issue="576612" />
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="7" Volume="2016" Year="2017">
-      <Id>9ee30fd9-c5dc-4927-bb2d-5d8ff2e05d3c</Id>
+    <Book Series="Deadpool &#38; The Mercs For Money" Number="7" Volume="2016" Year="2017">
+      <Database Name="cv" Series="92360" Issue="576620" />
     </Book>
     <Book Series="Extraordinary X-Men" Number="18" Volume="2015" Year="2017">
-      <Id>2cc28150-b698-46a4-8b91-3799f3c1a6ee</Id>
+      <Database Name="cv" Series="85756" Issue="578459" />
     </Book>
     <Book Series="IvX" Number="3" Volume="2016" Year="2017">
-      <Id>6d1d1a76-182c-4c31-b648-08051df5b0e9</Id>
+      <Database Name="cv" Series="96144" Issue="578465" />
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="8" Volume="2016" Year="2017">
-      <Id>9fd90470-7f01-4050-ab74-be42b5396641</Id>
+    <Book Series="Deadpool &#38; The Mercs For Money" Number="8" Volume="2016" Year="2017">
+      <Database Name="cv" Series="92360" Issue="579313" />
     </Book>
     <Book Series="Deadpool Annual" Number="1" Volume="2016" Year="2016">
-      <Id>e9ee5275-a617-4753-bf74-cc580400c571</Id>
+      <Database Name="cv" Series="94415" Issue="551302" />
     </Book>
     <Book Series="All-New X-Men" Number="18" Volume="2015" Year="2017">
-      <Id>e298505f-085e-49cd-aacc-b0d816526e8a</Id>
+      <Database Name="cv" Series="86334" Issue="579303" />
     </Book>
     <Book Series="IvX" Number="4" Volume="2016" Year="2017">
-      <Id>4af880e2-1e1e-4c1d-ab2e-692b1969063a</Id>
+      <Database Name="cv" Series="96144" Issue="580755" />
     </Book>
     <Book Series="Uncanny Inhumans" Number="19" Volume="2015" Year="2017">
-      <Id>d7dd5d1a-bcf3-4a96-b79c-e34b99b8ffb1</Id>
+      <Database Name="cv" Series="81092" Issue="581573" />
     </Book>
     <Book Series="Uncanny X-Men" Number="18" Volume="2016" Year="2017">
-      <Id>fa3b3071-416a-40f5-979b-e2623a6ff1c2</Id>
+      <Database Name="cv" Series="87190" Issue="581574" />
     </Book>
     <Book Series="IvX" Number="5" Volume="2016" Year="2017">
-      <Id>e5a82f47-710e-42e7-8680-4c4b94311334</Id>
+      <Database Name="cv" Series="96144" Issue="582534" />
     </Book>
     <Book Series="Extraordinary X-Men" Number="19" Volume="2015" Year="2017">
-      <Id>9f3e15d9-5c86-49e4-85d5-a7284f454ca3</Id>
+      <Database Name="cv" Series="85756" Issue="582529" />
     </Book>
     <Book Series="IvX" Number="6" Volume="2016" Year="2017">
-      <Id>37921e6f-c33c-4fe3-abf8-008f526758c9</Id>
+      <Database Name="cv" Series="96144" Issue="585080" />
     </Book>
     <Book Series="Uncanny Inhumans" Number="20" Volume="2015" Year="2017">
-      <Id>d8146776-4fea-4c45-aac1-e293164f23d8</Id>
+      <Database Name="cv" Series="81092" Issue="588578" />
     </Book>
     <Book Series="Uncanny X-Men" Number="19" Volume="2016" Year="2017">
-      <Id>2da5e3e1-e7b3-4ab5-bef8-35453e22c7a2</Id>
+      <Database Name="cv" Series="87190" Issue="587422" />
     </Book>
     <Book Series="Extraordinary X-Men" Number="20" Volume="2015" Year="2017">
-      <Id>7fc27102-7cb9-4a9e-8267-f1c77460f283</Id>
+      <Database Name="cv" Series="85756" Issue="588563" />
     </Book>
     <Book Series="All-New X-Men" Number="19" Volume="2015" Year="2017">
-      <Id>15000b02-680b-4dab-8a4a-794381551d24</Id>
+      <Database Name="cv" Series="86334" Issue="589821" />
     </Book>
-    <Book Series="Champions" Number="1" Volume="2016" Year="2016">
-      <Id>92d840fe-f08b-4444-a3ad-ca4da7d0f897</Id>
+    <Book Series="Champions" Number="1" Volume="2015" Year="1986">
+      <Database Name="cv" Series="141587" Issue="906605" />
     </Book>
-    <Book Series="Champions" Number="2" Volume="2016" Year="2017">
-      <Id>e5b35f20-57b5-4214-aa92-c6a48cb51889</Id>
+    <Book Series="Champions" Number="2" Volume="2015" Year="1986">
+      <Database Name="cv" Series="141587" Issue="906606" />
     </Book>
-    <Book Series="Champions" Number="3" Volume="2016" Year="2017">
-      <Id>b2f838f2-4335-485b-ab06-5d094783439e</Id>
+    <Book Series="Champions" Number="3" Volume="2015" Year="1986">
+      <Database Name="cv" Series="141587" Issue="906607" />
     </Book>
-    <Book Series="Champions" Number="4" Volume="2016" Year="2017">
-      <Id>0d49999e-abc3-4b61-bae8-1867910c9fd3</Id>
+    <Book Series="Champions" Number="4" Volume="2015" Year="1986">
+      <Database Name="cv" Series="141587" Issue="906608" />
     </Book>
-    <Book Series="Champions" Number="5" Volume="2016" Year="2017">
-      <Id>1882b925-3401-4ed0-a710-15599b60cbb7</Id>
+    <Book Series="Champions" Number="5" Volume="2015" Year="1987">
+      <Database Name="cv" Series="141587" Issue="906609" />
     </Book>
-    <Book Series="Champions" Number="6" Volume="2016" Year="2017">
-      <Id>3a4523c1-c905-462b-b14e-9a22a4ce4507</Id>
+    <Book Series="Champions" Number="6" Volume="2015" Year="1987">
+      <Database Name="cv" Series="141587" Issue="906610" />
     </Book>
     <Book Series="Deadpool: Too Soon?" Number="1" Volume="2017" Year="2017">
-      <Id>84e9261d-ec86-421c-bee1-48c41a9d022a</Id>
+      <Database Name="cv" Series="100073" Issue="588560" />
     </Book>
     <Book Series="Deadpool the Duck" Number="1" Volume="2017" Year="2017">
-      <Id>f1c8b10e-a579-450b-9498-bde036927399</Id>
+      <Database Name="cv" Series="97745" Issue="574862" />
     </Book>
     <Book Series="Deadpool the Duck" Number="2" Volume="2017" Year="2017">
-      <Id>67be9c8d-9d54-47fa-82fc-bc42f5992ea7</Id>
+      <Database Name="cv" Series="97745" Issue="576621" />
     </Book>
     <Book Series="Deadpool the Duck" Number="3" Volume="2017" Year="2017">
-      <Id>9164e58b-2a38-4f61-ad9e-1a5be92e8d3c</Id>
+      <Database Name="cv" Series="97745" Issue="580746" />
     </Book>
     <Book Series="Deadpool the Duck" Number="4" Volume="2017" Year="2017">
-      <Id>65e50fc4-c5d7-4c99-b8c5-f74c2fb0742a</Id>
+      <Database Name="cv" Series="97745" Issue="582524" />
     </Book>
     <Book Series="Deadpool the Duck" Number="5" Volume="2017" Year="2017">
-      <Id>bf88e333-f828-4caf-bb9c-b23b7a13625c</Id>
+      <Database Name="cv" Series="97745" Issue="587405" />
     </Book>
     <Book Series="Deadpool vs. The Punisher" Number="1" Volume="2017" Year="2017">
-      <Id>ffe9cf1f-a1b7-4f81-a6d7-f538120ea068</Id>
+      <Database Name="cv" Series="100691" Issue="591754" />
     </Book>
     <Book Series="Deadpool vs. The Punisher" Number="2" Volume="2017" Year="2017">
-      <Id>e34fa4b9-28bd-43da-b07d-4af7b4997d5e</Id>
+      <Database Name="cv" Series="100691" Issue="593257" />
     </Book>
     <Book Series="Deadpool vs. The Punisher" Number="3" Volume="2017" Year="2017">
-      <Id>3c3171c2-0bcb-4a2a-8808-cc2d935147c3</Id>
+      <Database Name="cv" Series="100691" Issue="595687" />
     </Book>
     <Book Series="Deadpool vs. The Punisher" Number="4" Volume="2017" Year="2017">
-      <Id>409e0b5f-462e-452c-a9ae-bdcde4896ea7</Id>
+      <Database Name="cv" Series="100691" Issue="598371" />
     </Book>
     <Book Series="Deadpool vs. The Punisher" Number="5" Volume="2017" Year="2017">
-      <Id>a1e4c26e-255a-4b56-8075-31c03e544e81</Id>
+      <Database Name="cv" Series="100691" Issue="605109" />
     </Book>
     <Book Series="Deadpool" Number="20" Volume="2015" Year="2016">
-      <Id>a419444e-fd27-4c65-b48e-0f6283b58895</Id>
+      <Database Name="cv" Series="85750" Issue="553007" />
     </Book>
     <Book Series="Deadpool" Number="21" Volume="2015" Year="2016">
-      <Id>4cbbc7b8-22e7-4822-a32f-355b94989bb1</Id>
+      <Database Name="cv" Series="85750" Issue="555516" />
     </Book>
     <Book Series="Deadpool" Number="22" Volume="2015" Year="2017">
-      <Id>2384c82f-6ec7-49ad-9146-2f4329159147</Id>
+      <Database Name="cv" Series="85750" Issue="558414" />
     </Book>
     <Book Series="Deadpool" Number="23" Volume="2015" Year="2017">
-      <Id>b916635a-6c34-4ecd-a5e7-4cb91013814b</Id>
+      <Database Name="cv" Series="85750" Issue="563720" />
     </Book>
     <Book Series="Deadpool" Number="24" Volume="2015" Year="2017">
-      <Id>ecb1a6fd-0527-4a2a-b08f-b11ccc4a075b</Id>
+      <Database Name="cv" Series="85750" Issue="575863" />
     </Book>
     <Book Series="Deadpool" Number="25" Volume="2015" Year="2017">
-      <Id>fe2b4990-de46-418a-b97e-da970f885198</Id>
+      <Database Name="cv" Series="85750" Issue="578456" />
     </Book>
     <Book Series="Deadpool" Number="26" Volume="2015" Year="2017">
-      <Id>9084cc3d-b7c9-4448-9a38-f04a353f0bbb</Id>
+      <Database Name="cv" Series="85750" Issue="579312" />
     </Book>
     <Book Series="Deadpool" Number="27" Volume="2015" Year="2017">
-      <Id>9803b087-0182-4a2c-a109-28f541bc4210</Id>
+      <Database Name="cv" Series="85750" Issue="581552" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 016 (All New, All Different).cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 016 (All New, All Different).cbl
@@ -2,688 +2,688 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>X-Men - Part 16 (All New, All Different)</Name>
   <Books>
-    <Book Series="Uncanny Avengers" Number="1" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="1" Volume="2015" Year="2015">
       <Id>847cb3f2-a2c9-4e5d-8860-c6747e960e86</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="2" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="2" Volume="2015" Year="2016">
       <Id>32751086-bbfb-48d2-b7f0-2769bc3b1407</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="3" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="3" Volume="2015" Year="2016">
       <Id>91f01a9d-7cb2-46ff-af68-736f3f38efb7</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="4" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="4" Volume="2015" Year="2016">
       <Id>299055df-8f87-44fa-ac89-7be9482c8ac6</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="5" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="5" Volume="2015" Year="2016">
       <Id>7c5bb256-18b3-40eb-b489-71ee972d3764</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="6" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="6" Volume="2015" Year="2016">
       <Id>270a8243-48eb-476a-bd26-b1c59b5a8b27</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="1" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="1" Volume="2016" Year="2016">
       <Id>f51be8fe-9243-403b-89d3-9645aaed2ef1</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="2" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="2" Volume="2016" Year="2016">
       <Id>a8eb5a19-7961-4f00-93d7-2063009c551a</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="3" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="3" Volume="2016" Year="2016">
       <Id>deee85d3-62c9-49b7-ae0c-dd2c4ff83516</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="4" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="4" Volume="2016" Year="2016">
       <Id>2efb2170-f680-4207-9534-5f04232b5e8f</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="5" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="5" Volume="2016" Year="2016">
       <Id>3cff998b-1163-4e90-a74a-b293b8c42132</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="6" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="6" Volume="2016" Year="2016">
       <Id>3e757424-195b-46d7-9bbd-1e1f86d6c3cd</Id>
     </Book>
-    <Book Series="Deadpool" Number="1" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Deadpool" Number="1" Volume="2015" Year="2016">
       <Id>13b2a5d5-0044-48b1-8770-13958a126aae</Id>
     </Book>
-    <Book Series="Deadpool" Number="2" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Deadpool" Number="2" Volume="2015" Year="2016">
       <Id>46154334-5193-4bf9-bfb3-3a84a49b0b82</Id>
     </Book>
-    <Book Series="Deadpool" Number="3" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Deadpool" Number="3" Volume="2015" Year="2016">
       <Id>21c52efe-92d6-4eef-8d69-715b7ba7db29</Id>
     </Book>
-    <Book Series="Deadpool" Number="4" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Deadpool" Number="4" Volume="2015" Year="2016">
       <Id>95b6a5f7-eaf3-4f97-8d5f-2a4a1ec5aa4e</Id>
     </Book>
-    <Book Series="Deadpool" Number="5" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Deadpool" Number="5" Volume="2015" Year="2016">
       <Id>f71571f4-3a97-47a6-aecf-12122c8de202</Id>
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="1" Volume="2016" Year="2016" Format="Limited Series">
+    <Book Series="Deadpool &amp; The Mercs For Money" Number="1" Volume="2016" Year="2016">
       <Id>72849c95-adb9-412c-bcad-04e8434a219b</Id>
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="2" Volume="2016" Year="2016" Format="Limited Series">
+    <Book Series="Deadpool &amp; The Mercs For Money" Number="2" Volume="2016" Year="2016">
       <Id>5caf6fe1-3799-485d-9ff0-a16396680531</Id>
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="3" Volume="2016" Year="2016" Format="Limited Series">
+    <Book Series="Deadpool &amp; The Mercs For Money" Number="3" Volume="2016" Year="2016">
       <Id>67f368e6-c2a6-448b-a496-30318556d58c</Id>
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="4" Volume="2016" Year="2016" Format="Limited Series">
+    <Book Series="Deadpool &amp; The Mercs For Money" Number="4" Volume="2016" Year="2016">
       <Id>4888961c-e72e-4c66-a7ee-df088ca70de8</Id>
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="5" Volume="2016" Year="2016" Format="Limited Series">
+    <Book Series="Deadpool &amp; The Mercs For Money" Number="5" Volume="2016" Year="2016">
       <Id>5c994245-d579-44f1-8da8-74e6a31607d2</Id>
     </Book>
-    <Book Series="Deadpool &amp; Cable: Split Second Infinite Comic" Number="1" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Deadpool &amp; Cable: Split Second Infinite Comic" Number="1" Volume="2015" Year="2015">
       <Id>e5959f09-3e81-4967-a0b7-8bb06a58517d</Id>
     </Book>
-    <Book Series="Deadpool &amp; Cable: Split Second Infinite Comic" Number="2" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Deadpool &amp; Cable: Split Second Infinite Comic" Number="2" Volume="2015" Year="2015">
       <Id>79500862-89ca-4356-a18d-1636bd28ec28</Id>
     </Book>
-    <Book Series="Deadpool &amp; Cable: Split Second Infinite Comic" Number="3" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Deadpool &amp; Cable: Split Second Infinite Comic" Number="3" Volume="2015" Year="2015">
       <Id>8429217f-4faf-4bac-94bc-b8bb6a27485d</Id>
     </Book>
-    <Book Series="Deadpool &amp; Cable: Split Second Infinite Comic" Number="4" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Deadpool &amp; Cable: Split Second Infinite Comic" Number="4" Volume="2015" Year="2015">
       <Id>70286bf4-bc5f-41a6-abee-12c69b4c87e5</Id>
     </Book>
-    <Book Series="Deadpool &amp; Cable: Split Second Infinite Comic" Number="5" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Deadpool &amp; Cable: Split Second Infinite Comic" Number="5" Volume="2015" Year="2015">
       <Id>dc4e775a-a141-4f75-97cf-0809cfe5ddfa</Id>
     </Book>
-    <Book Series="Deadpool &amp; Cable: Split Second Infinite Comic" Number="6" Volume="2015" Year="2016" Format="Limited Series">
+    <Book Series="Deadpool &amp; Cable: Split Second Infinite Comic" Number="6" Volume="2015" Year="2016">
       <Id>e3ce6b6e-0480-4e41-8083-3b96e62e504f</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="1" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Old Man Logan" Number="1" Volume="2016" Year="2016">
       <Id>2a72f82a-6f4d-4e1d-903b-a09a1a96df0b</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="2" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Old Man Logan" Number="2" Volume="2016" Year="2016">
       <Id>e37bcbef-f761-46ec-8f42-4e45c75b5590</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="3" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Old Man Logan" Number="3" Volume="2016" Year="2016">
       <Id>ac8fc7e0-5829-40d1-a934-8f1332a426a8</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="4" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Old Man Logan" Number="4" Volume="2016" Year="2016">
       <Id>9030059c-24c3-4137-91cf-44143eb936fd</Id>
     </Book>
-    <Book Series="Extraordinary X-Men" Number="1" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Extraordinary X-Men" Number="1" Volume="2015" Year="2016">
       <Id>8206b3fc-5540-4dd2-843d-b67113df7435</Id>
     </Book>
-    <Book Series="Extraordinary X-Men" Number="2" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Extraordinary X-Men" Number="2" Volume="2015" Year="2016">
       <Id>db31828a-7ed4-49cb-b60e-0d918ec07c4f</Id>
     </Book>
-    <Book Series="Extraordinary X-Men" Number="3" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Extraordinary X-Men" Number="3" Volume="2015" Year="2016">
       <Id>8d9d9b9a-71f2-457d-8cc2-bcdb946c68ce</Id>
     </Book>
-    <Book Series="Extraordinary X-Men" Number="4" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Extraordinary X-Men" Number="4" Volume="2015" Year="2016">
       <Id>bd7351b3-a80b-4427-8fda-50498ff8dbaf</Id>
     </Book>
-    <Book Series="Extraordinary X-Men" Number="5" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Extraordinary X-Men" Number="5" Volume="2015" Year="2016">
       <Id>a8dbbab0-b65e-44cd-bdca-45cdad563f05</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="1" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="1" Volume="2016" Year="2016">
       <Id>d3fc6ab6-c92d-444d-b268-8e20a70be29f</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="2" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="2" Volume="2016" Year="2016">
       <Id>2895223e-f67c-47f1-af1e-880da2815d74</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="3" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="3" Volume="2016" Year="2016">
       <Id>b66fe91b-477d-4974-a079-0b64b55fbcd7</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="4" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="4" Volume="2016" Year="2016">
       <Id>02dbc454-09c0-404a-954d-59de38c4c18b</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="5" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="5" Volume="2016" Year="2016">
       <Id>603ba46d-7c1c-49a1-af91-c8e89c116f38</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="1" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New X-Men" Number="1" Volume="2015" Year="2016">
       <Id>a0dd1ad1-5ceb-427b-bc93-75cc821b70f2</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="2" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New X-Men" Number="2" Volume="2015" Year="2016">
       <Id>6673441c-4f4b-4893-afeb-ffca8846cfe0</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="3" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New X-Men" Number="3" Volume="2015" Year="2016">
       <Id>ed77379d-df14-4b72-a57e-675b52effc86</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="1" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="1" Volume="2015" Year="2016">
       <Id>335c2f44-46a4-4dfc-a329-a9b0e2d335d2</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="2" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="2" Volume="2015" Year="2016">
       <Id>d16c4f31-f2f0-45c4-872b-214386c1b700</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="3" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="3" Volume="2015" Year="2016">
       <Id>3dc08010-1254-498b-9220-7c24dd2226ed</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="4" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="4" Volume="2015" Year="2016">
       <Id>b1c949f6-27ba-496f-9546-574c38a6f3b3</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="5" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="5" Volume="2015" Year="2016">
       <Id>6b51de20-e79a-4646-bdaf-8dd25b83901e</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="6" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="6" Volume="2015" Year="2016">
       <Id>531cab4a-6f56-4ac4-b3fc-ef2ebe868022</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="7" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="7" Volume="2015" Year="2016">
       <Id>f66fbc3d-78db-491f-912d-72454e850389</Id>
     </Book>
-    <Book Series="Extraordinary X-Men" Number="6" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Extraordinary X-Men" Number="6" Volume="2015" Year="2016">
       <Id>3ddec9dd-1b62-4658-ad5b-c5eb92e1efba</Id>
     </Book>
-    <Book Series="Extraordinary X-Men" Number="7" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Extraordinary X-Men" Number="7" Volume="2015" Year="2016">
       <Id>d525d055-6caa-4e70-8627-94ca05dfb5bf</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="4" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New X-Men" Number="4" Volume="2015" Year="2016">
       <Id>394be398-6a9d-4f38-98bf-4a29bf0079cb</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="5" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New X-Men" Number="5" Volume="2015" Year="2016">
       <Id>494c25ed-51a3-4f68-9417-9ef0555b4269</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="6" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New X-Men" Number="6" Volume="2015" Year="2016">
       <Id>e2eddf5e-9e26-44e3-b956-1bb9992247dc</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="7" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New X-Men" Number="7" Volume="2015" Year="2016">
       <Id>a390c6b2-2484-41e6-8f36-0e49d3f45c21</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="8" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New X-Men" Number="8" Volume="2015" Year="2016">
       <Id>ecdc8f29-e369-4b16-9aef-a595c02d2a86</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="7" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="7" Volume="2015" Year="2016">
       <Id>9b775e08-41b3-4b9c-a19a-8f64ffa7e18a</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="8" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="8" Volume="2015" Year="2016">
       <Id>be6fcb91-bb49-4f36-8498-bfec4ff49a09</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="9" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="9" Volume="2015" Year="2016">
       <Id>bab3d44a-cd8c-4d4d-b524-ebf900a0308c</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="10" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="10" Volume="2015" Year="2016">
       <Id>4ad11ea6-772f-438f-8711-510ade669574</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="11" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="11" Volume="2015" Year="2016">
       <Id>d5d25586-5136-4750-a4a1-be914285395f</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="12" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="12" Volume="2015" Year="2016">
       <Id>5989cb4f-13ef-44a8-a423-a8ba47818442</Id>
     </Book>
-    <Book Series="Extraordinary X-Men" Number="8" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Extraordinary X-Men" Number="8" Volume="2015" Year="2016">
       <Id>d097487c-74b0-470a-97ab-d1e0c27758cd</Id>
     </Book>
-    <Book Series="Extraordinary X-Men" Number="9" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Extraordinary X-Men" Number="9" Volume="2015" Year="2016">
       <Id>c7146472-857e-42e5-b536-d6c0be5978e3</Id>
     </Book>
-    <Book Series="Extraordinary X-Men" Number="10" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Extraordinary X-Men" Number="10" Volume="2015" Year="2016">
       <Id>88d01db8-c87d-4043-aec7-b8fcf1104318</Id>
     </Book>
-    <Book Series="Extraordinary X-Men" Number="11" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Extraordinary X-Men" Number="11" Volume="2015" Year="2016">
       <Id>041d5b29-aad3-4711-b340-979127368117</Id>
     </Book>
-    <Book Series="Extraordinary X-Men" Number="12" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Extraordinary X-Men" Number="12" Volume="2015" Year="2016">
       <Id>8d877a17-5ff5-4c90-8314-d2619f58c3c8</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="6" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="6" Volume="2016" Year="2016">
       <Id>53e3d0b2-d2d8-422a-b993-0d86c8659ec7</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="7" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="7" Volume="2016" Year="2016">
       <Id>39e91a78-2bc1-4486-85aa-911ac4d09ef5</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="8" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="8" Volume="2016" Year="2016">
       <Id>544383b3-9767-4f99-82b2-719033bd2844</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="9" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="9" Volume="2016" Year="2016">
       <Id>9f07e32b-759a-413c-a562-4344c6da1da9</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="10" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="10" Volume="2016" Year="2016">
       <Id>343c5bcc-703c-43c9-a312-341786ca2c4b</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="9" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New X-Men" Number="9" Volume="2015" Year="2016">
       <Id>3086a969-30cb-453f-84c5-1739eedb2233</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="10" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New X-Men" Number="10" Volume="2015" Year="2016">
       <Id>5d81630d-7f4d-42d5-aafb-cf4ce51fadb8</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="11" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New X-Men" Number="11" Volume="2015" Year="2016">
       <Id>43f2100b-8f81-42bd-80ce-6dc78784f0bf</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="5" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Old Man Logan" Number="5" Volume="2016" Year="2016">
       <Id>cac698f3-da06-4405-91c9-d717fb94f0b3</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="6" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Old Man Logan" Number="6" Volume="2016" Year="2016">
       <Id>cd726e06-8e1e-4969-a4cc-d6a95758ed46</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="7" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Old Man Logan" Number="7" Volume="2016" Year="2016">
       <Id>a94572c3-db71-4ccc-9863-23ebf49dca2f</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="8" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Old Man Logan" Number="8" Volume="2016" Year="2016">
       <Id>1e3ad2e7-23bf-4317-88d9-cb6ec66d4931</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="9" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Old Man Logan" Number="9" Volume="2016" Year="2016">
       <Id>f74cb549-09a7-4169-845a-92af76b831c2</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="10" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Old Man Logan" Number="10" Volume="2016" Year="2016">
       <Id>7f7abf51-d163-4fa7-b341-63a180aabb4e</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="11" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Old Man Logan" Number="11" Volume="2016" Year="2016">
       <Id>e963b6a6-bf7e-4f87-9b11-1aabe893cf1a</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="12" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Old Man Logan" Number="12" Volume="2016" Year="2016">
       <Id>5db04824-e767-47e9-a3bf-086f303cdb99</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="13" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Old Man Logan" Number="13" Volume="2016" Year="2017">
       <Id>f15ed69b-2391-42e4-8272-8fe8d21b9bf3</Id>
     </Book>
-    <Book Series="Deadpool" Number="3.1" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Deadpool" Number="3.1" Volume="2015" Year="2016">
       <Id>fa165c09-8087-4a42-84e4-99ea16c2ba80</Id>
     </Book>
-    <Book Series="Deadpool" Number="6" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Deadpool" Number="6" Volume="2015" Year="2016">
       <Id>c615a1e1-6745-45d8-9cfa-a0760459aa27</Id>
     </Book>
-    <Book Series="Deadpool" Number="7" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Deadpool" Number="7" Volume="2015" Year="2016">
       <Id>0b997c7d-df33-46ad-b6ca-7da5097ccb80</Id>
     </Book>
-    <Book Series="Deadpool" Number="8" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Deadpool" Number="8" Volume="2015" Year="2016">
       <Id>c88d3fe6-77fa-4344-be77-7dd20f260af2</Id>
     </Book>
-    <Book Series="Deadpool" Number="9" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Deadpool" Number="9" Volume="2015" Year="2016">
       <Id>2037fb23-03f0-4abb-afbc-53b4676da45b</Id>
     </Book>
-    <Book Series="Deadpool" Number="10" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Deadpool" Number="10" Volume="2015" Year="2016">
       <Id>b2ef5640-9d43-4d68-9912-723c3d4d18a5</Id>
     </Book>
-    <Book Series="Deadpool" Number="11" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Deadpool" Number="11" Volume="2015" Year="2016">
       <Id>436521e4-7a1f-47bf-bd7d-8ce072d585a6</Id>
     </Book>
-    <Book Series="Deadpool" Number="12" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Deadpool" Number="12" Volume="2015" Year="2016">
       <Id>22e38844-9d2c-4775-a090-6ead5000062b</Id>
     </Book>
-    <Book Series="Deadpool" Number="13" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Deadpool" Number="13" Volume="2015" Year="2016">
       <Id>a16b743f-47f1-4f90-bb76-1e3d52cd9827</Id>
     </Book>
-    <Book Series="Deadpool: Last Days of Magic" Number="1" Volume="2016" Year="2016" Format="One-Shot">
+    <Book Series="Deadpool: Last Days of Magic" Number="1" Volume="2016" Year="2016">
       <Id>5867d2a6-778c-4847-8a23-d4f3ebbcf58f</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="8" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="8" Volume="2015" Year="2016">
       <Id>3f76f8c5-d740-4779-9726-542889a960f6</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="9" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="9" Volume="2015" Year="2016">
       <Id>0c073db9-342a-474e-b453-8ae242db0edc</Id>
     </Book>
-    <Book Series="The Totally Awesome Hulk" Number="8" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="The Totally Awesome Hulk" Number="8" Volume="2015" Year="2016">
       <Id>d8b92e43-8821-4924-b86d-ef693b4ac68e</Id>
     </Book>
-    <Book Series="Civil War II" Number="1" Volume="2016" Year="2016" Format="Crossover">
+    <Book Series="Civil War II" Number="1" Volume="2016" Year="2016">
       <Id>1e1faaa3-336f-4103-85b0-41cc78f95a69</Id>
     </Book>
-    <Book Series="Deadpool" Number="14" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Deadpool" Number="14" Volume="2015" Year="2016">
       <Id>333c751d-2dae-4cad-bcf8-978b4dbe074e</Id>
     </Book>
-    <Book Series="Deadpool" Number="15" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Deadpool" Number="15" Volume="2015" Year="2016">
       <Id>7a962298-5b07-4ac7-9138-b838adaa5ad5</Id>
     </Book>
-    <Book Series="Deadpool" Number="16" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Deadpool" Number="16" Volume="2015" Year="2016">
       <Id>cdcc22bd-1ed6-4f1e-b34a-02ed41d191c0</Id>
     </Book>
-    <Book Series="Deadpool" Number="17" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Deadpool" Number="17" Volume="2015" Year="2016">
       <Id>2074bfc2-5f9a-46cc-a860-b38fc11e4894</Id>
     </Book>
-    <Book Series="Civil War II" Number="2" Volume="2016" Year="2016" Format="Crossover">
+    <Book Series="Civil War II" Number="2" Volume="2016" Year="2016">
       <Id>f8ce50d4-0280-4cfc-863e-f935e8888348</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="10" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="10" Volume="2015" Year="2016">
       <Id>c2b36531-5aec-4403-b2b2-41ea76f877ec</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="11" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="11" Volume="2015" Year="2016">
       <Id>8d30f0a0-d6d8-4aa2-b607-c00637b4e07e</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="12" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="12" Volume="2015" Year="2016">
       <Id>1edb8fbc-b176-4755-839b-480265fbedca</Id>
     </Book>
-    <Book Series="Civil War II" Number="3" Volume="2016" Year="2016" Format="Crossover">
+    <Book Series="Civil War II" Number="3" Volume="2016" Year="2016">
       <Id>e531c6c6-93b1-429a-b3e2-1a3179c984ce</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="13" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="13" Volume="2015" Year="2016">
       <Id>b4ce8201-722f-496b-bdc5-eaad2e83b428</Id>
     </Book>
-    <Book Series="Civil War II" Number="4" Volume="2016" Year="2016" Format="Crossover">
+    <Book Series="Civil War II" Number="4" Volume="2016" Year="2016">
       <Id>d7244968-f7d7-4246-bad5-447dd1cfb37b</Id>
     </Book>
-    <Book Series="Civil War II: X-Men" Number="1" Volume="2016" Year="2016" Format="Crossover">
+    <Book Series="Civil War II: X-Men" Number="1" Volume="2016" Year="2016">
       <Id>f46bf797-65e0-464c-a526-841673da3729</Id>
     </Book>
-    <Book Series="Civil War II: X-Men" Number="2" Volume="2016" Year="2016" Format="Crossover">
+    <Book Series="Civil War II: X-Men" Number="2" Volume="2016" Year="2016">
       <Id>75098f64-2206-43c4-8049-bca4cf32dda9</Id>
     </Book>
-    <Book Series="Civil War II: X-Men" Number="3" Volume="2016" Year="2016" Format="Crossover">
+    <Book Series="Civil War II: X-Men" Number="3" Volume="2016" Year="2016">
       <Id>9cc8efba-4a98-46ae-b150-61d76e16be4e</Id>
     </Book>
-    <Book Series="Civil War II: X-Men" Number="4" Volume="2016" Year="2016" Format="Crossover">
+    <Book Series="Civil War II: X-Men" Number="4" Volume="2016" Year="2016">
       <Id>268db7a8-4492-4187-99a7-ecb634446569</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="14" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="14" Volume="2015" Year="2016">
       <Id>f74108e6-eb28-457d-afe9-e6a262dffc28</Id>
     </Book>
-    <Book Series="Deadpool" Number="18" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Deadpool" Number="18" Volume="2015" Year="2016">
       <Id>d6eb55db-1246-43ae-827d-3837fd819999</Id>
     </Book>
-    <Book Series="Civil War II" Number="5" Volume="2016" Year="2016" Format="Crossover">
+    <Book Series="Civil War II" Number="5" Volume="2016" Year="2016">
       <Id>1a26881e-97e1-4e2b-8cd4-8b5d3ca97295</Id>
     </Book>
-    <Book Series="Civil War II" Number="6" Volume="2016" Year="2016" Format="Crossover">
+    <Book Series="Civil War II" Number="6" Volume="2016" Year="2016">
       <Id>99389268-e40a-419d-b320-730a218f285f</Id>
     </Book>
-    <Book Series="Civil War II" Number="7" Volume="2016" Year="2017" Format="Crossover">
+    <Book Series="Civil War II" Number="7" Volume="2016" Year="2017">
       <Id>5e2043b9-d846-4a9b-ae0a-9a17fe6c233e</Id>
     </Book>
-    <Book Series="Civil War II" Number="8" Volume="2016" Year="2017" Format="Crossover">
+    <Book Series="Civil War II" Number="8" Volume="2016" Year="2017">
       <Id>6634f12a-96e5-4552-b0f0-08a89186be8a</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="15" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="15" Volume="2015" Year="2016">
       <Id>ea057646-7bb2-42d2-a8bc-87f77a5b29d4</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="16" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="16" Volume="2015" Year="2017">
       <Id>9cb6e4b6-9eb2-4951-9655-ea51dfc03307</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="17" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="17" Volume="2015" Year="2017">
       <Id>79100cd8-61c7-4c72-83b8-a68e0edc104b</Id>
     </Book>
-    <Book Series="Deadpool" Number="19" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Deadpool" Number="19" Volume="2015" Year="2016">
       <Id>e160cf20-daa1-4e09-9165-c44c230dc466</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="7" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="7" Volume="2016" Year="2016">
       <Id>2f3e708a-6e26-48aa-a234-81a01b716b75</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="8" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="8" Volume="2016" Year="2016">
       <Id>0487ffd2-3b26-41a1-a674-30f3ca21159a</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="9" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="9" Volume="2016" Year="2016">
       <Id>55eccc15-4105-40f9-abba-5416f03a4594</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="10" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="10" Volume="2016" Year="2016">
       <Id>5d7495b4-941e-4677-a770-75fae3e0d447</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="11" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="11" Volume="2016" Year="2017">
       <Id>f701b7a7-ee5e-454a-8463-a384a0c80b71</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="12" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="12" Volume="2016" Year="2017">
       <Id>1e76fddf-dbcb-4e84-aa3f-6d911b0f8bfb</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="13" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="13" Volume="2016" Year="2017">
       <Id>5c494806-1cc8-417a-ab4e-e4aebc41f089</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="14" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="14" Volume="2016" Year="2017">
       <Id>ac88dcd9-5a46-4d90-91a0-1104e758da79</Id>
     </Book>
-    <Book Series="Extraordinary X-Men Annual" Number="1" Volume="2016" Year="2016" Format="Annual">
+    <Book Series="Extraordinary X-Men Annual" Number="1" Volume="2016" Year="2016">
       <Id>51691418-58a9-4fdc-aa1f-102974c287fb</Id>
     </Book>
-    <Book Series="Extraordinary X-Men" Number="13" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Extraordinary X-Men" Number="13" Volume="2015" Year="2016">
       <Id>08fd0f82-29da-4538-9a63-da9687b9c93f</Id>
     </Book>
-    <Book Series="Extraordinary X-Men" Number="14" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Extraordinary X-Men" Number="14" Volume="2015" Year="2016">
       <Id>508dfe51-ef8c-4385-829f-78610722b786</Id>
     </Book>
-    <Book Series="Extraordinary X-Men" Number="15" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Extraordinary X-Men" Number="15" Volume="2015" Year="2016">
       <Id>26e877a7-cc09-4cc6-a6ad-78654b177b0b</Id>
     </Book>
-    <Book Series="Extraordinary X-Men" Number="16" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Extraordinary X-Men" Number="16" Volume="2015" Year="2017">
       <Id>c19ec373-b66d-4860-aa82-44c91464888f</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="12" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New X-Men" Number="12" Volume="2015" Year="2016">
       <Id>b009f763-03b1-4a72-93c8-f8b212fc86cf</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="13" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New X-Men" Number="13" Volume="2015" Year="2016">
       <Id>1ee8e21a-ab6f-4cab-9b15-da9e1d593a7b</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="14" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New X-Men" Number="14" Volume="2015" Year="2016">
       <Id>c7b77933-66a5-442a-954f-a21f8e5d6b4e</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="15" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="All-New X-Men" Number="15" Volume="2015" Year="2017">
       <Id>8ca9a4d9-07f2-4bbf-8a12-b4223fe46286</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="16" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="All-New X-Men" Number="16" Volume="2015" Year="2017">
       <Id>fbe3fd2f-a4e2-42b4-b9c5-aa46da99af79</Id>
     </Book>
-    <Book Series="All-New X-Men Annual" Number="1" Volume="2016" Year="2017" Format="Annual">
+    <Book Series="All-New X-Men Annual" Number="1" Volume="2016" Year="2017">
       <Id>31793aae-6372-4a32-8f84-c1679be32cfd</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="11" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="11" Volume="2016" Year="2016">
       <Id>692ff962-c165-4f68-9f95-8ff38437e753</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="12" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="12" Volume="2016" Year="2016">
       <Id>209239ae-380a-4d51-b3f2-f9a4cc7383ca</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="13" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="13" Volume="2016" Year="2016">
       <Id>562349b0-7f5b-4a08-a836-48725270fe3d</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="14" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="14" Volume="2016" Year="2016">
       <Id>bfbdbcc4-3c9d-4a7d-894f-3a820d840524</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="15" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="15" Volume="2016" Year="2017">
       <Id>3580afb5-e947-4ec0-b63e-f01a0a20ed46</Id>
     </Book>
-    <Book Series="Uncanny X-Men Annual" Number="1" Volume="2016" Year="2017" Format="Annual">
+    <Book Series="Uncanny X-Men Annual" Number="1" Volume="2016" Year="2017">
       <Id>abcb6d7e-15bf-4f7d-9ed6-c6c687c31bd0</Id>
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="1" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Deadpool &amp; The Mercs For Money" Number="1" Volume="2016" Year="2016">
       <Id>3a27f24b-7032-4436-9593-84cae63f0a85</Id>
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="2" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Deadpool &amp; The Mercs For Money" Number="2" Volume="2016" Year="2016">
       <Id>c379a511-91b0-4ea0-9471-00ea2b1479ce</Id>
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="3" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Deadpool &amp; The Mercs For Money" Number="3" Volume="2016" Year="2016">
       <Id>b013c149-3d9b-4417-99b1-44802faed9bf</Id>
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="4" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Deadpool &amp; The Mercs For Money" Number="4" Volume="2016" Year="2016">
       <Id>131d9cc6-7f20-4653-9bb4-081cfbacfa8d</Id>
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="5" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Deadpool &amp; The Mercs For Money" Number="5" Volume="2016" Year="2017">
       <Id>65ff5a3f-25ab-49e5-83ce-662c19b69af2</Id>
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="6" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Deadpool &amp; The Mercs For Money" Number="6" Volume="2016" Year="2017">
       <Id>3541f223-4421-4240-9136-3231931e9bfa</Id>
     </Book>
-    <Book Series="All-New Wolverine Annual" Number="1" Volume="2016" Year="2016" Format="Annual">
+    <Book Series="All-New Wolverine Annual" Number="1" Volume="2016" Year="2016">
       <Id>8902210a-974c-4b50-96be-1bed53a77232</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="13" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="13" Volume="2015" Year="2016">
       <Id>b63ef5f7-c888-499b-9748-9b32f603945b</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="14" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="14" Volume="2015" Year="2017">
       <Id>95d044e9-7c70-4308-9d2b-5d55d2f98888</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="15" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="15" Volume="2015" Year="2017">
       <Id>90646286-ea00-4b7d-bb83-65862b314d1c</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="16" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="16" Volume="2015" Year="2017">
       <Id>eccd2aa5-1826-4509-9545-a3aae58d6989</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="17" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="17" Volume="2015" Year="2017">
       <Id>86dfada8-fd24-4f11-8743-42dc77c2fdcb</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="18" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="18" Volume="2015" Year="2017">
       <Id>69a3b4ed-133e-4d8e-a27c-407b28295f3f</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="14" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Old Man Logan" Number="14" Volume="2016" Year="2017">
       <Id>516e66a9-24e4-4ce7-ba3c-427b5c1ff10f</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="15" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Old Man Logan" Number="15" Volume="2016" Year="2017">
       <Id>9f132300-8920-478d-b6ad-16065ebf9003</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="16" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Old Man Logan" Number="16" Volume="2016" Year="2017">
       <Id>6dd7c809-75ab-4670-83e7-2075a5b4295b</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="17" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Old Man Logan" Number="17" Volume="2016" Year="2017">
       <Id>be55e612-5e72-4fac-80d5-104408a5744f</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="18" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Old Man Logan" Number="18" Volume="2016" Year="2017">
       <Id>eae2be90-689e-4189-9aa8-a4c086f11a79</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="19" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Old Man Logan" Number="19" Volume="2016" Year="2017">
       <Id>d494709b-7974-4268-bd83-af772b3bc917</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="20" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Old Man Logan" Number="20" Volume="2016" Year="2017">
       <Id>96295009-be90-4b57-9c9b-0be19702197f</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="21" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Old Man Logan" Number="21" Volume="2016" Year="2017">
       <Id>5c299e66-b443-465e-aee3-4fcf60f89770</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="22" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Old Man Logan" Number="22" Volume="2016" Year="2017">
       <Id>f8640cdd-5ed2-404e-ac54-7316ace835d7</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="23" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Old Man Logan" Number="23" Volume="2016" Year="2017">
       <Id>e3507e2c-050b-48db-b1d8-b88c3b8349c9</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="24" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Old Man Logan" Number="24" Volume="2016" Year="2017">
       <Id>1a0e423e-1cc8-448c-85c0-7a9dcb81819e</Id>
     </Book>
-    <Book Series="Death of X" Number="1" Volume="2016" Year="2016" Format="Limited Series">
+    <Book Series="Death of X" Number="1" Volume="2016" Year="2016">
       <Id>2a2e99d2-e8c7-4c97-942f-279d4b16ada9</Id>
     </Book>
-    <Book Series="Death of X" Number="2" Volume="2016" Year="2016" Format="Limited Series">
+    <Book Series="Death of X" Number="2" Volume="2016" Year="2016">
       <Id>c7f2bf69-7011-4e83-93cd-f8d7983bca09</Id>
     </Book>
-    <Book Series="Death of X" Number="3" Volume="2016" Year="2017" Format="Limited Series">
+    <Book Series="Death of X" Number="3" Volume="2016" Year="2017">
       <Id>85c3bcc0-29dd-4f64-8062-4b0d378e2dcf</Id>
     </Book>
-    <Book Series="Death of X" Number="4" Volume="2016" Year="2017" Format="Limited Series">
+    <Book Series="Death of X" Number="4" Volume="2016" Year="2017">
       <Id>ef61d9b1-bee3-4990-8474-e7c75962ef7e</Id>
     </Book>
-    <Book Series="IvX" Number="0" Volume="2016" Year="2017" Format="Limited Series">
+    <Book Series="IvX" Number="0" Volume="2016" Year="2017">
       <Id>948da7a8-f7db-4a2b-8b35-25bdcec43b7d</Id>
     </Book>
-    <Book Series="IvX" Number="1" Volume="2016" Year="2017" Format="Limited Series">
+    <Book Series="IvX" Number="1" Volume="2016" Year="2017">
       <Id>160da639-153a-4ad8-b4d7-1556a7118ced</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="16" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="16" Volume="2016" Year="2017">
       <Id>3c23e41f-8937-4c2c-9866-19d293450e90</Id>
     </Book>
-    <Book Series="Extraordinary X-Men" Number="17" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Extraordinary X-Men" Number="17" Volume="2015" Year="2017">
       <Id>33b7ac85-4fba-4a8c-b86b-8a6dabd01614</Id>
     </Book>
-    <Book Series="IvX" Number="2" Volume="2016" Year="2017" Format="Limited Series">
+    <Book Series="IvX" Number="2" Volume="2016" Year="2017">
       <Id>58cd78e6-5988-4943-8136-7d4f53644613</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="17" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="17" Volume="2016" Year="2017">
       <Id>ce8da992-8061-432f-9f37-4c9e3b4c7824</Id>
     </Book>
-    <Book Series="Uncanny Inhumans" Number="18" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Uncanny Inhumans" Number="18" Volume="2015" Year="2017">
       <Id>6b47e7d1-e4ba-4183-a46c-df5186924c3e</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="17" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="All-New X-Men" Number="17" Volume="2015" Year="2017">
       <Id>2d70ad25-f792-4651-a625-196ad4734ace</Id>
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="7" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Deadpool &amp; The Mercs For Money" Number="7" Volume="2016" Year="2017">
       <Id>9ee30fd9-c5dc-4927-bb2d-5d8ff2e05d3c</Id>
     </Book>
-    <Book Series="Extraordinary X-Men" Number="18" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Extraordinary X-Men" Number="18" Volume="2015" Year="2017">
       <Id>2cc28150-b698-46a4-8b91-3799f3c1a6ee</Id>
     </Book>
-    <Book Series="IvX" Number="3" Volume="2016" Year="2017" Format="Limited Series">
+    <Book Series="IvX" Number="3" Volume="2016" Year="2017">
       <Id>6d1d1a76-182c-4c31-b648-08051df5b0e9</Id>
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="8" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Deadpool &amp; The Mercs For Money" Number="8" Volume="2016" Year="2017">
       <Id>9fd90470-7f01-4050-ab74-be42b5396641</Id>
     </Book>
-    <Book Series="Deadpool Annual" Number="1" Volume="2016" Year="2016" Format="Annual">
+    <Book Series="Deadpool Annual" Number="1" Volume="2016" Year="2016">
       <Id>e9ee5275-a617-4753-bf74-cc580400c571</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="18" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="All-New X-Men" Number="18" Volume="2015" Year="2017">
       <Id>e298505f-085e-49cd-aacc-b0d816526e8a</Id>
     </Book>
-    <Book Series="IvX" Number="4" Volume="2016" Year="2017" Format="Limited Series">
+    <Book Series="IvX" Number="4" Volume="2016" Year="2017">
       <Id>4af880e2-1e1e-4c1d-ab2e-692b1969063a</Id>
     </Book>
-    <Book Series="Uncanny Inhumans" Number="19" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Uncanny Inhumans" Number="19" Volume="2015" Year="2017">
       <Id>d7dd5d1a-bcf3-4a96-b79c-e34b99b8ffb1</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="18" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="18" Volume="2016" Year="2017">
       <Id>fa3b3071-416a-40f5-979b-e2623a6ff1c2</Id>
     </Book>
-    <Book Series="IvX" Number="5" Volume="2016" Year="2017" Format="Limited Series">
+    <Book Series="IvX" Number="5" Volume="2016" Year="2017">
       <Id>e5a82f47-710e-42e7-8680-4c4b94311334</Id>
     </Book>
-    <Book Series="Extraordinary X-Men" Number="19" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Extraordinary X-Men" Number="19" Volume="2015" Year="2017">
       <Id>9f3e15d9-5c86-49e4-85d5-a7284f454ca3</Id>
     </Book>
-    <Book Series="IvX" Number="6" Volume="2016" Year="2017" Format="Limited Series">
+    <Book Series="IvX" Number="6" Volume="2016" Year="2017">
       <Id>37921e6f-c33c-4fe3-abf8-008f526758c9</Id>
     </Book>
-    <Book Series="Uncanny Inhumans" Number="20" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Uncanny Inhumans" Number="20" Volume="2015" Year="2017">
       <Id>d8146776-4fea-4c45-aac1-e293164f23d8</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="19" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="19" Volume="2016" Year="2017">
       <Id>2da5e3e1-e7b3-4ab5-bef8-35453e22c7a2</Id>
     </Book>
-    <Book Series="Extraordinary X-Men" Number="20" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Extraordinary X-Men" Number="20" Volume="2015" Year="2017">
       <Id>7fc27102-7cb9-4a9e-8267-f1c77460f283</Id>
     </Book>
-    <Book Series="All-New X-Men" Number="19" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="All-New X-Men" Number="19" Volume="2015" Year="2017">
       <Id>15000b02-680b-4dab-8a4a-794381551d24</Id>
     </Book>
-    <Book Series="Champions" Number="1" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Champions" Number="1" Volume="2016" Year="2016">
       <Id>92d840fe-f08b-4444-a3ad-ca4da7d0f897</Id>
     </Book>
-    <Book Series="Champions" Number="2" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Champions" Number="2" Volume="2016" Year="2017">
       <Id>e5b35f20-57b5-4214-aa92-c6a48cb51889</Id>
     </Book>
-    <Book Series="Champions" Number="3" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Champions" Number="3" Volume="2016" Year="2017">
       <Id>b2f838f2-4335-485b-ab06-5d094783439e</Id>
     </Book>
-    <Book Series="Champions" Number="4" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Champions" Number="4" Volume="2016" Year="2017">
       <Id>0d49999e-abc3-4b61-bae8-1867910c9fd3</Id>
     </Book>
-    <Book Series="Champions" Number="5" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Champions" Number="5" Volume="2016" Year="2017">
       <Id>1882b925-3401-4ed0-a710-15599b60cbb7</Id>
     </Book>
-    <Book Series="Champions" Number="6" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Champions" Number="6" Volume="2016" Year="2017">
       <Id>3a4523c1-c905-462b-b14e-9a22a4ce4507</Id>
     </Book>
-    <Book Series="Deadpool: Too Soon?" Number="1" Volume="2017" Year="2017" Format="TPB">
+    <Book Series="Deadpool: Too Soon?" Number="1" Volume="2017" Year="2017">
       <Id>84e9261d-ec86-421c-bee1-48c41a9d022a</Id>
     </Book>
-    <Book Series="Deadpool the Duck" Number="1" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Deadpool the Duck" Number="1" Volume="2017" Year="2017">
       <Id>f1c8b10e-a579-450b-9498-bde036927399</Id>
     </Book>
-    <Book Series="Deadpool the Duck" Number="2" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Deadpool the Duck" Number="2" Volume="2017" Year="2017">
       <Id>67be9c8d-9d54-47fa-82fc-bc42f5992ea7</Id>
     </Book>
-    <Book Series="Deadpool the Duck" Number="3" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Deadpool the Duck" Number="3" Volume="2017" Year="2017">
       <Id>9164e58b-2a38-4f61-ad9e-1a5be92e8d3c</Id>
     </Book>
-    <Book Series="Deadpool the Duck" Number="4" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Deadpool the Duck" Number="4" Volume="2017" Year="2017">
       <Id>65e50fc4-c5d7-4c99-b8c5-f74c2fb0742a</Id>
     </Book>
-    <Book Series="Deadpool the Duck" Number="5" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Deadpool the Duck" Number="5" Volume="2017" Year="2017">
       <Id>bf88e333-f828-4caf-bb9c-b23b7a13625c</Id>
     </Book>
-    <Book Series="Deadpool vs. The Punisher" Number="1" Volume="2017" Year="2017" Format="Limited Series">
+    <Book Series="Deadpool vs. The Punisher" Number="1" Volume="2017" Year="2017">
       <Id>ffe9cf1f-a1b7-4f81-a6d7-f538120ea068</Id>
     </Book>
-    <Book Series="Deadpool vs. The Punisher" Number="2" Volume="2017" Year="2017" Format="Limited Series">
+    <Book Series="Deadpool vs. The Punisher" Number="2" Volume="2017" Year="2017">
       <Id>e34fa4b9-28bd-43da-b07d-4af7b4997d5e</Id>
     </Book>
-    <Book Series="Deadpool vs. The Punisher" Number="3" Volume="2017" Year="2017" Format="Limited Series">
+    <Book Series="Deadpool vs. The Punisher" Number="3" Volume="2017" Year="2017">
       <Id>3c3171c2-0bcb-4a2a-8808-cc2d935147c3</Id>
     </Book>
-    <Book Series="Deadpool vs. The Punisher" Number="4" Volume="2017" Year="2017" Format="Limited Series">
+    <Book Series="Deadpool vs. The Punisher" Number="4" Volume="2017" Year="2017">
       <Id>409e0b5f-462e-452c-a9ae-bdcde4896ea7</Id>
     </Book>
-    <Book Series="Deadpool vs. The Punisher" Number="5" Volume="2017" Year="2017" Format="Limited Series">
+    <Book Series="Deadpool vs. The Punisher" Number="5" Volume="2017" Year="2017">
       <Id>a1e4c26e-255a-4b56-8075-31c03e544e81</Id>
     </Book>
-    <Book Series="Deadpool" Number="20" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Deadpool" Number="20" Volume="2015" Year="2016">
       <Id>a419444e-fd27-4c65-b48e-0f6283b58895</Id>
     </Book>
-    <Book Series="Deadpool" Number="21" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Deadpool" Number="21" Volume="2015" Year="2016">
       <Id>4cbbc7b8-22e7-4822-a32f-355b94989bb1</Id>
     </Book>
-    <Book Series="Deadpool" Number="22" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Deadpool" Number="22" Volume="2015" Year="2017">
       <Id>2384c82f-6ec7-49ad-9146-2f4329159147</Id>
     </Book>
-    <Book Series="Deadpool" Number="23" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Deadpool" Number="23" Volume="2015" Year="2017">
       <Id>b916635a-6c34-4ecd-a5e7-4cb91013814b</Id>
     </Book>
-    <Book Series="Deadpool" Number="24" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Deadpool" Number="24" Volume="2015" Year="2017">
       <Id>ecb1a6fd-0527-4a2a-b08f-b11ccc4a075b</Id>
     </Book>
-    <Book Series="Deadpool" Number="25" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Deadpool" Number="25" Volume="2015" Year="2017">
       <Id>fe2b4990-de46-418a-b97e-da970f885198</Id>
     </Book>
-    <Book Series="Deadpool" Number="26" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Deadpool" Number="26" Volume="2015" Year="2017">
       <Id>9084cc3d-b7c9-4448-9a38-f04a353f0bbb</Id>
     </Book>
-    <Book Series="Deadpool" Number="27" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Deadpool" Number="27" Volume="2015" Year="2017">
       <Id>9803b087-0182-4a2c-a109-28f541bc4210</Id>
     </Book>
   </Books>

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 017 - (Resurrection).cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 017 - (Resurrection).cbl
@@ -1,627 +1,628 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>X-Men - Part 17 - (Resurrection)</Name>
+  <Name>X-Men - Part 017 - (Resurrection)</Name>
+  <NumIssues>207</NumIssues>
   <Books>
     <Book Series="X-Men Prime" Number="1" Volume="2017" Year="2017">
-      <Id>49bb34fe-d989-44f0-b81f-242fd839aeca</Id>
+      <Database Name="cv" Series="100395" Issue="589842" />
     </Book>
     <Book Series="X-Men: Gold" Number="1" Volume="2017" Year="2017">
-      <Id>0ae2f9ab-99ca-41b7-ae3a-8fbe47706eab</Id>
+      <Database Name="cv" Series="100603" Issue="590811" />
     </Book>
     <Book Series="X-Men: Gold" Number="2" Volume="2017" Year="2017">
-      <Id>f2318c74-aa43-40e9-bf08-83ea222b2486</Id>
+      <Database Name="cv" Series="100603" Issue="593278" />
     </Book>
     <Book Series="X-Men: Gold" Number="3" Volume="2017" Year="2017">
-      <Id>2f394102-a605-4de8-8d3c-e394ef617ba3</Id>
+      <Database Name="cv" Series="100603" Issue="594129" />
     </Book>
     <Book Series="X-Men: Gold" Number="4" Volume="2017" Year="2017">
-      <Id>7bf3b380-1827-4c52-833f-774ced433cc9</Id>
+      <Database Name="cv" Series="100603" Issue="595708" />
     </Book>
     <Book Series="X-Men: Gold" Number="5" Volume="2017" Year="2017">
-      <Id>6b0e1770-4366-484d-b457-67a420a0f8ff</Id>
+      <Database Name="cv" Series="100603" Issue="599881" />
     </Book>
     <Book Series="X-Men: Gold" Number="6" Volume="2017" Year="2017">
-      <Id>38213940-eafb-4b81-8117-c0d91f7a4079</Id>
+      <Database Name="cv" Series="100603" Issue="603149" />
     </Book>
     <Book Series="X-Men: Blue" Number="1" Volume="2017" Year="2017">
-      <Id>6c30e0a2-e456-4ad0-828a-8df3e0657b2f</Id>
+      <Database Name="cv" Series="100712" Issue="591772" />
     </Book>
     <Book Series="X-Men: Blue" Number="2" Volume="2017" Year="2017">
-      <Id>0bb8a222-4424-469f-a44a-e65af25b162e</Id>
+      <Database Name="cv" Series="100712" Issue="593277" />
     </Book>
     <Book Series="X-Men: Blue" Number="3" Volume="2017" Year="2017">
-      <Id>c17c0460-9c5f-4511-8133-827c6897dfb7</Id>
+      <Database Name="cv" Series="100712" Issue="594979" />
     </Book>
     <Book Series="X-Men: Blue" Number="4" Volume="2017" Year="2017">
-      <Id>4a4a9d58-3612-46e9-8670-07781204d6f0</Id>
+      <Database Name="cv" Series="100712" Issue="597208" />
     </Book>
     <Book Series="X-Men: Blue" Number="5" Volume="2017" Year="2017">
-      <Id>2b662b58-6405-47c7-a9e0-7cf72725b3dd</Id>
+      <Database Name="cv" Series="100712" Issue="601813" />
     </Book>
     <Book Series="X-Men: Blue" Number="6" Volume="2017" Year="2017">
-      <Id>9fecdad1-e99e-47ed-b94b-beb0ea447c4f</Id>
+      <Database Name="cv" Series="100712" Issue="605139" />
     </Book>
     <Book Series="All-New Wolverine" Number="19" Volume="2015" Year="2017">
-      <Id>086599a4-35b5-457b-8cff-821d4b95d1aa</Id>
+      <Database Name="cv" Series="85930" Issue="590785" />
     </Book>
     <Book Series="All-New Wolverine" Number="20" Volume="2015" Year="2017">
-      <Id>b82affc6-3161-48bf-b9d2-9b7d1dcf3bd0</Id>
+      <Database Name="cv" Series="85930" Issue="594954" />
     </Book>
     <Book Series="All-New Wolverine" Number="21" Volume="2015" Year="2017">
-      <Id>10e3e525-5282-4aff-ac35-6858d9d78e60</Id>
+      <Database Name="cv" Series="85930" Issue="601783" />
     </Book>
     <Book Series="All-New Wolverine" Number="22" Volume="2015" Year="2017">
-      <Id>d3a68678-83ef-4e3c-9351-aa60e1bc2684</Id>
+      <Database Name="cv" Series="85930" Issue="606616" />
     </Book>
     <Book Series="All-New Wolverine" Number="23" Volume="2015" Year="2017">
-      <Id>008540b0-8899-4f73-89bc-76bd1321c565</Id>
+      <Database Name="cv" Series="85930" Issue="613782" />
     </Book>
     <Book Series="All-New Wolverine" Number="24" Volume="2015" Year="2017">
-      <Id>d93b548f-18f8-4711-b19d-963fc27e3679</Id>
+      <Database Name="cv" Series="85930" Issue="621655" />
     </Book>
     <Book Series="Generation X" Number="1" Volume="2017" Year="2017">
-      <Id>82e33790-2504-407e-b6fe-9a18bce8d575</Id>
+      <Database Name="cv" Series="101478" Issue="595688" />
     </Book>
     <Book Series="Generation X" Number="2" Volume="2017" Year="2017">
-      <Id>446b92f7-0420-4f53-9797-c38487283c40</Id>
+      <Database Name="cv" Series="101478" Issue="598374" />
     </Book>
     <Book Series="Generation X" Number="3" Volume="2017" Year="2017">
-      <Id>196160f0-2bc7-4374-808c-38504ac8b03c</Id>
+      <Database Name="cv" Series="101478" Issue="601793" />
     </Book>
     <Book Series="Generation X" Number="4" Volume="2017" Year="2017">
-      <Id>d5cfad42-d853-490b-ac24-ff1e584fe269</Id>
+      <Database Name="cv" Series="101478" Issue="608245" />
     </Book>
     <Book Series="Generation X" Number="5" Volume="2017" Year="2017">
-      <Id>784ee073-5f79-4d7c-ac44-a79cfc9bb950</Id>
+      <Database Name="cv" Series="101478" Issue="615020" />
     </Book>
     <Book Series="Iceman" Number="1" Volume="2017" Year="2017">
-      <Id>dfa05b47-6bb2-4373-b4ab-0835206ae54d</Id>
+      <Database Name="cv" Series="101937" Issue="599865" />
     </Book>
     <Book Series="Iceman" Number="2" Volume="2017" Year="2017">
-      <Id>01d904ab-5578-494e-9bad-0f55475696db</Id>
+      <Database Name="cv" Series="101937" Issue="603123" />
     </Book>
     <Book Series="Iceman" Number="3" Volume="2017" Year="2017">
-      <Id>16717778-4f83-4d8d-ace7-819ae97ffa35</Id>
+      <Database Name="cv" Series="101937" Issue="610527" />
     </Book>
     <Book Series="Iceman" Number="4" Volume="2017" Year="2017">
-      <Id>09c1bf80-ba00-4472-b902-278b0e005d52</Id>
+      <Database Name="cv" Series="101937" Issue="616194" />
     </Book>
     <Book Series="Iceman" Number="5" Volume="2017" Year="2017">
-      <Id>acad3ff7-7b18-4d93-9837-2900dbf2c35b</Id>
+      <Database Name="cv" Series="101937" Issue="619625" />
     </Book>
     <Book Series="Old Man Logan" Number="25" Volume="2016" Year="2017">
-      <Id>22bd922c-3251-4623-a2fa-6f16077281f2</Id>
+      <Database Name="cv" Series="87624" Issue="601799" />
     </Book>
     <Book Series="Old Man Logan" Number="26" Volume="2016" Year="2017">
-      <Id>9aa06245-0b38-4be5-a4aa-4bfae8bd0e9b</Id>
+      <Database Name="cv" Series="87624" Issue="608252" />
     </Book>
     <Book Series="Old Man Logan" Number="27" Volume="2016" Year="2017">
-      <Id>c51aee21-2c71-443a-b6ba-47001c0a1b0c</Id>
+      <Database Name="cv" Series="87624" Issue="613798" />
     </Book>
     <Book Series="Old Man Logan" Number="28" Volume="2016" Year="2017">
-      <Id>deddbda6-b2a8-42d5-8d42-ed12ffb5a0e3</Id>
+      <Database Name="cv" Series="87624" Issue="621673" />
     </Book>
     <Book Series="Old Man Logan" Number="29" Volume="2016" Year="2017">
-      <Id>904330f2-5430-41fd-9717-fbbe12c3919b</Id>
+      <Database Name="cv" Series="87624" Issue="626290" />
     </Book>
     <Book Series="Old Man Logan" Number="30" Volume="2016" Year="2018">
-      <Id>dbd2e7c2-11ec-4522-9c61-3af0860fa780</Id>
+      <Database Name="cv" Series="87624" Issue="634540" />
     </Book>
     <Book Series="Generation X" Number="6" Volume="2017" Year="2017">
-      <Id>eed9d6e4-2a24-4812-a0c4-89a95ae44dbd</Id>
+      <Database Name="cv" Series="101478" Issue="619622" />
     </Book>
     <Book Series="Generation X" Number="7" Volume="2017" Year="2017">
-      <Id>1836838d-b7eb-4a29-b259-a3664b7eecf5</Id>
+      <Database Name="cv" Series="101478" Issue="630521" />
     </Book>
     <Book Series="Generation X" Number="8" Volume="2017" Year="2018">
-      <Id>34fed9d5-9be6-4fd7-b1d6-b1ea7e277e09</Id>
+      <Database Name="cv" Series="101478" Issue="636373" />
     </Book>
     <Book Series="Generation X" Number="9" Volume="2017" Year="2018">
-      <Id>8e8d9e7f-e7e6-4e66-95d7-a0b4eb9d63ac</Id>
+      <Database Name="cv" Series="101478" Issue="641404" />
     </Book>
     <Book Series="Jean Grey" Number="1" Volume="2017" Year="2017">
-      <Id>461047e6-ba17-47a1-8066-6c9be66d61bc</Id>
+      <Database Name="cv" Series="101195" Issue="594114" />
     </Book>
     <Book Series="Jean Grey" Number="2" Volume="2017" Year="2017">
-      <Id>9a6c57ac-8e0e-44c5-a958-f35df5472947</Id>
+      <Database Name="cv" Series="101195" Issue="597195" />
     </Book>
     <Book Series="Jean Grey" Number="3" Volume="2017" Year="2017">
-      <Id>f4087701-0b6e-4be4-8176-a936eac51069</Id>
+      <Database Name="cv" Series="101195" Issue="605120" />
     </Book>
     <Book Series="Jean Grey" Number="4" Volume="2017" Year="2017">
-      <Id>e89b62a5-55c8-42d5-ae8b-84354cec7bc9</Id>
+      <Database Name="cv" Series="101195" Issue="608247" />
     </Book>
     <Book Series="Jean Grey" Number="5" Volume="2017" Year="2017">
-      <Id>ab944c49-8d5d-4818-9955-7bf608741aad</Id>
+      <Database Name="cv" Series="101195" Issue="613794" />
     </Book>
     <Book Series="Jean Grey" Number="6" Volume="2017" Year="2017">
-      <Id>cc0a2992-51ae-4874-bf00-ac9c7b67704a</Id>
+      <Database Name="cv" Series="101195" Issue="617845" />
     </Book>
     <Book Series="Deadpool" Number="28" Volume="2015" Year="2017">
-      <Id>d9e8750b-51e3-449d-9cbc-407d7d139def</Id>
+      <Database Name="cv" Series="85750" Issue="583716" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="15" Volume="2016" Year="2017">
-      <Id>653935bb-ae6a-4097-b68c-4b729ccd365e</Id>
+      <Database Name="cv" Series="87182" Issue="585093" />
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="9" Volume="2016" Year="2017">
-      <Id>35245e41-63ad-4b55-9bc6-0963ac714e7b</Id>
+    <Book Series="Deadpool &#38; The Mercs For Money" Number="9" Volume="2016" Year="2017">
+      <Database Name="cv" Series="92360" Issue="589825" />
     </Book>
     <Book Series="Deadpool" Number="29" Volume="2015" Year="2017">
-      <Id>ee030fd1-a6ff-4fe4-9888-feabfac9d36f</Id>
+      <Database Name="cv" Series="85750" Issue="592595" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="16" Volume="2016" Year="2017">
-      <Id>a5bc3fb3-7262-41d1-a9f6-acb6dc3901d8</Id>
+      <Database Name="cv" Series="87182" Issue="590805" />
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="10" Volume="2016" Year="2017">
-      <Id>7442c9b2-9618-4256-8aff-651509ba7be1</Id>
+    <Book Series="Deadpool &#38; The Mercs For Money" Number="10" Volume="2016" Year="2017">
+      <Database Name="cv" Series="92360" Issue="591753" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="17" Volume="2016" Year="2017">
-      <Id>5aeec02b-1e89-4ff8-9dad-ec2423194341</Id>
+      <Database Name="cv" Series="87182" Issue="594125" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="18" Volume="2016" Year="2017">
-      <Id>52fac5ca-73e7-49a0-a79f-bc54919fc259</Id>
+      <Database Name="cv" Series="87182" Issue="599875" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="19" Volume="2016" Year="2017">
-      <Id>5b504ac1-d9ee-4fec-9744-a726d795c945</Id>
+      <Database Name="cv" Series="87182" Issue="606637" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="20" Volume="2016" Year="2017">
-      <Id>09f1005d-7f14-44db-b391-342b1af955b1</Id>
+      <Database Name="cv" Series="87182" Issue="612051" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="21" Volume="2016" Year="2017">
-      <Id>bc766a2a-60c8-4a97-9e55-79c508334108</Id>
+      <Database Name="cv" Series="87182" Issue="619637" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="22" Volume="2016" Year="2017">
-      <Id>24231fd3-b252-4acf-9d1a-d7df04c5d8b1</Id>
+      <Database Name="cv" Series="87182" Issue="626296" />
     </Book>
     <Book Series="Deadpool" Number="30" Volume="2015" Year="2017">
-      <Id>d6b7e709-8685-4865-be25-43e4505ed2e2</Id>
+      <Database Name="cv" Series="85750" Issue="594962" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="1.MU" Volume="2016" Year="2017">
-      <Id>3f7737f2-7960-410f-a92d-43424b1c856b</Id>
+      <Database Name="cv" Series="87182" Issue="578473" />
     </Book>
     <Book Series="Champions" Number="1.MU" Volume="2016" Year="2017">
-      <Id>5b9b0df9-6017-417d-94cb-7834cf55ae0b</Id>
+      <Database Name="cv" Series="94612" Issue="582520" />
     </Book>
     <Book Series="Champions" Number="7" Volume="2016" Year="2017">
-      <Id>5a18c1e1-7d76-4fa9-a9eb-e10170a7f8aa</Id>
+      <Database Name="cv" Series="94612" Issue="590791" />
     </Book>
     <Book Series="Champions" Number="8" Volume="2016" Year="2017">
-      <Id>47a0d72c-ae56-45f6-914e-0fef3e53800f</Id>
+      <Database Name="cv" Series="94612" Issue="594108" />
     </Book>
     <Book Series="Uncanny Avengers" Number="18" Volume="2015" Year="2017">
-      <Id>75343677-347c-4236-a608-c30c99aed769</Id>
+      <Database Name="cv" Series="85318" Issue="571692" />
     </Book>
     <Book Series="Uncanny Avengers" Number="19" Volume="2015" Year="2017">
-      <Id>3dd56eb0-7c3f-493f-9af5-48cb873f7df0</Id>
+      <Database Name="cv" Series="85318" Issue="575886" />
     </Book>
     <Book Series="Uncanny Avengers" Number="20" Volume="2015" Year="2017">
-      <Id>fab4efc0-6f2a-4373-9eb1-31d8102f98cf</Id>
+      <Database Name="cv" Series="85318" Issue="582549" />
     </Book>
     <Book Series="Uncanny Avengers" Number="21" Volume="2015" Year="2017">
-      <Id>e600562d-c25d-4cf1-b40e-01de51f9d6ba</Id>
+      <Database Name="cv" Series="85318" Issue="587421" />
     </Book>
     <Book Series="Uncanny Avengers" Number="22" Volume="2015" Year="2017">
-      <Id>2bf94bc9-d703-44c9-9c9e-3562db8dac63</Id>
+      <Database Name="cv" Series="85318" Issue="590810" />
     </Book>
     <Book Series="Uncanny Avengers" Number="23" Volume="2015" Year="2017">
-      <Id>14804d4f-052e-48b0-bced-d508c1d49960</Id>
+      <Database Name="cv" Series="85318" Issue="594977" />
     </Book>
     <Book Series="Deadpool" Number="31" Volume="2015" Year="2017">
-      <Id>5d75e237-6171-46c1-b4de-944a92048e6d</Id>
+      <Database Name="cv" Series="85750" Issue="598369" />
     </Book>
     <Book Series="Secret Empire" Number="0" Volume="2017" Year="2017">
-      <Id>c9c826f6-1bd1-461e-81de-898c11a43c7c</Id>
+      <Database Name="cv" Series="100840" Issue="592609" />
     </Book>
     <Book Series="Uncanny Avengers" Number="24" Volume="2015" Year="2017">
-      <Id>c60bf0fb-8dce-47ff-83ef-64bda0537d24</Id>
+      <Database Name="cv" Series="85318" Issue="601808" />
     </Book>
     <Book Series="Uncanny Avengers" Number="25" Volume="2015" Year="2017">
-      <Id>bf1d9f52-4586-4ec2-b2a8-08d3e6f5a39b</Id>
+      <Database Name="cv" Series="85318" Issue="608262" />
     </Book>
     <Book Series="X-Men: Gold" Number="7" Volume="2017" Year="2017">
-      <Id>7a940d52-5fa3-44dd-b5d1-b68394611dc1</Id>
+      <Database Name="cv" Series="100603" Issue="606647" />
     </Book>
     <Book Series="X-Men: Gold" Number="8" Volume="2017" Year="2017">
-      <Id>299f7af7-bcb4-46e7-aebc-0afbbe5eb036</Id>
+      <Database Name="cv" Series="100603" Issue="609368" />
     </Book>
     <Book Series="Secret Empire" Number="1" Volume="2017" Year="2017">
-      <Id>326c68a9-af56-48c4-91ec-1329e755e360</Id>
+      <Database Name="cv" Series="100840" Issue="594120" />
     </Book>
     <Book Series="Deadpool" Number="32" Volume="2015" Year="2017">
-      <Id>4ce47bab-0dbe-4b56-b5d2-30f27b82524d</Id>
+      <Database Name="cv" Series="85750" Issue="601791" />
     </Book>
     <Book Series="Deadpool" Number="33" Volume="2015" Year="2017">
-      <Id>6e73a50f-fd6b-4c7b-88a7-17ac8982f8dd</Id>
+      <Database Name="cv" Series="85750" Issue="608241" />
     </Book>
     <Book Series="Secret Empire" Number="2" Volume="2017" Year="2017">
-      <Id>45ea9f1e-cb67-4a68-a084-d52926e0a441</Id>
+      <Database Name="cv" Series="100840" Issue="595700" />
     </Book>
     <Book Series="Secret Empire" Number="3" Volume="2017" Year="2017">
-      <Id>af72de8e-8519-4074-8d93-4a37ea0d6458</Id>
+      <Database Name="cv" Series="100840" Issue="598383" />
     </Book>
     <Book Series="Secret Empire" Number="4" Volume="2017" Year="2017">
-      <Id>0eea1124-bc08-4f03-a42a-52eae450eca2</Id>
+      <Database Name="cv" Series="100840" Issue="601800" />
     </Book>
     <Book Series="X-Men: Blue" Number="7" Volume="2017" Year="2017">
-      <Id>fc0840f7-0f41-4a15-b76c-20b807571ba3</Id>
+      <Database Name="cv" Series="100712" Issue="608266" />
     </Book>
     <Book Series="X-Men: Blue" Number="8" Volume="2017" Year="2017">
-      <Id>5bc814d1-3909-4152-b1ca-4711bee82e03</Id>
+      <Database Name="cv" Series="100712" Issue="610543" />
     </Book>
     <Book Series="X-Men: Blue" Number="9" Volume="2017" Year="2017">
-      <Id>732c674e-b0cd-4e1e-be6c-636257fbbea6</Id>
+      <Database Name="cv" Series="100712" Issue="615039" />
     </Book>
     <Book Series="Secret Empire" Number="5" Volume="2017" Year="2017">
-      <Id>6da82f1d-e1ee-4de2-b962-d3fce5a924a9</Id>
+      <Database Name="cv" Series="100840" Issue="605127" />
     </Book>
     <Book Series="Secret Empire" Number="6" Volume="2017" Year="2017">
-      <Id>5b39aaef-3019-49ea-bd2e-5cdea036a1cc</Id>
+      <Database Name="cv" Series="100840" Issue="609359" />
     </Book>
     <Book Series="Secret Empire" Number="7" Volume="2017" Year="2017">
-      <Id>4473ce43-2e4e-4167-9e1c-3546fbe731c9</Id>
+      <Database Name="cv" Series="100840" Issue="610534" />
     </Book>
     <Book Series="Deadpool" Number="34" Volume="2015" Year="2017">
-      <Id>25f7fae1-7348-4d50-971d-9803bf7edabb</Id>
+      <Database Name="cv" Series="85750" Issue="610522" />
     </Book>
     <Book Series="Deadpool" Number="35" Volume="2015" Year="2017">
-      <Id>85808696-7a72-4084-804b-d15d95124a92</Id>
+      <Database Name="cv" Series="85750" Issue="617837" />
     </Book>
     <Book Series="Secret Empire" Number="8" Volume="2017" Year="2017">
-      <Id>f3e61c17-d6be-4ab7-ab99-4ced7d939484</Id>
+      <Database Name="cv" Series="100840" Issue="613803" />
     </Book>
     <Book Series="Secret Empire" Number="9" Volume="2017" Year="2017">
-      <Id>1526a6be-88f4-4969-abb4-7f3226cff65c</Id>
+      <Database Name="cv" Series="100840" Issue="616200" />
     </Book>
     <Book Series="Secret Empire" Number="10" Volume="2017" Year="2017">
-      <Id>4e965c3b-ff57-49f7-93cb-2284427b7c4d</Id>
+      <Database Name="cv" Series="100840" Issue="617849" />
     </Book>
     <Book Series="X-Men: Blue" Number="10" Volume="2017" Year="2017">
-      <Id>5de683ed-7a3d-43f4-8202-422b120107a0</Id>
+      <Database Name="cv" Series="100712" Issue="617858" />
     </Book>
     <Book Series="X-Men: Blue" Number="11" Volume="2017" Year="2017">
-      <Id>7829187b-8349-4fc9-92f6-4c808ee4aedc</Id>
+      <Database Name="cv" Series="100712" Issue="621686" />
     </Book>
     <Book Series="X-Men: Blue" Number="12" Volume="2017" Year="2017">
-      <Id>b8f7d013-3197-40ce-a998-3d68099d9a0f</Id>
+      <Database Name="cv" Series="100712" Issue="625333" />
     </Book>
     <Book Series="X-Men: Gold" Number="9" Volume="2017" Year="2017">
-      <Id>ed8aa177-a7c9-4a7e-a070-dfd83ac71e1d</Id>
+      <Database Name="cv" Series="100603" Issue="612056" />
     </Book>
     <Book Series="X-Men: Gold" Number="10" Volume="2017" Year="2017">
-      <Id>0de64640-e9e0-4129-9323-c7452c2c1ca9</Id>
+      <Database Name="cv" Series="100603" Issue="616206" />
     </Book>
     <Book Series="X-Men: Gold" Number="11" Volume="2017" Year="2017">
-      <Id>ad80f45f-490e-40d7-b82f-178415d67e05</Id>
+      <Database Name="cv" Series="100603" Issue="619646" />
     </Book>
     <Book Series="X-Men: Gold" Number="12" Volume="2017" Year="2017">
-      <Id>91741cd7-2f67-4a9d-9216-2823b9854921</Id>
+      <Database Name="cv" Series="100603" Issue="622961" />
     </Book>
     <Book Series="Champions" Number="12" Volume="2016" Year="2017">
-      <Id>1f3a9cb8-818f-4fbf-89c4-9c7ff1a11e48</Id>
+      <Database Name="cv" Series="94612" Issue="619618" />
     </Book>
     <Book Series="Deadpool" Number="36" Volume="2015" Year="2017">
-      <Id>b159f691-553f-4cb3-b42e-4e1239dd399b</Id>
+      <Database Name="cv" Series="85750" Issue="621660" />
     </Book>
-    <Book Series="Generations: Phoenix &amp; Jean Grey" Number="1" Volume="2017" Year="2017">
-      <Id>8b4e1d6d-b73f-4adf-8ce2-871647b4b866</Id>
+    <Book Series="Generations: Phoenix &#38; Jean Grey" Number="1" Volume="2017" Year="2017">
+      <Database Name="cv" Series="103386" Issue="613790" />
     </Book>
-    <Book Series="Generations: Wolverine &amp; All-New Wolverine" Number="1" Volume="2017" Year="2017">
-      <Id>5de9d132-d0f3-4f94-a67b-fdd136b06f2d</Id>
+    <Book Series="Generations: Wolverine &#38; All-New Wolverine" Number="1" Volume="2017" Year="2017">
+      <Database Name="cv" Series="103514" Issue="615019" />
     </Book>
     <Book Series="Marvel Legacy" Number="1" Volume="2017" Year="2017">
-      <Id>0026d4a3-d0b4-45ca-b374-95971be685b1</Id>
+      <Database Name="cv" Series="104625" Issue="625313" />
     </Book>
     <Book Series="Champions" Number="13" Volume="2016" Year="2017">
-      <Id>1b80e1bc-282b-4c6e-8533-35cda1731b95</Id>
+      <Database Name="cv" Series="94612" Issue="630518" />
     </Book>
     <Book Series="Champions" Number="14" Volume="2016" Year="2018">
-      <Id>8c1861bb-912b-4771-ba80-b41f64d0dc16</Id>
+      <Database Name="cv" Series="94612" Issue="638591" />
     </Book>
     <Book Series="Champions" Number="15" Volume="2016" Year="2018">
-      <Id>0200a1d5-19bc-458c-b60a-75ccb5e421c3</Id>
+      <Database Name="cv" Series="94612" Issue="647936" />
     </Book>
     <Book Series="Champions" Number="16" Volume="2016" Year="2018">
-      <Id>eec4ad29-cf04-40ac-847f-62db8e9e8cd1</Id>
+      <Database Name="cv" Series="94612" Issue="654050" />
     </Book>
     <Book Series="Champions" Number="17" Volume="2016" Year="2018">
-      <Id>e95ec113-df23-4f7d-b08b-b576b959fc33</Id>
+      <Database Name="cv" Series="94612" Issue="661145" />
     </Book>
     <Book Series="Champions" Number="18" Volume="2016" Year="2018">
-      <Id>d31eb547-6906-4b83-a1e6-5c79ad3207d3</Id>
+      <Database Name="cv" Series="94612" Issue="664294" />
     </Book>
     <Book Series="Uncanny Avengers" Number="26" Volume="2015" Year="2017">
-      <Id>073052fa-da21-44e1-9139-48ecc0f4b4f2</Id>
+      <Database Name="cv" Series="85318" Issue="617856" />
     </Book>
     <Book Series="Uncanny Avengers" Number="27" Volume="2015" Year="2017">
-      <Id>3f8d572f-20e5-49ae-a165-ae65712976d5</Id>
+      <Database Name="cv" Series="85318" Issue="621682" />
     </Book>
     <Book Series="Uncanny Avengers" Number="28" Volume="2015" Year="2017">
-      <Id>a76e59ca-d995-41c1-b4cf-2d12802326d9</Id>
+      <Database Name="cv" Series="85318" Issue="628598" />
     </Book>
     <Book Series="Uncanny Avengers" Number="29" Volume="2015" Year="2018">
-      <Id>0bd0f610-1358-4f1a-86fd-082b1779a9b4</Id>
+      <Database Name="cv" Series="85318" Issue="636389" />
     </Book>
     <Book Series="Uncanny Avengers" Number="30" Volume="2015" Year="2018">
-      <Id>96e0b02f-c7ae-4498-a1f5-25088c8565e4</Id>
+      <Database Name="cv" Series="85318" Issue="647961" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="23" Volume="2016" Year="2018">
-      <Id>5d8e6c69-073f-4f43-9850-2abb571bfd1e</Id>
+      <Database Name="cv" Series="87182" Issue="636383" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="24" Volume="2016" Year="2018">
-      <Id>c73d9d4d-799c-4dc6-a53f-e294bbfe4059</Id>
+      <Database Name="cv" Series="87182" Issue="641416" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="25" Volume="2016" Year="2018">
-      <Id>19c9b02f-7840-4950-897c-64cc0cda2ce4</Id>
+      <Database Name="cv" Series="87182" Issue="649743" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="26" Volume="2016" Year="2018">
-      <Id>621b457d-8667-4f62-92ad-a76964b52c44</Id>
+      <Database Name="cv" Series="87182" Issue="652641" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="27" Volume="2016" Year="2018">
-      <Id>7a7f390d-53d7-4344-81f9-ba1afbfe7fa3</Id>
+      <Database Name="cv" Series="87182" Issue="658732" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="28" Volume="2016" Year="2018">
-      <Id>e68693bd-2849-4510-94ce-94a384b98386</Id>
+      <Database Name="cv" Series="87182" Issue="661160" />
     </Book>
     <Book Series="Iceman" Number="6" Volume="2017" Year="2017">
-      <Id>57427e9a-0fed-41ac-9fec-25aaf8006255</Id>
+      <Database Name="cv" Series="101937" Issue="626284" />
     </Book>
     <Book Series="Iceman" Number="7" Volume="2017" Year="2018">
-      <Id>7436f8bc-c951-4eef-aeab-693bae6a949d</Id>
+      <Database Name="cv" Series="101937" Issue="634535" />
     </Book>
     <Book Series="Iceman" Number="8" Volume="2017" Year="2018">
-      <Id>a3528ef9-6092-428a-af07-2d19507d51ae</Id>
+      <Database Name="cv" Series="101937" Issue="644508" />
     </Book>
     <Book Series="Iceman" Number="9" Volume="2017" Year="2018">
-      <Id>fc577ef6-d956-48b2-b745-f9ad727e7aed</Id>
+      <Database Name="cv" Series="101937" Issue="650918" />
     </Book>
     <Book Series="Iceman" Number="10" Volume="2017" Year="2018">
-      <Id>42def6e3-1751-4e1d-8dc8-a3ed1b428ad7</Id>
+      <Database Name="cv" Series="101937" Issue="658722" />
     </Book>
     <Book Series="Iceman" Number="11" Volume="2017" Year="2018">
-      <Id>1788c462-eea7-4c87-a7f2-c4bfe69ba5d1</Id>
+      <Database Name="cv" Series="101937" Issue="662089" />
     </Book>
     <Book Series="X-Men: Gold" Number="13" Volume="2017" Year="2017">
-      <Id>9c1c35af-a1aa-4d1b-b6c3-681db96c29c6</Id>
+      <Database Name="cv" Series="100603" Issue="626306" />
     </Book>
     <Book Series="X-Men: Blue" Number="13" Volume="2017" Year="2017">
-      <Id>37bb46d6-8627-49ff-9a48-eea037dcbb14</Id>
+      <Database Name="cv" Series="100712" Issue="628601" />
     </Book>
     <Book Series="X-Men: Gold" Number="14" Volume="2017" Year="2017">
-      <Id>5ab54143-5f9d-431a-abf8-757c99a00c35</Id>
+      <Database Name="cv" Series="100603" Issue="630540" />
     </Book>
     <Book Series="X-Men: Blue" Number="14" Volume="2017" Year="2017">
-      <Id>3526af69-28af-4a1c-ad08-94402de20b1c</Id>
+      <Database Name="cv" Series="100712" Issue="632512" />
     </Book>
     <Book Series="X-Men: Gold" Number="15" Volume="2017" Year="2018">
-      <Id>a9988813-bcc7-4a82-a28f-29219a3ac0f2</Id>
+      <Database Name="cv" Series="100603" Issue="636392" />
     </Book>
     <Book Series="X-Men: Blue" Number="15" Volume="2017" Year="2018">
-      <Id>9e1a6603-4cb4-4d44-9ca8-f4ca238282dc</Id>
+      <Database Name="cv" Series="100712" Issue="638615" />
     </Book>
     <Book Series="X-Men: Blue" Number="16" Volume="2017" Year="2018">
-      <Id>110b5260-3860-4c29-a01c-4a7950e9448d</Id>
+      <Database Name="cv" Series="100712" Issue="643049" />
     </Book>
     <Book Series="X-Men: Blue" Number="17" Volume="2017" Year="2018">
-      <Id>d1c03212-deed-41cd-8f4d-3ca46a4d847a</Id>
+      <Database Name="cv" Series="100712" Issue="646207" />
     </Book>
     <Book Series="X-Men: Blue" Number="18" Volume="2017" Year="2018">
-      <Id>1737dcb5-724b-4c39-82c1-0825d07159c7</Id>
+      <Database Name="cv" Series="100712" Issue="649753" />
     </Book>
     <Book Series="X-Men: Blue" Number="19" Volume="2017" Year="2018">
-      <Id>55cd83a8-e915-45d9-ac36-c4d923a2bd0e</Id>
+      <Database Name="cv" Series="100712" Issue="652646" />
     </Book>
     <Book Series="X-Men: Blue" Number="20" Volume="2017" Year="2018">
-      <Id>e9e3e5b3-2e87-4351-bb39-e1d9b602e065</Id>
+      <Database Name="cv" Series="100712" Issue="655516" />
     </Book>
     <Book Series="Generation X" Number="85" Volume="2017" Year="2018">
-      <Id>4b6f1e2b-07b5-44f6-9a13-cec179a97360</Id>
+      <Database Name="cv" Series="101478" Issue="647941" />
     </Book>
     <Book Series="Generation X" Number="86" Volume="2017" Year="2018">
-      <Id>ac1d6195-fa9f-48f0-8307-e8aaa553466a</Id>
+      <Database Name="cv" Series="101478" Issue="654054" />
     </Book>
     <Book Series="Generation X" Number="87" Volume="2017" Year="2018">
-      <Id>26380490-2672-4f16-96eb-1207a96c134e</Id>
+      <Database Name="cv" Series="101478" Issue="660662" />
     </Book>
     <Book Series="Old Man Logan" Number="31" Volume="2016" Year="2018">
-      <Id>c51894de-7895-4951-ade0-31c8fb982bd9</Id>
+      <Database Name="cv" Series="87624" Issue="643038" />
     </Book>
     <Book Series="Old Man Logan" Number="32" Volume="2016" Year="2018">
-      <Id>c0210cde-8e48-44ba-af5b-a3aaaf8914b3</Id>
+      <Database Name="cv" Series="87624" Issue="647951" />
     </Book>
     <Book Series="Old Man Logan" Number="33" Volume="2016" Year="2018">
-      <Id>64db04a0-3d81-459f-94a4-0eedb44e3e4b</Id>
+      <Database Name="cv" Series="87624" Issue="652634" />
     </Book>
     <Book Series="Old Man Logan" Number="34" Volume="2016" Year="2018">
-      <Id>3eaa2ada-0fbe-4da2-9fcd-be3ecd287679</Id>
+      <Database Name="cv" Series="87624" Issue="656711" />
     </Book>
     <Book Series="Old Man Logan" Number="35" Volume="2016" Year="2018">
-      <Id>97ee2d2e-2519-4313-aaf9-29f227b9076f</Id>
+      <Database Name="cv" Series="87624" Issue="660022" />
     </Book>
     <Book Series="Old Man Logan" Number="36" Volume="2016" Year="2018">
-      <Id>27213657-abf4-4e4e-b4eb-e8a056d130e7</Id>
+      <Database Name="cv" Series="87624" Issue="662750" />
     </Book>
     <Book Series="Weapon X" Number="12" Volume="2017" Year="2018">
-      <Id>1cf12032-786d-46e7-9e88-459f1c528692</Id>
+      <Database Name="cv" Series="100709" Issue="646206" />
     </Book>
     <Book Series="Weapon X" Number="13" Volume="2017" Year="2018">
-      <Id>4858d0ff-ecea-4694-9263-1468ddd09ca8</Id>
+      <Database Name="cv" Series="100709" Issue="654064" />
     </Book>
     <Book Series="Weapon X" Number="14" Volume="2017" Year="2018">
-      <Id>a70255ac-6601-4325-bd94-4302467f4792</Id>
+      <Database Name="cv" Series="100709" Issue="660027" />
     </Book>
     <Book Series="Weapon X" Number="15" Volume="2017" Year="2018">
-      <Id>3540ef07-9a85-4d31-83d9-5ef1452855c2</Id>
+      <Database Name="cv" Series="100709" Issue="662756" />
     </Book>
     <Book Series="Weapon X" Number="16" Volume="2017" Year="2018">
-      <Id>1e9053e8-bc56-4a8b-bd99-ea2e4f394021</Id>
+      <Database Name="cv" Series="100709" Issue="666819" />
     </Book>
     <Book Series="Cable" Number="150" Volume="2017" Year="2017">
-      <Id>d420fc63-dbb7-4127-9d2e-790e427a2187</Id>
+      <Database Name="cv" Series="101767" Issue="630517" />
     </Book>
     <Book Series="Cable" Number="151" Volume="2017" Year="2018">
-      <Id>6042ede7-a5df-4e9d-9d3e-177f6df1368a</Id>
+      <Database Name="cv" Series="101767" Issue="641399" />
     </Book>
     <Book Series="Cable" Number="152" Volume="2017" Year="2018">
-      <Id>d169c284-d2a7-4040-9a15-300028da5d6b</Id>
+      <Database Name="cv" Series="101767" Issue="646182" />
     </Book>
     <Book Series="Cable" Number="153" Volume="2017" Year="2018">
-      <Id>6cc9225a-94ab-448b-ac90-0097505cccb8</Id>
+      <Database Name="cv" Series="101767" Issue="652623" />
     </Book>
     <Book Series="Cable" Number="154" Volume="2017" Year="2018">
-      <Id>a86cd71b-8fb7-4400-87cc-fa23e7eda40e</Id>
+      <Database Name="cv" Series="101767" Issue="660010" />
     </Book>
     <Book Series="Deadpool vs. Old Man Logan" Number="1" Volume="2017" Year="2017">
-      <Id>7cb0e9b8-c185-4a32-ad48-3ff27bf5441d</Id>
+      <Database Name="cv" Series="105311" Issue="630519" />
     </Book>
     <Book Series="Deadpool vs. Old Man Logan" Number="2" Volume="2017" Year="2018">
-      <Id>51ed6b75-f3f4-4bfb-a5ff-efd121329343</Id>
+      <Database Name="cv" Series="105311" Issue="638593" />
     </Book>
     <Book Series="Deadpool vs. Old Man Logan" Number="3" Volume="2017" Year="2018">
-      <Id>078e3007-2ea0-4421-b4c8-70af1772eb58</Id>
+      <Database Name="cv" Series="105311" Issue="647938" />
     </Book>
     <Book Series="Deadpool vs. Old Man Logan" Number="4" Volume="2017" Year="2018">
-      <Id>4df11a9d-c063-4fd2-9391-88779703a787</Id>
+      <Database Name="cv" Series="105311" Issue="654052" />
     </Book>
     <Book Series="Deadpool vs. Old Man Logan" Number="5" Volume="2017" Year="2018">
-      <Id>1424ace1-74b9-431f-b30f-414220a8ed14</Id>
+      <Database Name="cv" Series="105311" Issue="660658" />
     </Book>
     <Book Series="Despicable Deadpool" Number="287" Volume="2017" Year="2017">
-      <Id>7882fee6-99d3-4869-aefd-b5d66740c485</Id>
+      <Database Name="cv" Series="104999" Issue="628579" />
     </Book>
     <Book Series="Despicable Deadpool" Number="288" Volume="2017" Year="2017">
-      <Id>fff4c7e1-656a-4a1e-8e74-5623746493a3</Id>
+      <Database Name="cv" Series="104999" Issue="632495" />
     </Book>
     <Book Series="Despicable Deadpool" Number="289" Volume="2017" Year="2018">
-      <Id>d6553b6b-6ffa-4160-9cf0-b73d6d9204d1</Id>
+      <Database Name="cv" Series="104999" Issue="636370" />
     </Book>
     <Book Series="Despicable Deadpool" Number="290" Volume="2017" Year="2018">
-      <Id>56e54254-1492-47b0-8f2c-e8c944981971</Id>
+      <Database Name="cv" Series="104999" Issue="646186" />
     </Book>
     <Book Series="Despicable Deadpool" Number="291" Volume="2017" Year="2018">
-      <Id>cf563d19-93a6-45ba-bb54-ebb05c53697d</Id>
+      <Database Name="cv" Series="104999" Issue="649729" />
     </Book>
-    <Book Series="Rogue &amp; Gambit" Number="1" Volume="2018" Year="2018">
-      <Id>e67e69d7-5c3d-4e23-bf4c-d96db3601e17</Id>
+    <Book Series="Rogue &#38; Gambit" Number="1" Volume="2018" Year="2018">
+      <Database Name="cv" Series="107513" Issue="650924" />
     </Book>
-    <Book Series="Rogue &amp; Gambit" Number="2" Volume="2018" Year="2018">
-      <Id>e626b780-abd9-4625-b6e1-28664f0dbaaa</Id>
+    <Book Series="Rogue &#38; Gambit" Number="2" Volume="2018" Year="2018">
+      <Database Name="cv" Series="107513" Issue="658728" />
     </Book>
-    <Book Series="Rogue &amp; Gambit" Number="3" Volume="2018" Year="2018">
-      <Id>d8a682d9-8df4-453a-a34e-13737b8904a1</Id>
+    <Book Series="Rogue &#38; Gambit" Number="3" Volume="2018" Year="2018">
+      <Database Name="cv" Series="107513" Issue="662094" />
     </Book>
-    <Book Series="Rogue &amp; Gambit" Number="4" Volume="2018" Year="2018">
-      <Id>0bd88c2d-92e9-463c-b68d-2bad42786a4b</Id>
+    <Book Series="Rogue &#38; Gambit" Number="4" Volume="2018" Year="2018">
+      <Database Name="cv" Series="107513" Issue="664920" />
     </Book>
-    <Book Series="Rogue &amp; Gambit" Number="5" Volume="2018" Year="2018">
-      <Id>a611ffd0-f2d8-42ba-8973-4458c090bc6d</Id>
+    <Book Series="Rogue &#38; Gambit" Number="5" Volume="2018" Year="2018">
+      <Database Name="cv" Series="107513" Issue="668780" />
     </Book>
     <Book Series="Jean Grey" Number="7" Volume="2017" Year="2017">
-      <Id>c05eb282-f33c-42d4-9cd7-206d5d78dbaa</Id>
+      <Database Name="cv" Series="101195" Issue="622942" />
     </Book>
     <Book Series="Jean Grey" Number="8" Volume="2017" Year="2017">
-      <Id>ad2f56cf-f118-448a-9647-4ecdedfe93b1</Id>
+      <Database Name="cv" Series="101195" Issue="632498" />
     </Book>
     <Book Series="Jean Grey" Number="9" Volume="2017" Year="2018">
-      <Id>3e360454-f0cd-4d5f-bdde-d67b75963310</Id>
+      <Database Name="cv" Series="101195" Issue="643031" />
     </Book>
     <Book Series="Phoenix Resurrection: The Return of Jean Grey" Number="1" Volume="2017" Year="2018">
-      <Id>c9482542-d4b8-4b54-8e11-b5aa4abc03c0</Id>
+      <Database Name="cv" Series="107368" Issue="649740" />
     </Book>
     <Book Series="Jean Grey" Number="10" Volume="2017" Year="2018">
-      <Id>472e04a0-3b4b-4cfc-9115-b46d3510cc68</Id>
+      <Database Name="cv" Series="101195" Issue="646189" />
     </Book>
     <Book Series="Phoenix Resurrection: The Return of Jean Grey" Number="2" Volume="2017" Year="2018">
-      <Id>5e3e6279-bdf2-4e3e-b433-7f594e8e23b2</Id>
+      <Database Name="cv" Series="107368" Issue="650922" />
     </Book>
     <Book Series="Phoenix Resurrection: The Return of Jean Grey" Number="3" Volume="2017" Year="2018">
-      <Id>95eda3e6-f4e3-4b8a-9086-b45dec572bc7</Id>
+      <Database Name="cv" Series="107368" Issue="652635" />
     </Book>
     <Book Series="Phoenix Resurrection: The Return of Jean Grey" Number="4" Volume="2017" Year="2018">
-      <Id>3deb08eb-46d2-423a-823c-5445ce599a3a</Id>
+      <Database Name="cv" Series="107368" Issue="655510" />
     </Book>
     <Book Series="Jean Grey" Number="11" Volume="2017" Year="2018">
-      <Id>56632b8e-92c3-47c3-bc6f-cbbdda9fcf72</Id>
+      <Database Name="cv" Series="101195" Issue="656706" />
     </Book>
     <Book Series="Phoenix Resurrection: The Return of Jean Grey" Number="5" Volume="2017" Year="2018">
-      <Id>f171f2d6-b236-4977-a576-c61f674be1bb</Id>
+      <Database Name="cv" Series="107368" Issue="656712" />
     </Book>
     <Book Series="Astonishing X-Men" Number="1" Volume="2017" Year="2017">
-      <Id>54282c02-8083-4b8b-8e56-a7d3fb6ef8c5</Id>
+      <Database Name="cv" Series="102882" Issue="609338" />
     </Book>
     <Book Series="Astonishing X-Men" Number="2" Volume="2017" Year="2017">
-      <Id>79258b97-fe06-432f-8e98-d36cb37ac661</Id>
+      <Database Name="cv" Series="102882" Issue="615015" />
     </Book>
     <Book Series="Astonishing X-Men" Number="3" Volume="2017" Year="2017">
-      <Id>300b43ae-cd5e-4c0c-a665-8f38e7a01c82</Id>
+      <Database Name="cv" Series="102882" Issue="619616" />
     </Book>
     <Book Series="Astonishing X-Men" Number="4" Volume="2017" Year="2017">
-      <Id>19af7114-86c2-4a51-85bd-9b682c637007</Id>
+      <Database Name="cv" Series="102882" Issue="626275" />
     </Book>
     <Book Series="Astonishing X-Men" Number="5" Volume="2017" Year="2018">
-      <Id>9d442407-6446-47c8-a7fc-f88956e14a8e</Id>
+      <Database Name="cv" Series="102882" Issue="634524" />
     </Book>
     <Book Series="Astonishing X-Men" Number="6" Volume="2017" Year="2018">
-      <Id>a929eafc-ba2c-4147-81dc-387e90e61013</Id>
+      <Database Name="cv" Series="102882" Issue="644496" />
     </Book>
     <Book Series="Astonishing X-Men" Number="7" Volume="2017" Year="2018">
-      <Id>cd7d5eb9-2315-45ab-ab04-37dc0ba15274</Id>
+      <Database Name="cv" Series="102882" Issue="650910" />
     </Book>
     <Book Series="Astonishing X-Men" Number="8" Volume="2017" Year="2018">
-      <Id>6de9378c-6104-4440-8acd-df61c225ff7c</Id>
+      <Database Name="cv" Series="102882" Issue="660652" />
     </Book>
     <Book Series="Astonishing X-Men" Number="9" Volume="2017" Year="2018">
-      <Id>059b1120-9a40-4518-a19b-b1cb5423884a</Id>
+      <Database Name="cv" Series="102882" Issue="662736" />
     </Book>
     <Book Series="Astonishing X-Men" Number="10" Volume="2017" Year="2018">
-      <Id>60008826-dad5-46e2-baeb-3f4ae712c33f</Id>
+      <Database Name="cv" Series="102882" Issue="664906" />
     </Book>
     <Book Series="Astonishing X-Men" Number="11" Volume="2017" Year="2018">
-      <Id>e362024e-5c50-4a4b-bf13-f81711d7e0a8</Id>
+      <Database Name="cv" Series="102882" Issue="668769" />
     </Book>
     <Book Series="Astonishing X-Men" Number="12" Volume="2017" Year="2018">
-      <Id>508512ba-61cf-49d2-b831-4f6a8aae83ce</Id>
+      <Database Name="cv" Series="102882" Issue="672275" />
     </Book>
     <Book Series="X-Men Blue Annual" Number="1" Volume="2018" Year="2018">
-      <Id>5b490ea3-da78-4682-9b87-3080a9cb725f</Id>
+      <Database Name="cv" Series="108127" Issue="655517" />
     </Book>
     <Book Series="X-Men: Blue" Number="21" Volume="2017" Year="2018">
-      <Id>fafdd25a-384e-462e-a38b-e90e78d59c0e</Id>
+      <Database Name="cv" Series="100712" Issue="660028" />
     </Book>
     <Book Series="X-Men: Blue" Number="22" Volume="2017" Year="2018">
-      <Id>eceda571-ca71-4912-bc49-d163cb02a3f0</Id>
+      <Database Name="cv" Series="100712" Issue="661168" />
     </Book>
     <Book Series="Venom" Number="163" Volume="2016" Year="2018">
-      <Id>883f8a38-8eee-4e76-b804-4b14f365c627</Id>
+      <Database Name="cv" Series="95845" Issue="662102" />
     </Book>
     <Book Series="X-Men: Gold" Number="16" Volume="2017" Year="2018">
-      <Id>ecc0d92d-96b7-4eb7-bf51-41f51e8fb6a7</Id>
+      <Database Name="cv" Series="100603" Issue="641422" />
     </Book>
     <Book Series="X-Men: Gold" Number="17" Volume="2017" Year="2018">
-      <Id>0669648c-ee05-4061-8a15-693f5be68320</Id>
+      <Database Name="cv" Series="100603" Issue="644521" />
     </Book>
     <Book Series="X-Men: Gold" Number="18" Volume="2017" Year="2018">
-      <Id>1f1096e5-c912-4784-b282-552f1e32a9a6</Id>
+      <Database Name="cv" Series="100603" Issue="647963" />
     </Book>
     <Book Series="X-Men: Gold" Number="19" Volume="2017" Year="2018">
-      <Id>5e911c59-0dc2-4849-a58c-a56e39838060</Id>
+      <Database Name="cv" Series="100603" Issue="650929" />
     </Book>
     <Book Series="X-Men: Gold" Number="20" Volume="2017" Year="2018">
-      <Id>0ed428e2-4d51-4a09-ab79-1bda5f4e1bb2</Id>
+      <Database Name="cv" Series="100603" Issue="654065" />
     </Book>
     <Book Series="X-Men: Gold" Number="21" Volume="2017" Year="2018">
-      <Id>6d11be2e-bca9-4c78-ac9c-aa9c12fa1ae3</Id>
+      <Database Name="cv" Series="100603" Issue="658737" />
     </Book>
     <Book Series="X-Men: Gold" Number="22" Volume="2017" Year="2018">
-      <Id>9869f246-4e11-4d10-81b9-fb0857e874c8</Id>
+      <Database Name="cv" Series="100603" Issue="660674" />
     </Book>
     <Book Series="X-Men: Gold" Number="23" Volume="2017" Year="2018">
-      <Id>da10018a-4e69-4091-9d55-292f30c66a37</Id>
+      <Database Name="cv" Series="100603" Issue="662103" />
     </Book>
     <Book Series="X-Men: Gold" Number="24" Volume="2017" Year="2018">
-      <Id>163dde90-61cd-4fc7-ae50-f6fb09fca5d3</Id>
+      <Database Name="cv" Series="100603" Issue="663595" />
     </Book>
     <Book Series="X-Men: Gold" Number="25" Volume="2017" Year="2018">
-      <Id>3387f0cd-b90c-4910-8f47-c4b54bb57b05</Id>
+      <Database Name="cv" Series="100603" Issue="664931" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 017 - (Resurrection).cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 017 - (Resurrection).cbl
@@ -2,625 +2,625 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>X-Men - Part 17 - (Resurrection)</Name>
   <Books>
-    <Book Series="X-Men Prime" Number="1" Volume="2017" Year="2017" Format="One-Shot">
+    <Book Series="X-Men Prime" Number="1" Volume="2017" Year="2017">
       <Id>49bb34fe-d989-44f0-b81f-242fd839aeca</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="1" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="1" Volume="2017" Year="2017">
       <Id>0ae2f9ab-99ca-41b7-ae3a-8fbe47706eab</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="2" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="2" Volume="2017" Year="2017">
       <Id>f2318c74-aa43-40e9-bf08-83ea222b2486</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="3" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="3" Volume="2017" Year="2017">
       <Id>2f394102-a605-4de8-8d3c-e394ef617ba3</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="4" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="4" Volume="2017" Year="2017">
       <Id>7bf3b380-1827-4c52-833f-774ced433cc9</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="5" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="5" Volume="2017" Year="2017">
       <Id>6b0e1770-4366-484d-b457-67a420a0f8ff</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="6" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="6" Volume="2017" Year="2017">
       <Id>38213940-eafb-4b81-8117-c0d91f7a4079</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="1" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="1" Volume="2017" Year="2017">
       <Id>6c30e0a2-e456-4ad0-828a-8df3e0657b2f</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="2" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="2" Volume="2017" Year="2017">
       <Id>0bb8a222-4424-469f-a44a-e65af25b162e</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="3" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="3" Volume="2017" Year="2017">
       <Id>c17c0460-9c5f-4511-8133-827c6897dfb7</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="4" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="4" Volume="2017" Year="2017">
       <Id>4a4a9d58-3612-46e9-8670-07781204d6f0</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="5" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="5" Volume="2017" Year="2017">
       <Id>2b662b58-6405-47c7-a9e0-7cf72725b3dd</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="6" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="6" Volume="2017" Year="2017">
       <Id>9fecdad1-e99e-47ed-b94b-beb0ea447c4f</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="19" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="19" Volume="2015" Year="2017">
       <Id>086599a4-35b5-457b-8cff-821d4b95d1aa</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="20" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="20" Volume="2015" Year="2017">
       <Id>b82affc6-3161-48bf-b9d2-9b7d1dcf3bd0</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="21" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="21" Volume="2015" Year="2017">
       <Id>10e3e525-5282-4aff-ac35-6858d9d78e60</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="22" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="22" Volume="2015" Year="2017">
       <Id>d3a68678-83ef-4e3c-9351-aa60e1bc2684</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="23" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="23" Volume="2015" Year="2017">
       <Id>008540b0-8899-4f73-89bc-76bd1321c565</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="24" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="24" Volume="2015" Year="2017">
       <Id>d93b548f-18f8-4711-b19d-963fc27e3679</Id>
     </Book>
-    <Book Series="Generation X" Number="1" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Generation X" Number="1" Volume="2017" Year="2017">
       <Id>82e33790-2504-407e-b6fe-9a18bce8d575</Id>
     </Book>
-    <Book Series="Generation X" Number="2" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Generation X" Number="2" Volume="2017" Year="2017">
       <Id>446b92f7-0420-4f53-9797-c38487283c40</Id>
     </Book>
-    <Book Series="Generation X" Number="3" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Generation X" Number="3" Volume="2017" Year="2017">
       <Id>196160f0-2bc7-4374-808c-38504ac8b03c</Id>
     </Book>
-    <Book Series="Generation X" Number="4" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Generation X" Number="4" Volume="2017" Year="2017">
       <Id>d5cfad42-d853-490b-ac24-ff1e584fe269</Id>
     </Book>
-    <Book Series="Generation X" Number="5" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Generation X" Number="5" Volume="2017" Year="2017">
       <Id>784ee073-5f79-4d7c-ac44-a79cfc9bb950</Id>
     </Book>
-    <Book Series="Iceman" Number="1" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Iceman" Number="1" Volume="2017" Year="2017">
       <Id>dfa05b47-6bb2-4373-b4ab-0835206ae54d</Id>
     </Book>
-    <Book Series="Iceman" Number="2" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Iceman" Number="2" Volume="2017" Year="2017">
       <Id>01d904ab-5578-494e-9bad-0f55475696db</Id>
     </Book>
-    <Book Series="Iceman" Number="3" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Iceman" Number="3" Volume="2017" Year="2017">
       <Id>16717778-4f83-4d8d-ace7-819ae97ffa35</Id>
     </Book>
-    <Book Series="Iceman" Number="4" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Iceman" Number="4" Volume="2017" Year="2017">
       <Id>09c1bf80-ba00-4472-b902-278b0e005d52</Id>
     </Book>
-    <Book Series="Iceman" Number="5" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Iceman" Number="5" Volume="2017" Year="2017">
       <Id>acad3ff7-7b18-4d93-9837-2900dbf2c35b</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="25" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Old Man Logan" Number="25" Volume="2016" Year="2017">
       <Id>22bd922c-3251-4623-a2fa-6f16077281f2</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="26" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Old Man Logan" Number="26" Volume="2016" Year="2017">
       <Id>9aa06245-0b38-4be5-a4aa-4bfae8bd0e9b</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="27" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Old Man Logan" Number="27" Volume="2016" Year="2017">
       <Id>c51aee21-2c71-443a-b6ba-47001c0a1b0c</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="28" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Old Man Logan" Number="28" Volume="2016" Year="2017">
       <Id>deddbda6-b2a8-42d5-8d42-ed12ffb5a0e3</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="29" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Old Man Logan" Number="29" Volume="2016" Year="2017">
       <Id>904330f2-5430-41fd-9717-fbbe12c3919b</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="30" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Old Man Logan" Number="30" Volume="2016" Year="2018">
       <Id>dbd2e7c2-11ec-4522-9c61-3af0860fa780</Id>
     </Book>
-    <Book Series="Generation X" Number="6" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Generation X" Number="6" Volume="2017" Year="2017">
       <Id>eed9d6e4-2a24-4812-a0c4-89a95ae44dbd</Id>
     </Book>
-    <Book Series="Generation X" Number="7" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Generation X" Number="7" Volume="2017" Year="2017">
       <Id>1836838d-b7eb-4a29-b259-a3664b7eecf5</Id>
     </Book>
-    <Book Series="Generation X" Number="8" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Generation X" Number="8" Volume="2017" Year="2018">
       <Id>34fed9d5-9be6-4fd7-b1d6-b1ea7e277e09</Id>
     </Book>
-    <Book Series="Generation X" Number="9" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Generation X" Number="9" Volume="2017" Year="2018">
       <Id>8e8d9e7f-e7e6-4e66-95d7-a0b4eb9d63ac</Id>
     </Book>
-    <Book Series="Jean Grey" Number="1" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Jean Grey" Number="1" Volume="2017" Year="2017">
       <Id>461047e6-ba17-47a1-8066-6c9be66d61bc</Id>
     </Book>
-    <Book Series="Jean Grey" Number="2" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Jean Grey" Number="2" Volume="2017" Year="2017">
       <Id>9a6c57ac-8e0e-44c5-a958-f35df5472947</Id>
     </Book>
-    <Book Series="Jean Grey" Number="3" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Jean Grey" Number="3" Volume="2017" Year="2017">
       <Id>f4087701-0b6e-4be4-8176-a936eac51069</Id>
     </Book>
-    <Book Series="Jean Grey" Number="4" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Jean Grey" Number="4" Volume="2017" Year="2017">
       <Id>e89b62a5-55c8-42d5-ae8b-84354cec7bc9</Id>
     </Book>
-    <Book Series="Jean Grey" Number="5" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Jean Grey" Number="5" Volume="2017" Year="2017">
       <Id>ab944c49-8d5d-4818-9955-7bf608741aad</Id>
     </Book>
-    <Book Series="Jean Grey" Number="6" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Jean Grey" Number="6" Volume="2017" Year="2017">
       <Id>cc0a2992-51ae-4874-bf00-ac9c7b67704a</Id>
     </Book>
-    <Book Series="Deadpool" Number="28" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Deadpool" Number="28" Volume="2015" Year="2017">
       <Id>d9e8750b-51e3-449d-9cbc-407d7d139def</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="15" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="15" Volume="2016" Year="2017">
       <Id>653935bb-ae6a-4097-b68c-4b729ccd365e</Id>
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="9" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Deadpool &amp; The Mercs For Money" Number="9" Volume="2016" Year="2017">
       <Id>35245e41-63ad-4b55-9bc6-0963ac714e7b</Id>
     </Book>
-    <Book Series="Deadpool" Number="29" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Deadpool" Number="29" Volume="2015" Year="2017">
       <Id>ee030fd1-a6ff-4fe4-9888-feabfac9d36f</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="16" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="16" Volume="2016" Year="2017">
       <Id>a5bc3fb3-7262-41d1-a9f6-acb6dc3901d8</Id>
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="10" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Deadpool &amp; The Mercs For Money" Number="10" Volume="2016" Year="2017">
       <Id>7442c9b2-9618-4256-8aff-651509ba7be1</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="17" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="17" Volume="2016" Year="2017">
       <Id>5aeec02b-1e89-4ff8-9dad-ec2423194341</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="18" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="18" Volume="2016" Year="2017">
       <Id>52fac5ca-73e7-49a0-a79f-bc54919fc259</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="19" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="19" Volume="2016" Year="2017">
       <Id>5b504ac1-d9ee-4fec-9744-a726d795c945</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="20" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="20" Volume="2016" Year="2017">
       <Id>09f1005d-7f14-44db-b391-342b1af955b1</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="21" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="21" Volume="2016" Year="2017">
       <Id>bc766a2a-60c8-4a97-9e55-79c508334108</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="22" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="22" Volume="2016" Year="2017">
       <Id>24231fd3-b252-4acf-9d1a-d7df04c5d8b1</Id>
     </Book>
-    <Book Series="Deadpool" Number="30" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Deadpool" Number="30" Volume="2015" Year="2017">
       <Id>d6b7e709-8685-4865-be25-43e4505ed2e2</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="1.MU" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="1.MU" Volume="2016" Year="2017">
       <Id>3f7737f2-7960-410f-a92d-43424b1c856b</Id>
     </Book>
-    <Book Series="Champions" Number="1.MU" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Champions" Number="1.MU" Volume="2016" Year="2017">
       <Id>5b9b0df9-6017-417d-94cb-7834cf55ae0b</Id>
     </Book>
-    <Book Series="Champions" Number="7" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Champions" Number="7" Volume="2016" Year="2017">
       <Id>5a18c1e1-7d76-4fa9-a9eb-e10170a7f8aa</Id>
     </Book>
-    <Book Series="Champions" Number="8" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Champions" Number="8" Volume="2016" Year="2017">
       <Id>47a0d72c-ae56-45f6-914e-0fef3e53800f</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="18" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="18" Volume="2015" Year="2017">
       <Id>75343677-347c-4236-a608-c30c99aed769</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="19" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="19" Volume="2015" Year="2017">
       <Id>3dd56eb0-7c3f-493f-9af5-48cb873f7df0</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="20" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="20" Volume="2015" Year="2017">
       <Id>fab4efc0-6f2a-4373-9eb1-31d8102f98cf</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="21" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="21" Volume="2015" Year="2017">
       <Id>e600562d-c25d-4cf1-b40e-01de51f9d6ba</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="22" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="22" Volume="2015" Year="2017">
       <Id>2bf94bc9-d703-44c9-9c9e-3562db8dac63</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="23" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="23" Volume="2015" Year="2017">
       <Id>14804d4f-052e-48b0-bced-d508c1d49960</Id>
     </Book>
-    <Book Series="Deadpool" Number="31" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Deadpool" Number="31" Volume="2015" Year="2017">
       <Id>5d75e237-6171-46c1-b4de-944a92048e6d</Id>
     </Book>
-    <Book Series="Secret Empire" Number="0" Volume="2017" Year="2017" Format="Crossover">
+    <Book Series="Secret Empire" Number="0" Volume="2017" Year="2017">
       <Id>c9c826f6-1bd1-461e-81de-898c11a43c7c</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="24" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="24" Volume="2015" Year="2017">
       <Id>c60bf0fb-8dce-47ff-83ef-64bda0537d24</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="25" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="25" Volume="2015" Year="2017">
       <Id>bf1d9f52-4586-4ec2-b2a8-08d3e6f5a39b</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="7" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="7" Volume="2017" Year="2017">
       <Id>7a940d52-5fa3-44dd-b5d1-b68394611dc1</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="8" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="8" Volume="2017" Year="2017">
       <Id>299f7af7-bcb4-46e7-aebc-0afbbe5eb036</Id>
     </Book>
-    <Book Series="Secret Empire" Number="1" Volume="2017" Year="2017" Format="Crossover">
+    <Book Series="Secret Empire" Number="1" Volume="2017" Year="2017">
       <Id>326c68a9-af56-48c4-91ec-1329e755e360</Id>
     </Book>
-    <Book Series="Deadpool" Number="32" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Deadpool" Number="32" Volume="2015" Year="2017">
       <Id>4ce47bab-0dbe-4b56-b5d2-30f27b82524d</Id>
     </Book>
-    <Book Series="Deadpool" Number="33" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Deadpool" Number="33" Volume="2015" Year="2017">
       <Id>6e73a50f-fd6b-4c7b-88a7-17ac8982f8dd</Id>
     </Book>
-    <Book Series="Secret Empire" Number="2" Volume="2017" Year="2017" Format="Crossover">
+    <Book Series="Secret Empire" Number="2" Volume="2017" Year="2017">
       <Id>45ea9f1e-cb67-4a68-a084-d52926e0a441</Id>
     </Book>
-    <Book Series="Secret Empire" Number="3" Volume="2017" Year="2017" Format="Crossover">
+    <Book Series="Secret Empire" Number="3" Volume="2017" Year="2017">
       <Id>af72de8e-8519-4074-8d93-4a37ea0d6458</Id>
     </Book>
-    <Book Series="Secret Empire" Number="4" Volume="2017" Year="2017" Format="Crossover">
+    <Book Series="Secret Empire" Number="4" Volume="2017" Year="2017">
       <Id>0eea1124-bc08-4f03-a42a-52eae450eca2</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="7" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="7" Volume="2017" Year="2017">
       <Id>fc0840f7-0f41-4a15-b76c-20b807571ba3</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="8" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="8" Volume="2017" Year="2017">
       <Id>5bc814d1-3909-4152-b1ca-4711bee82e03</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="9" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="9" Volume="2017" Year="2017">
       <Id>732c674e-b0cd-4e1e-be6c-636257fbbea6</Id>
     </Book>
-    <Book Series="Secret Empire" Number="5" Volume="2017" Year="2017" Format="Crossover">
+    <Book Series="Secret Empire" Number="5" Volume="2017" Year="2017">
       <Id>6da82f1d-e1ee-4de2-b962-d3fce5a924a9</Id>
     </Book>
-    <Book Series="Secret Empire" Number="6" Volume="2017" Year="2017" Format="Crossover">
+    <Book Series="Secret Empire" Number="6" Volume="2017" Year="2017">
       <Id>5b39aaef-3019-49ea-bd2e-5cdea036a1cc</Id>
     </Book>
-    <Book Series="Secret Empire" Number="7" Volume="2017" Year="2017" Format="Crossover">
+    <Book Series="Secret Empire" Number="7" Volume="2017" Year="2017">
       <Id>4473ce43-2e4e-4167-9e1c-3546fbe731c9</Id>
     </Book>
-    <Book Series="Deadpool" Number="34" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Deadpool" Number="34" Volume="2015" Year="2017">
       <Id>25f7fae1-7348-4d50-971d-9803bf7edabb</Id>
     </Book>
-    <Book Series="Deadpool" Number="35" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Deadpool" Number="35" Volume="2015" Year="2017">
       <Id>85808696-7a72-4084-804b-d15d95124a92</Id>
     </Book>
-    <Book Series="Secret Empire" Number="8" Volume="2017" Year="2017" Format="Crossover">
+    <Book Series="Secret Empire" Number="8" Volume="2017" Year="2017">
       <Id>f3e61c17-d6be-4ab7-ab99-4ced7d939484</Id>
     </Book>
-    <Book Series="Secret Empire" Number="9" Volume="2017" Year="2017" Format="Crossover">
+    <Book Series="Secret Empire" Number="9" Volume="2017" Year="2017">
       <Id>1526a6be-88f4-4969-abb4-7f3226cff65c</Id>
     </Book>
-    <Book Series="Secret Empire" Number="10" Volume="2017" Year="2017" Format="Crossover">
+    <Book Series="Secret Empire" Number="10" Volume="2017" Year="2017">
       <Id>4e965c3b-ff57-49f7-93cb-2284427b7c4d</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="10" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="10" Volume="2017" Year="2017">
       <Id>5de683ed-7a3d-43f4-8202-422b120107a0</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="11" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="11" Volume="2017" Year="2017">
       <Id>7829187b-8349-4fc9-92f6-4c808ee4aedc</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="12" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="12" Volume="2017" Year="2017">
       <Id>b8f7d013-3197-40ce-a998-3d68099d9a0f</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="9" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="9" Volume="2017" Year="2017">
       <Id>ed8aa177-a7c9-4a7e-a070-dfd83ac71e1d</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="10" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="10" Volume="2017" Year="2017">
       <Id>0de64640-e9e0-4129-9323-c7452c2c1ca9</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="11" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="11" Volume="2017" Year="2017">
       <Id>ad80f45f-490e-40d7-b82f-178415d67e05</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="12" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="12" Volume="2017" Year="2017">
       <Id>91741cd7-2f67-4a9d-9216-2823b9854921</Id>
     </Book>
-    <Book Series="Champions" Number="12" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Champions" Number="12" Volume="2016" Year="2017">
       <Id>1f3a9cb8-818f-4fbf-89c4-9c7ff1a11e48</Id>
     </Book>
-    <Book Series="Deadpool" Number="36" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Deadpool" Number="36" Volume="2015" Year="2017">
       <Id>b159f691-553f-4cb3-b42e-4e1239dd399b</Id>
     </Book>
-    <Book Series="Generations: Phoenix &amp; Jean Grey" Number="1" Volume="2017" Year="2017" Format="One-Shot">
+    <Book Series="Generations: Phoenix &amp; Jean Grey" Number="1" Volume="2017" Year="2017">
       <Id>8b4e1d6d-b73f-4adf-8ce2-871647b4b866</Id>
     </Book>
-    <Book Series="Generations: Wolverine &amp; All-New Wolverine" Number="1" Volume="2017" Year="2017" Format="One-Shot">
+    <Book Series="Generations: Wolverine &amp; All-New Wolverine" Number="1" Volume="2017" Year="2017">
       <Id>5de9d132-d0f3-4f94-a67b-fdd136b06f2d</Id>
     </Book>
-    <Book Series="Marvel Legacy" Number="1" Volume="2017" Year="2017" Format="One-Shot">
+    <Book Series="Marvel Legacy" Number="1" Volume="2017" Year="2017">
       <Id>0026d4a3-d0b4-45ca-b374-95971be685b1</Id>
     </Book>
-    <Book Series="Champions" Number="13" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Champions" Number="13" Volume="2016" Year="2017">
       <Id>1b80e1bc-282b-4c6e-8533-35cda1731b95</Id>
     </Book>
-    <Book Series="Champions" Number="14" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Champions" Number="14" Volume="2016" Year="2018">
       <Id>8c1861bb-912b-4771-ba80-b41f64d0dc16</Id>
     </Book>
-    <Book Series="Champions" Number="15" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Champions" Number="15" Volume="2016" Year="2018">
       <Id>0200a1d5-19bc-458c-b60a-75ccb5e421c3</Id>
     </Book>
-    <Book Series="Champions" Number="16" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Champions" Number="16" Volume="2016" Year="2018">
       <Id>eec4ad29-cf04-40ac-847f-62db8e9e8cd1</Id>
     </Book>
-    <Book Series="Champions" Number="17" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Champions" Number="17" Volume="2016" Year="2018">
       <Id>e95ec113-df23-4f7d-b08b-b576b959fc33</Id>
     </Book>
-    <Book Series="Champions" Number="18" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Champions" Number="18" Volume="2016" Year="2018">
       <Id>d31eb547-6906-4b83-a1e6-5c79ad3207d3</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="26" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="26" Volume="2015" Year="2017">
       <Id>073052fa-da21-44e1-9139-48ecc0f4b4f2</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="27" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="27" Volume="2015" Year="2017">
       <Id>3f8d572f-20e5-49ae-a165-ae65712976d5</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="28" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="28" Volume="2015" Year="2017">
       <Id>a76e59ca-d995-41c1-b4cf-2d12802326d9</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="29" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="29" Volume="2015" Year="2018">
       <Id>0bd0f610-1358-4f1a-86fd-082b1779a9b4</Id>
     </Book>
-    <Book Series="Uncanny Avengers" Number="30" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="Uncanny Avengers" Number="30" Volume="2015" Year="2018">
       <Id>96e0b02f-c7ae-4498-a1f5-25088c8565e4</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="23" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="23" Volume="2016" Year="2018">
       <Id>5d8e6c69-073f-4f43-9850-2abb571bfd1e</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="24" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="24" Volume="2016" Year="2018">
       <Id>c73d9d4d-799c-4dc6-a53f-e294bbfe4059</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="25" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="25" Volume="2016" Year="2018">
       <Id>19c9b02f-7840-4950-897c-64cc0cda2ce4</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="26" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="26" Volume="2016" Year="2018">
       <Id>621b457d-8667-4f62-92ad-a76964b52c44</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="27" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="27" Volume="2016" Year="2018">
       <Id>7a7f390d-53d7-4344-81f9-ba1afbfe7fa3</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="28" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="28" Volume="2016" Year="2018">
       <Id>e68693bd-2849-4510-94ce-94a384b98386</Id>
     </Book>
-    <Book Series="Iceman" Number="6" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Iceman" Number="6" Volume="2017" Year="2017">
       <Id>57427e9a-0fed-41ac-9fec-25aaf8006255</Id>
     </Book>
-    <Book Series="Iceman" Number="7" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Iceman" Number="7" Volume="2017" Year="2018">
       <Id>7436f8bc-c951-4eef-aeab-693bae6a949d</Id>
     </Book>
-    <Book Series="Iceman" Number="8" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Iceman" Number="8" Volume="2017" Year="2018">
       <Id>a3528ef9-6092-428a-af07-2d19507d51ae</Id>
     </Book>
-    <Book Series="Iceman" Number="9" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Iceman" Number="9" Volume="2017" Year="2018">
       <Id>fc577ef6-d956-48b2-b745-f9ad727e7aed</Id>
     </Book>
-    <Book Series="Iceman" Number="10" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Iceman" Number="10" Volume="2017" Year="2018">
       <Id>42def6e3-1751-4e1d-8dc8-a3ed1b428ad7</Id>
     </Book>
-    <Book Series="Iceman" Number="11" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Iceman" Number="11" Volume="2017" Year="2018">
       <Id>1788c462-eea7-4c87-a7f2-c4bfe69ba5d1</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="13" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="13" Volume="2017" Year="2017">
       <Id>9c1c35af-a1aa-4d1b-b6c3-681db96c29c6</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="13" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="13" Volume="2017" Year="2017">
       <Id>37bb46d6-8627-49ff-9a48-eea037dcbb14</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="14" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="14" Volume="2017" Year="2017">
       <Id>5ab54143-5f9d-431a-abf8-757c99a00c35</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="14" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="14" Volume="2017" Year="2017">
       <Id>3526af69-28af-4a1c-ad08-94402de20b1c</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="15" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="15" Volume="2017" Year="2018">
       <Id>a9988813-bcc7-4a82-a28f-29219a3ac0f2</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="15" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="15" Volume="2017" Year="2018">
       <Id>9e1a6603-4cb4-4d44-9ca8-f4ca238282dc</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="16" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="16" Volume="2017" Year="2018">
       <Id>110b5260-3860-4c29-a01c-4a7950e9448d</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="17" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="17" Volume="2017" Year="2018">
       <Id>d1c03212-deed-41cd-8f4d-3ca46a4d847a</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="18" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="18" Volume="2017" Year="2018">
       <Id>1737dcb5-724b-4c39-82c1-0825d07159c7</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="19" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="19" Volume="2017" Year="2018">
       <Id>55cd83a8-e915-45d9-ac36-c4d923a2bd0e</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="20" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="20" Volume="2017" Year="2018">
       <Id>e9e3e5b3-2e87-4351-bb39-e1d9b602e065</Id>
     </Book>
-    <Book Series="Generation X" Number="85" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Generation X" Number="85" Volume="2017" Year="2018">
       <Id>4b6f1e2b-07b5-44f6-9a13-cec179a97360</Id>
     </Book>
-    <Book Series="Generation X" Number="86" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Generation X" Number="86" Volume="2017" Year="2018">
       <Id>ac1d6195-fa9f-48f0-8307-e8aaa553466a</Id>
     </Book>
-    <Book Series="Generation X" Number="87" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Generation X" Number="87" Volume="2017" Year="2018">
       <Id>26380490-2672-4f16-96eb-1207a96c134e</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="31" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Old Man Logan" Number="31" Volume="2016" Year="2018">
       <Id>c51894de-7895-4951-ade0-31c8fb982bd9</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="32" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Old Man Logan" Number="32" Volume="2016" Year="2018">
       <Id>c0210cde-8e48-44ba-af5b-a3aaaf8914b3</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="33" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Old Man Logan" Number="33" Volume="2016" Year="2018">
       <Id>64db04a0-3d81-459f-94a4-0eedb44e3e4b</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="34" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Old Man Logan" Number="34" Volume="2016" Year="2018">
       <Id>3eaa2ada-0fbe-4da2-9fcd-be3ecd287679</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="35" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Old Man Logan" Number="35" Volume="2016" Year="2018">
       <Id>97ee2d2e-2519-4313-aaf9-29f227b9076f</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="36" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Old Man Logan" Number="36" Volume="2016" Year="2018">
       <Id>27213657-abf4-4e4e-b4eb-e8a056d130e7</Id>
     </Book>
-    <Book Series="Weapon X" Number="12" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Weapon X" Number="12" Volume="2017" Year="2018">
       <Id>1cf12032-786d-46e7-9e88-459f1c528692</Id>
     </Book>
-    <Book Series="Weapon X" Number="13" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Weapon X" Number="13" Volume="2017" Year="2018">
       <Id>4858d0ff-ecea-4694-9263-1468ddd09ca8</Id>
     </Book>
-    <Book Series="Weapon X" Number="14" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Weapon X" Number="14" Volume="2017" Year="2018">
       <Id>a70255ac-6601-4325-bd94-4302467f4792</Id>
     </Book>
-    <Book Series="Weapon X" Number="15" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Weapon X" Number="15" Volume="2017" Year="2018">
       <Id>3540ef07-9a85-4d31-83d9-5ef1452855c2</Id>
     </Book>
-    <Book Series="Weapon X" Number="16" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Weapon X" Number="16" Volume="2017" Year="2018">
       <Id>1e9053e8-bc56-4a8b-bd99-ea2e4f394021</Id>
     </Book>
-    <Book Series="Cable" Number="150" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Cable" Number="150" Volume="2017" Year="2017">
       <Id>d420fc63-dbb7-4127-9d2e-790e427a2187</Id>
     </Book>
-    <Book Series="Cable" Number="151" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Cable" Number="151" Volume="2017" Year="2018">
       <Id>6042ede7-a5df-4e9d-9d3e-177f6df1368a</Id>
     </Book>
-    <Book Series="Cable" Number="152" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Cable" Number="152" Volume="2017" Year="2018">
       <Id>d169c284-d2a7-4040-9a15-300028da5d6b</Id>
     </Book>
-    <Book Series="Cable" Number="153" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Cable" Number="153" Volume="2017" Year="2018">
       <Id>6cc9225a-94ab-448b-ac90-0097505cccb8</Id>
     </Book>
-    <Book Series="Cable" Number="154" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Cable" Number="154" Volume="2017" Year="2018">
       <Id>a86cd71b-8fb7-4400-87cc-fa23e7eda40e</Id>
     </Book>
-    <Book Series="Deadpool vs. Old Man Logan" Number="1" Volume="2017" Year="2017" Format="Limited Series">
+    <Book Series="Deadpool vs. Old Man Logan" Number="1" Volume="2017" Year="2017">
       <Id>7cb0e9b8-c185-4a32-ad48-3ff27bf5441d</Id>
     </Book>
-    <Book Series="Deadpool vs. Old Man Logan" Number="2" Volume="2017" Year="2018" Format="Limited Series">
+    <Book Series="Deadpool vs. Old Man Logan" Number="2" Volume="2017" Year="2018">
       <Id>51ed6b75-f3f4-4bfb-a5ff-efd121329343</Id>
     </Book>
-    <Book Series="Deadpool vs. Old Man Logan" Number="3" Volume="2017" Year="2018" Format="Limited Series">
+    <Book Series="Deadpool vs. Old Man Logan" Number="3" Volume="2017" Year="2018">
       <Id>078e3007-2ea0-4421-b4c8-70af1772eb58</Id>
     </Book>
-    <Book Series="Deadpool vs. Old Man Logan" Number="4" Volume="2017" Year="2018" Format="Limited Series">
+    <Book Series="Deadpool vs. Old Man Logan" Number="4" Volume="2017" Year="2018">
       <Id>4df11a9d-c063-4fd2-9391-88779703a787</Id>
     </Book>
-    <Book Series="Deadpool vs. Old Man Logan" Number="5" Volume="2017" Year="2018" Format="Limited Series">
+    <Book Series="Deadpool vs. Old Man Logan" Number="5" Volume="2017" Year="2018">
       <Id>1424ace1-74b9-431f-b30f-414220a8ed14</Id>
     </Book>
-    <Book Series="Despicable Deadpool" Number="287" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Despicable Deadpool" Number="287" Volume="2017" Year="2017">
       <Id>7882fee6-99d3-4869-aefd-b5d66740c485</Id>
     </Book>
-    <Book Series="Despicable Deadpool" Number="288" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Despicable Deadpool" Number="288" Volume="2017" Year="2017">
       <Id>fff4c7e1-656a-4a1e-8e74-5623746493a3</Id>
     </Book>
-    <Book Series="Despicable Deadpool" Number="289" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Despicable Deadpool" Number="289" Volume="2017" Year="2018">
       <Id>d6553b6b-6ffa-4160-9cf0-b73d6d9204d1</Id>
     </Book>
-    <Book Series="Despicable Deadpool" Number="290" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Despicable Deadpool" Number="290" Volume="2017" Year="2018">
       <Id>56e54254-1492-47b0-8f2c-e8c944981971</Id>
     </Book>
-    <Book Series="Despicable Deadpool" Number="291" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Despicable Deadpool" Number="291" Volume="2017" Year="2018">
       <Id>cf563d19-93a6-45ba-bb54-ebb05c53697d</Id>
     </Book>
-    <Book Series="Rogue &amp; Gambit" Number="1" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Rogue &amp; Gambit" Number="1" Volume="2018" Year="2018">
       <Id>e67e69d7-5c3d-4e23-bf4c-d96db3601e17</Id>
     </Book>
-    <Book Series="Rogue &amp; Gambit" Number="2" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Rogue &amp; Gambit" Number="2" Volume="2018" Year="2018">
       <Id>e626b780-abd9-4625-b6e1-28664f0dbaaa</Id>
     </Book>
-    <Book Series="Rogue &amp; Gambit" Number="3" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Rogue &amp; Gambit" Number="3" Volume="2018" Year="2018">
       <Id>d8a682d9-8df4-453a-a34e-13737b8904a1</Id>
     </Book>
-    <Book Series="Rogue &amp; Gambit" Number="4" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Rogue &amp; Gambit" Number="4" Volume="2018" Year="2018">
       <Id>0bd88c2d-92e9-463c-b68d-2bad42786a4b</Id>
     </Book>
-    <Book Series="Rogue &amp; Gambit" Number="5" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Rogue &amp; Gambit" Number="5" Volume="2018" Year="2018">
       <Id>a611ffd0-f2d8-42ba-8973-4458c090bc6d</Id>
     </Book>
-    <Book Series="Jean Grey" Number="7" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Jean Grey" Number="7" Volume="2017" Year="2017">
       <Id>c05eb282-f33c-42d4-9cd7-206d5d78dbaa</Id>
     </Book>
-    <Book Series="Jean Grey" Number="8" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Jean Grey" Number="8" Volume="2017" Year="2017">
       <Id>ad2f56cf-f118-448a-9647-4ecdedfe93b1</Id>
     </Book>
-    <Book Series="Jean Grey" Number="9" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Jean Grey" Number="9" Volume="2017" Year="2018">
       <Id>3e360454-f0cd-4d5f-bdde-d67b75963310</Id>
     </Book>
-    <Book Series="Phoenix Resurrection: The Return of Jean Grey" Number="1" Volume="2017" Year="2018" Format="Limited Series">
+    <Book Series="Phoenix Resurrection: The Return of Jean Grey" Number="1" Volume="2017" Year="2018">
       <Id>c9482542-d4b8-4b54-8e11-b5aa4abc03c0</Id>
     </Book>
-    <Book Series="Jean Grey" Number="10" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Jean Grey" Number="10" Volume="2017" Year="2018">
       <Id>472e04a0-3b4b-4cfc-9115-b46d3510cc68</Id>
     </Book>
-    <Book Series="Phoenix Resurrection: The Return of Jean Grey" Number="2" Volume="2017" Year="2018" Format="Limited Series">
+    <Book Series="Phoenix Resurrection: The Return of Jean Grey" Number="2" Volume="2017" Year="2018">
       <Id>5e3e6279-bdf2-4e3e-b433-7f594e8e23b2</Id>
     </Book>
-    <Book Series="Phoenix Resurrection: The Return of Jean Grey" Number="3" Volume="2017" Year="2018" Format="Limited Series">
+    <Book Series="Phoenix Resurrection: The Return of Jean Grey" Number="3" Volume="2017" Year="2018">
       <Id>95eda3e6-f4e3-4b8a-9086-b45dec572bc7</Id>
     </Book>
-    <Book Series="Phoenix Resurrection: The Return of Jean Grey" Number="4" Volume="2017" Year="2018" Format="Limited Series">
+    <Book Series="Phoenix Resurrection: The Return of Jean Grey" Number="4" Volume="2017" Year="2018">
       <Id>3deb08eb-46d2-423a-823c-5445ce599a3a</Id>
     </Book>
-    <Book Series="Jean Grey" Number="11" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Jean Grey" Number="11" Volume="2017" Year="2018">
       <Id>56632b8e-92c3-47c3-bc6f-cbbdda9fcf72</Id>
     </Book>
-    <Book Series="Phoenix Resurrection: The Return of Jean Grey" Number="5" Volume="2017" Year="2018" Format="Limited Series">
+    <Book Series="Phoenix Resurrection: The Return of Jean Grey" Number="5" Volume="2017" Year="2018">
       <Id>f171f2d6-b236-4977-a576-c61f674be1bb</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="1" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="1" Volume="2017" Year="2017">
       <Id>54282c02-8083-4b8b-8e56-a7d3fb6ef8c5</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="2" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="2" Volume="2017" Year="2017">
       <Id>79258b97-fe06-432f-8e98-d36cb37ac661</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="3" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="3" Volume="2017" Year="2017">
       <Id>300b43ae-cd5e-4c0c-a665-8f38e7a01c82</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="4" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="4" Volume="2017" Year="2017">
       <Id>19af7114-86c2-4a51-85bd-9b682c637007</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="5" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="5" Volume="2017" Year="2018">
       <Id>9d442407-6446-47c8-a7fc-f88956e14a8e</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="6" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="6" Volume="2017" Year="2018">
       <Id>a929eafc-ba2c-4147-81dc-387e90e61013</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="7" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="7" Volume="2017" Year="2018">
       <Id>cd7d5eb9-2315-45ab-ab04-37dc0ba15274</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="8" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="8" Volume="2017" Year="2018">
       <Id>6de9378c-6104-4440-8acd-df61c225ff7c</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="9" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="9" Volume="2017" Year="2018">
       <Id>059b1120-9a40-4518-a19b-b1cb5423884a</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="10" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="10" Volume="2017" Year="2018">
       <Id>60008826-dad5-46e2-baeb-3f4ae712c33f</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="11" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="11" Volume="2017" Year="2018">
       <Id>e362024e-5c50-4a4b-bf13-f81711d7e0a8</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="12" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="12" Volume="2017" Year="2018">
       <Id>508512ba-61cf-49d2-b831-4f6a8aae83ce</Id>
     </Book>
-    <Book Series="X-Men Blue Annual" Number="1" Volume="2018" Year="2018" Format="Annual">
+    <Book Series="X-Men Blue Annual" Number="1" Volume="2018" Year="2018">
       <Id>5b490ea3-da78-4682-9b87-3080a9cb725f</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="21" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="21" Volume="2017" Year="2018">
       <Id>fafdd25a-384e-462e-a38b-e90e78d59c0e</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="22" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="22" Volume="2017" Year="2018">
       <Id>eceda571-ca71-4912-bc49-d163cb02a3f0</Id>
     </Book>
-    <Book Series="Venom" Number="163" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Venom" Number="163" Volume="2016" Year="2018">
       <Id>883f8a38-8eee-4e76-b804-4b14f365c627</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="16" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="16" Volume="2017" Year="2018">
       <Id>ecc0d92d-96b7-4eb7-bf51-41f51e8fb6a7</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="17" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="17" Volume="2017" Year="2018">
       <Id>0669648c-ee05-4061-8a15-693f5be68320</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="18" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="18" Volume="2017" Year="2018">
       <Id>1f1096e5-c912-4784-b282-552f1e32a9a6</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="19" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="19" Volume="2017" Year="2018">
       <Id>5e911c59-0dc2-4849-a58c-a56e39838060</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="20" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="20" Volume="2017" Year="2018">
       <Id>0ed428e2-4d51-4a09-ab79-1bda5f4e1bb2</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="21" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="21" Volume="2017" Year="2018">
       <Id>6d11be2e-bca9-4c78-ac9c-aa9c12fa1ae3</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="22" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="22" Volume="2017" Year="2018">
       <Id>9869f246-4e11-4d10-81b9-fb0857e874c8</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="23" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="23" Volume="2017" Year="2018">
       <Id>da10018a-4e69-4091-9d55-292f30c66a37</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="24" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="24" Volume="2017" Year="2018">
       <Id>163dde90-61cd-4fc7-ae50-f6fb09fca5d3</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="25" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="25" Volume="2017" Year="2018">
       <Id>3387f0cd-b90c-4910-8f47-c4b54bb57b05</Id>
     </Book>
   </Books>

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 018.cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 018.cbl
@@ -1,699 +1,700 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>X-Men - Part 18</Name>
+  <Name>X-Men - Part 018</Name>
+  <NumIssues>231</NumIssues>
   <Books>
     <Book Series="X-Men: Blue" Number="23" Volume="2017" Year="2018">
-      <Id>28fec788-84ee-4e68-9b54-eac5ee5eb44f</Id>
+      <Database Name="cv" Series="100712" Issue="662757" />
     </Book>
     <Book Series="X-Men: Blue" Number="24" Volume="2017" Year="2018">
-      <Id>1abeb78f-94ae-426c-85db-ddfa43e3b57b</Id>
+      <Database Name="cv" Series="100712" Issue="664317" />
     </Book>
     <Book Series="X-Men: Blue" Number="25" Volume="2017" Year="2018">
-      <Id>49961c40-130f-43b2-9ea4-9cfc9fab8824</Id>
+      <Database Name="cv" Series="100712" Issue="665929" />
     </Book>
     <Book Series="X-Men: Blue" Number="26" Volume="2017" Year="2018">
-      <Id>30c19a36-7b74-4619-8a1a-ae12df4fea5c</Id>
+      <Database Name="cv" Series="100712" Issue="667666" />
     </Book>
     <Book Series="X-Men: Blue" Number="27" Volume="2017" Year="2018">
-      <Id>42f473fc-3cbb-4f43-91a1-571c1dbd7be2</Id>
+      <Database Name="cv" Series="100712" Issue="669466" />
     </Book>
     <Book Series="X-Men: Blue" Number="28" Volume="2017" Year="2018">
-      <Id>4d37f7c3-b8e9-4b90-97d7-e3bf9f10877a</Id>
+      <Database Name="cv" Series="100712" Issue="671344" />
     </Book>
     <Book Series="Old Man Logan" Number="37" Volume="2016" Year="2018">
-      <Id>fb4c7380-3ec0-42a0-b1ee-68cf8d109b2d</Id>
+      <Database Name="cv" Series="87624" Issue="664307" />
     </Book>
     <Book Series="Old Man Logan" Number="38" Volume="2016" Year="2018">
-      <Id>043cee82-4dfe-49e4-8ba6-8e1c0130ebb7</Id>
+      <Database Name="cv" Series="87624" Issue="665918" />
     </Book>
     <Book Series="Old Man Logan" Number="39" Volume="2016" Year="2018">
-      <Id>398f83e6-f8bf-4eae-bc70-9a258db4d080</Id>
+      <Database Name="cv" Series="87624" Issue="669455" />
     </Book>
     <Book Series="Old Man Logan" Number="40" Volume="2016" Year="2018">
-      <Id>aae431fb-3802-441c-970e-18719d94bc64</Id>
+      <Database Name="cv" Series="87624" Issue="670753" />
     </Book>
     <Book Series="Old Man Logan" Number="41" Volume="2016" Year="2018">
-      <Id>fe01256f-437d-44a3-a245-d7fd4a24acba</Id>
+      <Database Name="cv" Series="87624" Issue="673027" />
     </Book>
     <Book Series="Old Man Logan" Number="42" Volume="2016" Year="2018">
-      <Id>913c68a7-e4e9-4a6f-bb9f-cf4a2d5924fa</Id>
+      <Database Name="cv" Series="87624" Issue="675151" />
     </Book>
     <Book Series="Old Man Logan" Number="43" Volume="2016" Year="2018">
-      <Id>7cd36e3e-98bf-4b91-ad8d-b5783b275673</Id>
+      <Database Name="cv" Series="87624" Issue="676706" />
     </Book>
     <Book Series="Old Man Logan" Number="44" Volume="2016" Year="2018">
-      <Id>719071f0-608d-4ee2-a3d2-8ab80e7a1c11</Id>
+      <Database Name="cv" Series="87624" Issue="677972" />
     </Book>
     <Book Series="Old Man Logan" Number="45" Volume="2016" Year="2018">
-      <Id>c78b50c4-6e7d-4cc3-90e1-1c34472d75ce</Id>
+      <Database Name="cv" Series="87624" Issue="679415" />
     </Book>
     <Book Series="Old Man Logan" Number="46" Volume="2016" Year="2018">
-      <Id>7b4b2890-b6d8-49ea-95fa-964fca8a4c66</Id>
+      <Database Name="cv" Series="87624" Issue="680734" />
     </Book>
     <Book Series="Old Man Logan" Number="47" Volume="2016" Year="2018">
-      <Id>acbaea47-1d79-45b6-97e9-0cb7fa001c53</Id>
+      <Database Name="cv" Series="87624" Issue="684915" />
     </Book>
     <Book Series="Old Man Logan" Number="48" Volume="2016" Year="2018">
-      <Id>2af5d808-4ddc-4c7d-af31-ebb343957b1c</Id>
+      <Database Name="cv" Series="87624" Issue="686388" />
     </Book>
     <Book Series="Old Man Logan" Number="49" Volume="2016" Year="2018">
-      <Id>6a5e2dcb-8424-4f50-bd3b-75241ec03d4f</Id>
+      <Database Name="cv" Series="87624" Issue="689050" />
     </Book>
     <Book Series="Old Man Logan" Number="50" Volume="2016" Year="2018">
-      <Id>a570dfc5-6e9f-4c48-8804-47aa53aacaab</Id>
+      <Database Name="cv" Series="87624" Issue="690817" />
     </Book>
     <Book Series="Despicable Deadpool" Number="292" Volume="2017" Year="2018">
-      <Id>fb03711e-b91c-4b40-b05f-ad950759c724</Id>
+      <Database Name="cv" Series="104999" Issue="652627" />
     </Book>
     <Book Series="Despicable Deadpool" Number="293" Volume="2017" Year="2018">
-      <Id>cf9dc001-7ec0-4878-927e-2c08de43668a</Id>
+      <Database Name="cv" Series="104999" Issue="656702" />
     </Book>
     <Book Series="Despicable Deadpool" Number="294" Volume="2017" Year="2018">
-      <Id>d2592afd-a615-4041-b955-75ee0d3b84e1</Id>
+      <Database Name="cv" Series="104999" Issue="660015" />
     </Book>
     <Book Series="Despicable Deadpool" Number="295" Volume="2017" Year="2018">
-      <Id>f04b8b64-64fa-4dc0-914a-05fd7745bc6d</Id>
+      <Database Name="cv" Series="104999" Issue="661147" />
     </Book>
     <Book Series="Despicable Deadpool" Number="296" Volume="2017" Year="2018">
-      <Id>c2078ff5-b7e6-4509-9f02-2a011a8eca18</Id>
+      <Database Name="cv" Series="104999" Issue="662743" />
     </Book>
     <Book Series="Despicable Deadpool" Number="297" Volume="2017" Year="2018">
-      <Id>6ae01e6b-758b-4a65-9b98-e9b3d4310713</Id>
+      <Database Name="cv" Series="104999" Issue="664298" />
     </Book>
     <Book Series="Despicable Deadpool" Number="298" Volume="2017" Year="2018">
-      <Id>6ad5d2a5-ba1d-4b18-83fe-964b46c4e83a</Id>
+      <Database Name="cv" Series="104999" Issue="665911" />
     </Book>
     <Book Series="Despicable Deadpool" Number="299" Volume="2017" Year="2018">
-      <Id>f3f2c686-1dd2-40e1-9752-2d5ed515b5ce</Id>
+      <Database Name="cv" Series="104999" Issue="667637" />
     </Book>
     <Book Series="Despicable Deadpool" Number="300" Volume="2017" Year="2018">
-      <Id>b253575f-32b2-439a-8693-9518869ca3bf</Id>
+      <Database Name="cv" Series="104999" Issue="669446" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="29" Volume="2016" Year="2018">
-      <Id>eb9d8e1f-d241-4bf9-b76b-1b90e0c689f4</Id>
+      <Database Name="cv" Series="87182" Issue="662753" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="30" Volume="2016" Year="2018">
-      <Id>b6240def-8f97-4a6e-a686-2b225edb3a7d</Id>
+      <Database Name="cv" Series="87182" Issue="664309" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="31" Volume="2016" Year="2018">
-      <Id>2e904d86-c32c-4395-8e0b-b889ed6b709a</Id>
+      <Database Name="cv" Series="87182" Issue="665920" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="32" Volume="2016" Year="2018">
-      <Id>14c842f8-4827-4d62-9029-c5db347b25ce</Id>
+      <Database Name="cv" Series="87182" Issue="669458" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="33" Volume="2016" Year="2018">
-      <Id>075534c1-d7a2-4abe-b6c3-b4e4cdfaab55</Id>
+      <Database Name="cv" Series="87182" Issue="670755" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="34" Volume="2016" Year="2018">
-      <Id>636317a6-5a88-4686-bf5f-3155deef3f39</Id>
+      <Database Name="cv" Series="87182" Issue="673032" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="35" Volume="2016" Year="2018">
-      <Id>d21398a1-7984-4565-8ecf-12aa5f1e5a2a</Id>
+      <Database Name="cv" Series="87182" Issue="675987" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="36" Volume="2016" Year="2018">
-      <Id>abd8cefe-0154-4bcb-95c9-95a8a53f2a22</Id>
+      <Database Name="cv" Series="87182" Issue="677294" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="37" Volume="2016" Year="2018">
-      <Id>9f97e4cc-0bb1-4bdd-aa66-e55e23938c4c</Id>
+      <Database Name="cv" Series="87182" Issue="679418" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="38" Volume="2016" Year="2018">
-      <Id>f3965b22-3869-4971-99ef-052b83217284</Id>
+      <Database Name="cv" Series="87182" Issue="683835" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="39" Volume="2016" Year="2018">
-      <Id>6e71bb47-84e6-4349-b92f-fd1eb4a6ccb4</Id>
+      <Database Name="cv" Series="87182" Issue="686393" />
     </Book>
     <Book Series="Venom" Number="161" Volume="2016" Year="2018">
-      <Id>19ba3f7f-cdb3-46aa-97bf-b3ec8b08df59</Id>
+      <Database Name="cv" Series="95845" Issue="658736" />
     </Book>
     <Book Series="Venomized" Number="1" Volume="2018" Year="2018">
-      <Id>4124ab29-3529-469b-9d94-124b240137cc</Id>
+      <Database Name="cv" Series="109637" Issue="664930" />
     </Book>
     <Book Series="Venomized" Number="2" Volume="2018" Year="2018">
-      <Id>224c2893-d284-487d-ade5-27bcc4791220</Id>
+      <Database Name="cv" Series="109637" Issue="665928" />
     </Book>
     <Book Series="Venomized" Number="3" Volume="2018" Year="2018">
-      <Id>13c11b25-5580-4b8f-9b6e-716383e209ee</Id>
+      <Database Name="cv" Series="109637" Issue="666817" />
     </Book>
     <Book Series="Venomized" Number="4" Volume="2018" Year="2018">
-      <Id>7b3212d2-b3d7-4fb5-9a66-f797db5cf5f2</Id>
+      <Database Name="cv" Series="109637" Issue="667665" />
     </Book>
     <Book Series="Venomized" Number="5" Volume="2018" Year="2018">
-      <Id>6429f343-00a7-4e32-b9db-60f0f2670c78</Id>
+      <Database Name="cv" Series="109637" Issue="668788" />
     </Book>
     <Book Series="All-New Wolverine" Number="25" Volume="2015" Year="2017">
-      <Id>d8ca1f53-271d-4feb-86d3-06bc797e7d4c</Id>
+      <Database Name="cv" Series="85930" Issue="628574" />
     </Book>
     <Book Series="All-New Wolverine" Number="26" Volume="2015" Year="2017">
-      <Id>bfe1420f-d527-4b2f-80bc-9d0483af5ddd</Id>
+      <Database Name="cv" Series="85930" Issue="632487" />
     </Book>
     <Book Series="All-New Wolverine" Number="27" Volume="2015" Year="2018">
-      <Id>64d04365-d27c-4075-8249-0953834ad268</Id>
+      <Database Name="cv" Series="85930" Issue="641396" />
     </Book>
     <Book Series="All-New Wolverine" Number="28" Volume="2015" Year="2018">
-      <Id>9269f0e5-a181-4565-b123-e49853dd6e1f</Id>
+      <Database Name="cv" Series="85930" Issue="646178" />
     </Book>
     <Book Series="All-New Wolverine" Number="29" Volume="2015" Year="2018">
-      <Id>59bedb64-9d89-432d-a1fb-fb796e6ed603</Id>
+      <Database Name="cv" Series="85930" Issue="654046" />
     </Book>
     <Book Series="All-New Wolverine" Number="30" Volume="2015" Year="2018">
-      <Id>07938972-9a35-44f9-9963-248c9a6b9011</Id>
+      <Database Name="cv" Series="85930" Issue="656694" />
     </Book>
     <Book Series="All-New Wolverine" Number="31" Volume="2015" Year="2018">
-      <Id>3c9143bf-96ca-462e-bae8-c6edf33e911a</Id>
+      <Database Name="cv" Series="85930" Issue="661137" />
     </Book>
     <Book Series="All-New Wolverine" Number="32" Volume="2015" Year="2018">
-      <Id>1d4fd228-ba15-4d7a-afc4-b96b937fbadd</Id>
+      <Database Name="cv" Series="85930" Issue="662735" />
     </Book>
     <Book Series="All-New Wolverine" Number="33" Volume="2015" Year="2018">
-      <Id>51148006-8375-4954-8def-110b2607909a</Id>
+      <Database Name="cv" Series="85930" Issue="664904" />
     </Book>
     <Book Series="All-New Wolverine" Number="34" Volume="2015" Year="2018">
-      <Id>522a4434-1a26-4d9a-b4dc-857971e0095d</Id>
+      <Database Name="cv" Series="85930" Issue="667629" />
     </Book>
     <Book Series="All-New Wolverine" Number="35" Volume="2015" Year="2018">
-      <Id>d112c0a8-c935-4e97-ba45-e207151c8d32</Id>
+      <Database Name="cv" Series="85930" Issue="670104" />
     </Book>
     <Book Series="Astonishing X-Men" Number="13" Volume="2017" Year="2018">
-      <Id>ca7c992f-82e0-47e7-94d5-785065e89158</Id>
+      <Database Name="cv" Series="102882" Issue="675968" />
     </Book>
     <Book Series="Astonishing X-Men" Number="14" Volume="2017" Year="2018">
-      <Id>4c156f9d-bb1d-404b-a595-3ea59f7062ba</Id>
+      <Database Name="cv" Series="102882" Issue="678524" />
     </Book>
     <Book Series="Astonishing X-Men" Number="15" Volume="2017" Year="2018">
-      <Id>cc557f1d-d0e0-47c6-9068-bb76f307737f</Id>
+      <Database Name="cv" Series="102882" Issue="683819" />
     </Book>
     <Book Series="Astonishing X-Men" Number="16" Volume="2017" Year="2018">
-      <Id>5869749f-8ea6-4ef6-9443-76177cc5e57b</Id>
+      <Database Name="cv" Series="102882" Issue="689038" />
     </Book>
     <Book Series="Astonishing X-Men" Number="17" Volume="2017" Year="2019">
-      <Id>ec6fdfe3-fa53-4fcf-ac9e-1bd2a2865bab</Id>
+      <Database Name="cv" Series="102882" Issue="692540" />
     </Book>
     <Book Series="X-Men: Gold" Number="26" Volume="2017" Year="2018">
-      <Id>9000bb7f-b66c-4dc2-812f-9f9eba98860d</Id>
+      <Database Name="cv" Series="100603" Issue="666820" />
     </Book>
     <Book Series="X-Men: Gold" Number="27" Volume="2017" Year="2018">
-      <Id>25ea645e-08fa-4e96-bbbd-fd66f9322333</Id>
+      <Database Name="cv" Series="100603" Issue="668791" />
     </Book>
     <Book Series="X-Men: Gold" Number="28" Volume="2017" Year="2018">
-      <Id>0eca722f-f315-4adb-bc10-8e30ce8c7b18</Id>
+      <Database Name="cv" Series="100603" Issue="670766" />
     </Book>
     <Book Series="X-Men: Gold" Number="29" Volume="2017" Year="2018">
-      <Id>f9122643-df9b-4a59-9ad6-f27d584fb423</Id>
+      <Database Name="cv" Series="100603" Issue="672296" />
     </Book>
     <Book Series="X-Men: Gold" Number="30" Volume="2017" Year="2018">
-      <Id>4f08bbb8-e3ea-4eea-ae3a-9865be6123f2</Id>
+      <Database Name="cv" Series="100603" Issue="674147" />
     </Book>
     <Book Series="X-Men: Gold" Number="31" Volume="2017" Year="2018">
-      <Id>ca79af31-a0ae-46b3-a3a8-30ff682a031a</Id>
+      <Database Name="cv" Series="100603" Issue="675995" />
     </Book>
     <Book Series="X-Men: Gold" Number="32" Volume="2017" Year="2018">
-      <Id>0289ce49-7a94-4082-bdb0-21d203a1f95c</Id>
+      <Database Name="cv" Series="100603" Issue="677305" />
     </Book>
     <Book Series="X-Men: Gold" Number="33" Volume="2017" Year="2018">
-      <Id>97f8307a-7365-4499-b109-a55d0280d3ec</Id>
+      <Database Name="cv" Series="100603" Issue="678545" />
     </Book>
     <Book Series="X-Men: Gold" Number="34" Volume="2017" Year="2018">
-      <Id>e224d75a-70b8-4c52-a076-16163724dc54</Id>
+      <Database Name="cv" Series="100603" Issue="680743" />
     </Book>
     <Book Series="X-Men: Gold" Number="35" Volume="2017" Year="2018">
-      <Id>a3b345bb-92d1-48f8-9742-a6b482d993e9</Id>
+      <Database Name="cv" Series="100603" Issue="683845" />
     </Book>
     <Book Series="X-Men: Gold" Number="36" Volume="2017" Year="2018">
-      <Id>8ecfeb16-1a33-47f5-98a9-08868de2f712</Id>
+      <Database Name="cv" Series="100603" Issue="685869" />
     </Book>
     <Book Series="X-Men: Blue" Number="29" Volume="2017" Year="2018">
-      <Id>0af1f04e-5065-4692-b0cf-0b1c634f9231</Id>
+      <Database Name="cv" Series="100712" Issue="673041" />
     </Book>
     <Book Series="X-Men: Blue" Number="30" Volume="2017" Year="2018">
-      <Id>a11cba07-9fb4-49f0-b100-cb83a3955540</Id>
+      <Database Name="cv" Series="100712" Issue="675161" />
     </Book>
     <Book Series="X-Men: Blue" Number="31" Volume="2017" Year="2018">
-      <Id>e3a56f84-c9b4-4cc7-8d1c-769fbf59eba0</Id>
+      <Database Name="cv" Series="100712" Issue="676718" />
     </Book>
     <Book Series="X-Men: Blue" Number="32" Volume="2017" Year="2018">
-      <Id>4138cf0d-dca4-415c-9654-cb6262029330</Id>
+      <Database Name="cv" Series="100712" Issue="677987" />
     </Book>
     <Book Series="X-Men: Blue" Number="33" Volume="2017" Year="2018">
-      <Id>354b5db0-7d53-4c68-bcee-541f63ee8f0f</Id>
+      <Database Name="cv" Series="100712" Issue="679423" />
     </Book>
     <Book Series="X-Men: Blue" Number="34" Volume="2017" Year="2018">
-      <Id>6e4c6202-2428-4b3e-952e-adb356341d9d</Id>
+      <Database Name="cv" Series="100712" Issue="682670" />
     </Book>
     <Book Series="X-Men: Blue" Number="35" Volume="2017" Year="2018">
-      <Id>6709fb4d-ada4-44de-b393-75bb5256369c</Id>
+      <Database Name="cv" Series="100712" Issue="684931" />
     </Book>
     <Book Series="X-Men: Blue" Number="36" Volume="2017" Year="2018">
-      <Id>296d3b5e-fbd5-4188-8ae5-7f56a493c992</Id>
+      <Database Name="cv" Series="100712" Issue="686402" />
     </Book>
     <Book Series="Hunt For Wolverine" Number="1" Volume="2018" Year="2018">
-      <Id>f7fd7a0f-2cb5-4469-9587-9c35fe966e0b</Id>
+      <Database Name="cv" Series="110091" Issue="667641" />
     </Book>
     <Book Series="Hunt For Wolverine: Adamantium Agenda" Number="1" Volume="2018" Year="2018">
-      <Id>6277ebe4-8405-4b16-94e4-e55f5a93012c</Id>
+      <Database Name="cv" Series="110748" Issue="669451" />
     </Book>
     <Book Series="Hunt For Wolverine: Adamantium Agenda" Number="2" Volume="2018" Year="2018">
-      <Id>f6bc5c7c-8ee1-4b62-b94b-69a61d8c3d40</Id>
+      <Database Name="cv" Series="110748" Issue="673019" />
     </Book>
     <Book Series="Hunt For Wolverine: Adamantium Agenda" Number="3" Volume="2018" Year="2018">
-      <Id>8114c526-f7fd-4a68-be3c-38806572fd3b</Id>
+      <Database Name="cv" Series="110748" Issue="676700" />
     </Book>
     <Book Series="Hunt For Wolverine: Adamantium Agenda" Number="4" Volume="2018" Year="2018">
-      <Id>b37df063-5899-4be6-bbaa-1bbc0f7ee688</Id>
+      <Database Name="cv" Series="110748" Issue="679413" />
     </Book>
     <Book Series="Hunt For Wolverine: Claws Of A Killer" Number="1" Volume="2018" Year="2018">
-      <Id>a4b50d1a-6702-4c6a-a12c-60371fd4919d</Id>
+      <Database Name="cv" Series="110921" Issue="670115" />
     </Book>
     <Book Series="Hunt For Wolverine: Claws Of A Killer" Number="2" Volume="2018" Year="2018">
-      <Id>84669893-300d-4daf-a0df-16a41c32ab3a</Id>
+      <Database Name="cv" Series="110921" Issue="674132" />
     </Book>
     <Book Series="Hunt For Wolverine: Claws Of A Killer" Number="3" Volume="2018" Year="2018">
-      <Id>72facb92-1f18-4f20-98b1-5872a3bd7b96</Id>
+      <Database Name="cv" Series="110921" Issue="677278" />
     </Book>
     <Book Series="Hunt For Wolverine: Claws Of A Killer" Number="4" Volume="2018" Year="2018">
-      <Id>4127cd78-7445-42cf-b1e7-5ab598d6bd2c</Id>
+      <Database Name="cv" Series="110921" Issue="679995" />
     </Book>
     <Book Series="Hunt For Wolverine: Mystery In Madripoor" Number="1" Volume="2018" Year="2018">
-      <Id>d8733901-73f9-443c-b555-f2858fd46ad4</Id>
+      <Database Name="cv" Series="111043" Issue="670744" />
     </Book>
     <Book Series="Hunt For Wolverine: Mystery In Madripoor" Number="2" Volume="2018" Year="2018">
-      <Id>667f10f1-e780-4d82-a0d3-9356fe2f2140</Id>
+      <Database Name="cv" Series="111043" Issue="675140" />
     </Book>
     <Book Series="Hunt For Wolverine: Mystery In Madripoor" Number="3" Volume="2018" Year="2018">
-      <Id>80016306-a5eb-4238-9107-b9b7e165dea1</Id>
+      <Database Name="cv" Series="111043" Issue="677965" />
     </Book>
     <Book Series="Hunt For Wolverine: Mystery In Madripoor" Number="4" Volume="2018" Year="2018">
-      <Id>c5f86a0f-dfd7-4beb-b78c-92f860e78983</Id>
+      <Database Name="cv" Series="111043" Issue="680727" />
     </Book>
     <Book Series="Hunt For Wolverine: Weapon Lost" Number="1" Volume="2018" Year="2018">
-      <Id>335ee19b-9a03-42d0-9302-d695e23633b4</Id>
+      <Database Name="cv" Series="110516" Issue="668777" />
     </Book>
     <Book Series="Hunt For Wolverine: Weapon Lost" Number="2" Volume="2018" Year="2018">
-      <Id>b627f67c-915a-41e5-a21a-adfa6325e657</Id>
+      <Database Name="cv" Series="110516" Issue="672284" />
     </Book>
     <Book Series="Hunt For Wolverine: Weapon Lost" Number="3" Volume="2018" Year="2018">
-      <Id>77788aa4-d2f9-4314-b453-00c123a188c4</Id>
+      <Database Name="cv" Series="110516" Issue="675980" />
     </Book>
     <Book Series="Hunt For Wolverine: Weapon Lost" Number="4" Volume="2018" Year="2018">
-      <Id>3f9ab2bc-cdcc-4fed-ad56-dbf2f8b95fad</Id>
+      <Database Name="cv" Series="110516" Issue="678534" />
     </Book>
     <Book Series="Hunt For Wolverine: Dead Ends" Number="1" Volume="2018" Year="2018">
-      <Id>703ea42f-9d52-48fd-838a-a53c5db75794</Id>
+      <Database Name="cv" Series="113074" Issue="682657" />
     </Book>
     <Book Series="X-Men: Red" Number="1" Volume="2018" Year="2018">
-      <Id>b8c8b37e-9394-4042-b46d-bbae45a66923</Id>
+      <Database Name="cv" Series="108548" Issue="658738" />
     </Book>
     <Book Series="X-Men: Red" Number="2" Volume="2018" Year="2018">
-      <Id>59e8d164-70e6-4fcd-bfe6-47a5c2e1e50a</Id>
+      <Database Name="cv" Series="108548" Issue="662104" />
     </Book>
     <Book Series="X-Men: Red" Number="3" Volume="2018" Year="2018">
-      <Id>b3ef58c0-a3d2-4107-aee1-f186d7d52a99</Id>
+      <Database Name="cv" Series="108548" Issue="665930" />
     </Book>
     <Book Series="X-Men: Red" Number="4" Volume="2018" Year="2018">
-      <Id>700254a0-2b8e-44dd-bcf7-646721f443dd</Id>
+      <Database Name="cv" Series="108548" Issue="670128" />
     </Book>
     <Book Series="X-Men: Red" Number="5" Volume="2018" Year="2018">
-      <Id>70aa3207-33bc-4b69-ace8-fc8ec0e3b058</Id>
+      <Database Name="cv" Series="108548" Issue="672297" />
     </Book>
     <Book Series="X-Men: Red" Number="6" Volume="2018" Year="2018">
-      <Id>a2d6791f-14da-4f49-ba20-4ab7d219e5eb</Id>
+      <Database Name="cv" Series="108548" Issue="677306" />
     </Book>
     <Book Series="X-Men: Red" Number="7" Volume="2018" Year="2018">
-      <Id>43b71371-1383-4b65-ba62-5ec2d8fd13b6</Id>
+      <Database Name="cv" Series="108548" Issue="680744" />
     </Book>
     <Book Series="X-Men: Red" Number="8" Volume="2018" Year="2018">
-      <Id>e4070937-46e9-47b9-abbc-73207915f9aa</Id>
+      <Database Name="cv" Series="108548" Issue="686403" />
     </Book>
     <Book Series="X-Men: Red" Number="9" Volume="2018" Year="2018">
-      <Id>d10b6c8b-b60c-470c-9408-c19b1d8780ff</Id>
+      <Database Name="cv" Series="108548" Issue="689884" />
     </Book>
     <Book Series="X-Men: Red" Number="10" Volume="2018" Year="2019">
-      <Id>26c5c029-f350-42f8-bb6c-46a09a289565</Id>
+      <Database Name="cv" Series="108548" Issue="691400" />
     </Book>
     <Book Series="X-Men: Red" Number="11" Volume="2018" Year="2019">
-      <Id>c71917bc-6250-4785-929f-9703b0de3dbe</Id>
+      <Database Name="cv" Series="108548" Issue="694937" />
     </Book>
     <Book Series="X-Men: Black - Magneto" Number="1" Volume="2018" Year="2018">
-      <Id>8483e2ef-7595-4126-a16f-0fef65128dcf</Id>
+      <Database Name="cv" Series="114104" Issue="687031" />
     </Book>
     <Book Series="X-Men: Black - Mojo" Number="1" Volume="2018" Year="2018">
-      <Id>5d0e54d0-5418-417d-9409-c96da6024a92</Id>
+      <Database Name="cv" Series="114278" Issue="688333" />
     </Book>
     <Book Series="X-Men: Black - Mystique" Number="1" Volume="2018" Year="2018">
-      <Id>56da4330-790e-44aa-b1b7-0f72a4fc9770</Id>
+      <Database Name="cv" Series="114428" Issue="689064" />
     </Book>
     <Book Series="X-Men: Black - Juggernaut" Number="1" Volume="2018" Year="2018">
-      <Id>6f4c22f5-2e51-4098-9c78-1bc154cc0bd8</Id>
+      <Database Name="cv" Series="114744" Issue="689883" />
     </Book>
     <Book Series="X-Men: Black - Emma Frost" Number="1" Volume="2018" Year="2018">
-      <Id>bddb2a55-9754-4af9-bc52-2ea6dd204a05</Id>
+      <Database Name="cv" Series="114923" Issue="690825" />
     </Book>
     <Book Series="Wolverine: The Long Night Adaptation" Number="1" Volume="2019" Year="2019">
-      <Id>5af6287e-c804-4169-bfd8-f6054abfac26</Id>
+      <Database Name="cv" Series="116269" Issue="696373" />
     </Book>
     <Book Series="Wolverine: The Long Night Adaptation" Number="2" Volume="2019" Year="2019">
-      <Id>4af0c2d5-52eb-4eaa-9cbe-824173d1a687</Id>
+      <Database Name="cv" Series="116269" Issue="700155" />
     </Book>
     <Book Series="Wolverine: The Long Night Adaptation" Number="3" Volume="2019" Year="2019">
-      <Id>7a507920-3181-4505-bc7e-58dad7928c41</Id>
+      <Database Name="cv" Series="116269" Issue="703072" />
     </Book>
     <Book Series="Wolverine: The Long Night Adaptation" Number="4" Volume="2019" Year="2019">
-      <Id>a18c9f9f-c15c-47ca-abef-0902982693a5</Id>
+      <Database Name="cv" Series="116269" Issue="706977" />
     </Book>
     <Book Series="Wolverine: The Long Night Adaptation" Number="5" Volume="2019" Year="2019">
-      <Id>1ccd329c-a2b0-4f6a-b8de-5bd994bb435a</Id>
+      <Database Name="cv" Series="116269" Issue="710125" />
     </Book>
     <Book Series="Multiple Man" Number="1" Volume="2018" Year="2018">
-      <Id>94fdf0a6-f54c-4895-a5f5-e093c1f2beb5</Id>
+      <Database Name="cv" Series="111839" Issue="675148" />
     </Book>
     <Book Series="Multiple Man" Number="2" Volume="2018" Year="2018">
-      <Id>41de5b98-eab8-4a58-8475-a230c1d93eab</Id>
+      <Database Name="cv" Series="111839" Issue="677971" />
     </Book>
     <Book Series="Multiple Man" Number="3" Volume="2018" Year="2018">
-      <Id>890ce9ad-a86e-4b8d-9c64-61e4cb44895f</Id>
+      <Database Name="cv" Series="111839" Issue="679999" />
     </Book>
     <Book Series="Multiple Man" Number="4" Volume="2018" Year="2018">
-      <Id>885d67e7-0033-43d0-8740-d6545ac68b15</Id>
+      <Database Name="cv" Series="111839" Issue="685853" />
     </Book>
     <Book Series="Multiple Man" Number="5" Volume="2018" Year="2018">
-      <Id>097195e6-7fdb-4118-81f9-4fdf783dfa30</Id>
+      <Database Name="cv" Series="111839" Issue="690814" />
     </Book>
     <Book Series="New Mutants: Dead Souls" Number="1" Volume="2018" Year="2018">
-      <Id>3ce91d0b-7118-49c6-80ec-6c7fcaca3ccf</Id>
+      <Database Name="cv" Series="109202" Issue="662749" />
     </Book>
     <Book Series="New Mutants: Dead Souls" Number="2" Volume="2018" Year="2018">
-      <Id>c87f36a7-9d60-45a0-aa3c-dad51659c93b</Id>
+      <Database Name="cv" Series="109202" Issue="664917" />
     </Book>
     <Book Series="New Mutants: Dead Souls" Number="3" Volume="2018" Year="2018">
-      <Id>aaa71fb4-383e-416d-8903-4e9cf544ce8e</Id>
+      <Database Name="cv" Series="109202" Issue="669454" />
     </Book>
     <Book Series="New Mutants: Dead Souls" Number="4" Volume="2018" Year="2018">
-      <Id>bc40e0d9-eda5-454c-b189-239e9447af54</Id>
+      <Database Name="cv" Series="109202" Issue="673026" />
     </Book>
     <Book Series="New Mutants: Dead Souls" Number="5" Volume="2018" Year="2018">
-      <Id>bceca914-e451-48ed-8dcc-d97bbbab0b7e</Id>
+      <Database Name="cv" Series="109202" Issue="676704" />
     </Book>
     <Book Series="New Mutants: Dead Souls" Number="6" Volume="2018" Year="2018">
-      <Id>93180bb6-0d33-4648-ab0b-e67d2693bd45</Id>
+      <Database Name="cv" Series="109202" Issue="682662" />
     </Book>
     <Book Series="Dazzler: X-Song" Number="1" Volume="2018" Year="2018">
-      <Id>a3ca78e2-ab88-4da0-96fa-c9f4d89860a8</Id>
+      <Database Name="cv" Series="111413" Issue="672281" />
     </Book>
     <Book Series="Return of Wolverine" Number="1" Volume="2018" Year="2018">
-      <Id>8e06b2af-0564-494b-b54e-7755963b87b1</Id>
+      <Database Name="cv" Series="113726" Issue="685854" />
     </Book>
     <Book Series="Return of Wolverine" Number="2" Volume="2018" Year="2018">
-      <Id>20fdea52-aa09-474c-81a3-bcb08bc77c99</Id>
+      <Database Name="cv" Series="113726" Issue="689871" />
     </Book>
     <Book Series="Return of Wolverine" Number="3" Volume="2018" Year="2019">
-      <Id>61c59b64-cc70-41d1-9082-e15f6efcfbc5</Id>
+      <Database Name="cv" Series="113726" Issue="693470" />
     </Book>
     <Book Series="Return of Wolverine" Number="4" Volume="2018" Year="2019">
-      <Id>5bba658e-7aeb-4b9e-bf60-0bbff055f7b2</Id>
+      <Database Name="cv" Series="113726" Issue="697642" />
     </Book>
     <Book Series="Return of Wolverine" Number="5" Volume="2018" Year="2019">
-      <Id>7259c979-cef7-426c-949f-aebba989e020</Id>
+      <Database Name="cv" Series="113726" Issue="701321" />
     </Book>
     <Book Series="X-23" Number="1" Volume="2018" Year="2018">
-      <Id>14ffcfe9-64e9-4710-83ca-00405cd194c8</Id>
+      <Database Name="cv" Series="112212" Issue="676717" />
     </Book>
     <Book Series="X-23" Number="2" Volume="2018" Year="2018">
-      <Id>d53d625c-a714-42ad-a2e1-021a3d800053</Id>
+      <Database Name="cv" Series="112212" Issue="677986" />
     </Book>
     <Book Series="X-23" Number="3" Volume="2018" Year="2018">
-      <Id>339bd347-09b5-41ee-b87c-86fbabce09de</Id>
+      <Database Name="cv" Series="112212" Issue="682669" />
     </Book>
     <Book Series="X-23" Number="4" Volume="2018" Year="2018">
-      <Id>39b44cad-c385-47fe-aefc-30450a9cf102</Id>
+      <Database Name="cv" Series="112212" Issue="684930" />
     </Book>
     <Book Series="X-23" Number="5" Volume="2018" Year="2018">
-      <Id>aa143f20-7a61-438e-b707-b9c8be80fae4</Id>
+      <Database Name="cv" Series="112212" Issue="688332" />
     </Book>
     <Book Series="X-23" Number="6" Volume="2018" Year="2019">
-      <Id>96ea6757-c04a-48aa-a508-0367f412ed6c</Id>
+      <Database Name="cv" Series="112212" Issue="691398" />
     </Book>
     <Book Series="Dead Man Logan" Number="1" Volume="2018" Year="2019">
-      <Id>c2cbccda-a27f-44e0-8743-4e6a7ca88b8e</Id>
+      <Database Name="cv" Series="115566" Issue="693460" />
     </Book>
     <Book Series="Dead Man Logan" Number="2" Volume="2018" Year="2019">
-      <Id>63bdadcc-c9b0-46bf-a3bb-f57ce52db00c</Id>
+      <Database Name="cv" Series="115566" Issue="695630" />
     </Book>
     <Book Series="Dead Man Logan" Number="3" Volume="2018" Year="2019">
-      <Id>b6373b3f-711e-4963-b305-7a41cd597dde</Id>
+      <Database Name="cv" Series="115566" Issue="699396" />
     </Book>
     <Book Series="Dead Man Logan" Number="4" Volume="2018" Year="2019">
-      <Id>79d27035-dfc6-416a-be27-47eb4b246b55</Id>
+      <Database Name="cv" Series="115566" Issue="700664" />
     </Book>
     <Book Series="Dead Man Logan" Number="5" Volume="2018" Year="2019">
-      <Id>d28f7fe3-eace-43ed-82f1-b6e2bb83f6d1</Id>
+      <Database Name="cv" Series="115566" Issue="703047" />
     </Book>
     <Book Series="Dead Man Logan" Number="6" Volume="2018" Year="2019">
-      <Id>753bd5c7-bfb8-4d40-bdff-0602e5ee2f3e</Id>
+      <Database Name="cv" Series="115566" Issue="705917" />
     </Book>
     <Book Series="Dead Man Logan" Number="7" Volume="2018" Year="2019">
-      <Id>9ba8a018-98b2-4e89-94cf-fb7f37434ce9</Id>
+      <Database Name="cv" Series="115566" Issue="707509" />
     </Book>
     <Book Series="Dead Man Logan" Number="8" Volume="2018" Year="2019">
-      <Id>133cd921-792f-4e66-85f8-28d440e929fe</Id>
+      <Database Name="cv" Series="115566" Issue="710678" />
     </Book>
     <Book Series="Dead Man Logan" Number="9" Volume="2018" Year="2019">
-      <Id>35126f2d-c0ac-4fe3-85b6-2e79c2cf0039</Id>
+      <Database Name="cv" Series="115566" Issue="713069" />
     </Book>
     <Book Series="Dead Man Logan" Number="10" Volume="2018" Year="2019">
-      <Id>d9bffd49-4150-417e-a246-e3edef2f1ede</Id>
+      <Database Name="cv" Series="115566" Issue="715304" />
     </Book>
     <Book Series="Dead Man Logan" Number="11" Volume="2018" Year="2019">
-      <Id>c0b0d642-062a-4d35-949f-a64503f48cf9</Id>
+      <Database Name="cv" Series="115566" Issue="719435" />
     </Book>
     <Book Series="Extermination" Number="1" Volume="2018" Year="2018">
-      <Id>581891ef-262a-448a-a5cc-00a1ee1f0688</Id>
+      <Database Name="cv" Series="112807" Issue="679992" />
     </Book>
     <Book Series="Extermination" Number="2" Volume="2018" Year="2018">
-      <Id>824471fa-3e46-4aee-8b85-e10cc194012e</Id>
+      <Database Name="cv" Series="112807" Issue="682654" />
     </Book>
     <Book Series="Extermination" Number="3" Volume="2018" Year="2018">
-      <Id>a2bccbfc-cd11-4af9-8c49-8573e9b304a4</Id>
+      <Database Name="cv" Series="112807" Issue="686380" />
     </Book>
     <Book Series="Extermination" Number="4" Volume="2018" Year="2018">
-      <Id>f9df8810-3a06-47f9-b51a-686b4eb20847</Id>
+      <Database Name="cv" Series="112807" Issue="690809" />
     </Book>
     <Book Series="Extermination" Number="5" Volume="2018" Year="2019">
-      <Id>76252449-6795-44d3-8e08-b2f7e2229f2c</Id>
+      <Database Name="cv" Series="112807" Issue="695634" />
     </Book>
     <Book Series="X-Men: The Exterminated" Number="1" Volume="2018" Year="2019">
-      <Id>17036892-146e-4132-bd78-71647eb3e3ab</Id>
+      <Database Name="cv" Series="115775" Issue="694156" />
     </Book>
     <Book Series="Uncanny X-Men" Number="1" Volume="2018" Year="2019">
-      <Id>63df57d2-8dc1-4448-9206-40a2b3e8ca9b</Id>
+      <Database Name="cv" Series="115285" Issue="692088" />
     </Book>
     <Book Series="Uncanny X-Men" Number="2" Volume="2018" Year="2019">
-      <Id>32d08890-5cf0-4a31-9348-625391472ba6</Id>
+      <Database Name="cv" Series="115285" Issue="692562" />
     </Book>
     <Book Series="Uncanny X-Men" Number="3" Volume="2018" Year="2019">
-      <Id>e2c82279-84d1-472f-afe4-d97bf94cae23</Id>
+      <Database Name="cv" Series="115285" Issue="693475" />
     </Book>
     <Book Series="Uncanny X-Men" Number="4" Volume="2018" Year="2019">
-      <Id>8e828f90-c2e9-4962-9caa-db508fbac9fc</Id>
+      <Database Name="cv" Series="115285" Issue="694151" />
     </Book>
     <Book Series="Uncanny X-Men" Number="5" Volume="2018" Year="2019">
-      <Id>51115957-afc2-46bb-835e-5ccbf6c2ad8e</Id>
+      <Database Name="cv" Series="115285" Issue="694932" />
     </Book>
     <Book Series="Uncanny X-Men" Number="6" Volume="2018" Year="2019">
-      <Id>b48709dd-2499-4c16-94d0-95217a139a25</Id>
+      <Database Name="cv" Series="115285" Issue="695668" />
     </Book>
     <Book Series="Uncanny X-Men" Number="7" Volume="2018" Year="2019">
-      <Id>662ebdbb-1c31-4a8d-aa05-4d5933fc08c7</Id>
+      <Database Name="cv" Series="115285" Issue="695923" />
     </Book>
     <Book Series="Uncanny X-Men" Number="8" Volume="2018" Year="2019">
-      <Id>46893167-7feb-42ea-8a85-680c771c4a65</Id>
+      <Database Name="cv" Series="115285" Issue="696371" />
     </Book>
     <Book Series="Uncanny X-Men" Number="9" Volume="2018" Year="2019">
-      <Id>f22925e9-adb3-44f4-9131-191aab2c6bbc</Id>
+      <Database Name="cv" Series="115285" Issue="696961" />
     </Book>
     <Book Series="Uncanny X-Men" Number="10" Volume="2018" Year="2019">
-      <Id>7ae06611-b215-44ac-85e8-e3b2f6b5bcf5</Id>
+      <Database Name="cv" Series="115285" Issue="697647" />
     </Book>
     <Book Series="X-Force" Number="1" Volume="2018" Year="2019">
-      <Id>153f270f-5cbe-40cb-9021-a34505ac8191</Id>
+      <Database Name="cv" Series="116161" Issue="695924" />
     </Book>
     <Book Series="X-Force" Number="2" Volume="2018" Year="2019">
-      <Id>53eb1b0e-efbb-4833-b7a7-3164fde8246a</Id>
+      <Database Name="cv" Series="116161" Issue="699418" />
     </Book>
     <Book Series="X-Force" Number="3" Volume="2018" Year="2019">
-      <Id>8993e93a-de95-461b-9ff1-b45a432b6b38</Id>
+      <Database Name="cv" Series="116161" Issue="701954" />
     </Book>
     <Book Series="X-Force" Number="4" Volume="2018" Year="2019">
-      <Id>506cc42b-10d9-4a6c-9f55-5de39c052cef</Id>
+      <Database Name="cv" Series="116161" Issue="703074" />
     </Book>
     <Book Series="X-Force" Number="5" Volume="2018" Year="2019">
-      <Id>8ea14fbc-42b1-48a9-9abe-2e76174238ea</Id>
+      <Database Name="cv" Series="116161" Issue="704836" />
     </Book>
     <Book Series="Age of X-Man Alpha" Number="1" Volume="2019" Year="2019">
-      <Id>73a7ca1c-4a04-4f96-8347-abec62ceecb6</Id>
+      <Database Name="cv" Series="116812" Issue="699388" />
     </Book>
     <Book Series="Age of X-Man: NextGen" Number="1" Volume="2019" Year="2019">
-      <Id>36456f3c-315c-4432-97f0-88f96c2f6dff</Id>
+      <Database Name="cv" Series="117041" Issue="700657" />
     </Book>
     <Book Series="Age of X-Man: NextGen" Number="2" Volume="2019" Year="2019">
-      <Id>eea720c4-1d65-4e68-92b1-24d99f2db078</Id>
+      <Database Name="cv" Series="117041" Issue="703932" />
     </Book>
     <Book Series="Age of X-Man: NextGen" Number="3" Volume="2019" Year="2019">
-      <Id>35abc77b-45ff-43ed-89bb-a35e3e989327</Id>
+      <Database Name="cv" Series="117041" Issue="706400" />
     </Book>
     <Book Series="Age of X-Man: NextGen" Number="4" Volume="2019" Year="2019">
-      <Id>ced543ed-7235-4785-a9de-28deb3600d83</Id>
+      <Database Name="cv" Series="117041" Issue="709194" />
     </Book>
     <Book Series="Age of X-Man: NextGen" Number="5" Volume="2019" Year="2019">
-      <Id>794e4437-9364-4159-8d6f-c2c79d11944b</Id>
+      <Database Name="cv" Series="117041" Issue="711937" />
     </Book>
     <Book Series="Age of X-Man: X-Tremists" Number="1" Volume="2019" Year="2019">
-      <Id>73a019fb-b65a-489b-a3cb-0b277d5e60ed</Id>
+      <Database Name="cv" Series="117339" Issue="701926" />
     </Book>
     <Book Series="Age of X-Man: X-Tremists" Number="2" Volume="2019" Year="2019">
-      <Id>7485ca49-83c8-4779-97c0-43a8f82ba6c8</Id>
+      <Database Name="cv" Series="117339" Issue="704801" />
     </Book>
     <Book Series="Age of X-Man: X-Tremists" Number="3" Volume="2019" Year="2019">
-      <Id>359055e9-e125-4c6e-b290-1d329d3bbdcf</Id>
+      <Database Name="cv" Series="117339" Issue="706939" />
     </Book>
     <Book Series="Age of X-Man: X-Tremists" Number="4" Volume="2019" Year="2019">
-      <Id>6b35c222-64e9-4425-95b9-50fbadcdba2a</Id>
+      <Database Name="cv" Series="117339" Issue="710099" />
     </Book>
     <Book Series="Age of X-Man: X-Tremists" Number="5" Volume="2019" Year="2019">
-      <Id>d3b00f67-1afb-46da-bd92-fedb7e473c8b</Id>
+      <Database Name="cv" Series="117339" Issue="712523" />
     </Book>
     <Book Series="Age of X-Man: Prisoner X" Number="1" Volume="2019" Year="2019">
-      <Id>a0ffe7a6-e8fe-4309-879e-8e47066a5f49</Id>
+      <Database Name="cv" Series="117431" Issue="702452" />
     </Book>
     <Book Series="Age of X-Man: Prisoner X" Number="2" Volume="2019" Year="2019">
-      <Id>0107dee0-eb3b-4fb6-bd4d-4733959f4686</Id>
+      <Database Name="cv" Series="117431" Issue="705461" />
     </Book>
     <Book Series="Age of X-Man: Prisoner X" Number="3" Volume="2019" Year="2019">
-      <Id>8da9451b-0706-4f4b-8b6a-84ad25a32c5e</Id>
+      <Database Name="cv" Series="117431" Issue="707502" />
     </Book>
     <Book Series="Age of X-Man: Prisoner X" Number="4" Volume="2019" Year="2019">
-      <Id>1af11b8d-3e05-4043-80f3-4776db4d9a31</Id>
+      <Database Name="cv" Series="117431" Issue="710670" />
     </Book>
     <Book Series="Age of X-Man: Prisoner X" Number="5" Volume="2019" Year="2019">
-      <Id>dbc62fa7-692e-4d34-8772-f05678a4ec4d</Id>
+      <Database Name="cv" Series="117431" Issue="713063" />
     </Book>
     <Book Series="Age of X-Man: Apocalypse and the X-Tracts" Number="1" Volume="2019" Year="2019">
-      <Id>ad03616e-a26f-4b83-8fc3-d363e0a3d372</Id>
+      <Database Name="cv" Series="117569" Issue="703042" />
     </Book>
     <Book Series="Age of X-Man: Apocalypse and the X-Tracts" Number="2" Volume="2019" Year="2019">
-      <Id>d046a514-1e21-4aaa-9496-15a60cdbb341</Id>
+      <Database Name="cv" Series="117569" Issue="705909" />
     </Book>
     <Book Series="Age of X-Man: Apocalypse and the X-Tracts" Number="3" Volume="2019" Year="2019">
-      <Id>d77ecbe2-0a3f-4a7e-b8d6-804ce2064da4</Id>
+      <Database Name="cv" Series="117569" Issue="708126" />
     </Book>
     <Book Series="Age of X-Man: Apocalypse and the X-Tracts" Number="4" Volume="2019" Year="2019">
-      <Id>c8e45a93-80c6-44d1-b3d3-2d214bdf52f6</Id>
+      <Database Name="cv" Series="117569" Issue="711310" />
     </Book>
     <Book Series="Age of X-Man: Apocalypse and the X-Tracts" Number="5" Volume="2019" Year="2019">
-      <Id>51bae4b6-7aa8-4468-8e41-73c602cd435e</Id>
+      <Database Name="cv" Series="117569" Issue="713498" />
     </Book>
     <Book Series="Age of X-Man: The Marvelous X-Men" Number="1" Volume="2019" Year="2019">
-      <Id>d26b0bbc-b03d-4098-b4c0-0631008d463f</Id>
+      <Database Name="cv" Series="116954" Issue="700130" />
     </Book>
     <Book Series="Age of X-Man: The Marvelous X-Men" Number="2" Volume="2019" Year="2019">
-      <Id>e1e39d97-4c16-4bb6-83b9-6210672c634b</Id>
+      <Database Name="cv" Series="116954" Issue="703043" />
     </Book>
     <Book Series="Age of X-Man: The Marvelous X-Men" Number="3" Volume="2019" Year="2019">
-      <Id>3f0965a1-bb81-499e-a89b-ad85b5cd792b</Id>
+      <Database Name="cv" Series="116954" Issue="705910" />
     </Book>
     <Book Series="Age of X-Man: The Marvelous X-Men" Number="4" Volume="2019" Year="2019">
-      <Id>0a1d50fa-0a99-41f8-8fe7-d75960889dab</Id>
+      <Database Name="cv" Series="116954" Issue="709193" />
     </Book>
     <Book Series="Age of X-Man: The Marvelous X-Men" Number="5" Volume="2019" Year="2019">
-      <Id>92e4222a-c58b-4d1b-975e-c52bc46368ff</Id>
+      <Database Name="cv" Series="116954" Issue="711311" />
     </Book>
     <Book Series="Age of X-Man: The Amazing Nightcrawler" Number="1" Volume="2019" Year="2019">
-      <Id>ded96eac-8405-4b03-a187-cb12f2624e73</Id>
+      <Database Name="cv" Series="117190" Issue="701298" />
     </Book>
     <Book Series="Age of X-Man: The Amazing Nightcrawler" Number="2" Volume="2019" Year="2019">
-      <Id>96c266b8-465e-49b7-82eb-99f77c5e36b8</Id>
+      <Database Name="cv" Series="117190" Issue="703931" />
     </Book>
     <Book Series="Age of X-Man: The Amazing Nightcrawler" Number="3" Volume="2019" Year="2019">
-      <Id>865c8b4c-de82-4b06-9e3f-3ac1c56552f3</Id>
+      <Database Name="cv" Series="117190" Issue="706399" />
     </Book>
     <Book Series="Age of X-Man: The Amazing Nightcrawler" Number="4" Volume="2019" Year="2019">
-      <Id>5ab51770-d9f5-4b14-8b27-97b77ed45cc3</Id>
+      <Database Name="cv" Series="117190" Issue="709711" />
     </Book>
     <Book Series="Age of X-Man: The Amazing Nightcrawler" Number="5" Volume="2019" Year="2019">
-      <Id>b9decc58-2b36-44e0-a4c7-25a03b0e50c8</Id>
+      <Database Name="cv" Series="117190" Issue="711936" />
     </Book>
     <Book Series="Age of X-Man Omega" Number="1" Volume="2019" Year="2019">
-      <Id>b1aff437-4147-4e45-bff9-27416a1521f8</Id>
+      <Database Name="cv" Series="120236" Issue="713851" />
     </Book>
     <Book Series="Uncanny X-Men Annual" Number="1" Volume="2019" Year="2019">
-      <Id>874faff9-f1c3-4a6e-a660-a4f60da058f6</Id>
+      <Database Name="cv" Series="116708" Issue="698618" />
     </Book>
     <Book Series="Uncanny X-Men" Number="11" Volume="2018" Year="2019">
-      <Id>00574b28-b920-4b5c-bf3c-be1ceda7ba99</Id>
+      <Database Name="cv" Series="115285" Issue="700153" />
     </Book>
     <Book Series="Uncanny X-Men" Number="12" Volume="2018" Year="2019">
-      <Id>3fe9b44e-4ed2-4f9c-9372-71eec9442530</Id>
+      <Database Name="cv" Series="115285" Issue="701327" />
     </Book>
     <Book Series="Uncanny X-Men" Number="13" Volume="2018" Year="2019">
-      <Id>369cdfd8-5a43-49d2-9bcb-9da4a4e9baa6</Id>
+      <Database Name="cv" Series="115285" Issue="702477" />
     </Book>
     <Book Series="Uncanny X-Men" Number="14" Volume="2018" Year="2019">
-      <Id>7d0457a9-929a-439f-ad4e-39f18778b5ef</Id>
+      <Database Name="cv" Series="115285" Issue="703956" />
     </Book>
     <Book Series="Uncanny X-Men" Number="15" Volume="2018" Year="2019">
-      <Id>f7b7eee3-ea24-421d-a2ca-df5a64889c75</Id>
+      <Database Name="cv" Series="115285" Issue="705488" />
     </Book>
     <Book Series="Uncanny X-Men" Number="16" Volume="2018" Year="2019">
-      <Id>575a5107-0c90-4897-a9ff-bda7f826ffe1</Id>
+      <Database Name="cv" Series="115285" Issue="706426" />
     </Book>
     <Book Series="Uncanny X-Men" Number="17" Volume="2018" Year="2019">
-      <Id>50348bee-cac6-4d4d-8cac-e50809a965d5</Id>
+      <Database Name="cv" Series="115285" Issue="707533" />
     </Book>
     <Book Series="Uncanny X-Men" Number="18" Volume="2018" Year="2019">
-      <Id>023af50b-310b-4392-9f84-b09fb836ed56</Id>
+      <Database Name="cv" Series="115285" Issue="709217" />
     </Book>
     <Book Series="Uncanny X-Men" Number="19" Volume="2018" Year="2019">
-      <Id>8976ce27-44a9-4093-b45f-0818601c7f0e</Id>
+      <Database Name="cv" Series="115285" Issue="710699" />
     </Book>
     <Book Series="Uncanny X-Men" Number="20" Volume="2018" Year="2019">
-      <Id>3de69500-bf04-4368-a729-204f94afdd51</Id>
+      <Database Name="cv" Series="115285" Issue="711963" />
     </Book>
     <Book Series="Uncanny X-Men" Number="21" Volume="2018" Year="2019">
-      <Id>466fc750-afc0-4b91-b47d-efe052820c7c</Id>
+      <Database Name="cv" Series="115285" Issue="713087" />
     </Book>
     <Book Series="Uncanny X-Men" Number="22" Volume="2018" Year="2019">
-      <Id>64e7b103-016e-41e5-acf6-6cf27a5e04d0</Id>
+      <Database Name="cv" Series="115285" Issue="713870" />
     </Book>
     <Book Series="X-Force" Number="6" Volume="2018" Year="2019">
-      <Id>d6f2d582-1558-4b57-bc8e-c6d7a44f0c5d</Id>
+      <Database Name="cv" Series="116161" Issue="705942" />
     </Book>
     <Book Series="X-Force" Number="7" Volume="2018" Year="2019">
-      <Id>e0806d47-6123-42d2-b085-bf611594af5c</Id>
+      <Database Name="cv" Series="116161" Issue="708151" />
     </Book>
     <Book Series="X-Force" Number="8" Volume="2018" Year="2019">
-      <Id>9898a1d4-f2bc-4ab8-b145-6fdb1558ee69</Id>
+      <Database Name="cv" Series="116161" Issue="709741" />
     </Book>
     <Book Series="X-Force" Number="9" Volume="2018" Year="2019">
-      <Id>ab153f9b-853e-4ee9-9d0a-c06c39250f0e</Id>
+      <Database Name="cv" Series="116161" Issue="711339" />
     </Book>
     <Book Series="X-Force" Number="10" Volume="2018" Year="2019">
-      <Id>ea223919-c92e-4da0-ae00-e5bf0e8e7d4d</Id>
+      <Database Name="cv" Series="116161" Issue="713872" />
     </Book>
     <Book Series="X-23" Number="7" Volume="2018" Year="2019">
-      <Id>edae513e-e22b-4f56-8ebf-96df57f0d37e</Id>
+      <Database Name="cv" Series="112212" Issue="694935" />
     </Book>
     <Book Series="X-23" Number="8" Volume="2018" Year="2019">
-      <Id>0be04752-597d-481a-8282-4b40004b7961</Id>
+      <Database Name="cv" Series="112212" Issue="696964" />
     </Book>
     <Book Series="X-23" Number="9" Volume="2018" Year="2019">
-      <Id>7e78ea81-0b55-4d1e-99bd-6b4b0f411e4f</Id>
+      <Database Name="cv" Series="112212" Issue="700156" />
     </Book>
     <Book Series="X-23" Number="10" Volume="2018" Year="2019">
-      <Id>0a4d0261-ae52-4bc9-a195-65019dfdec8d</Id>
+      <Database Name="cv" Series="112212" Issue="703073" />
     </Book>
     <Book Series="X-23" Number="11" Volume="2018" Year="2019">
-      <Id>59908119-65df-4271-901c-e259840f4bf1</Id>
+      <Database Name="cv" Series="112212" Issue="705941" />
     </Book>
     <Book Series="X-23" Number="12" Volume="2018" Year="2019">
-      <Id>f80aee07-2c75-4b55-b449-dfbe1e50d3dd</Id>
+      <Database Name="cv" Series="112212" Issue="710126" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 018.cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 018.cbl
@@ -2,697 +2,697 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>X-Men - Part 18</Name>
   <Books>
-    <Book Series="X-Men: Blue" Number="23" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="23" Volume="2017" Year="2018">
       <Id>28fec788-84ee-4e68-9b54-eac5ee5eb44f</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="24" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="24" Volume="2017" Year="2018">
       <Id>1abeb78f-94ae-426c-85db-ddfa43e3b57b</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="25" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="25" Volume="2017" Year="2018">
       <Id>49961c40-130f-43b2-9ea4-9cfc9fab8824</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="26" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="26" Volume="2017" Year="2018">
       <Id>30c19a36-7b74-4619-8a1a-ae12df4fea5c</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="27" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="27" Volume="2017" Year="2018">
       <Id>42f473fc-3cbb-4f43-91a1-571c1dbd7be2</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="28" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="28" Volume="2017" Year="2018">
       <Id>4d37f7c3-b8e9-4b90-97d7-e3bf9f10877a</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="37" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Old Man Logan" Number="37" Volume="2016" Year="2018">
       <Id>fb4c7380-3ec0-42a0-b1ee-68cf8d109b2d</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="38" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Old Man Logan" Number="38" Volume="2016" Year="2018">
       <Id>043cee82-4dfe-49e4-8ba6-8e1c0130ebb7</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="39" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Old Man Logan" Number="39" Volume="2016" Year="2018">
       <Id>398f83e6-f8bf-4eae-bc70-9a258db4d080</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="40" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Old Man Logan" Number="40" Volume="2016" Year="2018">
       <Id>aae431fb-3802-441c-970e-18719d94bc64</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="41" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Old Man Logan" Number="41" Volume="2016" Year="2018">
       <Id>fe01256f-437d-44a3-a245-d7fd4a24acba</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="42" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Old Man Logan" Number="42" Volume="2016" Year="2018">
       <Id>913c68a7-e4e9-4a6f-bb9f-cf4a2d5924fa</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="43" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Old Man Logan" Number="43" Volume="2016" Year="2018">
       <Id>7cd36e3e-98bf-4b91-ad8d-b5783b275673</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="44" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Old Man Logan" Number="44" Volume="2016" Year="2018">
       <Id>719071f0-608d-4ee2-a3d2-8ab80e7a1c11</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="45" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Old Man Logan" Number="45" Volume="2016" Year="2018">
       <Id>c78b50c4-6e7d-4cc3-90e1-1c34472d75ce</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="46" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Old Man Logan" Number="46" Volume="2016" Year="2018">
       <Id>7b4b2890-b6d8-49ea-95fa-964fca8a4c66</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="47" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Old Man Logan" Number="47" Volume="2016" Year="2018">
       <Id>acbaea47-1d79-45b6-97e9-0cb7fa001c53</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="48" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Old Man Logan" Number="48" Volume="2016" Year="2018">
       <Id>2af5d808-4ddc-4c7d-af31-ebb343957b1c</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="49" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Old Man Logan" Number="49" Volume="2016" Year="2018">
       <Id>6a5e2dcb-8424-4f50-bd3b-75241ec03d4f</Id>
     </Book>
-    <Book Series="Old Man Logan" Number="50" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Old Man Logan" Number="50" Volume="2016" Year="2018">
       <Id>a570dfc5-6e9f-4c48-8804-47aa53aacaab</Id>
     </Book>
-    <Book Series="Despicable Deadpool" Number="292" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Despicable Deadpool" Number="292" Volume="2017" Year="2018">
       <Id>fb03711e-b91c-4b40-b05f-ad950759c724</Id>
     </Book>
-    <Book Series="Despicable Deadpool" Number="293" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Despicable Deadpool" Number="293" Volume="2017" Year="2018">
       <Id>cf9dc001-7ec0-4878-927e-2c08de43668a</Id>
     </Book>
-    <Book Series="Despicable Deadpool" Number="294" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Despicable Deadpool" Number="294" Volume="2017" Year="2018">
       <Id>d2592afd-a615-4041-b955-75ee0d3b84e1</Id>
     </Book>
-    <Book Series="Despicable Deadpool" Number="295" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Despicable Deadpool" Number="295" Volume="2017" Year="2018">
       <Id>f04b8b64-64fa-4dc0-914a-05fd7745bc6d</Id>
     </Book>
-    <Book Series="Despicable Deadpool" Number="296" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Despicable Deadpool" Number="296" Volume="2017" Year="2018">
       <Id>c2078ff5-b7e6-4509-9f02-2a011a8eca18</Id>
     </Book>
-    <Book Series="Despicable Deadpool" Number="297" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Despicable Deadpool" Number="297" Volume="2017" Year="2018">
       <Id>6ae01e6b-758b-4a65-9b98-e9b3d4310713</Id>
     </Book>
-    <Book Series="Despicable Deadpool" Number="298" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Despicable Deadpool" Number="298" Volume="2017" Year="2018">
       <Id>6ad5d2a5-ba1d-4b18-83fe-964b46c4e83a</Id>
     </Book>
-    <Book Series="Despicable Deadpool" Number="299" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Despicable Deadpool" Number="299" Volume="2017" Year="2018">
       <Id>f3f2c686-1dd2-40e1-9752-2d5ed515b5ce</Id>
     </Book>
-    <Book Series="Despicable Deadpool" Number="300" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Despicable Deadpool" Number="300" Volume="2017" Year="2018">
       <Id>b253575f-32b2-439a-8693-9518869ca3bf</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="29" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="29" Volume="2016" Year="2018">
       <Id>eb9d8e1f-d241-4bf9-b76b-1b90e0c689f4</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="30" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="30" Volume="2016" Year="2018">
       <Id>b6240def-8f97-4a6e-a686-2b225edb3a7d</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="31" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="31" Volume="2016" Year="2018">
       <Id>2e904d86-c32c-4395-8e0b-b889ed6b709a</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="32" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="32" Volume="2016" Year="2018">
       <Id>14c842f8-4827-4d62-9029-c5db347b25ce</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="33" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="33" Volume="2016" Year="2018">
       <Id>075534c1-d7a2-4abe-b6c3-b4e4cdfaab55</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="34" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="34" Volume="2016" Year="2018">
       <Id>636317a6-5a88-4686-bf5f-3155deef3f39</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="35" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="35" Volume="2016" Year="2018">
       <Id>d21398a1-7984-4565-8ecf-12aa5f1e5a2a</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="36" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="36" Volume="2016" Year="2018">
       <Id>abd8cefe-0154-4bcb-95c9-95a8a53f2a22</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="37" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="37" Volume="2016" Year="2018">
       <Id>9f97e4cc-0bb1-4bdd-aa66-e55e23938c4c</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="38" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="38" Volume="2016" Year="2018">
       <Id>f3965b22-3869-4971-99ef-052b83217284</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="39" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="39" Volume="2016" Year="2018">
       <Id>6e71bb47-84e6-4349-b92f-fd1eb4a6ccb4</Id>
     </Book>
-    <Book Series="Venom" Number="161" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Venom" Number="161" Volume="2016" Year="2018">
       <Id>19ba3f7f-cdb3-46aa-97bf-b3ec8b08df59</Id>
     </Book>
-    <Book Series="Venomized" Number="1" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Venomized" Number="1" Volume="2018" Year="2018">
       <Id>4124ab29-3529-469b-9d94-124b240137cc</Id>
     </Book>
-    <Book Series="Venomized" Number="2" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Venomized" Number="2" Volume="2018" Year="2018">
       <Id>224c2893-d284-487d-ade5-27bcc4791220</Id>
     </Book>
-    <Book Series="Venomized" Number="3" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Venomized" Number="3" Volume="2018" Year="2018">
       <Id>13c11b25-5580-4b8f-9b6e-716383e209ee</Id>
     </Book>
-    <Book Series="Venomized" Number="4" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Venomized" Number="4" Volume="2018" Year="2018">
       <Id>7b3212d2-b3d7-4fb5-9a66-f797db5cf5f2</Id>
     </Book>
-    <Book Series="Venomized" Number="5" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Venomized" Number="5" Volume="2018" Year="2018">
       <Id>6429f343-00a7-4e32-b9db-60f0f2670c78</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="25" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="25" Volume="2015" Year="2017">
       <Id>d8ca1f53-271d-4feb-86d3-06bc797e7d4c</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="26" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="26" Volume="2015" Year="2017">
       <Id>bfe1420f-d527-4b2f-80bc-9d0483af5ddd</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="27" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="27" Volume="2015" Year="2018">
       <Id>64d04365-d27c-4075-8249-0953834ad268</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="28" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="28" Volume="2015" Year="2018">
       <Id>9269f0e5-a181-4565-b123-e49853dd6e1f</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="29" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="29" Volume="2015" Year="2018">
       <Id>59bedb64-9d89-432d-a1fb-fb796e6ed603</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="30" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="30" Volume="2015" Year="2018">
       <Id>07938972-9a35-44f9-9963-248c9a6b9011</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="31" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="31" Volume="2015" Year="2018">
       <Id>3c9143bf-96ca-462e-bae8-c6edf33e911a</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="32" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="32" Volume="2015" Year="2018">
       <Id>1d4fd228-ba15-4d7a-afc4-b96b937fbadd</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="33" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="33" Volume="2015" Year="2018">
       <Id>51148006-8375-4954-8def-110b2607909a</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="34" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="34" Volume="2015" Year="2018">
       <Id>522a4434-1a26-4d9a-b4dc-857971e0095d</Id>
     </Book>
-    <Book Series="All-New Wolverine" Number="35" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="All-New Wolverine" Number="35" Volume="2015" Year="2018">
       <Id>d112c0a8-c935-4e97-ba45-e207151c8d32</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="13" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="13" Volume="2017" Year="2018">
       <Id>ca7c992f-82e0-47e7-94d5-785065e89158</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="14" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="14" Volume="2017" Year="2018">
       <Id>4c156f9d-bb1d-404b-a595-3ea59f7062ba</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="15" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="15" Volume="2017" Year="2018">
       <Id>cc557f1d-d0e0-47c6-9068-bb76f307737f</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="16" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="16" Volume="2017" Year="2018">
       <Id>5869749f-8ea6-4ef6-9443-76177cc5e57b</Id>
     </Book>
-    <Book Series="Astonishing X-Men" Number="17" Volume="2017" Year="2019" Format="Main Series">
+    <Book Series="Astonishing X-Men" Number="17" Volume="2017" Year="2019">
       <Id>ec6fdfe3-fa53-4fcf-ac9e-1bd2a2865bab</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="26" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="26" Volume="2017" Year="2018">
       <Id>9000bb7f-b66c-4dc2-812f-9f9eba98860d</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="27" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="27" Volume="2017" Year="2018">
       <Id>25ea645e-08fa-4e96-bbbd-fd66f9322333</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="28" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="28" Volume="2017" Year="2018">
       <Id>0eca722f-f315-4adb-bc10-8e30ce8c7b18</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="29" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="29" Volume="2017" Year="2018">
       <Id>f9122643-df9b-4a59-9ad6-f27d584fb423</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="30" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="30" Volume="2017" Year="2018">
       <Id>4f08bbb8-e3ea-4eea-ae3a-9865be6123f2</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="31" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="31" Volume="2017" Year="2018">
       <Id>ca79af31-a0ae-46b3-a3a8-30ff682a031a</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="32" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="32" Volume="2017" Year="2018">
       <Id>0289ce49-7a94-4082-bdb0-21d203a1f95c</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="33" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="33" Volume="2017" Year="2018">
       <Id>97f8307a-7365-4499-b109-a55d0280d3ec</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="34" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="34" Volume="2017" Year="2018">
       <Id>e224d75a-70b8-4c52-a076-16163724dc54</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="35" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="35" Volume="2017" Year="2018">
       <Id>a3b345bb-92d1-48f8-9742-a6b482d993e9</Id>
     </Book>
-    <Book Series="X-Men: Gold" Number="36" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Gold" Number="36" Volume="2017" Year="2018">
       <Id>8ecfeb16-1a33-47f5-98a9-08868de2f712</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="29" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="29" Volume="2017" Year="2018">
       <Id>0af1f04e-5065-4692-b0cf-0b1c634f9231</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="30" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="30" Volume="2017" Year="2018">
       <Id>a11cba07-9fb4-49f0-b100-cb83a3955540</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="31" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="31" Volume="2017" Year="2018">
       <Id>e3a56f84-c9b4-4cc7-8d1c-769fbf59eba0</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="32" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="32" Volume="2017" Year="2018">
       <Id>4138cf0d-dca4-415c-9654-cb6262029330</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="33" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="33" Volume="2017" Year="2018">
       <Id>354b5db0-7d53-4c68-bcee-541f63ee8f0f</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="34" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="34" Volume="2017" Year="2018">
       <Id>6e4c6202-2428-4b3e-952e-adb356341d9d</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="35" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="35" Volume="2017" Year="2018">
       <Id>6709fb4d-ada4-44de-b393-75bb5256369c</Id>
     </Book>
-    <Book Series="X-Men: Blue" Number="36" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Blue" Number="36" Volume="2017" Year="2018">
       <Id>296d3b5e-fbd5-4188-8ae5-7f56a493c992</Id>
     </Book>
-    <Book Series="Hunt For Wolverine" Number="1" Volume="2018" Year="2018" Format="One-Shot">
+    <Book Series="Hunt For Wolverine" Number="1" Volume="2018" Year="2018">
       <Id>f7fd7a0f-2cb5-4469-9587-9c35fe966e0b</Id>
     </Book>
-    <Book Series="Hunt For Wolverine: Adamantium Agenda" Number="1" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Hunt For Wolverine: Adamantium Agenda" Number="1" Volume="2018" Year="2018">
       <Id>6277ebe4-8405-4b16-94e4-e55f5a93012c</Id>
     </Book>
-    <Book Series="Hunt For Wolverine: Adamantium Agenda" Number="2" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Hunt For Wolverine: Adamantium Agenda" Number="2" Volume="2018" Year="2018">
       <Id>f6bc5c7c-8ee1-4b62-b94b-69a61d8c3d40</Id>
     </Book>
-    <Book Series="Hunt For Wolverine: Adamantium Agenda" Number="3" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Hunt For Wolverine: Adamantium Agenda" Number="3" Volume="2018" Year="2018">
       <Id>8114c526-f7fd-4a68-be3c-38806572fd3b</Id>
     </Book>
-    <Book Series="Hunt For Wolverine: Adamantium Agenda" Number="4" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Hunt For Wolverine: Adamantium Agenda" Number="4" Volume="2018" Year="2018">
       <Id>b37df063-5899-4be6-bbaa-1bbc0f7ee688</Id>
     </Book>
-    <Book Series="Hunt For Wolverine: Claws Of A Killer" Number="1" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Hunt For Wolverine: Claws Of A Killer" Number="1" Volume="2018" Year="2018">
       <Id>a4b50d1a-6702-4c6a-a12c-60371fd4919d</Id>
     </Book>
-    <Book Series="Hunt For Wolverine: Claws Of A Killer" Number="2" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Hunt For Wolverine: Claws Of A Killer" Number="2" Volume="2018" Year="2018">
       <Id>84669893-300d-4daf-a0df-16a41c32ab3a</Id>
     </Book>
-    <Book Series="Hunt For Wolverine: Claws Of A Killer" Number="3" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Hunt For Wolverine: Claws Of A Killer" Number="3" Volume="2018" Year="2018">
       <Id>72facb92-1f18-4f20-98b1-5872a3bd7b96</Id>
     </Book>
-    <Book Series="Hunt For Wolverine: Claws Of A Killer" Number="4" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Hunt For Wolverine: Claws Of A Killer" Number="4" Volume="2018" Year="2018">
       <Id>4127cd78-7445-42cf-b1e7-5ab598d6bd2c</Id>
     </Book>
-    <Book Series="Hunt For Wolverine: Mystery In Madripoor" Number="1" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Hunt For Wolverine: Mystery In Madripoor" Number="1" Volume="2018" Year="2018">
       <Id>d8733901-73f9-443c-b555-f2858fd46ad4</Id>
     </Book>
-    <Book Series="Hunt For Wolverine: Mystery In Madripoor" Number="2" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Hunt For Wolverine: Mystery In Madripoor" Number="2" Volume="2018" Year="2018">
       <Id>667f10f1-e780-4d82-a0d3-9356fe2f2140</Id>
     </Book>
-    <Book Series="Hunt For Wolverine: Mystery In Madripoor" Number="3" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Hunt For Wolverine: Mystery In Madripoor" Number="3" Volume="2018" Year="2018">
       <Id>80016306-a5eb-4238-9107-b9b7e165dea1</Id>
     </Book>
-    <Book Series="Hunt For Wolverine: Mystery In Madripoor" Number="4" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Hunt For Wolverine: Mystery In Madripoor" Number="4" Volume="2018" Year="2018">
       <Id>c5f86a0f-dfd7-4beb-b78c-92f860e78983</Id>
     </Book>
-    <Book Series="Hunt For Wolverine: Weapon Lost" Number="1" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Hunt For Wolverine: Weapon Lost" Number="1" Volume="2018" Year="2018">
       <Id>335ee19b-9a03-42d0-9302-d695e23633b4</Id>
     </Book>
-    <Book Series="Hunt For Wolverine: Weapon Lost" Number="2" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Hunt For Wolverine: Weapon Lost" Number="2" Volume="2018" Year="2018">
       <Id>b627f67c-915a-41e5-a21a-adfa6325e657</Id>
     </Book>
-    <Book Series="Hunt For Wolverine: Weapon Lost" Number="3" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Hunt For Wolverine: Weapon Lost" Number="3" Volume="2018" Year="2018">
       <Id>77788aa4-d2f9-4314-b453-00c123a188c4</Id>
     </Book>
-    <Book Series="Hunt For Wolverine: Weapon Lost" Number="4" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Hunt For Wolverine: Weapon Lost" Number="4" Volume="2018" Year="2018">
       <Id>3f9ab2bc-cdcc-4fed-ad56-dbf2f8b95fad</Id>
     </Book>
-    <Book Series="Hunt For Wolverine: Dead Ends" Number="1" Volume="2018" Year="2018" Format="One-Shot">
+    <Book Series="Hunt For Wolverine: Dead Ends" Number="1" Volume="2018" Year="2018">
       <Id>703ea42f-9d52-48fd-838a-a53c5db75794</Id>
     </Book>
-    <Book Series="X-Men: Red" Number="1" Volume="2018" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Red" Number="1" Volume="2018" Year="2018">
       <Id>b8c8b37e-9394-4042-b46d-bbae45a66923</Id>
     </Book>
-    <Book Series="X-Men: Red" Number="2" Volume="2018" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Red" Number="2" Volume="2018" Year="2018">
       <Id>59e8d164-70e6-4fcd-bfe6-47a5c2e1e50a</Id>
     </Book>
-    <Book Series="X-Men: Red" Number="3" Volume="2018" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Red" Number="3" Volume="2018" Year="2018">
       <Id>b3ef58c0-a3d2-4107-aee1-f186d7d52a99</Id>
     </Book>
-    <Book Series="X-Men: Red" Number="4" Volume="2018" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Red" Number="4" Volume="2018" Year="2018">
       <Id>700254a0-2b8e-44dd-bcf7-646721f443dd</Id>
     </Book>
-    <Book Series="X-Men: Red" Number="5" Volume="2018" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Red" Number="5" Volume="2018" Year="2018">
       <Id>70aa3207-33bc-4b69-ace8-fc8ec0e3b058</Id>
     </Book>
-    <Book Series="X-Men: Red" Number="6" Volume="2018" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Red" Number="6" Volume="2018" Year="2018">
       <Id>a2d6791f-14da-4f49-ba20-4ab7d219e5eb</Id>
     </Book>
-    <Book Series="X-Men: Red" Number="7" Volume="2018" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Red" Number="7" Volume="2018" Year="2018">
       <Id>43b71371-1383-4b65-ba62-5ec2d8fd13b6</Id>
     </Book>
-    <Book Series="X-Men: Red" Number="8" Volume="2018" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Red" Number="8" Volume="2018" Year="2018">
       <Id>e4070937-46e9-47b9-abbc-73207915f9aa</Id>
     </Book>
-    <Book Series="X-Men: Red" Number="9" Volume="2018" Year="2018" Format="Main Series">
+    <Book Series="X-Men: Red" Number="9" Volume="2018" Year="2018">
       <Id>d10b6c8b-b60c-470c-9408-c19b1d8780ff</Id>
     </Book>
-    <Book Series="X-Men: Red" Number="10" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="X-Men: Red" Number="10" Volume="2018" Year="2019">
       <Id>26c5c029-f350-42f8-bb6c-46a09a289565</Id>
     </Book>
-    <Book Series="X-Men: Red" Number="11" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="X-Men: Red" Number="11" Volume="2018" Year="2019">
       <Id>c71917bc-6250-4785-929f-9703b0de3dbe</Id>
     </Book>
-    <Book Series="X-Men: Black - Magneto" Number="1" Volume="2018" Year="2018" Format="One-Shot">
+    <Book Series="X-Men: Black - Magneto" Number="1" Volume="2018" Year="2018">
       <Id>8483e2ef-7595-4126-a16f-0fef65128dcf</Id>
     </Book>
-    <Book Series="X-Men: Black - Mojo" Number="1" Volume="2018" Year="2018" Format="One-Shot">
+    <Book Series="X-Men: Black - Mojo" Number="1" Volume="2018" Year="2018">
       <Id>5d0e54d0-5418-417d-9409-c96da6024a92</Id>
     </Book>
-    <Book Series="X-Men: Black - Mystique" Number="1" Volume="2018" Year="2018" Format="One-Shot">
+    <Book Series="X-Men: Black - Mystique" Number="1" Volume="2018" Year="2018">
       <Id>56da4330-790e-44aa-b1b7-0f72a4fc9770</Id>
     </Book>
-    <Book Series="X-Men: Black - Juggernaut" Number="1" Volume="2018" Year="2018" Format="One-Shot">
+    <Book Series="X-Men: Black - Juggernaut" Number="1" Volume="2018" Year="2018">
       <Id>6f4c22f5-2e51-4098-9c78-1bc154cc0bd8</Id>
     </Book>
-    <Book Series="X-Men: Black - Emma Frost" Number="1" Volume="2018" Year="2018" Format="One-Shot">
+    <Book Series="X-Men: Black - Emma Frost" Number="1" Volume="2018" Year="2018">
       <Id>bddb2a55-9754-4af9-bc52-2ea6dd204a05</Id>
     </Book>
-    <Book Series="Wolverine: The Long Night Adaptation" Number="1" Volume="2019" Year="2019" Format="Limited Series">
+    <Book Series="Wolverine: The Long Night Adaptation" Number="1" Volume="2019" Year="2019">
       <Id>5af6287e-c804-4169-bfd8-f6054abfac26</Id>
     </Book>
-    <Book Series="Wolverine: The Long Night Adaptation" Number="2" Volume="2019" Year="2019" Format="Limited Series">
+    <Book Series="Wolverine: The Long Night Adaptation" Number="2" Volume="2019" Year="2019">
       <Id>4af0c2d5-52eb-4eaa-9cbe-824173d1a687</Id>
     </Book>
-    <Book Series="Wolverine: The Long Night Adaptation" Number="3" Volume="2019" Year="2019" Format="Limited Series">
+    <Book Series="Wolverine: The Long Night Adaptation" Number="3" Volume="2019" Year="2019">
       <Id>7a507920-3181-4505-bc7e-58dad7928c41</Id>
     </Book>
-    <Book Series="Wolverine: The Long Night Adaptation" Number="4" Volume="2019" Year="2019" Format="Limited Series">
+    <Book Series="Wolverine: The Long Night Adaptation" Number="4" Volume="2019" Year="2019">
       <Id>a18c9f9f-c15c-47ca-abef-0902982693a5</Id>
     </Book>
-    <Book Series="Wolverine: The Long Night Adaptation" Number="5" Volume="2019" Year="2019" Format="Limited Series">
+    <Book Series="Wolverine: The Long Night Adaptation" Number="5" Volume="2019" Year="2019">
       <Id>1ccd329c-a2b0-4f6a-b8de-5bd994bb435a</Id>
     </Book>
-    <Book Series="Multiple Man" Number="1" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Multiple Man" Number="1" Volume="2018" Year="2018">
       <Id>94fdf0a6-f54c-4895-a5f5-e093c1f2beb5</Id>
     </Book>
-    <Book Series="Multiple Man" Number="2" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Multiple Man" Number="2" Volume="2018" Year="2018">
       <Id>41de5b98-eab8-4a58-8475-a230c1d93eab</Id>
     </Book>
-    <Book Series="Multiple Man" Number="3" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Multiple Man" Number="3" Volume="2018" Year="2018">
       <Id>890ce9ad-a86e-4b8d-9c64-61e4cb44895f</Id>
     </Book>
-    <Book Series="Multiple Man" Number="4" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Multiple Man" Number="4" Volume="2018" Year="2018">
       <Id>885d67e7-0033-43d0-8740-d6545ac68b15</Id>
     </Book>
-    <Book Series="Multiple Man" Number="5" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Multiple Man" Number="5" Volume="2018" Year="2018">
       <Id>097195e6-7fdb-4118-81f9-4fdf783dfa30</Id>
     </Book>
-    <Book Series="New Mutants: Dead Souls" Number="1" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="New Mutants: Dead Souls" Number="1" Volume="2018" Year="2018">
       <Id>3ce91d0b-7118-49c6-80ec-6c7fcaca3ccf</Id>
     </Book>
-    <Book Series="New Mutants: Dead Souls" Number="2" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="New Mutants: Dead Souls" Number="2" Volume="2018" Year="2018">
       <Id>c87f36a7-9d60-45a0-aa3c-dad51659c93b</Id>
     </Book>
-    <Book Series="New Mutants: Dead Souls" Number="3" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="New Mutants: Dead Souls" Number="3" Volume="2018" Year="2018">
       <Id>aaa71fb4-383e-416d-8903-4e9cf544ce8e</Id>
     </Book>
-    <Book Series="New Mutants: Dead Souls" Number="4" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="New Mutants: Dead Souls" Number="4" Volume="2018" Year="2018">
       <Id>bc40e0d9-eda5-454c-b189-239e9447af54</Id>
     </Book>
-    <Book Series="New Mutants: Dead Souls" Number="5" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="New Mutants: Dead Souls" Number="5" Volume="2018" Year="2018">
       <Id>bceca914-e451-48ed-8dcc-d97bbbab0b7e</Id>
     </Book>
-    <Book Series="New Mutants: Dead Souls" Number="6" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="New Mutants: Dead Souls" Number="6" Volume="2018" Year="2018">
       <Id>93180bb6-0d33-4648-ab0b-e67d2693bd45</Id>
     </Book>
-    <Book Series="Dazzler: X-Song" Number="1" Volume="2018" Year="2018" Format="One-Shot">
+    <Book Series="Dazzler: X-Song" Number="1" Volume="2018" Year="2018">
       <Id>a3ca78e2-ab88-4da0-96fa-c9f4d89860a8</Id>
     </Book>
-    <Book Series="Return of Wolverine" Number="1" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Return of Wolverine" Number="1" Volume="2018" Year="2018">
       <Id>8e06b2af-0564-494b-b54e-7755963b87b1</Id>
     </Book>
-    <Book Series="Return of Wolverine" Number="2" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Return of Wolverine" Number="2" Volume="2018" Year="2018">
       <Id>20fdea52-aa09-474c-81a3-bcb08bc77c99</Id>
     </Book>
-    <Book Series="Return of Wolverine" Number="3" Volume="2018" Year="2019" Format="Limited Series">
+    <Book Series="Return of Wolverine" Number="3" Volume="2018" Year="2019">
       <Id>61c59b64-cc70-41d1-9082-e15f6efcfbc5</Id>
     </Book>
-    <Book Series="Return of Wolverine" Number="4" Volume="2018" Year="2019" Format="Limited Series">
+    <Book Series="Return of Wolverine" Number="4" Volume="2018" Year="2019">
       <Id>5bba658e-7aeb-4b9e-bf60-0bbff055f7b2</Id>
     </Book>
-    <Book Series="Return of Wolverine" Number="5" Volume="2018" Year="2019" Format="Limited Series">
+    <Book Series="Return of Wolverine" Number="5" Volume="2018" Year="2019">
       <Id>7259c979-cef7-426c-949f-aebba989e020</Id>
     </Book>
-    <Book Series="X-23" Number="1" Volume="2018" Year="2018" Format="Main Series">
+    <Book Series="X-23" Number="1" Volume="2018" Year="2018">
       <Id>14ffcfe9-64e9-4710-83ca-00405cd194c8</Id>
     </Book>
-    <Book Series="X-23" Number="2" Volume="2018" Year="2018" Format="Main Series">
+    <Book Series="X-23" Number="2" Volume="2018" Year="2018">
       <Id>d53d625c-a714-42ad-a2e1-021a3d800053</Id>
     </Book>
-    <Book Series="X-23" Number="3" Volume="2018" Year="2018" Format="Main Series">
+    <Book Series="X-23" Number="3" Volume="2018" Year="2018">
       <Id>339bd347-09b5-41ee-b87c-86fbabce09de</Id>
     </Book>
-    <Book Series="X-23" Number="4" Volume="2018" Year="2018" Format="Main Series">
+    <Book Series="X-23" Number="4" Volume="2018" Year="2018">
       <Id>39b44cad-c385-47fe-aefc-30450a9cf102</Id>
     </Book>
-    <Book Series="X-23" Number="5" Volume="2018" Year="2018" Format="Main Series">
+    <Book Series="X-23" Number="5" Volume="2018" Year="2018">
       <Id>aa143f20-7a61-438e-b707-b9c8be80fae4</Id>
     </Book>
-    <Book Series="X-23" Number="6" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="X-23" Number="6" Volume="2018" Year="2019">
       <Id>96ea6757-c04a-48aa-a508-0367f412ed6c</Id>
     </Book>
-    <Book Series="Dead Man Logan" Number="1" Volume="2018" Year="2019" Format="Limited Series">
+    <Book Series="Dead Man Logan" Number="1" Volume="2018" Year="2019">
       <Id>c2cbccda-a27f-44e0-8743-4e6a7ca88b8e</Id>
     </Book>
-    <Book Series="Dead Man Logan" Number="2" Volume="2018" Year="2019" Format="Limited Series">
+    <Book Series="Dead Man Logan" Number="2" Volume="2018" Year="2019">
       <Id>63bdadcc-c9b0-46bf-a3bb-f57ce52db00c</Id>
     </Book>
-    <Book Series="Dead Man Logan" Number="3" Volume="2018" Year="2019" Format="Limited Series">
+    <Book Series="Dead Man Logan" Number="3" Volume="2018" Year="2019">
       <Id>b6373b3f-711e-4963-b305-7a41cd597dde</Id>
     </Book>
-    <Book Series="Dead Man Logan" Number="4" Volume="2018" Year="2019" Format="Limited Series">
+    <Book Series="Dead Man Logan" Number="4" Volume="2018" Year="2019">
       <Id>79d27035-dfc6-416a-be27-47eb4b246b55</Id>
     </Book>
-    <Book Series="Dead Man Logan" Number="5" Volume="2018" Year="2019" Format="Limited Series">
+    <Book Series="Dead Man Logan" Number="5" Volume="2018" Year="2019">
       <Id>d28f7fe3-eace-43ed-82f1-b6e2bb83f6d1</Id>
     </Book>
-    <Book Series="Dead Man Logan" Number="6" Volume="2018" Year="2019" Format="Limited Series">
+    <Book Series="Dead Man Logan" Number="6" Volume="2018" Year="2019">
       <Id>753bd5c7-bfb8-4d40-bdff-0602e5ee2f3e</Id>
     </Book>
-    <Book Series="Dead Man Logan" Number="7" Volume="2018" Year="2019" Format="Limited Series">
+    <Book Series="Dead Man Logan" Number="7" Volume="2018" Year="2019">
       <Id>9ba8a018-98b2-4e89-94cf-fb7f37434ce9</Id>
     </Book>
-    <Book Series="Dead Man Logan" Number="8" Volume="2018" Year="2019" Format="Limited Series">
+    <Book Series="Dead Man Logan" Number="8" Volume="2018" Year="2019">
       <Id>133cd921-792f-4e66-85f8-28d440e929fe</Id>
     </Book>
-    <Book Series="Dead Man Logan" Number="9" Volume="2018" Year="2019" Format="Limited Series">
+    <Book Series="Dead Man Logan" Number="9" Volume="2018" Year="2019">
       <Id>35126f2d-c0ac-4fe3-85b6-2e79c2cf0039</Id>
     </Book>
-    <Book Series="Dead Man Logan" Number="10" Volume="2018" Year="2019" Format="Limited Series">
+    <Book Series="Dead Man Logan" Number="10" Volume="2018" Year="2019">
       <Id>d9bffd49-4150-417e-a246-e3edef2f1ede</Id>
     </Book>
-    <Book Series="Dead Man Logan" Number="11" Volume="2018" Year="2019" Format="Limited Series">
+    <Book Series="Dead Man Logan" Number="11" Volume="2018" Year="2019">
       <Id>c0b0d642-062a-4d35-949f-a64503f48cf9</Id>
     </Book>
-    <Book Series="Extermination" Number="1" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Extermination" Number="1" Volume="2018" Year="2018">
       <Id>581891ef-262a-448a-a5cc-00a1ee1f0688</Id>
     </Book>
-    <Book Series="Extermination" Number="2" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Extermination" Number="2" Volume="2018" Year="2018">
       <Id>824471fa-3e46-4aee-8b85-e10cc194012e</Id>
     </Book>
-    <Book Series="Extermination" Number="3" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Extermination" Number="3" Volume="2018" Year="2018">
       <Id>a2bccbfc-cd11-4af9-8c49-8573e9b304a4</Id>
     </Book>
-    <Book Series="Extermination" Number="4" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Extermination" Number="4" Volume="2018" Year="2018">
       <Id>f9df8810-3a06-47f9-b51a-686b4eb20847</Id>
     </Book>
-    <Book Series="Extermination" Number="5" Volume="2018" Year="2019" Format="Limited Series">
+    <Book Series="Extermination" Number="5" Volume="2018" Year="2019">
       <Id>76252449-6795-44d3-8e08-b2f7e2229f2c</Id>
     </Book>
-    <Book Series="X-Men: The Exterminated" Number="1" Volume="2018" Year="2019" Format="One-Shot">
+    <Book Series="X-Men: The Exterminated" Number="1" Volume="2018" Year="2019">
       <Id>17036892-146e-4132-bd78-71647eb3e3ab</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="1" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="1" Volume="2018" Year="2019">
       <Id>63df57d2-8dc1-4448-9206-40a2b3e8ca9b</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="2" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="2" Volume="2018" Year="2019">
       <Id>32d08890-5cf0-4a31-9348-625391472ba6</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="3" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="3" Volume="2018" Year="2019">
       <Id>e2c82279-84d1-472f-afe4-d97bf94cae23</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="4" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="4" Volume="2018" Year="2019">
       <Id>8e828f90-c2e9-4962-9caa-db508fbac9fc</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="5" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="5" Volume="2018" Year="2019">
       <Id>51115957-afc2-46bb-835e-5ccbf6c2ad8e</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="6" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="6" Volume="2018" Year="2019">
       <Id>b48709dd-2499-4c16-94d0-95217a139a25</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="7" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="7" Volume="2018" Year="2019">
       <Id>662ebdbb-1c31-4a8d-aa05-4d5933fc08c7</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="8" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="8" Volume="2018" Year="2019">
       <Id>46893167-7feb-42ea-8a85-680c771c4a65</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="9" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="9" Volume="2018" Year="2019">
       <Id>f22925e9-adb3-44f4-9131-191aab2c6bbc</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="10" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="10" Volume="2018" Year="2019">
       <Id>7ae06611-b215-44ac-85e8-e3b2f6b5bcf5</Id>
     </Book>
-    <Book Series="X-Force" Number="1" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="X-Force" Number="1" Volume="2018" Year="2019">
       <Id>153f270f-5cbe-40cb-9021-a34505ac8191</Id>
     </Book>
-    <Book Series="X-Force" Number="2" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="X-Force" Number="2" Volume="2018" Year="2019">
       <Id>53eb1b0e-efbb-4833-b7a7-3164fde8246a</Id>
     </Book>
-    <Book Series="X-Force" Number="3" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="X-Force" Number="3" Volume="2018" Year="2019">
       <Id>8993e93a-de95-461b-9ff1-b45a432b6b38</Id>
     </Book>
-    <Book Series="X-Force" Number="4" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="X-Force" Number="4" Volume="2018" Year="2019">
       <Id>506cc42b-10d9-4a6c-9f55-5de39c052cef</Id>
     </Book>
-    <Book Series="X-Force" Number="5" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="X-Force" Number="5" Volume="2018" Year="2019">
       <Id>8ea14fbc-42b1-48a9-9abe-2e76174238ea</Id>
     </Book>
-    <Book Series="Age of X-Man Alpha" Number="1" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man Alpha" Number="1" Volume="2019" Year="2019">
       <Id>73a7ca1c-4a04-4f96-8347-abec62ceecb6</Id>
     </Book>
-    <Book Series="Age of X-Man: NextGen" Number="1" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: NextGen" Number="1" Volume="2019" Year="2019">
       <Id>36456f3c-315c-4432-97f0-88f96c2f6dff</Id>
     </Book>
-    <Book Series="Age of X-Man: NextGen" Number="2" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: NextGen" Number="2" Volume="2019" Year="2019">
       <Id>eea720c4-1d65-4e68-92b1-24d99f2db078</Id>
     </Book>
-    <Book Series="Age of X-Man: NextGen" Number="3" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: NextGen" Number="3" Volume="2019" Year="2019">
       <Id>35abc77b-45ff-43ed-89bb-a35e3e989327</Id>
     </Book>
-    <Book Series="Age of X-Man: NextGen" Number="4" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: NextGen" Number="4" Volume="2019" Year="2019">
       <Id>ced543ed-7235-4785-a9de-28deb3600d83</Id>
     </Book>
-    <Book Series="Age of X-Man: NextGen" Number="5" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: NextGen" Number="5" Volume="2019" Year="2019">
       <Id>794e4437-9364-4159-8d6f-c2c79d11944b</Id>
     </Book>
-    <Book Series="Age of X-Man: X-Tremists" Number="1" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: X-Tremists" Number="1" Volume="2019" Year="2019">
       <Id>73a019fb-b65a-489b-a3cb-0b277d5e60ed</Id>
     </Book>
-    <Book Series="Age of X-Man: X-Tremists" Number="2" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: X-Tremists" Number="2" Volume="2019" Year="2019">
       <Id>7485ca49-83c8-4779-97c0-43a8f82ba6c8</Id>
     </Book>
-    <Book Series="Age of X-Man: X-Tremists" Number="3" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: X-Tremists" Number="3" Volume="2019" Year="2019">
       <Id>359055e9-e125-4c6e-b290-1d329d3bbdcf</Id>
     </Book>
-    <Book Series="Age of X-Man: X-Tremists" Number="4" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: X-Tremists" Number="4" Volume="2019" Year="2019">
       <Id>6b35c222-64e9-4425-95b9-50fbadcdba2a</Id>
     </Book>
-    <Book Series="Age of X-Man: X-Tremists" Number="5" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: X-Tremists" Number="5" Volume="2019" Year="2019">
       <Id>d3b00f67-1afb-46da-bd92-fedb7e473c8b</Id>
     </Book>
-    <Book Series="Age of X-Man: Prisoner X" Number="1" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: Prisoner X" Number="1" Volume="2019" Year="2019">
       <Id>a0ffe7a6-e8fe-4309-879e-8e47066a5f49</Id>
     </Book>
-    <Book Series="Age of X-Man: Prisoner X" Number="2" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: Prisoner X" Number="2" Volume="2019" Year="2019">
       <Id>0107dee0-eb3b-4fb6-bd4d-4733959f4686</Id>
     </Book>
-    <Book Series="Age of X-Man: Prisoner X" Number="3" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: Prisoner X" Number="3" Volume="2019" Year="2019">
       <Id>8da9451b-0706-4f4b-8b6a-84ad25a32c5e</Id>
     </Book>
-    <Book Series="Age of X-Man: Prisoner X" Number="4" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: Prisoner X" Number="4" Volume="2019" Year="2019">
       <Id>1af11b8d-3e05-4043-80f3-4776db4d9a31</Id>
     </Book>
-    <Book Series="Age of X-Man: Prisoner X" Number="5" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: Prisoner X" Number="5" Volume="2019" Year="2019">
       <Id>dbc62fa7-692e-4d34-8772-f05678a4ec4d</Id>
     </Book>
-    <Book Series="Age of X-Man: Apocalypse and the X-Tracts" Number="1" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: Apocalypse and the X-Tracts" Number="1" Volume="2019" Year="2019">
       <Id>ad03616e-a26f-4b83-8fc3-d363e0a3d372</Id>
     </Book>
-    <Book Series="Age of X-Man: Apocalypse and the X-Tracts" Number="2" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: Apocalypse and the X-Tracts" Number="2" Volume="2019" Year="2019">
       <Id>d046a514-1e21-4aaa-9496-15a60cdbb341</Id>
     </Book>
-    <Book Series="Age of X-Man: Apocalypse and the X-Tracts" Number="3" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: Apocalypse and the X-Tracts" Number="3" Volume="2019" Year="2019">
       <Id>d77ecbe2-0a3f-4a7e-b8d6-804ce2064da4</Id>
     </Book>
-    <Book Series="Age of X-Man: Apocalypse and the X-Tracts" Number="4" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: Apocalypse and the X-Tracts" Number="4" Volume="2019" Year="2019">
       <Id>c8e45a93-80c6-44d1-b3d3-2d214bdf52f6</Id>
     </Book>
-    <Book Series="Age of X-Man: Apocalypse and the X-Tracts" Number="5" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: Apocalypse and the X-Tracts" Number="5" Volume="2019" Year="2019">
       <Id>51bae4b6-7aa8-4468-8e41-73c602cd435e</Id>
     </Book>
-    <Book Series="Age of X-Man: The Marvelous X-Men" Number="1" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: The Marvelous X-Men" Number="1" Volume="2019" Year="2019">
       <Id>d26b0bbc-b03d-4098-b4c0-0631008d463f</Id>
     </Book>
-    <Book Series="Age of X-Man: The Marvelous X-Men" Number="2" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: The Marvelous X-Men" Number="2" Volume="2019" Year="2019">
       <Id>e1e39d97-4c16-4bb6-83b9-6210672c634b</Id>
     </Book>
-    <Book Series="Age of X-Man: The Marvelous X-Men" Number="3" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: The Marvelous X-Men" Number="3" Volume="2019" Year="2019">
       <Id>3f0965a1-bb81-499e-a89b-ad85b5cd792b</Id>
     </Book>
-    <Book Series="Age of X-Man: The Marvelous X-Men" Number="4" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: The Marvelous X-Men" Number="4" Volume="2019" Year="2019">
       <Id>0a1d50fa-0a99-41f8-8fe7-d75960889dab</Id>
     </Book>
-    <Book Series="Age of X-Man: The Marvelous X-Men" Number="5" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: The Marvelous X-Men" Number="5" Volume="2019" Year="2019">
       <Id>92e4222a-c58b-4d1b-975e-c52bc46368ff</Id>
     </Book>
-    <Book Series="Age of X-Man: The Amazing Nightcrawler" Number="1" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: The Amazing Nightcrawler" Number="1" Volume="2019" Year="2019">
       <Id>ded96eac-8405-4b03-a187-cb12f2624e73</Id>
     </Book>
-    <Book Series="Age of X-Man: The Amazing Nightcrawler" Number="2" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: The Amazing Nightcrawler" Number="2" Volume="2019" Year="2019">
       <Id>96c266b8-465e-49b7-82eb-99f77c5e36b8</Id>
     </Book>
-    <Book Series="Age of X-Man: The Amazing Nightcrawler" Number="3" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: The Amazing Nightcrawler" Number="3" Volume="2019" Year="2019">
       <Id>865c8b4c-de82-4b06-9e3f-3ac1c56552f3</Id>
     </Book>
-    <Book Series="Age of X-Man: The Amazing Nightcrawler" Number="4" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: The Amazing Nightcrawler" Number="4" Volume="2019" Year="2019">
       <Id>5ab51770-d9f5-4b14-8b27-97b77ed45cc3</Id>
     </Book>
-    <Book Series="Age of X-Man: The Amazing Nightcrawler" Number="5" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man: The Amazing Nightcrawler" Number="5" Volume="2019" Year="2019">
       <Id>b9decc58-2b36-44e0-a4c7-25a03b0e50c8</Id>
     </Book>
-    <Book Series="Age of X-Man Omega" Number="1" Volume="2019" Year="2019" Format="Crossover">
+    <Book Series="Age of X-Man Omega" Number="1" Volume="2019" Year="2019">
       <Id>b1aff437-4147-4e45-bff9-27416a1521f8</Id>
     </Book>
-    <Book Series="Uncanny X-Men Annual" Number="1" Volume="2019" Year="2019" Format="Annual">
+    <Book Series="Uncanny X-Men Annual" Number="1" Volume="2019" Year="2019">
       <Id>874faff9-f1c3-4a6e-a660-a4f60da058f6</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="11" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="11" Volume="2018" Year="2019">
       <Id>00574b28-b920-4b5c-bf3c-be1ceda7ba99</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="12" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="12" Volume="2018" Year="2019">
       <Id>3fe9b44e-4ed2-4f9c-9372-71eec9442530</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="13" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="13" Volume="2018" Year="2019">
       <Id>369cdfd8-5a43-49d2-9bcb-9da4a4e9baa6</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="14" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="14" Volume="2018" Year="2019">
       <Id>7d0457a9-929a-439f-ad4e-39f18778b5ef</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="15" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="15" Volume="2018" Year="2019">
       <Id>f7b7eee3-ea24-421d-a2ca-df5a64889c75</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="16" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="16" Volume="2018" Year="2019">
       <Id>575a5107-0c90-4897-a9ff-bda7f826ffe1</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="17" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="17" Volume="2018" Year="2019">
       <Id>50348bee-cac6-4d4d-8cac-e50809a965d5</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="18" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="18" Volume="2018" Year="2019">
       <Id>023af50b-310b-4392-9f84-b09fb836ed56</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="19" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="19" Volume="2018" Year="2019">
       <Id>8976ce27-44a9-4093-b45f-0818601c7f0e</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="20" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="20" Volume="2018" Year="2019">
       <Id>3de69500-bf04-4368-a729-204f94afdd51</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="21" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="21" Volume="2018" Year="2019">
       <Id>466fc750-afc0-4b91-b47d-efe052820c7c</Id>
     </Book>
-    <Book Series="Uncanny X-Men" Number="22" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="Uncanny X-Men" Number="22" Volume="2018" Year="2019">
       <Id>64e7b103-016e-41e5-acf6-6cf27a5e04d0</Id>
     </Book>
-    <Book Series="X-Force" Number="6" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="X-Force" Number="6" Volume="2018" Year="2019">
       <Id>d6f2d582-1558-4b57-bc8e-c6d7a44f0c5d</Id>
     </Book>
-    <Book Series="X-Force" Number="7" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="X-Force" Number="7" Volume="2018" Year="2019">
       <Id>e0806d47-6123-42d2-b085-bf611594af5c</Id>
     </Book>
-    <Book Series="X-Force" Number="8" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="X-Force" Number="8" Volume="2018" Year="2019">
       <Id>9898a1d4-f2bc-4ab8-b145-6fdb1558ee69</Id>
     </Book>
-    <Book Series="X-Force" Number="9" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="X-Force" Number="9" Volume="2018" Year="2019">
       <Id>ab153f9b-853e-4ee9-9d0a-c06c39250f0e</Id>
     </Book>
-    <Book Series="X-Force" Number="10" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="X-Force" Number="10" Volume="2018" Year="2019">
       <Id>ea223919-c92e-4da0-ae00-e5bf0e8e7d4d</Id>
     </Book>
-    <Book Series="X-23" Number="7" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="X-23" Number="7" Volume="2018" Year="2019">
       <Id>edae513e-e22b-4f56-8ebf-96df57f0d37e</Id>
     </Book>
-    <Book Series="X-23" Number="8" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="X-23" Number="8" Volume="2018" Year="2019">
       <Id>0be04752-597d-481a-8282-4b40004b7961</Id>
     </Book>
-    <Book Series="X-23" Number="9" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="X-23" Number="9" Volume="2018" Year="2019">
       <Id>7e78ea81-0b55-4d1e-99bd-6b4b0f411e4f</Id>
     </Book>
-    <Book Series="X-23" Number="10" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="X-23" Number="10" Volume="2018" Year="2019">
       <Id>0a4d0261-ae52-4bc9-a195-65019dfdec8d</Id>
     </Book>
-    <Book Series="X-23" Number="11" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="X-23" Number="11" Volume="2018" Year="2019">
       <Id>59908119-65df-4271-901c-e259840f4bf1</Id>
     </Book>
-    <Book Series="X-23" Number="12" Volume="2018" Year="2019" Format="Main Series">
+    <Book Series="X-23" Number="12" Volume="2018" Year="2019">
       <Id>f80aee07-2c75-4b55-b449-dfbe1e50d3dd</Id>
     </Book>
   </Books>

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 019 - (Hickman Era).cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 019 - (Hickman Era).cbl
@@ -1,42 +1,43 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>X-Men - Part 19 - (Hickman Era)</Name>
+  <Name>X-Men - Part 019 - (Hickman Era)</Name>
+  <NumIssues>12</NumIssues>
   <Books>
-    <Book Series="House of X - Director's Cut" Number="1" Volume="2019" Year="2019">
-      <Id>bd33e258-efc1-4c2c-95be-cb66c7de48a1</Id>
+    <Book Series="House of X" Number="1" Volume="2019" Year="2019">
+      <Database Name="cv" Series="120309" Issue="714236" />
     </Book>
     <Book Series="Powers of X" Number="1" Volume="2019" Year="2019">
-      <Id>e761f758-25a8-4e98-addf-573a1086470a</Id>
+      <Database Name="cv" Series="120407" Issue="714669" />
     </Book>
     <Book Series="House of X" Number="2" Volume="2019" Year="2019">
-      <Id>141a1f83-6a4b-4be8-a63a-cd6b5654f820</Id>
+      <Database Name="cv" Series="120309" Issue="715306" />
     </Book>
     <Book Series="Powers of X" Number="2" Volume="2019" Year="2019">
-      <Id>63890f58-115d-4912-95d4-f397ca8a355e</Id>
+      <Database Name="cv" Series="120407" Issue="716371" />
     </Book>
     <Book Series="Powers of X" Number="3" Volume="2019" Year="2019">
-      <Id>774b1de0-3ffd-4eca-8752-0fbb725ed32a</Id>
+      <Database Name="cv" Series="120407" Issue="716968" />
     </Book>
     <Book Series="House of X" Number="3" Volume="2019" Year="2019">
-      <Id>a620bf9e-9e7b-41fb-bd99-dc9b1d3e48d9</Id>
+      <Database Name="cv" Series="120309" Issue="717519" />
     </Book>
     <Book Series="House of X" Number="4" Volume="2019" Year="2019">
-      <Id>fc184ed1-6d7f-4015-b045-f46847bfbe91</Id>
+      <Database Name="cv" Series="120309" Issue="718128" />
     </Book>
     <Book Series="Powers of X" Number="4" Volume="2019" Year="2019">
-      <Id>b7a34a1e-bb3e-44fa-86a4-874be8da28ab</Id>
+      <Database Name="cv" Series="120407" Issue="718763" />
     </Book>
     <Book Series="House of X" Number="5" Volume="2019" Year="2019">
-      <Id>b84b8556-0fb3-4ce1-8c30-0b3c412bba3e</Id>
+      <Database Name="cv" Series="120309" Issue="719439" />
     </Book>
     <Book Series="Powers of X" Number="5" Volume="2019" Year="2019">
-      <Id>764211c4-f8ba-4665-b368-f0fdac02ab86</Id>
+      <Database Name="cv" Series="120407" Issue="720169" />
     </Book>
     <Book Series="House of X" Number="6" Volume="2019" Year="2019">
-      <Id>9c6c8c93-29b1-4426-9f23-8b96ceb08713</Id>
+      <Database Name="cv" Series="120309" Issue="721154" />
     </Book>
     <Book Series="Powers of X" Number="6" Volume="2019" Year="2019">
-      <Id>7f1fbf24-c6b5-454d-8e70-34fe47c05d9e</Id>
+      <Database Name="cv" Series="120407" Issue="721789" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Teams/unsorted/X-Men/X-Men - Part 019 - (Hickman Era).cbl
+++ b/Marvel/Teams/unsorted/X-Men/X-Men - Part 019 - (Hickman Era).cbl
@@ -2,40 +2,40 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>X-Men - Part 19 - (Hickman Era)</Name>
   <Books>
-    <Book Series="House of X - Director's Cut" Number="1" Volume="2019" Year="2019" Format="Director's Cut">
+    <Book Series="House of X - Director's Cut" Number="1" Volume="2019" Year="2019">
       <Id>bd33e258-efc1-4c2c-95be-cb66c7de48a1</Id>
     </Book>
-    <Book Series="Powers of X" Number="1" Volume="2019" Year="2019" Format="Limited Series">
+    <Book Series="Powers of X" Number="1" Volume="2019" Year="2019">
       <Id>e761f758-25a8-4e98-addf-573a1086470a</Id>
     </Book>
-    <Book Series="House of X" Number="2" Volume="2019" Year="2019" Format="Limited Series">
+    <Book Series="House of X" Number="2" Volume="2019" Year="2019">
       <Id>141a1f83-6a4b-4be8-a63a-cd6b5654f820</Id>
     </Book>
-    <Book Series="Powers of X" Number="2" Volume="2019" Year="2019" Format="Limited Series">
+    <Book Series="Powers of X" Number="2" Volume="2019" Year="2019">
       <Id>63890f58-115d-4912-95d4-f397ca8a355e</Id>
     </Book>
-    <Book Series="Powers of X" Number="3" Volume="2019" Year="2019" Format="Limited Series">
+    <Book Series="Powers of X" Number="3" Volume="2019" Year="2019">
       <Id>774b1de0-3ffd-4eca-8752-0fbb725ed32a</Id>
     </Book>
-    <Book Series="House of X" Number="3" Volume="2019" Year="2019" Format="Limited Series">
+    <Book Series="House of X" Number="3" Volume="2019" Year="2019">
       <Id>a620bf9e-9e7b-41fb-bd99-dc9b1d3e48d9</Id>
     </Book>
-    <Book Series="House of X" Number="4" Volume="2019" Year="2019" Format="Limited Series">
+    <Book Series="House of X" Number="4" Volume="2019" Year="2019">
       <Id>fc184ed1-6d7f-4015-b045-f46847bfbe91</Id>
     </Book>
-    <Book Series="Powers of X" Number="4" Volume="2019" Year="2019" Format="Limited Series">
+    <Book Series="Powers of X" Number="4" Volume="2019" Year="2019">
       <Id>b7a34a1e-bb3e-44fa-86a4-874be8da28ab</Id>
     </Book>
-    <Book Series="House of X" Number="5" Volume="2019" Year="2019" Format="Limited Series">
+    <Book Series="House of X" Number="5" Volume="2019" Year="2019">
       <Id>b84b8556-0fb3-4ce1-8c30-0b3c412bba3e</Id>
     </Book>
-    <Book Series="Powers of X" Number="5" Volume="2019" Year="2019" Format="Limited Series">
+    <Book Series="Powers of X" Number="5" Volume="2019" Year="2019">
       <Id>764211c4-f8ba-4665-b368-f0fdac02ab86</Id>
     </Book>
-    <Book Series="House of X" Number="6" Volume="2019" Year="2019" Format="Limited Series">
+    <Book Series="House of X" Number="6" Volume="2019" Year="2019">
       <Id>9c6c8c93-29b1-4426-9f23-8b96ceb08713</Id>
     </Book>
-    <Book Series="Powers of X" Number="6" Volume="2019" Year="2019" Format="Limited Series">
+    <Book Series="Powers of X" Number="6" Volume="2019" Year="2019">
       <Id>7f1fbf24-c6b5-454d-8e70-34fe47c05d9e</Id>
     </Book>
   </Books>


### PR DESCRIPTION
Review notes:

- There are two commits.  The first was just to clear out some extraneous data from all lists in order to make the second diff clearer (i.e. should be 95% just swapping an <Id> for a <Database> element with no other metadata changes.
- Name changes mostly either ampersand differences or that period where Marvel's annuals weren't named "Annual" but with just the year (95-2001ish).  Some are the usual indicia obsession.
- Most date changes are subtle movements because of end of year cover/release year differences.
- Uncanny X-Men Annual has lots of name/date changes because of the way it is captured in CV (initially as "X-Men Annual", then an "Uncanny X-Men Annual" run from #16 starting in 1992).
- I've removed one issue where I literally could not find a Wolverine #0
- I added one where for some reason the final issue of the Chaos War series was not included (Part 12).