### PR TITLE
CV ID Mapping - Marvel/Characters/unsorted

### DIFF
--- a/Marvel/Characters/unsorted/Adam Warlock/Adam Warlock.cbl
+++ b/Marvel/Characters/unsorted/Adam Warlock/Adam Warlock.cbl
@@ -2,376 +2,376 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Adam Warlock</Name>
   <Books>
-    <Book Series="Fantastic Four" Number="66" Volume="1961" Year="1967" Format="Main Series">
+    <Book Series="Fantastic Four" Number="66" Volume="1961" Year="1967">
       <Id>5241682e-d0b9-48cb-94be-137a3f1d3d4a</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="67" Volume="1961" Year="1967" Format="Main Series">
+    <Book Series="Fantastic Four" Number="67" Volume="1961" Year="1967">
       <Id>d869401e-56b4-4ffe-9405-28f2093a875b</Id>
     </Book>
-    <Book Series="Thor" Number="164" Volume="1966" Year="1969" Format="Main Series">
+    <Book Series="Thor" Number="164" Volume="1966" Year="1969">
       <Id>0beb2fae-8a76-459a-9dda-7471819d8060</Id>
     </Book>
-    <Book Series="Thor" Number="165" Volume="1966" Year="1969" Format="Main Series">
+    <Book Series="Thor" Number="165" Volume="1966" Year="1969">
       <Id>32d57652-2f46-49ae-b1d1-23948b5ae228</Id>
     </Book>
-    <Book Series="Thor" Number="166" Volume="1966" Year="1969" Format="Main Series">
+    <Book Series="Thor" Number="166" Volume="1966" Year="1969">
       <Id>cfebf355-9388-456b-8d8f-540f161b98d1</Id>
     </Book>
-    <Book Series="Warlock" Number="1" Volume="1972" Year="1972" Format="Main Series">
+    <Book Series="Warlock" Number="1" Volume="1972" Year="1972">
       <Id>388e70bd-6f3c-482d-8568-7ba8191da821</Id>
     </Book>
-    <Book Series="Warlock" Number="2" Volume="1972" Year="1972" Format="Main Series">
+    <Book Series="Warlock" Number="2" Volume="1972" Year="1972">
       <Id>f1b0485c-527b-4b4e-a9f9-1fa66731c12c</Id>
     </Book>
-    <Book Series="Warlock" Number="3" Volume="1972" Year="1972" Format="Main Series">
+    <Book Series="Warlock" Number="3" Volume="1972" Year="1972">
       <Id>d22ba440-2d62-4fdd-a60d-d2216a596170</Id>
     </Book>
-    <Book Series="Warlock" Number="4" Volume="1972" Year="1973" Format="Main Series">
+    <Book Series="Warlock" Number="4" Volume="1972" Year="1973">
       <Id>7d30c001-0deb-43f4-988c-1869f8df4327</Id>
     </Book>
-    <Book Series="Warlock" Number="5" Volume="1972" Year="1973" Format="Main Series">
+    <Book Series="Warlock" Number="5" Volume="1972" Year="1973">
       <Id>d44d0fb8-3d80-40c5-9061-600113d921c6</Id>
     </Book>
-    <Book Series="Warlock" Number="6" Volume="1972" Year="1973" Format="Main Series">
+    <Book Series="Warlock" Number="6" Volume="1972" Year="1973">
       <Id>c17d5f53-dd18-4859-8226-505e6d63ccc3</Id>
     </Book>
-    <Book Series="Warlock" Number="7" Volume="1972" Year="1973" Format="Main Series">
+    <Book Series="Warlock" Number="7" Volume="1972" Year="1973">
       <Id>52d0cd54-8b15-415b-a8ad-a31f6247fd62</Id>
     </Book>
-    <Book Series="Warlock" Number="8" Volume="1972" Year="1973" Format="Main Series">
+    <Book Series="Warlock" Number="8" Volume="1972" Year="1973">
       <Id>32302ac6-7d9c-4a78-92cf-eef01e2cbdff</Id>
     </Book>
-    <Book Series="Warlock" Number="9" Volume="1972" Year="1975" Format="Main Series">
+    <Book Series="Warlock" Number="9" Volume="1972" Year="1975">
       <Id>1774d485-8205-484a-a85c-ac963dd18bd4</Id>
     </Book>
-    <Book Series="Warlock" Number="10" Volume="1972" Year="1975" Format="Main Series">
+    <Book Series="Warlock" Number="10" Volume="1972" Year="1975">
       <Id>3a05c737-d565-4e76-babe-54ff594b37dd</Id>
     </Book>
-    <Book Series="Warlock" Number="11" Volume="1972" Year="1976" Format="Main Series">
+    <Book Series="Warlock" Number="11" Volume="1972" Year="1976">
       <Id>6215a8f2-185f-4af9-8e23-8a4be1eb6a4d</Id>
     </Book>
-    <Book Series="Warlock" Number="12" Volume="1972" Year="1976" Format="Main Series">
+    <Book Series="Warlock" Number="12" Volume="1972" Year="1976">
       <Id>fad4172b-6960-4867-8474-78cd6d296f1b</Id>
     </Book>
-    <Book Series="Warlock" Number="13" Volume="1972" Year="1976" Format="Main Series">
+    <Book Series="Warlock" Number="13" Volume="1972" Year="1976">
       <Id>1db502e4-801c-4b61-aefb-f69ac71a4dbb</Id>
     </Book>
-    <Book Series="Warlock" Number="14" Volume="1972" Year="1976" Format="Main Series">
+    <Book Series="Warlock" Number="14" Volume="1972" Year="1976">
       <Id>5f532b6f-1f85-4e3f-9186-845f4ba819af</Id>
     </Book>
-    <Book Series="Warlock" Number="15" Volume="1972" Year="1976" Format="Main Series">
+    <Book Series="Warlock" Number="15" Volume="1972" Year="1976">
       <Id>71c44cc7-68b8-4e4e-a173-f01d4f722fb7</Id>
     </Book>
-    <Book Series="Strange Tales" Number="178" Volume="1973" Year="1975" Format="Main Series">
+    <Book Series="Strange Tales" Number="178" Volume="1973" Year="1975">
       <Id>5a8bf404-109c-42e3-8fc5-02d1410efb93</Id>
     </Book>
-    <Book Series="Strange Tales" Number="179" Volume="1973" Year="1975" Format="Main Series">
+    <Book Series="Strange Tales" Number="179" Volume="1973" Year="1975">
       <Id>52abe9bb-dc96-47f6-9caf-4098a5b047c9</Id>
     </Book>
-    <Book Series="Strange Tales" Number="180" Volume="1973" Year="1975" Format="Main Series">
+    <Book Series="Strange Tales" Number="180" Volume="1973" Year="1975">
       <Id>5b5e5177-5ad5-47b9-9ed5-ef8c289c5e09</Id>
     </Book>
-    <Book Series="Strange Tales" Number="181" Volume="1973" Year="1975" Format="Main Series">
+    <Book Series="Strange Tales" Number="181" Volume="1973" Year="1975">
       <Id>b191d907-ed58-4d0d-90f2-7016e0433d62</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="176" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="176" Volume="1968" Year="1974">
       <Id>1d4b4e27-ca59-4e17-abab-35e8b1067738</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="177" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="177" Volume="1968" Year="1974">
       <Id>5d66fa1e-be25-4105-8054-1ba0e4b4e420</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="178" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="178" Volume="1968" Year="1974">
       <Id>ea6291ff-af57-4450-b86f-d9eee6074f87</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="172" Volume="1961" Year="1976" Format="Main Series">
+    <Book Series="Fantastic Four" Number="172" Volume="1961" Year="1976">
       <Id>4e536e64-64fa-4b93-b80a-4d6135cefb02</Id>
     </Book>
-    <Book Series="Silver Surfer" Number="36" Volume="1987" Year="1990" Format="Main Series">
+    <Book Series="Silver Surfer" Number="36" Volume="1987" Year="1990">
       <Id>1cdec7f3-5360-4fee-92d5-a36f4eb96c64</Id>
     </Book>
-    <Book Series="Silver Surfer" Number="46" Volume="1987" Year="1991" Format="Main Series">
+    <Book Series="Silver Surfer" Number="46" Volume="1987" Year="1991">
       <Id>27ac6208-284e-430c-8ad5-ff469f384354</Id>
     </Book>
-    <Book Series="Silver Surfer" Number="47" Volume="1987" Year="1991" Format="Main Series">
+    <Book Series="Silver Surfer" Number="47" Volume="1987" Year="1991">
       <Id>423d4818-4ae6-4fd7-9ffc-3ce102b647e9</Id>
     </Book>
-    <Book Series="Silver Surfer" Number="48" Volume="1987" Year="1991" Format="Main Series">
+    <Book Series="Silver Surfer" Number="48" Volume="1987" Year="1991">
       <Id>63ad288f-73c1-4c59-a7c6-5373ed02f4f6</Id>
     </Book>
-    <Book Series="Silver Surfer" Number="52" Volume="1987" Year="1991" Format="Main Series">
+    <Book Series="Silver Surfer" Number="52" Volume="1987" Year="1991">
       <Id>3f138142-6c8a-4eb6-88a0-420d3f3c3051</Id>
     </Book>
-    <Book Series="Silver Surfer" Number="53" Volume="1987" Year="1991" Format="Main Series">
+    <Book Series="Silver Surfer" Number="53" Volume="1987" Year="1991">
       <Id>cc42bc49-f7cc-4c16-a7ef-828989ff26f2</Id>
     </Book>
-    <Book Series="Silver Surfer" Number="54" Volume="1987" Year="1991" Format="Main Series">
+    <Book Series="Silver Surfer" Number="54" Volume="1987" Year="1991">
       <Id>16a91a43-3f1d-49c3-8faf-98e40d1cc9e0</Id>
     </Book>
-    <Book Series="Silver Surfer" Number="55" Volume="1987" Year="1991" Format="Main Series">
+    <Book Series="Silver Surfer" Number="55" Volume="1987" Year="1991">
       <Id>9a7960fc-7bf8-4400-9b9f-2ccc6154422d</Id>
     </Book>
-    <Book Series="Silver Surfer" Number="56" Volume="1987" Year="1991" Format="Main Series">
+    <Book Series="Silver Surfer" Number="56" Volume="1987" Year="1991">
       <Id>06859ab8-082f-4c39-99dd-0e7109299c89</Id>
     </Book>
-    <Book Series="Silver Surfer" Number="57" Volume="1987" Year="1991" Format="Main Series">
+    <Book Series="Silver Surfer" Number="57" Volume="1987" Year="1991">
       <Id>872dae26-c74c-4c66-b786-78f1965d0063</Id>
     </Book>
-    <Book Series="Silver Surfer" Number="58" Volume="1987" Year="1991" Format="Main Series">
+    <Book Series="Silver Surfer" Number="58" Volume="1987" Year="1991">
       <Id>41132bd6-d73d-455f-9f48-9773ea28d119</Id>
     </Book>
-    <Book Series="Silver Surfer" Number="59" Volume="1987" Year="1991" Format="Main Series">
+    <Book Series="Silver Surfer" Number="59" Volume="1987" Year="1991">
       <Id>76ec896a-5e6d-4789-878c-617eeca51d70</Id>
     </Book>
-    <Book Series="Silver Surfer" Number="60" Volume="1987" Year="1991" Format="Main Series">
+    <Book Series="Silver Surfer" Number="60" Volume="1987" Year="1991">
       <Id>5e2d8577-142e-492f-ac84-ee602aeaa258</Id>
     </Book>
-    <Book Series="The Infinity Gauntlet" Number="1" Volume="1991" Year="1991" Format="Crossover">
+    <Book Series="The Infinity Gauntlet" Number="1" Volume="1991" Year="1991">
       <Id>2f23b825-4c7d-4ecb-b84d-4b6681197cc4</Id>
     </Book>
-    <Book Series="The Infinity Gauntlet" Number="2" Volume="1991" Year="1991" Format="Crossover">
+    <Book Series="The Infinity Gauntlet" Number="2" Volume="1991" Year="1991">
       <Id>1f63f4e8-cb7b-4b9b-a66b-28c6db76441d</Id>
     </Book>
-    <Book Series="The Infinity Gauntlet" Number="3" Volume="1991" Year="1991" Format="Crossover">
+    <Book Series="The Infinity Gauntlet" Number="3" Volume="1991" Year="1991">
       <Id>692b2852-59a3-48d7-9e16-d24e4fbe7c89</Id>
     </Book>
-    <Book Series="The Infinity Gauntlet" Number="4" Volume="1991" Year="1991" Format="Crossover">
+    <Book Series="The Infinity Gauntlet" Number="4" Volume="1991" Year="1991">
       <Id>964ff388-35dd-4666-8c7f-281e2be065d4</Id>
     </Book>
-    <Book Series="The Infinity Gauntlet" Number="5" Volume="1991" Year="1991" Format="Crossover">
+    <Book Series="The Infinity Gauntlet" Number="5" Volume="1991" Year="1991">
       <Id>f5a11a17-4854-4bba-9702-dd482bc009cc</Id>
     </Book>
-    <Book Series="The Infinity Gauntlet" Number="6" Volume="1991" Year="1991" Format="Crossover">
+    <Book Series="The Infinity Gauntlet" Number="6" Volume="1991" Year="1991">
       <Id>01e38e6c-6b68-4d69-acff-be79c486f01d</Id>
     </Book>
-    <Book Series="Wonder Man" Number="14" Volume="1991" Year="1992" Format="Main Series">
+    <Book Series="Wonder Man" Number="14" Volume="1991" Year="1992">
       <Id>0a84f7a5-a37f-4648-8ff4-f9746ff58f02</Id>
     </Book>
-    <Book Series="The Infinity War" Number="1" Volume="1992" Year="1992" Format="Crossover">
+    <Book Series="The Infinity War" Number="1" Volume="1992" Year="1992">
       <Id>59924df1-1d16-4945-b7b3-11026aa32400</Id>
     </Book>
-    <Book Series="The Infinity War" Number="2" Volume="1992" Year="1992" Format="Crossover">
+    <Book Series="The Infinity War" Number="2" Volume="1992" Year="1992">
       <Id>8cf0524d-bbdd-4b13-aeba-4a04f4fff951</Id>
     </Book>
-    <Book Series="The Infinity War" Number="3" Volume="1992" Year="1992" Format="Crossover">
+    <Book Series="The Infinity War" Number="3" Volume="1992" Year="1992">
       <Id>5383ed89-27b6-4caf-a0f2-3a1663f80876</Id>
     </Book>
-    <Book Series="The Infinity War" Number="4" Volume="1992" Year="1992" Format="Crossover">
+    <Book Series="The Infinity War" Number="4" Volume="1992" Year="1992">
       <Id>0bab7282-114d-4d32-b295-d73ef01dd9ec</Id>
     </Book>
-    <Book Series="The Infinity War" Number="5" Volume="1992" Year="1992" Format="Crossover">
+    <Book Series="The Infinity War" Number="5" Volume="1992" Year="1992">
       <Id>e022c32a-4829-46b7-a7f2-c87ddb33d5c3</Id>
     </Book>
-    <Book Series="The Infinity War" Number="6" Volume="1992" Year="1992" Format="Crossover">
+    <Book Series="The Infinity War" Number="6" Volume="1992" Year="1992">
       <Id>a10854d0-aa9b-49b6-a6d9-8733bc422d57</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="369" Volume="1961" Year="1992" Format="Main Series">
+    <Book Series="Fantastic Four" Number="369" Volume="1961" Year="1992">
       <Id>fcb7f755-1404-4090-90b6-a3c3f3b61cb2</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="370" Volume="1961" Year="1992" Format="Main Series">
+    <Book Series="Fantastic Four" Number="370" Volume="1961" Year="1992">
       <Id>417d7228-349e-48a2-8c9f-b64cbd97e1a0</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="1" Volume="1992" Year="1992" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="1" Volume="1992" Year="1992">
       <Id>47b5f905-d92a-4701-aa77-e0cebb34f982</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="2" Volume="1992" Year="1992" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="2" Volume="1992" Year="1992">
       <Id>c3f2bbc3-2d68-457a-8eba-2939e4b72e50</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="3" Volume="1992" Year="1992" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="3" Volume="1992" Year="1992">
       <Id>15450c11-8046-4933-add9-2e4c3a17a972</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="4" Volume="1992" Year="1992" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="4" Volume="1992" Year="1992">
       <Id>2270b14f-a9c7-4878-af18-01c178ab566e</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="5" Volume="1992" Year="1992" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="5" Volume="1992" Year="1992">
       <Id>803a557a-45c0-4024-b198-c18d23187792</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="6" Volume="1992" Year="1992" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="6" Volume="1992" Year="1992">
       <Id>3be75a31-f7a0-488d-8151-9f1e2485e4c2</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="7" Volume="1992" Year="1992" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="7" Volume="1992" Year="1992">
       <Id>1523391b-8aea-4e50-b790-9ae652e7ef64</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="8" Volume="1992" Year="1992" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="8" Volume="1992" Year="1992">
       <Id>b5244580-9d71-4787-be6d-4ef28d01b3b6</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="9" Volume="1992" Year="1992" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="9" Volume="1992" Year="1992">
       <Id>b84cc49e-adb4-47f6-9894-0975cbf766dc</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="10" Volume="1992" Year="1992" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="10" Volume="1992" Year="1992">
       <Id>8fb9da66-b72e-47d7-918e-fa23cd394e77</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="11" Volume="1992" Year="1992" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="11" Volume="1992" Year="1992">
       <Id>d7e4ab68-3dbc-4ac0-9568-b5b5a1c71211</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="12" Volume="1992" Year="1993" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="12" Volume="1992" Year="1993">
       <Id>beab8301-9084-42dc-b3a7-754cb38d35aa</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="13" Volume="1992" Year="1993" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="13" Volume="1992" Year="1993">
       <Id>1cc9e3a7-a578-46f3-b6c0-04e5e0ca822b</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="14" Volume="1992" Year="1993" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="14" Volume="1992" Year="1993">
       <Id>c0b120a4-b109-4cd1-b281-43f388550d45</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="15" Volume="1992" Year="1993" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="15" Volume="1992" Year="1993">
       <Id>92c84f05-e627-4fca-8fca-fe897d020a85</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="16" Volume="1992" Year="1993" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="16" Volume="1992" Year="1993">
       <Id>aa292959-c2fa-4c7f-876b-ff7463e70573</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="17" Volume="1992" Year="1993" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="17" Volume="1992" Year="1993">
       <Id>13a6ae2e-64b1-4f90-84ec-1cc7f414052a</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="18" Volume="1992" Year="1993" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="18" Volume="1992" Year="1993">
       <Id>da343a50-d738-44d9-b8e6-accd0fcc1eb5</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="19" Volume="1992" Year="1993" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="19" Volume="1992" Year="1993">
       <Id>ed84e6d9-a430-4eba-bcee-4772250e9a7a</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="20" Volume="1992" Year="1993" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="20" Volume="1992" Year="1993">
       <Id>6d8e447e-7e31-42d4-a184-b008a037b80f</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="21" Volume="1992" Year="1993" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="21" Volume="1992" Year="1993">
       <Id>795e1d3c-1e5b-4919-a462-b1596be0f6cb</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="22" Volume="1992" Year="1993" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="22" Volume="1992" Year="1993">
       <Id>4062b2ae-c007-4ac6-8925-ff70f65861aa</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="23" Volume="1992" Year="1993" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="23" Volume="1992" Year="1993">
       <Id>0505483f-ea9a-49b7-b8c2-3013b97121f5</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="24" Volume="1992" Year="1994" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="24" Volume="1992" Year="1994">
       <Id>00d4a764-2ad2-472a-86d9-80aec3cc6234</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="25" Volume="1992" Year="1994" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="25" Volume="1992" Year="1994">
       <Id>d82d90fb-ba8a-4aa1-97be-dc2f5e03c8cf</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="26" Volume="1992" Year="1994" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="26" Volume="1992" Year="1994">
       <Id>a0995bcc-6ad7-4613-8fbd-bc71d480c55f</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="27" Volume="1992" Year="1994" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="27" Volume="1992" Year="1994">
       <Id>d3c3675f-02c5-4b6c-b03b-e2af75a37f60</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="28" Volume="1992" Year="1994" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="28" Volume="1992" Year="1994">
       <Id>839a6b34-55e3-4ed8-bc37-0b03a8a01579</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="29" Volume="1992" Year="1994" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="29" Volume="1992" Year="1994">
       <Id>38aef9dd-122d-4e26-a592-90699d050e4d</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="30" Volume="1992" Year="1994" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="30" Volume="1992" Year="1994">
       <Id>a3ffbb03-6f5f-449f-9e14-a20d2912485b</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="31" Volume="1992" Year="1994" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="31" Volume="1992" Year="1994">
       <Id>261b2548-bedb-4eec-8924-99ebe250eb5f</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="32" Volume="1992" Year="1994" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="32" Volume="1992" Year="1994">
       <Id>4d6b3c0c-eb04-4ac9-bd37-6de919cf0856</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="33" Volume="1992" Year="1994" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="33" Volume="1992" Year="1994">
       <Id>54ca61e6-ac22-4da1-bf51-3f7192623888</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="34" Volume="1992" Year="1994" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="34" Volume="1992" Year="1994">
       <Id>84713841-65e5-4f84-957d-1e83f5f5a8fe</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="35" Volume="1992" Year="1994" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="35" Volume="1992" Year="1994">
       <Id>c8df7760-322c-42f7-8c6d-eb57e2fd29ac</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="36" Volume="1992" Year="1995" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="36" Volume="1992" Year="1995">
       <Id>535193b6-d3a1-426a-9a52-3435e9d9d367</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="37" Volume="1992" Year="1995" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="37" Volume="1992" Year="1995">
       <Id>a0b794d6-d615-4a45-95bd-f24160d05361</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="38" Volume="1992" Year="1995" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="38" Volume="1992" Year="1995">
       <Id>1e3a2fb3-0f54-4128-ab35-c7f05f074e1a</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="39" Volume="1992" Year="1995" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="39" Volume="1992" Year="1995">
       <Id>9800bce2-1afd-4da6-a188-739e14e6f9e0</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="40" Volume="1992" Year="1995" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="40" Volume="1992" Year="1995">
       <Id>561ceab9-7247-425c-a913-90ba6ee50c42</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="41" Volume="1992" Year="1995" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="41" Volume="1992" Year="1995">
       <Id>31770169-c36f-40c0-9f49-2f29c739d898</Id>
     </Book>
-    <Book Series="Warlock and the Infinity Watch" Number="42" Volume="1992" Year="1995" Format="Main Series">
+    <Book Series="Warlock and the Infinity Watch" Number="42" Volume="1992" Year="1995">
       <Id>b2f94d57-7587-4dcf-a062-f6282e5db2ac</Id>
     </Book>
-    <Book Series="Warlock Chronicles" Number="1" Volume="1993" Year="1993" Format="Main Series">
+    <Book Series="Warlock Chronicles" Number="1" Volume="1993" Year="1993">
       <Id>681eaacb-a957-4a49-8617-15f488827be8</Id>
     </Book>
-    <Book Series="Warlock Chronicles" Number="2" Volume="1993" Year="1993" Format="Main Series">
+    <Book Series="Warlock Chronicles" Number="2" Volume="1993" Year="1993">
       <Id>2bcdb8e6-2201-4fde-bd1a-7c167cfaaf21</Id>
     </Book>
-    <Book Series="Warlock Chronicles" Number="3" Volume="1993" Year="1993" Format="Main Series">
+    <Book Series="Warlock Chronicles" Number="3" Volume="1993" Year="1993">
       <Id>9c408b48-4683-4237-bf1c-9a449164e154</Id>
     </Book>
-    <Book Series="Warlock Chronicles" Number="4" Volume="1993" Year="1993" Format="Main Series">
+    <Book Series="Warlock Chronicles" Number="4" Volume="1993" Year="1993">
       <Id>fdd68c3c-e070-498b-91da-312d883a12eb</Id>
     </Book>
-    <Book Series="Warlock Chronicles" Number="5" Volume="1993" Year="1993" Format="Main Series">
+    <Book Series="Warlock Chronicles" Number="5" Volume="1993" Year="1993">
       <Id>7d2ca96b-2bd9-4c71-87b0-9195f62154fd</Id>
     </Book>
-    <Book Series="Warlock Chronicles" Number="6" Volume="1993" Year="1993" Format="Main Series">
+    <Book Series="Warlock Chronicles" Number="6" Volume="1993" Year="1993">
       <Id>f557f96a-6139-4812-81bc-64e0e7880067</Id>
     </Book>
-    <Book Series="Warlock Chronicles" Number="7" Volume="1993" Year="1994" Format="Main Series">
+    <Book Series="Warlock Chronicles" Number="7" Volume="1993" Year="1994">
       <Id>aab51554-b3e1-4e10-b139-a50691c26cf5</Id>
     </Book>
-    <Book Series="Warlock Chronicles" Number="8" Volume="1993" Year="1994" Format="Main Series">
+    <Book Series="Warlock Chronicles" Number="8" Volume="1993" Year="1994">
       <Id>225cf50d-2249-42b1-93b8-a37a8cb3925f</Id>
     </Book>
-    <Book Series="Silver Surfer" Number="86" Volume="1987" Year="1993" Format="Main Series">
+    <Book Series="Silver Surfer" Number="86" Volume="1987" Year="1993">
       <Id>9fe135ce-11ae-4e29-b220-99b94de980cb</Id>
     </Book>
-    <Book Series="Silver Surfer" Number="87" Volume="1987" Year="1993" Format="Main Series">
+    <Book Series="Silver Surfer" Number="87" Volume="1987" Year="1993">
       <Id>37df5cb1-ff67-423c-8b75-b0aab566c385</Id>
     </Book>
-    <Book Series="Silver Surfer" Number="88" Volume="1987" Year="1994" Format="Main Series">
+    <Book Series="Silver Surfer" Number="88" Volume="1987" Year="1994">
       <Id>5216683b-5f1d-4dd6-aadd-5bc4b8497237</Id>
     </Book>
-    <Book Series="Silver Surfer" Number="94" Volume="1987" Year="1994" Format="Main Series">
+    <Book Series="Silver Surfer" Number="94" Volume="1987" Year="1994">
       <Id>b25720ec-bcf7-49f4-95e5-1d9188ee8a4b</Id>
     </Book>
-    <Book Series="Silver Surfer" Number="111" Volume="1987" Year="1995" Format="Main Series">
+    <Book Series="Silver Surfer" Number="111" Volume="1987" Year="1995">
       <Id>ca8dfcf2-3de7-4d18-abd4-95813be5581a</Id>
     </Book>
-    <Book Series="Silver Surfer/Warlock: Resurrection" Number="1" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="Silver Surfer/Warlock: Resurrection" Number="1" Volume="1993" Year="1993">
       <Id>9a14f043-6a89-419a-8f49-37422d0e34dc</Id>
     </Book>
-    <Book Series="Silver Surfer/Warlock: Resurrection" Number="2" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="Silver Surfer/Warlock: Resurrection" Number="2" Volume="1993" Year="1993">
       <Id>e9f4cc2a-648d-4a0d-bfbb-950a76ba3dec</Id>
     </Book>
-    <Book Series="Silver Surfer/Warlock: Resurrection" Number="3" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="Silver Surfer/Warlock: Resurrection" Number="3" Volume="1993" Year="1993">
       <Id>5740add3-08ff-4247-ab45-21c6d6774dd3</Id>
     </Book>
-    <Book Series="Silver Surfer/Warlock: Resurrection" Number="4" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="Silver Surfer/Warlock: Resurrection" Number="4" Volume="1993" Year="1993">
       <Id>366855a2-27e0-40b4-ba59-93abd8e3aa1c</Id>
     </Book>
-    <Book Series="The Infinity Crusade" Number="1" Volume="1993" Year="1993" Format="Crossover">
+    <Book Series="The Infinity Crusade" Number="1" Volume="1993" Year="1993">
       <Id>4d712c58-3e96-4c10-ad93-bb1c0d2231e8</Id>
     </Book>
-    <Book Series="The Infinity Crusade" Number="2" Volume="1993" Year="1993" Format="Crossover">
+    <Book Series="The Infinity Crusade" Number="2" Volume="1993" Year="1993">
       <Id>286b67dd-c39d-4d13-b7e2-28f0a4affa36</Id>
     </Book>
-    <Book Series="The Infinity Crusade" Number="3" Volume="1993" Year="1993" Format="Crossover">
+    <Book Series="The Infinity Crusade" Number="3" Volume="1993" Year="1993">
       <Id>28b6a455-2b88-4cf7-a105-ba02cd35b5b8</Id>
     </Book>
-    <Book Series="The Infinity Crusade" Number="4" Volume="1993" Year="1993" Format="Crossover">
+    <Book Series="The Infinity Crusade" Number="4" Volume="1993" Year="1993">
       <Id>8982b62d-8e8a-4551-81d3-e7196463901b</Id>
     </Book>
-    <Book Series="The Infinity Crusade" Number="5" Volume="1993" Year="1993" Format="Crossover">
+    <Book Series="The Infinity Crusade" Number="5" Volume="1993" Year="1993">
       <Id>27aff520-8589-4fa5-92e9-4b213a358787</Id>
     </Book>
-    <Book Series="The Infinity Crusade" Number="6" Volume="1993" Year="1993" Format="Crossover">
+    <Book Series="The Infinity Crusade" Number="6" Volume="1993" Year="1993">
       <Id>a68e1f0b-08d6-4fd3-9de7-1512067e4fff</Id>
     </Book>
-    <Book Series="The Mighty Thor" Number="469" Volume="1989" Year="1993" Format="Main Series">
+    <Book Series="The Mighty Thor" Number="469" Volume="1989" Year="1993">
       <Id>c4d4d9b7-e998-43bb-aa35-67567430dcfc</Id>
     </Book>
-    <Book Series="The Mighty Thor" Number="470" Volume="1989" Year="1994" Format="Main Series">
+    <Book Series="The Mighty Thor" Number="470" Volume="1989" Year="1994">
       <Id>a8dc690e-5c17-41d7-94d3-afe282aea6dc</Id>
     </Book>
-    <Book Series="The Mighty Thor" Number="471" Volume="1989" Year="1994" Format="Main Series">
+    <Book Series="The Mighty Thor" Number="471" Volume="1989" Year="1994">
       <Id>16be0e9c-1636-4bc1-bbd3-ed26c3ec66ec</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Adam Warlock/Adam Warlock.cbl
+++ b/Marvel/Characters/unsorted/Adam Warlock/Adam Warlock.cbl
@@ -1,378 +1,379 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Adam Warlock</Name>
+  <NumIssues>124</NumIssues>
   <Books>
     <Book Series="Fantastic Four" Number="66" Volume="1961" Year="1967">
-      <Id>5241682e-d0b9-48cb-94be-137a3f1d3d4a</Id>
+      <Database Name="cv" Series="2045" Issue="9615" />
     </Book>
     <Book Series="Fantastic Four" Number="67" Volume="1961" Year="1967">
-      <Id>d869401e-56b4-4ffe-9405-28f2093a875b</Id>
+      <Database Name="cv" Series="2045" Issue="9685" />
     </Book>
     <Book Series="Thor" Number="164" Volume="1966" Year="1969">
-      <Id>0beb2fae-8a76-459a-9dda-7471819d8060</Id>
+      <Database Name="cv" Series="2294" Issue="10214" />
     </Book>
     <Book Series="Thor" Number="165" Volume="1966" Year="1969">
-      <Id>32d57652-2f46-49ae-b1d1-23948b5ae228</Id>
+      <Database Name="cv" Series="2294" Issue="10269" />
     </Book>
     <Book Series="Thor" Number="166" Volume="1966" Year="1969">
-      <Id>cfebf355-9388-456b-8d8f-540f161b98d1</Id>
+      <Database Name="cv" Series="2294" Issue="10316" />
     </Book>
     <Book Series="Warlock" Number="1" Volume="1972" Year="1972">
-      <Id>388e70bd-6f3c-482d-8568-7ba8191da821</Id>
+      <Database Name="cv" Series="2583" Issue="12430" />
     </Book>
     <Book Series="Warlock" Number="2" Volume="1972" Year="1972">
-      <Id>f1b0485c-527b-4b4e-a9f9-1fa66731c12c</Id>
+      <Database Name="cv" Series="2583" Issue="12590" />
     </Book>
     <Book Series="Warlock" Number="3" Volume="1972" Year="1972">
-      <Id>d22ba440-2d62-4fdd-a60d-d2216a596170</Id>
+      <Database Name="cv" Series="2583" Issue="12755" />
     </Book>
     <Book Series="Warlock" Number="4" Volume="1972" Year="1973">
-      <Id>7d30c001-0deb-43f4-988c-1869f8df4327</Id>
+      <Database Name="cv" Series="2583" Issue="12943" />
     </Book>
     <Book Series="Warlock" Number="5" Volume="1972" Year="1973">
-      <Id>d44d0fb8-3d80-40c5-9061-600113d921c6</Id>
+      <Database Name="cv" Series="2583" Issue="13128" />
     </Book>
     <Book Series="Warlock" Number="6" Volume="1972" Year="1973">
-      <Id>c17d5f53-dd18-4859-8226-505e6d63ccc3</Id>
+      <Database Name="cv" Series="2583" Issue="13299" />
     </Book>
     <Book Series="Warlock" Number="7" Volume="1972" Year="1973">
-      <Id>52d0cd54-8b15-415b-a8ad-a31f6247fd62</Id>
+      <Database Name="cv" Series="2583" Issue="13498" />
     </Book>
     <Book Series="Warlock" Number="8" Volume="1972" Year="1973">
-      <Id>32302ac6-7d9c-4a78-92cf-eef01e2cbdff</Id>
+      <Database Name="cv" Series="2583" Issue="13720" />
     </Book>
     <Book Series="Warlock" Number="9" Volume="1972" Year="1975">
-      <Id>1774d485-8205-484a-a85c-ac963dd18bd4</Id>
+      <Database Name="cv" Series="2583" Issue="15708" />
     </Book>
     <Book Series="Warlock" Number="10" Volume="1972" Year="1975">
-      <Id>3a05c737-d565-4e76-babe-54ff594b37dd</Id>
+      <Database Name="cv" Series="2583" Issue="15886" />
     </Book>
     <Book Series="Warlock" Number="11" Volume="1972" Year="1976">
-      <Id>6215a8f2-185f-4af9-8e23-8a4be1eb6a4d</Id>
+      <Database Name="cv" Series="2583" Issue="16099" />
     </Book>
     <Book Series="Warlock" Number="12" Volume="1972" Year="1976">
-      <Id>fad4172b-6960-4867-8474-78cd6d296f1b</Id>
+      <Database Name="cv" Series="2583" Issue="16277" />
     </Book>
     <Book Series="Warlock" Number="13" Volume="1972" Year="1976">
-      <Id>1db502e4-801c-4b61-aefb-f69ac71a4dbb</Id>
+      <Database Name="cv" Series="2583" Issue="16438" />
     </Book>
     <Book Series="Warlock" Number="14" Volume="1972" Year="1976">
-      <Id>5f532b6f-1f85-4e3f-9186-845f4ba819af</Id>
+      <Database Name="cv" Series="2583" Issue="16616" />
     </Book>
     <Book Series="Warlock" Number="15" Volume="1972" Year="1976">
-      <Id>71c44cc7-68b8-4e4e-a173-f01d4f722fb7</Id>
+      <Database Name="cv" Series="2583" Issue="16893" />
     </Book>
     <Book Series="Strange Tales" Number="178" Volume="1973" Year="1975">
-      <Id>5a8bf404-109c-42e3-8fc5-02d1410efb93</Id>
+      <Database Name="cv" Series="2643" Issue="15076" />
     </Book>
     <Book Series="Strange Tales" Number="179" Volume="1973" Year="1975">
-      <Id>52abe9bb-dc96-47f6-9caf-4098a5b047c9</Id>
+      <Database Name="cv" Series="2643" Issue="108987" />
     </Book>
     <Book Series="Strange Tales" Number="180" Volume="1973" Year="1975">
-      <Id>5b5e5177-5ad5-47b9-9ed5-ef8c289c5e09</Id>
+      <Database Name="cv" Series="2643" Issue="15291" />
     </Book>
     <Book Series="Strange Tales" Number="181" Volume="1973" Year="1975">
-      <Id>b191d907-ed58-4d0d-90f2-7016e0433d62</Id>
+      <Database Name="cv" Series="2643" Issue="15500" />
     </Book>
     <Book Series="The Incredible Hulk" Number="176" Volume="1968" Year="1974">
-      <Id>1d4b4e27-ca59-4e17-abab-35e8b1067738</Id>
+      <Database Name="cv" Series="2406" Issue="14340" />
     </Book>
     <Book Series="The Incredible Hulk" Number="177" Volume="1968" Year="1974">
-      <Id>5d66fa1e-be25-4105-8054-1ba0e4b4e420</Id>
+      <Database Name="cv" Series="2406" Issue="14423" />
     </Book>
     <Book Series="The Incredible Hulk" Number="178" Volume="1968" Year="1974">
-      <Id>ea6291ff-af57-4450-b86f-d9eee6074f87</Id>
+      <Database Name="cv" Series="2406" Issue="14493" />
     </Book>
     <Book Series="Fantastic Four" Number="172" Volume="1961" Year="1976">
-      <Id>4e536e64-64fa-4b93-b80a-4d6135cefb02</Id>
+      <Database Name="cv" Series="2045" Issue="16506" />
     </Book>
     <Book Series="Silver Surfer" Number="36" Volume="1987" Year="1990">
-      <Id>1cdec7f3-5360-4fee-92d5-a36f4eb96c64</Id>
+      <Database Name="cv" Series="3857" Issue="32645" />
     </Book>
     <Book Series="Silver Surfer" Number="46" Volume="1987" Year="1991">
-      <Id>27ac6208-284e-430c-8ad5-ff469f384354</Id>
+      <Database Name="cv" Series="3857" Issue="33891" />
     </Book>
     <Book Series="Silver Surfer" Number="47" Volume="1987" Year="1991">
-      <Id>423d4818-4ae6-4fd7-9ffc-3ce102b647e9</Id>
+      <Database Name="cv" Series="3857" Issue="34005" />
     </Book>
     <Book Series="Silver Surfer" Number="48" Volume="1987" Year="1991">
-      <Id>63ad288f-73c1-4c59-a7c6-5373ed02f4f6</Id>
+      <Database Name="cv" Series="3857" Issue="34109" />
     </Book>
     <Book Series="Silver Surfer" Number="52" Volume="1987" Year="1991">
-      <Id>3f138142-6c8a-4eb6-88a0-420d3f3c3051</Id>
+      <Database Name="cv" Series="3857" Issue="34543" />
     </Book>
     <Book Series="Silver Surfer" Number="53" Volume="1987" Year="1991">
-      <Id>cc42bc49-f7cc-4c16-a7ef-828989ff26f2</Id>
+      <Database Name="cv" Series="3857" Issue="34578" />
     </Book>
     <Book Series="Silver Surfer" Number="54" Volume="1987" Year="1991">
-      <Id>16a91a43-3f1d-49c3-8faf-98e40d1cc9e0</Id>
+      <Database Name="cv" Series="3857" Issue="34660" />
     </Book>
     <Book Series="Silver Surfer" Number="55" Volume="1987" Year="1991">
-      <Id>9a7960fc-7bf8-4400-9b9f-2ccc6154422d</Id>
+      <Database Name="cv" Series="3857" Issue="34695" />
     </Book>
     <Book Series="Silver Surfer" Number="56" Volume="1987" Year="1991">
-      <Id>06859ab8-082f-4c39-99dd-0e7109299c89</Id>
+      <Database Name="cv" Series="3857" Issue="34777" />
     </Book>
     <Book Series="Silver Surfer" Number="57" Volume="1987" Year="1991">
-      <Id>872dae26-c74c-4c66-b786-78f1965d0063</Id>
+      <Database Name="cv" Series="3857" Issue="34813" />
     </Book>
     <Book Series="Silver Surfer" Number="58" Volume="1987" Year="1991">
-      <Id>41132bd6-d73d-455f-9f48-9773ea28d119</Id>
+      <Database Name="cv" Series="3857" Issue="34893" />
     </Book>
     <Book Series="Silver Surfer" Number="59" Volume="1987" Year="1991">
-      <Id>76ec896a-5e6d-4789-878c-617eeca51d70</Id>
+      <Database Name="cv" Series="3857" Issue="34934" />
     </Book>
     <Book Series="Silver Surfer" Number="60" Volume="1987" Year="1991">
-      <Id>5e2d8577-142e-492f-ac84-ee602aeaa258</Id>
+      <Database Name="cv" Series="3857" Issue="35013" />
     </Book>
     <Book Series="The Infinity Gauntlet" Number="1" Volume="1991" Year="1991">
-      <Id>2f23b825-4c7d-4ecb-b84d-4b6681197cc4</Id>
+      <Database Name="cv" Series="4596" Issue="34415" />
     </Book>
     <Book Series="The Infinity Gauntlet" Number="2" Volume="1991" Year="1991">
-      <Id>1f63f4e8-cb7b-4b9b-a66b-28c6db76441d</Id>
+      <Database Name="cv" Series="4596" Issue="34529" />
     </Book>
     <Book Series="The Infinity Gauntlet" Number="3" Volume="1991" Year="1991">
-      <Id>692b2852-59a3-48d7-9e16-d24e4fbe7c89</Id>
+      <Database Name="cv" Series="4596" Issue="34647" />
     </Book>
     <Book Series="The Infinity Gauntlet" Number="4" Volume="1991" Year="1991">
-      <Id>964ff388-35dd-4666-8c7f-281e2be065d4</Id>
+      <Database Name="cv" Series="4596" Issue="34764" />
     </Book>
     <Book Series="The Infinity Gauntlet" Number="5" Volume="1991" Year="1991">
-      <Id>f5a11a17-4854-4bba-9702-dd482bc009cc</Id>
+      <Database Name="cv" Series="4596" Issue="34880" />
     </Book>
     <Book Series="The Infinity Gauntlet" Number="6" Volume="1991" Year="1991">
-      <Id>01e38e6c-6b68-4d69-acff-be79c486f01d</Id>
+      <Database Name="cv" Series="4596" Issue="35000" />
     </Book>
     <Book Series="Wonder Man" Number="14" Volume="1991" Year="1992">
-      <Id>0a84f7a5-a37f-4648-8ff4-f9746ff58f02</Id>
+      <Database Name="cv" Series="4603" Issue="136856" />
     </Book>
     <Book Series="The Infinity War" Number="1" Volume="1992" Year="1992">
-      <Id>59924df1-1d16-4945-b7b3-11026aa32400</Id>
+      <Database Name="cv" Series="4795" Issue="35783" />
     </Book>
     <Book Series="The Infinity War" Number="2" Volume="1992" Year="1992">
-      <Id>8cf0524d-bbdd-4b13-aeba-4a04f4fff951</Id>
+      <Database Name="cv" Series="4795" Issue="35907" />
     </Book>
     <Book Series="The Infinity War" Number="3" Volume="1992" Year="1992">
-      <Id>5383ed89-27b6-4caf-a0f2-3a1663f80876</Id>
+      <Database Name="cv" Series="4795" Issue="36025" />
     </Book>
     <Book Series="The Infinity War" Number="4" Volume="1992" Year="1992">
-      <Id>0bab7282-114d-4d32-b295-d73ef01dd9ec</Id>
+      <Database Name="cv" Series="4795" Issue="36152" />
     </Book>
     <Book Series="The Infinity War" Number="5" Volume="1992" Year="1992">
-      <Id>e022c32a-4829-46b7-a7f2-c87ddb33d5c3</Id>
+      <Database Name="cv" Series="4795" Issue="36276" />
     </Book>
     <Book Series="The Infinity War" Number="6" Volume="1992" Year="1992">
-      <Id>a10854d0-aa9b-49b6-a6d9-8733bc422d57</Id>
+      <Database Name="cv" Series="4795" Issue="36400" />
     </Book>
     <Book Series="Fantastic Four" Number="369" Volume="1961" Year="1992">
-      <Id>fcb7f755-1404-4090-90b6-a3c3f3b61cb2</Id>
+      <Database Name="cv" Series="2045" Issue="130904" />
     </Book>
     <Book Series="Fantastic Four" Number="370" Volume="1961" Year="1992">
-      <Id>417d7228-349e-48a2-8c9f-b64cbd97e1a0</Id>
+      <Database Name="cv" Series="2045" Issue="130906" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="1" Volume="1992" Year="1992">
-      <Id>47b5f905-d92a-4701-aa77-e0cebb34f982</Id>
+      <Database Name="cv" Series="4818" Issue="35385" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="2" Volume="1992" Year="1992">
-      <Id>c3f2bbc3-2d68-457a-8eba-2939e4b72e50</Id>
+      <Database Name="cv" Series="4818" Issue="35489" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="3" Volume="1992" Year="1992">
-      <Id>15450c11-8046-4933-add9-2e4c3a17a972</Id>
+      <Database Name="cv" Series="4818" Issue="35593" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="4" Volume="1992" Year="1992">
-      <Id>2270b14f-a9c7-4878-af18-01c178ab566e</Id>
+      <Database Name="cv" Series="4818" Issue="35698" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="5" Volume="1992" Year="1992">
-      <Id>803a557a-45c0-4024-b198-c18d23187792</Id>
+      <Database Name="cv" Series="4818" Issue="35802" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="6" Volume="1992" Year="1992">
-      <Id>3be75a31-f7a0-488d-8151-9f1e2485e4c2</Id>
+      <Database Name="cv" Series="4818" Issue="35926" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="7" Volume="1992" Year="1992">
-      <Id>1523391b-8aea-4e50-b790-9ae652e7ef64</Id>
+      <Database Name="cv" Series="4818" Issue="36048" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="8" Volume="1992" Year="1992">
-      <Id>b5244580-9d71-4787-be6d-4ef28d01b3b6</Id>
+      <Database Name="cv" Series="4818" Issue="36170" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="9" Volume="1992" Year="1992">
-      <Id>b84cc49e-adb4-47f6-9894-0975cbf766dc</Id>
+      <Database Name="cv" Series="4818" Issue="36299" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="10" Volume="1992" Year="1992">
-      <Id>8fb9da66-b72e-47d7-918e-fa23cd394e77</Id>
+      <Database Name="cv" Series="4818" Issue="36420" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="11" Volume="1992" Year="1992">
-      <Id>d7e4ab68-3dbc-4ac0-9568-b5b5a1c71211</Id>
+      <Database Name="cv" Series="4818" Issue="36535" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="12" Volume="1992" Year="1993">
-      <Id>beab8301-9084-42dc-b3a7-754cb38d35aa</Id>
+      <Database Name="cv" Series="4818" Issue="36776" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="13" Volume="1992" Year="1993">
-      <Id>1cc9e3a7-a578-46f3-b6c0-04e5e0ca822b</Id>
+      <Database Name="cv" Series="4818" Issue="36883" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="14" Volume="1992" Year="1993">
-      <Id>c0b120a4-b109-4cd1-b281-43f388550d45</Id>
+      <Database Name="cv" Series="4818" Issue="36998" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="15" Volume="1992" Year="1993">
-      <Id>92c84f05-e627-4fca-8fca-fe897d020a85</Id>
+      <Database Name="cv" Series="4818" Issue="37121" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="16" Volume="1992" Year="1993">
-      <Id>aa292959-c2fa-4c7f-876b-ff7463e70573</Id>
+      <Database Name="cv" Series="4818" Issue="37256" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="17" Volume="1992" Year="1993">
-      <Id>13a6ae2e-64b1-4f90-84ec-1cc7f414052a</Id>
+      <Database Name="cv" Series="4818" Issue="37396" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="18" Volume="1992" Year="1993">
-      <Id>da343a50-d738-44d9-b8e6-accd0fcc1eb5</Id>
+      <Database Name="cv" Series="4818" Issue="136883" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="19" Volume="1992" Year="1993">
-      <Id>ed84e6d9-a430-4eba-bcee-4772250e9a7a</Id>
+      <Database Name="cv" Series="4818" Issue="130938" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="20" Volume="1992" Year="1993">
-      <Id>6d8e447e-7e31-42d4-a184-b008a037b80f</Id>
+      <Database Name="cv" Series="4818" Issue="37826" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="21" Volume="1992" Year="1993">
-      <Id>795e1d3c-1e5b-4919-a462-b1596be0f6cb</Id>
+      <Database Name="cv" Series="4818" Issue="37971" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="22" Volume="1992" Year="1993">
-      <Id>4062b2ae-c007-4ac6-8925-ff70f65861aa</Id>
+      <Database Name="cv" Series="4818" Issue="38128" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="23" Volume="1992" Year="1993">
-      <Id>0505483f-ea9a-49b7-b8c2-3013b97121f5</Id>
+      <Database Name="cv" Series="4818" Issue="38282" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="24" Volume="1992" Year="1994">
-      <Id>00d4a764-2ad2-472a-86d9-80aec3cc6234</Id>
+      <Database Name="cv" Series="4818" Issue="38539" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="25" Volume="1992" Year="1994">
-      <Id>d82d90fb-ba8a-4aa1-97be-dc2f5e03c8cf</Id>
+      <Database Name="cv" Series="4818" Issue="38678" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="26" Volume="1992" Year="1994">
-      <Id>a0995bcc-6ad7-4613-8fbd-bc71d480c55f</Id>
+      <Database Name="cv" Series="4818" Issue="38827" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="27" Volume="1992" Year="1994">
-      <Id>d3c3675f-02c5-4b6c-b03b-e2af75a37f60</Id>
+      <Database Name="cv" Series="4818" Issue="38967" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="28" Volume="1992" Year="1994">
-      <Id>839a6b34-55e3-4ed8-bc37-0b03a8a01579</Id>
+      <Database Name="cv" Series="4818" Issue="39107" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="29" Volume="1992" Year="1994">
-      <Id>38aef9dd-122d-4e26-a592-90699d050e4d</Id>
+      <Database Name="cv" Series="4818" Issue="39257" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="30" Volume="1992" Year="1994">
-      <Id>a3ffbb03-6f5f-449f-9e14-a20d2912485b</Id>
+      <Database Name="cv" Series="4818" Issue="39399" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="31" Volume="1992" Year="1994">
-      <Id>261b2548-bedb-4eec-8924-99ebe250eb5f</Id>
+      <Database Name="cv" Series="4818" Issue="39541" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="32" Volume="1992" Year="1994">
-      <Id>4d6b3c0c-eb04-4ac9-bd37-6de919cf0856</Id>
+      <Database Name="cv" Series="4818" Issue="39676" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="33" Volume="1992" Year="1994">
-      <Id>54ca61e6-ac22-4da1-bf51-3f7192623888</Id>
+      <Database Name="cv" Series="4818" Issue="39826" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="34" Volume="1992" Year="1994">
-      <Id>84713841-65e5-4f84-957d-1e83f5f5a8fe</Id>
+      <Database Name="cv" Series="4818" Issue="39970" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="35" Volume="1992" Year="1994">
-      <Id>c8df7760-322c-42f7-8c6d-eb57e2fd29ac</Id>
+      <Database Name="cv" Series="4818" Issue="40111" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="36" Volume="1992" Year="1995">
-      <Id>535193b6-d3a1-426a-9a52-3435e9d9d367</Id>
+      <Database Name="cv" Series="4818" Issue="40351" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="37" Volume="1992" Year="1995">
-      <Id>a0b794d6-d615-4a45-95bd-f24160d05361</Id>
+      <Database Name="cv" Series="4818" Issue="40482" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="38" Volume="1992" Year="1995">
-      <Id>1e3a2fb3-0f54-4128-ab35-c7f05f074e1a</Id>
+      <Database Name="cv" Series="4818" Issue="40620" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="39" Volume="1992" Year="1995">
-      <Id>9800bce2-1afd-4da6-a188-739e14e6f9e0</Id>
+      <Database Name="cv" Series="4818" Issue="40754" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="40" Volume="1992" Year="1995">
-      <Id>561ceab9-7247-425c-a913-90ba6ee50c42</Id>
+      <Database Name="cv" Series="4818" Issue="40877" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="41" Volume="1992" Year="1995">
-      <Id>31770169-c36f-40c0-9f49-2f29c739d898</Id>
+      <Database Name="cv" Series="4818" Issue="41002" />
     </Book>
     <Book Series="Warlock and the Infinity Watch" Number="42" Volume="1992" Year="1995">
-      <Id>b2f94d57-7587-4dcf-a062-f6282e5db2ac</Id>
+      <Database Name="cv" Series="4818" Issue="41275" />
     </Book>
     <Book Series="Warlock Chronicles" Number="1" Volume="1993" Year="1993">
-      <Id>681eaacb-a957-4a49-8617-15f488827be8</Id>
+      <Database Name="cv" Series="5062" Issue="37559" />
     </Book>
     <Book Series="Warlock Chronicles" Number="2" Volume="1993" Year="1993">
-      <Id>2bcdb8e6-2201-4fde-bd1a-7c167cfaaf21</Id>
+      <Database Name="cv" Series="5062" Issue="37697" />
     </Book>
     <Book Series="Warlock Chronicles" Number="3" Volume="1993" Year="1993">
-      <Id>9c408b48-4683-4237-bf1c-9a449164e154</Id>
+      <Database Name="cv" Series="5062" Issue="37837" />
     </Book>
     <Book Series="Warlock Chronicles" Number="4" Volume="1993" Year="1993">
-      <Id>fdd68c3c-e070-498b-91da-312d883a12eb</Id>
+      <Database Name="cv" Series="5062" Issue="37982" />
     </Book>
     <Book Series="Warlock Chronicles" Number="5" Volume="1993" Year="1993">
-      <Id>7d2ca96b-2bd9-4c71-87b0-9195f62154fd</Id>
+      <Database Name="cv" Series="5062" Issue="38145" />
     </Book>
     <Book Series="Warlock Chronicles" Number="6" Volume="1993" Year="1993">
-      <Id>f557f96a-6139-4812-81bc-64e0e7880067</Id>
+      <Database Name="cv" Series="5062" Issue="38302" />
     </Book>
     <Book Series="Warlock Chronicles" Number="7" Volume="1993" Year="1994">
-      <Id>aab51554-b3e1-4e10-b139-a50691c26cf5</Id>
+      <Database Name="cv" Series="5062" Issue="38556" />
     </Book>
     <Book Series="Warlock Chronicles" Number="8" Volume="1993" Year="1994">
-      <Id>225cf50d-2249-42b1-93b8-a37a8cb3925f</Id>
+      <Database Name="cv" Series="5062" Issue="38696" />
     </Book>
     <Book Series="Silver Surfer" Number="86" Volume="1987" Year="1993">
-      <Id>9fe135ce-11ae-4e29-b220-99b94de980cb</Id>
+      <Database Name="cv" Series="3857" Issue="38105" />
     </Book>
     <Book Series="Silver Surfer" Number="87" Volume="1987" Year="1993">
-      <Id>37df5cb1-ff67-423c-8b75-b0aab566c385</Id>
+      <Database Name="cv" Series="3857" Issue="38263" />
     </Book>
     <Book Series="Silver Surfer" Number="88" Volume="1987" Year="1994">
-      <Id>5216683b-5f1d-4dd6-aadd-5bc4b8497237</Id>
+      <Database Name="cv" Series="3857" Issue="38512" />
     </Book>
     <Book Series="Silver Surfer" Number="94" Volume="1987" Year="1994">
-      <Id>b25720ec-bcf7-49f4-95e5-1d9188ee8a4b</Id>
+      <Database Name="cv" Series="3857" Issue="39377" />
     </Book>
     <Book Series="Silver Surfer" Number="111" Volume="1987" Year="1995">
-      <Id>ca8dfcf2-3de7-4d18-abd4-95813be5581a</Id>
+      <Database Name="cv" Series="3857" Issue="96271" />
     </Book>
     <Book Series="Silver Surfer/Warlock: Resurrection" Number="1" Volume="1993" Year="1993">
-      <Id>9a14f043-6a89-419a-8f49-37422d0e34dc</Id>
+      <Database Name="cv" Series="5046" Issue="36980" />
     </Book>
     <Book Series="Silver Surfer/Warlock: Resurrection" Number="2" Volume="1993" Year="1993">
-      <Id>e9f4cc2a-648d-4a0d-bfbb-950a76ba3dec</Id>
+      <Database Name="cv" Series="5046" Issue="37098" />
     </Book>
     <Book Series="Silver Surfer/Warlock: Resurrection" Number="3" Volume="1993" Year="1993">
-      <Id>5740add3-08ff-4247-ab45-21c6d6774dd3</Id>
+      <Database Name="cv" Series="5046" Issue="37236" />
     </Book>
     <Book Series="Silver Surfer/Warlock: Resurrection" Number="4" Volume="1993" Year="1993">
-      <Id>366855a2-27e0-40b4-ba59-93abd8e3aa1c</Id>
+      <Database Name="cv" Series="5046" Issue="37373" />
     </Book>
     <Book Series="The Infinity Crusade" Number="1" Volume="1993" Year="1993">
-      <Id>4d712c58-3e96-4c10-ad93-bb1c0d2231e8</Id>
+      <Database Name="cv" Series="5019" Issue="108552" />
     </Book>
     <Book Series="The Infinity Crusade" Number="2" Volume="1993" Year="1993">
-      <Id>286b67dd-c39d-4d13-b7e2-28f0a4affa36</Id>
+      <Database Name="cv" Series="5019" Issue="37517" />
     </Book>
     <Book Series="The Infinity Crusade" Number="3" Volume="1993" Year="1993">
-      <Id>28b6a455-2b88-4cf7-a105-ba02cd35b5b8</Id>
+      <Database Name="cv" Series="5019" Issue="37658" />
     </Book>
     <Book Series="The Infinity Crusade" Number="4" Volume="1993" Year="1993">
-      <Id>8982b62d-8e8a-4551-81d3-e7196463901b</Id>
+      <Database Name="cv" Series="5019" Issue="37797" />
     </Book>
     <Book Series="The Infinity Crusade" Number="5" Volume="1993" Year="1993">
-      <Id>27aff520-8589-4fa5-92e9-4b213a358787</Id>
+      <Database Name="cv" Series="5019" Issue="37950" />
     </Book>
     <Book Series="The Infinity Crusade" Number="6" Volume="1993" Year="1993">
-      <Id>a68e1f0b-08d6-4fd3-9de7-1512067e4fff</Id>
+      <Database Name="cv" Series="5019" Issue="38098" />
     </Book>
     <Book Series="The Mighty Thor" Number="469" Volume="1989" Year="1993">
-      <Id>c4d4d9b7-e998-43bb-aa35-67567430dcfc</Id>
+      <Database Name="cv" Series="61213" Issue="38266" />
     </Book>
     <Book Series="The Mighty Thor" Number="470" Volume="1989" Year="1994">
-      <Id>a8dc690e-5c17-41d7-94d3-afe282aea6dc</Id>
+      <Database Name="cv" Series="61213" Issue="38515" />
     </Book>
     <Book Series="The Mighty Thor" Number="471" Volume="1989" Year="1994">
-      <Id>16be0e9c-1636-4bc1-bbd3-ed26c3ec66ec</Id>
+      <Database Name="cv" Series="61213" Issue="38663" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Black Panther/Black Panther 001.cbl
+++ b/Marvel/Characters/unsorted/Black Panther/Black Panther 001.cbl
@@ -1,576 +1,577 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Black Panther 1</Name>
+  <Name>Black Panther 001</Name>
+  <NumIssues>190</NumIssues>
   <Books>
     <Book Series="Fantastic Four" Number="52" Volume="1961" Year="1966">
-      <Id>90c7ca8e-7096-4a6f-9816-273b59767991</Id>
+      <Database Name="cv" Series="2045" Issue="8666" />
     </Book>
     <Book Series="Fantastic Four" Number="53" Volume="1961" Year="1966">
-      <Id>5cf92acd-b718-48da-8a25-f8a61bf22540</Id>
+      <Database Name="cv" Series="2045" Issue="8732" />
     </Book>
     <Book Series="Fantastic Four" Number="54" Volume="1961" Year="1966">
-      <Id>d930b5c0-68db-4c26-8675-c5b9bfe9f491</Id>
+      <Database Name="cv" Series="2045" Issue="8810" />
     </Book>
     <Book Series="Tales of Suspense" Number="97" Volume="1959" Year="1968">
-      <Id>44aecc2f-d5a0-47c1-82d8-3c51282263d7</Id>
+      <Database Name="cv" Series="2007" Issue="9885" />
     </Book>
     <Book Series="Tales of Suspense" Number="98" Volume="1959" Year="1968">
-      <Id>57e2afdc-4be8-42cf-91b9-c44a3cb6a594</Id>
+      <Database Name="cv" Series="2007" Issue="9942" />
     </Book>
     <Book Series="Tales of Suspense" Number="99" Volume="1959" Year="1968">
-      <Id>27f09aae-f80b-4e78-98c8-25f5e4f7caad</Id>
+      <Database Name="cv" Series="2007" Issue="108988" />
     </Book>
     <Book Series="Captain America" Number="100" Volume="1968" Year="1968">
-      <Id>8e3e1473-ffb5-4155-8976-860af2dba80c</Id>
+      <Database Name="cv" Series="2400" Issue="105481" />
     </Book>
     <Book Series="The Avengers" Number="52" Volume="1963" Year="1968">
-      <Id>70ffad21-c917-4934-a098-36abde46030c</Id>
+      <Database Name="cv" Series="2128" Issue="113986" />
     </Book>
     <Book Series="Marvel Masterworks: Black Panther" Number="1" Volume="2010" Year="2010">
-      <Id>c579d0af-a0ac-42a4-ace0-a3e2ba2d9e3a</Id>
+      <Database Name="cv" Series="59098" Issue="394302" />
     </Book>
     <Book Series="Marvel Masterworks: Black Panther" Number="2" Volume="2010" Year="2016">
-      <Id>97fd5df8-c36f-4876-9512-d4171f64637f</Id>
+      <Database Name="cv" Series="59098" Issue="556473" />
     </Book>
     <Book Series="Iron Man Annual" Number="5" Volume="1970" Year="1982">
-      <Id>231bec3f-ae17-4915-b68d-2377d390a076</Id>
+      <Database Name="cv" Series="2905" Issue="22595" />
     </Book>
     <Book Series="Black Panther" Number="1" Volume="1988" Year="1988">
-      <Id>a68fdec8-d25e-4785-8c01-18aafcc86d8a</Id>
+      <Database Name="cv" Series="4045" Issue="29850" />
     </Book>
     <Book Series="Black Panther" Number="2" Volume="1988" Year="1988">
-      <Id>c09d879f-2f4e-4030-b3cf-99a902c5a4d6</Id>
+      <Database Name="cv" Series="4045" Issue="29962" />
     </Book>
     <Book Series="Black Panther" Number="3" Volume="1988" Year="1988">
-      <Id>9ac1a74b-229b-4340-a6a0-bce4fa5c2999</Id>
+      <Database Name="cv" Series="4045" Issue="30082" />
     </Book>
     <Book Series="Black Panther" Number="4" Volume="1988" Year="1988">
-      <Id>3fd63852-8d48-469c-9c9d-fdec43abfcb8</Id>
+      <Database Name="cv" Series="4045" Issue="30207" />
     </Book>
     <Book Series="Black Panther: Panther's Quest" Number="1" Volume="2017" Year="2017">
-      <Id>28974887-0a5a-4c1d-b999-c803643c8a81</Id>
+      <Database Name="cv" Series="107355" Issue="649727" />
     </Book>
     <Book Series="Black Panther: Panther's Prey" Number="1" Volume="1991" Year="1991">
-      <Id>24ab3758-a82a-478e-9152-1d6f13cb3024</Id>
+      <Database Name="cv" Series="28441" Issue="175086" />
     </Book>
     <Book Series="Black Panther: Panther's Prey" Number="2" Volume="1991" Year="1991">
-      <Id>7abbabaf-ab1a-402d-bf4e-28ea90962765</Id>
+      <Database Name="cv" Series="28441" Issue="175089" />
     </Book>
     <Book Series="Black Panther: Panther's Prey" Number="3" Volume="1991" Year="1991">
-      <Id>0940ac8c-6cc9-46d4-802a-ae677be266c1</Id>
+      <Database Name="cv" Series="28441" Issue="175090" />
     </Book>
     <Book Series="Black Panther: Panther's Prey" Number="4" Volume="1991" Year="1991">
-      <Id>2e0fe8c7-b2a5-4a7b-8d95-a47668cbf5c2</Id>
+      <Database Name="cv" Series="28441" Issue="175093" />
     </Book>
     <Book Series="Marvel Fanfare" Number="60" Volume="1982" Year="1992">
-      <Id>07ccb4c3-69d7-49b9-9d18-806c9df3ece7</Id>
+      <Database Name="cv" Series="3143" Issue="35262" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="25" Volume="1964" Year="1991">
-      <Id>0bae34f4-4922-4445-a105-c4253a0cb2fe</Id>
+      <Database Name="cv" Series="2189" Issue="64429" />
     </Book>
     <Book Series="The Spectacular Spider-Man Annual" Number="11" Volume="1979" Year="1991">
-      <Id>10d6f487-3c22-4064-98ce-d8799b308ce0</Id>
+      <Database Name="cv" Series="3012" Issue="33688" />
     </Book>
     <Book Series="Web of Spider-Man Annual" Number="7" Volume="1985" Year="1991">
-      <Id>ea55304c-55de-4711-892f-5b182d2bef5b</Id>
+      <Database Name="cv" Series="3520" Issue="77996" />
     </Book>
     <Book Series="The Avengers" Number="356" Volume="1963" Year="1992">
-      <Id>3234257e-c239-41cd-9f23-78f2f7c76c2e</Id>
+      <Database Name="cv" Series="2128" Issue="36392" />
     </Book>
     <Book Series="Captain America" Number="414" Volume="1968" Year="1993">
-      <Id>9ca6facb-3048-47b4-9612-d600df37d61a</Id>
+      <Database Name="cv" Series="2400" Issue="37086" />
     </Book>
     <Book Series="Captain America" Number="415" Volume="1968" Year="1993">
-      <Id>00687342-d465-4ecd-97ce-8c36a139dac3</Id>
+      <Database Name="cv" Series="2400" Issue="37222" />
     </Book>
     <Book Series="Captain America" Number="416" Volume="1968" Year="1993">
-      <Id>40e897cc-6a58-40bc-bd16-7506ef5a57c6</Id>
+      <Database Name="cv" Series="2400" Issue="37358" />
     </Book>
     <Book Series="Captain America" Number="417" Volume="1968" Year="1993">
-      <Id>12a3cf9c-5666-42a2-8a9a-47ea1bb0eb4b</Id>
+      <Database Name="cv" Series="2400" Issue="37511" />
     </Book>
     <Book Series="Black Panther" Number="1" Volume="1998" Year="1998">
-      <Id>9774a082-357c-436c-b916-aab89a952428</Id>
+      <Database Name="cv" Series="6496" Issue="46481" />
     </Book>
     <Book Series="Black Panther" Number="2" Volume="1998" Year="1998">
-      <Id>f948afea-172b-40d9-ba39-fec210131d60</Id>
+      <Database Name="cv" Series="6496" Issue="46482" />
     </Book>
     <Book Series="Black Panther" Number="3" Volume="1998" Year="1999">
-      <Id>22bc6d3f-8d1b-4bcd-b6ac-2f6cd5be2361</Id>
+      <Database Name="cv" Series="6496" Issue="46483" />
     </Book>
     <Book Series="Black Panther" Number="4" Volume="1998" Year="1999">
-      <Id>368ace55-aff1-4358-af62-ed8b17db809b</Id>
+      <Database Name="cv" Series="6496" Issue="46484" />
     </Book>
     <Book Series="Black Panther" Number="5" Volume="1998" Year="1999">
-      <Id>7a125f37-355f-48bb-a908-f435685841df</Id>
+      <Database Name="cv" Series="6496" Issue="46485" />
     </Book>
     <Book Series="Black Panther" Number="6" Volume="1998" Year="1999">
-      <Id>c0075f7e-3c9c-4ab5-958a-8702cbf57691</Id>
+      <Database Name="cv" Series="6496" Issue="46486" />
     </Book>
     <Book Series="Black Panther" Number="7" Volume="1998" Year="1999">
-      <Id>48495345-a4f3-4d76-9396-aed042f00996</Id>
+      <Database Name="cv" Series="6496" Issue="46487" />
     </Book>
     <Book Series="Black Panther" Number="8" Volume="1998" Year="1999">
-      <Id>f2dd18b8-9120-4b8b-8f3b-183c50dcd6fc</Id>
+      <Database Name="cv" Series="6496" Issue="46488" />
     </Book>
     <Book Series="Black Panther" Number="9" Volume="1998" Year="1999">
-      <Id>f6ffdf61-eddd-4916-b596-e07707b2d891</Id>
+      <Database Name="cv" Series="6496" Issue="46489" />
     </Book>
     <Book Series="Black Panther" Number="10" Volume="1998" Year="1999">
-      <Id>9d8fd0c6-60e9-47ca-bc93-93b424cffdf6</Id>
+      <Database Name="cv" Series="6496" Issue="46490" />
     </Book>
     <Book Series="Black Panther" Number="11" Volume="1998" Year="1999">
-      <Id>5d6041ec-e90b-40d9-87d7-45f004e83e33</Id>
+      <Database Name="cv" Series="6496" Issue="46491" />
     </Book>
     <Book Series="Black Panther" Number="12" Volume="1998" Year="1999">
-      <Id>76eb5830-0f6b-4788-b6ef-4315f5c2f104</Id>
+      <Database Name="cv" Series="6496" Issue="46492" />
     </Book>
     <Book Series="Black Panther" Number="13" Volume="1998" Year="1999">
-      <Id>98c1e901-806a-4d09-8130-537be662974b</Id>
+      <Database Name="cv" Series="6496" Issue="46493" />
     </Book>
     <Book Series="Black Panther" Number="14" Volume="1998" Year="2000">
-      <Id>1a6ba668-e9e0-436a-810e-3ccf757b07c5</Id>
+      <Database Name="cv" Series="6496" Issue="46494" />
     </Book>
     <Book Series="Black Panther" Number="15" Volume="1998" Year="2000">
-      <Id>4ba98d84-ef77-4fed-9a27-1b099c498144</Id>
+      <Database Name="cv" Series="6496" Issue="46495" />
     </Book>
     <Book Series="Black Panther" Number="16" Volume="1998" Year="2000">
-      <Id>cdc748f1-b3b4-48fd-9c01-41add4498197</Id>
+      <Database Name="cv" Series="6496" Issue="46496" />
     </Book>
     <Book Series="Black Panther" Number="17" Volume="1998" Year="2000">
-      <Id>e89e2a8b-b263-43f5-b191-a2984960dce3</Id>
+      <Database Name="cv" Series="6496" Issue="46497" />
     </Book>
     <Book Series="Black Panther" Number="18" Volume="1998" Year="2000">
-      <Id>711f485d-d405-4548-8509-c9fcf781300a</Id>
+      <Database Name="cv" Series="6496" Issue="46498" />
     </Book>
     <Book Series="Black Panther" Number="19" Volume="1998" Year="2000">
-      <Id>e7ef2dbb-3748-45fa-bb2c-12ae0f7546a0</Id>
+      <Database Name="cv" Series="6496" Issue="46499" />
     </Book>
     <Book Series="Black Panther" Number="20" Volume="1998" Year="2000">
-      <Id>0dd2c6db-6ab0-48de-bb5f-63f8cf62fb72</Id>
+      <Database Name="cv" Series="6496" Issue="46500" />
     </Book>
     <Book Series="Black Panther" Number="21" Volume="1998" Year="2000">
-      <Id>eb6a597c-a743-4936-b696-89f4da47e002</Id>
+      <Database Name="cv" Series="6496" Issue="46501" />
     </Book>
     <Book Series="Black Panther" Number="22" Volume="1998" Year="2000">
-      <Id>273ac3b4-931c-483c-b04d-052a6e25c7ca</Id>
+      <Database Name="cv" Series="6496" Issue="46502" />
     </Book>
     <Book Series="Deadpool" Number="44" Volume="1997" Year="2000">
-      <Id>91139eea-48d0-4db1-8838-4f699c8dd3db</Id>
+      <Database Name="cv" Series="6000" Issue="106457" />
     </Book>
     <Book Series="Black Panther" Number="23" Volume="1998" Year="2000">
-      <Id>2f515b33-bf57-4cfc-a57d-42a5d2f01710</Id>
+      <Database Name="cv" Series="6496" Issue="50807" />
     </Book>
     <Book Series="Black Panther" Number="24" Volume="1998" Year="2000">
-      <Id>eebc70ee-5405-4427-928d-f889966fca13</Id>
+      <Database Name="cv" Series="6496" Issue="50808" />
     </Book>
     <Book Series="Black Panther" Number="25" Volume="1998" Year="2000">
-      <Id>3929e910-b48e-4466-bba3-a82fc838a7b2</Id>
+      <Database Name="cv" Series="6496" Issue="50809" />
     </Book>
     <Book Series="Black Panther" Number="26" Volume="1998" Year="2001">
-      <Id>6b8bca21-c6be-43ef-b73e-00fea251ecc2</Id>
+      <Database Name="cv" Series="6496" Issue="50810" />
     </Book>
     <Book Series="Black Panther" Number="27" Volume="1998" Year="2001">
-      <Id>8531e5e4-9528-4fb8-89ac-bc8b2f7093ff</Id>
+      <Database Name="cv" Series="6496" Issue="50811" />
     </Book>
     <Book Series="Black Panther" Number="28" Volume="1998" Year="2001">
-      <Id>e9f52abe-5217-4ba5-8c90-4cd5ebdd45e5</Id>
+      <Database Name="cv" Series="6496" Issue="50812" />
     </Book>
     <Book Series="Black Panther" Number="29" Volume="1998" Year="2001">
-      <Id>ba2050be-0eb0-467c-a937-d1d0c98a231a</Id>
+      <Database Name="cv" Series="6496" Issue="50813" />
     </Book>
     <Book Series="Black Panther" Number="30" Volume="1998" Year="2001">
-      <Id>7f61eb40-bcf9-4822-bd40-f5eabab5a740</Id>
+      <Database Name="cv" Series="6496" Issue="50814" />
     </Book>
     <Book Series="Black Panther" Number="31" Volume="1998" Year="2001">
-      <Id>bc1c7282-f990-4c4b-a8c5-cc03657d2a10</Id>
+      <Database Name="cv" Series="6496" Issue="50815" />
     </Book>
     <Book Series="Black Panther" Number="32" Volume="1998" Year="2001">
-      <Id>25c31924-846a-4d7e-afb1-3e36cd82b073</Id>
+      <Database Name="cv" Series="6496" Issue="50816" />
     </Book>
     <Book Series="Black Panther" Number="33" Volume="1998" Year="2001">
-      <Id>e493c1e0-bfbd-484b-ad93-5b487223cd25</Id>
+      <Database Name="cv" Series="6496" Issue="50817" />
     </Book>
     <Book Series="Black Panther" Number="34" Volume="1998" Year="2001">
-      <Id>9bb7a11a-02b4-4f1d-902e-9d40cf42fb53</Id>
+      <Database Name="cv" Series="6496" Issue="50818" />
     </Book>
     <Book Series="Black Panther" Number="35" Volume="1998" Year="2001">
-      <Id>6ea18eaa-d980-4a00-9399-8914933caf7b</Id>
+      <Database Name="cv" Series="6496" Issue="50819" />
     </Book>
     <Book Series="Black Panther" Number="36" Volume="1998" Year="2001">
-      <Id>5e3bbaec-8d86-448f-ace7-aef9e87c185d</Id>
+      <Database Name="cv" Series="6496" Issue="50820" />
     </Book>
     <Book Series="Black Panther" Number="37" Volume="1998" Year="2002">
-      <Id>f5466fbd-bc08-4f7b-bbe5-61b0742f9a04</Id>
+      <Database Name="cv" Series="6496" Issue="50821" />
     </Book>
     <Book Series="Black Panther" Number="38" Volume="1998" Year="2002">
-      <Id>71b72024-b4f2-49d1-b000-71db0c0ff116</Id>
+      <Database Name="cv" Series="6496" Issue="50822" />
     </Book>
     <Book Series="Black Panther" Number="39" Volume="1998" Year="2002">
-      <Id>7c2df66c-ff5e-4968-923f-1f1dfee5b90c</Id>
+      <Database Name="cv" Series="6496" Issue="50823" />
     </Book>
     <Book Series="Black Panther" Number="40" Volume="1998" Year="2002">
-      <Id>fda70a85-5af2-485c-ad98-09e0a849aca3</Id>
+      <Database Name="cv" Series="6496" Issue="78166" />
     </Book>
     <Book Series="Black Panther" Number="41" Volume="1998" Year="2002">
-      <Id>fb709647-a7ef-4693-a5ea-9b0f2b8e2fe0</Id>
+      <Database Name="cv" Series="6496" Issue="78167" />
     </Book>
     <Book Series="Black Panther" Number="42" Volume="1998" Year="2002">
-      <Id>7c493050-ea2f-454c-9091-dec2984357a8</Id>
+      <Database Name="cv" Series="6496" Issue="78168" />
     </Book>
     <Book Series="Black Panther" Number="43" Volume="1998" Year="2002">
-      <Id>63cbde4e-cca4-4628-89fc-a4147bd01233</Id>
+      <Database Name="cv" Series="6496" Issue="78169" />
     </Book>
     <Book Series="Black Panther" Number="44" Volume="1998" Year="2002">
-      <Id>54282482-2d23-4335-a97b-298c7187b7ef</Id>
+      <Database Name="cv" Series="6496" Issue="78170" />
     </Book>
     <Book Series="Black Panther" Number="45" Volume="1998" Year="2002">
-      <Id>26c05ab1-01f5-44bd-bc26-d9a4e831e9ba</Id>
+      <Database Name="cv" Series="6496" Issue="78171" />
     </Book>
     <Book Series="Black Panther" Number="46" Volume="1998" Year="2002">
-      <Id>0c2e2292-6d33-4302-8808-80aa3749ff2a</Id>
+      <Database Name="cv" Series="6496" Issue="80543" />
     </Book>
     <Book Series="Black Panther" Number="47" Volume="1998" Year="2002">
-      <Id>2018e4e4-2787-4fd1-ada6-b20fcb35189c</Id>
+      <Database Name="cv" Series="6496" Issue="126057" />
     </Book>
     <Book Series="Black Panther" Number="48" Volume="1998" Year="2002">
-      <Id>17bd966f-f1a3-4801-b9cb-de8111887a26</Id>
+      <Database Name="cv" Series="6496" Issue="126058" />
     </Book>
     <Book Series="Black Panther" Number="49" Volume="1998" Year="2002">
-      <Id>7ac3a4a1-be0f-4bee-b0a6-283ef71b0998</Id>
+      <Database Name="cv" Series="6496" Issue="126067" />
     </Book>
     <Book Series="Black Panther" Number="50" Volume="1998" Year="2002">
-      <Id>b9327274-7ff4-4d16-9b01-8266e19a49ca</Id>
+      <Database Name="cv" Series="6496" Issue="126075" />
     </Book>
     <Book Series="Black Panther" Number="51" Volume="1998" Year="2003">
-      <Id>157077f9-92c1-4d99-b7cc-fa267c37e661</Id>
+      <Database Name="cv" Series="6496" Issue="126529" />
     </Book>
     <Book Series="Black Panther" Number="52" Volume="1998" Year="2003">
-      <Id>5adea838-73d8-4973-aa9e-39fbe40efec1</Id>
+      <Database Name="cv" Series="6496" Issue="126751" />
     </Book>
     <Book Series="Black Panther" Number="53" Volume="1998" Year="2003">
-      <Id>7c1643c8-b4a1-4f00-ae26-f2909d145d74</Id>
+      <Database Name="cv" Series="6496" Issue="149102" />
     </Book>
     <Book Series="Black Panther" Number="54" Volume="1998" Year="2003">
-      <Id>7b99425f-9843-4cb0-8f35-af0eddd60b65</Id>
+      <Database Name="cv" Series="6496" Issue="149103" />
     </Book>
     <Book Series="Black Panther" Number="55" Volume="1998" Year="2003">
-      <Id>031cf3fa-43b3-430f-94f8-52a7bc808bf4</Id>
+      <Database Name="cv" Series="6496" Issue="149104" />
     </Book>
     <Book Series="Black Panther" Number="56" Volume="1998" Year="2003">
-      <Id>28e940dd-ba1a-4ba4-b484-d2e02405520d</Id>
+      <Database Name="cv" Series="6496" Issue="149105" />
     </Book>
     <Book Series="Black Panther" Number="57" Volume="1998" Year="2003">
-      <Id>e8cbb543-b29e-4465-8267-454234312150</Id>
+      <Database Name="cv" Series="6496" Issue="149106" />
     </Book>
     <Book Series="Black Panther" Number="58" Volume="1998" Year="2003">
-      <Id>bf21d480-3f7f-413b-b9aa-c193f8f2b883</Id>
+      <Database Name="cv" Series="6496" Issue="149107" />
     </Book>
     <Book Series="Black Panther" Number="59" Volume="1998" Year="2003">
-      <Id>6581c2e8-1ae8-4123-8daf-d4851685ae2b</Id>
+      <Database Name="cv" Series="6496" Issue="149108" />
     </Book>
     <Book Series="Black Panther" Number="60" Volume="1998" Year="2003">
-      <Id>4fe98d56-d8fa-4017-9794-954724d4358b</Id>
+      <Database Name="cv" Series="6496" Issue="149109" />
     </Book>
     <Book Series="Black Panther" Number="61" Volume="1998" Year="2003">
-      <Id>a9ba1b89-8b1e-455e-b128-79457f687e77</Id>
+      <Database Name="cv" Series="6496" Issue="149110" />
     </Book>
     <Book Series="Black Panther" Number="62" Volume="1998" Year="2003">
-      <Id>dc5c1b73-4ff0-43cb-b3d2-acb5621abcc9</Id>
+      <Database Name="cv" Series="6496" Issue="149111" />
     </Book>
     <Book Series="Black Panther" Number="1" Volume="2005" Year="2005">
-      <Id>2af04e83-3568-4e85-83f8-dee0440b7208</Id>
+      <Database Name="cv" Series="11502" Issue="101456" />
     </Book>
     <Book Series="Black Panther" Number="2" Volume="2005" Year="2005">
-      <Id>48b5556e-4ecf-4214-829a-92b31b50a23d</Id>
+      <Database Name="cv" Series="11502" Issue="101457" />
     </Book>
     <Book Series="Black Panther" Number="3" Volume="2005" Year="2005">
-      <Id>9a8f8dd8-e1bc-4d41-9340-786204bf7886</Id>
+      <Database Name="cv" Series="11502" Issue="101458" />
     </Book>
     <Book Series="Black Panther" Number="4" Volume="2005" Year="2005">
-      <Id>1e47fd20-a142-49d7-a430-c45bdb900c33</Id>
+      <Database Name="cv" Series="11502" Issue="126175" />
     </Book>
     <Book Series="Black Panther" Number="5" Volume="2005" Year="2005">
-      <Id>5c911af5-ef04-4aa3-b011-54f537a9bf9c</Id>
+      <Database Name="cv" Series="11502" Issue="126176" />
     </Book>
     <Book Series="Black Panther" Number="6" Volume="2005" Year="2005">
-      <Id>c16d4a21-34a7-4c98-8416-e6b1915ce9c5</Id>
+      <Database Name="cv" Series="11502" Issue="126177" />
     </Book>
     <Book Series="Black Panther" Number="7" Volume="2005" Year="2005">
-      <Id>b54503e1-8bf5-446a-98b6-d1a1dd11de9f</Id>
+      <Database Name="cv" Series="11502" Issue="126178" />
     </Book>
     <Book Series="X-Men" Number="175" Volume="2004" Year="2005">
-      <Id>dce959c0-5895-4abe-bc7d-445bb3fbe9ea</Id>
+      <Database Name="cv" Series="10731" Issue="106174" />
     </Book>
     <Book Series="Black Panther" Number="8" Volume="2005" Year="2005">
-      <Id>904e246e-022f-4abb-975f-8e8962814166</Id>
+      <Database Name="cv" Series="11502" Issue="126179" />
     </Book>
     <Book Series="X-Men" Number="176" Volume="2004" Year="2005">
-      <Id>56527222-c3ce-4a66-8f04-11154801371a</Id>
+      <Database Name="cv" Series="10731" Issue="106175" />
     </Book>
     <Book Series="Black Panther" Number="9" Volume="2005" Year="2005">
-      <Id>600ca6f0-d912-4d6e-bd53-1d4787ef978a</Id>
+      <Database Name="cv" Series="11502" Issue="126180" />
     </Book>
     <Book Series="Black Panther" Number="10" Volume="2005" Year="2006">
-      <Id>aeb312b1-c06b-4f2f-bd0c-248556470e79</Id>
+      <Database Name="cv" Series="11502" Issue="126181" />
     </Book>
     <Book Series="Black Panther" Number="11" Volume="2005" Year="2006">
-      <Id>31f4e266-8c06-4b73-91c6-988e714009aa</Id>
+      <Database Name="cv" Series="11502" Issue="126182" />
     </Book>
     <Book Series="Black Panther" Number="12" Volume="2005" Year="2006">
-      <Id>8667fde6-f967-4d16-aa9b-bc1931b30ae4</Id>
+      <Database Name="cv" Series="11502" Issue="126183" />
     </Book>
     <Book Series="Black Panther" Number="13" Volume="2005" Year="2006">
-      <Id>9a51f575-0cc6-404a-89b2-d87536219c4a</Id>
+      <Database Name="cv" Series="11502" Issue="126184" />
     </Book>
     <Book Series="Black Panther" Number="14" Volume="2005" Year="2006">
-      <Id>768dac24-39ee-41ca-b3c9-7ae88edffb23</Id>
+      <Database Name="cv" Series="11502" Issue="107855" />
     </Book>
     <Book Series="Black Panther" Number="15" Volume="2005" Year="2006">
-      <Id>b7299f2f-1ad5-4d63-ba08-aa8508768b5b</Id>
+      <Database Name="cv" Series="11502" Issue="107856" />
     </Book>
     <Book Series="Black Panther" Number="16" Volume="2005" Year="2006">
-      <Id>60d7cb62-fa79-424c-8cf0-7c06028bab5e</Id>
+      <Database Name="cv" Series="11502" Issue="110528" />
     </Book>
     <Book Series="Black Panther" Number="17" Volume="2005" Year="2006">
-      <Id>27245776-966c-4ef5-995b-bb6956d8c706</Id>
+      <Database Name="cv" Series="11502" Issue="110605" />
     </Book>
     <Book Series="Black Panther" Number="18" Volume="2005" Year="2006">
-      <Id>a424936e-092b-4b61-ad62-e8d0e11929f3</Id>
+      <Database Name="cv" Series="11502" Issue="108675" />
     </Book>
     <Book Series="Black Panther" Number="19" Volume="2005" Year="2006">
-      <Id>b454b84d-d1d5-40c0-a054-d24eb253b78c</Id>
+      <Database Name="cv" Series="11502" Issue="107679" />
     </Book>
     <Book Series="Black Panther" Number="20" Volume="2005" Year="2006">
-      <Id>ae04fcdb-20a4-4732-a707-eaf174bf1b0d</Id>
+      <Database Name="cv" Series="11502" Issue="113821" />
     </Book>
     <Book Series="Black Panther" Number="21" Volume="2005" Year="2006">
-      <Id>74e13265-7df7-4d78-b3d7-c2c82a6e8a45</Id>
+      <Database Name="cv" Series="11502" Issue="113823" />
     </Book>
     <Book Series="Black Panther" Number="22" Volume="2005" Year="2007">
-      <Id>9ed19a65-2293-4f82-afd1-beca20bd03ce</Id>
+      <Database Name="cv" Series="11502" Issue="108784" />
     </Book>
     <Book Series="Black Panther" Number="23" Volume="2005" Year="2007">
-      <Id>85ee6ebd-2602-4696-ade4-5c0cd89c4736</Id>
+      <Database Name="cv" Series="11502" Issue="108954" />
     </Book>
     <Book Series="Black Panther" Number="24" Volume="2005" Year="2007">
-      <Id>446e4350-d313-4cce-9b9f-269b0b902b8a</Id>
+      <Database Name="cv" Series="11502" Issue="106282" />
     </Book>
     <Book Series="Black Panther" Number="25" Volume="2005" Year="2007">
-      <Id>7590376c-db1a-48b2-ac6b-aed02919edc3</Id>
+      <Database Name="cv" Series="11502" Issue="106708" />
     </Book>
     <Book Series="Storm" Number="1" Volume="2006" Year="2006">
-      <Id>93477a0e-f3ea-4a0d-9d4e-0597c59fe3ad</Id>
+      <Database Name="cv" Series="18260" Issue="106913" />
     </Book>
     <Book Series="Storm" Number="2" Volume="2006" Year="2006">
-      <Id>a15c6246-9080-45ee-9df0-5b5f5150bf38</Id>
+      <Database Name="cv" Series="18260" Issue="109536" />
     </Book>
     <Book Series="Storm" Number="3" Volume="2006" Year="2006">
-      <Id>60990175-5a68-44bd-a6a2-61356d8b4814</Id>
+      <Database Name="cv" Series="18260" Issue="109537" />
     </Book>
     <Book Series="Storm" Number="4" Volume="2006" Year="2006">
-      <Id>c7e38ae7-4835-43a3-8691-6b0cb5340615</Id>
+      <Database Name="cv" Series="18260" Issue="109538" />
     </Book>
     <Book Series="Storm" Number="5" Volume="2006" Year="2006">
-      <Id>ceffcf46-a74b-443e-91d6-df57494cc446</Id>
+      <Database Name="cv" Series="18260" Issue="109539" />
     </Book>
     <Book Series="Storm" Number="6" Volume="2006" Year="2006">
-      <Id>cd0a5397-dece-43f6-8aa3-965d1d8b9ac9</Id>
+      <Database Name="cv" Series="18260" Issue="109540" />
     </Book>
     <Book Series="Black Panther" Number="26" Volume="2005" Year="2007">
-      <Id>6b813f4a-e810-4af0-bd68-4fce68886123</Id>
+      <Database Name="cv" Series="11502" Issue="107598" />
     </Book>
     <Book Series="Black Panther" Number="27" Volume="2005" Year="2007">
-      <Id>82efa362-8bf8-4536-b0b9-bda669f3be76</Id>
+      <Database Name="cv" Series="11502" Issue="109262" />
     </Book>
     <Book Series="Black Panther" Number="28" Volume="2005" Year="2007">
-      <Id>d7e498c0-3eee-451e-bf4d-386bd2aa28f5</Id>
+      <Database Name="cv" Series="11502" Issue="111034" />
     </Book>
     <Book Series="Black Panther" Number="29" Volume="2005" Year="2007">
-      <Id>a923d65f-9972-47e6-b7ff-ea45b527706e</Id>
+      <Database Name="cv" Series="11502" Issue="112181" />
     </Book>
     <Book Series="Black Panther" Number="30" Volume="2005" Year="2007">
-      <Id>b50ab8bf-7d55-4ca6-88eb-7d95a5bb06dc</Id>
+      <Database Name="cv" Series="11502" Issue="113968" />
     </Book>
     <Book Series="Black Panther" Number="31" Volume="2005" Year="2007">
-      <Id>5e398007-fa6a-4b95-aced-27399297eeee</Id>
+      <Database Name="cv" Series="11502" Issue="115852" />
     </Book>
     <Book Series="Black Panther" Number="32" Volume="2005" Year="2008">
-      <Id>8c6a70d6-5809-407c-9184-3f104adea408</Id>
+      <Database Name="cv" Series="11502" Issue="118642" />
     </Book>
     <Book Series="Black Panther" Number="33" Volume="2005" Year="2008">
-      <Id>7f798370-b875-42b5-9c93-531986623fa4</Id>
+      <Database Name="cv" Series="11502" Issue="120543" />
     </Book>
     <Book Series="Black Panther" Number="34" Volume="2005" Year="2008">
-      <Id>1b7345f6-66bb-4686-964d-d33feb54d978</Id>
+      <Database Name="cv" Series="11502" Issue="123005" />
     </Book>
     <Book Series="Black Panther" Number="35" Volume="2005" Year="2008">
-      <Id>066d878c-bfd0-4e10-84ed-532169495faf</Id>
+      <Database Name="cv" Series="11502" Issue="125969" />
     </Book>
     <Book Series="Black Panther" Number="36" Volume="2005" Year="2008">
-      <Id>0921dda1-ade9-4fe6-a264-13a925a981f9</Id>
+      <Database Name="cv" Series="11502" Issue="130718" />
     </Book>
     <Book Series="Black Panther" Number="37" Volume="2005" Year="2008">
-      <Id>de1bcecb-0152-4ab9-9610-540f088a51ab</Id>
+      <Database Name="cv" Series="11502" Issue="133754" />
     </Book>
     <Book Series="Black Panther" Number="38" Volume="2005" Year="2008">
-      <Id>6ed21821-ed52-4552-891b-a06be8f2fd03</Id>
+      <Database Name="cv" Series="11502" Issue="134087" />
     </Book>
     <Book Series="Black Panther" Number="39" Volume="2005" Year="2008">
-      <Id>8a151a25-8f45-4672-90bf-790b31c86538</Id>
+      <Database Name="cv" Series="11502" Issue="134635" />
     </Book>
     <Book Series="Black Panther" Number="40" Volume="2005" Year="2008">
-      <Id>b7fde391-1adf-4366-bda6-50ef34497ebb</Id>
+      <Database Name="cv" Series="11502" Issue="136702" />
     </Book>
     <Book Series="Black Panther" Number="41" Volume="2005" Year="2008">
-      <Id>e057106b-a7cd-4f4c-bdf7-892b2d96e40e</Id>
+      <Database Name="cv" Series="11502" Issue="139342" />
     </Book>
     <Book Series="X-Men: Worlds Apart" Number="1" Volume="2008" Year="2008">
-      <Id>71285c4a-7548-4705-bbd7-29bd8003b8fc</Id>
+      <Database Name="cv" Series="23443" Issue="140555" />
     </Book>
     <Book Series="X-Men: Worlds Apart" Number="2" Volume="2008" Year="2009">
-      <Id>68c81ec6-2f34-4a20-8d58-3e7f94585164</Id>
+      <Database Name="cv" Series="23443" Issue="142743" />
     </Book>
     <Book Series="X-Men: Worlds Apart" Number="3" Volume="2008" Year="2009">
-      <Id>0ce9c510-ee6c-4008-bacb-3f918385daeb</Id>
+      <Database Name="cv" Series="23443" Issue="149297" />
     </Book>
     <Book Series="X-Men: Worlds Apart" Number="4" Volume="2008" Year="2009">
-      <Id>e9fd765d-49a4-4048-bc21-10d1970ca52e</Id>
+      <Database Name="cv" Series="23443" Issue="150654" />
     </Book>
     <Book Series="Black Panther" Number="1" Volume="2009" Year="2009">
-      <Id>df97903c-2539-4bc3-95cc-0478ea58e874</Id>
+      <Database Name="cv" Series="25638" Issue="151135" />
     </Book>
     <Book Series="Black Panther" Number="2" Volume="2009" Year="2009">
-      <Id>e5298357-3528-460e-86d4-4637ecdbd43b</Id>
+      <Database Name="cv" Series="25638" Issue="153059" />
     </Book>
     <Book Series="Black Panther" Number="3" Volume="2009" Year="2009">
-      <Id>c61a7764-3b44-4117-b609-a4236303e076</Id>
+      <Database Name="cv" Series="25638" Issue="154615" />
     </Book>
     <Book Series="Black Panther" Number="4" Volume="2009" Year="2009">
-      <Id>eeac1e9c-7bcc-4fcf-a17f-18ab7e0362af</Id>
+      <Database Name="cv" Series="25638" Issue="157928" />
     </Book>
     <Book Series="Black Panther" Number="5" Volume="2009" Year="2009">
-      <Id>7d2b261f-542d-4d9f-a7d6-4a18da7d4653</Id>
+      <Database Name="cv" Series="25638" Issue="159297" />
     </Book>
     <Book Series="Black Panther" Number="6" Volume="2009" Year="2009">
-      <Id>519beace-fabe-44cc-9e44-2f3e103afd23</Id>
+      <Database Name="cv" Series="25638" Issue="164816" />
     </Book>
     <Book Series="Black Panther Annual" Number="1" Volume="2008" Year="2008">
-      <Id>2f33d5c7-4dfc-4c0d-bfee-370ea85e0c90</Id>
+      <Database Name="cv" Series="20713" Issue="124232" />
     </Book>
     <Book Series="Black Panther" Number="7" Volume="2009" Year="2009">
-      <Id>6d6f8b42-69f0-41f2-8ef7-80b91e4e5c36</Id>
+      <Database Name="cv" Series="25638" Issue="166335" />
     </Book>
     <Book Series="Black Panther" Number="8" Volume="2009" Year="2009">
-      <Id>57c1752b-f7cd-4fbc-a9fa-cce04ed6667a</Id>
+      <Database Name="cv" Series="25638" Issue="169420" />
     </Book>
     <Book Series="Black Panther" Number="9" Volume="2009" Year="2009">
-      <Id>940d2f61-4f2d-4b53-986e-1946a46fa18a</Id>
+      <Database Name="cv" Series="25638" Issue="175229" />
     </Book>
     <Book Series="Black Panther" Number="10" Volume="2009" Year="2010">
-      <Id>72fafd64-11e2-4b48-8478-2f51ac4eb68a</Id>
+      <Database Name="cv" Series="25638" Issue="182755" />
     </Book>
     <Book Series="Black Panther" Number="11" Volume="2009" Year="2010">
-      <Id>442b0335-e256-4b75-8acb-43c69b462a60</Id>
+      <Database Name="cv" Series="25638" Issue="188255" />
     </Book>
     <Book Series="Black Panther" Number="12" Volume="2009" Year="2010">
-      <Id>1124dd06-d06b-4ca2-92e9-506e399d0301</Id>
+      <Database Name="cv" Series="25638" Issue="192672" />
     </Book>
     <Book Series="Klaws of the Panther" Number="1" Volume="2010" Year="2010">
-      <Id>c9e0ae2c-f041-4cd5-9ab7-2fee1d8a62f7</Id>
+      <Database Name="cv" Series="35848" Issue="237114" />
     </Book>
     <Book Series="Klaws of the Panther" Number="2" Volume="2010" Year="2010">
-      <Id>0e18fcc3-1424-4cf3-a604-8d8751417e8c</Id>
+      <Database Name="cv" Series="35848" Issue="240292" />
     </Book>
     <Book Series="Klaws of the Panther" Number="3" Volume="2010" Year="2011">
-      <Id>58f14fe5-cd70-46ec-9214-90bb3d90e738</Id>
+      <Database Name="cv" Series="35848" Issue="246618" />
     </Book>
     <Book Series="Klaws of the Panther" Number="4" Volume="2010" Year="2011">
-      <Id>a6aee1b6-a3ea-46ca-aa23-cc5c46c7a56f</Id>
+      <Database Name="cv" Series="35848" Issue="258940" />
     </Book>
     <Book Series="Doomwar" Number="1" Volume="2010" Year="2010">
-      <Id>bb848e94-b600-4528-95ba-86fc00138a4d</Id>
+      <Database Name="cv" Series="31608" Issue="197468" />
     </Book>
     <Book Series="Doomwar" Number="2" Volume="2010" Year="2010">
-      <Id>414060c1-3271-49f2-8366-3b2ddbc6bef0</Id>
+      <Database Name="cv" Series="31608" Issue="200985" />
     </Book>
     <Book Series="Doomwar" Number="3" Volume="2010" Year="2010">
-      <Id>3e320599-cb1f-4ba9-816d-22caf15f0062</Id>
+      <Database Name="cv" Series="31608" Issue="208516" />
     </Book>
     <Book Series="Doomwar" Number="4" Volume="2010" Year="2010">
-      <Id>a5cc67de-0277-4dae-a29e-19071b49b772</Id>
+      <Database Name="cv" Series="31608" Issue="216227" />
     </Book>
     <Book Series="Doomwar" Number="5" Volume="2010" Year="2010">
-      <Id>8617a587-93c9-444c-903b-146740409a6f</Id>
+      <Database Name="cv" Series="31608" Issue="222098" />
     </Book>
     <Book Series="Doomwar" Number="6" Volume="2010" Year="2010">
-      <Id>ac733589-f51c-45ed-93a7-19585e143306</Id>
+      <Database Name="cv" Series="31608" Issue="227711" />
     </Book>
     <Book Series="Black Panther: The Man Without Fear" Number="513" Volume="2011" Year="2011">
-      <Id>4a26b958-0388-4a90-9bb8-3f186e6964fb</Id>
+      <Database Name="cv" Series="37502" Issue="249295" />
     </Book>
     <Book Series="Black Panther: The Man Without Fear" Number="514" Volume="2011" Year="2011">
-      <Id>dd04c364-cce8-40fd-a4e5-0c3803f577bb</Id>
+      <Database Name="cv" Series="37502" Issue="255933" />
     </Book>
     <Book Series="Black Panther: The Man Without Fear" Number="515" Volume="2011" Year="2011">
-      <Id>a4684021-e612-4725-912a-9317e35e2972</Id>
+      <Database Name="cv" Series="37502" Issue="261345" />
     </Book>
     <Book Series="Black Panther: The Man Without Fear" Number="516" Volume="2011" Year="2011">
-      <Id>7b82fb05-8cad-46de-b762-7d290bc0c540</Id>
+      <Database Name="cv" Series="37502" Issue="267124" />
     </Book>
     <Book Series="Black Panther: The Man Without Fear" Number="517" Volume="2011" Year="2011">
-      <Id>3bec7ec0-ce55-40a3-abc7-98ba5b8ad7e9</Id>
+      <Database Name="cv" Series="37502" Issue="268232" />
     </Book>
     <Book Series="Black Panther: The Man Without Fear" Number="518" Volume="2011" Year="2011">
-      <Id>055c1764-7617-48d5-ac90-b3eb52d43ae9</Id>
+      <Database Name="cv" Series="37502" Issue="270010" />
     </Book>
     <Book Series="Black Panther: The Man Without Fear" Number="519" Volume="2011" Year="2011">
-      <Id>6f857a44-3126-4632-8395-8a417b417a53</Id>
+      <Database Name="cv" Series="37502" Issue="273107" />
     </Book>
     <Book Series="Black Panther: The Man Without Fear" Number="520" Volume="2011" Year="2011">
-      <Id>f9d642cb-74b5-4f23-824a-1f0ad9f465e4</Id>
+      <Database Name="cv" Series="37502" Issue="275796" />
     </Book>
     <Book Series="Black Panther: The Man Without Fear" Number="521" Volume="2011" Year="2011">
-      <Id>171f2ca5-0bfd-46e9-a426-a04126add0e8</Id>
+      <Database Name="cv" Series="37502" Issue="278712" />
     </Book>
     <Book Series="Black Panther: The Man Without Fear" Number="522" Volume="2011" Year="2011">
-      <Id>e84b7e72-c680-4471-9114-9e968331c983</Id>
+      <Database Name="cv" Series="37502" Issue="285926" />
     </Book>
     <Book Series="Black Panther: The Man Without Fear" Number="523" Volume="2011" Year="2011">
-      <Id>9b36e66c-81b4-4e00-b7a0-c80352f49b4c</Id>
+      <Database Name="cv" Series="37502" Issue="292610" />
     </Book>
     <Book Series="Black Panther: The Most Dangerous Man Alive" Number="523.1" Volume="2011" Year="2011">
-      <Id>7721c605-4464-4628-a045-0cad0552aa09</Id>
+      <Database Name="cv" Series="59534" Issue="293621" />
     </Book>
     <Book Series="Black Panther: The Most Dangerous Man Alive" Number="524" Volume="2011" Year="2011">
-      <Id>af9584d3-68f0-41ce-8a5d-e37788d1c0ef</Id>
+      <Database Name="cv" Series="59534" Issue="295601" />
     </Book>
     <Book Series="Black Panther: The Most Dangerous Man Alive" Number="525" Volume="2011" Year="2012">
-      <Id>4a6e616e-af3a-4e72-a8ed-871ad6236aad</Id>
+      <Database Name="cv" Series="59534" Issue="301729" />
     </Book>
     <Book Series="Black Panther: The Most Dangerous Man Alive" Number="526" Volume="2011" Year="2012">
-      <Id>0b30b490-b04a-4c23-bf6c-9830caa22413</Id>
+      <Database Name="cv" Series="59534" Issue="307135" />
     </Book>
     <Book Series="Black Panther: The Most Dangerous Man Alive" Number="527" Volume="2011" Year="2012">
-      <Id>9c6c2728-b36a-4790-982f-f056fb039343</Id>
+      <Database Name="cv" Series="59534" Issue="308558" />
     </Book>
     <Book Series="Black Panther: The Most Dangerous Man Alive" Number="528" Volume="2011" Year="2012">
-      <Id>1904da14-fab8-4bca-84dd-4a53f995948e</Id>
+      <Database Name="cv" Series="59534" Issue="311014" />
     </Book>
     <Book Series="Black Panther: The Most Dangerous Man Alive" Number="529" Volume="2011" Year="2012">
-      <Id>9f254be3-5a11-4eec-8002-07c6193be290</Id>
+      <Database Name="cv" Series="59534" Issue="315289" />
     </Book>
     <Book Series="Black Panther/Captain America: Flags of Our Fathers" Number="1" Volume="2010" Year="2010">
-      <Id>a7d3661e-d717-4cbe-90bd-de0391b5ee3b</Id>
+      <Database Name="cv" Series="32444" Issue="204624" />
     </Book>
     <Book Series="Black Panther/Captain America: Flags of Our Fathers" Number="2" Volume="2010" Year="2010">
-      <Id>31a90900-4027-43a1-901e-db934b111b09</Id>
+      <Database Name="cv" Series="32444" Issue="212020" />
     </Book>
     <Book Series="Black Panther/Captain America: Flags of Our Fathers" Number="3" Volume="2010" Year="2010">
-      <Id>c4a0abd4-007d-414e-a59c-a499ef387e28</Id>
+      <Database Name="cv" Series="32444" Issue="217754" />
     </Book>
     <Book Series="Black Panther/Captain America: Flags of Our Fathers" Number="4" Volume="2010" Year="2010">
-      <Id>05936eda-4959-4d16-9be8-09c496bd911f</Id>
+      <Database Name="cv" Series="32444" Issue="224631" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Black Panther/Black Panther 001.cbl
+++ b/Marvel/Characters/unsorted/Black Panther/Black Panther 001.cbl
@@ -2,574 +2,574 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Black Panther 1</Name>
   <Books>
-    <Book Series="Fantastic Four" Number="52" Volume="1961" Year="1966" Format="Main Series">
+    <Book Series="Fantastic Four" Number="52" Volume="1961" Year="1966">
       <Id>90c7ca8e-7096-4a6f-9816-273b59767991</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="53" Volume="1961" Year="1966" Format="Main Series">
+    <Book Series="Fantastic Four" Number="53" Volume="1961" Year="1966">
       <Id>5cf92acd-b718-48da-8a25-f8a61bf22540</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="54" Volume="1961" Year="1966" Format="Main Series">
+    <Book Series="Fantastic Four" Number="54" Volume="1961" Year="1966">
       <Id>d930b5c0-68db-4c26-8675-c5b9bfe9f491</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="97" Volume="1959" Year="1968" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="97" Volume="1959" Year="1968">
       <Id>44aecc2f-d5a0-47c1-82d8-3c51282263d7</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="98" Volume="1959" Year="1968" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="98" Volume="1959" Year="1968">
       <Id>57e2afdc-4be8-42cf-91b9-c44a3cb6a594</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="99" Volume="1959" Year="1968" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="99" Volume="1959" Year="1968">
       <Id>27f09aae-f80b-4e78-98c8-25f5e4f7caad</Id>
     </Book>
-    <Book Series="Captain America" Number="100" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="Captain America" Number="100" Volume="1968" Year="1968">
       <Id>8e3e1473-ffb5-4155-8976-860af2dba80c</Id>
     </Book>
-    <Book Series="The Avengers" Number="52" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The Avengers" Number="52" Volume="1963" Year="1968">
       <Id>70ffad21-c917-4934-a098-36abde46030c</Id>
     </Book>
-    <Book Series="Marvel Masterworks: Black Panther" Number="1" Volume="2010" Year="2010" Format="TPB">
+    <Book Series="Marvel Masterworks: Black Panther" Number="1" Volume="2010" Year="2010">
       <Id>c579d0af-a0ac-42a4-ace0-a3e2ba2d9e3a</Id>
     </Book>
-    <Book Series="Marvel Masterworks: Black Panther" Number="2" Volume="2010" Year="2016" Format="TPB">
+    <Book Series="Marvel Masterworks: Black Panther" Number="2" Volume="2010" Year="2016">
       <Id>97fd5df8-c36f-4876-9512-d4171f64637f</Id>
     </Book>
-    <Book Series="Iron Man Annual" Number="5" Volume="1970" Year="1982" Format="Annual">
+    <Book Series="Iron Man Annual" Number="5" Volume="1970" Year="1982">
       <Id>231bec3f-ae17-4915-b68d-2377d390a076</Id>
     </Book>
-    <Book Series="Black Panther" Number="1" Volume="1988" Year="1988" Format="Limited Series">
+    <Book Series="Black Panther" Number="1" Volume="1988" Year="1988">
       <Id>a68fdec8-d25e-4785-8c01-18aafcc86d8a</Id>
     </Book>
-    <Book Series="Black Panther" Number="2" Volume="1988" Year="1988" Format="Limited Series">
+    <Book Series="Black Panther" Number="2" Volume="1988" Year="1988">
       <Id>c09d879f-2f4e-4030-b3cf-99a902c5a4d6</Id>
     </Book>
-    <Book Series="Black Panther" Number="3" Volume="1988" Year="1988" Format="Limited Series">
+    <Book Series="Black Panther" Number="3" Volume="1988" Year="1988">
       <Id>9ac1a74b-229b-4340-a6a0-bce4fa5c2999</Id>
     </Book>
-    <Book Series="Black Panther" Number="4" Volume="1988" Year="1988" Format="Limited Series">
+    <Book Series="Black Panther" Number="4" Volume="1988" Year="1988">
       <Id>3fd63852-8d48-469c-9c9d-fdec43abfcb8</Id>
     </Book>
-    <Book Series="Black Panther: Panther's Quest" Number="1" Volume="2017" Year="2017" Format="TPB">
+    <Book Series="Black Panther: Panther's Quest" Number="1" Volume="2017" Year="2017">
       <Id>28974887-0a5a-4c1d-b999-c803643c8a81</Id>
     </Book>
-    <Book Series="Black Panther: Panther's Prey" Number="1" Volume="1991" Year="1991" Format="Limited Series">
+    <Book Series="Black Panther: Panther's Prey" Number="1" Volume="1991" Year="1991">
       <Id>24ab3758-a82a-478e-9152-1d6f13cb3024</Id>
     </Book>
-    <Book Series="Black Panther: Panther's Prey" Number="2" Volume="1991" Year="1991" Format="Limited Series">
+    <Book Series="Black Panther: Panther's Prey" Number="2" Volume="1991" Year="1991">
       <Id>7abbabaf-ab1a-402d-bf4e-28ea90962765</Id>
     </Book>
-    <Book Series="Black Panther: Panther's Prey" Number="3" Volume="1991" Year="1991" Format="Limited Series">
+    <Book Series="Black Panther: Panther's Prey" Number="3" Volume="1991" Year="1991">
       <Id>0940ac8c-6cc9-46d4-802a-ae677be266c1</Id>
     </Book>
-    <Book Series="Black Panther: Panther's Prey" Number="4" Volume="1991" Year="1991" Format="Limited Series">
+    <Book Series="Black Panther: Panther's Prey" Number="4" Volume="1991" Year="1991">
       <Id>2e0fe8c7-b2a5-4a7b-8d95-a47668cbf5c2</Id>
     </Book>
-    <Book Series="Marvel Fanfare" Number="60" Volume="1982" Year="1992" Format="Main Series">
+    <Book Series="Marvel Fanfare" Number="60" Volume="1982" Year="1992">
       <Id>07ccb4c3-69d7-49b9-9d18-806c9df3ece7</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="25" Volume="1964" Year="1991" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="25" Volume="1964" Year="1991">
       <Id>0bae34f4-4922-4445-a105-c4253a0cb2fe</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man Annual" Number="11" Volume="1979" Year="1991" Format="Annual">
+    <Book Series="The Spectacular Spider-Man Annual" Number="11" Volume="1979" Year="1991">
       <Id>10d6f487-3c22-4064-98ce-d8799b308ce0</Id>
     </Book>
-    <Book Series="Web of Spider-Man Annual" Number="7" Volume="1985" Year="1991" Format="Annual">
+    <Book Series="Web of Spider-Man Annual" Number="7" Volume="1985" Year="1991">
       <Id>ea55304c-55de-4711-892f-5b182d2bef5b</Id>
     </Book>
-    <Book Series="The Avengers" Number="356" Volume="1963" Year="1992" Format="Main Series">
+    <Book Series="The Avengers" Number="356" Volume="1963" Year="1992">
       <Id>3234257e-c239-41cd-9f23-78f2f7c76c2e</Id>
     </Book>
-    <Book Series="Captain America" Number="414" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="Captain America" Number="414" Volume="1968" Year="1993">
       <Id>9ca6facb-3048-47b4-9612-d600df37d61a</Id>
     </Book>
-    <Book Series="Captain America" Number="415" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="Captain America" Number="415" Volume="1968" Year="1993">
       <Id>00687342-d465-4ecd-97ce-8c36a139dac3</Id>
     </Book>
-    <Book Series="Captain America" Number="416" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="Captain America" Number="416" Volume="1968" Year="1993">
       <Id>40e897cc-6a58-40bc-bd16-7506ef5a57c6</Id>
     </Book>
-    <Book Series="Captain America" Number="417" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="Captain America" Number="417" Volume="1968" Year="1993">
       <Id>12a3cf9c-5666-42a2-8a9a-47ea1bb0eb4b</Id>
     </Book>
-    <Book Series="Black Panther" Number="1" Volume="1998" Year="1998" Format="Main Series">
+    <Book Series="Black Panther" Number="1" Volume="1998" Year="1998">
       <Id>9774a082-357c-436c-b916-aab89a952428</Id>
     </Book>
-    <Book Series="Black Panther" Number="2" Volume="1998" Year="1998" Format="Main Series">
+    <Book Series="Black Panther" Number="2" Volume="1998" Year="1998">
       <Id>f948afea-172b-40d9-ba39-fec210131d60</Id>
     </Book>
-    <Book Series="Black Panther" Number="3" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Black Panther" Number="3" Volume="1998" Year="1999">
       <Id>22bc6d3f-8d1b-4bcd-b6ac-2f6cd5be2361</Id>
     </Book>
-    <Book Series="Black Panther" Number="4" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Black Panther" Number="4" Volume="1998" Year="1999">
       <Id>368ace55-aff1-4358-af62-ed8b17db809b</Id>
     </Book>
-    <Book Series="Black Panther" Number="5" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Black Panther" Number="5" Volume="1998" Year="1999">
       <Id>7a125f37-355f-48bb-a908-f435685841df</Id>
     </Book>
-    <Book Series="Black Panther" Number="6" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Black Panther" Number="6" Volume="1998" Year="1999">
       <Id>c0075f7e-3c9c-4ab5-958a-8702cbf57691</Id>
     </Book>
-    <Book Series="Black Panther" Number="7" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Black Panther" Number="7" Volume="1998" Year="1999">
       <Id>48495345-a4f3-4d76-9396-aed042f00996</Id>
     </Book>
-    <Book Series="Black Panther" Number="8" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Black Panther" Number="8" Volume="1998" Year="1999">
       <Id>f2dd18b8-9120-4b8b-8f3b-183c50dcd6fc</Id>
     </Book>
-    <Book Series="Black Panther" Number="9" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Black Panther" Number="9" Volume="1998" Year="1999">
       <Id>f6ffdf61-eddd-4916-b596-e07707b2d891</Id>
     </Book>
-    <Book Series="Black Panther" Number="10" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Black Panther" Number="10" Volume="1998" Year="1999">
       <Id>9d8fd0c6-60e9-47ca-bc93-93b424cffdf6</Id>
     </Book>
-    <Book Series="Black Panther" Number="11" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Black Panther" Number="11" Volume="1998" Year="1999">
       <Id>5d6041ec-e90b-40d9-87d7-45f004e83e33</Id>
     </Book>
-    <Book Series="Black Panther" Number="12" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Black Panther" Number="12" Volume="1998" Year="1999">
       <Id>76eb5830-0f6b-4788-b6ef-4315f5c2f104</Id>
     </Book>
-    <Book Series="Black Panther" Number="13" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Black Panther" Number="13" Volume="1998" Year="1999">
       <Id>98c1e901-806a-4d09-8130-537be662974b</Id>
     </Book>
-    <Book Series="Black Panther" Number="14" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Black Panther" Number="14" Volume="1998" Year="2000">
       <Id>1a6ba668-e9e0-436a-810e-3ccf757b07c5</Id>
     </Book>
-    <Book Series="Black Panther" Number="15" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Black Panther" Number="15" Volume="1998" Year="2000">
       <Id>4ba98d84-ef77-4fed-9a27-1b099c498144</Id>
     </Book>
-    <Book Series="Black Panther" Number="16" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Black Panther" Number="16" Volume="1998" Year="2000">
       <Id>cdc748f1-b3b4-48fd-9c01-41add4498197</Id>
     </Book>
-    <Book Series="Black Panther" Number="17" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Black Panther" Number="17" Volume="1998" Year="2000">
       <Id>e89e2a8b-b263-43f5-b191-a2984960dce3</Id>
     </Book>
-    <Book Series="Black Panther" Number="18" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Black Panther" Number="18" Volume="1998" Year="2000">
       <Id>711f485d-d405-4548-8509-c9fcf781300a</Id>
     </Book>
-    <Book Series="Black Panther" Number="19" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Black Panther" Number="19" Volume="1998" Year="2000">
       <Id>e7ef2dbb-3748-45fa-bb2c-12ae0f7546a0</Id>
     </Book>
-    <Book Series="Black Panther" Number="20" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Black Panther" Number="20" Volume="1998" Year="2000">
       <Id>0dd2c6db-6ab0-48de-bb5f-63f8cf62fb72</Id>
     </Book>
-    <Book Series="Black Panther" Number="21" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Black Panther" Number="21" Volume="1998" Year="2000">
       <Id>eb6a597c-a743-4936-b696-89f4da47e002</Id>
     </Book>
-    <Book Series="Black Panther" Number="22" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Black Panther" Number="22" Volume="1998" Year="2000">
       <Id>273ac3b4-931c-483c-b04d-052a6e25c7ca</Id>
     </Book>
-    <Book Series="Deadpool" Number="44" Volume="1997" Year="2000" Format="Main Series">
+    <Book Series="Deadpool" Number="44" Volume="1997" Year="2000">
       <Id>91139eea-48d0-4db1-8838-4f699c8dd3db</Id>
     </Book>
-    <Book Series="Black Panther" Number="23" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Black Panther" Number="23" Volume="1998" Year="2000">
       <Id>2f515b33-bf57-4cfc-a57d-42a5d2f01710</Id>
     </Book>
-    <Book Series="Black Panther" Number="24" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Black Panther" Number="24" Volume="1998" Year="2000">
       <Id>eebc70ee-5405-4427-928d-f889966fca13</Id>
     </Book>
-    <Book Series="Black Panther" Number="25" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Black Panther" Number="25" Volume="1998" Year="2000">
       <Id>3929e910-b48e-4466-bba3-a82fc838a7b2</Id>
     </Book>
-    <Book Series="Black Panther" Number="26" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Black Panther" Number="26" Volume="1998" Year="2001">
       <Id>6b8bca21-c6be-43ef-b73e-00fea251ecc2</Id>
     </Book>
-    <Book Series="Black Panther" Number="27" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Black Panther" Number="27" Volume="1998" Year="2001">
       <Id>8531e5e4-9528-4fb8-89ac-bc8b2f7093ff</Id>
     </Book>
-    <Book Series="Black Panther" Number="28" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Black Panther" Number="28" Volume="1998" Year="2001">
       <Id>e9f52abe-5217-4ba5-8c90-4cd5ebdd45e5</Id>
     </Book>
-    <Book Series="Black Panther" Number="29" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Black Panther" Number="29" Volume="1998" Year="2001">
       <Id>ba2050be-0eb0-467c-a937-d1d0c98a231a</Id>
     </Book>
-    <Book Series="Black Panther" Number="30" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Black Panther" Number="30" Volume="1998" Year="2001">
       <Id>7f61eb40-bcf9-4822-bd40-f5eabab5a740</Id>
     </Book>
-    <Book Series="Black Panther" Number="31" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Black Panther" Number="31" Volume="1998" Year="2001">
       <Id>bc1c7282-f990-4c4b-a8c5-cc03657d2a10</Id>
     </Book>
-    <Book Series="Black Panther" Number="32" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Black Panther" Number="32" Volume="1998" Year="2001">
       <Id>25c31924-846a-4d7e-afb1-3e36cd82b073</Id>
     </Book>
-    <Book Series="Black Panther" Number="33" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Black Panther" Number="33" Volume="1998" Year="2001">
       <Id>e493c1e0-bfbd-484b-ad93-5b487223cd25</Id>
     </Book>
-    <Book Series="Black Panther" Number="34" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Black Panther" Number="34" Volume="1998" Year="2001">
       <Id>9bb7a11a-02b4-4f1d-902e-9d40cf42fb53</Id>
     </Book>
-    <Book Series="Black Panther" Number="35" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Black Panther" Number="35" Volume="1998" Year="2001">
       <Id>6ea18eaa-d980-4a00-9399-8914933caf7b</Id>
     </Book>
-    <Book Series="Black Panther" Number="36" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Black Panther" Number="36" Volume="1998" Year="2001">
       <Id>5e3bbaec-8d86-448f-ace7-aef9e87c185d</Id>
     </Book>
-    <Book Series="Black Panther" Number="37" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Black Panther" Number="37" Volume="1998" Year="2002">
       <Id>f5466fbd-bc08-4f7b-bbe5-61b0742f9a04</Id>
     </Book>
-    <Book Series="Black Panther" Number="38" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Black Panther" Number="38" Volume="1998" Year="2002">
       <Id>71b72024-b4f2-49d1-b000-71db0c0ff116</Id>
     </Book>
-    <Book Series="Black Panther" Number="39" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Black Panther" Number="39" Volume="1998" Year="2002">
       <Id>7c2df66c-ff5e-4968-923f-1f1dfee5b90c</Id>
     </Book>
-    <Book Series="Black Panther" Number="40" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Black Panther" Number="40" Volume="1998" Year="2002">
       <Id>fda70a85-5af2-485c-ad98-09e0a849aca3</Id>
     </Book>
-    <Book Series="Black Panther" Number="41" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Black Panther" Number="41" Volume="1998" Year="2002">
       <Id>fb709647-a7ef-4693-a5ea-9b0f2b8e2fe0</Id>
     </Book>
-    <Book Series="Black Panther" Number="42" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Black Panther" Number="42" Volume="1998" Year="2002">
       <Id>7c493050-ea2f-454c-9091-dec2984357a8</Id>
     </Book>
-    <Book Series="Black Panther" Number="43" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Black Panther" Number="43" Volume="1998" Year="2002">
       <Id>63cbde4e-cca4-4628-89fc-a4147bd01233</Id>
     </Book>
-    <Book Series="Black Panther" Number="44" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Black Panther" Number="44" Volume="1998" Year="2002">
       <Id>54282482-2d23-4335-a97b-298c7187b7ef</Id>
     </Book>
-    <Book Series="Black Panther" Number="45" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Black Panther" Number="45" Volume="1998" Year="2002">
       <Id>26c05ab1-01f5-44bd-bc26-d9a4e831e9ba</Id>
     </Book>
-    <Book Series="Black Panther" Number="46" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Black Panther" Number="46" Volume="1998" Year="2002">
       <Id>0c2e2292-6d33-4302-8808-80aa3749ff2a</Id>
     </Book>
-    <Book Series="Black Panther" Number="47" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Black Panther" Number="47" Volume="1998" Year="2002">
       <Id>2018e4e4-2787-4fd1-ada6-b20fcb35189c</Id>
     </Book>
-    <Book Series="Black Panther" Number="48" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Black Panther" Number="48" Volume="1998" Year="2002">
       <Id>17bd966f-f1a3-4801-b9cb-de8111887a26</Id>
     </Book>
-    <Book Series="Black Panther" Number="49" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Black Panther" Number="49" Volume="1998" Year="2002">
       <Id>7ac3a4a1-be0f-4bee-b0a6-283ef71b0998</Id>
     </Book>
-    <Book Series="Black Panther" Number="50" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Black Panther" Number="50" Volume="1998" Year="2002">
       <Id>b9327274-7ff4-4d16-9b01-8266e19a49ca</Id>
     </Book>
-    <Book Series="Black Panther" Number="51" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Black Panther" Number="51" Volume="1998" Year="2003">
       <Id>157077f9-92c1-4d99-b7cc-fa267c37e661</Id>
     </Book>
-    <Book Series="Black Panther" Number="52" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Black Panther" Number="52" Volume="1998" Year="2003">
       <Id>5adea838-73d8-4973-aa9e-39fbe40efec1</Id>
     </Book>
-    <Book Series="Black Panther" Number="53" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Black Panther" Number="53" Volume="1998" Year="2003">
       <Id>7c1643c8-b4a1-4f00-ae26-f2909d145d74</Id>
     </Book>
-    <Book Series="Black Panther" Number="54" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Black Panther" Number="54" Volume="1998" Year="2003">
       <Id>7b99425f-9843-4cb0-8f35-af0eddd60b65</Id>
     </Book>
-    <Book Series="Black Panther" Number="55" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Black Panther" Number="55" Volume="1998" Year="2003">
       <Id>031cf3fa-43b3-430f-94f8-52a7bc808bf4</Id>
     </Book>
-    <Book Series="Black Panther" Number="56" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Black Panther" Number="56" Volume="1998" Year="2003">
       <Id>28e940dd-ba1a-4ba4-b484-d2e02405520d</Id>
     </Book>
-    <Book Series="Black Panther" Number="57" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Black Panther" Number="57" Volume="1998" Year="2003">
       <Id>e8cbb543-b29e-4465-8267-454234312150</Id>
     </Book>
-    <Book Series="Black Panther" Number="58" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Black Panther" Number="58" Volume="1998" Year="2003">
       <Id>bf21d480-3f7f-413b-b9aa-c193f8f2b883</Id>
     </Book>
-    <Book Series="Black Panther" Number="59" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Black Panther" Number="59" Volume="1998" Year="2003">
       <Id>6581c2e8-1ae8-4123-8daf-d4851685ae2b</Id>
     </Book>
-    <Book Series="Black Panther" Number="60" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Black Panther" Number="60" Volume="1998" Year="2003">
       <Id>4fe98d56-d8fa-4017-9794-954724d4358b</Id>
     </Book>
-    <Book Series="Black Panther" Number="61" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Black Panther" Number="61" Volume="1998" Year="2003">
       <Id>a9ba1b89-8b1e-455e-b128-79457f687e77</Id>
     </Book>
-    <Book Series="Black Panther" Number="62" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Black Panther" Number="62" Volume="1998" Year="2003">
       <Id>dc5c1b73-4ff0-43cb-b3d2-acb5621abcc9</Id>
     </Book>
-    <Book Series="Black Panther" Number="1" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Black Panther" Number="1" Volume="2005" Year="2005">
       <Id>2af04e83-3568-4e85-83f8-dee0440b7208</Id>
     </Book>
-    <Book Series="Black Panther" Number="2" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Black Panther" Number="2" Volume="2005" Year="2005">
       <Id>48b5556e-4ecf-4214-829a-92b31b50a23d</Id>
     </Book>
-    <Book Series="Black Panther" Number="3" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Black Panther" Number="3" Volume="2005" Year="2005">
       <Id>9a8f8dd8-e1bc-4d41-9340-786204bf7886</Id>
     </Book>
-    <Book Series="Black Panther" Number="4" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Black Panther" Number="4" Volume="2005" Year="2005">
       <Id>1e47fd20-a142-49d7-a430-c45bdb900c33</Id>
     </Book>
-    <Book Series="Black Panther" Number="5" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Black Panther" Number="5" Volume="2005" Year="2005">
       <Id>5c911af5-ef04-4aa3-b011-54f537a9bf9c</Id>
     </Book>
-    <Book Series="Black Panther" Number="6" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Black Panther" Number="6" Volume="2005" Year="2005">
       <Id>c16d4a21-34a7-4c98-8416-e6b1915ce9c5</Id>
     </Book>
-    <Book Series="Black Panther" Number="7" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Black Panther" Number="7" Volume="2005" Year="2005">
       <Id>b54503e1-8bf5-446a-98b6-d1a1dd11de9f</Id>
     </Book>
-    <Book Series="X-Men" Number="175" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="X-Men" Number="175" Volume="2004" Year="2005">
       <Id>dce959c0-5895-4abe-bc7d-445bb3fbe9ea</Id>
     </Book>
-    <Book Series="Black Panther" Number="8" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Black Panther" Number="8" Volume="2005" Year="2005">
       <Id>904e246e-022f-4abb-975f-8e8962814166</Id>
     </Book>
-    <Book Series="X-Men" Number="176" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="X-Men" Number="176" Volume="2004" Year="2005">
       <Id>56527222-c3ce-4a66-8f04-11154801371a</Id>
     </Book>
-    <Book Series="Black Panther" Number="9" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Black Panther" Number="9" Volume="2005" Year="2005">
       <Id>600ca6f0-d912-4d6e-bd53-1d4787ef978a</Id>
     </Book>
-    <Book Series="Black Panther" Number="10" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Black Panther" Number="10" Volume="2005" Year="2006">
       <Id>aeb312b1-c06b-4f2f-bd0c-248556470e79</Id>
     </Book>
-    <Book Series="Black Panther" Number="11" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Black Panther" Number="11" Volume="2005" Year="2006">
       <Id>31f4e266-8c06-4b73-91c6-988e714009aa</Id>
     </Book>
-    <Book Series="Black Panther" Number="12" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Black Panther" Number="12" Volume="2005" Year="2006">
       <Id>8667fde6-f967-4d16-aa9b-bc1931b30ae4</Id>
     </Book>
-    <Book Series="Black Panther" Number="13" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Black Panther" Number="13" Volume="2005" Year="2006">
       <Id>9a51f575-0cc6-404a-89b2-d87536219c4a</Id>
     </Book>
-    <Book Series="Black Panther" Number="14" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Black Panther" Number="14" Volume="2005" Year="2006">
       <Id>768dac24-39ee-41ca-b3c9-7ae88edffb23</Id>
     </Book>
-    <Book Series="Black Panther" Number="15" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Black Panther" Number="15" Volume="2005" Year="2006">
       <Id>b7299f2f-1ad5-4d63-ba08-aa8508768b5b</Id>
     </Book>
-    <Book Series="Black Panther" Number="16" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Black Panther" Number="16" Volume="2005" Year="2006">
       <Id>60d7cb62-fa79-424c-8cf0-7c06028bab5e</Id>
     </Book>
-    <Book Series="Black Panther" Number="17" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Black Panther" Number="17" Volume="2005" Year="2006">
       <Id>27245776-966c-4ef5-995b-bb6956d8c706</Id>
     </Book>
-    <Book Series="Black Panther" Number="18" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Black Panther" Number="18" Volume="2005" Year="2006">
       <Id>a424936e-092b-4b61-ad62-e8d0e11929f3</Id>
     </Book>
-    <Book Series="Black Panther" Number="19" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Black Panther" Number="19" Volume="2005" Year="2006">
       <Id>b454b84d-d1d5-40c0-a054-d24eb253b78c</Id>
     </Book>
-    <Book Series="Black Panther" Number="20" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Black Panther" Number="20" Volume="2005" Year="2006">
       <Id>ae04fcdb-20a4-4732-a707-eaf174bf1b0d</Id>
     </Book>
-    <Book Series="Black Panther" Number="21" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Black Panther" Number="21" Volume="2005" Year="2006">
       <Id>74e13265-7df7-4d78-b3d7-c2c82a6e8a45</Id>
     </Book>
-    <Book Series="Black Panther" Number="22" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Black Panther" Number="22" Volume="2005" Year="2007">
       <Id>9ed19a65-2293-4f82-afd1-beca20bd03ce</Id>
     </Book>
-    <Book Series="Black Panther" Number="23" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Black Panther" Number="23" Volume="2005" Year="2007">
       <Id>85ee6ebd-2602-4696-ade4-5c0cd89c4736</Id>
     </Book>
-    <Book Series="Black Panther" Number="24" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Black Panther" Number="24" Volume="2005" Year="2007">
       <Id>446e4350-d313-4cce-9b9f-269b0b902b8a</Id>
     </Book>
-    <Book Series="Black Panther" Number="25" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Black Panther" Number="25" Volume="2005" Year="2007">
       <Id>7590376c-db1a-48b2-ac6b-aed02919edc3</Id>
     </Book>
-    <Book Series="Storm" Number="1" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="Storm" Number="1" Volume="2006" Year="2006">
       <Id>93477a0e-f3ea-4a0d-9d4e-0597c59fe3ad</Id>
     </Book>
-    <Book Series="Storm" Number="2" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="Storm" Number="2" Volume="2006" Year="2006">
       <Id>a15c6246-9080-45ee-9df0-5b5f5150bf38</Id>
     </Book>
-    <Book Series="Storm" Number="3" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="Storm" Number="3" Volume="2006" Year="2006">
       <Id>60990175-5a68-44bd-a6a2-61356d8b4814</Id>
     </Book>
-    <Book Series="Storm" Number="4" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="Storm" Number="4" Volume="2006" Year="2006">
       <Id>c7e38ae7-4835-43a3-8691-6b0cb5340615</Id>
     </Book>
-    <Book Series="Storm" Number="5" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="Storm" Number="5" Volume="2006" Year="2006">
       <Id>ceffcf46-a74b-443e-91d6-df57494cc446</Id>
     </Book>
-    <Book Series="Storm" Number="6" Volume="2006" Year="2006" Format="Limited Series">
+    <Book Series="Storm" Number="6" Volume="2006" Year="2006">
       <Id>cd0a5397-dece-43f6-8aa3-965d1d8b9ac9</Id>
     </Book>
-    <Book Series="Black Panther" Number="26" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Black Panther" Number="26" Volume="2005" Year="2007">
       <Id>6b813f4a-e810-4af0-bd68-4fce68886123</Id>
     </Book>
-    <Book Series="Black Panther" Number="27" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Black Panther" Number="27" Volume="2005" Year="2007">
       <Id>82efa362-8bf8-4536-b0b9-bda669f3be76</Id>
     </Book>
-    <Book Series="Black Panther" Number="28" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Black Panther" Number="28" Volume="2005" Year="2007">
       <Id>d7e498c0-3eee-451e-bf4d-386bd2aa28f5</Id>
     </Book>
-    <Book Series="Black Panther" Number="29" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Black Panther" Number="29" Volume="2005" Year="2007">
       <Id>a923d65f-9972-47e6-b7ff-ea45b527706e</Id>
     </Book>
-    <Book Series="Black Panther" Number="30" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Black Panther" Number="30" Volume="2005" Year="2007">
       <Id>b50ab8bf-7d55-4ca6-88eb-7d95a5bb06dc</Id>
     </Book>
-    <Book Series="Black Panther" Number="31" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Black Panther" Number="31" Volume="2005" Year="2007">
       <Id>5e398007-fa6a-4b95-aced-27399297eeee</Id>
     </Book>
-    <Book Series="Black Panther" Number="32" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="Black Panther" Number="32" Volume="2005" Year="2008">
       <Id>8c6a70d6-5809-407c-9184-3f104adea408</Id>
     </Book>
-    <Book Series="Black Panther" Number="33" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="Black Panther" Number="33" Volume="2005" Year="2008">
       <Id>7f798370-b875-42b5-9c93-531986623fa4</Id>
     </Book>
-    <Book Series="Black Panther" Number="34" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="Black Panther" Number="34" Volume="2005" Year="2008">
       <Id>1b7345f6-66bb-4686-964d-d33feb54d978</Id>
     </Book>
-    <Book Series="Black Panther" Number="35" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="Black Panther" Number="35" Volume="2005" Year="2008">
       <Id>066d878c-bfd0-4e10-84ed-532169495faf</Id>
     </Book>
-    <Book Series="Black Panther" Number="36" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="Black Panther" Number="36" Volume="2005" Year="2008">
       <Id>0921dda1-ade9-4fe6-a264-13a925a981f9</Id>
     </Book>
-    <Book Series="Black Panther" Number="37" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="Black Panther" Number="37" Volume="2005" Year="2008">
       <Id>de1bcecb-0152-4ab9-9610-540f088a51ab</Id>
     </Book>
-    <Book Series="Black Panther" Number="38" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="Black Panther" Number="38" Volume="2005" Year="2008">
       <Id>6ed21821-ed52-4552-891b-a06be8f2fd03</Id>
     </Book>
-    <Book Series="Black Panther" Number="39" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="Black Panther" Number="39" Volume="2005" Year="2008">
       <Id>8a151a25-8f45-4672-90bf-790b31c86538</Id>
     </Book>
-    <Book Series="Black Panther" Number="40" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="Black Panther" Number="40" Volume="2005" Year="2008">
       <Id>b7fde391-1adf-4366-bda6-50ef34497ebb</Id>
     </Book>
-    <Book Series="Black Panther" Number="41" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="Black Panther" Number="41" Volume="2005" Year="2008">
       <Id>e057106b-a7cd-4f4c-bdf7-892b2d96e40e</Id>
     </Book>
-    <Book Series="X-Men: Worlds Apart" Number="1" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="X-Men: Worlds Apart" Number="1" Volume="2008" Year="2008">
       <Id>71285c4a-7548-4705-bbd7-29bd8003b8fc</Id>
     </Book>
-    <Book Series="X-Men: Worlds Apart" Number="2" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="X-Men: Worlds Apart" Number="2" Volume="2008" Year="2009">
       <Id>68c81ec6-2f34-4a20-8d58-3e7f94585164</Id>
     </Book>
-    <Book Series="X-Men: Worlds Apart" Number="3" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="X-Men: Worlds Apart" Number="3" Volume="2008" Year="2009">
       <Id>0ce9c510-ee6c-4008-bacb-3f918385daeb</Id>
     </Book>
-    <Book Series="X-Men: Worlds Apart" Number="4" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="X-Men: Worlds Apart" Number="4" Volume="2008" Year="2009">
       <Id>e9fd765d-49a4-4048-bc21-10d1970ca52e</Id>
     </Book>
-    <Book Series="Black Panther" Number="1" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Black Panther" Number="1" Volume="2009" Year="2009">
       <Id>df97903c-2539-4bc3-95cc-0478ea58e874</Id>
     </Book>
-    <Book Series="Black Panther" Number="2" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Black Panther" Number="2" Volume="2009" Year="2009">
       <Id>e5298357-3528-460e-86d4-4637ecdbd43b</Id>
     </Book>
-    <Book Series="Black Panther" Number="3" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Black Panther" Number="3" Volume="2009" Year="2009">
       <Id>c61a7764-3b44-4117-b609-a4236303e076</Id>
     </Book>
-    <Book Series="Black Panther" Number="4" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Black Panther" Number="4" Volume="2009" Year="2009">
       <Id>eeac1e9c-7bcc-4fcf-a17f-18ab7e0362af</Id>
     </Book>
-    <Book Series="Black Panther" Number="5" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Black Panther" Number="5" Volume="2009" Year="2009">
       <Id>7d2b261f-542d-4d9f-a7d6-4a18da7d4653</Id>
     </Book>
-    <Book Series="Black Panther" Number="6" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Black Panther" Number="6" Volume="2009" Year="2009">
       <Id>519beace-fabe-44cc-9e44-2f3e103afd23</Id>
     </Book>
-    <Book Series="Black Panther Annual" Number="1" Volume="2008" Year="2008" Format="Annual">
+    <Book Series="Black Panther Annual" Number="1" Volume="2008" Year="2008">
       <Id>2f33d5c7-4dfc-4c0d-bfee-370ea85e0c90</Id>
     </Book>
-    <Book Series="Black Panther" Number="7" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Black Panther" Number="7" Volume="2009" Year="2009">
       <Id>6d6f8b42-69f0-41f2-8ef7-80b91e4e5c36</Id>
     </Book>
-    <Book Series="Black Panther" Number="8" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Black Panther" Number="8" Volume="2009" Year="2009">
       <Id>57c1752b-f7cd-4fbc-a9fa-cce04ed6667a</Id>
     </Book>
-    <Book Series="Black Panther" Number="9" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Black Panther" Number="9" Volume="2009" Year="2009">
       <Id>940d2f61-4f2d-4b53-986e-1946a46fa18a</Id>
     </Book>
-    <Book Series="Black Panther" Number="10" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Black Panther" Number="10" Volume="2009" Year="2010">
       <Id>72fafd64-11e2-4b48-8478-2f51ac4eb68a</Id>
     </Book>
-    <Book Series="Black Panther" Number="11" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Black Panther" Number="11" Volume="2009" Year="2010">
       <Id>442b0335-e256-4b75-8acb-43c69b462a60</Id>
     </Book>
-    <Book Series="Black Panther" Number="12" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Black Panther" Number="12" Volume="2009" Year="2010">
       <Id>1124dd06-d06b-4ca2-92e9-506e399d0301</Id>
     </Book>
-    <Book Series="Klaws of the Panther" Number="1" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Klaws of the Panther" Number="1" Volume="2010" Year="2010">
       <Id>c9e0ae2c-f041-4cd5-9ab7-2fee1d8a62f7</Id>
     </Book>
-    <Book Series="Klaws of the Panther" Number="2" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Klaws of the Panther" Number="2" Volume="2010" Year="2010">
       <Id>0e18fcc3-1424-4cf3-a604-8d8751417e8c</Id>
     </Book>
-    <Book Series="Klaws of the Panther" Number="3" Volume="2010" Year="2011" Format="Limited Series">
+    <Book Series="Klaws of the Panther" Number="3" Volume="2010" Year="2011">
       <Id>58f14fe5-cd70-46ec-9214-90bb3d90e738</Id>
     </Book>
-    <Book Series="Klaws of the Panther" Number="4" Volume="2010" Year="2011" Format="Limited Series">
+    <Book Series="Klaws of the Panther" Number="4" Volume="2010" Year="2011">
       <Id>a6aee1b6-a3ea-46ca-aa23-cc5c46c7a56f</Id>
     </Book>
-    <Book Series="Doomwar" Number="1" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Doomwar" Number="1" Volume="2010" Year="2010">
       <Id>bb848e94-b600-4528-95ba-86fc00138a4d</Id>
     </Book>
-    <Book Series="Doomwar" Number="2" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Doomwar" Number="2" Volume="2010" Year="2010">
       <Id>414060c1-3271-49f2-8366-3b2ddbc6bef0</Id>
     </Book>
-    <Book Series="Doomwar" Number="3" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Doomwar" Number="3" Volume="2010" Year="2010">
       <Id>3e320599-cb1f-4ba9-816d-22caf15f0062</Id>
     </Book>
-    <Book Series="Doomwar" Number="4" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Doomwar" Number="4" Volume="2010" Year="2010">
       <Id>a5cc67de-0277-4dae-a29e-19071b49b772</Id>
     </Book>
-    <Book Series="Doomwar" Number="5" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Doomwar" Number="5" Volume="2010" Year="2010">
       <Id>8617a587-93c9-444c-903b-146740409a6f</Id>
     </Book>
-    <Book Series="Doomwar" Number="6" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Doomwar" Number="6" Volume="2010" Year="2010">
       <Id>ac733589-f51c-45ed-93a7-19585e143306</Id>
     </Book>
-    <Book Series="Black Panther: The Man Without Fear" Number="513" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Black Panther: The Man Without Fear" Number="513" Volume="2011" Year="2011">
       <Id>4a26b958-0388-4a90-9bb8-3f186e6964fb</Id>
     </Book>
-    <Book Series="Black Panther: The Man Without Fear" Number="514" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Black Panther: The Man Without Fear" Number="514" Volume="2011" Year="2011">
       <Id>dd04c364-cce8-40fd-a4e5-0c3803f577bb</Id>
     </Book>
-    <Book Series="Black Panther: The Man Without Fear" Number="515" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Black Panther: The Man Without Fear" Number="515" Volume="2011" Year="2011">
       <Id>a4684021-e612-4725-912a-9317e35e2972</Id>
     </Book>
-    <Book Series="Black Panther: The Man Without Fear" Number="516" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Black Panther: The Man Without Fear" Number="516" Volume="2011" Year="2011">
       <Id>7b82fb05-8cad-46de-b762-7d290bc0c540</Id>
     </Book>
-    <Book Series="Black Panther: The Man Without Fear" Number="517" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Black Panther: The Man Without Fear" Number="517" Volume="2011" Year="2011">
       <Id>3bec7ec0-ce55-40a3-abc7-98ba5b8ad7e9</Id>
     </Book>
-    <Book Series="Black Panther: The Man Without Fear" Number="518" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Black Panther: The Man Without Fear" Number="518" Volume="2011" Year="2011">
       <Id>055c1764-7617-48d5-ac90-b3eb52d43ae9</Id>
     </Book>
-    <Book Series="Black Panther: The Man Without Fear" Number="519" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Black Panther: The Man Without Fear" Number="519" Volume="2011" Year="2011">
       <Id>6f857a44-3126-4632-8395-8a417b417a53</Id>
     </Book>
-    <Book Series="Black Panther: The Man Without Fear" Number="520" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Black Panther: The Man Without Fear" Number="520" Volume="2011" Year="2011">
       <Id>f9d642cb-74b5-4f23-824a-1f0ad9f465e4</Id>
     </Book>
-    <Book Series="Black Panther: The Man Without Fear" Number="521" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Black Panther: The Man Without Fear" Number="521" Volume="2011" Year="2011">
       <Id>171f2ca5-0bfd-46e9-a426-a04126add0e8</Id>
     </Book>
-    <Book Series="Black Panther: The Man Without Fear" Number="522" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Black Panther: The Man Without Fear" Number="522" Volume="2011" Year="2011">
       <Id>e84b7e72-c680-4471-9114-9e968331c983</Id>
     </Book>
-    <Book Series="Black Panther: The Man Without Fear" Number="523" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Black Panther: The Man Without Fear" Number="523" Volume="2011" Year="2011">
       <Id>9b36e66c-81b4-4e00-b7a0-c80352f49b4c</Id>
     </Book>
-    <Book Series="Black Panther: The Most Dangerous Man Alive" Number="523.1" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Black Panther: The Most Dangerous Man Alive" Number="523.1" Volume="2011" Year="2011">
       <Id>7721c605-4464-4628-a045-0cad0552aa09</Id>
     </Book>
-    <Book Series="Black Panther: The Most Dangerous Man Alive" Number="524" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Black Panther: The Most Dangerous Man Alive" Number="524" Volume="2011" Year="2011">
       <Id>af9584d3-68f0-41ce-8a5d-e37788d1c0ef</Id>
     </Book>
-    <Book Series="Black Panther: The Most Dangerous Man Alive" Number="525" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Black Panther: The Most Dangerous Man Alive" Number="525" Volume="2011" Year="2012">
       <Id>4a6e616e-af3a-4e72-a8ed-871ad6236aad</Id>
     </Book>
-    <Book Series="Black Panther: The Most Dangerous Man Alive" Number="526" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Black Panther: The Most Dangerous Man Alive" Number="526" Volume="2011" Year="2012">
       <Id>0b30b490-b04a-4c23-bf6c-9830caa22413</Id>
     </Book>
-    <Book Series="Black Panther: The Most Dangerous Man Alive" Number="527" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Black Panther: The Most Dangerous Man Alive" Number="527" Volume="2011" Year="2012">
       <Id>9c6c2728-b36a-4790-982f-f056fb039343</Id>
     </Book>
-    <Book Series="Black Panther: The Most Dangerous Man Alive" Number="528" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Black Panther: The Most Dangerous Man Alive" Number="528" Volume="2011" Year="2012">
       <Id>1904da14-fab8-4bca-84dd-4a53f995948e</Id>
     </Book>
-    <Book Series="Black Panther: The Most Dangerous Man Alive" Number="529" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Black Panther: The Most Dangerous Man Alive" Number="529" Volume="2011" Year="2012">
       <Id>9f254be3-5a11-4eec-8002-07c6193be290</Id>
     </Book>
-    <Book Series="Black Panther/Captain America: Flags of Our Fathers" Number="1" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Black Panther/Captain America: Flags of Our Fathers" Number="1" Volume="2010" Year="2010">
       <Id>a7d3661e-d717-4cbe-90bd-de0391b5ee3b</Id>
     </Book>
-    <Book Series="Black Panther/Captain America: Flags of Our Fathers" Number="2" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Black Panther/Captain America: Flags of Our Fathers" Number="2" Volume="2010" Year="2010">
       <Id>31a90900-4027-43a1-901e-db934b111b09</Id>
     </Book>
-    <Book Series="Black Panther/Captain America: Flags of Our Fathers" Number="3" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Black Panther/Captain America: Flags of Our Fathers" Number="3" Volume="2010" Year="2010">
       <Id>c4a0abd4-007d-414e-a59c-a499ef387e28</Id>
     </Book>
-    <Book Series="Black Panther/Captain America: Flags of Our Fathers" Number="4" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Black Panther/Captain America: Flags of Our Fathers" Number="4" Volume="2010" Year="2010">
       <Id>05936eda-4959-4d16-9be8-09c496bd911f</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Black Panther/Black Panther 002.cbl
+++ b/Marvel/Characters/unsorted/Black Panther/Black Panther 002.cbl
@@ -2,154 +2,154 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Black Panther 2</Name>
   <Books>
-    <Book Series="Rise of the Black Panther" Number="1" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Rise of the Black Panther" Number="1" Volume="2018" Year="2018">
       <Id>d50bf679-3839-425c-aa7f-110e00146661</Id>
     </Book>
-    <Book Series="Rise of the Black Panther" Number="2" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Rise of the Black Panther" Number="2" Volume="2018" Year="2018">
       <Id>7acb8d48-940d-48ed-8bcd-c012d55f14e8</Id>
     </Book>
-    <Book Series="Rise of the Black Panther" Number="3" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Rise of the Black Panther" Number="3" Volume="2018" Year="2018">
       <Id>ac92547f-75c5-4214-b10f-0b1239f0e12b</Id>
     </Book>
-    <Book Series="Rise of the Black Panther" Number="4" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Rise of the Black Panther" Number="4" Volume="2018" Year="2018">
       <Id>01af33c2-bb62-4e66-a42b-f9ad4ee53925</Id>
     </Book>
-    <Book Series="Rise of the Black Panther" Number="5" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Rise of the Black Panther" Number="5" Volume="2018" Year="2018">
       <Id>6a1c0def-9dcb-4569-bf17-bfcaf614e24f</Id>
     </Book>
-    <Book Series="Black Panther" Number="1" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Black Panther" Number="1" Volume="2016" Year="2016">
       <Id>87f03865-1085-484e-abe3-ff17aff98cbb</Id>
     </Book>
-    <Book Series="Black Panther" Number="2" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Black Panther" Number="2" Volume="2016" Year="2016">
       <Id>e53f0690-8d81-4a64-92aa-e94c5385f2a3</Id>
     </Book>
-    <Book Series="Black Panther" Number="3" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Black Panther" Number="3" Volume="2016" Year="2016">
       <Id>27d1b4ee-3a3a-4bab-b167-4fa7ccae695a</Id>
     </Book>
-    <Book Series="Black Panther" Number="4" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Black Panther" Number="4" Volume="2016" Year="2016">
       <Id>fbaaab96-fedd-400b-877f-3a96656407ba</Id>
     </Book>
-    <Book Series="Black Panther" Number="5" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Black Panther" Number="5" Volume="2016" Year="2016">
       <Id>4d620261-db27-4c65-8719-a45184f1b758</Id>
     </Book>
-    <Book Series="Black Panther" Number="6" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Black Panther" Number="6" Volume="2016" Year="2016">
       <Id>62dd5cdf-d253-4b99-b7ec-1159613c8f04</Id>
     </Book>
-    <Book Series="Black Panther" Number="7" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Black Panther" Number="7" Volume="2016" Year="2016">
       <Id>f4ab8d14-287b-45d5-8f0b-1ea33c98071f</Id>
     </Book>
-    <Book Series="Black Panther" Number="8" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Black Panther" Number="8" Volume="2016" Year="2017">
       <Id>cb4e2370-e9ca-46aa-b4bb-3a60a01286a3</Id>
     </Book>
-    <Book Series="Black Panther" Number="9" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Black Panther" Number="9" Volume="2016" Year="2017">
       <Id>2ae82bc0-dddb-4c14-8b02-c53ec9ebf21f</Id>
     </Book>
-    <Book Series="Black Panther" Number="10" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Black Panther" Number="10" Volume="2016" Year="2017">
       <Id>553d00f0-924e-4aab-9263-8ad20551637a</Id>
     </Book>
-    <Book Series="Black Panther" Number="11" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Black Panther" Number="11" Volume="2016" Year="2017">
       <Id>6fc7b95f-c91f-4f19-97e6-ed80bf73c2bc</Id>
     </Book>
-    <Book Series="Black Panther" Number="12" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Black Panther" Number="12" Volume="2016" Year="2017">
       <Id>f48ac4eb-d513-4db1-8b4a-ed8a6ae0f2f9</Id>
     </Book>
-    <Book Series="Black Panther: World of Wakanda" Number="1" Volume="2016" Year="2017" Format="Limited Series">
+    <Book Series="Black Panther: World of Wakanda" Number="1" Volume="2016" Year="2017">
       <Id>5d5aad1f-e43d-42f1-981a-7ad2b577c0d4</Id>
     </Book>
-    <Book Series="Black Panther: World of Wakanda" Number="2" Volume="2016" Year="2017" Format="Limited Series">
+    <Book Series="Black Panther: World of Wakanda" Number="2" Volume="2016" Year="2017">
       <Id>52c620e6-c4f6-4498-8f53-b8e77274654f</Id>
     </Book>
-    <Book Series="Black Panther: World of Wakanda" Number="3" Volume="2016" Year="2017" Format="Limited Series">
+    <Book Series="Black Panther: World of Wakanda" Number="3" Volume="2016" Year="2017">
       <Id>abb0acc5-10e8-43a7-acae-e6e6076caec4</Id>
     </Book>
-    <Book Series="Black Panther: World of Wakanda" Number="4" Volume="2016" Year="2017" Format="Limited Series">
+    <Book Series="Black Panther: World of Wakanda" Number="4" Volume="2016" Year="2017">
       <Id>ffdb0394-871c-4daa-aa55-c7496bd12952</Id>
     </Book>
-    <Book Series="Black Panther: World of Wakanda" Number="5" Volume="2016" Year="2017" Format="Limited Series">
+    <Book Series="Black Panther: World of Wakanda" Number="5" Volume="2016" Year="2017">
       <Id>5af8e8bd-362a-43cd-9bba-e53e17dd7031</Id>
     </Book>
-    <Book Series="Black Panther: World of Wakanda" Number="6" Volume="2016" Year="2017" Format="Limited Series">
+    <Book Series="Black Panther: World of Wakanda" Number="6" Volume="2016" Year="2017">
       <Id>c77cd9c9-61fc-43bc-bb89-d843134a6071</Id>
     </Book>
-    <Book Series="Black Panther &amp; the Crew" Number="1" Volume="2017" Year="2017" Format="Limited Series">
+    <Book Series="Black Panther &amp; the Crew" Number="1" Volume="2017" Year="2017">
       <Id>a6adeb96-e9e4-43f0-a59b-8cd60937b2df</Id>
     </Book>
-    <Book Series="Black Panther &amp; the Crew" Number="2" Volume="2017" Year="2017" Format="Limited Series">
+    <Book Series="Black Panther &amp; the Crew" Number="2" Volume="2017" Year="2017">
       <Id>9449fa91-7b8c-4036-a054-5a94969a4564</Id>
     </Book>
-    <Book Series="Black Panther &amp; the Crew" Number="3" Volume="2017" Year="2017" Format="Limited Series">
+    <Book Series="Black Panther &amp; the Crew" Number="3" Volume="2017" Year="2017">
       <Id>cd80491c-83f6-4765-a419-465281610e05</Id>
     </Book>
-    <Book Series="Black Panther &amp; the Crew" Number="4" Volume="2017" Year="2017" Format="Limited Series">
+    <Book Series="Black Panther &amp; the Crew" Number="4" Volume="2017" Year="2017">
       <Id>f4e38293-4062-41c1-810e-a85dbe7bb212</Id>
     </Book>
-    <Book Series="Black Panther and the Crew" Number="5" Volume="2017" Year="2017" Format="Limited Series">
+    <Book Series="Black Panther and the Crew" Number="5" Volume="2017" Year="2017">
       <Id>0a145f10-6c80-4e1d-b29f-f21f218c39ab</Id>
     </Book>
-    <Book Series="Black Panther and the Crew" Number="6" Volume="2017" Year="2017" Format="Limited Series">
+    <Book Series="Black Panther and the Crew" Number="6" Volume="2017" Year="2017">
       <Id>3080da32-a077-46c0-b6f2-2d5bd38d69de</Id>
     </Book>
-    <Book Series="Black Panther: Long Live the King" Number="1" Volume="2017" Year="2018" Format="Limited Series">
+    <Book Series="Black Panther: Long Live the King" Number="1" Volume="2017" Year="2018">
       <Id>73e1248a-5fbc-49f9-8b97-f541c3efce35</Id>
     </Book>
-    <Book Series="Black Panther: Long Live the King" Number="2" Volume="2017" Year="2018" Format="Limited Series">
+    <Book Series="Black Panther: Long Live the King" Number="2" Volume="2017" Year="2018">
       <Id>55a4b8d8-9d7a-4521-b571-2ae0adf33e40</Id>
     </Book>
-    <Book Series="Black Panther: Long Live the King" Number="3" Volume="2017" Year="2018" Format="Limited Series">
+    <Book Series="Black Panther: Long Live the King" Number="3" Volume="2017" Year="2018">
       <Id>67f24fe8-d768-47b1-8bfb-812ee4a89e9c</Id>
     </Book>
-    <Book Series="Black Panther: Long Live the King" Number="4" Volume="2017" Year="2018" Format="Limited Series">
+    <Book Series="Black Panther: Long Live the King" Number="4" Volume="2017" Year="2018">
       <Id>4f59e7d2-66e8-4090-be00-187c8a6b09b0</Id>
     </Book>
-    <Book Series="Black Panther: Long Live the King" Number="5" Volume="2017" Year="2018" Format="Limited Series">
+    <Book Series="Black Panther: Long Live the King" Number="5" Volume="2017" Year="2018">
       <Id>6de22813-b6e8-49d6-ae04-bed7e67360a7</Id>
     </Book>
-    <Book Series="Black Panther: Long Live the King" Number="6" Volume="2017" Year="2018" Format="Limited Series">
+    <Book Series="Black Panther: Long Live the King" Number="6" Volume="2017" Year="2018">
       <Id>88741f3b-5b81-405f-a3e1-3303448ba2e4</Id>
     </Book>
-    <Book Series="Black Panther" Number="13" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Black Panther" Number="13" Volume="2016" Year="2017">
       <Id>c005d744-fe8d-4805-b6c9-e2edfe1b07a7</Id>
     </Book>
-    <Book Series="Black Panther" Number="14" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Black Panther" Number="14" Volume="2016" Year="2017">
       <Id>95ced435-f28f-4635-bc08-659779be75ff</Id>
     </Book>
-    <Book Series="Black Panther" Number="15" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Black Panther" Number="15" Volume="2016" Year="2017">
       <Id>a5f136d1-d019-4b3e-a619-8cac86ba321e</Id>
     </Book>
-    <Book Series="Black Panther" Number="16" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Black Panther" Number="16" Volume="2016" Year="2017">
       <Id>b616a556-6c0f-4f71-bfc3-1ca134cbd886</Id>
     </Book>
-    <Book Series="Black Panther" Number="17" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Black Panther" Number="17" Volume="2016" Year="2017">
       <Id>2aceff22-11a6-4769-95a0-7fe694f5d164</Id>
     </Book>
-    <Book Series="Black Panther" Number="18" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Black Panther" Number="18" Volume="2016" Year="2017">
       <Id>486ba48e-ae3f-46f0-b697-928f5bf59a69</Id>
     </Book>
-    <Book Series="Black Panther: The Sound and the Fury" Number="1" Volume="2018" Year="2018" Format="One-Shot">
+    <Book Series="Black Panther: The Sound and the Fury" Number="1" Volume="2018" Year="2018">
       <Id>03a23f79-4934-42cd-9b69-c27a7b0cb0b8</Id>
     </Book>
-    <Book Series="Black Panther" Number="166" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Black Panther" Number="166" Volume="2016" Year="2017">
       <Id>775e966c-8a6b-4897-9540-3be56e6d404c</Id>
     </Book>
-    <Book Series="Black Panther" Number="167" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Black Panther" Number="167" Volume="2016" Year="2018">
       <Id>0caeb17f-d65e-4265-80a8-9ae9603cc6a0</Id>
     </Book>
-    <Book Series="Black Panther" Number="168" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Black Panther" Number="168" Volume="2016" Year="2018">
       <Id>a9a1cea9-5db3-4b66-af86-cbf0b49134b2</Id>
     </Book>
-    <Book Series="Black Panther" Number="169" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Black Panther" Number="169" Volume="2016" Year="2018">
       <Id>c01f7166-e2f5-426a-8d16-cf839aa9914d</Id>
     </Book>
-    <Book Series="Black Panther" Number="170" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Black Panther" Number="170" Volume="2016" Year="2018">
       <Id>76ad37ac-5178-469c-acc0-111ade6e8e5a</Id>
     </Book>
-    <Book Series="Black Panther" Number="171" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Black Panther" Number="171" Volume="2016" Year="2018">
       <Id>f48cddd3-a1ac-4f44-8889-222a26cb986d</Id>
     </Book>
-    <Book Series="Black Panther" Number="172" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Black Panther" Number="172" Volume="2016" Year="2018">
       <Id>de261830-fd28-4818-a8dd-304c493eb21b</Id>
     </Book>
-    <Book Series="Black Panther" Number="1" Volume="2018" Year="2018" Format="Main Series">
+    <Book Series="Black Panther" Number="1" Volume="2018" Year="2018">
       <Id>6f52aaf4-6fca-4a47-a087-66ce658b205a</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Black Panther/Black Panther 002.cbl
+++ b/Marvel/Characters/unsorted/Black Panther/Black Panther 002.cbl
@@ -1,156 +1,157 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Black Panther 2</Name>
+  <Name>Black Panther 002</Name>
+  <NumIssues>50</NumIssues>
   <Books>
     <Book Series="Rise of the Black Panther" Number="1" Volume="2018" Year="2018">
-      <Id>d50bf679-3839-425c-aa7f-110e00146661</Id>
+      <Database Name="cv" Series="107512" Issue="650923" />
     </Book>
     <Book Series="Rise of the Black Panther" Number="2" Volume="2018" Year="2018">
-      <Id>7acb8d48-940d-48ed-8bcd-c012d55f14e8</Id>
+      <Database Name="cv" Series="107512" Issue="658727" />
     </Book>
     <Book Series="Rise of the Black Panther" Number="3" Volume="2018" Year="2018">
-      <Id>ac92547f-75c5-4214-b10f-0b1239f0e12b</Id>
+      <Database Name="cv" Series="107512" Issue="662093" />
     </Book>
     <Book Series="Rise of the Black Panther" Number="4" Volume="2018" Year="2018">
-      <Id>01af33c2-bb62-4e66-a42b-f9ad4ee53925</Id>
+      <Database Name="cv" Series="107512" Issue="664919" />
     </Book>
     <Book Series="Rise of the Black Panther" Number="5" Volume="2018" Year="2018">
-      <Id>6a1c0def-9dcb-4569-bf17-bfcaf614e24f</Id>
+      <Database Name="cv" Series="107512" Issue="668779" />
     </Book>
     <Book Series="Black Panther" Number="1" Volume="2016" Year="2016">
-      <Id>87f03865-1085-484e-abe3-ff17aff98cbb</Id>
+      <Database Name="cv" Series="89350" Issue="523248" />
     </Book>
     <Book Series="Black Panther" Number="2" Volume="2016" Year="2016">
-      <Id>e53f0690-8d81-4a64-92aa-e94c5385f2a3</Id>
+      <Database Name="cv" Series="89350" Issue="529651" />
     </Book>
     <Book Series="Black Panther" Number="3" Volume="2016" Year="2016">
-      <Id>27d1b4ee-3a3a-4bab-b167-4fa7ccae695a</Id>
+      <Database Name="cv" Series="89350" Issue="537932" />
     </Book>
     <Book Series="Black Panther" Number="4" Volume="2016" Year="2016">
-      <Id>fbaaab96-fedd-400b-877f-3a96656407ba</Id>
+      <Database Name="cv" Series="89350" Issue="541195" />
     </Book>
     <Book Series="Black Panther" Number="5" Volume="2016" Year="2016">
-      <Id>4d620261-db27-4c65-8719-a45184f1b758</Id>
+      <Database Name="cv" Series="89350" Issue="543747" />
     </Book>
     <Book Series="Black Panther" Number="6" Volume="2016" Year="2016">
-      <Id>62dd5cdf-d253-4b99-b7ec-1159613c8f04</Id>
+      <Database Name="cv" Series="89350" Issue="549511" />
     </Book>
     <Book Series="Black Panther" Number="7" Volume="2016" Year="2016">
-      <Id>f4ab8d14-287b-45d5-8f0b-1ea33c98071f</Id>
+      <Database Name="cv" Series="89350" Issue="553947" />
     </Book>
     <Book Series="Black Panther" Number="8" Volume="2016" Year="2017">
-      <Id>cb4e2370-e9ca-46aa-b4bb-3a60a01286a3</Id>
+      <Database Name="cv" Series="89350" Issue="558409" />
     </Book>
     <Book Series="Black Panther" Number="9" Volume="2016" Year="2017">
-      <Id>2ae82bc0-dddb-4c14-8b02-c53ec9ebf21f</Id>
+      <Database Name="cv" Series="89350" Issue="571657" />
     </Book>
     <Book Series="Black Panther" Number="10" Volume="2016" Year="2017">
-      <Id>553d00f0-924e-4aab-9263-8ad20551637a</Id>
+      <Database Name="cv" Series="89350" Issue="578451" />
     </Book>
     <Book Series="Black Panther" Number="11" Volume="2016" Year="2017">
-      <Id>6fc7b95f-c91f-4f19-97e6-ed80bf73c2bc</Id>
+      <Database Name="cv" Series="89350" Issue="582518" />
     </Book>
     <Book Series="Black Panther" Number="12" Volume="2016" Year="2017">
-      <Id>f48ac4eb-d513-4db1-8b4a-ed8a6ae0f2f9</Id>
+      <Database Name="cv" Series="89350" Issue="588556" />
     </Book>
     <Book Series="Black Panther: World of Wakanda" Number="1" Volume="2016" Year="2017">
-      <Id>5d5aad1f-e43d-42f1-981a-7ad2b577c0d4</Id>
+      <Database Name="cv" Series="95579" Issue="557357" />
     </Book>
     <Book Series="Black Panther: World of Wakanda" Number="2" Volume="2016" Year="2017">
-      <Id>52c620e6-c4f6-4498-8f53-b8e77274654f</Id>
+      <Database Name="cv" Series="95579" Issue="569325" />
     </Book>
     <Book Series="Black Panther: World of Wakanda" Number="3" Volume="2016" Year="2017">
-      <Id>abb0acc5-10e8-43a7-acae-e6e6076caec4</Id>
+      <Database Name="cv" Series="95579" Issue="576615" />
     </Book>
     <Book Series="Black Panther: World of Wakanda" Number="4" Volume="2016" Year="2017">
-      <Id>ffdb0394-871c-4daa-aa55-c7496bd12952</Id>
+      <Database Name="cv" Series="95579" Issue="581547" />
     </Book>
     <Book Series="Black Panther: World of Wakanda" Number="5" Volume="2016" Year="2017">
-      <Id>5af8e8bd-362a-43cd-9bba-e53e17dd7031</Id>
+      <Database Name="cv" Series="95579" Issue="587401" />
     </Book>
     <Book Series="Black Panther: World of Wakanda" Number="6" Volume="2016" Year="2017">
-      <Id>c77cd9c9-61fc-43bc-bb89-d843134a6071</Id>
+      <Database Name="cv" Series="95579" Issue="592590" />
     </Book>
-    <Book Series="Black Panther &amp; the Crew" Number="1" Volume="2017" Year="2017">
-      <Id>a6adeb96-e9e4-43f0-a59b-8cd60937b2df</Id>
+    <Book Series="Black Panther and the Crew" Number="1" Volume="2017" Year="2017">
+      <Database Name="cv" Series="100687" Issue="591749" />
     </Book>
-    <Book Series="Black Panther &amp; the Crew" Number="2" Volume="2017" Year="2017">
-      <Id>9449fa91-7b8c-4036-a054-5a94969a4564</Id>
+    <Book Series="Black Panther and the Crew" Number="2" Volume="2017" Year="2017">
+      <Database Name="cv" Series="100687" Issue="594961" />
     </Book>
-    <Book Series="Black Panther &amp; the Crew" Number="3" Volume="2017" Year="2017">
-      <Id>cd80491c-83f6-4765-a419-465281610e05</Id>
+    <Book Series="Black Panther and the Crew" Number="3" Volume="2017" Year="2017">
+      <Database Name="cv" Series="100687" Issue="601787" />
     </Book>
-    <Book Series="Black Panther &amp; the Crew" Number="4" Volume="2017" Year="2017">
-      <Id>f4e38293-4062-41c1-810e-a85dbe7bb212</Id>
+    <Book Series="Black Panther and the Crew" Number="4" Volume="2017" Year="2017">
+      <Database Name="cv" Series="100687" Issue="608238" />
     </Book>
     <Book Series="Black Panther and the Crew" Number="5" Volume="2017" Year="2017">
-      <Id>0a145f10-6c80-4e1d-b29f-f21f218c39ab</Id>
+      <Database Name="cv" Series="100687" Issue="615017" />
     </Book>
     <Book Series="Black Panther and the Crew" Number="6" Volume="2017" Year="2017">
-      <Id>3080da32-a077-46c0-b6f2-2d5bd38d69de</Id>
+      <Database Name="cv" Series="100687" Issue="617835" />
     </Book>
     <Book Series="Black Panther: Long Live the King" Number="1" Volume="2017" Year="2018">
-      <Id>73e1248a-5fbc-49f9-8b97-f541c3efce35</Id>
+      <Database Name="cv" Series="106853" Issue="646181" />
     </Book>
     <Book Series="Black Panther: Long Live the King" Number="2" Volume="2017" Year="2018">
-      <Id>55a4b8d8-9d7a-4521-b571-2ae0adf33e40</Id>
+      <Database Name="cv" Series="106853" Issue="650025" />
     </Book>
     <Book Series="Black Panther: Long Live the King" Number="3" Volume="2017" Year="2018">
-      <Id>67f24fe8-d768-47b1-8bfb-812ee4a89e9c</Id>
+      <Database Name="cv" Series="106853" Issue="652622" />
     </Book>
     <Book Series="Black Panther: Long Live the King" Number="4" Volume="2017" Year="2018">
-      <Id>4f59e7d2-66e8-4090-be00-187c8a6b09b0</Id>
+      <Database Name="cv" Series="106853" Issue="656699" />
     </Book>
     <Book Series="Black Panther: Long Live the King" Number="5" Volume="2017" Year="2018">
-      <Id>6de22813-b6e8-49d6-ae04-bed7e67360a7</Id>
+      <Database Name="cv" Series="106853" Issue="660009" />
     </Book>
     <Book Series="Black Panther: Long Live the King" Number="6" Volume="2017" Year="2018">
-      <Id>88741f3b-5b81-405f-a3e1-3303448ba2e4</Id>
+      <Database Name="cv" Series="106853" Issue="661142" />
     </Book>
     <Book Series="Black Panther" Number="13" Volume="2016" Year="2017">
-      <Id>c005d744-fe8d-4805-b6c9-e2edfe1b07a7</Id>
+      <Database Name="cv" Series="89350" Issue="593251" />
     </Book>
     <Book Series="Black Panther" Number="14" Volume="2016" Year="2017">
-      <Id>95ced435-f28f-4635-bc08-659779be75ff</Id>
+      <Database Name="cv" Series="89350" Issue="597185" />
     </Book>
     <Book Series="Black Panther" Number="15" Volume="2016" Year="2017">
-      <Id>a5f136d1-d019-4b3e-a619-8cac86ba321e</Id>
+      <Database Name="cv" Series="89350" Issue="605107" />
     </Book>
     <Book Series="Black Panther" Number="16" Volume="2016" Year="2017">
-      <Id>b616a556-6c0f-4f71-bfc3-1ca134cbd886</Id>
+      <Database Name="cv" Series="89350" Issue="610518" />
     </Book>
     <Book Series="Black Panther" Number="17" Volume="2016" Year="2017">
-      <Id>2aceff22-11a6-4769-95a0-7fe694f5d164</Id>
+      <Database Name="cv" Series="89350" Issue="617834" />
     </Book>
     <Book Series="Black Panther" Number="18" Volume="2016" Year="2017">
-      <Id>486ba48e-ae3f-46f0-b697-928f5bf59a69</Id>
+      <Database Name="cv" Series="89350" Issue="625300" />
     </Book>
     <Book Series="Black Panther: The Sound and the Fury" Number="1" Volume="2018" Year="2018">
-      <Id>03a23f79-4934-42cd-9b69-c27a7b0cb0b8</Id>
+      <Database Name="cv" Series="108515" Issue="658719" />
     </Book>
     <Book Series="Black Panther" Number="166" Volume="2016" Year="2017">
-      <Id>775e966c-8a6b-4897-9540-3be56e6d404c</Id>
+      <Database Name="cv" Series="89350" Issue="632492" />
     </Book>
     <Book Series="Black Panther" Number="167" Volume="2016" Year="2018">
-      <Id>0caeb17f-d65e-4265-80a8-9ae9603cc6a0</Id>
+      <Database Name="cv" Series="89350" Issue="641398" />
     </Book>
     <Book Series="Black Panther" Number="168" Volume="2016" Year="2018">
-      <Id>a9a1cea9-5db3-4b66-af86-cbf0b49134b2</Id>
+      <Database Name="cv" Series="89350" Issue="649726" />
     </Book>
     <Book Series="Black Panther" Number="169" Volume="2016" Year="2018">
-      <Id>c01f7166-e2f5-426a-8d16-cf839aa9914d</Id>
+      <Database Name="cv" Series="89350" Issue="655500" />
     </Book>
     <Book Series="Black Panther" Number="170" Volume="2016" Year="2018">
-      <Id>76ad37ac-5178-469c-acc0-111ade6e8e5a</Id>
+      <Database Name="cv" Series="89350" Issue="661141" />
     </Book>
     <Book Series="Black Panther" Number="171" Volume="2016" Year="2018">
-      <Id>f48cddd3-a1ac-4f44-8889-222a26cb986d</Id>
+      <Database Name="cv" Series="89350" Issue="664292" />
     </Book>
     <Book Series="Black Panther" Number="172" Volume="2016" Year="2018">
-      <Id>de261830-fd28-4818-a8dd-304c493eb21b</Id>
+      <Database Name="cv" Series="89350" Issue="666801" />
     </Book>
     <Book Series="Black Panther" Number="1" Volume="2018" Year="2018">
-      <Id>6f52aaf4-6fca-4a47-a087-66ce658b205a</Id>
+      <Database Name="cv" Series="111034" Issue="670739" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Captain America/Captain America 001 - Golden Age.cbl
+++ b/Marvel/Characters/unsorted/Captain America/Captain America 001 - Golden Age.cbl
@@ -2,229 +2,229 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Captain America 01 - Golden Age</Name>
   <Books>
-    <Book Series="Marvel Masterworks: Golden Age Captain America" Number="1" Volume="2005" Year="2005" Format="TPB">
+    <Book Series="Marvel Masterworks: Golden Age Captain America" Number="1" Volume="2005" Year="2005">
       <Id>ffdadd89-2f16-4bd3-a875-0e6bc45580c6</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="5" Volume="1941" Year="1941" Format="Main Series">
+    <Book Series="Captain America Comics" Number="5" Volume="1941" Year="1941">
       <Id>d89afda8-8c57-4bd2-a9b1-bbff93ef7920</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="6" Volume="1941" Year="1941" Format="Main Series">
+    <Book Series="Captain America Comics" Number="6" Volume="1941" Year="1941">
       <Id>4a57edb9-c67b-4ac7-94be-7653a2ab7913</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="7" Volume="1941" Year="1941" Format="Main Series">
+    <Book Series="Captain America Comics" Number="7" Volume="1941" Year="1941">
       <Id>e7f602d0-5897-44a0-93bc-531f13bf15b1</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="8" Volume="1941" Year="1941" Format="Main Series">
+    <Book Series="Captain America Comics" Number="8" Volume="1941" Year="1941">
       <Id>ce6f6a96-a1ae-4a00-9706-0d082ae8be48</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="9" Volume="1941" Year="1941" Format="Main Series">
+    <Book Series="Captain America Comics" Number="9" Volume="1941" Year="1941">
       <Id>9dd0591b-7e7f-4481-8cb8-d2cc4b6bf759</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="10" Volume="1941" Year="1942" Format="Main Series">
+    <Book Series="Captain America Comics" Number="10" Volume="1941" Year="1942">
       <Id>ea510281-6df0-494a-9f46-d66a5d38814f</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="11" Volume="1941" Year="1942" Format="Main Series">
+    <Book Series="Captain America Comics" Number="11" Volume="1941" Year="1942">
       <Id>f9da2f2f-8c87-4148-88f3-883538e7e047</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="12" Volume="1941" Year="1942" Format="Main Series">
+    <Book Series="Captain America Comics" Number="12" Volume="1941" Year="1942">
       <Id>9b2d1b03-fb23-40b6-971c-c1d426b4c226</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="13" Volume="1941" Year="1942" Format="Main Series">
+    <Book Series="Captain America Comics" Number="13" Volume="1941" Year="1942">
       <Id>a70c79b2-6d4b-4396-b9e2-959c2c0529ea</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="14" Volume="1941" Year="1942" Format="Main Series">
+    <Book Series="Captain America Comics" Number="14" Volume="1941" Year="1942">
       <Id>ca0e8e6e-88e3-4930-80cc-6ef406f9d198</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="15" Volume="1941" Year="1942" Format="Main Series">
+    <Book Series="Captain America Comics" Number="15" Volume="1941" Year="1942">
       <Id>49c48224-a5a6-47f3-b55d-1c45ce12f78e</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="16" Volume="1941" Year="1942" Format="Main Series">
+    <Book Series="Captain America Comics" Number="16" Volume="1941" Year="1942">
       <Id>a4f4fc73-0639-42ed-95c7-9fbe0a9def8b</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="17" Volume="1941" Year="1942" Format="Main Series">
+    <Book Series="Captain America Comics" Number="17" Volume="1941" Year="1942">
       <Id>7874e280-5059-4f4e-89ab-18cb1912c626</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="18" Volume="1941" Year="1942" Format="Main Series">
+    <Book Series="Captain America Comics" Number="18" Volume="1941" Year="1942">
       <Id>d04680f5-9ecc-42e4-83bc-ab79035ff347</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="19" Volume="1941" Year="1942" Format="Main Series">
+    <Book Series="Captain America Comics" Number="19" Volume="1941" Year="1942">
       <Id>76cb3bbf-a076-441a-aa06-5b1fe67471ea</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="20" Volume="1941" Year="1942" Format="Main Series">
+    <Book Series="Captain America Comics" Number="20" Volume="1941" Year="1942">
       <Id>7993889d-54b9-4bce-a8f9-b9f05ab5dcdf</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="21" Volume="1941" Year="1942" Format="Main Series">
+    <Book Series="Captain America Comics" Number="21" Volume="1941" Year="1942">
       <Id>042d44c9-cb14-44fd-b832-2c7b2ab82ea5</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="22" Volume="1941" Year="1943" Format="Main Series">
+    <Book Series="Captain America Comics" Number="22" Volume="1941" Year="1943">
       <Id>58b31c1a-a436-4d67-a047-c4349f45baff</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="23" Volume="1941" Year="1943" Format="Main Series">
+    <Book Series="Captain America Comics" Number="23" Volume="1941" Year="1943">
       <Id>7d9fd948-512e-43da-b94e-aa1515aadcdc</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="24" Volume="1941" Year="1943" Format="Main Series">
+    <Book Series="Captain America Comics" Number="24" Volume="1941" Year="1943">
       <Id>d976f609-97ba-40e5-8d7b-b19800a5d141</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="25" Volume="1941" Year="1943" Format="Main Series">
+    <Book Series="Captain America Comics" Number="25" Volume="1941" Year="1943">
       <Id>bec3ce3a-4932-4bf8-a880-a41dee457391</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="26" Volume="1941" Year="1943" Format="Main Series">
+    <Book Series="Captain America Comics" Number="26" Volume="1941" Year="1943">
       <Id>9f7547f8-483d-4d5d-9d4c-3a846a50a5a3</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="27" Volume="1941" Year="1943" Format="Main Series">
+    <Book Series="Captain America Comics" Number="27" Volume="1941" Year="1943">
       <Id>aaace06b-842c-4868-b6e8-bc56bf6105b9</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="28" Volume="1941" Year="1943" Format="Main Series">
+    <Book Series="Captain America Comics" Number="28" Volume="1941" Year="1943">
       <Id>73d687da-1708-49a1-b791-a07aa06d9408</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="29" Volume="1941" Year="1943" Format="Main Series">
+    <Book Series="Captain America Comics" Number="29" Volume="1941" Year="1943">
       <Id>2ae1e358-1ff5-4c18-a6e4-6d0ba15ad2dc</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="30" Volume="1941" Year="1943" Format="Main Series">
+    <Book Series="Captain America Comics" Number="30" Volume="1941" Year="1943">
       <Id>2504ed6e-9d82-411b-996b-def57a9aa87f</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="31" Volume="1941" Year="1943" Format="Main Series">
+    <Book Series="Captain America Comics" Number="31" Volume="1941" Year="1943">
       <Id>4baa0d4c-9992-4092-a49b-57c55fabb05a</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="32" Volume="1941" Year="1943" Format="Main Series">
+    <Book Series="Captain America Comics" Number="32" Volume="1941" Year="1943">
       <Id>4dbd2ae1-bbb7-446c-93cc-2c557cb66c98</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="33" Volume="1941" Year="1943" Format="Main Series">
+    <Book Series="Captain America Comics" Number="33" Volume="1941" Year="1943">
       <Id>aae4a5be-aeee-451a-aaaa-c9bb0326f883</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="34" Volume="1941" Year="1944" Format="Main Series">
+    <Book Series="Captain America Comics" Number="34" Volume="1941" Year="1944">
       <Id>6223f3ae-5c5f-4a89-adcb-343f7b01ecf9</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="35" Volume="1941" Year="1944" Format="Main Series">
+    <Book Series="Captain America Comics" Number="35" Volume="1941" Year="1944">
       <Id>d8060b23-acd2-4a6c-b86d-e5a097db0575</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="36" Volume="1941" Year="1944" Format="Main Series">
+    <Book Series="Captain America Comics" Number="36" Volume="1941" Year="1944">
       <Id>bd148b34-293d-4c76-b4f4-cd66b8a9256d</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="37" Volume="1941" Year="1944" Format="Main Series">
+    <Book Series="Captain America Comics" Number="37" Volume="1941" Year="1944">
       <Id>92e09960-96ba-42df-8499-34c8dc848b61</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="38" Volume="1941" Year="1944" Format="Main Series">
+    <Book Series="Captain America Comics" Number="38" Volume="1941" Year="1944">
       <Id>c22227eb-8d2b-4a90-bfea-db25a205e0e1</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="39" Volume="1941" Year="1944" Format="Main Series">
+    <Book Series="Captain America Comics" Number="39" Volume="1941" Year="1944">
       <Id>356d9a36-a305-4aef-abe6-0b713f33133b</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="40" Volume="1941" Year="1944" Format="Main Series">
+    <Book Series="Captain America Comics" Number="40" Volume="1941" Year="1944">
       <Id>f468005e-683e-42b9-a316-0771f9b7d380</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="41" Volume="1941" Year="1944" Format="Main Series">
+    <Book Series="Captain America Comics" Number="41" Volume="1941" Year="1944">
       <Id>7721abf1-5e30-4f90-bbc0-7c755f2c3fae</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="42" Volume="1941" Year="1944" Format="Main Series">
+    <Book Series="Captain America Comics" Number="42" Volume="1941" Year="1944">
       <Id>1f014f41-f726-41df-a2e9-35a81f743fcc</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="43" Volume="1941" Year="1944" Format="Main Series">
+    <Book Series="Captain America Comics" Number="43" Volume="1941" Year="1944">
       <Id>a2e45bb1-6339-48f5-ada3-fc918f4873ed</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="44" Volume="1941" Year="1945" Format="Main Series">
+    <Book Series="Captain America Comics" Number="44" Volume="1941" Year="1945">
       <Id>965f0fc0-e356-4e97-ab0b-e89aaeb082a6</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="45" Volume="1941" Year="1945" Format="Main Series">
+    <Book Series="Captain America Comics" Number="45" Volume="1941" Year="1945">
       <Id>7ce4ac33-71c4-4ea8-9cdc-1f7c065ec26a</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="46" Volume="1941" Year="1945" Format="Main Series">
+    <Book Series="Captain America Comics" Number="46" Volume="1941" Year="1945">
       <Id>882b63f6-5293-403b-9835-64b657e578a7</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="47" Volume="1941" Year="1945" Format="Main Series">
+    <Book Series="Captain America Comics" Number="47" Volume="1941" Year="1945">
       <Id>d7339d45-ab7b-4b49-9be0-408c4f7d9081</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="48" Volume="1941" Year="1945" Format="Main Series">
+    <Book Series="Captain America Comics" Number="48" Volume="1941" Year="1945">
       <Id>9f046067-5d57-4a28-acb8-a04145b25b5d</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="49" Volume="1941" Year="1945" Format="Main Series">
+    <Book Series="Captain America Comics" Number="49" Volume="1941" Year="1945">
       <Id>fcd13d91-5322-476d-ba3c-87f587855812</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="50" Volume="1941" Year="1945" Format="Main Series">
+    <Book Series="Captain America Comics" Number="50" Volume="1941" Year="1945">
       <Id>fa4d4c11-bd2b-488e-ab67-65111e00c34f</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="51" Volume="1941" Year="1945" Format="Main Series">
+    <Book Series="Captain America Comics" Number="51" Volume="1941" Year="1945">
       <Id>2cc06d85-3a76-4517-a5ed-e494ad639605</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="52" Volume="1941" Year="1946" Format="Main Series">
+    <Book Series="Captain America Comics" Number="52" Volume="1941" Year="1946">
       <Id>a6276190-11a4-465d-9913-c661bbe58ef2</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="53" Volume="1941" Year="1946" Format="Main Series">
+    <Book Series="Captain America Comics" Number="53" Volume="1941" Year="1946">
       <Id>9462e12a-7616-4134-bd5a-5dfc4dc28213</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="54" Volume="1941" Year="1946" Format="Main Series">
+    <Book Series="Captain America Comics" Number="54" Volume="1941" Year="1946">
       <Id>1d622718-0552-4d9d-b6ec-bc83d9050baa</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="55" Volume="1941" Year="1946" Format="Main Series">
+    <Book Series="Captain America Comics" Number="55" Volume="1941" Year="1946">
       <Id>f26eae6f-1fe0-4a63-8bce-6ccd73b0fb64</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="56" Volume="1941" Year="1946" Format="Main Series">
+    <Book Series="Captain America Comics" Number="56" Volume="1941" Year="1946">
       <Id>5441f7f8-008a-4208-948a-073e78cb3621</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="57" Volume="1941" Year="1946" Format="Main Series">
+    <Book Series="Captain America Comics" Number="57" Volume="1941" Year="1946">
       <Id>26c46044-15d1-4e13-822a-ed4a5fc51dce</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="58" Volume="1941" Year="1946" Format="Main Series">
+    <Book Series="Captain America Comics" Number="58" Volume="1941" Year="1946">
       <Id>96c6a63d-7154-4595-bfaa-673036b7b8e8</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="59" Volume="1941" Year="1946" Format="Main Series">
+    <Book Series="Captain America Comics" Number="59" Volume="1941" Year="1946">
       <Id>7f28ee09-f19e-418f-969b-ccb69792eed3</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="60" Volume="1941" Year="1947" Format="Main Series">
+    <Book Series="Captain America Comics" Number="60" Volume="1941" Year="1947">
       <Id>7c905532-8d45-4592-bfde-1c79d418a422</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="61" Volume="1941" Year="1947" Format="Main Series">
+    <Book Series="Captain America Comics" Number="61" Volume="1941" Year="1947">
       <Id>4b3bc95f-8b80-471e-b033-95774ae09e43</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="62" Volume="1941" Year="1947" Format="Main Series">
+    <Book Series="Captain America Comics" Number="62" Volume="1941" Year="1947">
       <Id>acd320ec-d030-4116-ac23-ab3682b6d8f1</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="63" Volume="1941" Year="1947" Format="Main Series">
+    <Book Series="Captain America Comics" Number="63" Volume="1941" Year="1947">
       <Id>d7b140bc-ce90-4b92-8135-574c1319254c</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="64" Volume="1941" Year="1947" Format="Main Series">
+    <Book Series="Captain America Comics" Number="64" Volume="1941" Year="1947">
       <Id>24711efc-9198-4e73-90f3-b49f6f6e816e</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="65" Volume="1941" Year="1948" Format="Main Series">
+    <Book Series="Captain America Comics" Number="65" Volume="1941" Year="1948">
       <Id>9ed0771d-d5cf-41ca-ba19-c79c502c0a38</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="66" Volume="1941" Year="1948" Format="Main Series">
+    <Book Series="Captain America Comics" Number="66" Volume="1941" Year="1948">
       <Id>fdfc54d0-f239-4cba-8eb7-985ff6b81dca</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="67" Volume="1941" Year="1948" Format="Main Series">
+    <Book Series="Captain America Comics" Number="67" Volume="1941" Year="1948">
       <Id>d5da8274-7373-4ca0-b943-979b1ea5006a</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="68" Volume="1941" Year="1948" Format="Main Series">
+    <Book Series="Captain America Comics" Number="68" Volume="1941" Year="1948">
       <Id>f3920f8b-0122-44ef-a63e-fcc2539a485b</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="69" Volume="1941" Year="1948" Format="Main Series">
+    <Book Series="Captain America Comics" Number="69" Volume="1941" Year="1948">
       <Id>36815bba-7506-4c36-9be4-be994edc403c</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="70" Volume="1941" Year="1949" Format="Main Series">
+    <Book Series="Captain America Comics" Number="70" Volume="1941" Year="1949">
       <Id>97a4d6d0-30c9-42ff-834f-2ea70495251c</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="71" Volume="1941" Year="1949" Format="Main Series">
+    <Book Series="Captain America Comics" Number="71" Volume="1941" Year="1949">
       <Id>75e8490a-51d9-4665-8caf-f5bb49fd7966</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="72" Volume="1941" Year="1949" Format="Main Series">
+    <Book Series="Captain America Comics" Number="72" Volume="1941" Year="1949">
       <Id>c923dc18-4596-47f5-9651-10f2439606c1</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="73" Volume="1941" Year="1949" Format="Main Series">
+    <Book Series="Captain America Comics" Number="73" Volume="1941" Year="1949">
       <Id>94b02918-852c-427e-8105-4ac814f4e472</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="74" Volume="1941" Year="1949" Format="Main Series">
+    <Book Series="Captain America Comics" Number="74" Volume="1941" Year="1949">
       <Id>b53255a6-3dfe-473c-9060-852801971e73</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="75" Volume="1941" Year="1950" Format="Main Series">
+    <Book Series="Captain America Comics" Number="75" Volume="1941" Year="1950">
       <Id>527f604c-88af-4f37-9883-927c91c77258</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="76" Volume="1941" Year="1954" Format="Main Series">
+    <Book Series="Captain America Comics" Number="76" Volume="1941" Year="1954">
       <Id>e7e79273-3aa2-4a27-b357-e75be25e7f46</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="77" Volume="1941" Year="1954" Format="Main Series">
+    <Book Series="Captain America Comics" Number="77" Volume="1941" Year="1954">
       <Id>a9dfd770-c5e3-4400-b8c5-edcc49fd505d</Id>
     </Book>
-    <Book Series="Captain America Comics" Number="78" Volume="1941" Year="1954" Format="Main Series">
+    <Book Series="Captain America Comics" Number="78" Volume="1941" Year="1954">
       <Id>f8cbf957-3af0-42f8-9422-639cfcfd73dc</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Captain America/Captain America 001 - Golden Age.cbl
+++ b/Marvel/Characters/unsorted/Captain America/Captain America 001 - Golden Age.cbl
@@ -1,231 +1,232 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Captain America 01 - Golden Age</Name>
+  <Name>Captain America 001 - Golden Age</Name>
+  <NumIssues>75</NumIssues>
   <Books>
     <Book Series="Marvel Masterworks: Golden Age Captain America" Number="1" Volume="2005" Year="2005">
-      <Id>ffdadd89-2f16-4bd3-a875-0e6bc45580c6</Id>
+      <Database Name="cv" Series="35186" Issue="234969" />
     </Book>
     <Book Series="Captain America Comics" Number="5" Volume="1941" Year="1941">
-      <Id>d89afda8-8c57-4bd2-a9b1-bbff93ef7920</Id>
+      <Database Name="cv" Series="1628" Issue="117548" />
     </Book>
     <Book Series="Captain America Comics" Number="6" Volume="1941" Year="1941">
-      <Id>4a57edb9-c67b-4ac7-94be-7653a2ab7913</Id>
+      <Database Name="cv" Series="1628" Issue="117549" />
     </Book>
     <Book Series="Captain America Comics" Number="7" Volume="1941" Year="1941">
-      <Id>e7f602d0-5897-44a0-93bc-531f13bf15b1</Id>
+      <Database Name="cv" Series="1628" Issue="117551" />
     </Book>
     <Book Series="Captain America Comics" Number="8" Volume="1941" Year="1941">
-      <Id>ce6f6a96-a1ae-4a00-9706-0d082ae8be48</Id>
+      <Database Name="cv" Series="1628" Issue="117552" />
     </Book>
     <Book Series="Captain America Comics" Number="9" Volume="1941" Year="1941">
-      <Id>9dd0591b-7e7f-4481-8cb8-d2cc4b6bf759</Id>
+      <Database Name="cv" Series="1628" Issue="117553" />
     </Book>
     <Book Series="Captain America Comics" Number="10" Volume="1941" Year="1942">
-      <Id>ea510281-6df0-494a-9f46-d66a5d38814f</Id>
+      <Database Name="cv" Series="1628" Issue="117554" />
     </Book>
     <Book Series="Captain America Comics" Number="11" Volume="1941" Year="1942">
-      <Id>f9da2f2f-8c87-4148-88f3-883538e7e047</Id>
+      <Database Name="cv" Series="1628" Issue="117555" />
     </Book>
     <Book Series="Captain America Comics" Number="12" Volume="1941" Year="1942">
-      <Id>9b2d1b03-fb23-40b6-971c-c1d426b4c226</Id>
+      <Database Name="cv" Series="1628" Issue="117556" />
     </Book>
     <Book Series="Captain America Comics" Number="13" Volume="1941" Year="1942">
-      <Id>a70c79b2-6d4b-4396-b9e2-959c2c0529ea</Id>
+      <Database Name="cv" Series="1628" Issue="117557" />
     </Book>
     <Book Series="Captain America Comics" Number="14" Volume="1941" Year="1942">
-      <Id>ca0e8e6e-88e3-4930-80cc-6ef406f9d198</Id>
+      <Database Name="cv" Series="1628" Issue="117558" />
     </Book>
     <Book Series="Captain America Comics" Number="15" Volume="1941" Year="1942">
-      <Id>49c48224-a5a6-47f3-b55d-1c45ce12f78e</Id>
+      <Database Name="cv" Series="1628" Issue="117559" />
     </Book>
     <Book Series="Captain America Comics" Number="16" Volume="1941" Year="1942">
-      <Id>a4f4fc73-0639-42ed-95c7-9fbe0a9def8b</Id>
+      <Database Name="cv" Series="1628" Issue="117560" />
     </Book>
     <Book Series="Captain America Comics" Number="17" Volume="1941" Year="1942">
-      <Id>7874e280-5059-4f4e-89ab-18cb1912c626</Id>
+      <Database Name="cv" Series="1628" Issue="117561" />
     </Book>
     <Book Series="Captain America Comics" Number="18" Volume="1941" Year="1942">
-      <Id>d04680f5-9ecc-42e4-83bc-ab79035ff347</Id>
+      <Database Name="cv" Series="1628" Issue="117562" />
     </Book>
     <Book Series="Captain America Comics" Number="19" Volume="1941" Year="1942">
-      <Id>76cb3bbf-a076-441a-aa06-5b1fe67471ea</Id>
+      <Database Name="cv" Series="1628" Issue="117563" />
     </Book>
     <Book Series="Captain America Comics" Number="20" Volume="1941" Year="1942">
-      <Id>7993889d-54b9-4bce-a8f9-b9f05ab5dcdf</Id>
+      <Database Name="cv" Series="1628" Issue="117564" />
     </Book>
     <Book Series="Captain America Comics" Number="21" Volume="1941" Year="1942">
-      <Id>042d44c9-cb14-44fd-b832-2c7b2ab82ea5</Id>
+      <Database Name="cv" Series="1628" Issue="117565" />
     </Book>
     <Book Series="Captain America Comics" Number="22" Volume="1941" Year="1943">
-      <Id>58b31c1a-a436-4d67-a047-c4349f45baff</Id>
+      <Database Name="cv" Series="1628" Issue="117566" />
     </Book>
     <Book Series="Captain America Comics" Number="23" Volume="1941" Year="1943">
-      <Id>7d9fd948-512e-43da-b94e-aa1515aadcdc</Id>
+      <Database Name="cv" Series="1628" Issue="117567" />
     </Book>
     <Book Series="Captain America Comics" Number="24" Volume="1941" Year="1943">
-      <Id>d976f609-97ba-40e5-8d7b-b19800a5d141</Id>
+      <Database Name="cv" Series="1628" Issue="117568" />
     </Book>
     <Book Series="Captain America Comics" Number="25" Volume="1941" Year="1943">
-      <Id>bec3ce3a-4932-4bf8-a880-a41dee457391</Id>
+      <Database Name="cv" Series="1628" Issue="117569" />
     </Book>
     <Book Series="Captain America Comics" Number="26" Volume="1941" Year="1943">
-      <Id>9f7547f8-483d-4d5d-9d4c-3a846a50a5a3</Id>
+      <Database Name="cv" Series="1628" Issue="117570" />
     </Book>
     <Book Series="Captain America Comics" Number="27" Volume="1941" Year="1943">
-      <Id>aaace06b-842c-4868-b6e8-bc56bf6105b9</Id>
+      <Database Name="cv" Series="1628" Issue="117573" />
     </Book>
     <Book Series="Captain America Comics" Number="28" Volume="1941" Year="1943">
-      <Id>73d687da-1708-49a1-b791-a07aa06d9408</Id>
+      <Database Name="cv" Series="1628" Issue="117572" />
     </Book>
     <Book Series="Captain America Comics" Number="29" Volume="1941" Year="1943">
-      <Id>2ae1e358-1ff5-4c18-a6e4-6d0ba15ad2dc</Id>
+      <Database Name="cv" Series="1628" Issue="117574" />
     </Book>
     <Book Series="Captain America Comics" Number="30" Volume="1941" Year="1943">
-      <Id>2504ed6e-9d82-411b-996b-def57a9aa87f</Id>
+      <Database Name="cv" Series="1628" Issue="117575" />
     </Book>
     <Book Series="Captain America Comics" Number="31" Volume="1941" Year="1943">
-      <Id>4baa0d4c-9992-4092-a49b-57c55fabb05a</Id>
+      <Database Name="cv" Series="1628" Issue="116381" />
     </Book>
     <Book Series="Captain America Comics" Number="32" Volume="1941" Year="1943">
-      <Id>4dbd2ae1-bbb7-446c-93cc-2c557cb66c98</Id>
+      <Database Name="cv" Series="1628" Issue="130042" />
     </Book>
     <Book Series="Captain America Comics" Number="33" Volume="1941" Year="1943">
-      <Id>aae4a5be-aeee-451a-aaaa-c9bb0326f883</Id>
+      <Database Name="cv" Series="1628" Issue="131815" />
     </Book>
     <Book Series="Captain America Comics" Number="34" Volume="1941" Year="1944">
-      <Id>6223f3ae-5c5f-4a89-adcb-343f7b01ecf9</Id>
+      <Database Name="cv" Series="1628" Issue="134125" />
     </Book>
     <Book Series="Captain America Comics" Number="35" Volume="1941" Year="1944">
-      <Id>d8060b23-acd2-4a6c-b86d-e5a097db0575</Id>
+      <Database Name="cv" Series="1628" Issue="135826" />
     </Book>
     <Book Series="Captain America Comics" Number="36" Volume="1941" Year="1944">
-      <Id>bd148b34-293d-4c76-b4f4-cd66b8a9256d</Id>
+      <Database Name="cv" Series="1628" Issue="135828" />
     </Book>
     <Book Series="Captain America Comics" Number="37" Volume="1941" Year="1944">
-      <Id>92e09960-96ba-42df-8499-34c8dc848b61</Id>
+      <Database Name="cv" Series="1628" Issue="139214" />
     </Book>
     <Book Series="Captain America Comics" Number="38" Volume="1941" Year="1944">
-      <Id>c22227eb-8d2b-4a90-bfea-db25a205e0e1</Id>
+      <Database Name="cv" Series="1628" Issue="139259" />
     </Book>
     <Book Series="Captain America Comics" Number="39" Volume="1941" Year="1944">
-      <Id>356d9a36-a305-4aef-abe6-0b713f33133b</Id>
+      <Database Name="cv" Series="1628" Issue="139592" />
     </Book>
     <Book Series="Captain America Comics" Number="40" Volume="1941" Year="1944">
-      <Id>f468005e-683e-42b9-a316-0771f9b7d380</Id>
+      <Database Name="cv" Series="1628" Issue="140006" />
     </Book>
     <Book Series="Captain America Comics" Number="41" Volume="1941" Year="1944">
-      <Id>7721abf1-5e30-4f90-bbc0-7c755f2c3fae</Id>
+      <Database Name="cv" Series="1628" Issue="140215" />
     </Book>
     <Book Series="Captain America Comics" Number="42" Volume="1941" Year="1944">
-      <Id>1f014f41-f726-41df-a2e9-35a81f743fcc</Id>
+      <Database Name="cv" Series="1628" Issue="140216" />
     </Book>
     <Book Series="Captain America Comics" Number="43" Volume="1941" Year="1944">
-      <Id>a2e45bb1-6339-48f5-ada3-fc918f4873ed</Id>
+      <Database Name="cv" Series="1628" Issue="140226" />
     </Book>
     <Book Series="Captain America Comics" Number="44" Volume="1941" Year="1945">
-      <Id>965f0fc0-e356-4e97-ab0b-e89aaeb082a6</Id>
+      <Database Name="cv" Series="1628" Issue="140011" />
     </Book>
     <Book Series="Captain America Comics" Number="45" Volume="1941" Year="1945">
-      <Id>7ce4ac33-71c4-4ea8-9cdc-1f7c065ec26a</Id>
+      <Database Name="cv" Series="1628" Issue="140237" />
     </Book>
     <Book Series="Captain America Comics" Number="46" Volume="1941" Year="1945">
-      <Id>882b63f6-5293-403b-9835-64b657e578a7</Id>
+      <Database Name="cv" Series="1628" Issue="140228" />
     </Book>
     <Book Series="Captain America Comics" Number="47" Volume="1941" Year="1945">
-      <Id>d7339d45-ab7b-4b49-9be0-408c4f7d9081</Id>
+      <Database Name="cv" Series="1628" Issue="140227" />
     </Book>
     <Book Series="Captain America Comics" Number="48" Volume="1941" Year="1945">
-      <Id>9f046067-5d57-4a28-acb8-a04145b25b5d</Id>
+      <Database Name="cv" Series="1628" Issue="140012" />
     </Book>
     <Book Series="Captain America Comics" Number="49" Volume="1941" Year="1945">
-      <Id>fcd13d91-5322-476d-ba3c-87f587855812</Id>
+      <Database Name="cv" Series="1628" Issue="140014" />
     </Book>
     <Book Series="Captain America Comics" Number="50" Volume="1941" Year="1945">
-      <Id>fa4d4c11-bd2b-488e-ab67-65111e00c34f</Id>
+      <Database Name="cv" Series="1628" Issue="140013" />
     </Book>
     <Book Series="Captain America Comics" Number="51" Volume="1941" Year="1945">
-      <Id>2cc06d85-3a76-4517-a5ed-e494ad639605</Id>
+      <Database Name="cv" Series="1628" Issue="140238" />
     </Book>
     <Book Series="Captain America Comics" Number="52" Volume="1941" Year="1946">
-      <Id>a6276190-11a4-465d-9913-c661bbe58ef2</Id>
+      <Database Name="cv" Series="1628" Issue="140229" />
     </Book>
     <Book Series="Captain America Comics" Number="53" Volume="1941" Year="1946">
-      <Id>9462e12a-7616-4134-bd5a-5dfc4dc28213</Id>
+      <Database Name="cv" Series="1628" Issue="140235" />
     </Book>
     <Book Series="Captain America Comics" Number="54" Volume="1941" Year="1946">
-      <Id>1d622718-0552-4d9d-b6ec-bc83d9050baa</Id>
+      <Database Name="cv" Series="1628" Issue="116382" />
     </Book>
     <Book Series="Captain America Comics" Number="55" Volume="1941" Year="1946">
-      <Id>f26eae6f-1fe0-4a63-8bce-6ccd73b0fb64</Id>
+      <Database Name="cv" Series="1628" Issue="140239" />
     </Book>
     <Book Series="Captain America Comics" Number="56" Volume="1941" Year="1946">
-      <Id>5441f7f8-008a-4208-948a-073e78cb3621</Id>
+      <Database Name="cv" Series="1628" Issue="140236" />
     </Book>
     <Book Series="Captain America Comics" Number="57" Volume="1941" Year="1946">
-      <Id>26c46044-15d1-4e13-822a-ed4a5fc51dce</Id>
+      <Database Name="cv" Series="1628" Issue="140234" />
     </Book>
     <Book Series="Captain America Comics" Number="58" Volume="1941" Year="1946">
-      <Id>96c6a63d-7154-4595-bfaa-673036b7b8e8</Id>
+      <Database Name="cv" Series="1628" Issue="140233" />
     </Book>
     <Book Series="Captain America Comics" Number="59" Volume="1941" Year="1946">
-      <Id>7f28ee09-f19e-418f-969b-ccb69792eed3</Id>
+      <Database Name="cv" Series="1628" Issue="140232" />
     </Book>
     <Book Series="Captain America Comics" Number="60" Volume="1941" Year="1947">
-      <Id>7c905532-8d45-4592-bfde-1c79d418a422</Id>
+      <Database Name="cv" Series="1628" Issue="140010" />
     </Book>
     <Book Series="Captain America Comics" Number="61" Volume="1941" Year="1947">
-      <Id>4b3bc95f-8b80-471e-b033-95774ae09e43</Id>
+      <Database Name="cv" Series="1628" Issue="116383" />
     </Book>
     <Book Series="Captain America Comics" Number="62" Volume="1941" Year="1947">
-      <Id>acd320ec-d030-4116-ac23-ab3682b6d8f1</Id>
+      <Database Name="cv" Series="1628" Issue="140007" />
     </Book>
     <Book Series="Captain America Comics" Number="63" Volume="1941" Year="1947">
-      <Id>d7b140bc-ce90-4b92-8135-574c1319254c</Id>
+      <Database Name="cv" Series="1628" Issue="116384" />
     </Book>
     <Book Series="Captain America Comics" Number="64" Volume="1941" Year="1947">
-      <Id>24711efc-9198-4e73-90f3-b49f6f6e816e</Id>
+      <Database Name="cv" Series="1628" Issue="140003" />
     </Book>
     <Book Series="Captain America Comics" Number="65" Volume="1941" Year="1948">
-      <Id>9ed0771d-d5cf-41ca-ba19-c79c502c0a38</Id>
+      <Database Name="cv" Series="1628" Issue="140004" />
     </Book>
     <Book Series="Captain America Comics" Number="66" Volume="1941" Year="1948">
-      <Id>fdfc54d0-f239-4cba-8eb7-985ff6b81dca</Id>
+      <Database Name="cv" Series="1628" Issue="140005" />
     </Book>
     <Book Series="Captain America Comics" Number="67" Volume="1941" Year="1948">
-      <Id>d5da8274-7373-4ca0-b943-979b1ea5006a</Id>
+      <Database Name="cv" Series="1628" Issue="116385" />
     </Book>
     <Book Series="Captain America Comics" Number="68" Volume="1941" Year="1948">
-      <Id>f3920f8b-0122-44ef-a63e-fcc2539a485b</Id>
+      <Database Name="cv" Series="1628" Issue="140008" />
     </Book>
     <Book Series="Captain America Comics" Number="69" Volume="1941" Year="1948">
-      <Id>36815bba-7506-4c36-9be4-be994edc403c</Id>
+      <Database Name="cv" Series="1628" Issue="140009" />
     </Book>
     <Book Series="Captain America Comics" Number="70" Volume="1941" Year="1949">
-      <Id>97a4d6d0-30c9-42ff-834f-2ea70495251c</Id>
+      <Database Name="cv" Series="1628" Issue="140217" />
     </Book>
     <Book Series="Captain America Comics" Number="71" Volume="1941" Year="1949">
-      <Id>75e8490a-51d9-4665-8caf-f5bb49fd7966</Id>
+      <Database Name="cv" Series="1628" Issue="140218" />
     </Book>
     <Book Series="Captain America Comics" Number="72" Volume="1941" Year="1949">
-      <Id>c923dc18-4596-47f5-9651-10f2439606c1</Id>
+      <Database Name="cv" Series="1628" Issue="140219" />
     </Book>
     <Book Series="Captain America Comics" Number="73" Volume="1941" Year="1949">
-      <Id>94b02918-852c-427e-8105-4ac814f4e472</Id>
+      <Database Name="cv" Series="1628" Issue="140220" />
     </Book>
-    <Book Series="Captain America Comics" Number="74" Volume="1941" Year="1949">
-      <Id>b53255a6-3dfe-473c-9060-852801971e73</Id>
+    <Book Series="Captain America's Weird Tales" Number="74" Volume="1949" Year="1949">
+      <Database Name="cv" Series="51066" Issue="140224" />
     </Book>
-    <Book Series="Captain America Comics" Number="75" Volume="1941" Year="1950">
-      <Id>527f604c-88af-4f37-9883-927c91c77258</Id>
+    <Book Series="Captain America's Weird Tales" Number="75" Volume="1949" Year="1950">
+      <Database Name="cv" Series="51066" Issue="140225" />
     </Book>
-    <Book Series="Captain America Comics" Number="76" Volume="1941" Year="1954">
-      <Id>e7e79273-3aa2-4a27-b357-e75be25e7f46</Id>
+    <Book Series="Captain America" Number="76" Volume="1954" Year="1954">
+      <Database Name="cv" Series="98973" Issue="1060" />
     </Book>
-    <Book Series="Captain America Comics" Number="77" Volume="1941" Year="1954">
-      <Id>a9dfd770-c5e3-4400-b8c5-edcc49fd505d</Id>
+    <Book Series="Captain America" Number="77" Volume="1954" Year="1954">
+      <Database Name="cv" Series="98973" Issue="1246" />
     </Book>
-    <Book Series="Captain America Comics" Number="78" Volume="1941" Year="1954">
-      <Id>f8cbf957-3af0-42f8-9422-639cfcfd73dc</Id>
+    <Book Series="Captain America" Number="78" Volume="1954" Year="1954">
+      <Database Name="cv" Series="98973" Issue="1348" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Captain America/Captain America 002 - Silver Age.cbl
+++ b/Marvel/Characters/unsorted/Captain America/Captain America 002 - Silver Age.cbl
@@ -1,768 +1,769 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Captain America 02 - Silver Age</Name>
+  <Name>Captain America 002 - Silver Age</Name>
+  <NumIssues>254</NumIssues>
   <Books>
     <Book Series="The Avengers" Number="4" Volume="1963" Year="1964">
-      <Id>dec8c37d-594f-472b-9591-af96358b1272</Id>
+      <Database Name="cv" Series="2128" Issue="7025" />
     </Book>
     <Book Series="Tales of Suspense" Number="58" Volume="1959" Year="1964">
-      <Id>1ae3330c-0219-413d-800f-1bbd557b545c</Id>
+      <Database Name="cv" Series="2007" Issue="7377" />
     </Book>
     <Book Series="Tales of Suspense" Number="59" Volume="1959" Year="1964">
-      <Id>862229f9-067e-4945-9bc0-e20769adf52d</Id>
+      <Database Name="cv" Series="2007" Issue="7429" />
     </Book>
     <Book Series="Tales of Suspense" Number="60" Volume="1959" Year="1964">
-      <Id>27de895c-a9f8-45ee-ba32-90a33a3938e4</Id>
+      <Database Name="cv" Series="2007" Issue="7489" />
     </Book>
     <Book Series="Tales of Suspense" Number="61" Volume="1959" Year="1965">
-      <Id>ad3a5d9a-2086-4447-b27f-2d9c841f7999</Id>
+      <Database Name="cv" Series="2007" Issue="7557" />
     </Book>
     <Book Series="Tales of Suspense" Number="62" Volume="1959" Year="1965">
-      <Id>1c0beb5b-1313-4056-95f3-7680695ff79d</Id>
+      <Database Name="cv" Series="2007" Issue="7615" />
     </Book>
     <Book Series="Tales of Suspense" Number="63" Volume="1959" Year="1965">
-      <Id>9e0a29a6-4380-4ded-a114-d292bd6f98c2</Id>
+      <Database Name="cv" Series="2007" Issue="7672" />
     </Book>
     <Book Series="Tales of Suspense" Number="64" Volume="1959" Year="1965">
-      <Id>2d70519a-a7ce-403b-b7b0-8c685113a17e</Id>
+      <Database Name="cv" Series="2007" Issue="7731" />
     </Book>
     <Book Series="Tales of Suspense" Number="65" Volume="1959" Year="1965">
-      <Id>dd9b3d2b-d413-4f22-9145-bb9a7afdce37</Id>
+      <Database Name="cv" Series="2007" Issue="7780" />
     </Book>
     <Book Series="Tales of Suspense" Number="66" Volume="1959" Year="1965">
-      <Id>793b7cd8-8767-4fa5-9f7b-ef5d4c1db026</Id>
+      <Database Name="cv" Series="2007" Issue="7842" />
     </Book>
     <Book Series="Tales of Suspense" Number="67" Volume="1959" Year="1965">
-      <Id>441709b0-aa48-473f-9f33-bd286ad040b1</Id>
+      <Database Name="cv" Series="2007" Issue="7898" />
     </Book>
     <Book Series="Tales of Suspense" Number="68" Volume="1959" Year="1965">
-      <Id>1e4257b5-6848-49ba-8151-0f0fb64ed4e7</Id>
+      <Database Name="cv" Series="2007" Issue="7966" />
     </Book>
     <Book Series="Tales of Suspense" Number="69" Volume="1959" Year="1965">
-      <Id>ee52466c-12e1-4b62-8805-19c4157973f0</Id>
+      <Database Name="cv" Series="2007" Issue="8035" />
     </Book>
     <Book Series="Tales of Suspense" Number="70" Volume="1959" Year="1965">
-      <Id>a36d043e-a787-4dbc-826c-d5ec5d7c1fc6</Id>
+      <Database Name="cv" Series="2007" Issue="8108" />
     </Book>
     <Book Series="Tales of Suspense" Number="71" Volume="1959" Year="1965">
-      <Id>087ea7ea-3f0c-42bc-a1c3-b2b02e5e4dfa</Id>
+      <Database Name="cv" Series="2007" Issue="8168" />
     </Book>
     <Book Series="Tales of Suspense" Number="72" Volume="1959" Year="1965">
-      <Id>0c2d7a7f-12ca-44a9-acd0-92912a087f95</Id>
+      <Database Name="cv" Series="2007" Issue="8236" />
     </Book>
     <Book Series="Tales of Suspense" Number="73" Volume="1959" Year="1966">
-      <Id>828f82c8-020b-4bbe-9a9a-c3fbf5318ec3</Id>
+      <Database Name="cv" Series="2007" Issue="8313" />
     </Book>
     <Book Series="Tales of Suspense" Number="74" Volume="1959" Year="1966">
-      <Id>a986423d-03c9-43e8-97e6-f327788d12d3</Id>
+      <Database Name="cv" Series="2007" Issue="8373" />
     </Book>
     <Book Series="Tales of Suspense" Number="75" Volume="1959" Year="1966">
-      <Id>1e4166aa-38fa-475a-ac9c-515e8841a4a9</Id>
+      <Database Name="cv" Series="2007" Issue="8432" />
     </Book>
     <Book Series="Tales of Suspense" Number="76" Volume="1959" Year="1966">
-      <Id>e19c103d-6d2f-4115-b8c1-d3532c73ef43</Id>
+      <Database Name="cv" Series="2007" Issue="8495" />
     </Book>
     <Book Series="Tales of Suspense" Number="77" Volume="1959" Year="1966">
-      <Id>47cfd66a-5805-43f0-a1fb-b770d5e44ff9</Id>
+      <Database Name="cv" Series="2007" Issue="8550" />
     </Book>
     <Book Series="Tales of Suspense" Number="78" Volume="1959" Year="1966">
-      <Id>def328d0-6232-4777-8888-5dca23ef28dd</Id>
+      <Database Name="cv" Series="2007" Issue="8618" />
     </Book>
     <Book Series="Tales of Suspense" Number="79" Volume="1959" Year="1966">
-      <Id>37979fb2-8150-49e1-bebd-0d454b27766b</Id>
+      <Database Name="cv" Series="2007" Issue="8671" />
     </Book>
     <Book Series="Tales of Suspense" Number="80" Volume="1959" Year="1966">
-      <Id>53a2b6eb-651f-48a1-8c22-d113caca55de</Id>
+      <Database Name="cv" Series="2007" Issue="8737" />
     </Book>
     <Book Series="Tales of Suspense" Number="81" Volume="1959" Year="1966">
-      <Id>b3f73966-d4c9-4dfc-899c-a20b960d8235</Id>
+      <Database Name="cv" Series="2007" Issue="8815" />
     </Book>
     <Book Series="Tales of Suspense" Number="82" Volume="1959" Year="1966">
-      <Id>b7727770-5a4b-474e-bacd-aeccbdc5f80d</Id>
+      <Database Name="cv" Series="2007" Issue="8882" />
     </Book>
     <Book Series="Tales of Suspense" Number="83" Volume="1959" Year="1966">
-      <Id>f40da68d-3adf-4848-81ad-0e23f6e55fb6</Id>
+      <Database Name="cv" Series="2007" Issue="8948" />
     </Book>
     <Book Series="Tales of Suspense" Number="84" Volume="1959" Year="1966">
-      <Id>62a3d223-b0b3-445c-a136-623c490b1f14</Id>
+      <Database Name="cv" Series="2007" Issue="9022" />
     </Book>
     <Book Series="Tales of Suspense" Number="85" Volume="1959" Year="1967">
-      <Id>8a6435b0-10c8-415c-afdb-e4ac7f22e75c</Id>
+      <Database Name="cv" Series="2007" Issue="9095" />
     </Book>
     <Book Series="Tales of Suspense" Number="86" Volume="1959" Year="1967">
-      <Id>eaf3a486-b4c1-4086-92aa-36ce73f3b773</Id>
+      <Database Name="cv" Series="2007" Issue="9159" />
     </Book>
     <Book Series="Tales of Suspense" Number="87" Volume="1959" Year="1967">
-      <Id>a1fe0f02-e1dc-4de1-88a3-d38ef65e323b</Id>
+      <Database Name="cv" Series="2007" Issue="9231" />
     </Book>
     <Book Series="Tales of Suspense" Number="88" Volume="1959" Year="1967">
-      <Id>05a78ee3-ff1f-4bce-aecb-1722fe6bf5cc</Id>
+      <Database Name="cv" Series="2007" Issue="9299" />
     </Book>
     <Book Series="Tales of Suspense" Number="89" Volume="1959" Year="1967">
-      <Id>77c42367-0525-4ddc-a983-79ece40f5be8</Id>
+      <Database Name="cv" Series="2007" Issue="9361" />
     </Book>
     <Book Series="Tales of Suspense" Number="90" Volume="1959" Year="1967">
-      <Id>b406241d-7af3-4fc2-bf6e-ede51a9a2b9e</Id>
+      <Database Name="cv" Series="2007" Issue="9431" />
     </Book>
     <Book Series="Tales of Suspense" Number="91" Volume="1959" Year="1967">
-      <Id>5f3023c3-94ee-49cd-8374-8df42ec702bf</Id>
+      <Database Name="cv" Series="2007" Issue="9490" />
     </Book>
     <Book Series="Tales of Suspense" Number="92" Volume="1959" Year="1967">
-      <Id>e772f92e-8d7a-452e-be69-f84db0c9e12d</Id>
+      <Database Name="cv" Series="2007" Issue="9562" />
     </Book>
     <Book Series="Tales of Suspense" Number="93" Volume="1959" Year="1967">
-      <Id>f154eb9a-7193-4e3a-940b-5d3fae2a2df1</Id>
+      <Database Name="cv" Series="2007" Issue="9622" />
     </Book>
     <Book Series="Tales of Suspense" Number="94" Volume="1959" Year="1967">
-      <Id>594f9453-88e8-4998-a1cd-489466de92c1</Id>
+      <Database Name="cv" Series="2007" Issue="9692" />
     </Book>
     <Book Series="Tales of Suspense" Number="95" Volume="1959" Year="1967">
-      <Id>cf4fb303-4426-4fd4-812b-158ff76e1ad7</Id>
+      <Database Name="cv" Series="2007" Issue="9760" />
     </Book>
     <Book Series="Tales of Suspense" Number="96" Volume="1959" Year="1967">
-      <Id>3c152bc0-f378-42be-b156-c9af19afa984</Id>
+      <Database Name="cv" Series="2007" Issue="9822" />
     </Book>
     <Book Series="Tales of Suspense" Number="97" Volume="1959" Year="1968">
-      <Id>44aecc2f-d5a0-47c1-82d8-3c51282263d7</Id>
+      <Database Name="cv" Series="2007" Issue="9885" />
     </Book>
     <Book Series="Tales of Suspense" Number="98" Volume="1959" Year="1968">
-      <Id>57e2afdc-4be8-42cf-91b9-c44a3cb6a594</Id>
+      <Database Name="cv" Series="2007" Issue="9942" />
     </Book>
     <Book Series="Tales of Suspense" Number="99" Volume="1959" Year="1968">
-      <Id>27f09aae-f80b-4e78-98c8-25f5e4f7caad</Id>
+      <Database Name="cv" Series="2007" Issue="108988" />
     </Book>
     <Book Series="Captain America" Number="100" Volume="1968" Year="1968">
-      <Id>8e3e1473-ffb5-4155-8976-860af2dba80c</Id>
+      <Database Name="cv" Series="2400" Issue="105481" />
     </Book>
     <Book Series="Captain America" Number="101" Volume="1968" Year="1968">
-      <Id>f4fc816b-8aa9-426d-89bd-c9d4b233cbbf</Id>
+      <Database Name="cv" Series="2400" Issue="109141" />
     </Book>
     <Book Series="Captain America" Number="102" Volume="1968" Year="1968">
-      <Id>81e4a97a-5798-44f1-b1e3-5af7d99ecb95</Id>
+      <Database Name="cv" Series="2400" Issue="109142" />
     </Book>
     <Book Series="Captain America" Number="103" Volume="1968" Year="1968">
-      <Id>6eebd40e-ff6e-4f18-abba-e12b81aa9b62</Id>
+      <Database Name="cv" Series="2400" Issue="109143" />
     </Book>
     <Book Series="Captain America" Number="104" Volume="1968" Year="1968">
-      <Id>ff5b8c52-7123-4b33-8eb5-7944ec0be70f</Id>
+      <Database Name="cv" Series="2400" Issue="109144" />
     </Book>
     <Book Series="Captain America" Number="105" Volume="1968" Year="1968">
-      <Id>b4f74d47-4473-4afb-a523-f3a464c3af85</Id>
+      <Database Name="cv" Series="2400" Issue="109145" />
     </Book>
     <Book Series="Captain America" Number="106" Volume="1968" Year="1968">
-      <Id>c4a721dd-8169-42f3-a070-2d27fadd849d</Id>
+      <Database Name="cv" Series="2400" Issue="109146" />
     </Book>
     <Book Series="Captain America" Number="107" Volume="1968" Year="1968">
-      <Id>33a1d507-0539-4c8a-8f7d-74498439df20</Id>
+      <Database Name="cv" Series="2400" Issue="109147" />
     </Book>
     <Book Series="Captain America" Number="108" Volume="1968" Year="1968">
-      <Id>4bd4bb1e-0bb5-41e3-807a-04c5db44afc9</Id>
+      <Database Name="cv" Series="2400" Issue="109148" />
     </Book>
     <Book Series="Captain America" Number="109" Volume="1968" Year="1969">
-      <Id>2488b420-e8a1-4f37-86ef-1be6215d6f2a</Id>
+      <Database Name="cv" Series="2400" Issue="9988" />
     </Book>
     <Book Series="Captain America" Number="110" Volume="1968" Year="1969">
-      <Id>cfc22586-6ca9-4434-b103-9507e40e11d4</Id>
+      <Database Name="cv" Series="2400" Issue="10040" />
     </Book>
     <Book Series="Captain America" Number="111" Volume="1968" Year="1969">
-      <Id>f35b7c52-d469-401b-9292-09792493dcbc</Id>
+      <Database Name="cv" Series="2400" Issue="10093" />
     </Book>
     <Book Series="Captain America" Number="112" Volume="1968" Year="1969">
-      <Id>4122fec1-2d01-4ff7-bd58-abbdc609e23b</Id>
+      <Database Name="cv" Series="2400" Issue="10148" />
     </Book>
     <Book Series="Captain America" Number="113" Volume="1968" Year="1969">
-      <Id>ee62775e-7927-458c-96da-72c1c263632d</Id>
+      <Database Name="cv" Series="2400" Issue="10200" />
     </Book>
     <Book Series="Captain America" Number="114" Volume="1968" Year="1969">
-      <Id>f7f78372-26e6-4adc-8365-483af9379104</Id>
+      <Database Name="cv" Series="2400" Issue="10259" />
     </Book>
     <Book Series="Captain America" Number="115" Volume="1968" Year="1969">
-      <Id>eeccb5d9-bf3e-44ae-8772-8cfec65936c7</Id>
+      <Database Name="cv" Series="2400" Issue="10304" />
     </Book>
     <Book Series="Captain America" Number="116" Volume="1968" Year="1969">
-      <Id>1f012716-6206-4c59-ac29-2b0e2b3466a4</Id>
+      <Database Name="cv" Series="2400" Issue="10354" />
     </Book>
     <Book Series="Captain America" Number="117" Volume="1968" Year="1969">
-      <Id>0c54ff7a-3464-4727-9481-67f55ebb75e4</Id>
+      <Database Name="cv" Series="2400" Issue="10402" />
     </Book>
     <Book Series="Captain America" Number="118" Volume="1968" Year="1969">
-      <Id>e90b39f1-eca0-4416-b175-5bee337d40bd</Id>
+      <Database Name="cv" Series="2400" Issue="10463" />
     </Book>
     <Book Series="Captain America" Number="119" Volume="1968" Year="1969">
-      <Id>7db7f728-0b68-48db-bb3e-983a298c2c04</Id>
+      <Database Name="cv" Series="2400" Issue="10508" />
     </Book>
     <Book Series="Captain America" Number="120" Volume="1968" Year="1969">
-      <Id>e77368cf-0dec-4596-a5cc-a6fdd41f1a92</Id>
+      <Database Name="cv" Series="2400" Issue="10568" />
     </Book>
     <Book Series="Captain America" Number="121" Volume="1968" Year="1970">
-      <Id>240eb03d-c4a4-44c8-9fe8-5e981c024a01</Id>
+      <Database Name="cv" Series="2400" Issue="10618" />
     </Book>
     <Book Series="Captain America" Number="122" Volume="1968" Year="1970">
-      <Id>ce927f5d-8786-4a6c-b9b6-69c501f1139b</Id>
+      <Database Name="cv" Series="2400" Issue="10664" />
     </Book>
     <Book Series="Captain America" Number="123" Volume="1968" Year="1970">
-      <Id>4e6b4751-0798-46e9-9722-456ed273d81a</Id>
+      <Database Name="cv" Series="2400" Issue="10709" />
     </Book>
     <Book Series="Captain America" Number="124" Volume="1968" Year="1970">
-      <Id>f27b8c3e-aee7-4115-ad75-f3e77fa2cc0a</Id>
+      <Database Name="cv" Series="2400" Issue="10755" />
     </Book>
     <Book Series="Captain America" Number="125" Volume="1968" Year="1970">
-      <Id>7d9fcd4f-b383-4e4b-9d37-9e35d9a5633d</Id>
+      <Database Name="cv" Series="2400" Issue="10801" />
     </Book>
     <Book Series="Captain America" Number="126" Volume="1968" Year="1970">
-      <Id>7fd70ad2-1644-44d6-bdc6-75b4f852dba6</Id>
+      <Database Name="cv" Series="2400" Issue="10854" />
     </Book>
     <Book Series="Captain America" Number="127" Volume="1968" Year="1970">
-      <Id>b2fd5498-af95-4476-a457-518f92db28c5</Id>
+      <Database Name="cv" Series="2400" Issue="10897" />
     </Book>
     <Book Series="Captain America" Number="128" Volume="1968" Year="1970">
-      <Id>9e44d095-0275-48b8-bdb5-8e1172d62898</Id>
+      <Database Name="cv" Series="2400" Issue="10950" />
     </Book>
     <Book Series="Captain America" Number="129" Volume="1968" Year="1970">
-      <Id>1f78b265-7747-4fe1-8eb1-683bfd8579da</Id>
+      <Database Name="cv" Series="2400" Issue="11003" />
     </Book>
     <Book Series="Captain America" Number="130" Volume="1968" Year="1970">
-      <Id>2168b14c-2b86-4627-934a-f7dcd5a243b7</Id>
+      <Database Name="cv" Series="2400" Issue="11050" />
     </Book>
     <Book Series="Captain America" Number="131" Volume="1968" Year="1970">
-      <Id>28369d2c-82bd-4204-ac8e-951651e659d3</Id>
+      <Database Name="cv" Series="2400" Issue="11097" />
     </Book>
     <Book Series="Captain America" Number="132" Volume="1968" Year="1970">
-      <Id>7cf1c6fc-8ebe-4126-81d4-7b611f596fb1</Id>
+      <Database Name="cv" Series="2400" Issue="11153" />
     </Book>
     <Book Series="Captain America" Number="133" Volume="1968" Year="1971">
-      <Id>f6722501-084b-4db8-9d50-08d8e3fb98e7</Id>
+      <Database Name="cv" Series="2400" Issue="11217" />
     </Book>
     <Book Series="Captain America" Number="134" Volume="1968" Year="1971">
-      <Id>eb81abdc-79e8-49c3-8178-252df20ed54e</Id>
+      <Database Name="cv" Series="2400" Issue="11274" />
     </Book>
     <Book Series="Captain America" Number="135" Volume="1968" Year="1971">
-      <Id>b814e7e9-e68b-4444-879c-6ea4478cbd88</Id>
+      <Database Name="cv" Series="2400" Issue="11322" />
     </Book>
     <Book Series="Captain America" Number="136" Volume="1968" Year="1971">
-      <Id>4e89f44f-f65d-4693-9b1d-7d3dcbb42ef0</Id>
+      <Database Name="cv" Series="2400" Issue="11377" />
     </Book>
     <Book Series="Captain America" Number="137" Volume="1968" Year="1971">
-      <Id>a21f8360-7d93-429b-9bbc-5b75b5a33aa6</Id>
+      <Database Name="cv" Series="2400" Issue="11426" />
     </Book>
     <Book Series="Captain America" Number="138" Volume="1968" Year="1971">
-      <Id>fee38c06-414e-4784-b7fb-81b3bec286c0</Id>
+      <Database Name="cv" Series="2400" Issue="11486" />
     </Book>
     <Book Series="Captain America" Number="139" Volume="1968" Year="1971">
-      <Id>3f014f05-97de-4a08-8c18-ccd02dd790ea</Id>
+      <Database Name="cv" Series="2400" Issue="11540" />
     </Book>
     <Book Series="Captain America" Number="140" Volume="1968" Year="1971">
-      <Id>1fdc85cf-fa00-455a-a424-b589d31d4abd</Id>
+      <Database Name="cv" Series="2400" Issue="11600" />
     </Book>
     <Book Series="Captain America" Number="141" Volume="1968" Year="1971">
-      <Id>693af861-c1bb-45bf-89e6-e08c52d848ec</Id>
+      <Database Name="cv" Series="2400" Issue="11659" />
     </Book>
     <Book Series="Captain America" Number="142" Volume="1968" Year="1971">
-      <Id>a6c00a0c-19d8-4db1-abe9-bf2da88ee364</Id>
+      <Database Name="cv" Series="2400" Issue="11719" />
     </Book>
     <Book Series="Captain America" Number="143" Volume="1968" Year="1971">
-      <Id>95161bbc-7b08-4c36-8356-dfe3bc0ed3e6</Id>
+      <Database Name="cv" Series="2400" Issue="11778" />
     </Book>
     <Book Series="Captain America" Number="144" Volume="1968" Year="1971">
-      <Id>1b45a7d9-2061-4664-a26a-d6309f1d626a</Id>
+      <Database Name="cv" Series="2400" Issue="11841" />
     </Book>
     <Book Series="Captain America" Number="145" Volume="1968" Year="1972">
-      <Id>56ea9081-9a3a-48c2-a2d9-4d3e7c50ced1</Id>
+      <Database Name="cv" Series="2400" Issue="11919" />
     </Book>
     <Book Series="Captain America" Number="146" Volume="1968" Year="1972">
-      <Id>a718528b-3b0c-4b24-98df-bdc5b82de644</Id>
+      <Database Name="cv" Series="2400" Issue="11990" />
     </Book>
     <Book Series="Captain America" Number="147" Volume="1968" Year="1972">
-      <Id>85e4d018-8792-4c18-a5e0-2378504f68f5</Id>
+      <Database Name="cv" Series="2400" Issue="12049" />
     </Book>
     <Book Series="Captain America" Number="148" Volume="1968" Year="1972">
-      <Id>814ef044-11ca-4359-9b51-34b866b2183c</Id>
+      <Database Name="cv" Series="2400" Issue="12120" />
     </Book>
     <Book Series="Captain America" Number="149" Volume="1968" Year="1972">
-      <Id>f1deed5b-6091-413e-ae48-1952614a2b0c</Id>
+      <Database Name="cv" Series="2400" Issue="12184" />
     </Book>
     <Book Series="Captain America" Number="150" Volume="1968" Year="1972">
-      <Id>ea96045a-db66-488e-85d3-8e5bffc82c95</Id>
+      <Database Name="cv" Series="2400" Issue="12261" />
     </Book>
     <Book Series="Captain America" Number="151" Volume="1968" Year="1972">
-      <Id>37c39f70-451a-48ff-8ee3-c11d643db9bd</Id>
+      <Database Name="cv" Series="2400" Issue="12334" />
     </Book>
     <Book Series="Captain America" Number="152" Volume="1968" Year="1972">
-      <Id>8c620529-e047-4e10-b18d-fd5e9add8b93</Id>
+      <Database Name="cv" Series="2400" Issue="12412" />
     </Book>
     <Book Series="Captain America" Number="153" Volume="1968" Year="1972">
-      <Id>0fe8420a-755b-49ae-854f-3a964b6d3f02</Id>
+      <Database Name="cv" Series="2400" Issue="12475" />
     </Book>
     <Book Series="Captain America" Number="154" Volume="1968" Year="1972">
-      <Id>3ec7a28a-e882-410b-9aeb-bac332cbeffe</Id>
+      <Database Name="cv" Series="2400" Issue="12566" />
     </Book>
     <Book Series="Captain America" Number="155" Volume="1968" Year="1972">
-      <Id>0a30ad7b-32b2-43ce-91c9-f3435961619e</Id>
+      <Database Name="cv" Series="2400" Issue="12642" />
     </Book>
     <Book Series="Captain America" Number="156" Volume="1968" Year="1972">
-      <Id>68bf7b64-67c2-4392-8400-8c69e42aa1e8</Id>
+      <Database Name="cv" Series="2400" Issue="12731" />
     </Book>
     <Book Series="Captain America" Number="157" Volume="1968" Year="1973">
-      <Id>fe41446c-4445-40c8-aefd-10061b5caa78</Id>
+      <Database Name="cv" Series="2400" Issue="12824" />
     </Book>
     <Book Series="Captain America" Number="158" Volume="1968" Year="1973">
-      <Id>6cf3bd31-b997-472e-8de8-3757df2009fc</Id>
+      <Database Name="cv" Series="2400" Issue="12917" />
     </Book>
     <Book Series="Captain America" Number="159" Volume="1968" Year="1973">
-      <Id>d1b9c86b-d6fa-4069-9ed3-94a245f5b783</Id>
+      <Database Name="cv" Series="2400" Issue="13001" />
     </Book>
     <Book Series="Captain America" Number="160" Volume="1968" Year="1973">
-      <Id>2f34efa1-52ee-4317-9231-6df939e50a31</Id>
+      <Database Name="cv" Series="2400" Issue="13099" />
     </Book>
     <Book Series="Captain America" Number="161" Volume="1968" Year="1973">
-      <Id>28fcac9b-4883-4f30-b594-e83673f4f776</Id>
+      <Database Name="cv" Series="2400" Issue="13171" />
     </Book>
     <Book Series="Captain America" Number="162" Volume="1968" Year="1973">
-      <Id>2cbbf45d-8ea2-40d2-8400-48239759905a</Id>
+      <Database Name="cv" Series="2400" Issue="13266" />
     </Book>
     <Book Series="Captain America" Number="163" Volume="1968" Year="1973">
-      <Id>21a7509c-8166-4ac1-9014-dd540423a672</Id>
+      <Database Name="cv" Series="2400" Issue="13379" />
     </Book>
     <Book Series="Captain America" Number="164" Volume="1968" Year="1973">
-      <Id>0e0bc79d-a065-46ae-b2b7-a6782dc6a48a</Id>
+      <Database Name="cv" Series="2400" Issue="13470" />
     </Book>
     <Book Series="Captain America" Number="165" Volume="1968" Year="1973">
-      <Id>08fddfe5-8abb-40c0-a0fc-68d36e5d9fe6</Id>
+      <Database Name="cv" Series="2400" Issue="13566" />
     </Book>
     <Book Series="Captain America" Number="166" Volume="1968" Year="1973">
-      <Id>12334176-5de9-4e66-88aa-0f2faf981e56</Id>
+      <Database Name="cv" Series="2400" Issue="13685" />
     </Book>
     <Book Series="Captain America" Number="167" Volume="1968" Year="1973">
-      <Id>62f2a5f7-8444-4317-b252-c4cae7119cb7</Id>
+      <Database Name="cv" Series="2400" Issue="13784" />
     </Book>
     <Book Series="Captain America" Number="168" Volume="1968" Year="1973">
-      <Id>a84c0f43-4737-45db-8790-c87c29a64219</Id>
+      <Database Name="cv" Series="2400" Issue="13877" />
     </Book>
     <Book Series="Captain America" Number="169" Volume="1968" Year="1974">
-      <Id>b9d0edff-24e4-4e8c-8d0d-5f12901c389f</Id>
+      <Database Name="cv" Series="2400" Issue="13980" />
     </Book>
     <Book Series="Captain America" Number="170" Volume="1968" Year="1974">
-      <Id>dc06efc8-b20b-429a-940e-043eb1ee321d</Id>
+      <Database Name="cv" Series="2400" Issue="14053" />
     </Book>
     <Book Series="Captain America" Number="171" Volume="1968" Year="1974">
-      <Id>ad0d46d0-d621-403c-a85a-58ef9215783c</Id>
+      <Database Name="cv" Series="2400" Issue="14118" />
     </Book>
     <Book Series="Captain America" Number="172" Volume="1968" Year="1974">
-      <Id>89fe30fc-0395-4c97-bbad-a5a568aceaf0</Id>
+      <Database Name="cv" Series="2400" Issue="14190" />
     </Book>
     <Book Series="Captain America" Number="173" Volume="1968" Year="1974">
-      <Id>9083b981-d674-4da8-b57c-61ccc8060690</Id>
+      <Database Name="cv" Series="2400" Issue="14256" />
     </Book>
     <Book Series="Captain America" Number="174" Volume="1968" Year="1974">
-      <Id>6a189d49-747e-416d-b486-eec941fc1d00</Id>
+      <Database Name="cv" Series="2400" Issue="14330" />
     </Book>
     <Book Series="Captain America" Number="175" Volume="1968" Year="1974">
-      <Id>a4b69196-8689-41e8-80ab-3067724d7d6a</Id>
+      <Database Name="cv" Series="2400" Issue="14409" />
     </Book>
     <Book Series="Captain America" Number="176" Volume="1968" Year="1974">
-      <Id>ee71a66a-d0a6-401b-a83e-d626d16df66f</Id>
+      <Database Name="cv" Series="2400" Issue="14482" />
     </Book>
     <Book Series="Captain America" Number="177" Volume="1968" Year="1974">
-      <Id>d8b10d6d-bbe6-4cf7-b91f-ddd2f3b49f75</Id>
+      <Database Name="cv" Series="2400" Issue="14570" />
     </Book>
     <Book Series="Captain America" Number="178" Volume="1968" Year="1974">
-      <Id>c76e23b1-eb1a-41a3-a8ff-18d75f570c8c</Id>
+      <Database Name="cv" Series="2400" Issue="14655" />
     </Book>
     <Book Series="Captain America" Number="179" Volume="1968" Year="1974">
-      <Id>aa1fd3b1-45ce-48ae-8496-27e84449ab24</Id>
+      <Database Name="cv" Series="2400" Issue="14746" />
     </Book>
     <Book Series="Captain America" Number="180" Volume="1968" Year="1974">
-      <Id>871c882f-8a3f-4a69-b656-d5f04fccfea2</Id>
+      <Database Name="cv" Series="2400" Issue="14829" />
     </Book>
     <Book Series="Captain America" Number="181" Volume="1968" Year="1975">
-      <Id>db8819b9-b43d-4719-b4cf-7acf1d6a6308</Id>
+      <Database Name="cv" Series="2400" Issue="14954" />
     </Book>
     <Book Series="Captain America" Number="182" Volume="1968" Year="1975">
-      <Id>543c3a25-b06c-4c0c-ac7d-79ec463a0f71</Id>
+      <Database Name="cv" Series="2400" Issue="15048" />
     </Book>
     <Book Series="Captain America" Number="183" Volume="1968" Year="1975">
-      <Id>8b10fa91-eea4-4d28-895b-8f3ed29272d1</Id>
+      <Database Name="cv" Series="2400" Issue="15138" />
     </Book>
     <Book Series="Captain America" Number="184" Volume="1968" Year="1975">
-      <Id>0e66ec52-32cc-46d1-9078-2c32497adeb9</Id>
+      <Database Name="cv" Series="2400" Issue="109149" />
     </Book>
     <Book Series="Captain America" Number="185" Volume="1968" Year="1975">
-      <Id>d07801de-e878-4836-a016-1b8207618c97</Id>
+      <Database Name="cv" Series="2400" Issue="15171" />
     </Book>
     <Book Series="Captain America" Number="186" Volume="1968" Year="1975">
-      <Id>64f5ce86-1199-45ce-b40b-7a8d3ea3f82a</Id>
+      <Database Name="cv" Series="2400" Issue="15261" />
     </Book>
     <Book Series="Captain America" Number="187" Volume="1968" Year="1975">
-      <Id>266860a6-f246-4cf9-a74c-3e417b1b54a8</Id>
+      <Database Name="cv" Series="2400" Issue="15365" />
     </Book>
     <Book Series="Captain America" Number="188" Volume="1968" Year="1975">
-      <Id>d688a311-9aa3-464b-bbc3-f7317f805be7</Id>
+      <Database Name="cv" Series="2400" Issue="15471" />
     </Book>
     <Book Series="Captain America" Number="189" Volume="1968" Year="1975">
-      <Id>6a5429cd-dfaa-4ae4-9ba8-e007d560d46b</Id>
+      <Database Name="cv" Series="2400" Issue="15573" />
     </Book>
     <Book Series="Captain America" Number="190" Volume="1968" Year="1975">
-      <Id>b9e5ad28-2fe5-41e4-8281-482a7d9defc4</Id>
+      <Database Name="cv" Series="2400" Issue="15670" />
     </Book>
     <Book Series="Captain America" Number="191" Volume="1968" Year="1975">
-      <Id>a1cfcd8d-0e2f-45a1-87f3-72f85f037d33</Id>
+      <Database Name="cv" Series="2400" Issue="15774" />
     </Book>
     <Book Series="Captain America" Number="192" Volume="1968" Year="1975">
-      <Id>bc2d4493-ba1d-4ce8-a779-332f96d2bf06</Id>
+      <Database Name="cv" Series="2400" Issue="15856" />
     </Book>
     <Book Series="Captain America Annual" Number="3" Volume="1971" Year="1976">
-      <Id>e9e7241d-3d6d-4e42-a43c-00cea0743e1e</Id>
+      <Database Name="cv" Series="2510" Issue="15923" />
     </Book>
     <Book Series="Captain America" Number="193" Volume="1968" Year="1976">
-      <Id>0c8d373e-b5cb-4ee1-bf42-9dfbc7d3254a</Id>
+      <Database Name="cv" Series="2400" Issue="15994" />
     </Book>
     <Book Series="Captain America" Number="194" Volume="1968" Year="1976">
-      <Id>94c7dd3d-d06d-4871-aac7-5f45465bce0c</Id>
+      <Database Name="cv" Series="2400" Issue="16071" />
     </Book>
     <Book Series="Captain America" Number="195" Volume="1968" Year="1976">
-      <Id>df79ddcc-bf8c-4d71-a361-e7dcd6435a04</Id>
+      <Database Name="cv" Series="2400" Issue="16159" />
     </Book>
     <Book Series="Captain America" Number="196" Volume="1968" Year="1976">
-      <Id>2dde1303-340f-4cd0-93a0-bc3111e30117</Id>
+      <Database Name="cv" Series="2400" Issue="16246" />
     </Book>
     <Book Series="Captain America" Number="197" Volume="1968" Year="1976">
-      <Id>20faecb7-6fe1-4392-94f7-de11cc742c53</Id>
+      <Database Name="cv" Series="2400" Issue="16333" />
     </Book>
     <Book Series="Captain America" Number="198" Volume="1968" Year="1976">
-      <Id>df9f4152-23e4-4e99-b6fe-b7136c7784ff</Id>
+      <Database Name="cv" Series="2400" Issue="16408" />
     </Book>
     <Book Series="Captain America" Number="199" Volume="1968" Year="1976">
-      <Id>c3083a9b-6586-4d22-840e-a943e33ffb7d</Id>
+      <Database Name="cv" Series="2400" Issue="16497" />
     </Book>
     <Book Series="Captain America" Number="200" Volume="1968" Year="1976">
-      <Id>99c87c90-6c94-4091-860c-a43bd5be9e94</Id>
+      <Database Name="cv" Series="2400" Issue="16586" />
     </Book>
     <Book Series="Captain America" Number="201" Volume="1968" Year="1976">
-      <Id>9902ebcc-06e7-4722-971d-e9f88176d577</Id>
+      <Database Name="cv" Series="2400" Issue="16674" />
     </Book>
     <Book Series="Captain America" Number="202" Volume="1968" Year="1976">
-      <Id>82734ea8-25e4-40f3-9091-8d71ee5da0a7</Id>
+      <Database Name="cv" Series="2400" Issue="16762" />
     </Book>
     <Book Series="Captain America" Number="203" Volume="1968" Year="1976">
-      <Id>d86fa932-e129-46b1-ab3b-ff8a2a89260a</Id>
+      <Database Name="cv" Series="2400" Issue="16863" />
     </Book>
     <Book Series="Captain America" Number="204" Volume="1968" Year="1976">
-      <Id>7d51207c-2fa3-4cce-9e96-a9ebb04483a2</Id>
+      <Database Name="cv" Series="2400" Issue="16945" />
     </Book>
     <Book Series="Captain America" Number="205" Volume="1968" Year="1977">
-      <Id>f6421c63-15fe-493d-8cca-11faefaaa170</Id>
+      <Database Name="cv" Series="2400" Issue="17092" />
     </Book>
     <Book Series="Captain America" Number="206" Volume="1968" Year="1977">
-      <Id>7829c60c-18d1-49fe-9239-84982819a67a</Id>
+      <Database Name="cv" Series="2400" Issue="17173" />
     </Book>
     <Book Series="Captain America" Number="207" Volume="1968" Year="1977">
-      <Id>e25fcba8-1b99-4eb3-828c-f723004bc8e7</Id>
+      <Database Name="cv" Series="2400" Issue="17261" />
     </Book>
     <Book Series="Captain America" Number="208" Volume="1968" Year="1977">
-      <Id>2fed1bc8-9705-478b-a68a-70d4758fa8d4</Id>
+      <Database Name="cv" Series="2400" Issue="17337" />
     </Book>
     <Book Series="Captain America" Number="209" Volume="1968" Year="1977">
-      <Id>4f0fd148-6a48-433e-9698-c885385e3ba5</Id>
+      <Database Name="cv" Series="2400" Issue="17424" />
     </Book>
     <Book Series="Captain America" Number="210" Volume="1968" Year="1977">
-      <Id>fd90f6a2-353f-485c-995c-188c951ffde8</Id>
+      <Database Name="cv" Series="2400" Issue="17493" />
     </Book>
     <Book Series="Captain America" Number="211" Volume="1968" Year="1977">
-      <Id>65971e7a-4dcb-4a2f-b2c1-8b28cf334376</Id>
+      <Database Name="cv" Series="2400" Issue="17591" />
     </Book>
     <Book Series="Captain America" Number="212" Volume="1968" Year="1977">
-      <Id>db0b33b0-ec12-4a1a-aa6c-2473d2227ca5</Id>
+      <Database Name="cv" Series="2400" Issue="17674" />
     </Book>
     <Book Series="Captain America" Number="213" Volume="1968" Year="1977">
-      <Id>f1b1bcdc-98bf-43e1-a44b-ab468a7fd6c3</Id>
+      <Database Name="cv" Series="2400" Issue="17770" />
     </Book>
     <Book Series="Captain America" Number="214" Volume="1968" Year="1977">
-      <Id>ef3b3640-d12f-4d18-aa6f-38afda68133b</Id>
+      <Database Name="cv" Series="2400" Issue="17864" />
     </Book>
     <Book Series="Captain America" Number="215" Volume="1968" Year="1977">
-      <Id>8b1b311e-93ee-496e-a088-0568ccb669f9</Id>
+      <Database Name="cv" Series="2400" Issue="17955" />
     </Book>
     <Book Series="Captain America" Number="216" Volume="1968" Year="1977">
-      <Id>2fa41238-c5f5-4256-9b70-cc7eaa01e8d1</Id>
+      <Database Name="cv" Series="2400" Issue="18035" />
     </Book>
     <Book Series="Captain America" Number="217" Volume="1968" Year="1978">
-      <Id>5d3976ec-4ee3-4bbd-a20a-53f1762eaf6e</Id>
+      <Database Name="cv" Series="2400" Issue="18158" />
     </Book>
     <Book Series="Captain America" Number="218" Volume="1968" Year="1978">
-      <Id>069e7b3c-a453-499f-a3fa-03693a160242</Id>
+      <Database Name="cv" Series="2400" Issue="18240" />
     </Book>
     <Book Series="Captain America" Number="219" Volume="1968" Year="1978">
-      <Id>a7e1850d-c344-4c2a-bd18-3150e51969be</Id>
+      <Database Name="cv" Series="2400" Issue="18321" />
     </Book>
     <Book Series="Captain America" Number="220" Volume="1968" Year="1978">
-      <Id>96f7aa64-da3a-41a2-ae76-e879b8b3288b</Id>
+      <Database Name="cv" Series="2400" Issue="18404" />
     </Book>
     <Book Series="Captain America" Number="221" Volume="1968" Year="1978">
-      <Id>61c92e94-a9d0-45dd-bb15-118e1c53d634</Id>
+      <Database Name="cv" Series="2400" Issue="18490" />
     </Book>
     <Book Series="Captain America" Number="222" Volume="1968" Year="1978">
-      <Id>32f507cc-f305-4bce-a63e-27321de7e96b</Id>
+      <Database Name="cv" Series="2400" Issue="18570" />
     </Book>
     <Book Series="Captain America" Number="223" Volume="1968" Year="1978">
-      <Id>be06781a-6919-4859-bc46-4f33763356d8</Id>
+      <Database Name="cv" Series="2400" Issue="18651" />
     </Book>
     <Book Series="Captain America" Number="224" Volume="1968" Year="1978">
-      <Id>d11ffe40-0cb5-4ace-9d01-ea18f220bcf8</Id>
+      <Database Name="cv" Series="2400" Issue="18728" />
     </Book>
     <Book Series="Captain America" Number="225" Volume="1968" Year="1978">
-      <Id>92866c27-7f5f-4bed-8db8-3e823e96f5e8</Id>
+      <Database Name="cv" Series="2400" Issue="18811" />
     </Book>
     <Book Series="Captain America" Number="226" Volume="1968" Year="1978">
-      <Id>da1096ff-0f3e-403e-b66b-8f676224b576</Id>
+      <Database Name="cv" Series="2400" Issue="18886" />
     </Book>
     <Book Series="Captain America" Number="227" Volume="1968" Year="1978">
-      <Id>f0f41111-fc0e-422a-9749-e859104c7c33</Id>
+      <Database Name="cv" Series="2400" Issue="18957" />
     </Book>
     <Book Series="Captain America" Number="228" Volume="1968" Year="1978">
-      <Id>a91e0c4d-488b-4514-9cae-813898b51114</Id>
+      <Database Name="cv" Series="2400" Issue="19030" />
     </Book>
     <Book Series="Captain America" Number="229" Volume="1968" Year="1979">
-      <Id>783b1c33-14d4-41fc-b86e-22fd908770bf</Id>
+      <Database Name="cv" Series="2400" Issue="19185" />
     </Book>
     <Book Series="Captain America" Number="230" Volume="1968" Year="1979">
-      <Id>e36ec908-06c9-4b75-89b5-1163561435dd</Id>
+      <Database Name="cv" Series="2400" Issue="19286" />
     </Book>
     <Book Series="Captain America" Number="231" Volume="1968" Year="1979">
-      <Id>135f2b7c-9e57-48e3-b509-51ceffeaaff2</Id>
+      <Database Name="cv" Series="2400" Issue="19361" />
     </Book>
     <Book Series="Captain America" Number="232" Volume="1968" Year="1979">
-      <Id>15d8a433-25e9-48b3-96bc-a68bf2e21a8b</Id>
+      <Database Name="cv" Series="2400" Issue="19424" />
     </Book>
     <Book Series="Captain America" Number="233" Volume="1968" Year="1979">
-      <Id>7ddad416-abe8-4755-bf21-1461372d2fc2</Id>
+      <Database Name="cv" Series="2400" Issue="19500" />
     </Book>
     <Book Series="Captain America" Number="234" Volume="1968" Year="1979">
-      <Id>98f18d81-cf98-4d80-9a8f-65fb179daff0</Id>
+      <Database Name="cv" Series="2400" Issue="19570" />
     </Book>
     <Book Series="Captain America" Number="235" Volume="1968" Year="1979">
-      <Id>3fa324e8-5b1c-433e-84bb-bf9a19dc0ba2</Id>
+      <Database Name="cv" Series="2400" Issue="19636" />
     </Book>
     <Book Series="Captain America" Number="236" Volume="1968" Year="1979">
-      <Id>c1e39a37-a4be-40d2-b29c-0171e7a30f6b</Id>
+      <Database Name="cv" Series="2400" Issue="19700" />
     </Book>
     <Book Series="Captain America" Number="237" Volume="1968" Year="1979">
-      <Id>50d92a6b-0b5f-44a8-ad9a-fd150ded4634</Id>
+      <Database Name="cv" Series="2400" Issue="19775" />
     </Book>
     <Book Series="Captain America" Number="238" Volume="1968" Year="1979">
-      <Id>82ee4477-777b-440c-b63c-3dffa9c4e6f2</Id>
+      <Database Name="cv" Series="2400" Issue="19838" />
     </Book>
     <Book Series="Captain America" Number="239" Volume="1968" Year="1979">
-      <Id>a9c6b135-a632-4980-a771-900cc8326ff0</Id>
+      <Database Name="cv" Series="2400" Issue="19915" />
     </Book>
     <Book Series="Captain America" Number="240" Volume="1968" Year="1979">
-      <Id>1b4ae6d2-209b-4115-893a-ae39781d5c16</Id>
+      <Database Name="cv" Series="2400" Issue="19978" />
     </Book>
     <Book Series="Captain America" Number="241" Volume="1968" Year="1980">
-      <Id>07042ace-f99a-45e6-ae06-ef9497a240cc</Id>
+      <Database Name="cv" Series="2400" Issue="20093" />
     </Book>
     <Book Series="Captain America" Number="242" Volume="1968" Year="1980">
-      <Id>897b1209-05b2-4e87-9438-98f4c03e6240</Id>
+      <Database Name="cv" Series="2400" Issue="20160" />
     </Book>
     <Book Series="Captain America" Number="243" Volume="1968" Year="1980">
-      <Id>a16da5b7-daa2-46e6-9be9-9f096deec572</Id>
+      <Database Name="cv" Series="2400" Issue="20235" />
     </Book>
     <Book Series="Captain America" Number="244" Volume="1968" Year="1980">
-      <Id>3704c257-5f9c-4124-a101-912af3169d9e</Id>
+      <Database Name="cv" Series="2400" Issue="20304" />
     </Book>
     <Book Series="Captain America" Number="245" Volume="1968" Year="1980">
-      <Id>1a8b34b8-483f-4327-9970-ab281ad6ba93</Id>
+      <Database Name="cv" Series="2400" Issue="20381" />
     </Book>
     <Book Series="Captain America" Number="246" Volume="1968" Year="1980">
-      <Id>c28fae4b-8b31-4992-8979-f1f5ab280a99</Id>
+      <Database Name="cv" Series="2400" Issue="20447" />
     </Book>
     <Book Series="Captain America" Number="247" Volume="1968" Year="1980">
-      <Id>71672962-3aed-4e5b-bbb3-b86d170a86a8</Id>
+      <Database Name="cv" Series="2400" Issue="20522" />
     </Book>
     <Book Series="Captain America" Number="248" Volume="1968" Year="1980">
-      <Id>a3ad2cb6-5b1d-4e64-8f3a-8ce96a1691b3</Id>
+      <Database Name="cv" Series="2400" Issue="20585" />
     </Book>
     <Book Series="Captain America" Number="249" Volume="1968" Year="1980">
-      <Id>b2826534-3461-40ef-ad8f-2c14cbcb1e91</Id>
+      <Database Name="cv" Series="2400" Issue="20656" />
     </Book>
     <Book Series="Captain America" Number="250" Volume="1968" Year="1980">
-      <Id>3b4f0e99-4e10-4f81-821b-e6de106db16e</Id>
+      <Database Name="cv" Series="2400" Issue="20724" />
     </Book>
     <Book Series="Captain America" Number="251" Volume="1968" Year="1980">
-      <Id>1bf60b40-bf8a-44f0-93a7-c88c87160abb</Id>
+      <Database Name="cv" Series="2400" Issue="20789" />
     </Book>
     <Book Series="Captain America" Number="252" Volume="1968" Year="1980">
-      <Id>0a496bed-4176-43d5-9f2d-de66325d585e</Id>
+      <Database Name="cv" Series="2400" Issue="20853" />
     </Book>
     <Book Series="Captain America" Number="253" Volume="1968" Year="1981">
-      <Id>d821e030-930a-4bc3-a1bc-4aba98f0f098</Id>
+      <Database Name="cv" Series="2400" Issue="20963" />
     </Book>
     <Book Series="Captain America" Number="254" Volume="1968" Year="1981">
-      <Id>59d2eb66-0d64-4e5f-a032-1a7ecfcc6bb7</Id>
+      <Database Name="cv" Series="2400" Issue="21030" />
     </Book>
     <Book Series="Captain America" Number="255" Volume="1968" Year="1981">
-      <Id>b50a3a41-1004-48cd-a8cd-6e14b0f84579</Id>
+      <Database Name="cv" Series="2400" Issue="21103" />
     </Book>
     <Book Series="Captain America" Number="256" Volume="1968" Year="1981">
-      <Id>5c6b711e-c6ea-4c07-9a7f-faf0b2a70e42</Id>
+      <Database Name="cv" Series="2400" Issue="21169" />
     </Book>
     <Book Series="Captain America" Number="257" Volume="1968" Year="1981">
-      <Id>7f307d7d-4a3a-4ac5-908e-ce809d48c103</Id>
+      <Database Name="cv" Series="2400" Issue="21235" />
     </Book>
     <Book Series="Captain America" Number="258" Volume="1968" Year="1981">
-      <Id>5a07e036-3270-4f89-8565-c2e3983eeef5</Id>
+      <Database Name="cv" Series="2400" Issue="21293" />
     </Book>
     <Book Series="Captain America" Number="259" Volume="1968" Year="1981">
-      <Id>e2028931-b0d1-48ce-96b2-8e0f11ec8b68</Id>
+      <Database Name="cv" Series="2400" Issue="21369" />
     </Book>
     <Book Series="Captain America" Number="260" Volume="1968" Year="1981">
-      <Id>43269f9f-c670-4918-bb9c-0df07c5affbb</Id>
+      <Database Name="cv" Series="2400" Issue="21434" />
     </Book>
     <Book Series="Captain America" Number="261" Volume="1968" Year="1981">
-      <Id>6d0fe8e7-b04f-4aca-af77-e28d04b46916</Id>
+      <Database Name="cv" Series="2400" Issue="21506" />
     </Book>
     <Book Series="Captain America" Number="262" Volume="1968" Year="1981">
-      <Id>e4e45451-4016-48dc-b284-1a0bedb493ff</Id>
+      <Database Name="cv" Series="2400" Issue="21586" />
     </Book>
     <Book Series="Captain America" Number="263" Volume="1968" Year="1981">
-      <Id>5da41e98-5172-4f7a-8397-6fd8b35ca1f9</Id>
+      <Database Name="cv" Series="2400" Issue="21655" />
     </Book>
     <Book Series="Captain America Annual" Number="5" Volume="1971" Year="1981">
-      <Id>9dceaa68-c1a4-4b78-85e9-35eb15ddf24b</Id>
+      <Database Name="cv" Series="2510" Issue="20908" />
     </Book>
     <Book Series="Captain America" Number="264" Volume="1968" Year="1981">
-      <Id>2c7e6d55-0a2b-45bf-b4cd-1318bd573d67</Id>
+      <Database Name="cv" Series="2400" Issue="21722" />
     </Book>
     <Book Series="Captain America" Number="265" Volume="1968" Year="1982">
-      <Id>21d6a6c9-a762-4965-a310-ca515be9ea58</Id>
+      <Database Name="cv" Series="2400" Issue="21851" />
     </Book>
     <Book Series="Captain America" Number="266" Volume="1968" Year="1982">
-      <Id>ef8e15de-f83e-4214-8a3d-f1a8d8cdc09a</Id>
+      <Database Name="cv" Series="2400" Issue="21922" />
     </Book>
     <Book Series="Captain America" Number="267" Volume="1968" Year="1982">
-      <Id>cbb91f0c-9f8f-438c-b5a7-635804f24616</Id>
+      <Database Name="cv" Series="2400" Issue="22002" />
     </Book>
     <Book Series="Captain America" Number="268" Volume="1968" Year="1982">
-      <Id>f98f6870-e826-4569-a9f2-11470462538f</Id>
+      <Database Name="cv" Series="2400" Issue="22075" />
     </Book>
     <Book Series="Captain America" Number="269" Volume="1968" Year="1982">
-      <Id>a29f1562-240e-4778-8ae9-d33ee9f99ce0</Id>
+      <Database Name="cv" Series="2400" Issue="22154" />
     </Book>
     <Book Series="Captain America" Number="270" Volume="1968" Year="1982">
-      <Id>dd264798-0f22-4d9a-b82a-1a90184102c0</Id>
+      <Database Name="cv" Series="2400" Issue="22223" />
     </Book>
     <Book Series="Captain America" Number="271" Volume="1968" Year="1982">
-      <Id>b3252133-5ea9-4e6d-af91-0aa6c98366e8</Id>
+      <Database Name="cv" Series="2400" Issue="22294" />
     </Book>
     <Book Series="Captain America" Number="272" Volume="1968" Year="1982">
-      <Id>3f53ae7c-7cc8-494d-8260-8caa529df96e</Id>
+      <Database Name="cv" Series="2400" Issue="22367" />
     </Book>
     <Book Series="Captain America" Number="273" Volume="1968" Year="1982">
-      <Id>391969d9-8868-4899-aa7f-683b422bbd3d</Id>
+      <Database Name="cv" Series="2400" Issue="22437" />
     </Book>
     <Book Series="Captain America" Number="274" Volume="1968" Year="1982">
-      <Id>b05c3eba-daef-4518-adf3-9adc09dc6f4a</Id>
+      <Database Name="cv" Series="2400" Issue="22510" />
     </Book>
     <Book Series="Captain America Annual" Number="6" Volume="1971" Year="1982">
-      <Id>872bfa16-f284-4d2c-9375-0492621d07b0</Id>
+      <Database Name="cv" Series="2510" Issue="21799" />
     </Book>
     <Book Series="Captain America" Number="275" Volume="1968" Year="1982">
-      <Id>d19c6991-ad73-42d7-b8a8-dc197b859e88</Id>
+      <Database Name="cv" Series="2400" Issue="22585" />
     </Book>
     <Book Series="Captain America" Number="276" Volume="1968" Year="1982">
-      <Id>fcf31ec0-70b9-40f9-bebc-d1baab27a794</Id>
+      <Database Name="cv" Series="2400" Issue="22663" />
     </Book>
     <Book Series="Captain America" Number="277" Volume="1968" Year="1983">
-      <Id>ab5d3f7e-6997-45d7-99d0-5329fe97e981</Id>
+      <Database Name="cv" Series="2400" Issue="22783" />
     </Book>
     <Book Series="Captain America" Number="278" Volume="1968" Year="1983">
-      <Id>29dd038b-64d0-4d82-a8a6-d45e5ab837c5</Id>
+      <Database Name="cv" Series="2400" Issue="22855" />
     </Book>
     <Book Series="Captain America" Number="279" Volume="1968" Year="1983">
-      <Id>4228b4b6-a0b3-41f5-93aa-109f63704023</Id>
+      <Database Name="cv" Series="2400" Issue="22941" />
     </Book>
     <Book Series="Captain America" Number="280" Volume="1968" Year="1983">
-      <Id>a592aa70-100c-4a09-80fa-7839f087fe43</Id>
+      <Database Name="cv" Series="2400" Issue="23023" />
     </Book>
     <Book Series="Captain America" Number="281" Volume="1968" Year="1983">
-      <Id>4ab290e5-f2d3-4c1f-996f-e85ca0c3a86f</Id>
+      <Database Name="cv" Series="2400" Issue="23111" />
     </Book>
     <Book Series="Captain America" Number="282" Volume="1968" Year="1983">
-      <Id>20b6a37b-bbf4-4abf-8bfa-ace76892e650</Id>
+      <Database Name="cv" Series="2400" Issue="23194" />
     </Book>
     <Book Series="Captain America" Number="283" Volume="1968" Year="1983">
-      <Id>0bdf0988-b10d-4d1b-b752-7426cde52679</Id>
+      <Database Name="cv" Series="2400" Issue="23282" />
     </Book>
     <Book Series="Captain America" Number="284" Volume="1968" Year="1983">
-      <Id>d729abbf-2f8e-44ec-b1ee-a5a7658537c6</Id>
+      <Database Name="cv" Series="2400" Issue="23364" />
     </Book>
     <Book Series="Captain America" Number="285" Volume="1968" Year="1983">
-      <Id>f2c67d96-0b02-4a7a-8934-e4747ab3b0cd</Id>
+      <Database Name="cv" Series="2400" Issue="23443" />
     </Book>
     <Book Series="Captain America Annual" Number="7" Volume="1971" Year="1983">
-      <Id>fa5def2c-38ee-40a1-aa0d-111ae91f6380</Id>
+      <Database Name="cv" Series="2510" Issue="22725" />
     </Book>
     <Book Series="Captain America" Number="286" Volume="1968" Year="1983">
-      <Id>dbf7aeed-a5f8-43b8-a5b4-2bfb0388f9f1</Id>
+      <Database Name="cv" Series="2400" Issue="23533" />
     </Book>
     <Book Series="Captain America" Number="287" Volume="1968" Year="1983">
-      <Id>c00ca3e6-cf80-4714-8e5f-d39452772cdd</Id>
+      <Database Name="cv" Series="2400" Issue="23616" />
     </Book>
     <Book Series="Captain America" Number="288" Volume="1968" Year="1983">
-      <Id>29e4ad74-0bcc-4fc5-a151-fb5ba5571c2a</Id>
+      <Database Name="cv" Series="2400" Issue="23717" />
     </Book>
     <Book Series="Captain America" Number="289" Volume="1968" Year="1984">
-      <Id>da245116-ff61-4113-bb3a-39ba980ee664</Id>
+      <Database Name="cv" Series="2400" Issue="23864" />
     </Book>
     <Book Series="Captain America" Number="290" Volume="1968" Year="1984">
-      <Id>b3edae46-3ec6-417b-8fd0-fefadcc0f0e9</Id>
+      <Database Name="cv" Series="2400" Issue="23971" />
     </Book>
     <Book Series="Captain America" Number="291" Volume="1968" Year="1984">
-      <Id>33f1efb8-237c-45c3-9fd8-c28b628cfbaa</Id>
+      <Database Name="cv" Series="2400" Issue="24088" />
     </Book>
     <Book Series="Captain America" Number="292" Volume="1968" Year="1984">
-      <Id>bda215ed-6133-4fd6-b19a-bcbae7d777c6</Id>
+      <Database Name="cv" Series="2400" Issue="24193" />
     </Book>
     <Book Series="Captain America" Number="293" Volume="1968" Year="1984">
-      <Id>73140994-0782-4ab2-aca4-6bddcff733b6</Id>
+      <Database Name="cv" Series="2400" Issue="24299" />
     </Book>
     <Book Series="Captain America" Number="294" Volume="1968" Year="1984">
-      <Id>65eb3d16-38c0-488f-a8a7-adc4fbbf142d</Id>
+      <Database Name="cv" Series="2400" Issue="24398" />
     </Book>
     <Book Series="Captain America" Number="295" Volume="1968" Year="1984">
-      <Id>e588071e-9b66-4d0c-8e76-b07f6e7adab8</Id>
+      <Database Name="cv" Series="2400" Issue="24498" />
     </Book>
     <Book Series="Captain America" Number="296" Volume="1968" Year="1984">
-      <Id>dcdf9639-7ddd-4400-9573-b700d7ab6534</Id>
+      <Database Name="cv" Series="2400" Issue="24595" />
     </Book>
     <Book Series="Captain America" Number="297" Volume="1968" Year="1984">
-      <Id>0ced2ecf-5d52-4dab-af4e-0b7023428438</Id>
+      <Database Name="cv" Series="2400" Issue="24689" />
     </Book>
     <Book Series="Captain America" Number="298" Volume="1968" Year="1984">
-      <Id>fb490d1e-5deb-4985-b949-e4b177f5c816</Id>
+      <Database Name="cv" Series="2400" Issue="24779" />
     </Book>
     <Book Series="Captain America" Number="299" Volume="1968" Year="1984">
-      <Id>6d1c9e0e-15ae-4ec7-a087-722555a94c77</Id>
+      <Database Name="cv" Series="2400" Issue="24882" />
     </Book>
     <Book Series="Captain America" Number="300" Volume="1968" Year="1984">
-      <Id>ce172098-fbac-4a53-ae01-9cbe66c47a9a</Id>
+      <Database Name="cv" Series="2400" Issue="24984" />
     </Book>
     <Book Series="Captain America" Number="301" Volume="1968" Year="1985">
-      <Id>83f54cff-0ab9-4b14-8400-d60fa5866590</Id>
+      <Database Name="cv" Series="2400" Issue="25156" />
     </Book>
     <Book Series="Captain America" Number="302" Volume="1968" Year="1985">
-      <Id>c1ef8ac0-7031-4edd-ba4d-eb7ee8a6e24d</Id>
+      <Database Name="cv" Series="2400" Issue="25253" />
     </Book>
     <Book Series="Captain America" Number="303" Volume="1968" Year="1985">
-      <Id>abe66e8d-ea88-496e-9987-5658cd157a26</Id>
+      <Database Name="cv" Series="2400" Issue="133683" />
     </Book>
     <Book Series="Captain America" Number="304" Volume="1968" Year="1985">
-      <Id>585dddc7-171d-4d93-9c42-fd95e4665398</Id>
+      <Database Name="cv" Series="2400" Issue="25382" />
     </Book>
     <Book Series="Captain America" Number="305" Volume="1968" Year="1985">
-      <Id>449ea44c-4167-4810-b4c6-48874a97cbaa</Id>
+      <Database Name="cv" Series="2400" Issue="25482" />
     </Book>
     <Book Series="Captain America" Number="306" Volume="1968" Year="1985">
-      <Id>0d249c55-e002-43ac-9723-cc0207c646c7</Id>
+      <Database Name="cv" Series="2400" Issue="25578" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Captain America/Captain America 002 - Silver Age.cbl
+++ b/Marvel/Characters/unsorted/Captain America/Captain America 002 - Silver Age.cbl
@@ -2,766 +2,766 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Captain America 02 - Silver Age</Name>
   <Books>
-    <Book Series="The Avengers" Number="4" Volume="1963" Year="1964" Format="Main Series">
+    <Book Series="The Avengers" Number="4" Volume="1963" Year="1964">
       <Id>dec8c37d-594f-472b-9591-af96358b1272</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="58" Volume="1959" Year="1964" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="58" Volume="1959" Year="1964">
       <Id>1ae3330c-0219-413d-800f-1bbd557b545c</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="59" Volume="1959" Year="1964" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="59" Volume="1959" Year="1964">
       <Id>862229f9-067e-4945-9bc0-e20769adf52d</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="60" Volume="1959" Year="1964" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="60" Volume="1959" Year="1964">
       <Id>27de895c-a9f8-45ee-ba32-90a33a3938e4</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="61" Volume="1959" Year="1965" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="61" Volume="1959" Year="1965">
       <Id>ad3a5d9a-2086-4447-b27f-2d9c841f7999</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="62" Volume="1959" Year="1965" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="62" Volume="1959" Year="1965">
       <Id>1c0beb5b-1313-4056-95f3-7680695ff79d</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="63" Volume="1959" Year="1965" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="63" Volume="1959" Year="1965">
       <Id>9e0a29a6-4380-4ded-a114-d292bd6f98c2</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="64" Volume="1959" Year="1965" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="64" Volume="1959" Year="1965">
       <Id>2d70519a-a7ce-403b-b7b0-8c685113a17e</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="65" Volume="1959" Year="1965" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="65" Volume="1959" Year="1965">
       <Id>dd9b3d2b-d413-4f22-9145-bb9a7afdce37</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="66" Volume="1959" Year="1965" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="66" Volume="1959" Year="1965">
       <Id>793b7cd8-8767-4fa5-9f7b-ef5d4c1db026</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="67" Volume="1959" Year="1965" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="67" Volume="1959" Year="1965">
       <Id>441709b0-aa48-473f-9f33-bd286ad040b1</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="68" Volume="1959" Year="1965" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="68" Volume="1959" Year="1965">
       <Id>1e4257b5-6848-49ba-8151-0f0fb64ed4e7</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="69" Volume="1959" Year="1965" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="69" Volume="1959" Year="1965">
       <Id>ee52466c-12e1-4b62-8805-19c4157973f0</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="70" Volume="1959" Year="1965" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="70" Volume="1959" Year="1965">
       <Id>a36d043e-a787-4dbc-826c-d5ec5d7c1fc6</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="71" Volume="1959" Year="1965" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="71" Volume="1959" Year="1965">
       <Id>087ea7ea-3f0c-42bc-a1c3-b2b02e5e4dfa</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="72" Volume="1959" Year="1965" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="72" Volume="1959" Year="1965">
       <Id>0c2d7a7f-12ca-44a9-acd0-92912a087f95</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="73" Volume="1959" Year="1966" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="73" Volume="1959" Year="1966">
       <Id>828f82c8-020b-4bbe-9a9a-c3fbf5318ec3</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="74" Volume="1959" Year="1966" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="74" Volume="1959" Year="1966">
       <Id>a986423d-03c9-43e8-97e6-f327788d12d3</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="75" Volume="1959" Year="1966" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="75" Volume="1959" Year="1966">
       <Id>1e4166aa-38fa-475a-ac9c-515e8841a4a9</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="76" Volume="1959" Year="1966" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="76" Volume="1959" Year="1966">
       <Id>e19c103d-6d2f-4115-b8c1-d3532c73ef43</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="77" Volume="1959" Year="1966" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="77" Volume="1959" Year="1966">
       <Id>47cfd66a-5805-43f0-a1fb-b770d5e44ff9</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="78" Volume="1959" Year="1966" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="78" Volume="1959" Year="1966">
       <Id>def328d0-6232-4777-8888-5dca23ef28dd</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="79" Volume="1959" Year="1966" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="79" Volume="1959" Year="1966">
       <Id>37979fb2-8150-49e1-bebd-0d454b27766b</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="80" Volume="1959" Year="1966" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="80" Volume="1959" Year="1966">
       <Id>53a2b6eb-651f-48a1-8c22-d113caca55de</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="81" Volume="1959" Year="1966" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="81" Volume="1959" Year="1966">
       <Id>b3f73966-d4c9-4dfc-899c-a20b960d8235</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="82" Volume="1959" Year="1966" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="82" Volume="1959" Year="1966">
       <Id>b7727770-5a4b-474e-bacd-aeccbdc5f80d</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="83" Volume="1959" Year="1966" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="83" Volume="1959" Year="1966">
       <Id>f40da68d-3adf-4848-81ad-0e23f6e55fb6</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="84" Volume="1959" Year="1966" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="84" Volume="1959" Year="1966">
       <Id>62a3d223-b0b3-445c-a136-623c490b1f14</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="85" Volume="1959" Year="1967" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="85" Volume="1959" Year="1967">
       <Id>8a6435b0-10c8-415c-afdb-e4ac7f22e75c</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="86" Volume="1959" Year="1967" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="86" Volume="1959" Year="1967">
       <Id>eaf3a486-b4c1-4086-92aa-36ce73f3b773</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="87" Volume="1959" Year="1967" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="87" Volume="1959" Year="1967">
       <Id>a1fe0f02-e1dc-4de1-88a3-d38ef65e323b</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="88" Volume="1959" Year="1967" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="88" Volume="1959" Year="1967">
       <Id>05a78ee3-ff1f-4bce-aecb-1722fe6bf5cc</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="89" Volume="1959" Year="1967" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="89" Volume="1959" Year="1967">
       <Id>77c42367-0525-4ddc-a983-79ece40f5be8</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="90" Volume="1959" Year="1967" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="90" Volume="1959" Year="1967">
       <Id>b406241d-7af3-4fc2-bf6e-ede51a9a2b9e</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="91" Volume="1959" Year="1967" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="91" Volume="1959" Year="1967">
       <Id>5f3023c3-94ee-49cd-8374-8df42ec702bf</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="92" Volume="1959" Year="1967" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="92" Volume="1959" Year="1967">
       <Id>e772f92e-8d7a-452e-be69-f84db0c9e12d</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="93" Volume="1959" Year="1967" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="93" Volume="1959" Year="1967">
       <Id>f154eb9a-7193-4e3a-940b-5d3fae2a2df1</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="94" Volume="1959" Year="1967" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="94" Volume="1959" Year="1967">
       <Id>594f9453-88e8-4998-a1cd-489466de92c1</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="95" Volume="1959" Year="1967" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="95" Volume="1959" Year="1967">
       <Id>cf4fb303-4426-4fd4-812b-158ff76e1ad7</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="96" Volume="1959" Year="1967" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="96" Volume="1959" Year="1967">
       <Id>3c152bc0-f378-42be-b156-c9af19afa984</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="97" Volume="1959" Year="1968" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="97" Volume="1959" Year="1968">
       <Id>44aecc2f-d5a0-47c1-82d8-3c51282263d7</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="98" Volume="1959" Year="1968" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="98" Volume="1959" Year="1968">
       <Id>57e2afdc-4be8-42cf-91b9-c44a3cb6a594</Id>
     </Book>
-    <Book Series="Tales of Suspense" Number="99" Volume="1959" Year="1968" Format="Main Series">
+    <Book Series="Tales of Suspense" Number="99" Volume="1959" Year="1968">
       <Id>27f09aae-f80b-4e78-98c8-25f5e4f7caad</Id>
     </Book>
-    <Book Series="Captain America" Number="100" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="Captain America" Number="100" Volume="1968" Year="1968">
       <Id>8e3e1473-ffb5-4155-8976-860af2dba80c</Id>
     </Book>
-    <Book Series="Captain America" Number="101" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="Captain America" Number="101" Volume="1968" Year="1968">
       <Id>f4fc816b-8aa9-426d-89bd-c9d4b233cbbf</Id>
     </Book>
-    <Book Series="Captain America" Number="102" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="Captain America" Number="102" Volume="1968" Year="1968">
       <Id>81e4a97a-5798-44f1-b1e3-5af7d99ecb95</Id>
     </Book>
-    <Book Series="Captain America" Number="103" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="Captain America" Number="103" Volume="1968" Year="1968">
       <Id>6eebd40e-ff6e-4f18-abba-e12b81aa9b62</Id>
     </Book>
-    <Book Series="Captain America" Number="104" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="Captain America" Number="104" Volume="1968" Year="1968">
       <Id>ff5b8c52-7123-4b33-8eb5-7944ec0be70f</Id>
     </Book>
-    <Book Series="Captain America" Number="105" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="Captain America" Number="105" Volume="1968" Year="1968">
       <Id>b4f74d47-4473-4afb-a523-f3a464c3af85</Id>
     </Book>
-    <Book Series="Captain America" Number="106" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="Captain America" Number="106" Volume="1968" Year="1968">
       <Id>c4a721dd-8169-42f3-a070-2d27fadd849d</Id>
     </Book>
-    <Book Series="Captain America" Number="107" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="Captain America" Number="107" Volume="1968" Year="1968">
       <Id>33a1d507-0539-4c8a-8f7d-74498439df20</Id>
     </Book>
-    <Book Series="Captain America" Number="108" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="Captain America" Number="108" Volume="1968" Year="1968">
       <Id>4bd4bb1e-0bb5-41e3-807a-04c5db44afc9</Id>
     </Book>
-    <Book Series="Captain America" Number="109" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="Captain America" Number="109" Volume="1968" Year="1969">
       <Id>2488b420-e8a1-4f37-86ef-1be6215d6f2a</Id>
     </Book>
-    <Book Series="Captain America" Number="110" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="Captain America" Number="110" Volume="1968" Year="1969">
       <Id>cfc22586-6ca9-4434-b103-9507e40e11d4</Id>
     </Book>
-    <Book Series="Captain America" Number="111" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="Captain America" Number="111" Volume="1968" Year="1969">
       <Id>f35b7c52-d469-401b-9292-09792493dcbc</Id>
     </Book>
-    <Book Series="Captain America" Number="112" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="Captain America" Number="112" Volume="1968" Year="1969">
       <Id>4122fec1-2d01-4ff7-bd58-abbdc609e23b</Id>
     </Book>
-    <Book Series="Captain America" Number="113" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="Captain America" Number="113" Volume="1968" Year="1969">
       <Id>ee62775e-7927-458c-96da-72c1c263632d</Id>
     </Book>
-    <Book Series="Captain America" Number="114" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="Captain America" Number="114" Volume="1968" Year="1969">
       <Id>f7f78372-26e6-4adc-8365-483af9379104</Id>
     </Book>
-    <Book Series="Captain America" Number="115" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="Captain America" Number="115" Volume="1968" Year="1969">
       <Id>eeccb5d9-bf3e-44ae-8772-8cfec65936c7</Id>
     </Book>
-    <Book Series="Captain America" Number="116" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="Captain America" Number="116" Volume="1968" Year="1969">
       <Id>1f012716-6206-4c59-ac29-2b0e2b3466a4</Id>
     </Book>
-    <Book Series="Captain America" Number="117" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="Captain America" Number="117" Volume="1968" Year="1969">
       <Id>0c54ff7a-3464-4727-9481-67f55ebb75e4</Id>
     </Book>
-    <Book Series="Captain America" Number="118" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="Captain America" Number="118" Volume="1968" Year="1969">
       <Id>e90b39f1-eca0-4416-b175-5bee337d40bd</Id>
     </Book>
-    <Book Series="Captain America" Number="119" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="Captain America" Number="119" Volume="1968" Year="1969">
       <Id>7db7f728-0b68-48db-bb3e-983a298c2c04</Id>
     </Book>
-    <Book Series="Captain America" Number="120" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="Captain America" Number="120" Volume="1968" Year="1969">
       <Id>e77368cf-0dec-4596-a5cc-a6fdd41f1a92</Id>
     </Book>
-    <Book Series="Captain America" Number="121" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="Captain America" Number="121" Volume="1968" Year="1970">
       <Id>240eb03d-c4a4-44c8-9fe8-5e981c024a01</Id>
     </Book>
-    <Book Series="Captain America" Number="122" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="Captain America" Number="122" Volume="1968" Year="1970">
       <Id>ce927f5d-8786-4a6c-b9b6-69c501f1139b</Id>
     </Book>
-    <Book Series="Captain America" Number="123" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="Captain America" Number="123" Volume="1968" Year="1970">
       <Id>4e6b4751-0798-46e9-9722-456ed273d81a</Id>
     </Book>
-    <Book Series="Captain America" Number="124" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="Captain America" Number="124" Volume="1968" Year="1970">
       <Id>f27b8c3e-aee7-4115-ad75-f3e77fa2cc0a</Id>
     </Book>
-    <Book Series="Captain America" Number="125" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="Captain America" Number="125" Volume="1968" Year="1970">
       <Id>7d9fcd4f-b383-4e4b-9d37-9e35d9a5633d</Id>
     </Book>
-    <Book Series="Captain America" Number="126" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="Captain America" Number="126" Volume="1968" Year="1970">
       <Id>7fd70ad2-1644-44d6-bdc6-75b4f852dba6</Id>
     </Book>
-    <Book Series="Captain America" Number="127" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="Captain America" Number="127" Volume="1968" Year="1970">
       <Id>b2fd5498-af95-4476-a457-518f92db28c5</Id>
     </Book>
-    <Book Series="Captain America" Number="128" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="Captain America" Number="128" Volume="1968" Year="1970">
       <Id>9e44d095-0275-48b8-bdb5-8e1172d62898</Id>
     </Book>
-    <Book Series="Captain America" Number="129" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="Captain America" Number="129" Volume="1968" Year="1970">
       <Id>1f78b265-7747-4fe1-8eb1-683bfd8579da</Id>
     </Book>
-    <Book Series="Captain America" Number="130" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="Captain America" Number="130" Volume="1968" Year="1970">
       <Id>2168b14c-2b86-4627-934a-f7dcd5a243b7</Id>
     </Book>
-    <Book Series="Captain America" Number="131" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="Captain America" Number="131" Volume="1968" Year="1970">
       <Id>28369d2c-82bd-4204-ac8e-951651e659d3</Id>
     </Book>
-    <Book Series="Captain America" Number="132" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="Captain America" Number="132" Volume="1968" Year="1970">
       <Id>7cf1c6fc-8ebe-4126-81d4-7b611f596fb1</Id>
     </Book>
-    <Book Series="Captain America" Number="133" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Captain America" Number="133" Volume="1968" Year="1971">
       <Id>f6722501-084b-4db8-9d50-08d8e3fb98e7</Id>
     </Book>
-    <Book Series="Captain America" Number="134" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Captain America" Number="134" Volume="1968" Year="1971">
       <Id>eb81abdc-79e8-49c3-8178-252df20ed54e</Id>
     </Book>
-    <Book Series="Captain America" Number="135" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Captain America" Number="135" Volume="1968" Year="1971">
       <Id>b814e7e9-e68b-4444-879c-6ea4478cbd88</Id>
     </Book>
-    <Book Series="Captain America" Number="136" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Captain America" Number="136" Volume="1968" Year="1971">
       <Id>4e89f44f-f65d-4693-9b1d-7d3dcbb42ef0</Id>
     </Book>
-    <Book Series="Captain America" Number="137" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Captain America" Number="137" Volume="1968" Year="1971">
       <Id>a21f8360-7d93-429b-9bbc-5b75b5a33aa6</Id>
     </Book>
-    <Book Series="Captain America" Number="138" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Captain America" Number="138" Volume="1968" Year="1971">
       <Id>fee38c06-414e-4784-b7fb-81b3bec286c0</Id>
     </Book>
-    <Book Series="Captain America" Number="139" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Captain America" Number="139" Volume="1968" Year="1971">
       <Id>3f014f05-97de-4a08-8c18-ccd02dd790ea</Id>
     </Book>
-    <Book Series="Captain America" Number="140" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Captain America" Number="140" Volume="1968" Year="1971">
       <Id>1fdc85cf-fa00-455a-a424-b589d31d4abd</Id>
     </Book>
-    <Book Series="Captain America" Number="141" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Captain America" Number="141" Volume="1968" Year="1971">
       <Id>693af861-c1bb-45bf-89e6-e08c52d848ec</Id>
     </Book>
-    <Book Series="Captain America" Number="142" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Captain America" Number="142" Volume="1968" Year="1971">
       <Id>a6c00a0c-19d8-4db1-abe9-bf2da88ee364</Id>
     </Book>
-    <Book Series="Captain America" Number="143" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Captain America" Number="143" Volume="1968" Year="1971">
       <Id>95161bbc-7b08-4c36-8356-dfe3bc0ed3e6</Id>
     </Book>
-    <Book Series="Captain America" Number="144" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Captain America" Number="144" Volume="1968" Year="1971">
       <Id>1b45a7d9-2061-4664-a26a-d6309f1d626a</Id>
     </Book>
-    <Book Series="Captain America" Number="145" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="Captain America" Number="145" Volume="1968" Year="1972">
       <Id>56ea9081-9a3a-48c2-a2d9-4d3e7c50ced1</Id>
     </Book>
-    <Book Series="Captain America" Number="146" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="Captain America" Number="146" Volume="1968" Year="1972">
       <Id>a718528b-3b0c-4b24-98df-bdc5b82de644</Id>
     </Book>
-    <Book Series="Captain America" Number="147" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="Captain America" Number="147" Volume="1968" Year="1972">
       <Id>85e4d018-8792-4c18-a5e0-2378504f68f5</Id>
     </Book>
-    <Book Series="Captain America" Number="148" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="Captain America" Number="148" Volume="1968" Year="1972">
       <Id>814ef044-11ca-4359-9b51-34b866b2183c</Id>
     </Book>
-    <Book Series="Captain America" Number="149" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="Captain America" Number="149" Volume="1968" Year="1972">
       <Id>f1deed5b-6091-413e-ae48-1952614a2b0c</Id>
     </Book>
-    <Book Series="Captain America" Number="150" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="Captain America" Number="150" Volume="1968" Year="1972">
       <Id>ea96045a-db66-488e-85d3-8e5bffc82c95</Id>
     </Book>
-    <Book Series="Captain America" Number="151" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="Captain America" Number="151" Volume="1968" Year="1972">
       <Id>37c39f70-451a-48ff-8ee3-c11d643db9bd</Id>
     </Book>
-    <Book Series="Captain America" Number="152" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="Captain America" Number="152" Volume="1968" Year="1972">
       <Id>8c620529-e047-4e10-b18d-fd5e9add8b93</Id>
     </Book>
-    <Book Series="Captain America" Number="153" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="Captain America" Number="153" Volume="1968" Year="1972">
       <Id>0fe8420a-755b-49ae-854f-3a964b6d3f02</Id>
     </Book>
-    <Book Series="Captain America" Number="154" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="Captain America" Number="154" Volume="1968" Year="1972">
       <Id>3ec7a28a-e882-410b-9aeb-bac332cbeffe</Id>
     </Book>
-    <Book Series="Captain America" Number="155" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="Captain America" Number="155" Volume="1968" Year="1972">
       <Id>0a30ad7b-32b2-43ce-91c9-f3435961619e</Id>
     </Book>
-    <Book Series="Captain America" Number="156" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="Captain America" Number="156" Volume="1968" Year="1972">
       <Id>68bf7b64-67c2-4392-8400-8c69e42aa1e8</Id>
     </Book>
-    <Book Series="Captain America" Number="157" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="Captain America" Number="157" Volume="1968" Year="1973">
       <Id>fe41446c-4445-40c8-aefd-10061b5caa78</Id>
     </Book>
-    <Book Series="Captain America" Number="158" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="Captain America" Number="158" Volume="1968" Year="1973">
       <Id>6cf3bd31-b997-472e-8de8-3757df2009fc</Id>
     </Book>
-    <Book Series="Captain America" Number="159" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="Captain America" Number="159" Volume="1968" Year="1973">
       <Id>d1b9c86b-d6fa-4069-9ed3-94a245f5b783</Id>
     </Book>
-    <Book Series="Captain America" Number="160" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="Captain America" Number="160" Volume="1968" Year="1973">
       <Id>2f34efa1-52ee-4317-9231-6df939e50a31</Id>
     </Book>
-    <Book Series="Captain America" Number="161" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="Captain America" Number="161" Volume="1968" Year="1973">
       <Id>28fcac9b-4883-4f30-b594-e83673f4f776</Id>
     </Book>
-    <Book Series="Captain America" Number="162" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="Captain America" Number="162" Volume="1968" Year="1973">
       <Id>2cbbf45d-8ea2-40d2-8400-48239759905a</Id>
     </Book>
-    <Book Series="Captain America" Number="163" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="Captain America" Number="163" Volume="1968" Year="1973">
       <Id>21a7509c-8166-4ac1-9014-dd540423a672</Id>
     </Book>
-    <Book Series="Captain America" Number="164" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="Captain America" Number="164" Volume="1968" Year="1973">
       <Id>0e0bc79d-a065-46ae-b2b7-a6782dc6a48a</Id>
     </Book>
-    <Book Series="Captain America" Number="165" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="Captain America" Number="165" Volume="1968" Year="1973">
       <Id>08fddfe5-8abb-40c0-a0fc-68d36e5d9fe6</Id>
     </Book>
-    <Book Series="Captain America" Number="166" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="Captain America" Number="166" Volume="1968" Year="1973">
       <Id>12334176-5de9-4e66-88aa-0f2faf981e56</Id>
     </Book>
-    <Book Series="Captain America" Number="167" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="Captain America" Number="167" Volume="1968" Year="1973">
       <Id>62f2a5f7-8444-4317-b252-c4cae7119cb7</Id>
     </Book>
-    <Book Series="Captain America" Number="168" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="Captain America" Number="168" Volume="1968" Year="1973">
       <Id>a84c0f43-4737-45db-8790-c87c29a64219</Id>
     </Book>
-    <Book Series="Captain America" Number="169" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="Captain America" Number="169" Volume="1968" Year="1974">
       <Id>b9d0edff-24e4-4e8c-8d0d-5f12901c389f</Id>
     </Book>
-    <Book Series="Captain America" Number="170" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="Captain America" Number="170" Volume="1968" Year="1974">
       <Id>dc06efc8-b20b-429a-940e-043eb1ee321d</Id>
     </Book>
-    <Book Series="Captain America" Number="171" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="Captain America" Number="171" Volume="1968" Year="1974">
       <Id>ad0d46d0-d621-403c-a85a-58ef9215783c</Id>
     </Book>
-    <Book Series="Captain America" Number="172" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="Captain America" Number="172" Volume="1968" Year="1974">
       <Id>89fe30fc-0395-4c97-bbad-a5a568aceaf0</Id>
     </Book>
-    <Book Series="Captain America" Number="173" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="Captain America" Number="173" Volume="1968" Year="1974">
       <Id>9083b981-d674-4da8-b57c-61ccc8060690</Id>
     </Book>
-    <Book Series="Captain America" Number="174" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="Captain America" Number="174" Volume="1968" Year="1974">
       <Id>6a189d49-747e-416d-b486-eec941fc1d00</Id>
     </Book>
-    <Book Series="Captain America" Number="175" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="Captain America" Number="175" Volume="1968" Year="1974">
       <Id>a4b69196-8689-41e8-80ab-3067724d7d6a</Id>
     </Book>
-    <Book Series="Captain America" Number="176" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="Captain America" Number="176" Volume="1968" Year="1974">
       <Id>ee71a66a-d0a6-401b-a83e-d626d16df66f</Id>
     </Book>
-    <Book Series="Captain America" Number="177" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="Captain America" Number="177" Volume="1968" Year="1974">
       <Id>d8b10d6d-bbe6-4cf7-b91f-ddd2f3b49f75</Id>
     </Book>
-    <Book Series="Captain America" Number="178" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="Captain America" Number="178" Volume="1968" Year="1974">
       <Id>c76e23b1-eb1a-41a3-a8ff-18d75f570c8c</Id>
     </Book>
-    <Book Series="Captain America" Number="179" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="Captain America" Number="179" Volume="1968" Year="1974">
       <Id>aa1fd3b1-45ce-48ae-8496-27e84449ab24</Id>
     </Book>
-    <Book Series="Captain America" Number="180" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="Captain America" Number="180" Volume="1968" Year="1974">
       <Id>871c882f-8a3f-4a69-b656-d5f04fccfea2</Id>
     </Book>
-    <Book Series="Captain America" Number="181" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="Captain America" Number="181" Volume="1968" Year="1975">
       <Id>db8819b9-b43d-4719-b4cf-7acf1d6a6308</Id>
     </Book>
-    <Book Series="Captain America" Number="182" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="Captain America" Number="182" Volume="1968" Year="1975">
       <Id>543c3a25-b06c-4c0c-ac7d-79ec463a0f71</Id>
     </Book>
-    <Book Series="Captain America" Number="183" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="Captain America" Number="183" Volume="1968" Year="1975">
       <Id>8b10fa91-eea4-4d28-895b-8f3ed29272d1</Id>
     </Book>
-    <Book Series="Captain America" Number="184" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="Captain America" Number="184" Volume="1968" Year="1975">
       <Id>0e66ec52-32cc-46d1-9078-2c32497adeb9</Id>
     </Book>
-    <Book Series="Captain America" Number="185" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="Captain America" Number="185" Volume="1968" Year="1975">
       <Id>d07801de-e878-4836-a016-1b8207618c97</Id>
     </Book>
-    <Book Series="Captain America" Number="186" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="Captain America" Number="186" Volume="1968" Year="1975">
       <Id>64f5ce86-1199-45ce-b40b-7a8d3ea3f82a</Id>
     </Book>
-    <Book Series="Captain America" Number="187" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="Captain America" Number="187" Volume="1968" Year="1975">
       <Id>266860a6-f246-4cf9-a74c-3e417b1b54a8</Id>
     </Book>
-    <Book Series="Captain America" Number="188" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="Captain America" Number="188" Volume="1968" Year="1975">
       <Id>d688a311-9aa3-464b-bbc3-f7317f805be7</Id>
     </Book>
-    <Book Series="Captain America" Number="189" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="Captain America" Number="189" Volume="1968" Year="1975">
       <Id>6a5429cd-dfaa-4ae4-9ba8-e007d560d46b</Id>
     </Book>
-    <Book Series="Captain America" Number="190" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="Captain America" Number="190" Volume="1968" Year="1975">
       <Id>b9e5ad28-2fe5-41e4-8281-482a7d9defc4</Id>
     </Book>
-    <Book Series="Captain America" Number="191" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="Captain America" Number="191" Volume="1968" Year="1975">
       <Id>a1cfcd8d-0e2f-45a1-87f3-72f85f037d33</Id>
     </Book>
-    <Book Series="Captain America" Number="192" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="Captain America" Number="192" Volume="1968" Year="1975">
       <Id>bc2d4493-ba1d-4ce8-a779-332f96d2bf06</Id>
     </Book>
-    <Book Series="Captain America Annual" Number="3" Volume="1971" Year="1976" Format="Annual">
+    <Book Series="Captain America Annual" Number="3" Volume="1971" Year="1976">
       <Id>e9e7241d-3d6d-4e42-a43c-00cea0743e1e</Id>
     </Book>
-    <Book Series="Captain America" Number="193" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="Captain America" Number="193" Volume="1968" Year="1976">
       <Id>0c8d373e-b5cb-4ee1-bf42-9dfbc7d3254a</Id>
     </Book>
-    <Book Series="Captain America" Number="194" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="Captain America" Number="194" Volume="1968" Year="1976">
       <Id>94c7dd3d-d06d-4871-aac7-5f45465bce0c</Id>
     </Book>
-    <Book Series="Captain America" Number="195" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="Captain America" Number="195" Volume="1968" Year="1976">
       <Id>df79ddcc-bf8c-4d71-a361-e7dcd6435a04</Id>
     </Book>
-    <Book Series="Captain America" Number="196" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="Captain America" Number="196" Volume="1968" Year="1976">
       <Id>2dde1303-340f-4cd0-93a0-bc3111e30117</Id>
     </Book>
-    <Book Series="Captain America" Number="197" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="Captain America" Number="197" Volume="1968" Year="1976">
       <Id>20faecb7-6fe1-4392-94f7-de11cc742c53</Id>
     </Book>
-    <Book Series="Captain America" Number="198" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="Captain America" Number="198" Volume="1968" Year="1976">
       <Id>df9f4152-23e4-4e99-b6fe-b7136c7784ff</Id>
     </Book>
-    <Book Series="Captain America" Number="199" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="Captain America" Number="199" Volume="1968" Year="1976">
       <Id>c3083a9b-6586-4d22-840e-a943e33ffb7d</Id>
     </Book>
-    <Book Series="Captain America" Number="200" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="Captain America" Number="200" Volume="1968" Year="1976">
       <Id>99c87c90-6c94-4091-860c-a43bd5be9e94</Id>
     </Book>
-    <Book Series="Captain America" Number="201" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="Captain America" Number="201" Volume="1968" Year="1976">
       <Id>9902ebcc-06e7-4722-971d-e9f88176d577</Id>
     </Book>
-    <Book Series="Captain America" Number="202" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="Captain America" Number="202" Volume="1968" Year="1976">
       <Id>82734ea8-25e4-40f3-9091-8d71ee5da0a7</Id>
     </Book>
-    <Book Series="Captain America" Number="203" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="Captain America" Number="203" Volume="1968" Year="1976">
       <Id>d86fa932-e129-46b1-ab3b-ff8a2a89260a</Id>
     </Book>
-    <Book Series="Captain America" Number="204" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="Captain America" Number="204" Volume="1968" Year="1976">
       <Id>7d51207c-2fa3-4cce-9e96-a9ebb04483a2</Id>
     </Book>
-    <Book Series="Captain America" Number="205" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="Captain America" Number="205" Volume="1968" Year="1977">
       <Id>f6421c63-15fe-493d-8cca-11faefaaa170</Id>
     </Book>
-    <Book Series="Captain America" Number="206" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="Captain America" Number="206" Volume="1968" Year="1977">
       <Id>7829c60c-18d1-49fe-9239-84982819a67a</Id>
     </Book>
-    <Book Series="Captain America" Number="207" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="Captain America" Number="207" Volume="1968" Year="1977">
       <Id>e25fcba8-1b99-4eb3-828c-f723004bc8e7</Id>
     </Book>
-    <Book Series="Captain America" Number="208" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="Captain America" Number="208" Volume="1968" Year="1977">
       <Id>2fed1bc8-9705-478b-a68a-70d4758fa8d4</Id>
     </Book>
-    <Book Series="Captain America" Number="209" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="Captain America" Number="209" Volume="1968" Year="1977">
       <Id>4f0fd148-6a48-433e-9698-c885385e3ba5</Id>
     </Book>
-    <Book Series="Captain America" Number="210" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="Captain America" Number="210" Volume="1968" Year="1977">
       <Id>fd90f6a2-353f-485c-995c-188c951ffde8</Id>
     </Book>
-    <Book Series="Captain America" Number="211" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="Captain America" Number="211" Volume="1968" Year="1977">
       <Id>65971e7a-4dcb-4a2f-b2c1-8b28cf334376</Id>
     </Book>
-    <Book Series="Captain America" Number="212" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="Captain America" Number="212" Volume="1968" Year="1977">
       <Id>db0b33b0-ec12-4a1a-aa6c-2473d2227ca5</Id>
     </Book>
-    <Book Series="Captain America" Number="213" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="Captain America" Number="213" Volume="1968" Year="1977">
       <Id>f1b1bcdc-98bf-43e1-a44b-ab468a7fd6c3</Id>
     </Book>
-    <Book Series="Captain America" Number="214" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="Captain America" Number="214" Volume="1968" Year="1977">
       <Id>ef3b3640-d12f-4d18-aa6f-38afda68133b</Id>
     </Book>
-    <Book Series="Captain America" Number="215" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="Captain America" Number="215" Volume="1968" Year="1977">
       <Id>8b1b311e-93ee-496e-a088-0568ccb669f9</Id>
     </Book>
-    <Book Series="Captain America" Number="216" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="Captain America" Number="216" Volume="1968" Year="1977">
       <Id>2fa41238-c5f5-4256-9b70-cc7eaa01e8d1</Id>
     </Book>
-    <Book Series="Captain America" Number="217" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="Captain America" Number="217" Volume="1968" Year="1978">
       <Id>5d3976ec-4ee3-4bbd-a20a-53f1762eaf6e</Id>
     </Book>
-    <Book Series="Captain America" Number="218" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="Captain America" Number="218" Volume="1968" Year="1978">
       <Id>069e7b3c-a453-499f-a3fa-03693a160242</Id>
     </Book>
-    <Book Series="Captain America" Number="219" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="Captain America" Number="219" Volume="1968" Year="1978">
       <Id>a7e1850d-c344-4c2a-bd18-3150e51969be</Id>
     </Book>
-    <Book Series="Captain America" Number="220" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="Captain America" Number="220" Volume="1968" Year="1978">
       <Id>96f7aa64-da3a-41a2-ae76-e879b8b3288b</Id>
     </Book>
-    <Book Series="Captain America" Number="221" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="Captain America" Number="221" Volume="1968" Year="1978">
       <Id>61c92e94-a9d0-45dd-bb15-118e1c53d634</Id>
     </Book>
-    <Book Series="Captain America" Number="222" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="Captain America" Number="222" Volume="1968" Year="1978">
       <Id>32f507cc-f305-4bce-a63e-27321de7e96b</Id>
     </Book>
-    <Book Series="Captain America" Number="223" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="Captain America" Number="223" Volume="1968" Year="1978">
       <Id>be06781a-6919-4859-bc46-4f33763356d8</Id>
     </Book>
-    <Book Series="Captain America" Number="224" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="Captain America" Number="224" Volume="1968" Year="1978">
       <Id>d11ffe40-0cb5-4ace-9d01-ea18f220bcf8</Id>
     </Book>
-    <Book Series="Captain America" Number="225" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="Captain America" Number="225" Volume="1968" Year="1978">
       <Id>92866c27-7f5f-4bed-8db8-3e823e96f5e8</Id>
     </Book>
-    <Book Series="Captain America" Number="226" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="Captain America" Number="226" Volume="1968" Year="1978">
       <Id>da1096ff-0f3e-403e-b66b-8f676224b576</Id>
     </Book>
-    <Book Series="Captain America" Number="227" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="Captain America" Number="227" Volume="1968" Year="1978">
       <Id>f0f41111-fc0e-422a-9749-e859104c7c33</Id>
     </Book>
-    <Book Series="Captain America" Number="228" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="Captain America" Number="228" Volume="1968" Year="1978">
       <Id>a91e0c4d-488b-4514-9cae-813898b51114</Id>
     </Book>
-    <Book Series="Captain America" Number="229" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="Captain America" Number="229" Volume="1968" Year="1979">
       <Id>783b1c33-14d4-41fc-b86e-22fd908770bf</Id>
     </Book>
-    <Book Series="Captain America" Number="230" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="Captain America" Number="230" Volume="1968" Year="1979">
       <Id>e36ec908-06c9-4b75-89b5-1163561435dd</Id>
     </Book>
-    <Book Series="Captain America" Number="231" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="Captain America" Number="231" Volume="1968" Year="1979">
       <Id>135f2b7c-9e57-48e3-b509-51ceffeaaff2</Id>
     </Book>
-    <Book Series="Captain America" Number="232" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="Captain America" Number="232" Volume="1968" Year="1979">
       <Id>15d8a433-25e9-48b3-96bc-a68bf2e21a8b</Id>
     </Book>
-    <Book Series="Captain America" Number="233" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="Captain America" Number="233" Volume="1968" Year="1979">
       <Id>7ddad416-abe8-4755-bf21-1461372d2fc2</Id>
     </Book>
-    <Book Series="Captain America" Number="234" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="Captain America" Number="234" Volume="1968" Year="1979">
       <Id>98f18d81-cf98-4d80-9a8f-65fb179daff0</Id>
     </Book>
-    <Book Series="Captain America" Number="235" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="Captain America" Number="235" Volume="1968" Year="1979">
       <Id>3fa324e8-5b1c-433e-84bb-bf9a19dc0ba2</Id>
     </Book>
-    <Book Series="Captain America" Number="236" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="Captain America" Number="236" Volume="1968" Year="1979">
       <Id>c1e39a37-a4be-40d2-b29c-0171e7a30f6b</Id>
     </Book>
-    <Book Series="Captain America" Number="237" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="Captain America" Number="237" Volume="1968" Year="1979">
       <Id>50d92a6b-0b5f-44a8-ad9a-fd150ded4634</Id>
     </Book>
-    <Book Series="Captain America" Number="238" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="Captain America" Number="238" Volume="1968" Year="1979">
       <Id>82ee4477-777b-440c-b63c-3dffa9c4e6f2</Id>
     </Book>
-    <Book Series="Captain America" Number="239" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="Captain America" Number="239" Volume="1968" Year="1979">
       <Id>a9c6b135-a632-4980-a771-900cc8326ff0</Id>
     </Book>
-    <Book Series="Captain America" Number="240" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="Captain America" Number="240" Volume="1968" Year="1979">
       <Id>1b4ae6d2-209b-4115-893a-ae39781d5c16</Id>
     </Book>
-    <Book Series="Captain America" Number="241" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="Captain America" Number="241" Volume="1968" Year="1980">
       <Id>07042ace-f99a-45e6-ae06-ef9497a240cc</Id>
     </Book>
-    <Book Series="Captain America" Number="242" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="Captain America" Number="242" Volume="1968" Year="1980">
       <Id>897b1209-05b2-4e87-9438-98f4c03e6240</Id>
     </Book>
-    <Book Series="Captain America" Number="243" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="Captain America" Number="243" Volume="1968" Year="1980">
       <Id>a16da5b7-daa2-46e6-9be9-9f096deec572</Id>
     </Book>
-    <Book Series="Captain America" Number="244" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="Captain America" Number="244" Volume="1968" Year="1980">
       <Id>3704c257-5f9c-4124-a101-912af3169d9e</Id>
     </Book>
-    <Book Series="Captain America" Number="245" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="Captain America" Number="245" Volume="1968" Year="1980">
       <Id>1a8b34b8-483f-4327-9970-ab281ad6ba93</Id>
     </Book>
-    <Book Series="Captain America" Number="246" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="Captain America" Number="246" Volume="1968" Year="1980">
       <Id>c28fae4b-8b31-4992-8979-f1f5ab280a99</Id>
     </Book>
-    <Book Series="Captain America" Number="247" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="Captain America" Number="247" Volume="1968" Year="1980">
       <Id>71672962-3aed-4e5b-bbb3-b86d170a86a8</Id>
     </Book>
-    <Book Series="Captain America" Number="248" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="Captain America" Number="248" Volume="1968" Year="1980">
       <Id>a3ad2cb6-5b1d-4e64-8f3a-8ce96a1691b3</Id>
     </Book>
-    <Book Series="Captain America" Number="249" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="Captain America" Number="249" Volume="1968" Year="1980">
       <Id>b2826534-3461-40ef-ad8f-2c14cbcb1e91</Id>
     </Book>
-    <Book Series="Captain America" Number="250" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="Captain America" Number="250" Volume="1968" Year="1980">
       <Id>3b4f0e99-4e10-4f81-821b-e6de106db16e</Id>
     </Book>
-    <Book Series="Captain America" Number="251" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="Captain America" Number="251" Volume="1968" Year="1980">
       <Id>1bf60b40-bf8a-44f0-93a7-c88c87160abb</Id>
     </Book>
-    <Book Series="Captain America" Number="252" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="Captain America" Number="252" Volume="1968" Year="1980">
       <Id>0a496bed-4176-43d5-9f2d-de66325d585e</Id>
     </Book>
-    <Book Series="Captain America" Number="253" Volume="1968" Year="1981" Format="Main Series">
+    <Book Series="Captain America" Number="253" Volume="1968" Year="1981">
       <Id>d821e030-930a-4bc3-a1bc-4aba98f0f098</Id>
     </Book>
-    <Book Series="Captain America" Number="254" Volume="1968" Year="1981" Format="Main Series">
+    <Book Series="Captain America" Number="254" Volume="1968" Year="1981">
       <Id>59d2eb66-0d64-4e5f-a032-1a7ecfcc6bb7</Id>
     </Book>
-    <Book Series="Captain America" Number="255" Volume="1968" Year="1981" Format="Main Series">
+    <Book Series="Captain America" Number="255" Volume="1968" Year="1981">
       <Id>b50a3a41-1004-48cd-a8cd-6e14b0f84579</Id>
     </Book>
-    <Book Series="Captain America" Number="256" Volume="1968" Year="1981" Format="Main Series">
+    <Book Series="Captain America" Number="256" Volume="1968" Year="1981">
       <Id>5c6b711e-c6ea-4c07-9a7f-faf0b2a70e42</Id>
     </Book>
-    <Book Series="Captain America" Number="257" Volume="1968" Year="1981" Format="Main Series">
+    <Book Series="Captain America" Number="257" Volume="1968" Year="1981">
       <Id>7f307d7d-4a3a-4ac5-908e-ce809d48c103</Id>
     </Book>
-    <Book Series="Captain America" Number="258" Volume="1968" Year="1981" Format="Main Series">
+    <Book Series="Captain America" Number="258" Volume="1968" Year="1981">
       <Id>5a07e036-3270-4f89-8565-c2e3983eeef5</Id>
     </Book>
-    <Book Series="Captain America" Number="259" Volume="1968" Year="1981" Format="Main Series">
+    <Book Series="Captain America" Number="259" Volume="1968" Year="1981">
       <Id>e2028931-b0d1-48ce-96b2-8e0f11ec8b68</Id>
     </Book>
-    <Book Series="Captain America" Number="260" Volume="1968" Year="1981" Format="Main Series">
+    <Book Series="Captain America" Number="260" Volume="1968" Year="1981">
       <Id>43269f9f-c670-4918-bb9c-0df07c5affbb</Id>
     </Book>
-    <Book Series="Captain America" Number="261" Volume="1968" Year="1981" Format="Main Series">
+    <Book Series="Captain America" Number="261" Volume="1968" Year="1981">
       <Id>6d0fe8e7-b04f-4aca-af77-e28d04b46916</Id>
     </Book>
-    <Book Series="Captain America" Number="262" Volume="1968" Year="1981" Format="Main Series">
+    <Book Series="Captain America" Number="262" Volume="1968" Year="1981">
       <Id>e4e45451-4016-48dc-b284-1a0bedb493ff</Id>
     </Book>
-    <Book Series="Captain America" Number="263" Volume="1968" Year="1981" Format="Main Series">
+    <Book Series="Captain America" Number="263" Volume="1968" Year="1981">
       <Id>5da41e98-5172-4f7a-8397-6fd8b35ca1f9</Id>
     </Book>
-    <Book Series="Captain America Annual" Number="5" Volume="1971" Year="1981" Format="Annual">
+    <Book Series="Captain America Annual" Number="5" Volume="1971" Year="1981">
       <Id>9dceaa68-c1a4-4b78-85e9-35eb15ddf24b</Id>
     </Book>
-    <Book Series="Captain America" Number="264" Volume="1968" Year="1981" Format="Main Series">
+    <Book Series="Captain America" Number="264" Volume="1968" Year="1981">
       <Id>2c7e6d55-0a2b-45bf-b4cd-1318bd573d67</Id>
     </Book>
-    <Book Series="Captain America" Number="265" Volume="1968" Year="1982" Format="Main Series">
+    <Book Series="Captain America" Number="265" Volume="1968" Year="1982">
       <Id>21d6a6c9-a762-4965-a310-ca515be9ea58</Id>
     </Book>
-    <Book Series="Captain America" Number="266" Volume="1968" Year="1982" Format="Main Series">
+    <Book Series="Captain America" Number="266" Volume="1968" Year="1982">
       <Id>ef8e15de-f83e-4214-8a3d-f1a8d8cdc09a</Id>
     </Book>
-    <Book Series="Captain America" Number="267" Volume="1968" Year="1982" Format="Main Series">
+    <Book Series="Captain America" Number="267" Volume="1968" Year="1982">
       <Id>cbb91f0c-9f8f-438c-b5a7-635804f24616</Id>
     </Book>
-    <Book Series="Captain America" Number="268" Volume="1968" Year="1982" Format="Main Series">
+    <Book Series="Captain America" Number="268" Volume="1968" Year="1982">
       <Id>f98f6870-e826-4569-a9f2-11470462538f</Id>
     </Book>
-    <Book Series="Captain America" Number="269" Volume="1968" Year="1982" Format="Main Series">
+    <Book Series="Captain America" Number="269" Volume="1968" Year="1982">
       <Id>a29f1562-240e-4778-8ae9-d33ee9f99ce0</Id>
     </Book>
-    <Book Series="Captain America" Number="270" Volume="1968" Year="1982" Format="Main Series">
+    <Book Series="Captain America" Number="270" Volume="1968" Year="1982">
       <Id>dd264798-0f22-4d9a-b82a-1a90184102c0</Id>
     </Book>
-    <Book Series="Captain America" Number="271" Volume="1968" Year="1982" Format="Main Series">
+    <Book Series="Captain America" Number="271" Volume="1968" Year="1982">
       <Id>b3252133-5ea9-4e6d-af91-0aa6c98366e8</Id>
     </Book>
-    <Book Series="Captain America" Number="272" Volume="1968" Year="1982" Format="Main Series">
+    <Book Series="Captain America" Number="272" Volume="1968" Year="1982">
       <Id>3f53ae7c-7cc8-494d-8260-8caa529df96e</Id>
     </Book>
-    <Book Series="Captain America" Number="273" Volume="1968" Year="1982" Format="Main Series">
+    <Book Series="Captain America" Number="273" Volume="1968" Year="1982">
       <Id>391969d9-8868-4899-aa7f-683b422bbd3d</Id>
     </Book>
-    <Book Series="Captain America" Number="274" Volume="1968" Year="1982" Format="Main Series">
+    <Book Series="Captain America" Number="274" Volume="1968" Year="1982">
       <Id>b05c3eba-daef-4518-adf3-9adc09dc6f4a</Id>
     </Book>
-    <Book Series="Captain America Annual" Number="6" Volume="1971" Year="1982" Format="Annual">
+    <Book Series="Captain America Annual" Number="6" Volume="1971" Year="1982">
       <Id>872bfa16-f284-4d2c-9375-0492621d07b0</Id>
     </Book>
-    <Book Series="Captain America" Number="275" Volume="1968" Year="1982" Format="Main Series">
+    <Book Series="Captain America" Number="275" Volume="1968" Year="1982">
       <Id>d19c6991-ad73-42d7-b8a8-dc197b859e88</Id>
     </Book>
-    <Book Series="Captain America" Number="276" Volume="1968" Year="1982" Format="Main Series">
+    <Book Series="Captain America" Number="276" Volume="1968" Year="1982">
       <Id>fcf31ec0-70b9-40f9-bebc-d1baab27a794</Id>
     </Book>
-    <Book Series="Captain America" Number="277" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="Captain America" Number="277" Volume="1968" Year="1983">
       <Id>ab5d3f7e-6997-45d7-99d0-5329fe97e981</Id>
     </Book>
-    <Book Series="Captain America" Number="278" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="Captain America" Number="278" Volume="1968" Year="1983">
       <Id>29dd038b-64d0-4d82-a8a6-d45e5ab837c5</Id>
     </Book>
-    <Book Series="Captain America" Number="279" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="Captain America" Number="279" Volume="1968" Year="1983">
       <Id>4228b4b6-a0b3-41f5-93aa-109f63704023</Id>
     </Book>
-    <Book Series="Captain America" Number="280" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="Captain America" Number="280" Volume="1968" Year="1983">
       <Id>a592aa70-100c-4a09-80fa-7839f087fe43</Id>
     </Book>
-    <Book Series="Captain America" Number="281" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="Captain America" Number="281" Volume="1968" Year="1983">
       <Id>4ab290e5-f2d3-4c1f-996f-e85ca0c3a86f</Id>
     </Book>
-    <Book Series="Captain America" Number="282" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="Captain America" Number="282" Volume="1968" Year="1983">
       <Id>20b6a37b-bbf4-4abf-8bfa-ace76892e650</Id>
     </Book>
-    <Book Series="Captain America" Number="283" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="Captain America" Number="283" Volume="1968" Year="1983">
       <Id>0bdf0988-b10d-4d1b-b752-7426cde52679</Id>
     </Book>
-    <Book Series="Captain America" Number="284" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="Captain America" Number="284" Volume="1968" Year="1983">
       <Id>d729abbf-2f8e-44ec-b1ee-a5a7658537c6</Id>
     </Book>
-    <Book Series="Captain America" Number="285" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="Captain America" Number="285" Volume="1968" Year="1983">
       <Id>f2c67d96-0b02-4a7a-8934-e4747ab3b0cd</Id>
     </Book>
-    <Book Series="Captain America Annual" Number="7" Volume="1971" Year="1983" Format="Annual">
+    <Book Series="Captain America Annual" Number="7" Volume="1971" Year="1983">
       <Id>fa5def2c-38ee-40a1-aa0d-111ae91f6380</Id>
     </Book>
-    <Book Series="Captain America" Number="286" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="Captain America" Number="286" Volume="1968" Year="1983">
       <Id>dbf7aeed-a5f8-43b8-a5b4-2bfb0388f9f1</Id>
     </Book>
-    <Book Series="Captain America" Number="287" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="Captain America" Number="287" Volume="1968" Year="1983">
       <Id>c00ca3e6-cf80-4714-8e5f-d39452772cdd</Id>
     </Book>
-    <Book Series="Captain America" Number="288" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="Captain America" Number="288" Volume="1968" Year="1983">
       <Id>29e4ad74-0bcc-4fc5-a151-fb5ba5571c2a</Id>
     </Book>
-    <Book Series="Captain America" Number="289" Volume="1968" Year="1984" Format="Main Series">
+    <Book Series="Captain America" Number="289" Volume="1968" Year="1984">
       <Id>da245116-ff61-4113-bb3a-39ba980ee664</Id>
     </Book>
-    <Book Series="Captain America" Number="290" Volume="1968" Year="1984" Format="Main Series">
+    <Book Series="Captain America" Number="290" Volume="1968" Year="1984">
       <Id>b3edae46-3ec6-417b-8fd0-fefadcc0f0e9</Id>
     </Book>
-    <Book Series="Captain America" Number="291" Volume="1968" Year="1984" Format="Main Series">
+    <Book Series="Captain America" Number="291" Volume="1968" Year="1984">
       <Id>33f1efb8-237c-45c3-9fd8-c28b628cfbaa</Id>
     </Book>
-    <Book Series="Captain America" Number="292" Volume="1968" Year="1984" Format="Main Series">
+    <Book Series="Captain America" Number="292" Volume="1968" Year="1984">
       <Id>bda215ed-6133-4fd6-b19a-bcbae7d777c6</Id>
     </Book>
-    <Book Series="Captain America" Number="293" Volume="1968" Year="1984" Format="Main Series">
+    <Book Series="Captain America" Number="293" Volume="1968" Year="1984">
       <Id>73140994-0782-4ab2-aca4-6bddcff733b6</Id>
     </Book>
-    <Book Series="Captain America" Number="294" Volume="1968" Year="1984" Format="Main Series">
+    <Book Series="Captain America" Number="294" Volume="1968" Year="1984">
       <Id>65eb3d16-38c0-488f-a8a7-adc4fbbf142d</Id>
     </Book>
-    <Book Series="Captain America" Number="295" Volume="1968" Year="1984" Format="Main Series">
+    <Book Series="Captain America" Number="295" Volume="1968" Year="1984">
       <Id>e588071e-9b66-4d0c-8e76-b07f6e7adab8</Id>
     </Book>
-    <Book Series="Captain America" Number="296" Volume="1968" Year="1984" Format="Main Series">
+    <Book Series="Captain America" Number="296" Volume="1968" Year="1984">
       <Id>dcdf9639-7ddd-4400-9573-b700d7ab6534</Id>
     </Book>
-    <Book Series="Captain America" Number="297" Volume="1968" Year="1984" Format="Main Series">
+    <Book Series="Captain America" Number="297" Volume="1968" Year="1984">
       <Id>0ced2ecf-5d52-4dab-af4e-0b7023428438</Id>
     </Book>
-    <Book Series="Captain America" Number="298" Volume="1968" Year="1984" Format="Main Series">
+    <Book Series="Captain America" Number="298" Volume="1968" Year="1984">
       <Id>fb490d1e-5deb-4985-b949-e4b177f5c816</Id>
     </Book>
-    <Book Series="Captain America" Number="299" Volume="1968" Year="1984" Format="Main Series">
+    <Book Series="Captain America" Number="299" Volume="1968" Year="1984">
       <Id>6d1c9e0e-15ae-4ec7-a087-722555a94c77</Id>
     </Book>
-    <Book Series="Captain America" Number="300" Volume="1968" Year="1984" Format="Main Series">
+    <Book Series="Captain America" Number="300" Volume="1968" Year="1984">
       <Id>ce172098-fbac-4a53-ae01-9cbe66c47a9a</Id>
     </Book>
-    <Book Series="Captain America" Number="301" Volume="1968" Year="1985" Format="Main Series">
+    <Book Series="Captain America" Number="301" Volume="1968" Year="1985">
       <Id>83f54cff-0ab9-4b14-8400-d60fa5866590</Id>
     </Book>
-    <Book Series="Captain America" Number="302" Volume="1968" Year="1985" Format="Main Series">
+    <Book Series="Captain America" Number="302" Volume="1968" Year="1985">
       <Id>c1ef8ac0-7031-4edd-ba4d-eb7ee8a6e24d</Id>
     </Book>
-    <Book Series="Captain America" Number="303" Volume="1968" Year="1985" Format="Main Series">
+    <Book Series="Captain America" Number="303" Volume="1968" Year="1985">
       <Id>abe66e8d-ea88-496e-9987-5658cd157a26</Id>
     </Book>
-    <Book Series="Captain America" Number="304" Volume="1968" Year="1985" Format="Main Series">
+    <Book Series="Captain America" Number="304" Volume="1968" Year="1985">
       <Id>585dddc7-171d-4d93-9c42-fd95e4665398</Id>
     </Book>
-    <Book Series="Captain America" Number="305" Volume="1968" Year="1985" Format="Main Series">
+    <Book Series="Captain America" Number="305" Volume="1968" Year="1985">
       <Id>449ea44c-4167-4810-b4c6-48874a97cbaa</Id>
     </Book>
-    <Book Series="Captain America" Number="306" Volume="1968" Year="1985" Format="Main Series">
+    <Book Series="Captain America" Number="306" Volume="1968" Year="1985">
       <Id>0d249c55-e002-43ac-9723-cc0207c646c7</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Captain America/Captain America 003.cbl
+++ b/Marvel/Characters/unsorted/Captain America/Captain America 003.cbl
@@ -2,739 +2,739 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Captain America 03</Name>
   <Books>
-    <Book Series="Captain America" Number="307" Volume="1968" Year="1985" Format="Main Series">
+    <Book Series="Captain America" Number="307" Volume="1968" Year="1985">
       <Id>a098e9e7-85c7-4104-b716-946a8835e8cf</Id>
     </Book>
-    <Book Series="Captain America" Number="308" Volume="1968" Year="1985" Format="Main Series">
+    <Book Series="Captain America" Number="308" Volume="1968" Year="1985">
       <Id>94af0548-2f83-4efd-a48e-d8c2f9319155</Id>
     </Book>
-    <Book Series="Captain America" Number="309" Volume="1968" Year="1985" Format="Main Series">
+    <Book Series="Captain America" Number="309" Volume="1968" Year="1985">
       <Id>97f7bcc8-a509-4cf3-bb8f-d783b3a2f8d0</Id>
     </Book>
-    <Book Series="Captain America" Number="310" Volume="1968" Year="1985" Format="Main Series">
+    <Book Series="Captain America" Number="310" Volume="1968" Year="1985">
       <Id>94f589cc-cc70-4e6c-b98c-157631dc2bd7</Id>
     </Book>
-    <Book Series="Captain America" Number="311" Volume="1968" Year="1985" Format="Main Series">
+    <Book Series="Captain America" Number="311" Volume="1968" Year="1985">
       <Id>60856f0f-bf43-4144-a9ff-a03b127fa242</Id>
     </Book>
-    <Book Series="Captain America" Number="312" Volume="1968" Year="1985" Format="Main Series">
+    <Book Series="Captain America" Number="312" Volume="1968" Year="1985">
       <Id>8e479c68-5337-4977-b625-c1ffce3ce147</Id>
     </Book>
-    <Book Series="Captain America" Number="313" Volume="1968" Year="1986" Format="Main Series">
+    <Book Series="Captain America" Number="313" Volume="1968" Year="1986">
       <Id>4af74f76-9327-46d9-a778-a19037078c9e</Id>
     </Book>
-    <Book Series="Captain America" Number="314" Volume="1968" Year="1986" Format="Main Series">
+    <Book Series="Captain America" Number="314" Volume="1968" Year="1986">
       <Id>cc0916ef-3c4d-4dd6-a042-ae1c140f9d23</Id>
     </Book>
-    <Book Series="Captain America" Number="315" Volume="1968" Year="1986" Format="Main Series">
+    <Book Series="Captain America" Number="315" Volume="1968" Year="1986">
       <Id>3eee4721-62a5-4994-a097-ac01f6977030</Id>
     </Book>
-    <Book Series="Captain America" Number="316" Volume="1968" Year="1986" Format="Main Series">
+    <Book Series="Captain America" Number="316" Volume="1968" Year="1986">
       <Id>3ea01faf-c00f-4afb-968d-9cc66603b631</Id>
     </Book>
-    <Book Series="Captain America" Number="317" Volume="1968" Year="1986" Format="Main Series">
+    <Book Series="Captain America" Number="317" Volume="1968" Year="1986">
       <Id>fd79835c-24c3-4c46-8f92-e5f737951a83</Id>
     </Book>
-    <Book Series="Captain America" Number="318" Volume="1968" Year="1986" Format="Main Series">
+    <Book Series="Captain America" Number="318" Volume="1968" Year="1986">
       <Id>bd911ea8-78ae-4c4d-a5dd-6004a5fa8f74</Id>
     </Book>
-    <Book Series="Captain America" Number="319" Volume="1968" Year="1986" Format="Main Series">
+    <Book Series="Captain America" Number="319" Volume="1968" Year="1986">
       <Id>0fc32306-72a1-4958-91a0-a04650652013</Id>
     </Book>
-    <Book Series="Captain America" Number="320" Volume="1968" Year="1986" Format="Main Series">
+    <Book Series="Captain America" Number="320" Volume="1968" Year="1986">
       <Id>d95a600a-6534-489b-b2bc-402b83be41e8</Id>
     </Book>
-    <Book Series="Captain America" Number="321" Volume="1968" Year="1986" Format="Main Series">
+    <Book Series="Captain America" Number="321" Volume="1968" Year="1986">
       <Id>63431dc7-fe94-4d96-a4db-f42811a32578</Id>
     </Book>
-    <Book Series="Captain America" Number="322" Volume="1968" Year="1986" Format="Main Series">
+    <Book Series="Captain America" Number="322" Volume="1968" Year="1986">
       <Id>11cfa80a-d520-450e-9099-acffa4b423b3</Id>
     </Book>
-    <Book Series="Captain America" Number="323" Volume="1968" Year="1986" Format="Main Series">
+    <Book Series="Captain America" Number="323" Volume="1968" Year="1986">
       <Id>3b78b124-7c6f-44a6-bad8-dc3b4db73b59</Id>
     </Book>
-    <Book Series="Captain America" Number="324" Volume="1968" Year="1986" Format="Main Series">
+    <Book Series="Captain America" Number="324" Volume="1968" Year="1986">
       <Id>58030cde-759a-43d9-a27c-97c6d84b70e7</Id>
     </Book>
-    <Book Series="Captain America" Number="325" Volume="1968" Year="1987" Format="Main Series">
+    <Book Series="Captain America" Number="325" Volume="1968" Year="1987">
       <Id>67fc4c37-71c1-4922-b3f2-8a349c3a8e36</Id>
     </Book>
-    <Book Series="Captain America" Number="326" Volume="1968" Year="1987" Format="Main Series">
+    <Book Series="Captain America" Number="326" Volume="1968" Year="1987">
       <Id>52fcc150-147e-40ca-9535-d808a0ea4eae</Id>
     </Book>
-    <Book Series="Captain America" Number="327" Volume="1968" Year="1987" Format="Main Series">
+    <Book Series="Captain America" Number="327" Volume="1968" Year="1987">
       <Id>8f31544a-683e-4aba-8a8a-b5cc00322ad6</Id>
     </Book>
-    <Book Series="Captain America" Number="328" Volume="1968" Year="1987" Format="Main Series">
+    <Book Series="Captain America" Number="328" Volume="1968" Year="1987">
       <Id>998d8d4d-a121-43c8-a69c-7f7cc69a9c7f</Id>
     </Book>
-    <Book Series="Captain America" Number="329" Volume="1968" Year="1987" Format="Main Series">
+    <Book Series="Captain America" Number="329" Volume="1968" Year="1987">
       <Id>d7430886-468c-43cb-816d-0196b807633a</Id>
     </Book>
-    <Book Series="Captain America" Number="330" Volume="1968" Year="1987" Format="Main Series">
+    <Book Series="Captain America" Number="330" Volume="1968" Year="1987">
       <Id>22edcd59-621c-453d-bc89-e4778b9e8752</Id>
     </Book>
-    <Book Series="Captain America" Number="331" Volume="1968" Year="1987" Format="Main Series">
+    <Book Series="Captain America" Number="331" Volume="1968" Year="1987">
       <Id>fa911264-a439-4a7e-b213-2f3e19b0bf56</Id>
     </Book>
-    <Book Series="Captain America" Number="332" Volume="1968" Year="1987" Format="Main Series">
+    <Book Series="Captain America" Number="332" Volume="1968" Year="1987">
       <Id>2701bbfa-7f07-4976-b219-af38305b48f5</Id>
     </Book>
-    <Book Series="Captain America" Number="333" Volume="1968" Year="1987" Format="Main Series">
+    <Book Series="Captain America" Number="333" Volume="1968" Year="1987">
       <Id>24c64c41-74c5-465a-858f-6e7342a9e157</Id>
     </Book>
-    <Book Series="Captain America" Number="334" Volume="1968" Year="1987" Format="Main Series">
+    <Book Series="Captain America" Number="334" Volume="1968" Year="1987">
       <Id>23c0b344-7da6-4f4e-a44c-25204ea8ec55</Id>
     </Book>
-    <Book Series="Captain America" Number="335" Volume="1968" Year="1987" Format="Main Series">
+    <Book Series="Captain America" Number="335" Volume="1968" Year="1987">
       <Id>0bad9a45-97f0-4474-8138-d16c3def7d11</Id>
     </Book>
-    <Book Series="Captain America" Number="336" Volume="1968" Year="1987" Format="Main Series">
+    <Book Series="Captain America" Number="336" Volume="1968" Year="1987">
       <Id>1f8b7149-101d-46d4-8cea-425b9eba5666</Id>
     </Book>
-    <Book Series="Captain America" Number="337" Volume="1968" Year="1988" Format="Main Series">
+    <Book Series="Captain America" Number="337" Volume="1968" Year="1988">
       <Id>6ea6a1f3-f5e6-4668-a423-beaefb8a378a</Id>
     </Book>
-    <Book Series="Captain America" Number="338" Volume="1968" Year="1988" Format="Main Series">
+    <Book Series="Captain America" Number="338" Volume="1968" Year="1988">
       <Id>5d90bdd4-8807-4414-95bc-3e490a4835ce</Id>
     </Book>
-    <Book Series="Captain America" Number="339" Volume="1968" Year="1988" Format="Main Series">
+    <Book Series="Captain America" Number="339" Volume="1968" Year="1988">
       <Id>543e43b4-2aef-495e-aaeb-c3d493e7fda4</Id>
     </Book>
-    <Book Series="Captain America" Number="340" Volume="1968" Year="1988" Format="Main Series">
+    <Book Series="Captain America" Number="340" Volume="1968" Year="1988">
       <Id>bbff0722-bd91-4210-a114-2ab14e566e5b</Id>
     </Book>
-    <Book Series="Captain America" Number="341" Volume="1968" Year="1988" Format="Main Series">
+    <Book Series="Captain America" Number="341" Volume="1968" Year="1988">
       <Id>a8d528ea-a8b4-44d0-b989-8b6aac2c9194</Id>
     </Book>
-    <Book Series="Captain America" Number="342" Volume="1968" Year="1988" Format="Main Series">
+    <Book Series="Captain America" Number="342" Volume="1968" Year="1988">
       <Id>c21a67cf-f649-4ace-8359-03ad2147b81e</Id>
     </Book>
-    <Book Series="Captain America" Number="343" Volume="1968" Year="1988" Format="Main Series">
+    <Book Series="Captain America" Number="343" Volume="1968" Year="1988">
       <Id>46ecece6-a1f8-487e-889f-4b4b954ffed6</Id>
     </Book>
-    <Book Series="Captain America" Number="344" Volume="1968" Year="1988" Format="Main Series">
+    <Book Series="Captain America" Number="344" Volume="1968" Year="1988">
       <Id>a45387aa-72f2-49d0-a927-e115bc4f9efa</Id>
     </Book>
-    <Book Series="Captain America" Number="345" Volume="1968" Year="1988" Format="Main Series">
+    <Book Series="Captain America" Number="345" Volume="1968" Year="1988">
       <Id>96507f74-315b-4771-a290-4fe05c7f37bb</Id>
     </Book>
-    <Book Series="Captain America" Number="346" Volume="1968" Year="1988" Format="Main Series">
+    <Book Series="Captain America" Number="346" Volume="1968" Year="1988">
       <Id>598171ba-6620-4d94-a147-1abe69075131</Id>
     </Book>
-    <Book Series="Captain America" Number="347" Volume="1968" Year="1988" Format="Main Series">
+    <Book Series="Captain America" Number="347" Volume="1968" Year="1988">
       <Id>4a2efbeb-611c-48be-9200-3beb58b0d264</Id>
     </Book>
-    <Book Series="Captain America" Number="348" Volume="1968" Year="1988" Format="Main Series">
+    <Book Series="Captain America" Number="348" Volume="1968" Year="1988">
       <Id>bb55258a-7ebc-4686-9b35-23017884b334</Id>
     </Book>
-    <Book Series="Captain America" Number="349" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="Captain America" Number="349" Volume="1968" Year="1989">
       <Id>a95d5ece-4f12-48bf-a4fe-24cbd61481c6</Id>
     </Book>
-    <Book Series="Captain America" Number="350" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="Captain America" Number="350" Volume="1968" Year="1989">
       <Id>29c7a754-b22c-4426-b695-84dc2f66d323</Id>
     </Book>
-    <Book Series="Captain America" Number="351" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="Captain America" Number="351" Volume="1968" Year="1989">
       <Id>c5d43f18-2080-48a5-8c92-debbdfbe4f73</Id>
     </Book>
-    <Book Series="Captain America" Number="352" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="Captain America" Number="352" Volume="1968" Year="1989">
       <Id>88f3a328-0d69-4f10-8e46-a231f1c780f5</Id>
     </Book>
-    <Book Series="Captain America" Number="353" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="Captain America" Number="353" Volume="1968" Year="1989">
       <Id>2ee63c45-51a6-489c-8383-0d3cb4278fca</Id>
     </Book>
-    <Book Series="Captain America" Number="354" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="Captain America" Number="354" Volume="1968" Year="1989">
       <Id>42502815-e53f-4743-a389-93b518a68ce6</Id>
     </Book>
-    <Book Series="Captain America" Number="355" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="Captain America" Number="355" Volume="1968" Year="1989">
       <Id>004d3512-7917-4852-b36a-b9ac5dc3a65d</Id>
     </Book>
-    <Book Series="Captain America" Number="356" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="Captain America" Number="356" Volume="1968" Year="1989">
       <Id>a27123cc-c1b6-4877-9262-f8fc54cd7470</Id>
     </Book>
-    <Book Series="Captain America" Number="357" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="Captain America" Number="357" Volume="1968" Year="1989">
       <Id>f239d9ec-d95d-4ddb-b082-429c68967c01</Id>
     </Book>
-    <Book Series="Captain America" Number="358" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="Captain America" Number="358" Volume="1968" Year="1989">
       <Id>44faf08c-5e74-45b6-a7f9-56c37a6abf3c</Id>
     </Book>
-    <Book Series="Captain America" Number="359" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="Captain America" Number="359" Volume="1968" Year="1989">
       <Id>04a0253b-cb4c-4032-8479-3a60fc3321d8</Id>
     </Book>
-    <Book Series="Captain America" Number="360" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="Captain America" Number="360" Volume="1968" Year="1989">
       <Id>88a41729-4255-4ae3-99ab-85c1ad6e8be9</Id>
     </Book>
-    <Book Series="Captain America" Number="361" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="Captain America" Number="361" Volume="1968" Year="1989">
       <Id>d8fab2c5-9788-4ee5-a04a-d5dd6f54bf9a</Id>
     </Book>
-    <Book Series="Captain America" Number="362" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="Captain America" Number="362" Volume="1968" Year="1989">
       <Id>10c580ea-6ee2-435e-8197-4520f7ce4534</Id>
     </Book>
-    <Book Series="Captain America" Number="363" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="Captain America" Number="363" Volume="1968" Year="1989">
       <Id>dc4bea65-9129-4b80-b1ec-16e89e04bf88</Id>
     </Book>
-    <Book Series="Captain America" Number="364" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="Captain America" Number="364" Volume="1968" Year="1989">
       <Id>0ced77fc-78a4-45c2-b120-b3ad6891c372</Id>
     </Book>
-    <Book Series="Captain America" Number="365" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="Captain America" Number="365" Volume="1968" Year="1989">
       <Id>0b18b2e6-ff7a-485d-bfd0-630aa1edbe44</Id>
     </Book>
-    <Book Series="Captain America" Number="366" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="Captain America" Number="366" Volume="1968" Year="1990">
       <Id>3c840c58-02c3-4943-8ccc-f8e6ce1b3e9d</Id>
     </Book>
-    <Book Series="Captain America" Number="367" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="Captain America" Number="367" Volume="1968" Year="1990">
       <Id>0c114b06-7718-4dea-a98f-5cbc5004642a</Id>
     </Book>
-    <Book Series="Captain America" Number="368" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="Captain America" Number="368" Volume="1968" Year="1990">
       <Id>145af707-8807-4464-aef6-c8865308d334</Id>
     </Book>
-    <Book Series="Captain America" Number="369" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="Captain America" Number="369" Volume="1968" Year="1990">
       <Id>f2bfcad5-a0f3-4f79-9819-4842be16d93c</Id>
     </Book>
-    <Book Series="Captain America" Number="370" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="Captain America" Number="370" Volume="1968" Year="1990">
       <Id>06439e08-e5ae-44c9-8607-71cf0cb82667</Id>
     </Book>
-    <Book Series="Captain America" Number="371" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="Captain America" Number="371" Volume="1968" Year="1990">
       <Id>0324d9e4-0863-48d1-bf28-d65141408f21</Id>
     </Book>
-    <Book Series="Captain America Annual" Number="9" Volume="1971" Year="1990" Format="Annual">
+    <Book Series="Captain America Annual" Number="9" Volume="1971" Year="1990">
       <Id>70073a80-af71-476c-9990-4e111a21573c</Id>
     </Book>
-    <Book Series="Avengers West Coast Annual" Number="5" Volume="1989" Year="1990" Format="Annual">
+    <Book Series="Avengers West Coast Annual" Number="5" Volume="1989" Year="1990">
       <Id>e8991afe-7d0c-401c-8c92-01614c6c338d</Id>
     </Book>
-    <Book Series="The Avengers Annual" Number="19" Volume="1967" Year="1990" Format="Annual">
+    <Book Series="The Avengers Annual" Number="19" Volume="1967" Year="1990">
       <Id>1b723182-654b-41e1-a11b-3e03bc269271</Id>
     </Book>
-    <Book Series="Captain America" Number="372" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="Captain America" Number="372" Volume="1968" Year="1990">
       <Id>052e61d9-97a6-49d2-9682-f3c1439abb19</Id>
     </Book>
-    <Book Series="Captain America" Number="373" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="Captain America" Number="373" Volume="1968" Year="1990">
       <Id>e8d0b358-382c-47bf-a498-d599f6aba1e9</Id>
     </Book>
-    <Book Series="Captain America" Number="374" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="Captain America" Number="374" Volume="1968" Year="1990">
       <Id>e3935705-b1e4-4ddb-bcfc-7437c82f1b55</Id>
     </Book>
-    <Book Series="Captain America" Number="375" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="Captain America" Number="375" Volume="1968" Year="1990">
       <Id>1fb98319-b836-43fd-b8cb-1693282763df</Id>
     </Book>
-    <Book Series="Captain America" Number="376" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="Captain America" Number="376" Volume="1968" Year="1990">
       <Id>8204b2b0-24c1-40a2-9e53-1bcc55e96919</Id>
     </Book>
-    <Book Series="Captain America" Number="377" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="Captain America" Number="377" Volume="1968" Year="1990">
       <Id>51847b19-5344-499e-b701-bfe24715229b</Id>
     </Book>
-    <Book Series="Captain America" Number="378" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="Captain America" Number="378" Volume="1968" Year="1990">
       <Id>d9c1e192-d2ea-4be3-96e3-3297d9f0c158</Id>
     </Book>
-    <Book Series="Captain America" Number="379" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="Captain America" Number="379" Volume="1968" Year="1990">
       <Id>a7e42544-3817-41e7-b364-08dea5400f7f</Id>
     </Book>
-    <Book Series="Captain America" Number="380" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="Captain America" Number="380" Volume="1968" Year="1990">
       <Id>b8f2bbc6-724b-4e65-900f-65b016562975</Id>
     </Book>
-    <Book Series="Captain America" Number="381" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="Captain America" Number="381" Volume="1968" Year="1991">
       <Id>7056d0c8-e71c-4b46-a469-998007e520d1</Id>
     </Book>
-    <Book Series="Captain America" Number="382" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="Captain America" Number="382" Volume="1968" Year="1991">
       <Id>a3a8b220-9594-4024-9f8f-381151c18c55</Id>
     </Book>
-    <Book Series="Captain America" Number="383" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="Captain America" Number="383" Volume="1968" Year="1991">
       <Id>255b84a6-4024-446f-8b21-d0aea5fc3b1e</Id>
     </Book>
-    <Book Series="Captain America" Number="384" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="Captain America" Number="384" Volume="1968" Year="1991">
       <Id>00b68f2b-236a-478c-ad48-dc9c9369682a</Id>
     </Book>
-    <Book Series="Captain America" Number="385" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="Captain America" Number="385" Volume="1968" Year="1991">
       <Id>f776b616-b002-4ea2-87fc-70a33825702c</Id>
     </Book>
-    <Book Series="Captain America" Number="386" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="Captain America" Number="386" Volume="1968" Year="1991">
       <Id>ac18acb2-12ee-4dc1-9874-55d2889ab06c</Id>
     </Book>
-    <Book Series="Captain America" Number="387" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="Captain America" Number="387" Volume="1968" Year="1991">
       <Id>5b03c2ab-ab98-4a5d-a57e-c3fd21644cdb</Id>
     </Book>
-    <Book Series="Captain America" Number="388" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="Captain America" Number="388" Volume="1968" Year="1991">
       <Id>a4d2887f-6bcb-4f9a-81fc-a5a90a5f688e</Id>
     </Book>
-    <Book Series="Captain America" Number="389" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="Captain America" Number="389" Volume="1968" Year="1991">
       <Id>6e1c16d6-6a19-447d-a798-91c17540d5b3</Id>
     </Book>
-    <Book Series="Captain America" Number="390" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="Captain America" Number="390" Volume="1968" Year="1991">
       <Id>3f314394-d7ab-49b2-b5ab-7798ef0883b4</Id>
     </Book>
-    <Book Series="Captain America" Number="391" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="Captain America" Number="391" Volume="1968" Year="1991">
       <Id>d56e71cd-7c50-432c-91a0-7d369c677c0c</Id>
     </Book>
-    <Book Series="Captain America" Number="392" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="Captain America" Number="392" Volume="1968" Year="1991">
       <Id>32485335-8c74-433d-bed5-f00363e297be</Id>
     </Book>
-    <Book Series="Captain America" Number="393" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="Captain America" Number="393" Volume="1968" Year="1991">
       <Id>2f491fbf-ce36-4eea-a76a-f867845fd4e6</Id>
     </Book>
-    <Book Series="Captain America" Number="394" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="Captain America" Number="394" Volume="1968" Year="1991">
       <Id>aba960eb-42e4-4228-b721-162e54a658e9</Id>
     </Book>
-    <Book Series="Captain America" Number="395" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="Captain America" Number="395" Volume="1968" Year="1991">
       <Id>b47d6fc3-ca3e-4416-b867-04670368be17</Id>
     </Book>
-    <Book Series="Captain America" Number="396" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="Captain America" Number="396" Volume="1968" Year="1992">
       <Id>a3230340-e716-4ad4-b778-348c59ae64b8</Id>
     </Book>
-    <Book Series="Captain America" Number="397" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="Captain America" Number="397" Volume="1968" Year="1992">
       <Id>0e844cf7-d148-4e26-b322-0e7498a179b1</Id>
     </Book>
-    <Book Series="Captain America" Number="398" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="Captain America" Number="398" Volume="1968" Year="1992">
       <Id>04e99782-73bb-4b13-b0d3-5be03eab007a</Id>
     </Book>
-    <Book Series="Captain America" Number="399" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="Captain America" Number="399" Volume="1968" Year="1992">
       <Id>9dd0d311-f117-40f5-9b52-bebf93fec304</Id>
     </Book>
-    <Book Series="Captain America" Number="400" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="Captain America" Number="400" Volume="1968" Year="1992">
       <Id>b8393858-595d-46ff-ba75-a8d82b858eaa</Id>
     </Book>
-    <Book Series="Captain America" Number="401" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="Captain America" Number="401" Volume="1968" Year="1992">
       <Id>30aae588-daf8-4e26-a3b9-dca89054de6c</Id>
     </Book>
-    <Book Series="Captain America" Number="402" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="Captain America" Number="402" Volume="1968" Year="1992">
       <Id>9a1ec9da-59bf-4305-86d6-7fafe65e974e</Id>
     </Book>
-    <Book Series="Captain America" Number="403" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="Captain America" Number="403" Volume="1968" Year="1992">
       <Id>5db914ba-6fd8-4b13-bf6a-d38b45b5fef5</Id>
     </Book>
-    <Book Series="Captain America" Number="404" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="Captain America" Number="404" Volume="1968" Year="1992">
       <Id>fb524018-2189-416d-843c-9be69e85e3c6</Id>
     </Book>
-    <Book Series="Captain America" Number="405" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="Captain America" Number="405" Volume="1968" Year="1992">
       <Id>f620da19-0f40-4764-90f3-cd5b21df833e</Id>
     </Book>
-    <Book Series="Captain America" Number="406" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="Captain America" Number="406" Volume="1968" Year="1992">
       <Id>b782a2b2-d705-478c-89e4-e8911d64290e</Id>
     </Book>
-    <Book Series="Captain America" Number="407" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="Captain America" Number="407" Volume="1968" Year="1992">
       <Id>b6112c14-b4e5-4c81-af60-da1ab63e4de8</Id>
     </Book>
-    <Book Series="Captain America" Number="408" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="Captain America" Number="408" Volume="1968" Year="1992">
       <Id>041cd5ea-4376-4a4d-857a-c75c7639af30</Id>
     </Book>
-    <Book Series="Captain America Annual" Number="11" Volume="1971" Year="1992" Format="Annual">
+    <Book Series="Captain America Annual" Number="11" Volume="1971" Year="1992">
       <Id>8c9121b8-759f-4c69-a90b-ea3277a1d412</Id>
     </Book>
-    <Book Series="Captain America" Number="409" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="Captain America" Number="409" Volume="1968" Year="1992">
       <Id>0317aa62-001e-48fb-ab6c-9f16b42e888b</Id>
     </Book>
-    <Book Series="Captain America" Number="410" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="Captain America" Number="410" Volume="1968" Year="1992">
       <Id>a0c0f7c3-9f81-40e8-974d-0379b5d36228</Id>
     </Book>
-    <Book Series="Captain America" Number="411" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="Captain America" Number="411" Volume="1968" Year="1993">
       <Id>ef852ef9-4dfb-48ca-91fe-1a20a1ff558e</Id>
     </Book>
-    <Book Series="Captain America" Number="412" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="Captain America" Number="412" Volume="1968" Year="1993">
       <Id>9d0d5802-f168-4787-8929-7864c2a4094a</Id>
     </Book>
-    <Book Series="Captain America" Number="413" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="Captain America" Number="413" Volume="1968" Year="1993">
       <Id>550e40df-5bbb-4370-9492-917a642f3471</Id>
     </Book>
-    <Book Series="Captain America" Number="414" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="Captain America" Number="414" Volume="1968" Year="1993">
       <Id>9ca6facb-3048-47b4-9612-d600df37d61a</Id>
     </Book>
-    <Book Series="Captain America" Number="415" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="Captain America" Number="415" Volume="1968" Year="1993">
       <Id>00687342-d465-4ecd-97ce-8c36a139dac3</Id>
     </Book>
-    <Book Series="Captain America" Number="416" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="Captain America" Number="416" Volume="1968" Year="1993">
       <Id>40e897cc-6a58-40bc-bd16-7506ef5a57c6</Id>
     </Book>
-    <Book Series="Captain America" Number="417" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="Captain America" Number="417" Volume="1968" Year="1993">
       <Id>12a3cf9c-5666-42a2-8a9a-47ea1bb0eb4b</Id>
     </Book>
-    <Book Series="Captain America" Number="418" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="Captain America" Number="418" Volume="1968" Year="1993">
       <Id>ba97fb4e-523a-426a-8b18-b49051180a45</Id>
     </Book>
-    <Book Series="Captain America" Number="419" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="Captain America" Number="419" Volume="1968" Year="1993">
       <Id>8257b091-3faf-415e-88d8-94364f4fe304</Id>
     </Book>
-    <Book Series="Captain America" Number="420" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="Captain America" Number="420" Volume="1968" Year="1993">
       <Id>8bf6ce8f-6160-497e-b455-d17bf886e7ed</Id>
     </Book>
-    <Book Series="Captain America" Number="421" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="Captain America" Number="421" Volume="1968" Year="1993">
       <Id>9b73df13-dc4b-48e9-aaff-ae0161df13d2</Id>
     </Book>
-    <Book Series="Captain America" Number="422" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="Captain America" Number="422" Volume="1968" Year="1993">
       <Id>cea97af0-055d-4036-a85f-e5e19486ab4f</Id>
     </Book>
-    <Book Series="Captain America" Number="423" Volume="1968" Year="1994" Format="Main Series">
+    <Book Series="Captain America" Number="423" Volume="1968" Year="1994">
       <Id>e5263f53-2d6e-4dee-b7d4-d636979ee8c0</Id>
     </Book>
-    <Book Series="Captain America" Number="424" Volume="1968" Year="1994" Format="Main Series">
+    <Book Series="Captain America" Number="424" Volume="1968" Year="1994">
       <Id>33f73d84-4b43-41f4-b498-ea530f983b62</Id>
     </Book>
-    <Book Series="Captain America" Number="425" Volume="1968" Year="1994" Format="Main Series">
+    <Book Series="Captain America" Number="425" Volume="1968" Year="1994">
       <Id>7509fe8c-7277-4dce-a0f2-dd1134724946</Id>
     </Book>
-    <Book Series="Captain America" Number="426" Volume="1968" Year="1994" Format="Main Series">
+    <Book Series="Captain America" Number="426" Volume="1968" Year="1994">
       <Id>65a2b53b-b875-4088-9131-0bee5bc6e170</Id>
     </Book>
-    <Book Series="Captain America" Number="427" Volume="1968" Year="1994" Format="Main Series">
+    <Book Series="Captain America" Number="427" Volume="1968" Year="1994">
       <Id>a496df44-3fea-450c-9c4f-c3ab7206f8e0</Id>
     </Book>
-    <Book Series="Captain America" Number="428" Volume="1968" Year="1994" Format="Main Series">
+    <Book Series="Captain America" Number="428" Volume="1968" Year="1994">
       <Id>8dfc0dc7-af51-49c3-a2fb-598ab937e5b9</Id>
     </Book>
-    <Book Series="Captain America" Number="429" Volume="1968" Year="1994" Format="Main Series">
+    <Book Series="Captain America" Number="429" Volume="1968" Year="1994">
       <Id>dbb7b179-9506-49e0-bd6b-3ad21109c2f1</Id>
     </Book>
-    <Book Series="Captain America" Number="430" Volume="1968" Year="1994" Format="Main Series">
+    <Book Series="Captain America" Number="430" Volume="1968" Year="1994">
       <Id>f08925ad-0970-474f-bc6e-d6bf4f4f9795</Id>
     </Book>
-    <Book Series="Captain America Annual" Number="13" Volume="1971" Year="1994" Format="Annual">
+    <Book Series="Captain America Annual" Number="13" Volume="1971" Year="1994">
       <Id>c53f7fb5-3f34-4db7-a227-244cc8ee5f52</Id>
     </Book>
-    <Book Series="Captain America" Number="431" Volume="1968" Year="1994" Format="Main Series">
+    <Book Series="Captain America" Number="431" Volume="1968" Year="1994">
       <Id>bdebef6b-820f-463f-8968-aaebb39ca744</Id>
     </Book>
-    <Book Series="Captain America" Number="432" Volume="1968" Year="1994" Format="Main Series">
+    <Book Series="Captain America" Number="432" Volume="1968" Year="1994">
       <Id>7b4c9db6-c508-49bc-b064-83a01a5d27c1</Id>
     </Book>
-    <Book Series="Captain America" Number="433" Volume="1968" Year="1994" Format="Main Series">
+    <Book Series="Captain America" Number="433" Volume="1968" Year="1994">
       <Id>e38ed3c2-b08d-477e-89da-900e2da37e76</Id>
     </Book>
-    <Book Series="Captain America" Number="434" Volume="1968" Year="1994" Format="Main Series">
+    <Book Series="Captain America" Number="434" Volume="1968" Year="1994">
       <Id>624397e7-7f97-47b1-8b5e-5774b6d62dbd</Id>
     </Book>
-    <Book Series="Captain America" Number="435" Volume="1968" Year="1995" Format="Main Series">
+    <Book Series="Captain America" Number="435" Volume="1968" Year="1995">
       <Id>c4c2c9fa-9299-4f28-9dd3-f5f84c9ea6e3</Id>
     </Book>
-    <Book Series="Captain America" Number="436" Volume="1968" Year="1995" Format="Main Series">
+    <Book Series="Captain America" Number="436" Volume="1968" Year="1995">
       <Id>b26d4f7b-ba33-48cb-8ad6-4bda759632a8</Id>
     </Book>
-    <Book Series="Captain America" Number="437" Volume="1968" Year="1995" Format="Main Series">
+    <Book Series="Captain America" Number="437" Volume="1968" Year="1995">
       <Id>2fd43a32-519e-4c6b-a6ab-36c5844ca097</Id>
     </Book>
-    <Book Series="Captain America" Number="438" Volume="1968" Year="1995" Format="Main Series">
+    <Book Series="Captain America" Number="438" Volume="1968" Year="1995">
       <Id>4f0098b4-511b-4eca-a0c4-982769cc01b8</Id>
     </Book>
-    <Book Series="Captain America" Number="439" Volume="1968" Year="1995" Format="Main Series">
+    <Book Series="Captain America" Number="439" Volume="1968" Year="1995">
       <Id>47b76c85-82aa-4f13-8183-3a88497e229b</Id>
     </Book>
-    <Book Series="Captain America" Number="440" Volume="1968" Year="1995" Format="Main Series">
+    <Book Series="Captain America" Number="440" Volume="1968" Year="1995">
       <Id>ecaac075-dbe5-4cde-81c6-d8422c0934b7</Id>
     </Book>
-    <Book Series="Captain America" Number="441" Volume="1968" Year="1995" Format="Main Series">
+    <Book Series="Captain America" Number="441" Volume="1968" Year="1995">
       <Id>320ce270-a949-4840-b08b-92e525efa5d5</Id>
     </Book>
-    <Book Series="Captain America" Number="442" Volume="1968" Year="1995" Format="Main Series">
+    <Book Series="Captain America" Number="442" Volume="1968" Year="1995">
       <Id>08094b0d-f80e-4dbf-9cb4-e9e1b3c559fb</Id>
     </Book>
-    <Book Series="Captain America" Number="443" Volume="1968" Year="1995" Format="Main Series">
+    <Book Series="Captain America" Number="443" Volume="1968" Year="1995">
       <Id>87af6479-6edd-4099-b8ad-79b77e60806c</Id>
     </Book>
-    <Book Series="Captain America" Number="444" Volume="1968" Year="1995" Format="Main Series">
+    <Book Series="Captain America" Number="444" Volume="1968" Year="1995">
       <Id>da83fd4d-e6e9-46e9-b8b8-bc67f58f2866</Id>
     </Book>
-    <Book Series="Captain America" Number="445" Volume="1968" Year="1995" Format="Main Series">
+    <Book Series="Captain America" Number="445" Volume="1968" Year="1995">
       <Id>7d49f480-93c6-4120-8712-afb3cb482d0a</Id>
     </Book>
-    <Book Series="Captain America" Number="446" Volume="1968" Year="1995" Format="Main Series">
+    <Book Series="Captain America" Number="446" Volume="1968" Year="1995">
       <Id>f31cd702-ce57-4696-b372-46104e461084</Id>
     </Book>
-    <Book Series="Captain America" Number="447" Volume="1968" Year="1996" Format="Main Series">
+    <Book Series="Captain America" Number="447" Volume="1968" Year="1996">
       <Id>a2ff78e7-d322-47d4-9364-38bb4242e03b</Id>
     </Book>
-    <Book Series="Captain America" Number="448" Volume="1968" Year="1996" Format="Main Series">
+    <Book Series="Captain America" Number="448" Volume="1968" Year="1996">
       <Id>74975094-eecb-4379-a40c-8ee7ebd1da82</Id>
     </Book>
-    <Book Series="Captain America" Number="449" Volume="1968" Year="1996" Format="Main Series">
+    <Book Series="Captain America" Number="449" Volume="1968" Year="1996">
       <Id>04787f51-46f2-460e-b470-8ab787d67ad0</Id>
     </Book>
-    <Book Series="Captain America" Number="450" Volume="1968" Year="1996" Format="Main Series">
+    <Book Series="Captain America" Number="450" Volume="1968" Year="1996">
       <Id>6a2ecc63-9928-4cfa-80c0-8fb09e2865ea</Id>
     </Book>
-    <Book Series="Captain America" Number="451" Volume="1968" Year="1996" Format="Main Series">
+    <Book Series="Captain America" Number="451" Volume="1968" Year="1996">
       <Id>f4ee4603-e398-45d9-8cb2-38f04c90fd2b</Id>
     </Book>
-    <Book Series="Captain America" Number="452" Volume="1968" Year="1996" Format="Main Series">
+    <Book Series="Captain America" Number="452" Volume="1968" Year="1996">
       <Id>9c4e569c-649f-4cb0-a3e3-19ff590f34c8</Id>
     </Book>
-    <Book Series="Captain America" Number="453" Volume="1968" Year="1996" Format="Main Series">
+    <Book Series="Captain America" Number="453" Volume="1968" Year="1996">
       <Id>e3080c42-82c7-48e9-b4bd-cf1c37a2fb95</Id>
     </Book>
-    <Book Series="Captain America" Number="454" Volume="1968" Year="1996" Format="Main Series">
+    <Book Series="Captain America" Number="454" Volume="1968" Year="1996">
       <Id>7513c5fc-78a8-44c4-be08-7a150deb742f</Id>
     </Book>
-    <Book Series="Captain America: The Legend" Number="1" Volume="1996" Year="1996" Format="One-Shot">
+    <Book Series="Captain America: The Legend" Number="1" Volume="1996" Year="1996">
       <Id>8988877f-b268-424d-ba62-5ef049256f54</Id>
     </Book>
-    <Book Series="Onslaught: Marvel Universe" Number="1" Volume="1996" Year="1996" Format="Crossover">
+    <Book Series="Onslaught: Marvel Universe" Number="1" Volume="1996" Year="1996">
       <Id>ece634bb-a5de-4c95-95ea-1af6403e9f39</Id>
     </Book>
-    <Book Series="Captain America" Number="1" Volume="1996" Year="1996" Format="Main Series">
+    <Book Series="Captain America" Number="1" Volume="1996" Year="1996">
       <Id>2dd59724-bc99-4658-b73f-aac0230f7e95</Id>
     </Book>
-    <Book Series="Captain America" Number="2" Volume="1996" Year="1996" Format="Main Series">
+    <Book Series="Captain America" Number="2" Volume="1996" Year="1996">
       <Id>8ff7c902-bf2d-46d3-b65e-32268de75f56</Id>
     </Book>
-    <Book Series="Captain America" Number="3" Volume="1996" Year="1997" Format="Main Series">
+    <Book Series="Captain America" Number="3" Volume="1996" Year="1997">
       <Id>e55b8da2-bc15-4df5-bb1a-b9ab36dc61d0</Id>
     </Book>
-    <Book Series="Captain America" Number="4" Volume="1996" Year="1997" Format="Main Series">
+    <Book Series="Captain America" Number="4" Volume="1996" Year="1997">
       <Id>e6d97ee5-458a-432b-ae9b-6110eb6d8475</Id>
     </Book>
-    <Book Series="Captain America" Number="5" Volume="1996" Year="1997" Format="Main Series">
+    <Book Series="Captain America" Number="5" Volume="1996" Year="1997">
       <Id>afdf379c-5585-4f7c-a7d7-4ac677aa93b4</Id>
     </Book>
-    <Book Series="Captain America" Number="6" Volume="1996" Year="1997" Format="Main Series">
+    <Book Series="Captain America" Number="6" Volume="1996" Year="1997">
       <Id>7da771dc-84f7-4514-a982-2dcbe3e857ad</Id>
     </Book>
-    <Book Series="Captain America" Number="7" Volume="1996" Year="1997" Format="Main Series">
+    <Book Series="Captain America" Number="7" Volume="1996" Year="1997">
       <Id>a0bfcf86-4f99-45f1-bb06-bb42eb4cc154</Id>
     </Book>
-    <Book Series="Captain America" Number="8" Volume="1996" Year="1997" Format="Main Series">
+    <Book Series="Captain America" Number="8" Volume="1996" Year="1997">
       <Id>53729d8a-3f53-412b-9240-f5a746476ae4</Id>
     </Book>
-    <Book Series="Captain America" Number="9" Volume="1996" Year="1997" Format="Main Series">
+    <Book Series="Captain America" Number="9" Volume="1996" Year="1997">
       <Id>a09c3476-7441-4b86-8cc6-c1f012a4bedc</Id>
     </Book>
-    <Book Series="Captain America" Number="10" Volume="1996" Year="1997" Format="Main Series">
+    <Book Series="Captain America" Number="10" Volume="1996" Year="1997">
       <Id>3378262d-9c4a-4f41-ab48-5f2e53a1e310</Id>
     </Book>
-    <Book Series="Captain America" Number="11" Volume="1996" Year="1997" Format="Main Series">
+    <Book Series="Captain America" Number="11" Volume="1996" Year="1997">
       <Id>96601123-a49b-4cb7-9ec0-9b3243647b91</Id>
     </Book>
-    <Book Series="Captain America" Number="12" Volume="1996" Year="1997" Format="Main Series">
+    <Book Series="Captain America" Number="12" Volume="1996" Year="1997">
       <Id>9c0ed7c2-98d5-4e52-9fe8-edcfb66cbe2d</Id>
     </Book>
-    <Book Series="Captain America" Number="13" Volume="1996" Year="1997" Format="Main Series">
+    <Book Series="Captain America" Number="13" Volume="1996" Year="1997">
       <Id>7c1724f2-2915-4320-8b1d-ce086d27d269</Id>
     </Book>
-    <Book Series="Heroes Reborn: The Return" Number="1" Volume="1997" Year="1997" Format="Crossover">
+    <Book Series="Heroes Reborn: The Return" Number="1" Volume="1997" Year="1997">
       <Id>1170998d-d6cb-4286-8fda-7ea406f62a1e</Id>
     </Book>
-    <Book Series="Heroes Reborn: The Return" Number="2" Volume="1997" Year="1997" Format="Crossover">
+    <Book Series="Heroes Reborn: The Return" Number="2" Volume="1997" Year="1997">
       <Id>05e64ceb-c733-4554-bc61-4bc1a1e646b5</Id>
     </Book>
-    <Book Series="Heroes Reborn: The Return" Number="3" Volume="1997" Year="1997" Format="Crossover">
+    <Book Series="Heroes Reborn: The Return" Number="3" Volume="1997" Year="1997">
       <Id>c73d3825-c930-4e30-b3ac-552330099fb5</Id>
     </Book>
-    <Book Series="Heroes Reborn: The Return" Number="4" Volume="1997" Year="1997" Format="Crossover">
+    <Book Series="Heroes Reborn: The Return" Number="4" Volume="1997" Year="1997">
       <Id>bdb31726-63d8-4827-832f-e3b671617878</Id>
     </Book>
-    <Book Series="Captain America" Number="1" Volume="1998" Year="1998" Format="Main Series">
+    <Book Series="Captain America" Number="1" Volume="1998" Year="1998">
       <Id>4f2675d5-db29-4a1d-8454-da8f36039d61</Id>
     </Book>
-    <Book Series="Captain America" Number="2" Volume="1998" Year="1998" Format="Main Series">
+    <Book Series="Captain America" Number="2" Volume="1998" Year="1998">
       <Id>cd3c743b-6864-4366-8f65-89967599d5a8</Id>
     </Book>
-    <Book Series="Captain America" Number="3" Volume="1998" Year="1998" Format="Main Series">
+    <Book Series="Captain America" Number="3" Volume="1998" Year="1998">
       <Id>c59db714-b402-4d95-9dac-3ae2c26b07e5</Id>
     </Book>
-    <Book Series="Captain America" Number="4" Volume="1998" Year="1998" Format="Main Series">
+    <Book Series="Captain America" Number="4" Volume="1998" Year="1998">
       <Id>046d96b9-5460-491a-99b2-a901764dd3dd</Id>
     </Book>
-    <Book Series="Captain America" Number="5" Volume="1998" Year="1998" Format="Main Series">
+    <Book Series="Captain America" Number="5" Volume="1998" Year="1998">
       <Id>de1fd727-dbee-4cb4-b938-b6174ce10a9d</Id>
     </Book>
-    <Book Series="Captain America" Number="6" Volume="1998" Year="1998" Format="Main Series">
+    <Book Series="Captain America" Number="6" Volume="1998" Year="1998">
       <Id>65691d76-5d91-4543-a83f-dadfa434f27a</Id>
     </Book>
-    <Book Series="Captain America" Number="7" Volume="1998" Year="1998" Format="Main Series">
+    <Book Series="Captain America" Number="7" Volume="1998" Year="1998">
       <Id>02458204-b6c1-4690-ad36-dfccdfcc15f7</Id>
     </Book>
-    <Book Series="Captain America" Number="8" Volume="1998" Year="1998" Format="Main Series">
+    <Book Series="Captain America" Number="8" Volume="1998" Year="1998">
       <Id>9593d394-b6a1-4d11-9e5a-f19f4d4a93f2</Id>
     </Book>
-    <Book Series="Captain America" Number="9" Volume="1998" Year="1998" Format="Main Series">
+    <Book Series="Captain America" Number="9" Volume="1998" Year="1998">
       <Id>73ba930f-ed43-4c27-a914-3257105fb40b</Id>
     </Book>
-    <Book Series="Captain America" Number="10" Volume="1998" Year="1998" Format="Main Series">
+    <Book Series="Captain America" Number="10" Volume="1998" Year="1998">
       <Id>a1e9c582-418d-471c-8801-76812ad9a859</Id>
     </Book>
-    <Book Series="Captain America" Number="11" Volume="1998" Year="1998" Format="Main Series">
+    <Book Series="Captain America" Number="11" Volume="1998" Year="1998">
       <Id>97d70ba0-970e-4944-9f99-c500450ef25c</Id>
     </Book>
-    <Book Series="Captain America" Number="12" Volume="1998" Year="1998" Format="Main Series">
+    <Book Series="Captain America" Number="12" Volume="1998" Year="1998">
       <Id>8728b21d-dab5-4666-b32f-a04c33684705</Id>
     </Book>
-    <Book Series="Captain America / Citizen V Annual '98" Number="1" Volume="1998" Year="1998" Format="Annual">
+    <Book Series="Captain America / Citizen V Annual '98" Number="1" Volume="1998" Year="1998">
       <Id>2c846eec-fa6b-4ec9-9084-856bd1e0cb8e</Id>
     </Book>
-    <Book Series="Captain America" Number="13" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Captain America" Number="13" Volume="1998" Year="1999">
       <Id>444a03ad-efe0-4d0b-9fd4-7da0dbd87a7e</Id>
     </Book>
-    <Book Series="Captain America" Number="14" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Captain America" Number="14" Volume="1998" Year="1999">
       <Id>4b59f86a-d935-40aa-bece-bd2059b84fcb</Id>
     </Book>
-    <Book Series="Captain America" Number="15" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Captain America" Number="15" Volume="1998" Year="1999">
       <Id>5dc09a44-2472-42e5-a194-fc877c792068</Id>
     </Book>
-    <Book Series="Captain America" Number="16" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Captain America" Number="16" Volume="1998" Year="1999">
       <Id>4313de3b-ce5e-4555-b5e2-68936d7a4c26</Id>
     </Book>
-    <Book Series="Captain America" Number="17" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Captain America" Number="17" Volume="1998" Year="1999">
       <Id>adcb1b85-1021-430a-9f6c-a726d196f9dc</Id>
     </Book>
-    <Book Series="Captain America" Number="18" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Captain America" Number="18" Volume="1998" Year="1999">
       <Id>93cc70fa-f4bd-46ce-a266-dc76782968dc</Id>
     </Book>
-    <Book Series="Captain America" Number="19" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Captain America" Number="19" Volume="1998" Year="1999">
       <Id>f09a7b59-ede4-461d-a8e9-655e1cd4a6cd</Id>
     </Book>
-    <Book Series="Captain America" Number="20" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Captain America" Number="20" Volume="1998" Year="1999">
       <Id>760a1f71-e40b-48e7-9582-487f610bf67f</Id>
     </Book>
-    <Book Series="Captain America" Number="21" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Captain America" Number="21" Volume="1998" Year="1999">
       <Id>7ac14add-e53d-49fc-ae15-91c6c4b282f4</Id>
     </Book>
-    <Book Series="Captain America" Number="22" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Captain America" Number="22" Volume="1998" Year="1999">
       <Id>52baa501-7e46-4a4b-8523-e086a70041c9</Id>
     </Book>
-    <Book Series="Captain America Annual 1999" Number="1" Volume="1999" Year="1999" Format="Annual">
+    <Book Series="Captain America Annual 1999" Number="1" Volume="1999" Year="1999">
       <Id>ad6c52eb-d3cc-4b39-ac1c-1cc29535685b</Id>
     </Book>
-    <Book Series="Captain America" Number="23" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Captain America" Number="23" Volume="1998" Year="1999">
       <Id>4a71b496-e0c8-4b9b-8b0e-55f171e341c1</Id>
     </Book>
-    <Book Series="Captain America" Number="24" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Captain America" Number="24" Volume="1998" Year="1999">
       <Id>24247cc1-22df-4590-912b-8ce2daf3ea71</Id>
     </Book>
-    <Book Series="Captain America" Number="25" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Captain America" Number="25" Volume="1998" Year="2000">
       <Id>8e9e0dbf-5f9b-44f9-94b0-faa6dc3c9fe2</Id>
     </Book>
-    <Book Series="Captain America" Number="26" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Captain America" Number="26" Volume="1998" Year="2000">
       <Id>6b3904e1-e06b-4b43-8264-633113938ea7</Id>
     </Book>
-    <Book Series="Captain America" Number="27" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Captain America" Number="27" Volume="1998" Year="2000">
       <Id>9945c09e-f8b2-42a1-adfb-b06e9188fb04</Id>
     </Book>
-    <Book Series="Captain America" Number="28" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Captain America" Number="28" Volume="1998" Year="2000">
       <Id>dd3fc30c-a54a-467a-8fc5-f146f2bd519f</Id>
     </Book>
-    <Book Series="Captain America" Number="29" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Captain America" Number="29" Volume="1998" Year="2000">
       <Id>bf71d7cf-640c-4125-b9ee-e8e41ad3a0fe</Id>
     </Book>
-    <Book Series="Captain America" Number="30" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Captain America" Number="30" Volume="1998" Year="2000">
       <Id>f431a8db-0585-4cb3-a49b-cff52a62b904</Id>
     </Book>
-    <Book Series="Captain America" Number="31" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Captain America" Number="31" Volume="1998" Year="2000">
       <Id>2b0b2900-d7f1-4a7a-a3c8-f9ceba9abcfb</Id>
     </Book>
-    <Book Series="Captain America" Number="32" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Captain America" Number="32" Volume="1998" Year="2000">
       <Id>f6cefd53-8904-40b3-937d-05037a962c42</Id>
     </Book>
-    <Book Series="Captain America: Sentinel of Liberty" Number="1" Volume="1998" Year="1998" Format="Main Series">
+    <Book Series="Captain America: Sentinel of Liberty" Number="1" Volume="1998" Year="1998">
       <Id>f4f09d86-adf6-4a24-8297-385ccd4c17c9</Id>
     </Book>
-    <Book Series="Captain America: Sentinel of Liberty" Number="2" Volume="1998" Year="1998" Format="Main Series">
+    <Book Series="Captain America: Sentinel of Liberty" Number="2" Volume="1998" Year="1998">
       <Id>3c1d3efc-22e5-4578-9700-dbce573f048b</Id>
     </Book>
-    <Book Series="Captain America: Sentinel of Liberty" Number="3" Volume="1998" Year="1998" Format="Main Series">
+    <Book Series="Captain America: Sentinel of Liberty" Number="3" Volume="1998" Year="1998">
       <Id>3c4b5da1-ddd2-409b-8c2e-714e42f98b06</Id>
     </Book>
-    <Book Series="Captain America: Sentinel of Liberty" Number="4" Volume="1998" Year="1998" Format="Main Series">
+    <Book Series="Captain America: Sentinel of Liberty" Number="4" Volume="1998" Year="1998">
       <Id>fe4da0f2-1dfc-4545-b30e-a5906f4d7991</Id>
     </Book>
-    <Book Series="Captain America: Sentinel of Liberty" Number="5" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Captain America: Sentinel of Liberty" Number="5" Volume="1998" Year="1999">
       <Id>d7523941-4340-47e9-8ff8-93980e547230</Id>
     </Book>
-    <Book Series="Captain America: Sentinel of Liberty" Number="6" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Captain America: Sentinel of Liberty" Number="6" Volume="1998" Year="1999">
       <Id>df01db57-1c98-4a74-b1a0-c4cff47cec25</Id>
     </Book>
-    <Book Series="Captain America: Sentinel of Liberty" Number="7" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Captain America: Sentinel of Liberty" Number="7" Volume="1998" Year="1999">
       <Id>91b10074-6fe3-4768-949e-50f50e8a248c</Id>
     </Book>
-    <Book Series="Captain America: Sentinel of Liberty" Number="8" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Captain America: Sentinel of Liberty" Number="8" Volume="1998" Year="1999">
       <Id>da1b0f06-280e-4e2b-a0e0-7ec5d03e0fb5</Id>
     </Book>
-    <Book Series="Captain America: Sentinel of Liberty" Number="9" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Captain America: Sentinel of Liberty" Number="9" Volume="1998" Year="1999">
       <Id>eab0d89f-19a4-4eb3-904f-40add9938617</Id>
     </Book>
-    <Book Series="Captain America: Sentinel of Liberty" Number="10" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Captain America: Sentinel of Liberty" Number="10" Volume="1998" Year="1999">
       <Id>8fd5d4c2-64e1-4d27-a218-90d10df13772</Id>
     </Book>
-    <Book Series="Captain America: Sentinel of Liberty" Number="11" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Captain America: Sentinel of Liberty" Number="11" Volume="1998" Year="1999">
       <Id>c3aba782-8d12-46f4-acf0-06700b8a6ad4</Id>
     </Book>
-    <Book Series="Captain America: Sentinel of Liberty" Number="12" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Captain America: Sentinel of Liberty" Number="12" Volume="1998" Year="1999">
       <Id>462ca30c-624a-408d-98e9-050b2b1268dc</Id>
     </Book>
-    <Book Series="Captain America" Number="33" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Captain America" Number="33" Volume="1998" Year="2000">
       <Id>d8f90ee6-cfa5-40a7-bb83-6d516fa8e23b</Id>
     </Book>
-    <Book Series="Captain America" Number="34" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Captain America" Number="34" Volume="1998" Year="2000">
       <Id>d8929c5f-9af9-474a-bfad-ecf21fbf90d6</Id>
     </Book>
-    <Book Series="Captain America" Number="35" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Captain America" Number="35" Volume="1998" Year="2000">
       <Id>cc583316-16e0-4140-85e0-64749e277cbe</Id>
     </Book>
-    <Book Series="Captain America Annual 2000" Number="1" Volume="2000" Year="2000" Format="Annual">
+    <Book Series="Captain America Annual 2000" Number="1" Volume="2000" Year="2000">
       <Id>b8bb30c3-62de-42d9-a57f-b7f51d090c28</Id>
     </Book>
-    <Book Series="Captain America" Number="36" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Captain America" Number="36" Volume="1998" Year="2000">
       <Id>fc99bcd3-0719-4313-a4b1-3b1d9a7e228b</Id>
     </Book>
-    <Book Series="Captain America" Number="37" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Captain America" Number="37" Volume="1998" Year="2001">
       <Id>f4380d3e-923a-4b2a-9256-18afbe93b486</Id>
     </Book>
-    <Book Series="Captain America" Number="38" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Captain America" Number="38" Volume="1998" Year="2001">
       <Id>f3bcc7d0-ec81-4c64-a22c-aecccc1adc96</Id>
     </Book>
-    <Book Series="Captain America" Number="39" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Captain America" Number="39" Volume="1998" Year="2001">
       <Id>7c020852-7c43-4170-b639-bf5ecb274fbc</Id>
     </Book>
-    <Book Series="Captain America" Number="40" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Captain America" Number="40" Volume="1998" Year="2001">
       <Id>69d325ce-943f-4824-87d1-d282c98587c1</Id>
     </Book>
-    <Book Series="Captain America" Number="41" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Captain America" Number="41" Volume="1998" Year="2001">
       <Id>c84160b2-5bea-4ef4-a933-956e2f4e1a5b</Id>
     </Book>
-    <Book Series="Captain America" Number="42" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Captain America" Number="42" Volume="1998" Year="2001">
       <Id>01418897-99cb-4e1b-839b-9cdb65ed3a7d</Id>
     </Book>
-    <Book Series="Captain America" Number="43" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Captain America" Number="43" Volume="1998" Year="2001">
       <Id>7c5298a7-e858-4111-8d9b-11bc89772feb</Id>
     </Book>
-    <Book Series="Captain America" Number="44" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Captain America" Number="44" Volume="1998" Year="2001">
       <Id>cc8c9e90-0977-414c-95ce-1db7d65d95ca</Id>
     </Book>
-    <Book Series="Captain America" Number="45" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Captain America" Number="45" Volume="1998" Year="2001">
       <Id>92675b0c-27da-48a8-ad40-c9843cc61fa4</Id>
     </Book>
-    <Book Series="Captain America" Number="46" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Captain America" Number="46" Volume="1998" Year="2001">
       <Id>a66da39e-3a71-4b72-a0db-065c5e9baf69</Id>
     </Book>
-    <Book Series="Captain America" Number="47" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Captain America" Number="47" Volume="1998" Year="2001">
       <Id>fa2a952f-4456-4fa7-9fc4-8472273e80c6</Id>
     </Book>
-    <Book Series="Captain America" Number="48" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Captain America" Number="48" Volume="1998" Year="2001">
       <Id>149c8545-ab9b-4815-bcca-deb7614fd7ae</Id>
     </Book>
-    <Book Series="Captain America Annual 2001" Number="1" Volume="2001" Year="2001" Format="Annual">
+    <Book Series="Captain America Annual 2001" Number="1" Volume="2001" Year="2001">
       <Id>cd7cce46-ca6d-4ff2-9d94-3d0464ce8ef8</Id>
     </Book>
-    <Book Series="Captain America" Number="49" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Captain America" Number="49" Volume="1998" Year="2002">
       <Id>08af566c-fffc-4bf8-b774-621b94741b74</Id>
     </Book>
-    <Book Series="Captain America" Number="50" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Captain America" Number="50" Volume="1998" Year="2002">
       <Id>eaa6e9ec-21aa-4ce4-9185-c46beadac2ab</Id>
     </Book>
-    <Book Series="Captain America: Dead Men Running" Number="1" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="Captain America: Dead Men Running" Number="1" Volume="2002" Year="2002">
       <Id>8040cf21-f388-40a7-86a1-7e6382be5087</Id>
     </Book>
-    <Book Series="Captain America: Dead Men Running" Number="2" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="Captain America: Dead Men Running" Number="2" Volume="2002" Year="2002">
       <Id>6d8acb27-bc41-439b-b1c5-7ee9cd4be1ba</Id>
     </Book>
-    <Book Series="Captain America: Dead Men Running" Number="3" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="Captain America: Dead Men Running" Number="3" Volume="2002" Year="2002">
       <Id>4b6e0521-e27e-42a8-8ebf-b35e1f0fc325</Id>
     </Book>
-    <Book Series="Captain America: What Price Glory?" Number="1" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Captain America: What Price Glory?" Number="1" Volume="2003" Year="2003">
       <Id>64c0820d-0fa2-4339-8b21-1536802622f5</Id>
     </Book>
-    <Book Series="Captain America: What Price Glory?" Number="2" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Captain America: What Price Glory?" Number="2" Volume="2003" Year="2003">
       <Id>ac9d9982-d0a5-4f46-99c0-fed41627112f</Id>
     </Book>
-    <Book Series="Captain America: What Price Glory?" Number="3" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Captain America: What Price Glory?" Number="3" Volume="2003" Year="2003">
       <Id>66878f8d-6b13-492c-8c18-eb41f40ffcce</Id>
     </Book>
-    <Book Series="Captain America: What Price Glory?" Number="4" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Captain America: What Price Glory?" Number="4" Volume="2003" Year="2003">
       <Id>3692d808-a82c-4d39-994b-8c0ff426c5f9</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Captain America/Captain America 003.cbl
+++ b/Marvel/Characters/unsorted/Captain America/Captain America 003.cbl
@@ -1,741 +1,742 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Captain America 03</Name>
+  <Name>Captain America 003</Name>
+  <NumIssues>245</NumIssues>
   <Books>
     <Book Series="Captain America" Number="307" Volume="1968" Year="1985">
-      <Id>a098e9e7-85c7-4104-b716-946a8835e8cf</Id>
+      <Database Name="cv" Series="2400" Issue="25676" />
     </Book>
     <Book Series="Captain America" Number="308" Volume="1968" Year="1985">
-      <Id>94af0548-2f83-4efd-a48e-d8c2f9319155</Id>
+      <Database Name="cv" Series="2400" Issue="25778" />
     </Book>
     <Book Series="Captain America" Number="309" Volume="1968" Year="1985">
-      <Id>97f7bcc8-a509-4cf3-bb8f-d783b3a2f8d0</Id>
+      <Database Name="cv" Series="2400" Issue="25869" />
     </Book>
     <Book Series="Captain America" Number="310" Volume="1968" Year="1985">
-      <Id>94f589cc-cc70-4e6c-b98c-157631dc2bd7</Id>
+      <Database Name="cv" Series="2400" Issue="25974" />
     </Book>
     <Book Series="Captain America" Number="311" Volume="1968" Year="1985">
-      <Id>60856f0f-bf43-4144-a9ff-a03b127fa242</Id>
+      <Database Name="cv" Series="2400" Issue="26074" />
     </Book>
     <Book Series="Captain America" Number="312" Volume="1968" Year="1985">
-      <Id>8e479c68-5337-4977-b625-c1ffce3ce147</Id>
+      <Database Name="cv" Series="2400" Issue="26186" />
     </Book>
     <Book Series="Captain America" Number="313" Volume="1968" Year="1986">
-      <Id>4af74f76-9327-46d9-a778-a19037078c9e</Id>
+      <Database Name="cv" Series="2400" Issue="26390" />
     </Book>
     <Book Series="Captain America" Number="314" Volume="1968" Year="1986">
-      <Id>cc0916ef-3c4d-4dd6-a042-ae1c140f9d23</Id>
+      <Database Name="cv" Series="2400" Issue="26498" />
     </Book>
     <Book Series="Captain America" Number="315" Volume="1968" Year="1986">
-      <Id>3eee4721-62a5-4994-a097-ac01f6977030</Id>
+      <Database Name="cv" Series="2400" Issue="26595" />
     </Book>
     <Book Series="Captain America" Number="316" Volume="1968" Year="1986">
-      <Id>3ea01faf-c00f-4afb-968d-9cc66603b631</Id>
+      <Database Name="cv" Series="2400" Issue="26694" />
     </Book>
     <Book Series="Captain America" Number="317" Volume="1968" Year="1986">
-      <Id>fd79835c-24c3-4c46-8f92-e5f737951a83</Id>
+      <Database Name="cv" Series="2400" Issue="26787" />
     </Book>
     <Book Series="Captain America" Number="318" Volume="1968" Year="1986">
-      <Id>bd911ea8-78ae-4c4d-a5dd-6004a5fa8f74</Id>
+      <Database Name="cv" Series="2400" Issue="26886" />
     </Book>
     <Book Series="Captain America" Number="319" Volume="1968" Year="1986">
-      <Id>0fc32306-72a1-4958-91a0-a04650652013</Id>
+      <Database Name="cv" Series="2400" Issue="26985" />
     </Book>
     <Book Series="Captain America" Number="320" Volume="1968" Year="1986">
-      <Id>d95a600a-6534-489b-b2bc-402b83be41e8</Id>
+      <Database Name="cv" Series="2400" Issue="27078" />
     </Book>
     <Book Series="Captain America" Number="321" Volume="1968" Year="1986">
-      <Id>63431dc7-fe94-4d96-a4db-f42811a32578</Id>
+      <Database Name="cv" Series="2400" Issue="27177" />
     </Book>
     <Book Series="Captain America" Number="322" Volume="1968" Year="1986">
-      <Id>11cfa80a-d520-450e-9099-acffa4b423b3</Id>
+      <Database Name="cv" Series="2400" Issue="27272" />
     </Book>
     <Book Series="Captain America" Number="323" Volume="1968" Year="1986">
-      <Id>3b78b124-7c6f-44a6-bad8-dc3b4db73b59</Id>
+      <Database Name="cv" Series="2400" Issue="27378" />
     </Book>
     <Book Series="Captain America" Number="324" Volume="1968" Year="1986">
-      <Id>58030cde-759a-43d9-a27c-97c6d84b70e7</Id>
+      <Database Name="cv" Series="2400" Issue="27483" />
     </Book>
     <Book Series="Captain America" Number="325" Volume="1968" Year="1987">
-      <Id>67fc4c37-71c1-4922-b3f2-8a349c3a8e36</Id>
+      <Database Name="cv" Series="2400" Issue="27673" />
     </Book>
     <Book Series="Captain America" Number="326" Volume="1968" Year="1987">
-      <Id>52fcc150-147e-40ca-9535-d808a0ea4eae</Id>
+      <Database Name="cv" Series="2400" Issue="27785" />
     </Book>
     <Book Series="Captain America" Number="327" Volume="1968" Year="1987">
-      <Id>8f31544a-683e-4aba-8a8a-b5cc00322ad6</Id>
+      <Database Name="cv" Series="2400" Issue="27895" />
     </Book>
     <Book Series="Captain America" Number="328" Volume="1968" Year="1987">
-      <Id>998d8d4d-a121-43c8-a69c-7f7cc69a9c7f</Id>
+      <Database Name="cv" Series="2400" Issue="28009" />
     </Book>
     <Book Series="Captain America" Number="329" Volume="1968" Year="1987">
-      <Id>d7430886-468c-43cb-816d-0196b807633a</Id>
+      <Database Name="cv" Series="2400" Issue="28110" />
     </Book>
     <Book Series="Captain America" Number="330" Volume="1968" Year="1987">
-      <Id>22edcd59-621c-453d-bc89-e4778b9e8752</Id>
+      <Database Name="cv" Series="2400" Issue="28220" />
     </Book>
     <Book Series="Captain America" Number="331" Volume="1968" Year="1987">
-      <Id>fa911264-a439-4a7e-b213-2f3e19b0bf56</Id>
+      <Database Name="cv" Series="2400" Issue="28334" />
     </Book>
     <Book Series="Captain America" Number="332" Volume="1968" Year="1987">
-      <Id>2701bbfa-7f07-4976-b219-af38305b48f5</Id>
+      <Database Name="cv" Series="2400" Issue="28455" />
     </Book>
     <Book Series="Captain America" Number="333" Volume="1968" Year="1987">
-      <Id>24c64c41-74c5-465a-858f-6e7342a9e157</Id>
+      <Database Name="cv" Series="2400" Issue="28562" />
     </Book>
     <Book Series="Captain America" Number="334" Volume="1968" Year="1987">
-      <Id>23c0b344-7da6-4f4e-a44c-25204ea8ec55</Id>
+      <Database Name="cv" Series="2400" Issue="28684" />
     </Book>
     <Book Series="Captain America" Number="335" Volume="1968" Year="1987">
-      <Id>0bad9a45-97f0-4474-8138-d16c3def7d11</Id>
+      <Database Name="cv" Series="2400" Issue="28798" />
     </Book>
     <Book Series="Captain America" Number="336" Volume="1968" Year="1987">
-      <Id>1f8b7149-101d-46d4-8cea-425b9eba5666</Id>
+      <Database Name="cv" Series="2400" Issue="28921" />
     </Book>
     <Book Series="Captain America" Number="337" Volume="1968" Year="1988">
-      <Id>6ea6a1f3-f5e6-4668-a423-beaefb8a378a</Id>
+      <Database Name="cv" Series="2400" Issue="29140" />
     </Book>
     <Book Series="Captain America" Number="338" Volume="1968" Year="1988">
-      <Id>5d90bdd4-8807-4414-95bc-3e490a4835ce</Id>
+      <Database Name="cv" Series="2400" Issue="29258" />
     </Book>
     <Book Series="Captain America" Number="339" Volume="1968" Year="1988">
-      <Id>543e43b4-2aef-495e-aaeb-c3d493e7fda4</Id>
+      <Database Name="cv" Series="2400" Issue="29368" />
     </Book>
     <Book Series="Captain America" Number="340" Volume="1968" Year="1988">
-      <Id>bbff0722-bd91-4210-a114-2ab14e566e5b</Id>
+      <Database Name="cv" Series="2400" Issue="29478" />
     </Book>
     <Book Series="Captain America" Number="341" Volume="1968" Year="1988">
-      <Id>a8d528ea-a8b4-44d0-b989-8b6aac2c9194</Id>
+      <Database Name="cv" Series="2400" Issue="29587" />
     </Book>
     <Book Series="Captain America" Number="342" Volume="1968" Year="1988">
-      <Id>c21a67cf-f649-4ace-8359-03ad2147b81e</Id>
+      <Database Name="cv" Series="2400" Issue="29703" />
     </Book>
     <Book Series="Captain America" Number="343" Volume="1968" Year="1988">
-      <Id>46ecece6-a1f8-487e-889f-4b4b954ffed6</Id>
+      <Database Name="cv" Series="2400" Issue="29822" />
     </Book>
     <Book Series="Captain America" Number="344" Volume="1968" Year="1988">
-      <Id>a45387aa-72f2-49d0-a927-e115bc4f9efa</Id>
+      <Database Name="cv" Series="2400" Issue="29938" />
     </Book>
     <Book Series="Captain America" Number="345" Volume="1968" Year="1988">
-      <Id>96507f74-315b-4771-a290-4fe05c7f37bb</Id>
+      <Database Name="cv" Series="2400" Issue="30051" />
     </Book>
     <Book Series="Captain America" Number="346" Volume="1968" Year="1988">
-      <Id>598171ba-6620-4d94-a147-1abe69075131</Id>
+      <Database Name="cv" Series="2400" Issue="30175" />
     </Book>
     <Book Series="Captain America" Number="347" Volume="1968" Year="1988">
-      <Id>4a2efbeb-611c-48be-9200-3beb58b0d264</Id>
+      <Database Name="cv" Series="2400" Issue="30304" />
     </Book>
     <Book Series="Captain America" Number="348" Volume="1968" Year="1988">
-      <Id>bb55258a-7ebc-4686-9b35-23017884b334</Id>
+      <Database Name="cv" Series="2400" Issue="30425" />
     </Book>
     <Book Series="Captain America" Number="349" Volume="1968" Year="1989">
-      <Id>a95d5ece-4f12-48bf-a4fe-24cbd61481c6</Id>
+      <Database Name="cv" Series="2400" Issue="30776" />
     </Book>
     <Book Series="Captain America" Number="350" Volume="1968" Year="1989">
-      <Id>29c7a754-b22c-4426-b695-84dc2f66d323</Id>
+      <Database Name="cv" Series="2400" Issue="30885" />
     </Book>
     <Book Series="Captain America" Number="351" Volume="1968" Year="1989">
-      <Id>c5d43f18-2080-48a5-8c92-debbdfbe4f73</Id>
+      <Database Name="cv" Series="2400" Issue="30985" />
     </Book>
     <Book Series="Captain America" Number="352" Volume="1968" Year="1989">
-      <Id>88f3a328-0d69-4f10-8e46-a231f1c780f5</Id>
+      <Database Name="cv" Series="2400" Issue="31096" />
     </Book>
     <Book Series="Captain America" Number="353" Volume="1968" Year="1989">
-      <Id>2ee63c45-51a6-489c-8383-0d3cb4278fca</Id>
+      <Database Name="cv" Series="2400" Issue="31209" />
     </Book>
     <Book Series="Captain America" Number="354" Volume="1968" Year="1989">
-      <Id>42502815-e53f-4743-a389-93b518a68ce6</Id>
+      <Database Name="cv" Series="2400" Issue="31318" />
     </Book>
     <Book Series="Captain America" Number="355" Volume="1968" Year="1989">
-      <Id>004d3512-7917-4852-b36a-b9ac5dc3a65d</Id>
+      <Database Name="cv" Series="2400" Issue="31431" />
     </Book>
     <Book Series="Captain America" Number="356" Volume="1968" Year="1989">
-      <Id>a27123cc-c1b6-4877-9262-f8fc54cd7470</Id>
+      <Database Name="cv" Series="2400" Issue="31536" />
     </Book>
     <Book Series="Captain America" Number="357" Volume="1968" Year="1989">
-      <Id>f239d9ec-d95d-4ddb-b082-429c68967c01</Id>
+      <Database Name="cv" Series="2400" Issue="31649" />
     </Book>
     <Book Series="Captain America" Number="358" Volume="1968" Year="1989">
-      <Id>44faf08c-5e74-45b6-a7f9-56c37a6abf3c</Id>
+      <Database Name="cv" Series="2400" Issue="31699" />
     </Book>
     <Book Series="Captain America" Number="359" Volume="1968" Year="1989">
-      <Id>04a0253b-cb4c-4032-8479-3a60fc3321d8</Id>
+      <Database Name="cv" Series="2400" Issue="31759" />
     </Book>
     <Book Series="Captain America" Number="360" Volume="1968" Year="1989">
-      <Id>88a41729-4255-4ae3-99ab-85c1ad6e8be9</Id>
+      <Database Name="cv" Series="2400" Issue="31805" />
     </Book>
     <Book Series="Captain America" Number="361" Volume="1968" Year="1989">
-      <Id>d8fab2c5-9788-4ee5-a04a-d5dd6f54bf9a</Id>
+      <Database Name="cv" Series="2400" Issue="31864" />
     </Book>
     <Book Series="Captain America" Number="362" Volume="1968" Year="1989">
-      <Id>10c580ea-6ee2-435e-8197-4520f7ce4534</Id>
+      <Database Name="cv" Series="2400" Issue="31919" />
     </Book>
     <Book Series="Captain America" Number="363" Volume="1968" Year="1989">
-      <Id>dc4bea65-9129-4b80-b1ec-16e89e04bf88</Id>
+      <Database Name="cv" Series="2400" Issue="31942" />
     </Book>
     <Book Series="Captain America" Number="364" Volume="1968" Year="1989">
-      <Id>0ced77fc-78a4-45c2-b120-b3ad6891c372</Id>
+      <Database Name="cv" Series="2400" Issue="31994" />
     </Book>
     <Book Series="Captain America" Number="365" Volume="1968" Year="1989">
-      <Id>0b18b2e6-ff7a-485d-bfd0-630aa1edbe44</Id>
+      <Database Name="cv" Series="2400" Issue="32056" />
     </Book>
     <Book Series="Captain America" Number="366" Volume="1968" Year="1990">
-      <Id>3c840c58-02c3-4943-8ccc-f8e6ce1b3e9d</Id>
+      <Database Name="cv" Series="2400" Issue="32317" />
     </Book>
     <Book Series="Captain America" Number="367" Volume="1968" Year="1990">
-      <Id>0c114b06-7718-4dea-a98f-5cbc5004642a</Id>
+      <Database Name="cv" Series="2400" Issue="32415" />
     </Book>
     <Book Series="Captain America" Number="368" Volume="1968" Year="1990">
-      <Id>145af707-8807-4464-aef6-c8865308d334</Id>
+      <Database Name="cv" Series="2400" Issue="32516" />
     </Book>
     <Book Series="Captain America" Number="369" Volume="1968" Year="1990">
-      <Id>f2bfcad5-a0f3-4f79-9819-4842be16d93c</Id>
+      <Database Name="cv" Series="2400" Issue="32625" />
     </Book>
     <Book Series="Captain America" Number="370" Volume="1968" Year="1990">
-      <Id>06439e08-e5ae-44c9-8607-71cf0cb82667</Id>
+      <Database Name="cv" Series="2400" Issue="32723" />
     </Book>
     <Book Series="Captain America" Number="371" Volume="1968" Year="1990">
-      <Id>0324d9e4-0863-48d1-bf28-d65141408f21</Id>
+      <Database Name="cv" Series="2400" Issue="32834" />
     </Book>
     <Book Series="Captain America Annual" Number="9" Volume="1971" Year="1990">
-      <Id>70073a80-af71-476c-9990-4e111a21573c</Id>
+      <Database Name="cv" Series="2510" Issue="32189" />
     </Book>
     <Book Series="Avengers West Coast Annual" Number="5" Volume="1989" Year="1990">
-      <Id>e8991afe-7d0c-401c-8c92-01614c6c338d</Id>
+      <Database Name="cv" Series="4219" Issue="33189" />
     </Book>
     <Book Series="The Avengers Annual" Number="19" Volume="1967" Year="1990">
-      <Id>1b723182-654b-41e1-a11b-3e03bc269271</Id>
+      <Database Name="cv" Series="2350" Issue="32238" />
     </Book>
     <Book Series="Captain America" Number="372" Volume="1968" Year="1990">
-      <Id>052e61d9-97a6-49d2-9682-f3c1439abb19</Id>
+      <Database Name="cv" Series="2400" Issue="32960" />
     </Book>
     <Book Series="Captain America" Number="373" Volume="1968" Year="1990">
-      <Id>e8d0b358-382c-47bf-a498-d599f6aba1e9</Id>
+      <Database Name="cv" Series="2400" Issue="33013" />
     </Book>
     <Book Series="Captain America" Number="374" Volume="1968" Year="1990">
-      <Id>e3935705-b1e4-4ddb-bcfc-7437c82f1b55</Id>
+      <Database Name="cv" Series="2400" Issue="33074" />
     </Book>
     <Book Series="Captain America" Number="375" Volume="1968" Year="1990">
-      <Id>1fb98319-b836-43fd-b8cb-1693282763df</Id>
+      <Database Name="cv" Series="2400" Issue="33133" />
     </Book>
     <Book Series="Captain America" Number="376" Volume="1968" Year="1990">
-      <Id>8204b2b0-24c1-40a2-9e53-1bcc55e96919</Id>
+      <Database Name="cv" Series="2400" Issue="33191" />
     </Book>
     <Book Series="Captain America" Number="377" Volume="1968" Year="1990">
-      <Id>51847b19-5344-499e-b701-bfe24715229b</Id>
+      <Database Name="cv" Series="2400" Issue="33252" />
     </Book>
     <Book Series="Captain America" Number="378" Volume="1968" Year="1990">
-      <Id>d9c1e192-d2ea-4be3-96e3-3297d9f0c158</Id>
+      <Database Name="cv" Series="2400" Issue="33309" />
     </Book>
     <Book Series="Captain America" Number="379" Volume="1968" Year="1990">
-      <Id>a7e42544-3817-41e7-b364-08dea5400f7f</Id>
+      <Database Name="cv" Series="2400" Issue="33421" />
     </Book>
     <Book Series="Captain America" Number="380" Volume="1968" Year="1990">
-      <Id>b8f2bbc6-724b-4e65-900f-65b016562975</Id>
+      <Database Name="cv" Series="2400" Issue="33528" />
     </Book>
     <Book Series="Captain America" Number="381" Volume="1968" Year="1991">
-      <Id>7056d0c8-e71c-4b46-a469-998007e520d1</Id>
+      <Database Name="cv" Series="2400" Issue="33772" />
     </Book>
     <Book Series="Captain America" Number="382" Volume="1968" Year="1991">
-      <Id>a3a8b220-9594-4024-9f8f-381151c18c55</Id>
+      <Database Name="cv" Series="2400" Issue="33869" />
     </Book>
     <Book Series="Captain America" Number="383" Volume="1968" Year="1991">
-      <Id>255b84a6-4024-446f-8b21-d0aea5fc3b1e</Id>
+      <Database Name="cv" Series="2400" Issue="33986" />
     </Book>
     <Book Series="Captain America" Number="384" Volume="1968" Year="1991">
-      <Id>00b68f2b-236a-478c-ad48-dc9c9369682a</Id>
+      <Database Name="cv" Series="2400" Issue="34089" />
     </Book>
     <Book Series="Captain America" Number="385" Volume="1968" Year="1991">
-      <Id>f776b616-b002-4ea2-87fc-70a33825702c</Id>
+      <Database Name="cv" Series="2400" Issue="34194" />
     </Book>
     <Book Series="Captain America" Number="386" Volume="1968" Year="1991">
-      <Id>ac18acb2-12ee-4dc1-9874-55d2889ab06c</Id>
+      <Database Name="cv" Series="2400" Issue="34292" />
     </Book>
     <Book Series="Captain America" Number="387" Volume="1968" Year="1991">
-      <Id>5b03c2ab-ab98-4a5d-a57e-c3fd21644cdb</Id>
+      <Database Name="cv" Series="2400" Issue="34407" />
     </Book>
     <Book Series="Captain America" Number="388" Volume="1968" Year="1991">
-      <Id>a4d2887f-6bcb-4f9a-81fc-a5a90a5f688e</Id>
+      <Database Name="cv" Series="2400" Issue="34464" />
     </Book>
     <Book Series="Captain America" Number="389" Volume="1968" Year="1991">
-      <Id>6e1c16d6-6a19-447d-a798-91c17540d5b3</Id>
+      <Database Name="cv" Series="2400" Issue="34522" />
     </Book>
     <Book Series="Captain America" Number="390" Volume="1968" Year="1991">
-      <Id>3f314394-d7ab-49b2-b5ab-7798ef0883b4</Id>
+      <Database Name="cv" Series="2400" Issue="34576" />
     </Book>
     <Book Series="Captain America" Number="391" Volume="1968" Year="1991">
-      <Id>d56e71cd-7c50-432c-91a0-7d369c677c0c</Id>
+      <Database Name="cv" Series="2400" Issue="34640" />
     </Book>
     <Book Series="Captain America" Number="392" Volume="1968" Year="1991">
-      <Id>32485335-8c74-433d-bed5-f00363e297be</Id>
+      <Database Name="cv" Series="2400" Issue="34693" />
     </Book>
     <Book Series="Captain America" Number="393" Volume="1968" Year="1991">
-      <Id>2f491fbf-ce36-4eea-a76a-f867845fd4e6</Id>
+      <Database Name="cv" Series="2400" Issue="34758" />
     </Book>
     <Book Series="Captain America" Number="394" Volume="1968" Year="1991">
-      <Id>aba960eb-42e4-4228-b721-162e54a658e9</Id>
+      <Database Name="cv" Series="2400" Issue="34873" />
     </Book>
     <Book Series="Captain America" Number="395" Volume="1968" Year="1991">
-      <Id>b47d6fc3-ca3e-4416-b867-04670368be17</Id>
+      <Database Name="cv" Series="2400" Issue="34995" />
     </Book>
     <Book Series="Captain America" Number="396" Volume="1968" Year="1992">
-      <Id>a3230340-e716-4ad4-b778-348c59ae64b8</Id>
+      <Database Name="cv" Series="2400" Issue="35255" />
     </Book>
     <Book Series="Captain America" Number="397" Volume="1968" Year="1992">
-      <Id>0e844cf7-d148-4e26-b322-0e7498a179b1</Id>
+      <Database Name="cv" Series="2400" Issue="35361" />
     </Book>
     <Book Series="Captain America" Number="398" Volume="1968" Year="1992">
-      <Id>04e99782-73bb-4b13-b0d3-5be03eab007a</Id>
+      <Database Name="cv" Series="2400" Issue="35466" />
     </Book>
     <Book Series="Captain America" Number="399" Volume="1968" Year="1992">
-      <Id>9dd0d311-f117-40f5-9b52-bebf93fec304</Id>
+      <Database Name="cv" Series="2400" Issue="35570" />
     </Book>
     <Book Series="Captain America" Number="400" Volume="1968" Year="1992">
-      <Id>b8393858-595d-46ff-ba75-a8d82b858eaa</Id>
+      <Database Name="cv" Series="2400" Issue="35672" />
     </Book>
     <Book Series="Captain America" Number="401" Volume="1968" Year="1992">
-      <Id>30aae588-daf8-4e26-a3b9-dca89054de6c</Id>
+      <Database Name="cv" Series="2400" Issue="35777" />
     </Book>
     <Book Series="Captain America" Number="402" Volume="1968" Year="1992">
-      <Id>9a1ec9da-59bf-4305-86d6-7fafe65e974e</Id>
+      <Database Name="cv" Series="2400" Issue="35901" />
     </Book>
     <Book Series="Captain America" Number="403" Volume="1968" Year="1992">
-      <Id>5db914ba-6fd8-4b13-bf6a-d38b45b5fef5</Id>
+      <Database Name="cv" Series="2400" Issue="35955" />
     </Book>
     <Book Series="Captain America" Number="404" Volume="1968" Year="1992">
-      <Id>fb524018-2189-416d-843c-9be69e85e3c6</Id>
+      <Database Name="cv" Series="2400" Issue="36020" />
     </Book>
     <Book Series="Captain America" Number="405" Volume="1968" Year="1992">
-      <Id>f620da19-0f40-4764-90f3-cd5b21df833e</Id>
+      <Database Name="cv" Series="2400" Issue="36075" />
     </Book>
     <Book Series="Captain America" Number="406" Volume="1968" Year="1992">
-      <Id>b782a2b2-d705-478c-89e4-e8911d64290e</Id>
+      <Database Name="cv" Series="2400" Issue="36146" />
     </Book>
     <Book Series="Captain America" Number="407" Volume="1968" Year="1992">
-      <Id>b6112c14-b4e5-4c81-af60-da1ab63e4de8</Id>
+      <Database Name="cv" Series="2400" Issue="36197" />
     </Book>
     <Book Series="Captain America" Number="408" Volume="1968" Year="1992">
-      <Id>041cd5ea-4376-4a4d-857a-c75c7639af30</Id>
+      <Database Name="cv" Series="2400" Issue="36269" />
     </Book>
     <Book Series="Captain America Annual" Number="11" Volume="1971" Year="1992">
-      <Id>8c9121b8-759f-4c69-a90b-ea3277a1d412</Id>
+      <Database Name="cv" Series="2510" Issue="35170" />
     </Book>
     <Book Series="Captain America" Number="409" Volume="1968" Year="1992">
-      <Id>0317aa62-001e-48fb-ab6c-9f16b42e888b</Id>
+      <Database Name="cv" Series="2400" Issue="36393" />
     </Book>
     <Book Series="Captain America" Number="410" Volume="1968" Year="1992">
-      <Id>a0c0f7c3-9f81-40e8-974d-0379b5d36228</Id>
+      <Database Name="cv" Series="2400" Issue="36509" />
     </Book>
     <Book Series="Captain America" Number="411" Volume="1968" Year="1993">
-      <Id>ef852ef9-4dfb-48ca-91fe-1a20a1ff558e</Id>
+      <Database Name="cv" Series="2400" Issue="36750" />
     </Book>
     <Book Series="Captain America" Number="412" Volume="1968" Year="1993">
-      <Id>9d0d5802-f168-4787-8929-7864c2a4094a</Id>
+      <Database Name="cv" Series="2400" Issue="36857" />
     </Book>
     <Book Series="Captain America" Number="413" Volume="1968" Year="1993">
-      <Id>550e40df-5bbb-4370-9492-917a642f3471</Id>
+      <Database Name="cv" Series="2400" Issue="36967" />
     </Book>
     <Book Series="Captain America" Number="414" Volume="1968" Year="1993">
-      <Id>9ca6facb-3048-47b4-9612-d600df37d61a</Id>
+      <Database Name="cv" Series="2400" Issue="37086" />
     </Book>
     <Book Series="Captain America" Number="415" Volume="1968" Year="1993">
-      <Id>00687342-d465-4ecd-97ce-8c36a139dac3</Id>
+      <Database Name="cv" Series="2400" Issue="37222" />
     </Book>
     <Book Series="Captain America" Number="416" Volume="1968" Year="1993">
-      <Id>40e897cc-6a58-40bc-bd16-7506ef5a57c6</Id>
+      <Database Name="cv" Series="2400" Issue="37358" />
     </Book>
     <Book Series="Captain America" Number="417" Volume="1968" Year="1993">
-      <Id>12a3cf9c-5666-42a2-8a9a-47ea1bb0eb4b</Id>
+      <Database Name="cv" Series="2400" Issue="37511" />
     </Book>
     <Book Series="Captain America" Number="418" Volume="1968" Year="1993">
-      <Id>ba97fb4e-523a-426a-8b18-b49051180a45</Id>
+      <Database Name="cv" Series="2400" Issue="37653" />
     </Book>
     <Book Series="Captain America" Number="419" Volume="1968" Year="1993">
-      <Id>8257b091-3faf-415e-88d8-94364f4fe304</Id>
+      <Database Name="cv" Series="2400" Issue="37792" />
     </Book>
     <Book Series="Captain America" Number="420" Volume="1968" Year="1993">
-      <Id>8bf6ce8f-6160-497e-b455-d17bf886e7ed</Id>
+      <Database Name="cv" Series="2400" Issue="37943" />
     </Book>
     <Book Series="Captain America" Number="421" Volume="1968" Year="1993">
-      <Id>9b73df13-dc4b-48e9-aaff-ae0161df13d2</Id>
+      <Database Name="cv" Series="2400" Issue="38092" />
     </Book>
     <Book Series="Captain America" Number="422" Volume="1968" Year="1993">
-      <Id>cea97af0-055d-4036-a85f-e5e19486ab4f</Id>
+      <Database Name="cv" Series="2400" Issue="38248" />
     </Book>
     <Book Series="Captain America" Number="423" Volume="1968" Year="1994">
-      <Id>e5263f53-2d6e-4dee-b7d4-d636979ee8c0</Id>
+      <Database Name="cv" Series="2400" Issue="38496" />
     </Book>
     <Book Series="Captain America" Number="424" Volume="1968" Year="1994">
-      <Id>33f73d84-4b43-41f4-b498-ea530f983b62</Id>
+      <Database Name="cv" Series="2400" Issue="38645" />
     </Book>
     <Book Series="Captain America" Number="425" Volume="1968" Year="1994">
-      <Id>7509fe8c-7277-4dce-a0f2-dd1134724946</Id>
+      <Database Name="cv" Series="2400" Issue="38788" />
     </Book>
     <Book Series="Captain America" Number="426" Volume="1968" Year="1994">
-      <Id>65a2b53b-b875-4088-9131-0bee5bc6e170</Id>
+      <Database Name="cv" Series="2400" Issue="38936" />
     </Book>
     <Book Series="Captain America" Number="427" Volume="1968" Year="1994">
-      <Id>a496df44-3fea-450c-9c4f-c3ab7206f8e0</Id>
+      <Database Name="cv" Series="2400" Issue="39078" />
     </Book>
     <Book Series="Captain America" Number="428" Volume="1968" Year="1994">
-      <Id>8dfc0dc7-af51-49c3-a2fb-598ab937e5b9</Id>
+      <Database Name="cv" Series="2400" Issue="39216" />
     </Book>
     <Book Series="Captain America" Number="429" Volume="1968" Year="1994">
-      <Id>dbb7b179-9506-49e0-bd6b-3ad21109c2f1</Id>
+      <Database Name="cv" Series="2400" Issue="39367" />
     </Book>
     <Book Series="Captain America" Number="430" Volume="1968" Year="1994">
-      <Id>f08925ad-0970-474f-bc6e-d6bf4f4f9795</Id>
+      <Database Name="cv" Series="2400" Issue="39500" />
     </Book>
     <Book Series="Captain America Annual" Number="13" Volume="1971" Year="1994">
-      <Id>c53f7fb5-3f34-4db7-a227-244cc8ee5f52</Id>
+      <Database Name="cv" Series="2510" Issue="38407" />
     </Book>
     <Book Series="Captain America" Number="431" Volume="1968" Year="1994">
-      <Id>bdebef6b-820f-463f-8968-aaebb39ca744</Id>
+      <Database Name="cv" Series="2400" Issue="39643" />
     </Book>
     <Book Series="Captain America" Number="432" Volume="1968" Year="1994">
-      <Id>7b4c9db6-c508-49bc-b064-83a01a5d27c1</Id>
+      <Database Name="cv" Series="2400" Issue="39787" />
     </Book>
     <Book Series="Captain America" Number="433" Volume="1968" Year="1994">
-      <Id>e38ed3c2-b08d-477e-89da-900e2da37e76</Id>
+      <Database Name="cv" Series="2400" Issue="39930" />
     </Book>
     <Book Series="Captain America" Number="434" Volume="1968" Year="1994">
-      <Id>624397e7-7f97-47b1-8b5e-5774b6d62dbd</Id>
+      <Database Name="cv" Series="2400" Issue="40073" />
     </Book>
     <Book Series="Captain America" Number="435" Volume="1968" Year="1995">
-      <Id>c4c2c9fa-9299-4f28-9dd3-f5f84c9ea6e3</Id>
+      <Database Name="cv" Series="2400" Issue="40314" />
     </Book>
     <Book Series="Captain America" Number="436" Volume="1968" Year="1995">
-      <Id>b26d4f7b-ba33-48cb-8ad6-4bda759632a8</Id>
+      <Database Name="cv" Series="2400" Issue="40452" />
     </Book>
     <Book Series="Captain America" Number="437" Volume="1968" Year="1995">
-      <Id>2fd43a32-519e-4c6b-a6ab-36c5844ca097</Id>
+      <Database Name="cv" Series="2400" Issue="40584" />
     </Book>
     <Book Series="Captain America" Number="438" Volume="1968" Year="1995">
-      <Id>4f0098b4-511b-4eca-a0c4-982769cc01b8</Id>
+      <Database Name="cv" Series="2400" Issue="40722" />
     </Book>
     <Book Series="Captain America" Number="439" Volume="1968" Year="1995">
-      <Id>47b76c85-82aa-4f13-8183-3a88497e229b</Id>
+      <Database Name="cv" Series="2400" Issue="40847" />
     </Book>
     <Book Series="Captain America" Number="440" Volume="1968" Year="1995">
-      <Id>ecaac075-dbe5-4cde-81c6-d8422c0934b7</Id>
+      <Database Name="cv" Series="2400" Issue="40970" />
     </Book>
     <Book Series="Captain America" Number="441" Volume="1968" Year="1995">
-      <Id>320ce270-a949-4840-b08b-92e525efa5d5</Id>
+      <Database Name="cv" Series="2400" Issue="41109" />
     </Book>
     <Book Series="Captain America" Number="442" Volume="1968" Year="1995">
-      <Id>08094b0d-f80e-4dbf-9cb4-e9e1b3c559fb</Id>
+      <Database Name="cv" Series="2400" Issue="41250" />
     </Book>
     <Book Series="Captain America" Number="443" Volume="1968" Year="1995">
-      <Id>87af6479-6edd-4099-b8ad-79b77e60806c</Id>
+      <Database Name="cv" Series="2400" Issue="41378" />
     </Book>
     <Book Series="Captain America" Number="444" Volume="1968" Year="1995">
-      <Id>da83fd4d-e6e9-46e9-b8b8-bc67f58f2866</Id>
+      <Database Name="cv" Series="2400" Issue="41511" />
     </Book>
     <Book Series="Captain America" Number="445" Volume="1968" Year="1995">
-      <Id>7d49f480-93c6-4120-8712-afb3cb482d0a</Id>
+      <Database Name="cv" Series="2400" Issue="41638" />
     </Book>
     <Book Series="Captain America" Number="446" Volume="1968" Year="1995">
-      <Id>f31cd702-ce57-4696-b372-46104e461084</Id>
+      <Database Name="cv" Series="2400" Issue="41767" />
     </Book>
     <Book Series="Captain America" Number="447" Volume="1968" Year="1996">
-      <Id>a2ff78e7-d322-47d4-9364-38bb4242e03b</Id>
+      <Database Name="cv" Series="2400" Issue="41986" />
     </Book>
     <Book Series="Captain America" Number="448" Volume="1968" Year="1996">
-      <Id>74975094-eecb-4379-a40c-8ee7ebd1da82</Id>
+      <Database Name="cv" Series="2400" Issue="42095" />
     </Book>
     <Book Series="Captain America" Number="449" Volume="1968" Year="1996">
-      <Id>04787f51-46f2-460e-b470-8ab787d67ad0</Id>
+      <Database Name="cv" Series="2400" Issue="42203" />
     </Book>
     <Book Series="Captain America" Number="450" Volume="1968" Year="1996">
-      <Id>6a2ecc63-9928-4cfa-80c0-8fb09e2865ea</Id>
+      <Database Name="cv" Series="2400" Issue="42300" />
     </Book>
     <Book Series="Captain America" Number="451" Volume="1968" Year="1996">
-      <Id>f4ee4603-e398-45d9-8cb2-38f04c90fd2b</Id>
+      <Database Name="cv" Series="2400" Issue="42396" />
     </Book>
     <Book Series="Captain America" Number="452" Volume="1968" Year="1996">
-      <Id>9c4e569c-649f-4cb0-a3e3-19ff590f34c8</Id>
+      <Database Name="cv" Series="2400" Issue="42489" />
     </Book>
     <Book Series="Captain America" Number="453" Volume="1968" Year="1996">
-      <Id>e3080c42-82c7-48e9-b4bd-cf1c37a2fb95</Id>
+      <Database Name="cv" Series="2400" Issue="42600" />
     </Book>
     <Book Series="Captain America" Number="454" Volume="1968" Year="1996">
-      <Id>7513c5fc-78a8-44c4-be08-7a150deb742f</Id>
+      <Database Name="cv" Series="2400" Issue="42698" />
     </Book>
     <Book Series="Captain America: The Legend" Number="1" Volume="1996" Year="1996">
-      <Id>8988877f-b268-424d-ba62-5ef049256f54</Id>
+      <Database Name="cv" Series="33835" Issue="235172" />
     </Book>
     <Book Series="Onslaught: Marvel Universe" Number="1" Volume="1996" Year="1996">
-      <Id>ece634bb-a5de-4c95-95ea-1af6403e9f39</Id>
+      <Database Name="cv" Series="18278" Issue="107019" />
     </Book>
     <Book Series="Captain America" Number="1" Volume="1996" Year="1996">
-      <Id>2dd59724-bc99-4658-b73f-aac0230f7e95</Id>
+      <Database Name="cv" Series="5776" Issue="42979" />
     </Book>
     <Book Series="Captain America" Number="2" Volume="1996" Year="1996">
-      <Id>8ff7c902-bf2d-46d3-b65e-32268de75f56</Id>
+      <Database Name="cv" Series="5776" Issue="43072" />
     </Book>
     <Book Series="Captain America" Number="3" Volume="1996" Year="1997">
-      <Id>e55b8da2-bc15-4df5-bb1a-b9ab36dc61d0</Id>
+      <Database Name="cv" Series="5776" Issue="65827" />
     </Book>
     <Book Series="Captain America" Number="4" Volume="1996" Year="1997">
-      <Id>e6d97ee5-458a-432b-ae9b-6110eb6d8475</Id>
+      <Database Name="cv" Series="5776" Issue="65828" />
     </Book>
     <Book Series="Captain America" Number="5" Volume="1996" Year="1997">
-      <Id>afdf379c-5585-4f7c-a7d7-4ac677aa93b4</Id>
+      <Database Name="cv" Series="5776" Issue="65829" />
     </Book>
     <Book Series="Captain America" Number="6" Volume="1996" Year="1997">
-      <Id>7da771dc-84f7-4514-a982-2dcbe3e857ad</Id>
+      <Database Name="cv" Series="5776" Issue="43574" />
     </Book>
     <Book Series="Captain America" Number="7" Volume="1996" Year="1997">
-      <Id>a0bfcf86-4f99-45f1-bb06-bb42eb4cc154</Id>
+      <Database Name="cv" Series="5776" Issue="43680" />
     </Book>
     <Book Series="Captain America" Number="8" Volume="1996" Year="1997">
-      <Id>53729d8a-3f53-412b-9240-f5a746476ae4</Id>
+      <Database Name="cv" Series="5776" Issue="43770" />
     </Book>
     <Book Series="Captain America" Number="9" Volume="1996" Year="1997">
-      <Id>a09c3476-7441-4b86-8cc6-c1f012a4bedc</Id>
+      <Database Name="cv" Series="5776" Issue="65830" />
     </Book>
     <Book Series="Captain America" Number="10" Volume="1996" Year="1997">
-      <Id>3378262d-9c4a-4f41-ab48-5f2e53a1e310</Id>
+      <Database Name="cv" Series="5776" Issue="43969" />
     </Book>
     <Book Series="Captain America" Number="11" Volume="1996" Year="1997">
-      <Id>96601123-a49b-4cb7-9ec0-9b3243647b91</Id>
+      <Database Name="cv" Series="5776" Issue="65831" />
     </Book>
     <Book Series="Captain America" Number="12" Volume="1996" Year="1997">
-      <Id>9c0ed7c2-98d5-4e52-9fe8-edcfb66cbe2d</Id>
+      <Database Name="cv" Series="5776" Issue="65832" />
     </Book>
     <Book Series="Captain America" Number="13" Volume="1996" Year="1997">
-      <Id>7c1724f2-2915-4320-8b1d-ce086d27d269</Id>
+      <Database Name="cv" Series="5776" Issue="65833" />
     </Book>
     <Book Series="Heroes Reborn: The Return" Number="1" Volume="1997" Year="1997">
-      <Id>1170998d-d6cb-4286-8fda-7ea406f62a1e</Id>
+      <Database Name="cv" Series="6004" Issue="44392" />
     </Book>
     <Book Series="Heroes Reborn: The Return" Number="2" Volume="1997" Year="1997">
-      <Id>05e64ceb-c733-4554-bc61-4bc1a1e646b5</Id>
+      <Database Name="cv" Series="6004" Issue="44451" />
     </Book>
     <Book Series="Heroes Reborn: The Return" Number="3" Volume="1997" Year="1997">
-      <Id>c73d3825-c930-4e30-b3ac-552330099fb5</Id>
+      <Database Name="cv" Series="6004" Issue="44454" />
     </Book>
     <Book Series="Heroes Reborn: The Return" Number="4" Volume="1997" Year="1997">
-      <Id>bdb31726-63d8-4827-832f-e3b671617878</Id>
+      <Database Name="cv" Series="6004" Issue="44455" />
     </Book>
     <Book Series="Captain America" Number="1" Volume="1998" Year="1998">
-      <Id>4f2675d5-db29-4a1d-8454-da8f36039d61</Id>
+      <Database Name="cv" Series="6206" Issue="44561" />
     </Book>
     <Book Series="Captain America" Number="2" Volume="1998" Year="1998">
-      <Id>cd3c743b-6864-4366-8f65-89967599d5a8</Id>
+      <Database Name="cv" Series="6206" Issue="44673" />
     </Book>
     <Book Series="Captain America" Number="3" Volume="1998" Year="1998">
-      <Id>c59db714-b402-4d95-9dac-3ae2c26b07e5</Id>
+      <Database Name="cv" Series="6206" Issue="44765" />
     </Book>
     <Book Series="Captain America" Number="4" Volume="1998" Year="1998">
-      <Id>046d96b9-5460-491a-99b2-a901764dd3dd</Id>
+      <Database Name="cv" Series="6206" Issue="95867" />
     </Book>
     <Book Series="Captain America" Number="5" Volume="1998" Year="1998">
-      <Id>de1fd727-dbee-4cb4-b938-b6174ce10a9d</Id>
+      <Database Name="cv" Series="6206" Issue="44938" />
     </Book>
     <Book Series="Captain America" Number="6" Volume="1998" Year="1998">
-      <Id>65691d76-5d91-4543-a83f-dadfa434f27a</Id>
+      <Database Name="cv" Series="6206" Issue="65834" />
     </Book>
     <Book Series="Captain America" Number="7" Volume="1998" Year="1998">
-      <Id>02458204-b6c1-4690-ad36-dfccdfcc15f7</Id>
+      <Database Name="cv" Series="6206" Issue="65835" />
     </Book>
     <Book Series="Captain America" Number="8" Volume="1998" Year="1998">
-      <Id>9593d394-b6a1-4d11-9e5a-f19f4d4a93f2</Id>
+      <Database Name="cv" Series="6206" Issue="66213" />
     </Book>
     <Book Series="Captain America" Number="9" Volume="1998" Year="1998">
-      <Id>73ba930f-ed43-4c27-a914-3257105fb40b</Id>
+      <Database Name="cv" Series="6206" Issue="66214" />
     </Book>
     <Book Series="Captain America" Number="10" Volume="1998" Year="1998">
-      <Id>a1e9c582-418d-471c-8801-76812ad9a859</Id>
+      <Database Name="cv" Series="6206" Issue="66215" />
     </Book>
     <Book Series="Captain America" Number="11" Volume="1998" Year="1998">
-      <Id>97d70ba0-970e-4944-9f99-c500450ef25c</Id>
+      <Database Name="cv" Series="6206" Issue="66216" />
     </Book>
     <Book Series="Captain America" Number="12" Volume="1998" Year="1998">
-      <Id>8728b21d-dab5-4666-b32f-a04c33684705</Id>
+      <Database Name="cv" Series="6206" Issue="66217" />
     </Book>
-    <Book Series="Captain America / Citizen V Annual '98" Number="1" Volume="1998" Year="1998">
-      <Id>2c846eec-fa6b-4ec9-9084-856bd1e0cb8e</Id>
+    <Book Series="Captain America / Citizen V '98" Number="1" Volume="1998" Year="1998">
+      <Database Name="cv" Series="60452" Issue="142566" />
     </Book>
     <Book Series="Captain America" Number="13" Volume="1998" Year="1999">
-      <Id>444a03ad-efe0-4d0b-9fd4-7da0dbd87a7e</Id>
+      <Database Name="cv" Series="6206" Issue="66218" />
     </Book>
     <Book Series="Captain America" Number="14" Volume="1998" Year="1999">
-      <Id>4b59f86a-d935-40aa-bece-bd2059b84fcb</Id>
+      <Database Name="cv" Series="6206" Issue="66219" />
     </Book>
     <Book Series="Captain America" Number="15" Volume="1998" Year="1999">
-      <Id>5dc09a44-2472-42e5-a194-fc877c792068</Id>
+      <Database Name="cv" Series="6206" Issue="66220" />
     </Book>
     <Book Series="Captain America" Number="16" Volume="1998" Year="1999">
-      <Id>4313de3b-ce5e-4555-b5e2-68936d7a4c26</Id>
+      <Database Name="cv" Series="6206" Issue="66221" />
     </Book>
     <Book Series="Captain America" Number="17" Volume="1998" Year="1999">
-      <Id>adcb1b85-1021-430a-9f6c-a726d196f9dc</Id>
+      <Database Name="cv" Series="6206" Issue="66222" />
     </Book>
     <Book Series="Captain America" Number="18" Volume="1998" Year="1999">
-      <Id>93cc70fa-f4bd-46ce-a266-dc76782968dc</Id>
+      <Database Name="cv" Series="6206" Issue="66223" />
     </Book>
     <Book Series="Captain America" Number="19" Volume="1998" Year="1999">
-      <Id>f09a7b59-ede4-461d-a8e9-655e1cd4a6cd</Id>
+      <Database Name="cv" Series="6206" Issue="66224" />
     </Book>
     <Book Series="Captain America" Number="20" Volume="1998" Year="1999">
-      <Id>760a1f71-e40b-48e7-9582-487f610bf67f</Id>
+      <Database Name="cv" Series="6206" Issue="66225" />
     </Book>
     <Book Series="Captain America" Number="21" Volume="1998" Year="1999">
-      <Id>7ac14add-e53d-49fc-ae15-91c6c4b282f4</Id>
+      <Database Name="cv" Series="6206" Issue="66226" />
     </Book>
     <Book Series="Captain America" Number="22" Volume="1998" Year="1999">
-      <Id>52baa501-7e46-4a4b-8523-e086a70041c9</Id>
+      <Database Name="cv" Series="6206" Issue="66227" />
     </Book>
-    <Book Series="Captain America Annual 1999" Number="1" Volume="1999" Year="1999">
-      <Id>ad6c52eb-d3cc-4b39-ac1c-1cc29535685b</Id>
+    <Book Series="Captain America 1999" Number="1" Volume="1999" Year="1999">
+      <Database Name="cv" Series="60453" Issue="142567" />
     </Book>
     <Book Series="Captain America" Number="23" Volume="1998" Year="1999">
-      <Id>4a71b496-e0c8-4b9b-8b0e-55f171e341c1</Id>
+      <Database Name="cv" Series="6206" Issue="66228" />
     </Book>
     <Book Series="Captain America" Number="24" Volume="1998" Year="1999">
-      <Id>24247cc1-22df-4590-912b-8ce2daf3ea71</Id>
+      <Database Name="cv" Series="6206" Issue="66229" />
     </Book>
     <Book Series="Captain America" Number="25" Volume="1998" Year="2000">
-      <Id>8e9e0dbf-5f9b-44f9-94b0-faa6dc3c9fe2</Id>
+      <Database Name="cv" Series="6206" Issue="66230" />
     </Book>
     <Book Series="Captain America" Number="26" Volume="1998" Year="2000">
-      <Id>6b3904e1-e06b-4b43-8264-633113938ea7</Id>
+      <Database Name="cv" Series="6206" Issue="66231" />
     </Book>
     <Book Series="Captain America" Number="27" Volume="1998" Year="2000">
-      <Id>9945c09e-f8b2-42a1-adfb-b06e9188fb04</Id>
+      <Database Name="cv" Series="6206" Issue="66232" />
     </Book>
     <Book Series="Captain America" Number="28" Volume="1998" Year="2000">
-      <Id>dd3fc30c-a54a-467a-8fc5-f146f2bd519f</Id>
+      <Database Name="cv" Series="6206" Issue="66233" />
     </Book>
     <Book Series="Captain America" Number="29" Volume="1998" Year="2000">
-      <Id>bf71d7cf-640c-4125-b9ee-e8e41ad3a0fe</Id>
+      <Database Name="cv" Series="6206" Issue="66234" />
     </Book>
     <Book Series="Captain America" Number="30" Volume="1998" Year="2000">
-      <Id>f431a8db-0585-4cb3-a49b-cff52a62b904</Id>
+      <Database Name="cv" Series="6206" Issue="66235" />
     </Book>
     <Book Series="Captain America" Number="31" Volume="1998" Year="2000">
-      <Id>2b0b2900-d7f1-4a7a-a3c8-f9ceba9abcfb</Id>
+      <Database Name="cv" Series="6206" Issue="66236" />
     </Book>
     <Book Series="Captain America" Number="32" Volume="1998" Year="2000">
-      <Id>f6cefd53-8904-40b3-937d-05037a962c42</Id>
+      <Database Name="cv" Series="6206" Issue="66237" />
     </Book>
     <Book Series="Captain America: Sentinel of Liberty" Number="1" Volume="1998" Year="1998">
-      <Id>f4f09d86-adf6-4a24-8297-385ccd4c17c9</Id>
+      <Database Name="cv" Series="19381" Issue="116163" />
     </Book>
     <Book Series="Captain America: Sentinel of Liberty" Number="2" Volume="1998" Year="1998">
-      <Id>3c1d3efc-22e5-4578-9700-dbce573f048b</Id>
+      <Database Name="cv" Series="19381" Issue="127688" />
     </Book>
     <Book Series="Captain America: Sentinel of Liberty" Number="3" Volume="1998" Year="1998">
-      <Id>3c4b5da1-ddd2-409b-8c2e-714e42f98b06</Id>
+      <Database Name="cv" Series="19381" Issue="127689" />
     </Book>
     <Book Series="Captain America: Sentinel of Liberty" Number="4" Volume="1998" Year="1998">
-      <Id>fe4da0f2-1dfc-4545-b30e-a5906f4d7991</Id>
+      <Database Name="cv" Series="19381" Issue="127690" />
     </Book>
     <Book Series="Captain America: Sentinel of Liberty" Number="5" Volume="1998" Year="1999">
-      <Id>d7523941-4340-47e9-8ff8-93980e547230</Id>
+      <Database Name="cv" Series="19381" Issue="127691" />
     </Book>
     <Book Series="Captain America: Sentinel of Liberty" Number="6" Volume="1998" Year="1999">
-      <Id>df01db57-1c98-4a74-b1a0-c4cff47cec25</Id>
+      <Database Name="cv" Series="19381" Issue="127692" />
     </Book>
     <Book Series="Captain America: Sentinel of Liberty" Number="7" Volume="1998" Year="1999">
-      <Id>91b10074-6fe3-4768-949e-50f50e8a248c</Id>
+      <Database Name="cv" Series="19381" Issue="127693" />
     </Book>
     <Book Series="Captain America: Sentinel of Liberty" Number="8" Volume="1998" Year="1999">
-      <Id>da1b0f06-280e-4e2b-a0e0-7ec5d03e0fb5</Id>
+      <Database Name="cv" Series="19381" Issue="127694" />
     </Book>
     <Book Series="Captain America: Sentinel of Liberty" Number="9" Volume="1998" Year="1999">
-      <Id>eab0d89f-19a4-4eb3-904f-40add9938617</Id>
+      <Database Name="cv" Series="19381" Issue="127695" />
     </Book>
     <Book Series="Captain America: Sentinel of Liberty" Number="10" Volume="1998" Year="1999">
-      <Id>8fd5d4c2-64e1-4d27-a218-90d10df13772</Id>
+      <Database Name="cv" Series="19381" Issue="127820" />
     </Book>
     <Book Series="Captain America: Sentinel of Liberty" Number="11" Volume="1998" Year="1999">
-      <Id>c3aba782-8d12-46f4-acf0-06700b8a6ad4</Id>
+      <Database Name="cv" Series="19381" Issue="124234" />
     </Book>
     <Book Series="Captain America: Sentinel of Liberty" Number="12" Volume="1998" Year="1999">
-      <Id>462ca30c-624a-408d-98e9-050b2b1268dc</Id>
+      <Database Name="cv" Series="19381" Issue="127822" />
     </Book>
     <Book Series="Captain America" Number="33" Volume="1998" Year="2000">
-      <Id>d8f90ee6-cfa5-40a7-bb83-6d516fa8e23b</Id>
+      <Database Name="cv" Series="6206" Issue="65836" />
     </Book>
     <Book Series="Captain America" Number="34" Volume="1998" Year="2000">
-      <Id>d8929c5f-9af9-474a-bfad-ecf21fbf90d6</Id>
+      <Database Name="cv" Series="6206" Issue="65837" />
     </Book>
     <Book Series="Captain America" Number="35" Volume="1998" Year="2000">
-      <Id>cc583316-16e0-4140-85e0-64749e277cbe</Id>
+      <Database Name="cv" Series="6206" Issue="65838" />
     </Book>
-    <Book Series="Captain America Annual 2000" Number="1" Volume="2000" Year="2000">
-      <Id>b8bb30c3-62de-42d9-a57f-b7f51d090c28</Id>
+    <Book Series="Captain America 2000" Number="1" Volume="2000" Year="2000">
+      <Database Name="cv" Series="60454" Issue="142568" />
     </Book>
     <Book Series="Captain America" Number="36" Volume="1998" Year="2000">
-      <Id>fc99bcd3-0719-4313-a4b1-3b1d9a7e228b</Id>
+      <Database Name="cv" Series="6206" Issue="65839" />
     </Book>
     <Book Series="Captain America" Number="37" Volume="1998" Year="2001">
-      <Id>f4380d3e-923a-4b2a-9256-18afbe93b486</Id>
+      <Database Name="cv" Series="6206" Issue="65840" />
     </Book>
     <Book Series="Captain America" Number="38" Volume="1998" Year="2001">
-      <Id>f3bcc7d0-ec81-4c64-a22c-aecccc1adc96</Id>
+      <Database Name="cv" Series="6206" Issue="65841" />
     </Book>
     <Book Series="Captain America" Number="39" Volume="1998" Year="2001">
-      <Id>7c020852-7c43-4170-b639-bf5ecb274fbc</Id>
+      <Database Name="cv" Series="6206" Issue="66238" />
     </Book>
     <Book Series="Captain America" Number="40" Volume="1998" Year="2001">
-      <Id>69d325ce-943f-4824-87d1-d282c98587c1</Id>
+      <Database Name="cv" Series="6206" Issue="66239" />
     </Book>
     <Book Series="Captain America" Number="41" Volume="1998" Year="2001">
-      <Id>c84160b2-5bea-4ef4-a933-956e2f4e1a5b</Id>
+      <Database Name="cv" Series="6206" Issue="66240" />
     </Book>
     <Book Series="Captain America" Number="42" Volume="1998" Year="2001">
-      <Id>01418897-99cb-4e1b-839b-9cdb65ed3a7d</Id>
+      <Database Name="cv" Series="6206" Issue="66241" />
     </Book>
     <Book Series="Captain America" Number="43" Volume="1998" Year="2001">
-      <Id>7c5298a7-e858-4111-8d9b-11bc89772feb</Id>
+      <Database Name="cv" Series="6206" Issue="66242" />
     </Book>
     <Book Series="Captain America" Number="44" Volume="1998" Year="2001">
-      <Id>cc8c9e90-0977-414c-95ce-1db7d65d95ca</Id>
+      <Database Name="cv" Series="6206" Issue="66243" />
     </Book>
     <Book Series="Captain America" Number="45" Volume="1998" Year="2001">
-      <Id>92675b0c-27da-48a8-ad40-c9843cc61fa4</Id>
+      <Database Name="cv" Series="6206" Issue="66244" />
     </Book>
     <Book Series="Captain America" Number="46" Volume="1998" Year="2001">
-      <Id>a66da39e-3a71-4b72-a0db-065c5e9baf69</Id>
+      <Database Name="cv" Series="6206" Issue="66245" />
     </Book>
     <Book Series="Captain America" Number="47" Volume="1998" Year="2001">
-      <Id>fa2a952f-4456-4fa7-9fc4-8472273e80c6</Id>
+      <Database Name="cv" Series="6206" Issue="66246" />
     </Book>
     <Book Series="Captain America" Number="48" Volume="1998" Year="2001">
-      <Id>149c8545-ab9b-4815-bcca-deb7614fd7ae</Id>
+      <Database Name="cv" Series="6206" Issue="66247" />
     </Book>
-    <Book Series="Captain America Annual 2001" Number="1" Volume="2001" Year="2001">
-      <Id>cd7cce46-ca6d-4ff2-9d94-3d0464ce8ef8</Id>
+    <Book Series="Captain America 2001" Number="1" Volume="2001" Year="2001">
+      <Database Name="cv" Series="60455" Issue="142569" />
     </Book>
     <Book Series="Captain America" Number="49" Volume="1998" Year="2002">
-      <Id>08af566c-fffc-4bf8-b774-621b94741b74</Id>
+      <Database Name="cv" Series="6206" Issue="66248" />
     </Book>
     <Book Series="Captain America" Number="50" Volume="1998" Year="2002">
-      <Id>eaa6e9ec-21aa-4ce4-9185-c46beadac2ab</Id>
+      <Database Name="cv" Series="6206" Issue="66249" />
     </Book>
     <Book Series="Captain America: Dead Men Running" Number="1" Volume="2002" Year="2002">
-      <Id>8040cf21-f388-40a7-86a1-7e6382be5087</Id>
+      <Database Name="cv" Series="9458" Issue="77751" />
     </Book>
     <Book Series="Captain America: Dead Men Running" Number="2" Volume="2002" Year="2002">
-      <Id>6d8acb27-bc41-439b-b1c5-7ee9cd4be1ba</Id>
+      <Database Name="cv" Series="9458" Issue="77752" />
     </Book>
     <Book Series="Captain America: Dead Men Running" Number="3" Volume="2002" Year="2002">
-      <Id>4b6e0521-e27e-42a8-8ebf-b35e1f0fc325</Id>
+      <Database Name="cv" Series="9458" Issue="77753" />
     </Book>
     <Book Series="Captain America: What Price Glory?" Number="1" Volume="2003" Year="2003">
-      <Id>64c0820d-0fa2-4339-8b21-1536802622f5</Id>
+      <Database Name="cv" Series="20608" Issue="150715" />
     </Book>
     <Book Series="Captain America: What Price Glory?" Number="2" Volume="2003" Year="2003">
-      <Id>ac9d9982-d0a5-4f46-99c0-fed41627112f</Id>
+      <Database Name="cv" Series="20608" Issue="123536" />
     </Book>
     <Book Series="Captain America: What Price Glory?" Number="3" Volume="2003" Year="2003">
-      <Id>66878f8d-6b13-492c-8c18-eb41f40ffcce</Id>
+      <Database Name="cv" Series="20608" Issue="150716" />
     </Book>
     <Book Series="Captain America: What Price Glory?" Number="4" Volume="2003" Year="2003">
-      <Id>3692d808-a82c-4d39-994b-8c0ff426c5f9</Id>
+      <Database Name="cv" Series="20608" Issue="150717" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Captain America/Captain America 004 - Marvel Knights.cbl
+++ b/Marvel/Characters/unsorted/Captain America/Captain America 004 - Marvel Knights.cbl
@@ -1,777 +1,778 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Captain America 04 - Marvel Knights</Name>
+  <Name>Captain America 004 - Marvel Knights</Name>
+  <NumIssues>257</NumIssues>
   <Books>
     <Book Series="Captain America" Number="1" Volume="2002" Year="2002">
-      <Id>99a06bdc-63f3-4faf-8803-59922f5d830b</Id>
+      <Database Name="cv" Series="9088" Issue="66250" />
     </Book>
     <Book Series="Captain America" Number="2" Volume="2002" Year="2002">
-      <Id>2e5ca6f7-e88c-40ef-9bf9-d86a21512b8c</Id>
+      <Database Name="cv" Series="9088" Issue="66251" />
     </Book>
     <Book Series="Captain America" Number="3" Volume="2002" Year="2002">
-      <Id>4712ad55-1b62-4273-9c71-f6ddb0f703e1</Id>
+      <Database Name="cv" Series="9088" Issue="80544" />
     </Book>
     <Book Series="Captain America" Number="4" Volume="2002" Year="2002">
-      <Id>89f65f9b-346e-46eb-92ab-473bfc2d3e01</Id>
+      <Database Name="cv" Series="9088" Issue="123467" />
     </Book>
     <Book Series="Captain America" Number="5" Volume="2002" Year="2002">
-      <Id>5cb9f8d2-f372-46ed-9d3d-f1b6ecd4fba9</Id>
+      <Database Name="cv" Series="9088" Issue="150470" />
     </Book>
     <Book Series="Captain America" Number="6" Volume="2002" Year="2002">
-      <Id>82349473-b2dc-4ef5-bb7d-b72ca16b7dd2</Id>
+      <Database Name="cv" Series="9088" Issue="150471" />
     </Book>
     <Book Series="Captain America" Number="7" Volume="2002" Year="2002">
-      <Id>f410ceb3-cec2-42d0-b257-4aa897ae25b4</Id>
+      <Database Name="cv" Series="9088" Issue="150472" />
     </Book>
     <Book Series="Captain America" Number="8" Volume="2002" Year="2003">
-      <Id>19a8bd3f-dcfe-4c55-9a5b-c87a951b2e93</Id>
+      <Database Name="cv" Series="9088" Issue="150473" />
     </Book>
     <Book Series="Captain America" Number="9" Volume="2002" Year="2003">
-      <Id>eba032dc-f633-468b-a6a1-4cce71b33d85</Id>
+      <Database Name="cv" Series="9088" Issue="150475" />
     </Book>
     <Book Series="Captain America" Number="10" Volume="2002" Year="2003">
-      <Id>32f9bbff-6a84-44a0-bf16-60362e6e741b</Id>
+      <Database Name="cv" Series="9088" Issue="150476" />
     </Book>
     <Book Series="Captain America" Number="11" Volume="2002" Year="2003">
-      <Id>dd37dfe1-5dff-4681-ba62-6a6f5a888646</Id>
+      <Database Name="cv" Series="9088" Issue="150477" />
     </Book>
     <Book Series="Captain America" Number="12" Volume="2002" Year="2003">
-      <Id>a5f795fd-221f-43bb-93d2-3b7e946b2c04</Id>
+      <Database Name="cv" Series="9088" Issue="150478" />
     </Book>
     <Book Series="Captain America" Number="13" Volume="2002" Year="2003">
-      <Id>2332bee1-e567-44f9-91a7-388a7b70802f</Id>
+      <Database Name="cv" Series="9088" Issue="150479" />
     </Book>
     <Book Series="Captain America" Number="14" Volume="2002" Year="2003">
-      <Id>89f6d73e-734b-4280-8a8e-7688c0286730</Id>
+      <Database Name="cv" Series="9088" Issue="150480" />
     </Book>
     <Book Series="Captain America" Number="15" Volume="2002" Year="2003">
-      <Id>cbc908b9-309c-4ff8-adcb-664455207aee</Id>
+      <Database Name="cv" Series="9088" Issue="150481" />
     </Book>
     <Book Series="Captain America" Number="16" Volume="2002" Year="2003">
-      <Id>7b5e77c5-2afb-4c1f-a4ac-71e979774392</Id>
+      <Database Name="cv" Series="9088" Issue="150482" />
     </Book>
     <Book Series="Captain America" Number="17" Volume="2002" Year="2003">
-      <Id>6717efcc-26a3-4cee-aabd-eefa6b04003a</Id>
+      <Database Name="cv" Series="9088" Issue="123513" />
     </Book>
     <Book Series="Captain America" Number="18" Volume="2002" Year="2003">
-      <Id>2f414138-994e-4f46-961b-8248a16125d6</Id>
+      <Database Name="cv" Series="9088" Issue="123510" />
     </Book>
     <Book Series="Captain America" Number="19" Volume="2002" Year="2003">
-      <Id>398eb164-156e-4f30-8925-228034790e81</Id>
+      <Database Name="cv" Series="9088" Issue="123508" />
     </Book>
     <Book Series="Captain America" Number="20" Volume="2002" Year="2004">
-      <Id>1ee6d6a3-c834-40c0-afc7-d8a4f7e3e334</Id>
+      <Database Name="cv" Series="9088" Issue="123506" />
     </Book>
     <Book Series="Captain America" Number="21" Volume="2002" Year="2004">
-      <Id>f330d114-c0b2-443e-ad0e-5c21aa8beb76</Id>
+      <Database Name="cv" Series="9088" Issue="123482" />
     </Book>
     <Book Series="Captain America" Number="22" Volume="2002" Year="2004">
-      <Id>2200ea25-69e0-4b89-ba6a-c1fcda099769</Id>
+      <Database Name="cv" Series="9088" Issue="123480" />
     </Book>
     <Book Series="Captain America" Number="23" Volume="2002" Year="2004">
-      <Id>44afedff-2ac5-4199-b33e-4c092109ae78</Id>
+      <Database Name="cv" Series="9088" Issue="123478" />
     </Book>
     <Book Series="Captain America" Number="24" Volume="2002" Year="2004">
-      <Id>10904edb-5c2c-4b32-ae05-41196c8f74f3</Id>
+      <Database Name="cv" Series="9088" Issue="123477" />
     </Book>
     <Book Series="Captain America" Number="25" Volume="2002" Year="2004">
-      <Id>5f20e4f7-ded6-4539-9e2e-ca13d08ecbeb</Id>
+      <Database Name="cv" Series="9088" Issue="123476" />
     </Book>
     <Book Series="Wolverine/Captain America" Number="1" Volume="2004" Year="2004">
-      <Id>b51d368e-fe0b-4d54-8e3b-adca003cc824</Id>
+      <Database Name="cv" Series="10812" Issue="92162" />
     </Book>
     <Book Series="Wolverine/Captain America" Number="2" Volume="2004" Year="2004">
-      <Id>4067a515-2a3a-4e33-bca9-afd2142ab5b8</Id>
+      <Database Name="cv" Series="10812" Issue="92163" />
     </Book>
     <Book Series="Wolverine/Captain America" Number="3" Volume="2004" Year="2004">
-      <Id>7421a9fa-6ffa-4aa7-9448-695e22a7436f</Id>
+      <Database Name="cv" Series="10812" Issue="92164" />
     </Book>
     <Book Series="Wolverine/Captain America" Number="4" Volume="2004" Year="2004">
-      <Id>f132b266-414f-491a-bad3-77ff9a6d6307</Id>
+      <Database Name="cv" Series="10812" Issue="92165" />
     </Book>
     <Book Series="Captain America" Number="26" Volume="2002" Year="2004">
-      <Id>5a7008fb-4520-49c5-8125-f62ba11e1507</Id>
+      <Database Name="cv" Series="9088" Issue="99091" />
     </Book>
     <Book Series="Captain America" Number="27" Volume="2002" Year="2004">
-      <Id>918de13a-4731-4c2f-be45-928cf6b5cfe9</Id>
+      <Database Name="cv" Series="9088" Issue="99092" />
     </Book>
     <Book Series="Captain America" Number="28" Volume="2002" Year="2004">
-      <Id>acaa2a81-c87d-4ec7-ad71-6c61811e133c</Id>
+      <Database Name="cv" Series="9088" Issue="99093" />
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="1" Volume="2004" Year="2004">
-      <Id>1304c00c-b246-4b98-ba23-d7f506979b35</Id>
+    <Book Series="Captain America &#38; the Falcon" Number="1" Volume="2004" Year="2004">
+      <Database Name="cv" Series="10973" Issue="94288" />
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="2" Volume="2004" Year="2004">
-      <Id>c0d46016-9243-4874-ae2d-36d07865d090</Id>
+    <Book Series="Captain America &#38; the Falcon" Number="2" Volume="2004" Year="2004">
+      <Database Name="cv" Series="10973" Issue="94289" />
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="3" Volume="2004" Year="2004">
-      <Id>1db53bef-9a0e-4343-8a67-39a09c2475c2</Id>
+    <Book Series="Captain America &#38; the Falcon" Number="3" Volume="2004" Year="2004">
+      <Database Name="cv" Series="10973" Issue="94290" />
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="4" Volume="2004" Year="2004">
-      <Id>9fb055b6-c3fc-4606-be15-2093befc0a8e</Id>
+    <Book Series="Captain America &#38; the Falcon" Number="4" Volume="2004" Year="2004">
+      <Database Name="cv" Series="10973" Issue="94291" />
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="5" Volume="2004" Year="2004">
-      <Id>72854219-ed32-4376-ac70-a6a545a352d6</Id>
+    <Book Series="Captain America &#38; the Falcon" Number="5" Volume="2004" Year="2004">
+      <Database Name="cv" Series="10973" Issue="94292" />
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="6" Volume="2004" Year="2004">
-      <Id>56e1d43e-75c8-4ab2-9d38-cc58dd5b2fa6</Id>
+    <Book Series="Captain America &#38; the Falcon" Number="6" Volume="2004" Year="2004">
+      <Database Name="cv" Series="10973" Issue="94293" />
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="7" Volume="2004" Year="2004">
-      <Id>3e969b14-d089-45c8-bde3-317413223ef0</Id>
+    <Book Series="Captain America &#38; the Falcon" Number="7" Volume="2004" Year="2004">
+      <Database Name="cv" Series="10973" Issue="94294" />
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="8" Volume="2004" Year="2004">
-      <Id>99ed20de-2972-4d19-9035-d9aefd07a408</Id>
+    <Book Series="Captain America &#38; the Falcon" Number="8" Volume="2004" Year="2004">
+      <Database Name="cv" Series="10973" Issue="100917" />
     </Book>
     <Book Series="Captain America" Number="29" Volume="2002" Year="2004">
-      <Id>b3fdd0bf-b472-462b-b329-2f251789ed07</Id>
+      <Database Name="cv" Series="9088" Issue="99094" />
     </Book>
     <Book Series="Captain America" Number="30" Volume="2002" Year="2004">
-      <Id>26dee2c5-c6f1-4565-b713-5d926fcb7d6c</Id>
+      <Database Name="cv" Series="9088" Issue="99095" />
     </Book>
     <Book Series="Captain America" Number="31" Volume="2002" Year="2004">
-      <Id>15960bce-bf06-41cf-b976-dd968688518e</Id>
+      <Database Name="cv" Series="9088" Issue="99096" />
     </Book>
     <Book Series="Captain America" Number="32" Volume="2002" Year="2004">
-      <Id>8fbc1f41-9a06-423c-b56a-022330f0331e</Id>
+      <Database Name="cv" Series="9088" Issue="99097" />
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="9" Volume="2004" Year="2005">
-      <Id>8d349fc7-e563-48de-b11f-e621126ec29c</Id>
+    <Book Series="Captain America &#38; the Falcon" Number="9" Volume="2004" Year="2005">
+      <Database Name="cv" Series="10973" Issue="100918" />
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="10" Volume="2004" Year="2005">
-      <Id>0eab4f37-7169-4052-9a8c-61e66e5a3b2d</Id>
+    <Book Series="Captain America &#38; the Falcon" Number="10" Volume="2004" Year="2005">
+      <Database Name="cv" Series="10973" Issue="100919" />
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="11" Volume="2004" Year="2005">
-      <Id>0e9a0c10-4d9d-4fee-9887-f8db10905635</Id>
+    <Book Series="Captain America &#38; the Falcon" Number="11" Volume="2004" Year="2005">
+      <Database Name="cv" Series="10973" Issue="100920" />
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="12" Volume="2004" Year="2005">
-      <Id>3d6cb62a-1a09-4f0c-b27a-6974522185cc</Id>
+    <Book Series="Captain America &#38; the Falcon" Number="12" Volume="2004" Year="2005">
+      <Database Name="cv" Series="10973" Issue="100921" />
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="13" Volume="2004" Year="2005">
-      <Id>01d30edc-cd7f-4d61-8545-5371a8538d59</Id>
+    <Book Series="Captain America &#38; the Falcon" Number="13" Volume="2004" Year="2005">
+      <Database Name="cv" Series="10973" Issue="100922" />
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="14" Volume="2004" Year="2005">
-      <Id>480c892d-ecb8-41a6-88c9-c594ca41b432</Id>
+    <Book Series="Captain America &#38; the Falcon" Number="14" Volume="2004" Year="2005">
+      <Database Name="cv" Series="10973" Issue="100923" />
     </Book>
     <Book Series="Secret War" Number="1" Volume="2004" Year="2004">
-      <Id>656b0c01-2210-46e1-b339-0425383d04f8</Id>
+      <Database Name="cv" Series="18234" Issue="106863" />
     </Book>
     <Book Series="Secret War" Number="2" Volume="2004" Year="2004">
-      <Id>ffb4246d-e097-4e7c-ac18-8fb13bb6f318</Id>
+      <Database Name="cv" Series="18234" Issue="106864" />
     </Book>
     <Book Series="Secret War" Number="3" Volume="2004" Year="2004">
-      <Id>d1f6a606-2cd2-4889-92aa-823f023f98d2</Id>
+      <Database Name="cv" Series="18234" Issue="106865" />
     </Book>
     <Book Series="Secret War" Number="4" Volume="2004" Year="2005">
-      <Id>bb509e6f-eeaa-44c1-b6cc-c2081712832c</Id>
+      <Database Name="cv" Series="18234" Issue="106866" />
     </Book>
     <Book Series="Secret War" Number="5" Volume="2004" Year="2005">
-      <Id>b8d9c94c-348d-411b-8b8e-9d55a0e6bbed</Id>
+      <Database Name="cv" Series="18234" Issue="106867" />
     </Book>
-    <Book Series="Captain America" Number="1" Volume="2005" Year="2005">
-      <Id>f8fd9f2f-33bd-4bf1-b9f0-b6abd603bf0b</Id>
+    <Book Series="Captain America" Number="1" Volume="2004" Year="2005">
+      <Database Name="cv" Series="11499" Issue="101412" />
     </Book>
-    <Book Series="Captain America" Number="2" Volume="2005" Year="2005">
-      <Id>d31974ca-c2ec-496c-9f81-a04f5270a3b8</Id>
+    <Book Series="Captain America" Number="2" Volume="2004" Year="2005">
+      <Database Name="cv" Series="11499" Issue="101413" />
     </Book>
-    <Book Series="Captain America" Number="3" Volume="2005" Year="2005">
-      <Id>147c3df8-a052-414a-9e23-0ed270bf4787</Id>
+    <Book Series="Captain America" Number="3" Volume="2004" Year="2005">
+      <Database Name="cv" Series="11499" Issue="101414" />
     </Book>
-    <Book Series="Captain America" Number="4" Volume="2005" Year="2005">
-      <Id>9f153103-9d0a-4620-a73f-cb2bb8f14400</Id>
+    <Book Series="Captain America" Number="4" Volume="2004" Year="2005">
+      <Database Name="cv" Series="11499" Issue="101415" />
     </Book>
-    <Book Series="Captain America" Number="5" Volume="2005" Year="2005">
-      <Id>56b7ad13-6803-4b17-b6c6-1266f00b6f52</Id>
+    <Book Series="Captain America" Number="5" Volume="2004" Year="2005">
+      <Database Name="cv" Series="11499" Issue="115184" />
     </Book>
-    <Book Series="Captain America" Number="6" Volume="2005" Year="2005">
-      <Id>6f77b5ac-f031-4fa7-9bdb-7e8964ca8b0c</Id>
+    <Book Series="Captain America" Number="6" Volume="2004" Year="2005">
+      <Database Name="cv" Series="11499" Issue="115187" />
     </Book>
-    <Book Series="Captain America" Number="7" Volume="2005" Year="2005">
-      <Id>d427e684-5f2f-4717-9151-26645ab480e2</Id>
+    <Book Series="Captain America" Number="7" Volume="2004" Year="2005">
+      <Database Name="cv" Series="11499" Issue="115267" />
     </Book>
-    <Book Series="Captain America" Number="8" Volume="2005" Year="2005">
-      <Id>601439d3-9e2a-4667-9a14-62f6136b79bc</Id>
+    <Book Series="Captain America" Number="8" Volume="2004" Year="2005">
+      <Database Name="cv" Series="11499" Issue="115268" />
     </Book>
-    <Book Series="Captain America" Number="9" Volume="2005" Year="2005">
-      <Id>b08288a8-1572-43ce-b1b8-6d886d640241</Id>
+    <Book Series="Captain America" Number="9" Volume="2004" Year="2005">
+      <Database Name="cv" Series="11499" Issue="115269" />
     </Book>
-    <Book Series="Captain America" Number="10" Volume="2005" Year="2005">
-      <Id>ffee4aa1-d013-4867-9f49-d0193bd1451e</Id>
+    <Book Series="Captain America" Number="10" Volume="2004" Year="2005">
+      <Database Name="cv" Series="11499" Issue="115271" />
     </Book>
-    <Book Series="Captain America" Number="11" Volume="2005" Year="2005">
-      <Id>fee9a040-8020-4164-b434-2c4224fbe8fb</Id>
+    <Book Series="Captain America" Number="11" Volume="2004" Year="2005">
+      <Database Name="cv" Series="11499" Issue="115273" />
     </Book>
-    <Book Series="Captain America" Number="12" Volume="2005" Year="2005">
-      <Id>ba492654-2435-4bf8-a7bd-db878fe70809</Id>
+    <Book Series="Captain America" Number="12" Volume="2004" Year="2005">
+      <Database Name="cv" Series="11499" Issue="115303" />
     </Book>
-    <Book Series="Captain America" Number="13" Volume="2005" Year="2006">
-      <Id>c8b79e91-5079-4453-ad49-ac8ecc803146</Id>
+    <Book Series="Captain America" Number="13" Volume="2004" Year="2006">
+      <Database Name="cv" Series="11499" Issue="115308" />
     </Book>
-    <Book Series="Captain America" Number="14" Volume="2005" Year="2006">
-      <Id>3b60cbc1-2139-4aac-9aed-6987a61cbf3c</Id>
+    <Book Series="Captain America" Number="14" Volume="2004" Year="2006">
+      <Database Name="cv" Series="11499" Issue="113175" />
     </Book>
-    <Book Series="Captain America" Number="15" Volume="2005" Year="2006">
-      <Id>2c3c4685-e4c6-49cd-9b64-67e8da0ed1ea</Id>
+    <Book Series="Captain America" Number="15" Volume="2004" Year="2006">
+      <Database Name="cv" Series="11499" Issue="113174" />
     </Book>
-    <Book Series="Captain America" Number="16" Volume="2005" Year="2006">
-      <Id>ab1c988c-bbfc-41a6-87f4-978ba1020857</Id>
+    <Book Series="Captain America" Number="16" Volume="2004" Year="2006">
+      <Database Name="cv" Series="11499" Issue="105970" />
     </Book>
-    <Book Series="Captain America" Number="17" Volume="2005" Year="2006">
-      <Id>699f07fa-7904-4663-b0f6-c914dcca3095</Id>
+    <Book Series="Captain America" Number="17" Volume="2004" Year="2006">
+      <Database Name="cv" Series="11499" Issue="105957" />
     </Book>
-    <Book Series="Captain America" Number="18" Volume="2005" Year="2006">
-      <Id>17ad3b97-b4af-4c4e-9567-89efde3c0711</Id>
+    <Book Series="Captain America" Number="18" Volume="2004" Year="2006">
+      <Database Name="cv" Series="11499" Issue="107025" />
     </Book>
-    <Book Series="Captain America" Number="19" Volume="2005" Year="2006">
-      <Id>23f3f7e8-0343-46c1-b5b2-f407b52dfe2b</Id>
+    <Book Series="Captain America" Number="19" Volume="2004" Year="2006">
+      <Database Name="cv" Series="11499" Issue="107026" />
     </Book>
-    <Book Series="Captain America" Number="20" Volume="2005" Year="2006">
-      <Id>5626d6b6-7d6c-496f-b113-49e6921b11cf</Id>
+    <Book Series="Captain America" Number="20" Volume="2004" Year="2006">
+      <Database Name="cv" Series="11499" Issue="108405" />
     </Book>
-    <Book Series="Captain America" Number="21" Volume="2005" Year="2006">
-      <Id>b1a6acae-3886-457d-b011-972ed3d006b1</Id>
+    <Book Series="Captain America" Number="21" Volume="2004" Year="2006">
+      <Database Name="cv" Series="11499" Issue="109859" />
     </Book>
     <Book Series="Civil War" Number="1" Volume="2006" Year="2006">
-      <Id>8a3b618d-9877-4c00-8d7f-48d65f4599dd</Id>
+      <Database Name="cv" Series="18023" Issue="105525" />
     </Book>
     <Book Series="Civil War" Number="2" Volume="2006" Year="2006">
-      <Id>346dc7b4-7523-40ae-8fab-1df067deffd5</Id>
+      <Database Name="cv" Series="18023" Issue="105570" />
     </Book>
     <Book Series="Civil War" Number="3" Volume="2006" Year="2006">
-      <Id>7bbd5df4-e746-40d8-9ad1-b135c26c0c20</Id>
+      <Database Name="cv" Series="18023" Issue="105624" />
     </Book>
     <Book Series="Civil War" Number="4" Volume="2006" Year="2006">
-      <Id>4ed27e2e-d39c-4e8e-9dd6-ef44419ec683</Id>
+      <Database Name="cv" Series="18023" Issue="105682" />
     </Book>
-    <Book Series="Captain America" Number="22" Volume="2005" Year="2006">
-      <Id>88bbe9cd-c892-49f0-93f1-68055b31fff6</Id>
+    <Book Series="Captain America" Number="22" Volume="2004" Year="2006">
+      <Database Name="cv" Series="11499" Issue="108673" />
     </Book>
-    <Book Series="Captain America" Number="23" Volume="2005" Year="2006">
-      <Id>e5ac1190-5a0b-4311-800a-43a03bd193ea</Id>
+    <Book Series="Captain America" Number="23" Volume="2004" Year="2006">
+      <Database Name="cv" Series="11499" Issue="108891" />
     </Book>
     <Book Series="Civil War" Number="5" Volume="2006" Year="2006">
-      <Id>52958b4a-aa5d-4429-b844-9ca8c0ba5b02</Id>
+      <Database Name="cv" Series="18023" Issue="106999" />
     </Book>
-    <Book Series="Captain America" Number="24" Volume="2005" Year="2007">
-      <Id>7d5424cd-de24-4800-947d-62441a82711a</Id>
+    <Book Series="Captain America" Number="24" Volume="2004" Year="2007">
+      <Database Name="cv" Series="11499" Issue="108901" />
     </Book>
     <Book Series="Civil War" Number="6" Volume="2006" Year="2006">
-      <Id>72de0c39-09f3-43a0-93dd-5d35d3c409c5</Id>
+      <Database Name="cv" Series="18023" Issue="107000" />
     </Book>
     <Book Series="Civil War" Number="7" Volume="2006" Year="2007">
-      <Id>88a586c8-129f-4c95-af85-aeff87628b25</Id>
+      <Database Name="cv" Series="18023" Issue="106626" />
     </Book>
-    <Book Series="Captain America" Number="25" Volume="2005" Year="2007">
-      <Id>c8c32d68-44f5-4f58-b285-775bde88aba2</Id>
+    <Book Series="Captain America" Number="25" Volume="2004" Year="2007">
+      <Database Name="cv" Series="11499" Issue="106788" />
     </Book>
     <Book Series="Fallen Son: The Death of Captain America" Number="1" Volume="2007" Year="2007">
-      <Id>acbced34-2804-4e21-a1a4-464a526f2667</Id>
+      <Database Name="cv" Series="18420" Issue="108004" />
     </Book>
     <Book Series="Fallen Son: The Death of Captain America" Number="2" Volume="2007" Year="2007">
-      <Id>71d43347-0b2d-4ad7-a2e2-e6c6281f5d14</Id>
+      <Database Name="cv" Series="18420" Issue="127434" />
     </Book>
     <Book Series="Fallen Son: The Death of Captain America" Number="3" Volume="2007" Year="2007">
-      <Id>85e267b8-07f5-4b75-a5de-5c58219ba607</Id>
+      <Database Name="cv" Series="18420" Issue="109602" />
     </Book>
     <Book Series="Fallen Son: The Death of Captain America" Number="4" Volume="2007" Year="2007">
-      <Id>cc5846fc-8b40-478f-9ba6-70fc8aa5ffb5</Id>
+      <Database Name="cv" Series="18420" Issue="110668" />
     </Book>
     <Book Series="Fallen Son: The Death of Captain America" Number="5" Volume="2007" Year="2007">
-      <Id>c37b9864-6285-4197-ba38-c49369b37b8b</Id>
+      <Database Name="cv" Series="18420" Issue="111251" />
     </Book>
-    <Book Series="Captain America" Number="26" Volume="2005" Year="2007">
-      <Id>ee69304e-2542-4ff6-b476-4cf7ffa1bc37</Id>
+    <Book Series="Captain America" Number="26" Volume="2004" Year="2007">
+      <Database Name="cv" Series="11499" Issue="109835" />
     </Book>
-    <Book Series="Captain America" Number="27" Volume="2005" Year="2007">
-      <Id>e9a12bf1-c65b-415a-a2f7-9e45bce7d19f</Id>
+    <Book Series="Captain America" Number="27" Volume="2004" Year="2007">
+      <Database Name="cv" Series="11499" Issue="110669" />
     </Book>
-    <Book Series="Captain America" Number="28" Volume="2005" Year="2007">
-      <Id>9565c5ce-33e8-442a-b524-05678f104b33</Id>
+    <Book Series="Captain America" Number="28" Volume="2004" Year="2007">
+      <Database Name="cv" Series="11499" Issue="111671" />
     </Book>
-    <Book Series="Captain America" Number="29" Volume="2005" Year="2007">
-      <Id>cd475f87-04cb-44c5-91c8-6c9aff3e560d</Id>
+    <Book Series="Captain America" Number="29" Volume="2004" Year="2007">
+      <Database Name="cv" Series="11499" Issue="113543" />
     </Book>
-    <Book Series="Captain America" Number="30" Volume="2005" Year="2007">
-      <Id>a2ad03c6-21b3-4ed1-879c-3533e7bf1a8c</Id>
+    <Book Series="Captain America" Number="30" Volume="2004" Year="2007">
+      <Database Name="cv" Series="11499" Issue="114665" />
     </Book>
-    <Book Series="Captain America" Number="31" Volume="2005" Year="2007">
-      <Id>ebe398e8-9963-4d6d-ac49-10d6761a5504</Id>
+    <Book Series="Captain America" Number="31" Volume="2004" Year="2007">
+      <Database Name="cv" Series="11499" Issue="115675" />
     </Book>
-    <Book Series="Captain America" Number="32" Volume="2005" Year="2008">
-      <Id>48bff835-41ff-4b37-9326-7ac6e3c2e672</Id>
+    <Book Series="Captain America" Number="32" Volume="2004" Year="2008">
+      <Database Name="cv" Series="11499" Issue="118235" />
     </Book>
-    <Book Series="Captain America" Number="33" Volume="2005" Year="2008">
-      <Id>d1379974-f5b0-4f80-ac29-99b4bfaf8a73</Id>
+    <Book Series="Captain America" Number="33" Volume="2004" Year="2008">
+      <Database Name="cv" Series="11499" Issue="120541" />
     </Book>
-    <Book Series="Captain America" Number="34" Volume="2005" Year="2008">
-      <Id>89c34721-75ac-46e7-86c2-d0bbbdad6a03</Id>
+    <Book Series="Captain America" Number="34" Volume="2004" Year="2008">
+      <Database Name="cv" Series="11499" Issue="122069" />
     </Book>
-    <Book Series="Captain America" Number="35" Volume="2005" Year="2008">
-      <Id>3db24eab-0974-4236-88a5-cbcfaeaa08d4</Id>
+    <Book Series="Captain America" Number="35" Volume="2004" Year="2008">
+      <Database Name="cv" Series="11499" Issue="124075" />
     </Book>
-    <Book Series="Captain America" Number="36" Volume="2005" Year="2008">
-      <Id>aa428da7-1d00-481c-9599-fed6b4b6c3ae</Id>
+    <Book Series="Captain America" Number="36" Volume="2004" Year="2008">
+      <Database Name="cv" Series="11499" Issue="125669" />
     </Book>
-    <Book Series="Captain America" Number="37" Volume="2005" Year="2008">
-      <Id>c0645fea-1171-43d7-b092-3cb5e7f8d55a</Id>
+    <Book Series="Captain America" Number="37" Volume="2004" Year="2008">
+      <Database Name="cv" Series="11499" Issue="127500" />
     </Book>
-    <Book Series="Captain America" Number="38" Volume="2005" Year="2008">
-      <Id>2d530e00-d430-4343-b00b-8a152c2537f2</Id>
+    <Book Series="Captain America" Number="38" Volume="2004" Year="2008">
+      <Database Name="cv" Series="11499" Issue="130594" />
     </Book>
-    <Book Series="Captain America" Number="39" Volume="2005" Year="2008">
-      <Id>4009d38c-b212-4ae8-9e16-654081700986</Id>
+    <Book Series="Captain America" Number="39" Volume="2004" Year="2008">
+      <Database Name="cv" Series="11499" Issue="131810" />
     </Book>
-    <Book Series="Captain America" Number="40" Volume="2005" Year="2008">
-      <Id>3e608768-7827-4abd-8b33-f09b68499f7d</Id>
+    <Book Series="Captain America" Number="40" Volume="2004" Year="2008">
+      <Database Name="cv" Series="11499" Issue="133665" />
     </Book>
-    <Book Series="Captain America" Number="41" Volume="2005" Year="2008">
-      <Id>f30c10da-dbb3-45f6-953e-b4bfbdf149f2</Id>
+    <Book Series="Captain America" Number="41" Volume="2004" Year="2008">
+      <Database Name="cv" Series="11499" Issue="135981" />
     </Book>
-    <Book Series="Captain America" Number="42" Volume="2005" Year="2008">
-      <Id>81f2eb82-8d0b-409a-b55c-326e83de9e8a</Id>
+    <Book Series="Captain America" Number="42" Volume="2004" Year="2008">
+      <Database Name="cv" Series="11499" Issue="139326" />
     </Book>
-    <Book Series="Captain America" Number="43" Volume="2005" Year="2008">
-      <Id>321e938b-11e7-4e50-a84d-f937b4c0856a</Id>
+    <Book Series="Captain America" Number="43" Volume="2004" Year="2008">
+      <Database Name="cv" Series="11499" Issue="140845" />
     </Book>
-    <Book Series="Captain America" Number="44" Volume="2005" Year="2009">
-      <Id>d53d8609-5b5d-47b6-9a07-5477e17dbac1</Id>
+    <Book Series="Captain America" Number="44" Volume="2004" Year="2009">
+      <Database Name="cv" Series="11499" Issue="143155" />
     </Book>
-    <Book Series="Captain America" Number="45" Volume="2005" Year="2009">
-      <Id>62f46571-d538-4c3f-904e-cba5a1c096de</Id>
+    <Book Series="Captain America" Number="45" Volume="2004" Year="2009">
+      <Database Name="cv" Series="11499" Issue="149286" />
     </Book>
-    <Book Series="Captain America" Number="46" Volume="2005" Year="2009">
-      <Id>ac22e8b7-18b3-4ad8-9bb1-fcab7d5519dc</Id>
+    <Book Series="Captain America" Number="46" Volume="2004" Year="2009">
+      <Database Name="cv" Series="11499" Issue="150591" />
     </Book>
-    <Book Series="Captain America" Number="47" Volume="2005" Year="2009">
-      <Id>c36ea875-f54a-4742-880a-3669ee8ad515</Id>
+    <Book Series="Captain America" Number="47" Volume="2004" Year="2009">
+      <Database Name="cv" Series="11499" Issue="152714" />
     </Book>
-    <Book Series="Captain America" Number="48" Volume="2005" Year="2009">
-      <Id>6a7a1a0f-4026-436f-adeb-0c895a3318cc</Id>
+    <Book Series="Captain America" Number="48" Volume="2004" Year="2009">
+      <Database Name="cv" Series="11499" Issue="153957" />
     </Book>
     <Book Series="Secret Invasion Director's Cut" Number="1" Volume="2008" Year="2008">
-      <Id>6a2d34ba-8a32-4b2b-977b-2aacc2692b31</Id>
+      <Database Name="cv" Series="22284" Issue="134003" />
     </Book>
     <Book Series="Secret Invasion" Number="2" Volume="2008" Year="2008">
-      <Id>7ee44784-000e-4c8d-9bd0-8ae2704a66fb</Id>
+      <Database Name="cv" Series="21076" Issue="129598" />
     </Book>
     <Book Series="Secret Invasion" Number="3" Volume="2008" Year="2008">
-      <Id>7d646eac-8160-49db-8771-c6fc261fa833</Id>
+      <Database Name="cv" Series="21076" Issue="131297" />
     </Book>
     <Book Series="Secret Invasion" Number="4" Volume="2008" Year="2008">
-      <Id>6c6eca88-3515-4f4f-9834-1d97d64355d1</Id>
+      <Database Name="cv" Series="21076" Issue="132926" />
     </Book>
     <Book Series="Secret Invasion" Number="5" Volume="2008" Year="2008">
-      <Id>6d8808bf-b64d-4b12-b16d-e034d833bafd</Id>
+      <Database Name="cv" Series="21076" Issue="135430" />
     </Book>
     <Book Series="Secret Invasion" Number="6" Volume="2008" Year="2008">
-      <Id>cf384a0e-69b1-4743-b7ae-2e49bcd3b887</Id>
+      <Database Name="cv" Series="21076" Issue="138234" />
     </Book>
     <Book Series="Secret Invasion" Number="7" Volume="2008" Year="2008">
-      <Id>aed9b2a9-a77c-4c71-8abe-beb2d207326a</Id>
+      <Database Name="cv" Series="21076" Issue="140851" />
     </Book>
     <Book Series="Secret Invasion" Number="8" Volume="2008" Year="2009">
-      <Id>02491013-82d8-4f8b-8748-10994aa8426e</Id>
+      <Database Name="cv" Series="21076" Issue="144233" />
     </Book>
-    <Book Series="Captain America" Number="49" Volume="2005" Year="2009">
-      <Id>8c23c2bf-0cc0-4b32-a6bc-200175bbf8bb</Id>
+    <Book Series="Captain America" Number="49" Volume="2004" Year="2009">
+      <Database Name="cv" Series="11499" Issue="155509" />
     </Book>
-    <Book Series="Captain America" Number="50" Volume="2005" Year="2009">
-      <Id>33594723-e4e2-42cf-8552-7fb678bf6fcd</Id>
+    <Book Series="Captain America" Number="50" Volume="2004" Year="2009">
+      <Database Name="cv" Series="11499" Issue="157737" />
     </Book>
-    <Book Series="Captain America" Number="600" Volume="2005" Year="2009">
-      <Id>bbb79f62-b63d-4587-9054-39fd5cd047fa</Id>
+    <Book Series="Captain America" Number="600" Volume="2004" Year="2009">
+      <Database Name="cv" Series="11499" Issue="160412" />
     </Book>
-    <Book Series="Captain America" Number="601" Volume="2005" Year="2009">
-      <Id>575d83d1-de38-4804-b872-db8a5ac399b4</Id>
+    <Book Series="Captain America" Number="601" Volume="2004" Year="2009">
+      <Database Name="cv" Series="11499" Issue="164034" />
     </Book>
     <Book Series="Captain America: Reborn" Number="1" Volume="2009" Year="2009">
-      <Id>d2804b88-9c7e-407c-b476-1dee0470f334</Id>
+      <Database Name="cv" Series="26966" Issue="162615" />
     </Book>
     <Book Series="Captain America: Reborn" Number="2" Volume="2009" Year="2009">
-      <Id>a2c57d9a-d562-49ae-bce6-5e0000878eff</Id>
+      <Database Name="cv" Series="26966" Issue="166223" />
     </Book>
     <Book Series="Captain America: Reborn" Number="3" Volume="2009" Year="2009">
-      <Id>84f1e8d1-4728-4f35-9f58-58508435b099</Id>
+      <Database Name="cv" Series="26966" Issue="171208" />
     </Book>
     <Book Series="Captain America: Reborn" Number="4" Volume="2009" Year="2010">
-      <Id>57abe501-7cc4-4264-97d8-aca80e0deb27</Id>
+      <Database Name="cv" Series="26966" Issue="181437" />
     </Book>
     <Book Series="Captain America: Reborn" Number="5" Volume="2009" Year="2010">
-      <Id>768c0d68-cfb3-4aa7-9ecf-0c68e88eef61</Id>
+      <Database Name="cv" Series="26966" Issue="187627" />
     </Book>
     <Book Series="Captain America: Reborn" Number="6" Volume="2009" Year="2010">
-      <Id>7d88976d-3a97-4511-8ec6-0eb9dce99f4e</Id>
+      <Database Name="cv" Series="26966" Issue="194589" />
     </Book>
     <Book Series="Avengers: Prime" Number="1" Volume="2010" Year="2010">
-      <Id>64f86715-0af4-4d46-8e80-91dae4951a30</Id>
+      <Database Name="cv" Series="33495" Issue="217323" />
     </Book>
     <Book Series="Avengers: Prime" Number="2" Volume="2010" Year="2010">
-      <Id>72c606fd-8c89-4c84-996d-8e2701af7176</Id>
+      <Database Name="cv" Series="33495" Issue="227872" />
     </Book>
     <Book Series="Avengers: Prime" Number="3" Volume="2010" Year="2010">
-      <Id>8e633fa2-3ba9-4cfd-b489-2ad82570144f</Id>
+      <Database Name="cv" Series="33495" Issue="236711" />
     </Book>
     <Book Series="Avengers: Prime" Number="4" Volume="2010" Year="2011">
-      <Id>99d3d89d-f29a-44c2-8f4d-66e3e1ccdd1f</Id>
+      <Database Name="cv" Series="33495" Issue="242900" />
     </Book>
     <Book Series="Avengers: Prime" Number="5" Volume="2010" Year="2011">
-      <Id>ac1ce361-db26-4a8d-bf11-3d2fba1090ca</Id>
+      <Database Name="cv" Series="33495" Issue="254666" />
     </Book>
-    <Book Series="Captain America" Number="602" Volume="2005" Year="2010">
-      <Id>7e698b04-632f-4f7f-87f5-594cc17a1132</Id>
+    <Book Series="Captain America" Number="602" Volume="2004" Year="2010">
+      <Database Name="cv" Series="11499" Issue="193414" />
     </Book>
-    <Book Series="Captain America" Number="603" Volume="2005" Year="2010">
-      <Id>438929b8-4edc-4af8-b489-cfafc7744fd9</Id>
+    <Book Series="Captain America" Number="603" Volume="2004" Year="2010">
+      <Database Name="cv" Series="11499" Issue="197668" />
     </Book>
-    <Book Series="Captain America" Number="604" Volume="2005" Year="2010">
-      <Id>4e681a79-d36e-4d06-b858-dfd4f5966d75</Id>
+    <Book Series="Captain America" Number="604" Volume="2004" Year="2010">
+      <Database Name="cv" Series="11499" Issue="201710" />
     </Book>
-    <Book Series="Captain America" Number="605" Volume="2005" Year="2010">
-      <Id>e1994030-f1f5-4925-afe0-6d0ddd64f488</Id>
+    <Book Series="Captain America" Number="605" Volume="2004" Year="2010">
+      <Database Name="cv" Series="11499" Issue="210223" />
     </Book>
     <Book Series="Captain America: Who Won't Wield the Shield?" Number="1" Volume="2010" Year="2010">
-      <Id>baad4687-ba41-4b4d-8113-0d1d94d93a3b</Id>
+      <Database Name="cv" Series="32672" Issue="208752" />
     </Book>
-    <Book Series="Captain America and..." Number="1" Volume="2011" Year="2011">
-      <Id>11f38b33-c64a-46d2-99d9-c7831fd3b1cb</Id>
+    <Book Series="Captain America and Falcon" Number="1" Volume="2011" Year="2011">
+      <Database Name="cv" Series="39276" Issue="265178" />
     </Book>
-    <Book Series="Captain America and..." Number="1" Volume="2011" Year="2011">
-      <Id>c7044bb0-747e-4734-a3ac-cd3c5e03662e</Id>
+    <Book Series="Captain America and Crossbones" Number="1" Volume="2011" Year="2011">
+      <Database Name="cv" Series="39382" Issue="266065" />
     </Book>
-    <Book Series="Captain America and..." Number="1" Volume="2011" Year="2011">
-      <Id>036d4a3b-e475-4a93-9519-a203265dba6f</Id>
+    <Book Series="Captain America and Batroc" Number="1" Volume="2011" Year="2011">
+      <Database Name="cv" Series="39497" Issue="266843" />
     </Book>
-    <Book Series="Captain America and..." Number="1" Volume="2011" Year="2011">
-      <Id>fe5a6747-9483-4024-9e77-7ca4e89964a9</Id>
+    <Book Series="Captain America and the First Thirteen" Number="1" Volume="2011" Year="2011">
+      <Database Name="cv" Series="39310" Issue="265578" />
     </Book>
     <Book Series="Captain America and the Secret Avengers" Number="1" Volume="2011" Year="2011">
-      <Id>87606054-3770-4517-a5b1-5210e66dcec5</Id>
+      <Database Name="cv" Series="39773" Issue="268414" />
     </Book>
-    <Book Series="Captain America" Number="606" Volume="2005" Year="2010">
-      <Id>b3c0c671-0ab4-414f-a0d4-f9cf230907b1</Id>
+    <Book Series="Captain America" Number="606" Volume="2004" Year="2010">
+      <Database Name="cv" Series="11499" Issue="218588" />
     </Book>
-    <Book Series="Captain America" Number="607" Volume="2005" Year="2010">
-      <Id>a9a0af64-abc3-4fd3-ac5b-5ae1c3d274ee</Id>
+    <Book Series="Captain America" Number="607" Volume="2004" Year="2010">
+      <Database Name="cv" Series="11499" Issue="222132" />
     </Book>
-    <Book Series="Captain America" Number="608" Volume="2005" Year="2010">
-      <Id>ef18efbc-3e62-4007-9969-e619da727871</Id>
+    <Book Series="Captain America" Number="608" Volume="2004" Year="2010">
+      <Database Name="cv" Series="11499" Issue="227787" />
     </Book>
-    <Book Series="Captain America" Number="609" Volume="2005" Year="2010">
-      <Id>6e958ee9-1b6c-4e63-82b2-df30e2e31296</Id>
+    <Book Series="Captain America" Number="609" Volume="2004" Year="2010">
+      <Database Name="cv" Series="11499" Issue="231702" />
     </Book>
-    <Book Series="Captain America" Number="610" Volume="2005" Year="2010">
-      <Id>06d0db9e-7c68-4f74-a20f-8a54892566e3</Id>
+    <Book Series="Captain America" Number="610" Volume="2004" Year="2010">
+      <Database Name="cv" Series="11499" Issue="236323" />
     </Book>
-    <Book Series="Captain America" Number="611" Volume="2005" Year="2010">
-      <Id>255d58f2-b8aa-4a13-b0ca-28a22b5fb49c</Id>
+    <Book Series="Captain America" Number="611" Volume="2004" Year="2010">
+      <Database Name="cv" Series="11499" Issue="238923" />
     </Book>
-    <Book Series="Captain America" Number="612" Volume="2005" Year="2011">
-      <Id>a8471b0a-07ef-4fe4-bd69-de5db645b760</Id>
+    <Book Series="Captain America" Number="612" Volume="2004" Year="2011">
+      <Database Name="cv" Series="11499" Issue="246465" />
     </Book>
-    <Book Series="Captain America" Number="613" Volume="2005" Year="2011">
-      <Id>a7d23956-8553-4654-a7d4-d63f423167c6</Id>
+    <Book Series="Captain America" Number="613" Volume="2004" Year="2011">
+      <Database Name="cv" Series="11499" Issue="253003" />
     </Book>
-    <Book Series="Captain America" Number="614" Volume="2005" Year="2011">
-      <Id>3882027d-1e5d-4cf1-8649-7cf22917f82a</Id>
+    <Book Series="Captain America" Number="614" Volume="2004" Year="2011">
+      <Database Name="cv" Series="11499" Issue="259190" />
     </Book>
-    <Book Series="Captain America" Number="615" Volume="2005" Year="2011">
-      <Id>f298074d-b725-465a-909d-5bd1d512e78b</Id>
+    <Book Series="Captain America" Number="615" Volume="2004" Year="2011">
+      <Database Name="cv" Series="11499" Issue="263731" />
     </Book>
-    <Book Series="Captain America" Number="615.1" Volume="2005" Year="2011">
-      <Id>ecf67e20-cb24-43e9-90b5-d7038e18feae</Id>
+    <Book Series="Captain America" Number="615.1" Volume="2004" Year="2011">
+      <Database Name="cv" Series="11499" Issue="266624" />
     </Book>
     <Book Series="Secret Avengers" Number="1" Volume="2010" Year="2010">
-      <Id>64b12259-c0cb-4df3-b3ee-6be5b5eb0b9f</Id>
+      <Database Name="cv" Series="33350" Issue="216182" />
     </Book>
     <Book Series="Secret Avengers" Number="2" Volume="2010" Year="2010">
-      <Id>6df1fdf4-93eb-425d-9df8-345797308f13</Id>
+      <Database Name="cv" Series="33350" Issue="221791" />
     </Book>
     <Book Series="Secret Avengers" Number="3" Volume="2010" Year="2010">
-      <Id>490cf062-ecc2-48b3-a0c5-27b8f960a6e7</Id>
+      <Database Name="cv" Series="33350" Issue="226878" />
     </Book>
     <Book Series="Secret Avengers" Number="4" Volume="2010" Year="2010">
-      <Id>fec2b557-a48b-4311-bdd2-d1133ddf03aa</Id>
+      <Database Name="cv" Series="33350" Issue="230303" />
     </Book>
     <Book Series="Secret Avengers" Number="5" Volume="2010" Year="2010">
-      <Id>e678393c-9376-4fa8-9629-0f715e8912ec</Id>
+      <Database Name="cv" Series="33350" Issue="235393" />
     </Book>
     <Book Series="Captain America: Hail Hydra" Number="1" Volume="2011" Year="2011">
-      <Id>6f54f148-f74d-4813-96a9-05863d2ec306</Id>
+      <Database Name="cv" Series="38157" Issue="254992" />
     </Book>
     <Book Series="Captain America: Hail Hydra" Number="2" Volume="2011" Year="2011">
-      <Id>21d7b066-0d2e-469e-9be8-ba419fe03292</Id>
+      <Database Name="cv" Series="38157" Issue="260598" />
     </Book>
     <Book Series="Captain America: Hail Hydra" Number="3" Volume="2011" Year="2011">
-      <Id>944b8a29-2541-43db-a0e1-b53f96eba9fb</Id>
+      <Database Name="cv" Series="38157" Issue="265148" />
     </Book>
     <Book Series="Captain America: Hail Hydra" Number="4" Volume="2011" Year="2011">
-      <Id>89f9eee1-66a6-43ba-926f-8cfd50aca57a</Id>
+      <Database Name="cv" Series="38157" Issue="267767" />
     </Book>
     <Book Series="Captain America: Hail Hydra" Number="5" Volume="2011" Year="2011">
-      <Id>87565bbe-c2ee-4d7a-9b69-661e89e4dea5</Id>
+      <Database Name="cv" Series="38157" Issue="269682" />
     </Book>
     <Book Series="Steve Rogers: Super Soldier" Number="1" Volume="2010" Year="2010">
-      <Id>a36f70fd-7f1d-4205-bbf9-9bfc9918daca</Id>
+      <Database Name="cv" Series="34244" Issue="223427" />
     </Book>
     <Book Series="Steve Rogers: Super Soldier" Number="2" Volume="2010" Year="2010">
-      <Id>648e3f78-dee0-458c-842f-73ea0de5ab70</Id>
+      <Database Name="cv" Series="34244" Issue="228962" />
     </Book>
     <Book Series="Steve Rogers: Super Soldier" Number="3" Volume="2010" Year="2010">
-      <Id>cd2459a4-747b-4c81-b531-84487867958a</Id>
+      <Database Name="cv" Series="34244" Issue="234653" />
     </Book>
     <Book Series="Steve Rogers: Super Soldier" Number="4" Volume="2010" Year="2010">
-      <Id>fa272fe4-fe07-4f43-b6ac-cabcbb586d88</Id>
+      <Database Name="cv" Series="34244" Issue="239042" />
     </Book>
     <Book Series="Steve Rogers: Super Soldier Annual" Number="1" Volume="2011" Year="2011">
-      <Id>3f7a120f-756d-4c7b-841e-bb6c7414ba43</Id>
+      <Database Name="cv" Series="39765" Issue="268365" />
     </Book>
     <Book Series="Namor: The First Mutant Annual" Number="1" Volume="2011" Year="2011">
-      <Id>09fd3fe0-0ff4-4400-8efb-70114ff7b245</Id>
+      <Database Name="cv" Series="40215" Issue="270428" />
     </Book>
     <Book Series="Fear Itself" Number="1" Volume="2011" Year="2011">
-      <Id>f7b6b461-3686-46e9-a5c8-faaa26abe61f</Id>
+      <Database Name="cv" Series="39611" Issue="267534" />
     </Book>
     <Book Series="Fear Itself" Number="2" Volume="2011" Year="2011">
-      <Id>657ea318-89cc-4107-959a-18dbeaef810c</Id>
+      <Database Name="cv" Series="39611" Issue="269476" />
     </Book>
     <Book Series="Fear Itself" Number="3" Volume="2011" Year="2011">
-      <Id>fee3109e-a456-4ca7-884a-bb54c3ad7880</Id>
+      <Database Name="cv" Series="39611" Issue="272330" />
     </Book>
     <Book Series="Fear Itself" Number="4" Volume="2011" Year="2011">
-      <Id>fe09a64f-eda8-4633-8f95-0ec6e3f08323</Id>
+      <Database Name="cv" Series="39611" Issue="277536" />
     </Book>
     <Book Series="Fear Itself" Number="5" Volume="2011" Year="2011">
-      <Id>f9a10c83-e35e-4786-8579-ae2f9801a80b</Id>
+      <Database Name="cv" Series="39611" Issue="285335" />
     </Book>
     <Book Series="Fear Itself" Number="6" Volume="2011" Year="2011">
-      <Id>43146781-8a88-44d2-9751-5e862bc22b16</Id>
+      <Database Name="cv" Series="39611" Issue="292590" />
     </Book>
     <Book Series="Fear Itself" Number="7" Volume="2011" Year="2011">
-      <Id>cfe1aac4-1232-494e-8a06-d6e18d2339be</Id>
+      <Database Name="cv" Series="39611" Issue="297217" />
     </Book>
     <Book Series="Fear Itself" Number="7.1" Volume="2011" Year="2012">
-      <Id>2601e84f-8c13-48c8-beae-35f4ea5b62d0</Id>
+      <Database Name="cv" Series="39611" Issue="301059" />
     </Book>
     <Book Series="Winter Soldier" Number="1" Volume="2012" Year="2012">
-      <Id>4235ce32-a8d1-416e-908e-698596af7a11</Id>
+      <Database Name="cv" Series="45518" Issue="313496" />
     </Book>
     <Book Series="Winter Soldier" Number="2" Volume="2012" Year="2012">
-      <Id>8f3a19e8-4829-468d-8744-aa553516dd16</Id>
+      <Database Name="cv" Series="45518" Issue="315739" />
     </Book>
     <Book Series="Winter Soldier" Number="3" Volume="2012" Year="2012">
-      <Id>42630467-b201-44f7-bed2-179676f92e58</Id>
+      <Database Name="cv" Series="45518" Issue="319362" />
     </Book>
     <Book Series="Winter Soldier" Number="4" Volume="2012" Year="2012">
-      <Id>9bce9f4b-459b-4751-9c07-9d1bd2d9000b</Id>
+      <Database Name="cv" Series="45518" Issue="329197" />
     </Book>
     <Book Series="Winter Soldier" Number="5" Volume="2012" Year="2012">
-      <Id>676a7674-3b19-4ccd-98a7-0d7eb27e908c</Id>
+      <Database Name="cv" Series="45518" Issue="335913" />
     </Book>
     <Book Series="Winter Soldier" Number="6" Volume="2012" Year="2012">
-      <Id>b5479352-7ef4-431e-af25-17cf60f2ff59</Id>
+      <Database Name="cv" Series="45518" Issue="338483" />
     </Book>
     <Book Series="Winter Soldier" Number="7" Volume="2012" Year="2012">
-      <Id>be8ef396-a56b-49ea-b188-59c68a87d21c</Id>
+      <Database Name="cv" Series="45518" Issue="341675" />
     </Book>
     <Book Series="Winter Soldier" Number="8" Volume="2012" Year="2012">
-      <Id>51ab5b72-1f6c-4415-bf80-f524ba17440b</Id>
+      <Database Name="cv" Series="45518" Issue="347240" />
     </Book>
     <Book Series="Winter Soldier" Number="9" Volume="2012" Year="2012">
-      <Id>936880ae-3222-4ab9-a0bc-99a06da88200</Id>
+      <Database Name="cv" Series="45518" Issue="354098" />
     </Book>
     <Book Series="Winter Soldier" Number="10" Volume="2012" Year="2012">
-      <Id>8053cac1-c571-47bc-86df-37de4ebf3ea3</Id>
+      <Database Name="cv" Series="45518" Issue="356775" />
     </Book>
     <Book Series="Winter Soldier" Number="11" Volume="2012" Year="2012">
-      <Id>b1326f21-43f0-4545-a8dc-38c60abf0274</Id>
+      <Database Name="cv" Series="45518" Issue="358908" />
     </Book>
     <Book Series="Winter Soldier" Number="12" Volume="2012" Year="2012">
-      <Id>8e35d538-0aeb-4f8c-a9b7-37ac95d5b48e</Id>
+      <Database Name="cv" Series="45518" Issue="364152" />
     </Book>
     <Book Series="Winter Soldier" Number="13" Volume="2012" Year="2013">
-      <Id>6527c37a-bfb2-4ea3-aab5-7245a10cfaf3</Id>
+      <Database Name="cv" Series="45518" Issue="372449" />
     </Book>
     <Book Series="Winter Soldier" Number="14" Volume="2012" Year="2013">
-      <Id>ccdf09fa-a9a1-49bb-b72b-560d9b486e83</Id>
+      <Database Name="cv" Series="45518" Issue="381420" />
     </Book>
     <Book Series="Winter Soldier" Number="15" Volume="2012" Year="2013">
-      <Id>1651b9ff-e394-4d23-8f9d-ce1b45c3f2c8</Id>
+      <Database Name="cv" Series="45518" Issue="384968" />
     </Book>
     <Book Series="Winter Soldier" Number="16" Volume="2012" Year="2013">
-      <Id>57a7fb9f-4880-41db-b51f-c40868cd68ac</Id>
+      <Database Name="cv" Series="45518" Issue="390456" />
     </Book>
     <Book Series="Winter Soldier" Number="17" Volume="2012" Year="2013">
-      <Id>27faecbe-3914-4cca-96ee-bca2ed31272d</Id>
+      <Database Name="cv" Series="45518" Issue="395708" />
     </Book>
     <Book Series="Winter Soldier" Number="18" Volume="2012" Year="2013">
-      <Id>886deaad-afda-4b39-8f46-a0a4d762a484</Id>
+      <Database Name="cv" Series="45518" Issue="400155" />
     </Book>
     <Book Series="Winter Soldier" Number="19" Volume="2012" Year="2013">
-      <Id>4894eb49-ab90-446c-aabc-0a54f05fa381</Id>
+      <Database Name="cv" Series="45518" Issue="409003" />
     </Book>
     <Book Series="Captain America" Number="1" Volume="2011" Year="2011">
-      <Id>d4da6492-2885-4413-a561-6e38d677a728</Id>
+      <Database Name="cv" Series="41245" Issue="278553" />
     </Book>
     <Book Series="Captain America" Number="2" Volume="2011" Year="2011">
-      <Id>a2120ccf-9307-443e-a851-08a93fc565f2</Id>
+      <Database Name="cv" Series="41245" Issue="286817" />
     </Book>
     <Book Series="Captain America" Number="3" Volume="2011" Year="2011">
-      <Id>a6377b66-2efe-4777-a403-d113f8db1b15</Id>
+      <Database Name="cv" Series="41245" Issue="293318" />
     </Book>
     <Book Series="Captain America" Number="4" Volume="2011" Year="2012">
-      <Id>489cbc0d-b3f2-47e5-87e3-c08a2f80bee6</Id>
+      <Database Name="cv" Series="41245" Issue="302641" />
     </Book>
     <Book Series="Captain America" Number="5" Volume="2011" Year="2012">
-      <Id>32671452-f5ae-46f4-9dd0-850e008e53ce</Id>
+      <Database Name="cv" Series="41245" Issue="308466" />
     </Book>
-    <Book Series="Captain America and..." Number="625" Volume="2011" Year="2012">
-      <Id>b3ebbda1-2e13-4e6f-be1e-f686f26b5ff3</Id>
+    <Book Series="Captain America and Bucky" Number="625" Volume="2011" Year="2012">
+      <Database Name="cv" Series="41552" Issue="308554" />
     </Book>
-    <Book Series="Captain America and..." Number="626" Volume="2011" Year="2012">
-      <Id>0e5ae297-940d-4361-8efd-104e2ec0ea2e</Id>
+    <Book Series="Captain America and Bucky" Number="626" Volume="2011" Year="2012">
+      <Database Name="cv" Series="41552" Issue="312716" />
     </Book>
-    <Book Series="Captain America and..." Number="627" Volume="2011" Year="2012">
-      <Id>1c911c52-6c28-44ab-96b5-68f44417d71c</Id>
+    <Book Series="Captain America and Bucky" Number="627" Volume="2011" Year="2012">
+      <Database Name="cv" Series="41552" Issue="316788" />
     </Book>
-    <Book Series="Captain America and..." Number="628" Volume="2011" Year="2012">
-      <Id>d47736e6-371f-405a-9c9c-35e183859c74</Id>
+    <Book Series="Captain America and Bucky" Number="628" Volume="2011" Year="2012">
+      <Database Name="cv" Series="41552" Issue="324974" />
     </Book>
     <Book Series="Captain America" Number="6" Volume="2011" Year="2012">
-      <Id>696924df-5df3-4ae2-a0f1-0afcebe3a516</Id>
+      <Database Name="cv" Series="41245" Issue="308841" />
     </Book>
     <Book Series="Captain America" Number="7" Volume="2011" Year="2012">
-      <Id>51f25126-822b-4ee1-a86a-af014238b63b</Id>
+      <Database Name="cv" Series="41245" Issue="310916" />
     </Book>
     <Book Series="Captain America" Number="8" Volume="2011" Year="2012">
-      <Id>4e05d694-b37d-4690-8b3a-382095b5bf50</Id>
+      <Database Name="cv" Series="41245" Issue="315148" />
     </Book>
     <Book Series="Captain America" Number="9" Volume="2011" Year="2012">
-      <Id>af4e74a6-11d2-4a19-ab83-a18e691f608e</Id>
+      <Database Name="cv" Series="41245" Issue="321311" />
     </Book>
     <Book Series="Captain America" Number="10" Volume="2011" Year="2012">
-      <Id>506f1e88-a676-4fdd-ad48-b610296c8bdf</Id>
+      <Database Name="cv" Series="41245" Issue="333399" />
     </Book>
-    <Book Series="Captain America and..." Number="629" Volume="2011" Year="2012">
-      <Id>14596c7c-9ab7-47a4-9d47-95000a911f21</Id>
+    <Book Series="Captain America and Hawkeye" Number="629" Volume="2012" Year="2012">
+      <Database Name="cv" Series="50803" Issue="347462" />
     </Book>
-    <Book Series="Captain America and..." Number="630" Volume="2011" Year="2012">
-      <Id>78fce42f-9c54-41b4-81d8-caf210dbecf6</Id>
+    <Book Series="Captain America and Hawkeye" Number="630" Volume="2012" Year="2012">
+      <Database Name="cv" Series="50803" Issue="347463" />
     </Book>
-    <Book Series="Captain America and..." Number="631" Volume="2011" Year="2012">
-      <Id>5be0e692-01db-4a96-8afa-75308f62d8ef</Id>
+    <Book Series="Captain America and Hawkeye" Number="631" Volume="2012" Year="2012">
+      <Database Name="cv" Series="50803" Issue="347464" />
     </Book>
-    <Book Series="Captain America and..." Number="632" Volume="2011" Year="2012">
-      <Id>3f933ab0-a820-449e-ae70-70869d71ff66</Id>
+    <Book Series="Captain America and Hawkeye" Number="632" Volume="2012" Year="2012">
+      <Database Name="cv" Series="50803" Issue="347465" />
     </Book>
-    <Book Series="Captain America and..." Number="633" Volume="2011" Year="2012">
-      <Id>cf61861f-4ae3-4c49-b08d-28156a22b4d4</Id>
+    <Book Series="Captain America and Iron Man" Number="633" Volume="2012" Year="2012">
+      <Database Name="cv" Series="48362" Issue="342872" />
     </Book>
-    <Book Series="Captain America and..." Number="634" Volume="2011" Year="2012">
-      <Id>5f1f04f8-9469-475c-9ba8-6e79712044bf</Id>
+    <Book Series="Captain America and Iron Man" Number="634" Volume="2012" Year="2012">
+      <Database Name="cv" Series="48362" Issue="347225" />
     </Book>
-    <Book Series="Captain America and..." Number="635" Volume="2011" Year="2012">
-      <Id>4eab7984-abac-42fb-bf84-b5326715bdb5</Id>
+    <Book Series="Captain America and Iron Man" Number="635" Volume="2012" Year="2012">
+      <Database Name="cv" Series="48362" Issue="349644" />
     </Book>
-    <Book Series="Captain America and..." Number="635.1" Volume="2011" Year="2012">
-      <Id>b3dc1565-43ea-4378-83c0-de1df024697d</Id>
+    <Book Series="Captain America and Namor" Number="635.1" Volume="2012" Year="2012">
+      <Database Name="cv" Series="51436" Issue="352719" />
     </Book>
     <Book Series="Captain America" Number="11" Volume="2011" Year="2012">
-      <Id>6377dbca-7252-49b8-b25d-13002d4a2769</Id>
+      <Database Name="cv" Series="41245" Issue="335252" />
     </Book>
     <Book Series="Captain America" Number="12" Volume="2011" Year="2012">
-      <Id>d16aa1a3-f118-489d-ba27-0c36f4c29aae</Id>
+      <Database Name="cv" Series="41245" Issue="336586" />
     </Book>
     <Book Series="Captain America" Number="13" Volume="2011" Year="2012">
-      <Id>88928679-3de1-42d4-99b7-90f037fa5c2d</Id>
+      <Database Name="cv" Series="41245" Issue="340261" />
     </Book>
     <Book Series="Captain America" Number="14" Volume="2011" Year="2012">
-      <Id>6b7312e3-d289-4c7e-8135-767525767001</Id>
+      <Database Name="cv" Series="41245" Issue="345410" />
     </Book>
     <Book Series="Avengers: X-Sanction" Number="1" Volume="2012" Year="2012">
-      <Id>c83bc85f-783c-4e16-b7b9-f3d91e435bb9</Id>
+      <Database Name="cv" Series="44477" Issue="306478" />
     </Book>
     <Book Series="Avengers: X-Sanction" Number="2" Volume="2012" Year="2012">
-      <Id>4d4a684b-c77d-4adf-b93e-5d5c55adc17b</Id>
+      <Database Name="cv" Series="44477" Issue="309396" />
     </Book>
     <Book Series="Avengers: X-Sanction" Number="3" Volume="2012" Year="2012">
-      <Id>0550b34e-e235-45b3-81d2-368d0ccd9601</Id>
+      <Database Name="cv" Series="44477" Issue="313883" />
     </Book>
     <Book Series="Avengers: X-Sanction" Number="4" Volume="2012" Year="2012">
-      <Id>04a79481-a1da-4ee9-94f1-c3956688eb01</Id>
+      <Database Name="cv" Series="44477" Issue="322751" />
     </Book>
     <Book Series="Avengers Vs. X-Men" Number="1" Volume="2012" Year="2012">
-      <Id>dc149da3-d855-40da-982b-b9e988034d1e</Id>
+      <Database Name="cv" Series="47331" Issue="326860" />
     </Book>
     <Book Series="Captain America" Number="15" Volume="2011" Year="2012">
-      <Id>e4c20f4c-4f5c-4b07-83ff-a877b95a9cdc</Id>
+      <Database Name="cv" Series="41245" Issue="347183" />
     </Book>
     <Book Series="Captain America" Number="16" Volume="2011" Year="2012">
-      <Id>5f8187c1-97c1-4e8c-8e22-160734c9b96c</Id>
+      <Database Name="cv" Series="41245" Issue="349679" />
     </Book>
     <Book Series="Captain America" Number="17" Volume="2011" Year="2012">
-      <Id>a62095e5-cd1c-4562-bd01-fcb2a87192f3</Id>
+      <Database Name="cv" Series="41245" Issue="356766" />
     </Book>
     <Book Series="Captain America" Number="18" Volume="2011" Year="2012">
-      <Id>fb3324cf-cb4b-487d-9bb6-b882c7894f09</Id>
+      <Database Name="cv" Series="41245" Issue="360924" />
     </Book>
     <Book Series="Captain America" Number="19" Volume="2011" Year="2012">
-      <Id>37ba1466-3b01-465e-9daa-73573c4b9e9a</Id>
+      <Database Name="cv" Series="41245" Issue="363153" />
     </Book>
     <Book Series="Captain America" Number="1" Volume="2013" Year="2013">
-      <Id>78e3e9fe-608f-44f5-a97d-c097f2cdedef</Id>
+      <Database Name="cv" Series="54110" Issue="369008" />
     </Book>
     <Book Series="Captain America" Number="2" Volume="2013" Year="2013">
-      <Id>e9b4ff43-4b08-440b-af4f-1485eefb261e</Id>
+      <Database Name="cv" Series="54110" Issue="373297" />
     </Book>
     <Book Series="Captain America" Number="3" Volume="2013" Year="2013">
-      <Id>7541724e-089b-4eb5-9a03-96561465edef</Id>
+      <Database Name="cv" Series="54110" Issue="380351" />
     </Book>
     <Book Series="Captain America" Number="4" Volume="2013" Year="2013">
-      <Id>3c93fbf0-8716-42ca-8591-01aded036f1a</Id>
+      <Database Name="cv" Series="54110" Issue="387253" />
     </Book>
     <Book Series="Captain America" Number="5" Volume="2013" Year="2013">
-      <Id>854f9941-86ff-44ad-9797-cccdcaee887b</Id>
+      <Database Name="cv" Series="54110" Issue="394703" />
     </Book>
     <Book Series="Captain America" Number="6" Volume="2013" Year="2013">
-      <Id>e1d8a5f0-0af7-46ed-a971-8b7c47970c18</Id>
+      <Database Name="cv" Series="54110" Issue="397542" />
     </Book>
     <Book Series="Captain America" Number="7" Volume="2013" Year="2013">
-      <Id>2f940545-93e0-49a4-9b63-f624c5ba43a7</Id>
+      <Database Name="cv" Series="54110" Issue="406972" />
     </Book>
     <Book Series="A+X" Number="1" Volume="2012" Year="2012">
-      <Id>5cdada2c-01e2-4fc8-a87c-a7b944b9be43</Id>
+      <Database Name="cv" Series="53535" Issue="364153" />
     </Book>
     <Book Series="Winter Soldier: The Bitter March" Number="1" Volume="2014" Year="2014">
-      <Id>042d87ad-f2ef-4701-b048-dcc1c2d70b95</Id>
+      <Database Name="cv" Series="71613" Issue="445186" />
     </Book>
     <Book Series="Winter Soldier: The Bitter March" Number="2" Volume="2014" Year="2014">
-      <Id>f296436a-41f3-4a60-a8a5-fbdb7e9f87f6</Id>
+      <Database Name="cv" Series="71613" Issue="448007" />
     </Book>
     <Book Series="Winter Soldier: The Bitter March" Number="3" Volume="2014" Year="2014">
-      <Id>8bdde3c0-a19b-41ec-b1c4-e1535dace203</Id>
+      <Database Name="cv" Series="71613" Issue="450559" />
     </Book>
     <Book Series="Winter Soldier: The Bitter March" Number="4" Volume="2014" Year="2014">
-      <Id>088a4a61-8b9c-4a0a-8407-57e506d798f9</Id>
+      <Database Name="cv" Series="71613" Issue="454110" />
     </Book>
     <Book Series="Winter Soldier: The Bitter March" Number="5" Volume="2014" Year="2014">
-      <Id>d558df2e-f203-43f8-8023-067917f3411a</Id>
+      <Database Name="cv" Series="71613" Issue="459179" />
     </Book>
     <Book Series="Captain America" Number="16" Volume="2013" Year="2014">
-      <Id>83f6a6ae-7d09-4863-b2f3-d2116c8651b5</Id>
+      <Database Name="cv" Series="54110" Issue="444530" />
     </Book>
     <Book Series="Captain America" Number="17" Volume="2013" Year="2014">
-      <Id>32694612-e10f-46d3-824d-16dec12015bc</Id>
+      <Database Name="cv" Series="54110" Issue="445810" />
     </Book>
     <Book Series="Captain America" Number="18" Volume="2013" Year="2014">
-      <Id>4083d0b1-d006-4ff7-8171-93a55ec1f1bb</Id>
+      <Database Name="cv" Series="54110" Issue="446990" />
     </Book>
     <Book Series="Captain America" Number="19" Volume="2013" Year="2014">
-      <Id>884444a5-9ea3-4d55-aacd-dad146c94d4c</Id>
+      <Database Name="cv" Series="54110" Issue="449589" />
     </Book>
     <Book Series="Captain America" Number="20" Volume="2013" Year="2014">
-      <Id>faa70440-587f-480c-96d2-05c1cd0a7974</Id>
+      <Database Name="cv" Series="54110" Issue="452848" />
     </Book>
     <Book Series="Captain America" Number="21" Volume="2013" Year="2014">
-      <Id>f6ce99ff-5eeb-4860-860b-1da8f748b438</Id>
+      <Database Name="cv" Series="54110" Issue="455485" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Captain America/Captain America 004 - Marvel Knights.cbl
+++ b/Marvel/Characters/unsorted/Captain America/Captain America 004 - Marvel Knights.cbl
@@ -2,775 +2,775 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Captain America 04 - Marvel Knights</Name>
   <Books>
-    <Book Series="Captain America" Number="1" Volume="2002" Year="2002" Format="Main Series">
+    <Book Series="Captain America" Number="1" Volume="2002" Year="2002">
       <Id>99a06bdc-63f3-4faf-8803-59922f5d830b</Id>
     </Book>
-    <Book Series="Captain America" Number="2" Volume="2002" Year="2002" Format="Main Series">
+    <Book Series="Captain America" Number="2" Volume="2002" Year="2002">
       <Id>2e5ca6f7-e88c-40ef-9bf9-d86a21512b8c</Id>
     </Book>
-    <Book Series="Captain America" Number="3" Volume="2002" Year="2002" Format="Main Series">
+    <Book Series="Captain America" Number="3" Volume="2002" Year="2002">
       <Id>4712ad55-1b62-4273-9c71-f6ddb0f703e1</Id>
     </Book>
-    <Book Series="Captain America" Number="4" Volume="2002" Year="2002" Format="Main Series">
+    <Book Series="Captain America" Number="4" Volume="2002" Year="2002">
       <Id>89f65f9b-346e-46eb-92ab-473bfc2d3e01</Id>
     </Book>
-    <Book Series="Captain America" Number="5" Volume="2002" Year="2002" Format="Main Series">
+    <Book Series="Captain America" Number="5" Volume="2002" Year="2002">
       <Id>5cb9f8d2-f372-46ed-9d3d-f1b6ecd4fba9</Id>
     </Book>
-    <Book Series="Captain America" Number="6" Volume="2002" Year="2002" Format="Main Series">
+    <Book Series="Captain America" Number="6" Volume="2002" Year="2002">
       <Id>82349473-b2dc-4ef5-bb7d-b72ca16b7dd2</Id>
     </Book>
-    <Book Series="Captain America" Number="7" Volume="2002" Year="2002" Format="Main Series">
+    <Book Series="Captain America" Number="7" Volume="2002" Year="2002">
       <Id>f410ceb3-cec2-42d0-b257-4aa897ae25b4</Id>
     </Book>
-    <Book Series="Captain America" Number="8" Volume="2002" Year="2003" Format="Main Series">
+    <Book Series="Captain America" Number="8" Volume="2002" Year="2003">
       <Id>19a8bd3f-dcfe-4c55-9a5b-c87a951b2e93</Id>
     </Book>
-    <Book Series="Captain America" Number="9" Volume="2002" Year="2003" Format="Main Series">
+    <Book Series="Captain America" Number="9" Volume="2002" Year="2003">
       <Id>eba032dc-f633-468b-a6a1-4cce71b33d85</Id>
     </Book>
-    <Book Series="Captain America" Number="10" Volume="2002" Year="2003" Format="Main Series">
+    <Book Series="Captain America" Number="10" Volume="2002" Year="2003">
       <Id>32f9bbff-6a84-44a0-bf16-60362e6e741b</Id>
     </Book>
-    <Book Series="Captain America" Number="11" Volume="2002" Year="2003" Format="Main Series">
+    <Book Series="Captain America" Number="11" Volume="2002" Year="2003">
       <Id>dd37dfe1-5dff-4681-ba62-6a6f5a888646</Id>
     </Book>
-    <Book Series="Captain America" Number="12" Volume="2002" Year="2003" Format="Main Series">
+    <Book Series="Captain America" Number="12" Volume="2002" Year="2003">
       <Id>a5f795fd-221f-43bb-93d2-3b7e946b2c04</Id>
     </Book>
-    <Book Series="Captain America" Number="13" Volume="2002" Year="2003" Format="Main Series">
+    <Book Series="Captain America" Number="13" Volume="2002" Year="2003">
       <Id>2332bee1-e567-44f9-91a7-388a7b70802f</Id>
     </Book>
-    <Book Series="Captain America" Number="14" Volume="2002" Year="2003" Format="Main Series">
+    <Book Series="Captain America" Number="14" Volume="2002" Year="2003">
       <Id>89f6d73e-734b-4280-8a8e-7688c0286730</Id>
     </Book>
-    <Book Series="Captain America" Number="15" Volume="2002" Year="2003" Format="Main Series">
+    <Book Series="Captain America" Number="15" Volume="2002" Year="2003">
       <Id>cbc908b9-309c-4ff8-adcb-664455207aee</Id>
     </Book>
-    <Book Series="Captain America" Number="16" Volume="2002" Year="2003" Format="Main Series">
+    <Book Series="Captain America" Number="16" Volume="2002" Year="2003">
       <Id>7b5e77c5-2afb-4c1f-a4ac-71e979774392</Id>
     </Book>
-    <Book Series="Captain America" Number="17" Volume="2002" Year="2003" Format="Main Series">
+    <Book Series="Captain America" Number="17" Volume="2002" Year="2003">
       <Id>6717efcc-26a3-4cee-aabd-eefa6b04003a</Id>
     </Book>
-    <Book Series="Captain America" Number="18" Volume="2002" Year="2003" Format="Main Series">
+    <Book Series="Captain America" Number="18" Volume="2002" Year="2003">
       <Id>2f414138-994e-4f46-961b-8248a16125d6</Id>
     </Book>
-    <Book Series="Captain America" Number="19" Volume="2002" Year="2003" Format="Main Series">
+    <Book Series="Captain America" Number="19" Volume="2002" Year="2003">
       <Id>398eb164-156e-4f30-8925-228034790e81</Id>
     </Book>
-    <Book Series="Captain America" Number="20" Volume="2002" Year="2004" Format="Main Series">
+    <Book Series="Captain America" Number="20" Volume="2002" Year="2004">
       <Id>1ee6d6a3-c834-40c0-afc7-d8a4f7e3e334</Id>
     </Book>
-    <Book Series="Captain America" Number="21" Volume="2002" Year="2004" Format="Main Series">
+    <Book Series="Captain America" Number="21" Volume="2002" Year="2004">
       <Id>f330d114-c0b2-443e-ad0e-5c21aa8beb76</Id>
     </Book>
-    <Book Series="Captain America" Number="22" Volume="2002" Year="2004" Format="Main Series">
+    <Book Series="Captain America" Number="22" Volume="2002" Year="2004">
       <Id>2200ea25-69e0-4b89-ba6a-c1fcda099769</Id>
     </Book>
-    <Book Series="Captain America" Number="23" Volume="2002" Year="2004" Format="Main Series">
+    <Book Series="Captain America" Number="23" Volume="2002" Year="2004">
       <Id>44afedff-2ac5-4199-b33e-4c092109ae78</Id>
     </Book>
-    <Book Series="Captain America" Number="24" Volume="2002" Year="2004" Format="Main Series">
+    <Book Series="Captain America" Number="24" Volume="2002" Year="2004">
       <Id>10904edb-5c2c-4b32-ae05-41196c8f74f3</Id>
     </Book>
-    <Book Series="Captain America" Number="25" Volume="2002" Year="2004" Format="Main Series">
+    <Book Series="Captain America" Number="25" Volume="2002" Year="2004">
       <Id>5f20e4f7-ded6-4539-9e2e-ca13d08ecbeb</Id>
     </Book>
-    <Book Series="Wolverine/Captain America" Number="1" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Wolverine/Captain America" Number="1" Volume="2004" Year="2004">
       <Id>b51d368e-fe0b-4d54-8e3b-adca003cc824</Id>
     </Book>
-    <Book Series="Wolverine/Captain America" Number="2" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Wolverine/Captain America" Number="2" Volume="2004" Year="2004">
       <Id>4067a515-2a3a-4e33-bca9-afd2142ab5b8</Id>
     </Book>
-    <Book Series="Wolverine/Captain America" Number="3" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Wolverine/Captain America" Number="3" Volume="2004" Year="2004">
       <Id>7421a9fa-6ffa-4aa7-9448-695e22a7436f</Id>
     </Book>
-    <Book Series="Wolverine/Captain America" Number="4" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Wolverine/Captain America" Number="4" Volume="2004" Year="2004">
       <Id>f132b266-414f-491a-bad3-77ff9a6d6307</Id>
     </Book>
-    <Book Series="Captain America" Number="26" Volume="2002" Year="2004" Format="Main Series">
+    <Book Series="Captain America" Number="26" Volume="2002" Year="2004">
       <Id>5a7008fb-4520-49c5-8125-f62ba11e1507</Id>
     </Book>
-    <Book Series="Captain America" Number="27" Volume="2002" Year="2004" Format="Main Series">
+    <Book Series="Captain America" Number="27" Volume="2002" Year="2004">
       <Id>918de13a-4731-4c2f-be45-928cf6b5cfe9</Id>
     </Book>
-    <Book Series="Captain America" Number="28" Volume="2002" Year="2004" Format="Main Series">
+    <Book Series="Captain America" Number="28" Volume="2002" Year="2004">
       <Id>acaa2a81-c87d-4ec7-ad71-6c61811e133c</Id>
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="1" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Captain America &amp; the Falcon" Number="1" Volume="2004" Year="2004">
       <Id>1304c00c-b246-4b98-ba23-d7f506979b35</Id>
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="2" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Captain America &amp; the Falcon" Number="2" Volume="2004" Year="2004">
       <Id>c0d46016-9243-4874-ae2d-36d07865d090</Id>
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="3" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Captain America &amp; the Falcon" Number="3" Volume="2004" Year="2004">
       <Id>1db53bef-9a0e-4343-8a67-39a09c2475c2</Id>
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="4" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Captain America &amp; the Falcon" Number="4" Volume="2004" Year="2004">
       <Id>9fb055b6-c3fc-4606-be15-2093befc0a8e</Id>
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="5" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Captain America &amp; the Falcon" Number="5" Volume="2004" Year="2004">
       <Id>72854219-ed32-4376-ac70-a6a545a352d6</Id>
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="6" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Captain America &amp; the Falcon" Number="6" Volume="2004" Year="2004">
       <Id>56e1d43e-75c8-4ab2-9d38-cc58dd5b2fa6</Id>
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="7" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Captain America &amp; the Falcon" Number="7" Volume="2004" Year="2004">
       <Id>3e969b14-d089-45c8-bde3-317413223ef0</Id>
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="8" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Captain America &amp; the Falcon" Number="8" Volume="2004" Year="2004">
       <Id>99ed20de-2972-4d19-9035-d9aefd07a408</Id>
     </Book>
-    <Book Series="Captain America" Number="29" Volume="2002" Year="2004" Format="Main Series">
+    <Book Series="Captain America" Number="29" Volume="2002" Year="2004">
       <Id>b3fdd0bf-b472-462b-b329-2f251789ed07</Id>
     </Book>
-    <Book Series="Captain America" Number="30" Volume="2002" Year="2004" Format="Main Series">
+    <Book Series="Captain America" Number="30" Volume="2002" Year="2004">
       <Id>26dee2c5-c6f1-4565-b713-5d926fcb7d6c</Id>
     </Book>
-    <Book Series="Captain America" Number="31" Volume="2002" Year="2004" Format="Main Series">
+    <Book Series="Captain America" Number="31" Volume="2002" Year="2004">
       <Id>15960bce-bf06-41cf-b976-dd968688518e</Id>
     </Book>
-    <Book Series="Captain America" Number="32" Volume="2002" Year="2004" Format="Main Series">
+    <Book Series="Captain America" Number="32" Volume="2002" Year="2004">
       <Id>8fbc1f41-9a06-423c-b56a-022330f0331e</Id>
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="9" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Captain America &amp; the Falcon" Number="9" Volume="2004" Year="2005">
       <Id>8d349fc7-e563-48de-b11f-e621126ec29c</Id>
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="10" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Captain America &amp; the Falcon" Number="10" Volume="2004" Year="2005">
       <Id>0eab4f37-7169-4052-9a8c-61e66e5a3b2d</Id>
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="11" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Captain America &amp; the Falcon" Number="11" Volume="2004" Year="2005">
       <Id>0e9a0c10-4d9d-4fee-9887-f8db10905635</Id>
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="12" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Captain America &amp; the Falcon" Number="12" Volume="2004" Year="2005">
       <Id>3d6cb62a-1a09-4f0c-b27a-6974522185cc</Id>
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="13" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Captain America &amp; the Falcon" Number="13" Volume="2004" Year="2005">
       <Id>01d30edc-cd7f-4d61-8545-5371a8538d59</Id>
     </Book>
-    <Book Series="Captain America &amp; the Falcon" Number="14" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Captain America &amp; the Falcon" Number="14" Volume="2004" Year="2005">
       <Id>480c892d-ecb8-41a6-88c9-c594ca41b432</Id>
     </Book>
-    <Book Series="Secret War" Number="1" Volume="2004" Year="2004" Format="Crossover">
+    <Book Series="Secret War" Number="1" Volume="2004" Year="2004">
       <Id>656b0c01-2210-46e1-b339-0425383d04f8</Id>
     </Book>
-    <Book Series="Secret War" Number="2" Volume="2004" Year="2004" Format="Crossover">
+    <Book Series="Secret War" Number="2" Volume="2004" Year="2004">
       <Id>ffb4246d-e097-4e7c-ac18-8fb13bb6f318</Id>
     </Book>
-    <Book Series="Secret War" Number="3" Volume="2004" Year="2004" Format="Crossover">
+    <Book Series="Secret War" Number="3" Volume="2004" Year="2004">
       <Id>d1f6a606-2cd2-4889-92aa-823f023f98d2</Id>
     </Book>
-    <Book Series="Secret War" Number="4" Volume="2004" Year="2005" Format="Crossover">
+    <Book Series="Secret War" Number="4" Volume="2004" Year="2005">
       <Id>bb509e6f-eeaa-44c1-b6cc-c2081712832c</Id>
     </Book>
-    <Book Series="Secret War" Number="5" Volume="2004" Year="2005" Format="Crossover">
+    <Book Series="Secret War" Number="5" Volume="2004" Year="2005">
       <Id>b8d9c94c-348d-411b-8b8e-9d55a0e6bbed</Id>
     </Book>
-    <Book Series="Captain America" Number="1" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Captain America" Number="1" Volume="2005" Year="2005">
       <Id>f8fd9f2f-33bd-4bf1-b9f0-b6abd603bf0b</Id>
     </Book>
-    <Book Series="Captain America" Number="2" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Captain America" Number="2" Volume="2005" Year="2005">
       <Id>d31974ca-c2ec-496c-9f81-a04f5270a3b8</Id>
     </Book>
-    <Book Series="Captain America" Number="3" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Captain America" Number="3" Volume="2005" Year="2005">
       <Id>147c3df8-a052-414a-9e23-0ed270bf4787</Id>
     </Book>
-    <Book Series="Captain America" Number="4" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Captain America" Number="4" Volume="2005" Year="2005">
       <Id>9f153103-9d0a-4620-a73f-cb2bb8f14400</Id>
     </Book>
-    <Book Series="Captain America" Number="5" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Captain America" Number="5" Volume="2005" Year="2005">
       <Id>56b7ad13-6803-4b17-b6c6-1266f00b6f52</Id>
     </Book>
-    <Book Series="Captain America" Number="6" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Captain America" Number="6" Volume="2005" Year="2005">
       <Id>6f77b5ac-f031-4fa7-9bdb-7e8964ca8b0c</Id>
     </Book>
-    <Book Series="Captain America" Number="7" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Captain America" Number="7" Volume="2005" Year="2005">
       <Id>d427e684-5f2f-4717-9151-26645ab480e2</Id>
     </Book>
-    <Book Series="Captain America" Number="8" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Captain America" Number="8" Volume="2005" Year="2005">
       <Id>601439d3-9e2a-4667-9a14-62f6136b79bc</Id>
     </Book>
-    <Book Series="Captain America" Number="9" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Captain America" Number="9" Volume="2005" Year="2005">
       <Id>b08288a8-1572-43ce-b1b8-6d886d640241</Id>
     </Book>
-    <Book Series="Captain America" Number="10" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Captain America" Number="10" Volume="2005" Year="2005">
       <Id>ffee4aa1-d013-4867-9f49-d0193bd1451e</Id>
     </Book>
-    <Book Series="Captain America" Number="11" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Captain America" Number="11" Volume="2005" Year="2005">
       <Id>fee9a040-8020-4164-b434-2c4224fbe8fb</Id>
     </Book>
-    <Book Series="Captain America" Number="12" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Captain America" Number="12" Volume="2005" Year="2005">
       <Id>ba492654-2435-4bf8-a7bd-db878fe70809</Id>
     </Book>
-    <Book Series="Captain America" Number="13" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Captain America" Number="13" Volume="2005" Year="2006">
       <Id>c8b79e91-5079-4453-ad49-ac8ecc803146</Id>
     </Book>
-    <Book Series="Captain America" Number="14" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Captain America" Number="14" Volume="2005" Year="2006">
       <Id>3b60cbc1-2139-4aac-9aed-6987a61cbf3c</Id>
     </Book>
-    <Book Series="Captain America" Number="15" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Captain America" Number="15" Volume="2005" Year="2006">
       <Id>2c3c4685-e4c6-49cd-9b64-67e8da0ed1ea</Id>
     </Book>
-    <Book Series="Captain America" Number="16" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Captain America" Number="16" Volume="2005" Year="2006">
       <Id>ab1c988c-bbfc-41a6-87f4-978ba1020857</Id>
     </Book>
-    <Book Series="Captain America" Number="17" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Captain America" Number="17" Volume="2005" Year="2006">
       <Id>699f07fa-7904-4663-b0f6-c914dcca3095</Id>
     </Book>
-    <Book Series="Captain America" Number="18" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Captain America" Number="18" Volume="2005" Year="2006">
       <Id>17ad3b97-b4af-4c4e-9567-89efde3c0711</Id>
     </Book>
-    <Book Series="Captain America" Number="19" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Captain America" Number="19" Volume="2005" Year="2006">
       <Id>23f3f7e8-0343-46c1-b5b2-f407b52dfe2b</Id>
     </Book>
-    <Book Series="Captain America" Number="20" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Captain America" Number="20" Volume="2005" Year="2006">
       <Id>5626d6b6-7d6c-496f-b113-49e6921b11cf</Id>
     </Book>
-    <Book Series="Captain America" Number="21" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Captain America" Number="21" Volume="2005" Year="2006">
       <Id>b1a6acae-3886-457d-b011-972ed3d006b1</Id>
     </Book>
-    <Book Series="Civil War" Number="1" Volume="2006" Year="2006" Format="Crossover">
+    <Book Series="Civil War" Number="1" Volume="2006" Year="2006">
       <Id>8a3b618d-9877-4c00-8d7f-48d65f4599dd</Id>
     </Book>
-    <Book Series="Civil War" Number="2" Volume="2006" Year="2006" Format="Crossover">
+    <Book Series="Civil War" Number="2" Volume="2006" Year="2006">
       <Id>346dc7b4-7523-40ae-8fab-1df067deffd5</Id>
     </Book>
-    <Book Series="Civil War" Number="3" Volume="2006" Year="2006" Format="Crossover">
+    <Book Series="Civil War" Number="3" Volume="2006" Year="2006">
       <Id>7bbd5df4-e746-40d8-9ad1-b135c26c0c20</Id>
     </Book>
-    <Book Series="Civil War" Number="4" Volume="2006" Year="2006" Format="Crossover">
+    <Book Series="Civil War" Number="4" Volume="2006" Year="2006">
       <Id>4ed27e2e-d39c-4e8e-9dd6-ef44419ec683</Id>
     </Book>
-    <Book Series="Captain America" Number="22" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Captain America" Number="22" Volume="2005" Year="2006">
       <Id>88bbe9cd-c892-49f0-93f1-68055b31fff6</Id>
     </Book>
-    <Book Series="Captain America" Number="23" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Captain America" Number="23" Volume="2005" Year="2006">
       <Id>e5ac1190-5a0b-4311-800a-43a03bd193ea</Id>
     </Book>
-    <Book Series="Civil War" Number="5" Volume="2006" Year="2006" Format="Crossover">
+    <Book Series="Civil War" Number="5" Volume="2006" Year="2006">
       <Id>52958b4a-aa5d-4429-b844-9ca8c0ba5b02</Id>
     </Book>
-    <Book Series="Captain America" Number="24" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Captain America" Number="24" Volume="2005" Year="2007">
       <Id>7d5424cd-de24-4800-947d-62441a82711a</Id>
     </Book>
-    <Book Series="Civil War" Number="6" Volume="2006" Year="2006" Format="Crossover">
+    <Book Series="Civil War" Number="6" Volume="2006" Year="2006">
       <Id>72de0c39-09f3-43a0-93dd-5d35d3c409c5</Id>
     </Book>
-    <Book Series="Civil War" Number="7" Volume="2006" Year="2007" Format="Crossover">
+    <Book Series="Civil War" Number="7" Volume="2006" Year="2007">
       <Id>88a586c8-129f-4c95-af85-aeff87628b25</Id>
     </Book>
-    <Book Series="Captain America" Number="25" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Captain America" Number="25" Volume="2005" Year="2007">
       <Id>c8c32d68-44f5-4f58-b285-775bde88aba2</Id>
     </Book>
-    <Book Series="Fallen Son: The Death of Captain America" Number="1" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="Fallen Son: The Death of Captain America" Number="1" Volume="2007" Year="2007">
       <Id>acbced34-2804-4e21-a1a4-464a526f2667</Id>
     </Book>
-    <Book Series="Fallen Son: The Death of Captain America" Number="2" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="Fallen Son: The Death of Captain America" Number="2" Volume="2007" Year="2007">
       <Id>71d43347-0b2d-4ad7-a2e2-e6c6281f5d14</Id>
     </Book>
-    <Book Series="Fallen Son: The Death of Captain America" Number="3" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="Fallen Son: The Death of Captain America" Number="3" Volume="2007" Year="2007">
       <Id>85e267b8-07f5-4b75-a5de-5c58219ba607</Id>
     </Book>
-    <Book Series="Fallen Son: The Death of Captain America" Number="4" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="Fallen Son: The Death of Captain America" Number="4" Volume="2007" Year="2007">
       <Id>cc5846fc-8b40-478f-9ba6-70fc8aa5ffb5</Id>
     </Book>
-    <Book Series="Fallen Son: The Death of Captain America" Number="5" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="Fallen Son: The Death of Captain America" Number="5" Volume="2007" Year="2007">
       <Id>c37b9864-6285-4197-ba38-c49369b37b8b</Id>
     </Book>
-    <Book Series="Captain America" Number="26" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Captain America" Number="26" Volume="2005" Year="2007">
       <Id>ee69304e-2542-4ff6-b476-4cf7ffa1bc37</Id>
     </Book>
-    <Book Series="Captain America" Number="27" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Captain America" Number="27" Volume="2005" Year="2007">
       <Id>e9a12bf1-c65b-415a-a2f7-9e45bce7d19f</Id>
     </Book>
-    <Book Series="Captain America" Number="28" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Captain America" Number="28" Volume="2005" Year="2007">
       <Id>9565c5ce-33e8-442a-b524-05678f104b33</Id>
     </Book>
-    <Book Series="Captain America" Number="29" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Captain America" Number="29" Volume="2005" Year="2007">
       <Id>cd475f87-04cb-44c5-91c8-6c9aff3e560d</Id>
     </Book>
-    <Book Series="Captain America" Number="30" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Captain America" Number="30" Volume="2005" Year="2007">
       <Id>a2ad03c6-21b3-4ed1-879c-3533e7bf1a8c</Id>
     </Book>
-    <Book Series="Captain America" Number="31" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Captain America" Number="31" Volume="2005" Year="2007">
       <Id>ebe398e8-9963-4d6d-ac49-10d6761a5504</Id>
     </Book>
-    <Book Series="Captain America" Number="32" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="Captain America" Number="32" Volume="2005" Year="2008">
       <Id>48bff835-41ff-4b37-9326-7ac6e3c2e672</Id>
     </Book>
-    <Book Series="Captain America" Number="33" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="Captain America" Number="33" Volume="2005" Year="2008">
       <Id>d1379974-f5b0-4f80-ac29-99b4bfaf8a73</Id>
     </Book>
-    <Book Series="Captain America" Number="34" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="Captain America" Number="34" Volume="2005" Year="2008">
       <Id>89c34721-75ac-46e7-86c2-d0bbbdad6a03</Id>
     </Book>
-    <Book Series="Captain America" Number="35" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="Captain America" Number="35" Volume="2005" Year="2008">
       <Id>3db24eab-0974-4236-88a5-cbcfaeaa08d4</Id>
     </Book>
-    <Book Series="Captain America" Number="36" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="Captain America" Number="36" Volume="2005" Year="2008">
       <Id>aa428da7-1d00-481c-9599-fed6b4b6c3ae</Id>
     </Book>
-    <Book Series="Captain America" Number="37" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="Captain America" Number="37" Volume="2005" Year="2008">
       <Id>c0645fea-1171-43d7-b092-3cb5e7f8d55a</Id>
     </Book>
-    <Book Series="Captain America" Number="38" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="Captain America" Number="38" Volume="2005" Year="2008">
       <Id>2d530e00-d430-4343-b00b-8a152c2537f2</Id>
     </Book>
-    <Book Series="Captain America" Number="39" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="Captain America" Number="39" Volume="2005" Year="2008">
       <Id>4009d38c-b212-4ae8-9e16-654081700986</Id>
     </Book>
-    <Book Series="Captain America" Number="40" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="Captain America" Number="40" Volume="2005" Year="2008">
       <Id>3e608768-7827-4abd-8b33-f09b68499f7d</Id>
     </Book>
-    <Book Series="Captain America" Number="41" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="Captain America" Number="41" Volume="2005" Year="2008">
       <Id>f30c10da-dbb3-45f6-953e-b4bfbdf149f2</Id>
     </Book>
-    <Book Series="Captain America" Number="42" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="Captain America" Number="42" Volume="2005" Year="2008">
       <Id>81f2eb82-8d0b-409a-b55c-326e83de9e8a</Id>
     </Book>
-    <Book Series="Captain America" Number="43" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="Captain America" Number="43" Volume="2005" Year="2008">
       <Id>321e938b-11e7-4e50-a84d-f937b4c0856a</Id>
     </Book>
-    <Book Series="Captain America" Number="44" Volume="2005" Year="2009" Format="Main Series">
+    <Book Series="Captain America" Number="44" Volume="2005" Year="2009">
       <Id>d53d8609-5b5d-47b6-9a07-5477e17dbac1</Id>
     </Book>
-    <Book Series="Captain America" Number="45" Volume="2005" Year="2009" Format="Main Series">
+    <Book Series="Captain America" Number="45" Volume="2005" Year="2009">
       <Id>62f46571-d538-4c3f-904e-cba5a1c096de</Id>
     </Book>
-    <Book Series="Captain America" Number="46" Volume="2005" Year="2009" Format="Main Series">
+    <Book Series="Captain America" Number="46" Volume="2005" Year="2009">
       <Id>ac22e8b7-18b3-4ad8-9bb1-fcab7d5519dc</Id>
     </Book>
-    <Book Series="Captain America" Number="47" Volume="2005" Year="2009" Format="Main Series">
+    <Book Series="Captain America" Number="47" Volume="2005" Year="2009">
       <Id>c36ea875-f54a-4742-880a-3669ee8ad515</Id>
     </Book>
-    <Book Series="Captain America" Number="48" Volume="2005" Year="2009" Format="Main Series">
+    <Book Series="Captain America" Number="48" Volume="2005" Year="2009">
       <Id>6a7a1a0f-4026-436f-adeb-0c895a3318cc</Id>
     </Book>
-    <Book Series="Secret Invasion Director's Cut" Number="1" Volume="2008" Year="2008" Format="Crossover">
+    <Book Series="Secret Invasion Director's Cut" Number="1" Volume="2008" Year="2008">
       <Id>6a2d34ba-8a32-4b2b-977b-2aacc2692b31</Id>
     </Book>
-    <Book Series="Secret Invasion" Number="2" Volume="2008" Year="2008" Format="Crossover">
+    <Book Series="Secret Invasion" Number="2" Volume="2008" Year="2008">
       <Id>7ee44784-000e-4c8d-9bd0-8ae2704a66fb</Id>
     </Book>
-    <Book Series="Secret Invasion" Number="3" Volume="2008" Year="2008" Format="Crossover">
+    <Book Series="Secret Invasion" Number="3" Volume="2008" Year="2008">
       <Id>7d646eac-8160-49db-8771-c6fc261fa833</Id>
     </Book>
-    <Book Series="Secret Invasion" Number="4" Volume="2008" Year="2008" Format="Crossover">
+    <Book Series="Secret Invasion" Number="4" Volume="2008" Year="2008">
       <Id>6c6eca88-3515-4f4f-9834-1d97d64355d1</Id>
     </Book>
-    <Book Series="Secret Invasion" Number="5" Volume="2008" Year="2008" Format="Crossover">
+    <Book Series="Secret Invasion" Number="5" Volume="2008" Year="2008">
       <Id>6d8808bf-b64d-4b12-b16d-e034d833bafd</Id>
     </Book>
-    <Book Series="Secret Invasion" Number="6" Volume="2008" Year="2008" Format="Crossover">
+    <Book Series="Secret Invasion" Number="6" Volume="2008" Year="2008">
       <Id>cf384a0e-69b1-4743-b7ae-2e49bcd3b887</Id>
     </Book>
-    <Book Series="Secret Invasion" Number="7" Volume="2008" Year="2008" Format="Crossover">
+    <Book Series="Secret Invasion" Number="7" Volume="2008" Year="2008">
       <Id>aed9b2a9-a77c-4c71-8abe-beb2d207326a</Id>
     </Book>
-    <Book Series="Secret Invasion" Number="8" Volume="2008" Year="2009" Format="Crossover">
+    <Book Series="Secret Invasion" Number="8" Volume="2008" Year="2009">
       <Id>02491013-82d8-4f8b-8748-10994aa8426e</Id>
     </Book>
-    <Book Series="Captain America" Number="49" Volume="2005" Year="2009" Format="Main Series">
+    <Book Series="Captain America" Number="49" Volume="2005" Year="2009">
       <Id>8c23c2bf-0cc0-4b32-a6bc-200175bbf8bb</Id>
     </Book>
-    <Book Series="Captain America" Number="50" Volume="2005" Year="2009" Format="Main Series">
+    <Book Series="Captain America" Number="50" Volume="2005" Year="2009">
       <Id>33594723-e4e2-42cf-8552-7fb678bf6fcd</Id>
     </Book>
-    <Book Series="Captain America" Number="600" Volume="2005" Year="2009" Format="Main Series">
+    <Book Series="Captain America" Number="600" Volume="2005" Year="2009">
       <Id>bbb79f62-b63d-4587-9054-39fd5cd047fa</Id>
     </Book>
-    <Book Series="Captain America" Number="601" Volume="2005" Year="2009" Format="Main Series">
+    <Book Series="Captain America" Number="601" Volume="2005" Year="2009">
       <Id>575d83d1-de38-4804-b872-db8a5ac399b4</Id>
     </Book>
-    <Book Series="Captain America: Reborn" Number="1" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="Captain America: Reborn" Number="1" Volume="2009" Year="2009">
       <Id>d2804b88-9c7e-407c-b476-1dee0470f334</Id>
     </Book>
-    <Book Series="Captain America: Reborn" Number="2" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="Captain America: Reborn" Number="2" Volume="2009" Year="2009">
       <Id>a2c57d9a-d562-49ae-bce6-5e0000878eff</Id>
     </Book>
-    <Book Series="Captain America: Reborn" Number="3" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="Captain America: Reborn" Number="3" Volume="2009" Year="2009">
       <Id>84f1e8d1-4728-4f35-9f58-58508435b099</Id>
     </Book>
-    <Book Series="Captain America: Reborn" Number="4" Volume="2009" Year="2010" Format="Limited Series">
+    <Book Series="Captain America: Reborn" Number="4" Volume="2009" Year="2010">
       <Id>57abe501-7cc4-4264-97d8-aca80e0deb27</Id>
     </Book>
-    <Book Series="Captain America: Reborn" Number="5" Volume="2009" Year="2010" Format="Limited Series">
+    <Book Series="Captain America: Reborn" Number="5" Volume="2009" Year="2010">
       <Id>768c0d68-cfb3-4aa7-9ecf-0c68e88eef61</Id>
     </Book>
-    <Book Series="Captain America: Reborn" Number="6" Volume="2009" Year="2010" Format="Limited Series">
+    <Book Series="Captain America: Reborn" Number="6" Volume="2009" Year="2010">
       <Id>7d88976d-3a97-4511-8ec6-0eb9dce99f4e</Id>
     </Book>
-    <Book Series="Avengers: Prime" Number="1" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Avengers: Prime" Number="1" Volume="2010" Year="2010">
       <Id>64f86715-0af4-4d46-8e80-91dae4951a30</Id>
     </Book>
-    <Book Series="Avengers: Prime" Number="2" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Avengers: Prime" Number="2" Volume="2010" Year="2010">
       <Id>72c606fd-8c89-4c84-996d-8e2701af7176</Id>
     </Book>
-    <Book Series="Avengers: Prime" Number="3" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Avengers: Prime" Number="3" Volume="2010" Year="2010">
       <Id>8e633fa2-3ba9-4cfd-b489-2ad82570144f</Id>
     </Book>
-    <Book Series="Avengers: Prime" Number="4" Volume="2010" Year="2011" Format="Limited Series">
+    <Book Series="Avengers: Prime" Number="4" Volume="2010" Year="2011">
       <Id>99d3d89d-f29a-44c2-8f4d-66e3e1ccdd1f</Id>
     </Book>
-    <Book Series="Avengers: Prime" Number="5" Volume="2010" Year="2011" Format="Limited Series">
+    <Book Series="Avengers: Prime" Number="5" Volume="2010" Year="2011">
       <Id>ac1ce361-db26-4a8d-bf11-3d2fba1090ca</Id>
     </Book>
-    <Book Series="Captain America" Number="602" Volume="2005" Year="2010" Format="Main Series">
+    <Book Series="Captain America" Number="602" Volume="2005" Year="2010">
       <Id>7e698b04-632f-4f7f-87f5-594cc17a1132</Id>
     </Book>
-    <Book Series="Captain America" Number="603" Volume="2005" Year="2010" Format="Main Series">
+    <Book Series="Captain America" Number="603" Volume="2005" Year="2010">
       <Id>438929b8-4edc-4af8-b489-cfafc7744fd9</Id>
     </Book>
-    <Book Series="Captain America" Number="604" Volume="2005" Year="2010" Format="Main Series">
+    <Book Series="Captain America" Number="604" Volume="2005" Year="2010">
       <Id>4e681a79-d36e-4d06-b858-dfd4f5966d75</Id>
     </Book>
-    <Book Series="Captain America" Number="605" Volume="2005" Year="2010" Format="Main Series">
+    <Book Series="Captain America" Number="605" Volume="2005" Year="2010">
       <Id>e1994030-f1f5-4925-afe0-6d0ddd64f488</Id>
     </Book>
-    <Book Series="Captain America: Who Won't Wield the Shield?" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="Captain America: Who Won't Wield the Shield?" Number="1" Volume="2010" Year="2010">
       <Id>baad4687-ba41-4b4d-8113-0d1d94d93a3b</Id>
     </Book>
-    <Book Series="Captain America and..." Number="1" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Captain America and..." Number="1" Volume="2011" Year="2011">
       <Id>11f38b33-c64a-46d2-99d9-c7831fd3b1cb</Id>
     </Book>
-    <Book Series="Captain America and..." Number="1" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Captain America and..." Number="1" Volume="2011" Year="2011">
       <Id>c7044bb0-747e-4734-a3ac-cd3c5e03662e</Id>
     </Book>
-    <Book Series="Captain America and..." Number="1" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Captain America and..." Number="1" Volume="2011" Year="2011">
       <Id>036d4a3b-e475-4a93-9519-a203265dba6f</Id>
     </Book>
-    <Book Series="Captain America and..." Number="1" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Captain America and..." Number="1" Volume="2011" Year="2011">
       <Id>fe5a6747-9483-4024-9e77-7ca4e89964a9</Id>
     </Book>
-    <Book Series="Captain America and the Secret Avengers" Number="1" Volume="2011" Year="2011" Format="One-Shot">
+    <Book Series="Captain America and the Secret Avengers" Number="1" Volume="2011" Year="2011">
       <Id>87606054-3770-4517-a5b1-5210e66dcec5</Id>
     </Book>
-    <Book Series="Captain America" Number="606" Volume="2005" Year="2010" Format="Main Series">
+    <Book Series="Captain America" Number="606" Volume="2005" Year="2010">
       <Id>b3c0c671-0ab4-414f-a0d4-f9cf230907b1</Id>
     </Book>
-    <Book Series="Captain America" Number="607" Volume="2005" Year="2010" Format="Main Series">
+    <Book Series="Captain America" Number="607" Volume="2005" Year="2010">
       <Id>a9a0af64-abc3-4fd3-ac5b-5ae1c3d274ee</Id>
     </Book>
-    <Book Series="Captain America" Number="608" Volume="2005" Year="2010" Format="Main Series">
+    <Book Series="Captain America" Number="608" Volume="2005" Year="2010">
       <Id>ef18efbc-3e62-4007-9969-e619da727871</Id>
     </Book>
-    <Book Series="Captain America" Number="609" Volume="2005" Year="2010" Format="Main Series">
+    <Book Series="Captain America" Number="609" Volume="2005" Year="2010">
       <Id>6e958ee9-1b6c-4e63-82b2-df30e2e31296</Id>
     </Book>
-    <Book Series="Captain America" Number="610" Volume="2005" Year="2010" Format="Main Series">
+    <Book Series="Captain America" Number="610" Volume="2005" Year="2010">
       <Id>06d0db9e-7c68-4f74-a20f-8a54892566e3</Id>
     </Book>
-    <Book Series="Captain America" Number="611" Volume="2005" Year="2010" Format="Main Series">
+    <Book Series="Captain America" Number="611" Volume="2005" Year="2010">
       <Id>255d58f2-b8aa-4a13-b0ca-28a22b5fb49c</Id>
     </Book>
-    <Book Series="Captain America" Number="612" Volume="2005" Year="2011" Format="Main Series">
+    <Book Series="Captain America" Number="612" Volume="2005" Year="2011">
       <Id>a8471b0a-07ef-4fe4-bd69-de5db645b760</Id>
     </Book>
-    <Book Series="Captain America" Number="613" Volume="2005" Year="2011" Format="Main Series">
+    <Book Series="Captain America" Number="613" Volume="2005" Year="2011">
       <Id>a7d23956-8553-4654-a7d4-d63f423167c6</Id>
     </Book>
-    <Book Series="Captain America" Number="614" Volume="2005" Year="2011" Format="Main Series">
+    <Book Series="Captain America" Number="614" Volume="2005" Year="2011">
       <Id>3882027d-1e5d-4cf1-8649-7cf22917f82a</Id>
     </Book>
-    <Book Series="Captain America" Number="615" Volume="2005" Year="2011" Format="Main Series">
+    <Book Series="Captain America" Number="615" Volume="2005" Year="2011">
       <Id>f298074d-b725-465a-909d-5bd1d512e78b</Id>
     </Book>
-    <Book Series="Captain America" Number="615.1" Volume="2005" Year="2011" Format="Main Series">
+    <Book Series="Captain America" Number="615.1" Volume="2005" Year="2011">
       <Id>ecf67e20-cb24-43e9-90b5-d7038e18feae</Id>
     </Book>
-    <Book Series="Secret Avengers" Number="1" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="Secret Avengers" Number="1" Volume="2010" Year="2010">
       <Id>64b12259-c0cb-4df3-b3ee-6be5b5eb0b9f</Id>
     </Book>
-    <Book Series="Secret Avengers" Number="2" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="Secret Avengers" Number="2" Volume="2010" Year="2010">
       <Id>6df1fdf4-93eb-425d-9df8-345797308f13</Id>
     </Book>
-    <Book Series="Secret Avengers" Number="3" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="Secret Avengers" Number="3" Volume="2010" Year="2010">
       <Id>490cf062-ecc2-48b3-a0c5-27b8f960a6e7</Id>
     </Book>
-    <Book Series="Secret Avengers" Number="4" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="Secret Avengers" Number="4" Volume="2010" Year="2010">
       <Id>fec2b557-a48b-4311-bdd2-d1133ddf03aa</Id>
     </Book>
-    <Book Series="Secret Avengers" Number="5" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="Secret Avengers" Number="5" Volume="2010" Year="2010">
       <Id>e678393c-9376-4fa8-9629-0f715e8912ec</Id>
     </Book>
-    <Book Series="Captain America: Hail Hydra" Number="1" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Captain America: Hail Hydra" Number="1" Volume="2011" Year="2011">
       <Id>6f54f148-f74d-4813-96a9-05863d2ec306</Id>
     </Book>
-    <Book Series="Captain America: Hail Hydra" Number="2" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Captain America: Hail Hydra" Number="2" Volume="2011" Year="2011">
       <Id>21d7b066-0d2e-469e-9be8-ba419fe03292</Id>
     </Book>
-    <Book Series="Captain America: Hail Hydra" Number="3" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Captain America: Hail Hydra" Number="3" Volume="2011" Year="2011">
       <Id>944b8a29-2541-43db-a0e1-b53f96eba9fb</Id>
     </Book>
-    <Book Series="Captain America: Hail Hydra" Number="4" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Captain America: Hail Hydra" Number="4" Volume="2011" Year="2011">
       <Id>89f9eee1-66a6-43ba-926f-8cfd50aca57a</Id>
     </Book>
-    <Book Series="Captain America: Hail Hydra" Number="5" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Captain America: Hail Hydra" Number="5" Volume="2011" Year="2011">
       <Id>87565bbe-c2ee-4d7a-9b69-661e89e4dea5</Id>
     </Book>
-    <Book Series="Steve Rogers: Super Soldier" Number="1" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Steve Rogers: Super Soldier" Number="1" Volume="2010" Year="2010">
       <Id>a36f70fd-7f1d-4205-bbf9-9bfc9918daca</Id>
     </Book>
-    <Book Series="Steve Rogers: Super Soldier" Number="2" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Steve Rogers: Super Soldier" Number="2" Volume="2010" Year="2010">
       <Id>648e3f78-dee0-458c-842f-73ea0de5ab70</Id>
     </Book>
-    <Book Series="Steve Rogers: Super Soldier" Number="3" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Steve Rogers: Super Soldier" Number="3" Volume="2010" Year="2010">
       <Id>cd2459a4-747b-4c81-b531-84487867958a</Id>
     </Book>
-    <Book Series="Steve Rogers: Super Soldier" Number="4" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Steve Rogers: Super Soldier" Number="4" Volume="2010" Year="2010">
       <Id>fa272fe4-fe07-4f43-b6ac-cabcbb586d88</Id>
     </Book>
-    <Book Series="Steve Rogers: Super Soldier Annual" Number="1" Volume="2011" Year="2011" Format="Annual">
+    <Book Series="Steve Rogers: Super Soldier Annual" Number="1" Volume="2011" Year="2011">
       <Id>3f7a120f-756d-4c7b-841e-bb6c7414ba43</Id>
     </Book>
-    <Book Series="Namor: The First Mutant Annual" Number="1" Volume="2011" Year="2011" Format="Annual">
+    <Book Series="Namor: The First Mutant Annual" Number="1" Volume="2011" Year="2011">
       <Id>09fd3fe0-0ff4-4400-8efb-70114ff7b245</Id>
     </Book>
-    <Book Series="Fear Itself" Number="1" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Fear Itself" Number="1" Volume="2011" Year="2011">
       <Id>f7b6b461-3686-46e9-a5c8-faaa26abe61f</Id>
     </Book>
-    <Book Series="Fear Itself" Number="2" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Fear Itself" Number="2" Volume="2011" Year="2011">
       <Id>657ea318-89cc-4107-959a-18dbeaef810c</Id>
     </Book>
-    <Book Series="Fear Itself" Number="3" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Fear Itself" Number="3" Volume="2011" Year="2011">
       <Id>fee3109e-a456-4ca7-884a-bb54c3ad7880</Id>
     </Book>
-    <Book Series="Fear Itself" Number="4" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Fear Itself" Number="4" Volume="2011" Year="2011">
       <Id>fe09a64f-eda8-4633-8f95-0ec6e3f08323</Id>
     </Book>
-    <Book Series="Fear Itself" Number="5" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Fear Itself" Number="5" Volume="2011" Year="2011">
       <Id>f9a10c83-e35e-4786-8579-ae2f9801a80b</Id>
     </Book>
-    <Book Series="Fear Itself" Number="6" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Fear Itself" Number="6" Volume="2011" Year="2011">
       <Id>43146781-8a88-44d2-9751-5e862bc22b16</Id>
     </Book>
-    <Book Series="Fear Itself" Number="7" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Fear Itself" Number="7" Volume="2011" Year="2011">
       <Id>cfe1aac4-1232-494e-8a06-d6e18d2339be</Id>
     </Book>
     <Book Series="Fear Itself" Number="7.1" Volume="2011" Year="2012">
       <Id>2601e84f-8c13-48c8-beae-35f4ea5b62d0</Id>
     </Book>
-    <Book Series="Winter Soldier" Number="1" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Winter Soldier" Number="1" Volume="2012" Year="2012">
       <Id>4235ce32-a8d1-416e-908e-698596af7a11</Id>
     </Book>
-    <Book Series="Winter Soldier" Number="2" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Winter Soldier" Number="2" Volume="2012" Year="2012">
       <Id>8f3a19e8-4829-468d-8744-aa553516dd16</Id>
     </Book>
-    <Book Series="Winter Soldier" Number="3" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Winter Soldier" Number="3" Volume="2012" Year="2012">
       <Id>42630467-b201-44f7-bed2-179676f92e58</Id>
     </Book>
-    <Book Series="Winter Soldier" Number="4" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Winter Soldier" Number="4" Volume="2012" Year="2012">
       <Id>9bce9f4b-459b-4751-9c07-9d1bd2d9000b</Id>
     </Book>
-    <Book Series="Winter Soldier" Number="5" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Winter Soldier" Number="5" Volume="2012" Year="2012">
       <Id>676a7674-3b19-4ccd-98a7-0d7eb27e908c</Id>
     </Book>
-    <Book Series="Winter Soldier" Number="6" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Winter Soldier" Number="6" Volume="2012" Year="2012">
       <Id>b5479352-7ef4-431e-af25-17cf60f2ff59</Id>
     </Book>
-    <Book Series="Winter Soldier" Number="7" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Winter Soldier" Number="7" Volume="2012" Year="2012">
       <Id>be8ef396-a56b-49ea-b188-59c68a87d21c</Id>
     </Book>
-    <Book Series="Winter Soldier" Number="8" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Winter Soldier" Number="8" Volume="2012" Year="2012">
       <Id>51ab5b72-1f6c-4415-bf80-f524ba17440b</Id>
     </Book>
-    <Book Series="Winter Soldier" Number="9" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Winter Soldier" Number="9" Volume="2012" Year="2012">
       <Id>936880ae-3222-4ab9-a0bc-99a06da88200</Id>
     </Book>
-    <Book Series="Winter Soldier" Number="10" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Winter Soldier" Number="10" Volume="2012" Year="2012">
       <Id>8053cac1-c571-47bc-86df-37de4ebf3ea3</Id>
     </Book>
-    <Book Series="Winter Soldier" Number="11" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Winter Soldier" Number="11" Volume="2012" Year="2012">
       <Id>b1326f21-43f0-4545-a8dc-38c60abf0274</Id>
     </Book>
-    <Book Series="Winter Soldier" Number="12" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Winter Soldier" Number="12" Volume="2012" Year="2012">
       <Id>8e35d538-0aeb-4f8c-a9b7-37ac95d5b48e</Id>
     </Book>
-    <Book Series="Winter Soldier" Number="13" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Winter Soldier" Number="13" Volume="2012" Year="2013">
       <Id>6527c37a-bfb2-4ea3-aab5-7245a10cfaf3</Id>
     </Book>
-    <Book Series="Winter Soldier" Number="14" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Winter Soldier" Number="14" Volume="2012" Year="2013">
       <Id>ccdf09fa-a9a1-49bb-b72b-560d9b486e83</Id>
     </Book>
-    <Book Series="Winter Soldier" Number="15" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Winter Soldier" Number="15" Volume="2012" Year="2013">
       <Id>1651b9ff-e394-4d23-8f9d-ce1b45c3f2c8</Id>
     </Book>
-    <Book Series="Winter Soldier" Number="16" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Winter Soldier" Number="16" Volume="2012" Year="2013">
       <Id>57a7fb9f-4880-41db-b51f-c40868cd68ac</Id>
     </Book>
-    <Book Series="Winter Soldier" Number="17" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Winter Soldier" Number="17" Volume="2012" Year="2013">
       <Id>27faecbe-3914-4cca-96ee-bca2ed31272d</Id>
     </Book>
-    <Book Series="Winter Soldier" Number="18" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Winter Soldier" Number="18" Volume="2012" Year="2013">
       <Id>886deaad-afda-4b39-8f46-a0a4d762a484</Id>
     </Book>
-    <Book Series="Winter Soldier" Number="19" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Winter Soldier" Number="19" Volume="2012" Year="2013">
       <Id>4894eb49-ab90-446c-aabc-0a54f05fa381</Id>
     </Book>
-    <Book Series="Captain America" Number="1" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Captain America" Number="1" Volume="2011" Year="2011">
       <Id>d4da6492-2885-4413-a561-6e38d677a728</Id>
     </Book>
-    <Book Series="Captain America" Number="2" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Captain America" Number="2" Volume="2011" Year="2011">
       <Id>a2120ccf-9307-443e-a851-08a93fc565f2</Id>
     </Book>
-    <Book Series="Captain America" Number="3" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Captain America" Number="3" Volume="2011" Year="2011">
       <Id>a6377b66-2efe-4777-a403-d113f8db1b15</Id>
     </Book>
-    <Book Series="Captain America" Number="4" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America" Number="4" Volume="2011" Year="2012">
       <Id>489cbc0d-b3f2-47e5-87e3-c08a2f80bee6</Id>
     </Book>
-    <Book Series="Captain America" Number="5" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America" Number="5" Volume="2011" Year="2012">
       <Id>32671452-f5ae-46f4-9dd0-850e008e53ce</Id>
     </Book>
-    <Book Series="Captain America and..." Number="625" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America and..." Number="625" Volume="2011" Year="2012">
       <Id>b3ebbda1-2e13-4e6f-be1e-f686f26b5ff3</Id>
     </Book>
-    <Book Series="Captain America and..." Number="626" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America and..." Number="626" Volume="2011" Year="2012">
       <Id>0e5ae297-940d-4361-8efd-104e2ec0ea2e</Id>
     </Book>
-    <Book Series="Captain America and..." Number="627" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America and..." Number="627" Volume="2011" Year="2012">
       <Id>1c911c52-6c28-44ab-96b5-68f44417d71c</Id>
     </Book>
-    <Book Series="Captain America and..." Number="628" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America and..." Number="628" Volume="2011" Year="2012">
       <Id>d47736e6-371f-405a-9c9c-35e183859c74</Id>
     </Book>
-    <Book Series="Captain America" Number="6" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America" Number="6" Volume="2011" Year="2012">
       <Id>696924df-5df3-4ae2-a0f1-0afcebe3a516</Id>
     </Book>
-    <Book Series="Captain America" Number="7" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America" Number="7" Volume="2011" Year="2012">
       <Id>51f25126-822b-4ee1-a86a-af014238b63b</Id>
     </Book>
-    <Book Series="Captain America" Number="8" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America" Number="8" Volume="2011" Year="2012">
       <Id>4e05d694-b37d-4690-8b3a-382095b5bf50</Id>
     </Book>
-    <Book Series="Captain America" Number="9" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America" Number="9" Volume="2011" Year="2012">
       <Id>af4e74a6-11d2-4a19-ab83-a18e691f608e</Id>
     </Book>
-    <Book Series="Captain America" Number="10" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America" Number="10" Volume="2011" Year="2012">
       <Id>506f1e88-a676-4fdd-ad48-b610296c8bdf</Id>
     </Book>
-    <Book Series="Captain America and..." Number="629" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America and..." Number="629" Volume="2011" Year="2012">
       <Id>14596c7c-9ab7-47a4-9d47-95000a911f21</Id>
     </Book>
-    <Book Series="Captain America and..." Number="630" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America and..." Number="630" Volume="2011" Year="2012">
       <Id>78fce42f-9c54-41b4-81d8-caf210dbecf6</Id>
     </Book>
-    <Book Series="Captain America and..." Number="631" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America and..." Number="631" Volume="2011" Year="2012">
       <Id>5be0e692-01db-4a96-8afa-75308f62d8ef</Id>
     </Book>
-    <Book Series="Captain America and..." Number="632" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America and..." Number="632" Volume="2011" Year="2012">
       <Id>3f933ab0-a820-449e-ae70-70869d71ff66</Id>
     </Book>
-    <Book Series="Captain America and..." Number="633" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America and..." Number="633" Volume="2011" Year="2012">
       <Id>cf61861f-4ae3-4c49-b08d-28156a22b4d4</Id>
     </Book>
-    <Book Series="Captain America and..." Number="634" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America and..." Number="634" Volume="2011" Year="2012">
       <Id>5f1f04f8-9469-475c-9ba8-6e79712044bf</Id>
     </Book>
-    <Book Series="Captain America and..." Number="635" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America and..." Number="635" Volume="2011" Year="2012">
       <Id>4eab7984-abac-42fb-bf84-b5326715bdb5</Id>
     </Book>
-    <Book Series="Captain America and..." Number="635.1" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America and..." Number="635.1" Volume="2011" Year="2012">
       <Id>b3dc1565-43ea-4378-83c0-de1df024697d</Id>
     </Book>
-    <Book Series="Captain America" Number="11" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America" Number="11" Volume="2011" Year="2012">
       <Id>6377dbca-7252-49b8-b25d-13002d4a2769</Id>
     </Book>
-    <Book Series="Captain America" Number="12" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America" Number="12" Volume="2011" Year="2012">
       <Id>d16aa1a3-f118-489d-ba27-0c36f4c29aae</Id>
     </Book>
-    <Book Series="Captain America" Number="13" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America" Number="13" Volume="2011" Year="2012">
       <Id>88928679-3de1-42d4-99b7-90f037fa5c2d</Id>
     </Book>
-    <Book Series="Captain America" Number="14" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America" Number="14" Volume="2011" Year="2012">
       <Id>6b7312e3-d289-4c7e-8135-767525767001</Id>
     </Book>
-    <Book Series="Avengers: X-Sanction" Number="1" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Avengers: X-Sanction" Number="1" Volume="2012" Year="2012">
       <Id>c83bc85f-783c-4e16-b7b9-f3d91e435bb9</Id>
     </Book>
-    <Book Series="Avengers: X-Sanction" Number="2" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Avengers: X-Sanction" Number="2" Volume="2012" Year="2012">
       <Id>4d4a684b-c77d-4adf-b93e-5d5c55adc17b</Id>
     </Book>
-    <Book Series="Avengers: X-Sanction" Number="3" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Avengers: X-Sanction" Number="3" Volume="2012" Year="2012">
       <Id>0550b34e-e235-45b3-81d2-368d0ccd9601</Id>
     </Book>
-    <Book Series="Avengers: X-Sanction" Number="4" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Avengers: X-Sanction" Number="4" Volume="2012" Year="2012">
       <Id>04a79481-a1da-4ee9-94f1-c3956688eb01</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men" Number="1" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men" Number="1" Volume="2012" Year="2012">
       <Id>dc149da3-d855-40da-982b-b9e988034d1e</Id>
     </Book>
-    <Book Series="Captain America" Number="15" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America" Number="15" Volume="2011" Year="2012">
       <Id>e4c20f4c-4f5c-4b07-83ff-a877b95a9cdc</Id>
     </Book>
-    <Book Series="Captain America" Number="16" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America" Number="16" Volume="2011" Year="2012">
       <Id>5f8187c1-97c1-4e8c-8e22-160734c9b96c</Id>
     </Book>
-    <Book Series="Captain America" Number="17" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America" Number="17" Volume="2011" Year="2012">
       <Id>a62095e5-cd1c-4562-bd01-fcb2a87192f3</Id>
     </Book>
-    <Book Series="Captain America" Number="18" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America" Number="18" Volume="2011" Year="2012">
       <Id>fb3324cf-cb4b-487d-9bb6-b882c7894f09</Id>
     </Book>
-    <Book Series="Captain America" Number="19" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Captain America" Number="19" Volume="2011" Year="2012">
       <Id>37ba1466-3b01-465e-9daa-73573c4b9e9a</Id>
     </Book>
-    <Book Series="Captain America" Number="1" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Captain America" Number="1" Volume="2013" Year="2013">
       <Id>78e3e9fe-608f-44f5-a97d-c097f2cdedef</Id>
     </Book>
-    <Book Series="Captain America" Number="2" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Captain America" Number="2" Volume="2013" Year="2013">
       <Id>e9b4ff43-4b08-440b-af4f-1485eefb261e</Id>
     </Book>
-    <Book Series="Captain America" Number="3" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Captain America" Number="3" Volume="2013" Year="2013">
       <Id>7541724e-089b-4eb5-9a03-96561465edef</Id>
     </Book>
-    <Book Series="Captain America" Number="4" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Captain America" Number="4" Volume="2013" Year="2013">
       <Id>3c93fbf0-8716-42ca-8591-01aded036f1a</Id>
     </Book>
-    <Book Series="Captain America" Number="5" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Captain America" Number="5" Volume="2013" Year="2013">
       <Id>854f9941-86ff-44ad-9797-cccdcaee887b</Id>
     </Book>
-    <Book Series="Captain America" Number="6" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Captain America" Number="6" Volume="2013" Year="2013">
       <Id>e1d8a5f0-0af7-46ed-a971-8b7c47970c18</Id>
     </Book>
-    <Book Series="Captain America" Number="7" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Captain America" Number="7" Volume="2013" Year="2013">
       <Id>2f940545-93e0-49a4-9b63-f624c5ba43a7</Id>
     </Book>
-    <Book Series="A+X" Number="1" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="A+X" Number="1" Volume="2012" Year="2012">
       <Id>5cdada2c-01e2-4fc8-a87c-a7b944b9be43</Id>
     </Book>
-    <Book Series="Winter Soldier: The Bitter March" Number="1" Volume="2014" Year="2014" Format="Limited Series">
+    <Book Series="Winter Soldier: The Bitter March" Number="1" Volume="2014" Year="2014">
       <Id>042d87ad-f2ef-4701-b048-dcc1c2d70b95</Id>
     </Book>
-    <Book Series="Winter Soldier: The Bitter March" Number="2" Volume="2014" Year="2014" Format="Limited Series">
+    <Book Series="Winter Soldier: The Bitter March" Number="2" Volume="2014" Year="2014">
       <Id>f296436a-41f3-4a60-a8a5-fbdb7e9f87f6</Id>
     </Book>
-    <Book Series="Winter Soldier: The Bitter March" Number="3" Volume="2014" Year="2014" Format="Limited Series">
+    <Book Series="Winter Soldier: The Bitter March" Number="3" Volume="2014" Year="2014">
       <Id>8bdde3c0-a19b-41ec-b1c4-e1535dace203</Id>
     </Book>
-    <Book Series="Winter Soldier: The Bitter March" Number="4" Volume="2014" Year="2014" Format="Limited Series">
+    <Book Series="Winter Soldier: The Bitter March" Number="4" Volume="2014" Year="2014">
       <Id>088a4a61-8b9c-4a0a-8407-57e506d798f9</Id>
     </Book>
-    <Book Series="Winter Soldier: The Bitter March" Number="5" Volume="2014" Year="2014" Format="Limited Series">
+    <Book Series="Winter Soldier: The Bitter March" Number="5" Volume="2014" Year="2014">
       <Id>d558df2e-f203-43f8-8023-067917f3411a</Id>
     </Book>
-    <Book Series="Captain America" Number="16" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Captain America" Number="16" Volume="2013" Year="2014">
       <Id>83f6a6ae-7d09-4863-b2f3-d2116c8651b5</Id>
     </Book>
-    <Book Series="Captain America" Number="17" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Captain America" Number="17" Volume="2013" Year="2014">
       <Id>32694612-e10f-46d3-824d-16dec12015bc</Id>
     </Book>
-    <Book Series="Captain America" Number="18" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Captain America" Number="18" Volume="2013" Year="2014">
       <Id>4083d0b1-d006-4ff7-8171-93a55ec1f1bb</Id>
     </Book>
-    <Book Series="Captain America" Number="19" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Captain America" Number="19" Volume="2013" Year="2014">
       <Id>884444a5-9ea3-4d55-aacd-dad146c94d4c</Id>
     </Book>
-    <Book Series="Captain America" Number="20" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Captain America" Number="20" Volume="2013" Year="2014">
       <Id>faa70440-587f-480c-96d2-05c1cd0a7974</Id>
     </Book>
-    <Book Series="Captain America" Number="21" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Captain America" Number="21" Volume="2013" Year="2014">
       <Id>f6ce99ff-5eeb-4860-860b-1da8f748b438</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Captain Marvel/Captain Marvel.cbl
+++ b/Marvel/Characters/unsorted/Captain Marvel/Captain Marvel.cbl
@@ -1,921 +1,922 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Captain Marvel</Name>
+  <NumIssues>305</NumIssues>
   <Books>
     <Book Series="Marvel Super-Heroes" Number="12" Volume="1967" Year="1967">
-      <Id>cc9ef5f3-98d0-451e-98f6-e925c80ad53e</Id>
+      <Database Name="cv" Series="2353" Issue="9817" />
     </Book>
     <Book Series="Marvel Super-Heroes" Number="13" Volume="1967" Year="1968">
-      <Id>25140366-e59e-4245-b44c-d5d089fe0fb3</Id>
+      <Database Name="cv" Series="2353" Issue="115904" />
     </Book>
     <Book Series="Captain Marvel" Number="1" Volume="1968" Year="1968">
-      <Id>51436de0-e07d-4318-a0e0-218a6cc61877</Id>
+      <Database Name="cv" Series="2401" Issue="115896" />
     </Book>
     <Book Series="Captain Marvel" Number="2" Volume="1968" Year="1968">
-      <Id>2273b3ff-2247-407b-b753-12ce7198f171</Id>
+      <Database Name="cv" Series="2401" Issue="115897" />
     </Book>
     <Book Series="Captain Marvel" Number="3" Volume="1968" Year="1968">
-      <Id>23eccdb6-1668-4a6c-8af8-9c9e9a52b226</Id>
+      <Database Name="cv" Series="2401" Issue="115898" />
     </Book>
     <Book Series="Captain Marvel" Number="4" Volume="1968" Year="1968">
-      <Id>5169f841-f744-4b92-9771-0def965b664f</Id>
+      <Database Name="cv" Series="2401" Issue="115899" />
     </Book>
     <Book Series="Captain Marvel" Number="5" Volume="1968" Year="1968">
-      <Id>b24678a6-2d34-4b06-adf4-87e8e6f86f42</Id>
+      <Database Name="cv" Series="2401" Issue="115900" />
     </Book>
     <Book Series="Captain Marvel" Number="6" Volume="1968" Year="1968">
-      <Id>ece6ec58-c4cf-41e2-8ef1-3db9d61580b9</Id>
+      <Database Name="cv" Series="2401" Issue="115901" />
     </Book>
     <Book Series="Captain Marvel" Number="7" Volume="1968" Year="1968">
-      <Id>c292aead-5a80-4ca5-99a1-eead6b8cb248</Id>
+      <Database Name="cv" Series="2401" Issue="115902" />
     </Book>
     <Book Series="Captain Marvel" Number="8" Volume="1968" Year="1968">
-      <Id>4153f503-6f2e-4f0d-a190-80a797a635c2</Id>
+      <Database Name="cv" Series="2401" Issue="115903" />
     </Book>
     <Book Series="Captain Marvel" Number="9" Volume="1968" Year="1969">
-      <Id>3bb0704c-bcac-4d66-9888-5cf2cfacaeb5</Id>
+      <Database Name="cv" Series="2401" Issue="9989" />
     </Book>
     <Book Series="Captain Marvel" Number="10" Volume="1968" Year="1969">
-      <Id>a339d5e2-b7e7-4255-af15-f8731533d250</Id>
+      <Database Name="cv" Series="2401" Issue="10041" />
     </Book>
     <Book Series="Captain Marvel" Number="11" Volume="1968" Year="1969">
-      <Id>3699236a-3ef6-4804-9a57-0a66fc4366a3</Id>
+      <Database Name="cv" Series="2401" Issue="10094" />
     </Book>
     <Book Series="Captain Marvel" Number="12" Volume="1968" Year="1969">
-      <Id>abfc9a8a-2df0-4585-8db8-9d68d0b2ba2e</Id>
+      <Database Name="cv" Series="2401" Issue="10149" />
     </Book>
     <Book Series="Captain Marvel" Number="13" Volume="1968" Year="1969">
-      <Id>c796b85f-bac4-4186-97e1-d04af8a59691</Id>
+      <Database Name="cv" Series="2401" Issue="10201" />
     </Book>
     <Book Series="Captain Marvel" Number="14" Volume="1968" Year="1969">
-      <Id>25463d88-ddd0-4131-9ff8-2489751bdca0</Id>
+      <Database Name="cv" Series="2401" Issue="10305" />
     </Book>
     <Book Series="Captain Marvel" Number="15" Volume="1968" Year="1969">
-      <Id>4a231b19-e7c0-4561-9181-867b31b94677</Id>
+      <Database Name="cv" Series="2401" Issue="10355" />
     </Book>
     <Book Series="Captain Marvel" Number="16" Volume="1968" Year="1969">
-      <Id>51d66256-87ef-43ed-8195-d735a6dfde79</Id>
+      <Database Name="cv" Series="2401" Issue="10403" />
     </Book>
     <Book Series="Captain Marvel" Number="17" Volume="1968" Year="1969">
-      <Id>821d7417-2ac3-4845-a890-f839f0783734</Id>
+      <Database Name="cv" Series="2401" Issue="10464" />
     </Book>
     <Book Series="Captain Marvel" Number="18" Volume="1968" Year="1969">
-      <Id>b7ae33cb-2169-4371-9d0b-fc96e5c7ce5d</Id>
+      <Database Name="cv" Series="2401" Issue="10509" />
     </Book>
     <Book Series="Captain Marvel" Number="19" Volume="1968" Year="1969">
-      <Id>186dac36-4f05-4e6f-b1cd-845724368c8d</Id>
+      <Database Name="cv" Series="2401" Issue="10569" />
     </Book>
     <Book Series="The Avengers" Number="72" Volume="1963" Year="1970">
-      <Id>61f49a89-d8d8-45db-892a-253bd1048769</Id>
+      <Database Name="cv" Series="2128" Issue="10617" />
     </Book>
     <Book Series="Captain Marvel" Number="20" Volume="1968" Year="1970">
-      <Id>3810e3c2-cf67-4ef1-b4ab-044c7d993282</Id>
+      <Database Name="cv" Series="2401" Issue="10855" />
     </Book>
     <Book Series="Captain Marvel" Number="21" Volume="1968" Year="1970">
-      <Id>6243c9e2-a24e-4b0b-a4ea-5c992e6a0037</Id>
+      <Database Name="cv" Series="2401" Issue="10951" />
     </Book>
     <Book Series="Iron Man" Number="55" Volume="1968" Year="1973">
-      <Id>caf69006-c97f-4c8e-9d86-aea0d67f0d4b</Id>
+      <Database Name="cv" Series="2407" Issue="12928" />
     </Book>
     <Book Series="Sub-Mariner" Number="30" Volume="1968" Year="1970">
-      <Id>6987c868-6051-4000-a2ef-ea3558e01eca</Id>
+      <Database Name="cv" Series="2413" Issue="11062" />
     </Book>
     <Book Series="The Avengers" Number="89" Volume="1963" Year="1971">
-      <Id>2b86fcd6-c08b-436b-8840-c7aeacb3776b</Id>
+      <Database Name="cv" Series="2128" Issue="11485" />
     </Book>
     <Book Series="The Avengers" Number="90" Volume="1963" Year="1971">
-      <Id>4fef8ed3-c5d5-41a7-ad93-a2b6313a8b6a</Id>
+      <Database Name="cv" Series="2128" Issue="11539" />
     </Book>
     <Book Series="The Avengers" Number="91" Volume="1963" Year="1971">
-      <Id>8aaadfe0-f4a1-421f-b869-81d1a9d93e0e</Id>
+      <Database Name="cv" Series="2128" Issue="11599" />
     </Book>
     <Book Series="The Avengers" Number="92" Volume="1963" Year="1971">
-      <Id>60a1e9c0-e7b3-4a53-b72a-ca211ccde05f</Id>
+      <Database Name="cv" Series="2128" Issue="11658" />
     </Book>
     <Book Series="The Avengers" Number="93" Volume="1963" Year="1971">
-      <Id>fe5fcc09-5659-4feb-907a-6cdbc6b35cb9</Id>
+      <Database Name="cv" Series="2128" Issue="11777" />
     </Book>
     <Book Series="The Avengers" Number="94" Volume="1963" Year="1971">
-      <Id>9f5eb565-f394-4f45-8723-5f5f0e9fe7f0</Id>
+      <Database Name="cv" Series="2128" Issue="11840" />
     </Book>
     <Book Series="The Avengers" Number="95" Volume="1963" Year="1972">
-      <Id>7724d45b-83ca-40ab-bcf1-4cf54b8f6b08</Id>
+      <Database Name="cv" Series="2128" Issue="11918" />
     </Book>
     <Book Series="The Avengers" Number="96" Volume="1963" Year="1972">
-      <Id>031957cd-7ff0-4489-8077-3957ca23a9bb</Id>
+      <Database Name="cv" Series="2128" Issue="11989" />
     </Book>
     <Book Series="The Avengers" Number="97" Volume="1963" Year="1972">
-      <Id>fc09a34b-aa82-464f-bc62-767de1d877a9</Id>
+      <Database Name="cv" Series="2128" Issue="12048" />
     </Book>
     <Book Series="Captain Marvel" Number="22" Volume="1968" Year="1972">
-      <Id>01e77595-ad42-4a01-8c5e-f18d9522c012</Id>
+      <Database Name="cv" Series="2401" Issue="12476" />
     </Book>
     <Book Series="Captain Marvel" Number="23" Volume="1968" Year="1972">
-      <Id>57e545cc-ad69-4f62-8aed-b4e9e17677e8</Id>
+      <Database Name="cv" Series="2401" Issue="12643" />
     </Book>
     <Book Series="Captain Marvel" Number="24" Volume="1968" Year="1973">
-      <Id>a49f487b-9016-46cb-8c8c-bcf50da94c18</Id>
+      <Database Name="cv" Series="2401" Issue="12825" />
     </Book>
     <Book Series="Captain Marvel" Number="25" Volume="1968" Year="1973">
-      <Id>96914c7b-f6f8-4186-835e-7c582f8bd09f</Id>
+      <Database Name="cv" Series="2401" Issue="13002" />
     </Book>
     <Book Series="Captain Marvel" Number="26" Volume="1968" Year="1973">
-      <Id>55250504-d211-48ee-ab69-aa2ea1da26a1</Id>
+      <Database Name="cv" Series="2401" Issue="13172" />
     </Book>
     <Book Series="Captain Marvel" Number="27" Volume="1968" Year="1973">
-      <Id>a88e7531-075c-4468-a3d5-f7ebc2a8fdf7</Id>
+      <Database Name="cv" Series="2401" Issue="13380" />
     </Book>
     <Book Series="Captain Marvel" Number="28" Volume="1968" Year="1973">
-      <Id>4c8286a3-619a-42a7-a6e3-0d33514c254d</Id>
+      <Database Name="cv" Series="2401" Issue="13567" />
     </Book>
     <Book Series="Captain Marvel" Number="29" Volume="1968" Year="1973">
-      <Id>c4588694-ca54-4ace-9b2b-5b741ed4df0a</Id>
+      <Database Name="cv" Series="2401" Issue="13785" />
     </Book>
     <Book Series="Captain Marvel" Number="30" Volume="1968" Year="1974">
-      <Id>4552c428-162b-4f84-91b7-44f8ac53c37b</Id>
+      <Database Name="cv" Series="2401" Issue="13981" />
     </Book>
     <Book Series="Marvel Team-Up" Number="16" Volume="1972" Year="1973">
-      <Id>61fc3960-f82f-4b29-9ae1-b123ee13be41</Id>
+      <Database Name="cv" Series="2576" Issue="13891" />
     </Book>
     <Book Series="Marvel Team-Up" Number="17" Volume="1972" Year="1974">
-      <Id>1d20df12-2e90-4627-ab7f-daa6f1203168</Id>
+      <Database Name="cv" Series="2576" Issue="13999" />
     </Book>
     <Book Series="Daredevil" Number="107" Volume="1964" Year="1974">
-      <Id>440da1ba-654d-45eb-9f33-61a9db690ecd</Id>
+      <Database Name="cv" Series="2190" Issue="13985" />
     </Book>
     <Book Series="Captain Marvel" Number="31" Volume="1968" Year="1974">
-      <Id>d6d468ec-b052-45b6-8993-9e9278628d12</Id>
+      <Database Name="cv" Series="2401" Issue="14119" />
     </Book>
     <Book Series="Captain Marvel" Number="32" Volume="1968" Year="1974">
-      <Id>8aa93bc6-7759-470e-aa39-ab309b24054e</Id>
+      <Database Name="cv" Series="2401" Issue="14257" />
     </Book>
     <Book Series="Captain Marvel" Number="33" Volume="1968" Year="1974">
-      <Id>b4bac5ad-b46c-4735-b048-84d0ba668e4f</Id>
+      <Database Name="cv" Series="2401" Issue="14410" />
     </Book>
     <Book Series="The Avengers" Number="125" Volume="1963" Year="1974">
-      <Id>77c6aad0-fec8-491e-8afc-bb45ee458f2d</Id>
+      <Database Name="cv" Series="2128" Issue="14454" />
     </Book>
     <Book Series="Captain Marvel" Number="34" Volume="1968" Year="1974">
-      <Id>b7b964e2-00ec-424d-b0e2-a77890d47966</Id>
+      <Database Name="cv" Series="2401" Issue="14571" />
     </Book>
     <Book Series="Captain Marvel" Number="35" Volume="1968" Year="1974">
-      <Id>a50551b0-8dbe-42be-afb4-8aaa38c56e89</Id>
+      <Database Name="cv" Series="2401" Issue="14747" />
     </Book>
     <Book Series="Captain Marvel" Number="36" Volume="1968" Year="1975">
-      <Id>67f25840-e265-4a8e-b43c-e9fdcff2a331</Id>
+      <Database Name="cv" Series="2401" Issue="14955" />
     </Book>
     <Book Series="Captain Marvel" Number="37" Volume="1968" Year="1975">
-      <Id>0f8a5663-9979-4ec6-9d7c-1b4a5ae1229d</Id>
+      <Database Name="cv" Series="2401" Issue="15139" />
     </Book>
     <Book Series="Captain Marvel" Number="38" Volume="1968" Year="1975">
-      <Id>f37923c5-8dd4-4bb0-a747-a8ad4e6690ca</Id>
+      <Database Name="cv" Series="2401" Issue="15172" />
     </Book>
     <Book Series="Captain Marvel" Number="39" Volume="1968" Year="1975">
-      <Id>63695395-b78d-40d3-9f4e-dcd8a7fe1104</Id>
+      <Database Name="cv" Series="2401" Issue="15366" />
     </Book>
     <Book Series="Captain Marvel" Number="40" Volume="1968" Year="1975">
-      <Id>67668a0a-8d32-4e8f-b8a6-0c3fc7190a19</Id>
+      <Database Name="cv" Series="2401" Issue="15574" />
     </Book>
     <Book Series="Captain Marvel" Number="41" Volume="1968" Year="1975">
-      <Id>ae8881db-e650-42dd-a202-3c7b0c63e413</Id>
+      <Database Name="cv" Series="2401" Issue="15775" />
     </Book>
     <Book Series="Captain Marvel" Number="42" Volume="1968" Year="1976">
-      <Id>585a6f01-02ba-4cee-9bbe-a4fbf25e5cd5</Id>
+      <Database Name="cv" Series="2401" Issue="15995" />
     </Book>
     <Book Series="Warlock" Number="10" Volume="1972" Year="1975">
-      <Id>3a05c737-d565-4e76-babe-54ff594b37dd</Id>
+      <Database Name="cv" Series="2583" Issue="15886" />
     </Book>
     <Book Series="Captain Marvel" Number="43" Volume="1968" Year="1976">
-      <Id>b5b6042d-6337-4bef-bf90-86a944c9d64d</Id>
+      <Database Name="cv" Series="2401" Issue="16160" />
     </Book>
     <Book Series="Captain Marvel" Number="44" Volume="1968" Year="1976">
-      <Id>e963648c-f5b7-42e8-9896-dde494fc85b9</Id>
+      <Database Name="cv" Series="2401" Issue="16334" />
     </Book>
     <Book Series="Captain Marvel" Number="45" Volume="1968" Year="1976">
-      <Id>1c76bd65-2611-476b-8522-f4cb38114c25</Id>
+      <Database Name="cv" Series="2401" Issue="16498" />
     </Book>
     <Book Series="Captain Marvel" Number="46" Volume="1968" Year="1976">
-      <Id>d9065e43-92dd-4fff-8f8e-f8049f15161f</Id>
+      <Database Name="cv" Series="2401" Issue="16675" />
     </Book>
     <Book Series="Captain Marvel" Number="47" Volume="1968" Year="1976">
-      <Id>d9a7f90d-65c0-4c7d-81e0-b91277a454d8</Id>
+      <Database Name="cv" Series="2401" Issue="16865" />
     </Book>
     <Book Series="Captain Marvel" Number="48" Volume="1968" Year="1977">
-      <Id>9bd3dde0-f5d8-43f2-994b-e2d1a657d088</Id>
+      <Database Name="cv" Series="2401" Issue="17094" />
     </Book>
     <Book Series="Captain Marvel" Number="49" Volume="1968" Year="1977">
-      <Id>200d34c9-a252-4bfd-aeb1-aa35acf4515a</Id>
+      <Database Name="cv" Series="2401" Issue="17263" />
     </Book>
     <Book Series="Captain Marvel" Number="50" Volume="1968" Year="1977">
-      <Id>424c52b6-c304-4c81-90bd-c2edfcd285ef</Id>
+      <Database Name="cv" Series="2401" Issue="17426" />
     </Book>
     <Book Series="Captain Marvel" Number="51" Volume="1968" Year="1977">
-      <Id>23693453-8676-42eb-bb80-930e48263653</Id>
+      <Database Name="cv" Series="2401" Issue="17593" />
     </Book>
     <Book Series="Captain Marvel" Number="52" Volume="1968" Year="1977">
-      <Id>02dcb85f-568e-4323-a3e8-ec63c45d32af</Id>
+      <Database Name="cv" Series="2401" Issue="17771" />
     </Book>
     <Book Series="Captain Marvel" Number="53" Volume="1968" Year="1977">
-      <Id>500729af-5ebd-489f-81d9-e498c109151b</Id>
+      <Database Name="cv" Series="2401" Issue="17956" />
     </Book>
     <Book Series="Captain Marvel" Number="54" Volume="1968" Year="1978">
-      <Id>593ee455-8a98-4d78-923f-ba7cb41ef825</Id>
+      <Database Name="cv" Series="2401" Issue="18159" />
     </Book>
     <Book Series="Captain Marvel" Number="55" Volume="1968" Year="1978">
-      <Id>c2d78412-0606-4f47-9267-007f489ad4d4</Id>
+      <Database Name="cv" Series="2401" Issue="18322" />
     </Book>
     <Book Series="Captain Marvel" Number="56" Volume="1968" Year="1978">
-      <Id>a2ef7453-4a38-4edb-a074-8b248c5964a1</Id>
+      <Database Name="cv" Series="2401" Issue="18491" />
     </Book>
     <Book Series="The Avengers Annual" Number="7" Volume="1967" Year="1977">
-      <Id>0aa90811-03da-40cd-8bd4-e8238a5f5597</Id>
+      <Database Name="cv" Series="2350" Issue="17030" />
     </Book>
     <Book Series="Marvel Two-in-One Annual" Number="2" Volume="1976" Year="1977">
-      <Id>2f77e350-ea10-40c6-9466-27ab677093e8</Id>
+      <Database Name="cv" Series="2865" Issue="17015" />
     </Book>
     <Book Series="Captain Marvel" Number="57" Volume="1968" Year="1978">
-      <Id>8b6ddae5-8b0c-4a7e-8eef-1b4f784a9119</Id>
+      <Database Name="cv" Series="2401" Issue="18652" />
     </Book>
     <Book Series="Marvel Two-in-One" Number="45" Volume="1974" Year="1978">
-      <Id>038fa77f-3f1c-4f4e-b02c-16b3c08e50ee</Id>
+      <Database Name="cv" Series="2696" Issue="18972" />
     </Book>
     <Book Series="Captain Marvel" Number="58" Volume="1968" Year="1978">
-      <Id>9c36b50a-1b5b-46f5-b37c-56523bb3392f</Id>
+      <Database Name="cv" Series="2401" Issue="18812" />
     </Book>
     <Book Series="Captain Marvel" Number="59" Volume="1968" Year="1978">
-      <Id>94c4f1e4-de29-4d16-8eff-caea1b77362d</Id>
+      <Database Name="cv" Series="2401" Issue="18958" />
     </Book>
     <Book Series="Captain Marvel" Number="60" Volume="1968" Year="1979">
-      <Id>a0385fc2-606f-4b25-827d-15d7b3cc71f4</Id>
+      <Database Name="cv" Series="2401" Issue="19186" />
     </Book>
     <Book Series="Captain Marvel" Number="61" Volume="1968" Year="1979">
-      <Id>52162ce1-cd2b-45f0-9eea-c07c193e5f17</Id>
+      <Database Name="cv" Series="2401" Issue="19362" />
     </Book>
     <Book Series="Captain Marvel" Number="62" Volume="1968" Year="1979">
-      <Id>62db833e-2919-48bb-a13b-198479f2f03f</Id>
+      <Database Name="cv" Series="2401" Issue="19501" />
     </Book>
     <Book Series="Marvel Spotlight" Number="1" Volume="1979" Year="1979">
-      <Id>6e9bb067-152a-4150-9939-75b924b44527</Id>
+      <Database Name="cv" Series="3007" Issue="19647" />
     </Book>
     <Book Series="Marvel Spotlight" Number="2" Volume="1979" Year="1979">
-      <Id>64111d13-8216-48cd-9497-401a62fcb1f8</Id>
+      <Database Name="cv" Series="3007" Issue="19783" />
     </Book>
     <Book Series="Marvel Spotlight" Number="3" Volume="1979" Year="1979">
-      <Id>faaf988f-9312-4e6f-9944-cb7ff78a644a</Id>
+      <Database Name="cv" Series="3007" Issue="19924" />
     </Book>
     <Book Series="Marvel Spotlight" Number="4" Volume="1979" Year="1980">
-      <Id>41920409-fcb5-40bc-a284-c770f58a9650</Id>
+      <Database Name="cv" Series="3007" Issue="20103" />
     </Book>
     <Book Series="Marvel Two-in-One" Number="69" Volume="1974" Year="1980">
-      <Id>effe2a8e-b559-4df0-8690-8f72a85614ce</Id>
+      <Database Name="cv" Series="2696" Issue="20800" />
     </Book>
     <Book Series="Marvel Spotlight" Number="8" Volume="1979" Year="1980">
-      <Id>2721fc3e-49e4-4564-a715-01ad9b737db5</Id>
+      <Database Name="cv" Series="3007" Issue="20668" />
     </Book>
     <Book Series="Marvel Graphic Novel" Number="1" Volume="1982" Year="1982">
-      <Id>6655ec2d-c2c7-4ce1-a5e9-e39956983b3a</Id>
+      <Database Name="cv" Series="3144" Issue="21782" />
     </Book>
     <Book Series="Ms. Marvel" Number="1" Volume="1977" Year="1977">
-      <Id>b8f60cc5-79b0-4508-891c-a312c3a2f5f7</Id>
+      <Database Name="cv" Series="2910" Issue="17111" />
     </Book>
     <Book Series="Ms. Marvel" Number="2" Volume="1977" Year="1977">
-      <Id>4b5275d4-7f29-4832-8e7f-cb6b787c852f</Id>
+      <Database Name="cv" Series="2910" Issue="17198" />
     </Book>
     <Book Series="Ms. Marvel" Number="3" Volume="1977" Year="1977">
-      <Id>bfb2f820-e8c2-4cdc-b3dc-8c16cda8c802</Id>
+      <Database Name="cv" Series="2910" Issue="17277" />
     </Book>
     <Book Series="Ms. Marvel" Number="4" Volume="1977" Year="1977">
-      <Id>ec45ce30-07b3-4a68-b785-076292b0190c</Id>
+      <Database Name="cv" Series="2910" Issue="17360" />
     </Book>
     <Book Series="Ms. Marvel" Number="5" Volume="1977" Year="1977">
-      <Id>f0fdf2bc-ebd2-4cc4-9db1-1f540e3a7ff1</Id>
+      <Database Name="cv" Series="2910" Issue="17439" />
     </Book>
     <Book Series="Ms. Marvel" Number="6" Volume="1977" Year="1977">
-      <Id>bfb767ba-c24d-4e95-8884-7e47e0c2ff8d</Id>
+      <Database Name="cv" Series="2910" Issue="17515" />
     </Book>
     <Book Series="Ms. Marvel" Number="7" Volume="1977" Year="1977">
-      <Id>c7be81d8-b781-4be8-afe1-9c0963b69d47</Id>
+      <Database Name="cv" Series="2910" Issue="17608" />
     </Book>
     <Book Series="Ms. Marvel" Number="8" Volume="1977" Year="1977">
-      <Id>58f3c712-1c05-4249-90ec-8573113336c7</Id>
+      <Database Name="cv" Series="2910" Issue="109219" />
     </Book>
     <Book Series="Ms. Marvel" Number="9" Volume="1977" Year="1977">
-      <Id>30caa3b5-afc7-404d-b6e2-460c561ca88f</Id>
+      <Database Name="cv" Series="2910" Issue="17790" />
     </Book>
     <Book Series="Ms. Marvel" Number="10" Volume="1977" Year="1977">
-      <Id>615fd8d4-37c2-41ce-91b9-fa8decd6602b</Id>
+      <Database Name="cv" Series="2910" Issue="17883" />
     </Book>
     <Book Series="Marvel Team-Up" Number="61" Volume="1972" Year="1977">
-      <Id>4fb505ec-4d28-4e31-b10c-663b53c784e1</Id>
+      <Database Name="cv" Series="2576" Issue="17787" />
     </Book>
     <Book Series="Marvel Team-Up" Number="62" Volume="1972" Year="1977">
-      <Id>bf924923-901b-4796-a9fe-f3de78b6cee2</Id>
+      <Database Name="cv" Series="2576" Issue="17880" />
     </Book>
     <Book Series="Ms. Marvel" Number="11" Volume="1977" Year="1977">
-      <Id>96e14d8d-22e1-454f-84f6-f1184d0b15f8</Id>
+      <Database Name="cv" Series="2910" Issue="17973" />
     </Book>
     <Book Series="Ms. Marvel" Number="12" Volume="1977" Year="1977">
-      <Id>dfa0161b-b7d6-4576-8bf9-51ffba6a29b3</Id>
+      <Database Name="cv" Series="2910" Issue="18054" />
     </Book>
     <Book Series="Ms. Marvel" Number="13" Volume="1977" Year="1978">
-      <Id>9e82d82a-cba9-45d5-88c3-6b91fcaa65d4</Id>
+      <Database Name="cv" Series="2910" Issue="18176" />
     </Book>
     <Book Series="Ms. Marvel" Number="14" Volume="1977" Year="1978">
-      <Id>95160f93-3364-4847-8aef-62c531d6be97</Id>
+      <Database Name="cv" Series="2910" Issue="18259" />
     </Book>
     <Book Series="The Defenders" Number="57" Volume="1972" Year="1978">
-      <Id>aacb64c0-2509-4522-a913-6242765b9f48</Id>
+      <Database Name="cv" Series="2569" Issue="18325" />
     </Book>
     <Book Series="Ms. Marvel" Number="15" Volume="1977" Year="1978">
-      <Id>ffa14b74-e408-41e9-9025-3dc51fbc0025</Id>
+      <Database Name="cv" Series="2910" Issue="18336" />
     </Book>
     <Book Series="Ms. Marvel" Number="16" Volume="1977" Year="1978">
-      <Id>43890636-55b5-4bb3-99a8-3c8c9e9b52cc</Id>
+      <Database Name="cv" Series="2910" Issue="18425" />
     </Book>
     <Book Series="Ms. Marvel" Number="17" Volume="1977" Year="1978">
-      <Id>0614b984-5179-432e-a9b3-7923a2a2f70d</Id>
+      <Database Name="cv" Series="2910" Issue="18506" />
     </Book>
     <Book Series="Ms. Marvel" Number="19" Volume="1977" Year="1978">
-      <Id>84069a59-92ee-4f60-8214-2bc6e2fc9986</Id>
+      <Database Name="cv" Series="2910" Issue="18748" />
     </Book>
     <Book Series="Ms. Marvel" Number="18" Volume="1977" Year="1978">
-      <Id>bd03bd91-6bfb-4c26-a248-bb410ea245ea</Id>
+      <Database Name="cv" Series="2910" Issue="18589" />
     </Book>
     <Book Series="Ms. Marvel" Number="20" Volume="1977" Year="1978">
-      <Id>decc950a-846b-4c10-a2fe-02b80687ffcb</Id>
+      <Database Name="cv" Series="2910" Issue="18907" />
     </Book>
     <Book Series="Ms. Marvel" Number="21" Volume="1977" Year="1978">
-      <Id>219c245d-5466-4bc4-8a07-38f01d983f07</Id>
+      <Database Name="cv" Series="2910" Issue="19051" />
     </Book>
     <Book Series="Ms. Marvel" Number="22" Volume="1977" Year="1979">
-      <Id>b1f53964-039c-4bb6-b8e8-ccf09d23ffd6</Id>
+      <Database Name="cv" Series="2910" Issue="19306" />
     </Book>
     <Book Series="Marvel Team-Up" Number="77" Volume="1972" Year="1979">
-      <Id>26a2d197-62f9-45e0-96e1-3bd61fe537dd</Id>
+      <Database Name="cv" Series="2576" Issue="19200" />
     </Book>
     <Book Series="Ms. Marvel" Number="23" Volume="1977" Year="1979">
-      <Id>fe9a7db3-90a7-4f9c-9801-caf87f69170d</Id>
+      <Database Name="cv" Series="2910" Issue="19444" />
     </Book>
     <Book Series="Marvel Two-in-One" Number="51" Volume="1974" Year="1979">
-      <Id>d665e7c3-1736-41ea-913a-e50c1fafc7ce</Id>
+      <Database Name="cv" Series="2696" Issue="19514" />
     </Book>
-    <Book Series="Ms. Marvel" Number="24" Volume="1977" Year="1979">
-      <Id>4dd7106c-8b93-4c9d-b4a2-31af764e2c56</Id>
+    <Book Series="Marvel Super-Heroes" Number="10" Volume="1990" Year="1992">
+      <Database Name="cv" Series="4404" Issue="86092" />
     </Book>
-    <Book Series="Ms. Marvel" Number="25" Volume="1977" Year="1979">
-      <Id>e6848c02-6ae6-4292-9b2f-841f2e633085</Id>
+    <Book Series="Marvel Super-Heroes" Number="11" Volume="1990" Year="1992">
+      <Database Name="cv" Series="4404" Issue="86093" />
     </Book>
     <Book Series="Captain Marvel" Number="1" Volume="1989" Year="1989">
-      <Id>6ce86e1c-7968-4f5a-8102-b142700dd70d</Id>
+      <Database Name="cv" Series="19319" Issue="115963" />
     </Book>
     <Book Series="Captain Marvel" Number="1" Volume="1994" Year="1994">
-      <Id>774e93cd-293e-46ca-9377-efdcd0f308f6</Id>
+      <Database Name="cv" Series="19326" Issue="116006" />
     </Book>
     <Book Series="Captain Marvel" Number="1" Volume="1995" Year="1995">
-      <Id>6b92b4d5-6171-41c6-851d-88eb3adfb1eb</Id>
+      <Database Name="cv" Series="18270" Issue="106997" />
     </Book>
     <Book Series="Captain Marvel" Number="2" Volume="1995" Year="1996">
-      <Id>4a2151ab-6576-45e8-9970-6fe60fa7ee47</Id>
+      <Database Name="cv" Series="18270" Issue="107051" />
     </Book>
     <Book Series="Captain Marvel" Number="3" Volume="1995" Year="1996">
-      <Id>23afa3eb-3cdc-4380-bca4-576256880909</Id>
+      <Database Name="cv" Series="18270" Issue="107046" />
     </Book>
     <Book Series="Captain Marvel" Number="4" Volume="1995" Year="1996">
-      <Id>9ec9b023-db44-4f82-9ca8-25751576be0c</Id>
+      <Database Name="cv" Series="18270" Issue="107047" />
     </Book>
     <Book Series="Captain Marvel" Number="5" Volume="1995" Year="1996">
-      <Id>2f1230e1-f295-4159-89ac-4fb3ad82d3dd</Id>
+      <Database Name="cv" Series="18270" Issue="107048" />
     </Book>
     <Book Series="Captain Marvel" Number="6" Volume="1995" Year="1996">
-      <Id>34a2c325-bf91-48d0-aa43-8d816199e997</Id>
+      <Database Name="cv" Series="18270" Issue="107049" />
     </Book>
     <Book Series="Captain Marvel" Number="0" Volume="2000" Year="1999">
-      <Id>5323f4a0-07a9-4336-b96e-7da9daf089e3</Id>
+      <Database Name="cv" Series="6458" Issue="46105" />
     </Book>
     <Book Series="Captain Marvel" Number="1" Volume="2000" Year="2000">
-      <Id>d1c84fc7-cb66-4924-b05e-7143c2ece5f4</Id>
+      <Database Name="cv" Series="6458" Issue="65843" />
     </Book>
     <Book Series="Captain Marvel" Number="2" Volume="2000" Year="2000">
-      <Id>c9c92888-223a-43cd-8867-8a12bd807ed5</Id>
+      <Database Name="cv" Series="6458" Issue="46250" />
     </Book>
     <Book Series="Captain Marvel" Number="3" Volume="2000" Year="2000">
-      <Id>3ec62eae-7af4-4818-9f26-c0025e564a0b</Id>
+      <Database Name="cv" Series="6458" Issue="65844" />
     </Book>
     <Book Series="Captain Marvel" Number="4" Volume="2000" Year="2000">
-      <Id>2a841d27-d687-44c8-b9c6-ea90541531e4</Id>
+      <Database Name="cv" Series="6458" Issue="65845" />
     </Book>
     <Book Series="Captain Marvel" Number="5" Volume="2000" Year="2000">
-      <Id>da7ebcda-03da-4d56-90b3-565df15506c9</Id>
+      <Database Name="cv" Series="6458" Issue="65846" />
     </Book>
     <Book Series="Captain Marvel" Number="6" Volume="2000" Year="2000">
-      <Id>35ed5526-858d-4183-ae03-afa4bb5a8b4d</Id>
+      <Database Name="cv" Series="6458" Issue="65847" />
     </Book>
     <Book Series="Captain Marvel" Number="7" Volume="2000" Year="2000">
-      <Id>fe635d83-e173-4a2e-8897-5b3c9b787b4e</Id>
+      <Database Name="cv" Series="6458" Issue="80545" />
     </Book>
     <Book Series="Captain Marvel" Number="8" Volume="2000" Year="2000">
-      <Id>ab836853-ddef-45c4-9696-178df208e8fe</Id>
+      <Database Name="cv" Series="6458" Issue="80546" />
     </Book>
     <Book Series="Captain Marvel" Number="9" Volume="2000" Year="2000">
-      <Id>0a3e2feb-e9e8-42f8-a6e2-d702ca2605f2</Id>
+      <Database Name="cv" Series="6458" Issue="80547" />
     </Book>
     <Book Series="Captain Marvel" Number="10" Volume="2000" Year="2000">
-      <Id>6b1a8715-c310-4f75-812d-0c2c2c95967b</Id>
+      <Database Name="cv" Series="6458" Issue="80548" />
     </Book>
     <Book Series="Captain Marvel" Number="11" Volume="2000" Year="2000">
-      <Id>1ba351df-5f94-456d-b529-5c5d47f9ebcd</Id>
+      <Database Name="cv" Series="6458" Issue="80549" />
     </Book>
     <Book Series="Captain Marvel" Number="12" Volume="2000" Year="2000">
-      <Id>7272e1ce-e998-4571-a090-62ef6eded8ed</Id>
+      <Database Name="cv" Series="6458" Issue="80550" />
     </Book>
     <Book Series="Captain Marvel" Number="13" Volume="2000" Year="2001">
-      <Id>c1874472-abe4-499e-bf85-f985e2780e7e</Id>
+      <Database Name="cv" Series="6458" Issue="80551" />
     </Book>
     <Book Series="Captain Marvel" Number="14" Volume="2000" Year="2001">
-      <Id>14ffc486-bdf6-4455-b2ca-30960daa799d</Id>
+      <Database Name="cv" Series="6458" Issue="80552" />
     </Book>
     <Book Series="Captain Marvel" Number="15" Volume="2000" Year="2001">
-      <Id>b249b95c-54ed-48df-b8b5-e278abd23cff</Id>
+      <Database Name="cv" Series="6458" Issue="80553" />
     </Book>
     <Book Series="Captain Marvel" Number="16" Volume="2000" Year="2001">
-      <Id>dacb7686-b0e0-423d-b1b9-3c7bfc114c31</Id>
+      <Database Name="cv" Series="6458" Issue="80554" />
     </Book>
     <Book Series="Captain Marvel" Number="17" Volume="2000" Year="2001">
-      <Id>fc09084c-6c11-453c-8fc6-18b4a00c0a17</Id>
+      <Database Name="cv" Series="6458" Issue="80555" />
     </Book>
     <Book Series="Captain Marvel" Number="18" Volume="2000" Year="2001">
-      <Id>c3e92fe1-9e0e-451f-b62c-53ad86303fe9</Id>
+      <Database Name="cv" Series="6458" Issue="80556" />
     </Book>
     <Book Series="Captain Marvel" Number="19" Volume="2000" Year="2001">
-      <Id>b295b9d3-32cb-4267-9a87-cde25d180be3</Id>
+      <Database Name="cv" Series="6458" Issue="80557" />
     </Book>
     <Book Series="Captain Marvel" Number="20" Volume="2000" Year="2001">
-      <Id>0874e1c7-939b-423f-abd6-87f1c2448d9c</Id>
+      <Database Name="cv" Series="6458" Issue="80558" />
     </Book>
     <Book Series="Captain Marvel" Number="21" Volume="2000" Year="2001">
-      <Id>59f0268b-c699-4538-a078-ed766a59035e</Id>
+      <Database Name="cv" Series="6458" Issue="80559" />
     </Book>
     <Book Series="Captain Marvel" Number="22" Volume="2000" Year="2001">
-      <Id>3c0c505c-fff5-454e-b078-ee024d5fc83f</Id>
+      <Database Name="cv" Series="6458" Issue="80560" />
     </Book>
     <Book Series="Captain Marvel" Number="23" Volume="2000" Year="2001">
-      <Id>f1b1cdd3-857b-4af8-97f3-2aff7090a299</Id>
+      <Database Name="cv" Series="6458" Issue="80561" />
     </Book>
     <Book Series="Captain Marvel" Number="24" Volume="2000" Year="2001">
-      <Id>9a995ba3-e51f-49df-a25c-229efdd4bfa2</Id>
+      <Database Name="cv" Series="6458" Issue="80562" />
     </Book>
     <Book Series="Captain Marvel" Number="25" Volume="2000" Year="2002">
-      <Id>90d42173-2960-47a2-8d14-dad90e599db6</Id>
+      <Database Name="cv" Series="6458" Issue="80563" />
     </Book>
     <Book Series="Captain Marvel" Number="26" Volume="2000" Year="2002">
-      <Id>cfddb514-6657-4bb7-9fa9-af6215b78da8</Id>
+      <Database Name="cv" Series="6458" Issue="80564" />
     </Book>
     <Book Series="Captain Marvel" Number="27" Volume="2000" Year="2002">
-      <Id>3bfbe80a-55c0-43c1-bf7f-6e41d076e2fc</Id>
+      <Database Name="cv" Series="6458" Issue="80565" />
     </Book>
     <Book Series="Captain Marvel" Number="28" Volume="2000" Year="2002">
-      <Id>d2210fc0-53a6-48a3-963a-a6eaf9d0e721</Id>
+      <Database Name="cv" Series="6458" Issue="80566" />
     </Book>
     <Book Series="Captain Marvel" Number="29" Volume="2000" Year="2002">
-      <Id>c71678e5-d680-47b3-8941-cb42f71ebce1</Id>
+      <Database Name="cv" Series="6458" Issue="80567" />
     </Book>
     <Book Series="Captain Marvel" Number="30" Volume="2000" Year="2002">
-      <Id>1fc51db8-77ce-4467-9f8c-355a47d003fb</Id>
+      <Database Name="cv" Series="6458" Issue="80568" />
     </Book>
     <Book Series="Captain Marvel" Number="31" Volume="2000" Year="2002">
-      <Id>8d3b2b97-869b-4d86-938c-3ff3f007e622</Id>
+      <Database Name="cv" Series="6458" Issue="80569" />
     </Book>
     <Book Series="Captain Marvel" Number="32" Volume="2000" Year="2002">
-      <Id>3a3e5a75-01a2-4218-81d2-5a395f5955c8</Id>
+      <Database Name="cv" Series="6458" Issue="80570" />
     </Book>
     <Book Series="Captain Marvel" Number="33" Volume="2000" Year="2002">
-      <Id>d04d3ee5-ca4a-42a8-9f00-bda771febd8a</Id>
+      <Database Name="cv" Series="6458" Issue="80571" />
     </Book>
     <Book Series="Captain Marvel" Number="34" Volume="2000" Year="2002">
-      <Id>239f15b4-2c01-4d01-8a72-0c7d68967503</Id>
+      <Database Name="cv" Series="6458" Issue="106951" />
     </Book>
     <Book Series="Captain Marvel" Number="35" Volume="2000" Year="2002">
-      <Id>a18fde17-5137-4c68-992a-fcf640d574cb</Id>
+      <Database Name="cv" Series="6458" Issue="106952" />
     </Book>
     <Book Series="Captain Marvel" Number="1" Volume="2002" Year="2002">
-      <Id>6deed2ba-9c8b-421c-9c29-82731d7ec874</Id>
+      <Database Name="cv" Series="18296" Issue="107084" />
     </Book>
     <Book Series="Captain Marvel" Number="2" Volume="2002" Year="2002">
-      <Id>d046f68d-fbaa-4c0a-85d2-c5a8f858ca6a</Id>
+      <Database Name="cv" Series="18296" Issue="124084" />
     </Book>
     <Book Series="Captain Marvel" Number="3" Volume="2002" Year="2003">
-      <Id>b1519a45-c260-46d3-901d-0be584defc59</Id>
+      <Database Name="cv" Series="18296" Issue="152535" />
     </Book>
     <Book Series="Captain Marvel" Number="4" Volume="2002" Year="2003">
-      <Id>44a4a458-2feb-4e60-b9ab-249eabdf3506</Id>
+      <Database Name="cv" Series="18296" Issue="124628" />
     </Book>
     <Book Series="Captain Marvel" Number="5" Volume="2002" Year="2003">
-      <Id>e2067224-01d7-4960-b767-e95b8028b307</Id>
+      <Database Name="cv" Series="18296" Issue="123543" />
     </Book>
     <Book Series="Captain Marvel" Number="6" Volume="2002" Year="2003">
-      <Id>9d816892-3490-4403-86ec-420f7c62c63f</Id>
+      <Database Name="cv" Series="18296" Issue="152536" />
     </Book>
     <Book Series="Captain Marvel" Number="7" Volume="2002" Year="2003">
-      <Id>33b9982d-c289-4fe4-b08f-adc5b3212a98</Id>
+      <Database Name="cv" Series="18296" Issue="152537" />
     </Book>
     <Book Series="Captain Marvel" Number="8" Volume="2002" Year="2003">
-      <Id>6159ff7f-2927-4836-9d21-b6787085e6ad</Id>
+      <Database Name="cv" Series="18296" Issue="152538" />
     </Book>
     <Book Series="Captain Marvel" Number="9" Volume="2002" Year="2003">
-      <Id>31936a53-1873-4789-a7dd-ff3cf1b025c9</Id>
+      <Database Name="cv" Series="18296" Issue="152539" />
     </Book>
     <Book Series="Captain Marvel" Number="10" Volume="2002" Year="2003">
-      <Id>10bcccfb-596f-4536-be09-4ecc5322e08b</Id>
+      <Database Name="cv" Series="18296" Issue="152543" />
     </Book>
     <Book Series="Captain Marvel" Number="11" Volume="2002" Year="2003">
-      <Id>41b36985-ad41-4328-9ea6-3b714fdf2cee</Id>
+      <Database Name="cv" Series="18296" Issue="152551" />
     </Book>
     <Book Series="Captain Marvel" Number="12" Volume="2002" Year="2003">
-      <Id>d4a7c073-2149-431d-93ee-19fef4d9ed40</Id>
+      <Database Name="cv" Series="18296" Issue="152552" />
     </Book>
     <Book Series="Captain Marvel" Number="13" Volume="2002" Year="2003">
-      <Id>1ebf151d-e588-4fc9-b236-b77f4885262c</Id>
+      <Database Name="cv" Series="18296" Issue="152553" />
     </Book>
     <Book Series="Captain Marvel" Number="14" Volume="2002" Year="2003">
-      <Id>c7cadb2e-563f-4e47-8983-d3c6ec90b5d9</Id>
+      <Database Name="cv" Series="18296" Issue="152554" />
     </Book>
     <Book Series="Captain Marvel" Number="15" Volume="2002" Year="2003">
-      <Id>0e4aec78-7efa-4ae1-998b-d4b6e292ffb0</Id>
+      <Database Name="cv" Series="18296" Issue="152555" />
     </Book>
     <Book Series="Captain Marvel" Number="16" Volume="2002" Year="2004">
-      <Id>2a96109a-c594-4767-b408-d5f39154cc28</Id>
+      <Database Name="cv" Series="18296" Issue="125654" />
     </Book>
     <Book Series="Captain Marvel" Number="17" Volume="2002" Year="2004">
-      <Id>d2dbb23f-f655-4ab7-bb2f-dcfd5a271e83</Id>
+      <Database Name="cv" Series="18296" Issue="152550" />
     </Book>
     <Book Series="Captain Marvel" Number="18" Volume="2002" Year="2004">
-      <Id>fa371130-ee66-4d7e-8909-3cc37a27106e</Id>
+      <Database Name="cv" Series="18296" Issue="152549" />
     </Book>
     <Book Series="Captain Marvel" Number="19" Volume="2002" Year="2004">
-      <Id>2c52277e-d09d-4a23-962d-732012da05d3</Id>
+      <Database Name="cv" Series="18296" Issue="152548" />
     </Book>
     <Book Series="Captain Marvel" Number="20" Volume="2002" Year="2004">
-      <Id>a4a81a5d-9096-48d2-94cf-c18485823951</Id>
+      <Database Name="cv" Series="18296" Issue="152547" />
     </Book>
     <Book Series="Captain Marvel" Number="21" Volume="2002" Year="2004">
-      <Id>e85aeef6-78c2-4125-8ac5-51b590d1cdfe</Id>
+      <Database Name="cv" Series="18296" Issue="141477" />
     </Book>
     <Book Series="Captain Marvel" Number="22" Volume="2002" Year="2004">
-      <Id>8b140dd5-b13c-46e9-8e2d-ac23333098ad</Id>
+      <Database Name="cv" Series="18296" Issue="152546" />
     </Book>
     <Book Series="Captain Marvel" Number="23" Volume="2002" Year="2004">
-      <Id>1cb818b1-6e72-401a-b4f6-3034b8c6573b</Id>
+      <Database Name="cv" Series="18296" Issue="152545" />
     </Book>
     <Book Series="Captain Marvel" Number="24" Volume="2002" Year="2004">
-      <Id>35b59b0c-512f-46dc-87cd-450397365cf6</Id>
+      <Database Name="cv" Series="18296" Issue="152544" />
     </Book>
     <Book Series="Captain Marvel" Number="25" Volume="2002" Year="2004">
-      <Id>2f95b539-7409-4486-a939-a76cfd3102c9</Id>
+      <Database Name="cv" Series="18296" Issue="152490" />
     </Book>
     <Book Series="House of M" Number="1" Volume="2005" Year="2005">
-      <Id>87c12880-5952-4edd-87b2-17ca0f8a8412</Id>
+      <Database Name="cv" Series="12049" Issue="104861" />
     </Book>
     <Book Series="House of M" Number="2" Volume="2005" Year="2005">
-      <Id>cd404553-6dd2-46e2-a706-b44501cceeb5</Id>
+      <Database Name="cv" Series="12049" Issue="104862" />
     </Book>
     <Book Series="House of M" Number="3" Volume="2005" Year="2005">
-      <Id>52c3157a-6b7b-4a3f-93a3-5c65d8105904</Id>
+      <Database Name="cv" Series="12049" Issue="104863" />
     </Book>
     <Book Series="House of M" Number="4" Volume="2005" Year="2005">
-      <Id>a9152579-cd4a-4fcf-a9fc-a28706d29844</Id>
+      <Database Name="cv" Series="12049" Issue="104864" />
     </Book>
     <Book Series="House of M" Number="5" Volume="2005" Year="2005">
-      <Id>83190f73-884a-416f-968b-d52aaebeacf9</Id>
+      <Database Name="cv" Series="12049" Issue="104865" />
     </Book>
     <Book Series="House of M" Number="6" Volume="2005" Year="2005">
-      <Id>4e3ef330-2fe0-4dbb-9f12-13b2c25ec7ae</Id>
+      <Database Name="cv" Series="12049" Issue="104866" />
     </Book>
     <Book Series="House of M" Number="7" Volume="2005" Year="2005">
-      <Id>f0bdd681-2378-4e2d-a243-4b14799eb6ca</Id>
+      <Database Name="cv" Series="12049" Issue="104867" />
     </Book>
     <Book Series="House of M" Number="8" Volume="2005" Year="2005">
-      <Id>8a2532e6-142d-45e2-ac8a-f8a8548d6e7b</Id>
+      <Database Name="cv" Series="12049" Issue="104868" />
     </Book>
     <Book Series="Ms. Marvel" Number="1" Volume="2006" Year="2006">
-      <Id>c5713eb0-b005-4621-aaec-c49bf52402c0</Id>
+      <Database Name="cv" Series="17990" Issue="105338" />
     </Book>
     <Book Series="Ms. Marvel" Number="2" Volume="2006" Year="2006">
-      <Id>d82b7a36-8e48-413f-b1b8-a51045e2cf02</Id>
+      <Database Name="cv" Series="17990" Issue="108171" />
     </Book>
     <Book Series="Ms. Marvel" Number="3" Volume="2006" Year="2006">
-      <Id>956884a0-1f0d-402f-9a87-78b123f0435f</Id>
+      <Database Name="cv" Series="17990" Issue="108172" />
     </Book>
     <Book Series="Ms. Marvel" Number="4" Volume="2006" Year="2006">
-      <Id>fde31705-e7a1-426d-af57-e8ed53f6cfa9</Id>
+      <Database Name="cv" Series="17990" Issue="108173" />
     </Book>
     <Book Series="Ms. Marvel" Number="5" Volume="2006" Year="2006">
-      <Id>1bb401c0-0595-4e66-b67b-af8288efed78</Id>
+      <Database Name="cv" Series="17990" Issue="108174" />
     </Book>
     <Book Series="Giant-Size Ms. Marvel" Number="1" Volume="2006" Year="2006">
-      <Id>9a569040-5e2e-4349-8fc5-3a6adc7bbe4a</Id>
+      <Database Name="cv" Series="22510" Issue="135114" />
     </Book>
     <Book Series="Ms. Marvel" Number="6" Volume="2006" Year="2006">
-      <Id>26e11a93-16bd-49bd-a944-b1e157c7487c</Id>
+      <Database Name="cv" Series="17990" Issue="108041" />
     </Book>
     <Book Series="Ms. Marvel" Number="7" Volume="2006" Year="2006">
-      <Id>0c406573-f376-4d2f-9d9c-9aa86208af66</Id>
+      <Database Name="cv" Series="17990" Issue="108175" />
     </Book>
     <Book Series="Ms. Marvel" Number="8" Volume="2006" Year="2006">
-      <Id>1741658a-a67c-4d66-8fbd-7332373ca5d2</Id>
+      <Database Name="cv" Series="17990" Issue="108176" />
     </Book>
     <Book Series="Ms. Marvel" Number="9" Volume="2006" Year="2007">
-      <Id>96a41692-ee3b-4350-967c-e4e09b016a17</Id>
+      <Database Name="cv" Series="17990" Issue="108214" />
     </Book>
     <Book Series="Ms. Marvel" Number="10" Volume="2006" Year="2007">
-      <Id>fb940de6-d265-4b1f-9683-9914f7485233</Id>
+      <Database Name="cv" Series="17990" Issue="108340" />
     </Book>
     <Book Series="Ms. Marvel" Number="11" Volume="2006" Year="2007">
-      <Id>0f444614-9d40-4101-96fe-37f9ce8da080</Id>
+      <Database Name="cv" Series="17990" Issue="108341" />
     </Book>
     <Book Series="Ms. Marvel" Number="12" Volume="2006" Year="2007">
-      <Id>1a4ab880-fe7b-430e-aa01-aa2dc66e3070</Id>
+      <Database Name="cv" Series="17990" Issue="106387" />
     </Book>
     <Book Series="Ms. Marvel" Number="13" Volume="2006" Year="2007">
-      <Id>5cff6805-b961-4e27-aced-620807e41ddc</Id>
+      <Database Name="cv" Series="17990" Issue="107228" />
     </Book>
     <Book Series="Ms. Marvel" Number="14" Volume="2006" Year="2007">
-      <Id>a2225bc7-0154-4722-8c0d-c03a0ea95ca6</Id>
+      <Database Name="cv" Series="17990" Issue="107995" />
     </Book>
     <Book Series="Ms. Marvel" Number="15" Volume="2006" Year="2007">
-      <Id>634c83f4-26af-49e0-b437-28d0946b8862</Id>
+      <Database Name="cv" Series="17990" Issue="109131" />
     </Book>
     <Book Series="Ms. Marvel" Number="16" Volume="2006" Year="2007">
-      <Id>235504ba-3cd0-4f8b-8bac-da372ad61870</Id>
+      <Database Name="cv" Series="17990" Issue="110265" />
     </Book>
     <Book Series="Ms. Marvel" Number="17" Volume="2006" Year="2007">
-      <Id>39ac6bb7-d3d2-437b-bd2f-abafbc89e99b</Id>
+      <Database Name="cv" Series="17990" Issue="111348" />
     </Book>
     <Book Series="Ms. Marvel Annual" Number="1" Volume="2008" Year="2008">
-      <Id>107d3334-f68a-4381-923d-a2f15760f4cd</Id>
+      <Database Name="cv" Series="22871" Issue="137372" />
     </Book>
     <Book Series="Ms. Marvel" Number="18" Volume="2006" Year="2007">
-      <Id>a002ceef-54d8-434e-a1dd-6a4e330e2df6</Id>
+      <Database Name="cv" Series="17990" Issue="112672" />
     </Book>
     <Book Series="Ms. Marvel" Number="19" Volume="2006" Year="2007">
-      <Id>a6b50cdf-5080-4e82-849b-67b11313b91c</Id>
+      <Database Name="cv" Series="17990" Issue="110266" />
     </Book>
     <Book Series="Ms. Marvel" Number="20" Volume="2006" Year="2007">
-      <Id>dcc77139-6e51-4fbf-b3a0-a36c926cc9cb</Id>
+      <Database Name="cv" Series="17990" Issue="115209" />
     </Book>
     <Book Series="Ms. Marvel" Number="21" Volume="2006" Year="2008">
-      <Id>e66cecc8-3786-4494-9477-b6f1b157c902</Id>
+      <Database Name="cv" Series="17990" Issue="116980" />
     </Book>
     <Book Series="Ms. Marvel" Number="22" Volume="2006" Year="2008">
-      <Id>fa02e984-49ea-4d4d-8665-59a0d8180aca</Id>
+      <Database Name="cv" Series="17990" Issue="119194" />
     </Book>
     <Book Series="Ms. Marvel" Number="23" Volume="2006" Year="2008">
-      <Id>4505fa0b-fbfe-4ac4-b1b7-887b0aeb268a</Id>
+      <Database Name="cv" Series="17990" Issue="120864" />
     </Book>
     <Book Series="Ms. Marvel" Number="24" Volume="2006" Year="2008">
-      <Id>d2ac9271-7a05-4484-88b8-ed4c089de116</Id>
+      <Database Name="cv" Series="17990" Issue="122546" />
     </Book>
-    <Book Series="Captain Marvel" Number="1" Volume="2008" Year="2008">
-      <Id>2c7a4e69-4afe-49ec-a810-77e3b1c41819</Id>
+    <Book Series="Captain Marvel" Number="1" Volume="2007" Year="2008">
+      <Database Name="cv" Series="19633" Issue="117782" />
     </Book>
-    <Book Series="Captain Marvel" Number="2" Volume="2008" Year="2008">
-      <Id>4d9aa056-361f-4ca8-8700-840cb870593a</Id>
+    <Book Series="Captain Marvel" Number="2" Volume="2007" Year="2008">
+      <Database Name="cv" Series="19633" Issue="120875" />
     </Book>
-    <Book Series="Captain Marvel" Number="3" Volume="2008" Year="2008">
-      <Id>1224c341-9cc5-4de4-9f49-ffc6c5c03614</Id>
+    <Book Series="Captain Marvel" Number="3" Volume="2007" Year="2008">
+      <Database Name="cv" Series="19633" Issue="122806" />
     </Book>
-    <Book Series="Captain Marvel" Number="4" Volume="2008" Year="2008">
-      <Id>7e3e92df-0f0b-4b82-8f32-e0061ca634a2</Id>
+    <Book Series="Captain Marvel" Number="4" Volume="2007" Year="2008">
+      <Database Name="cv" Series="19633" Issue="125718" />
     </Book>
-    <Book Series="Captain Marvel" Number="5" Volume="2008" Year="2008">
-      <Id>f13ef942-f9c3-4972-bce1-10ffb045cbd5</Id>
+    <Book Series="Captain Marvel" Number="5" Volume="2007" Year="2008">
+      <Database Name="cv" Series="19633" Issue="127560" />
     </Book>
     <Book Series="Ms. Marvel" Number="25" Volume="2006" Year="2008">
-      <Id>2a9053d8-8fe5-4e2f-8553-e9ae6d866837</Id>
+      <Database Name="cv" Series="17990" Issue="125974" />
     </Book>
     <Book Series="Ms. Marvel" Number="26" Volume="2006" Year="2008">
-      <Id>2d14cd4f-fb37-4c5f-991f-f303e9b78815</Id>
+      <Database Name="cv" Series="17990" Issue="128190" />
     </Book>
     <Book Series="Ms. Marvel" Number="27" Volume="2006" Year="2008">
-      <Id>dffa203f-cb58-4704-84fa-d133068a7ba3</Id>
+      <Database Name="cv" Series="17990" Issue="130975" />
     </Book>
     <Book Series="Ms. Marvel" Number="28" Volume="2006" Year="2008">
-      <Id>272918e9-39fb-4756-99c0-2bbb5a4f1461</Id>
+      <Database Name="cv" Series="17990" Issue="131799" />
     </Book>
     <Book Series="Ms. Marvel" Number="29" Volume="2006" Year="2008">
-      <Id>8506058f-881b-4626-87d3-09e101405cb7</Id>
+      <Database Name="cv" Series="17990" Issue="134593" />
     </Book>
     <Book Series="Ms. Marvel" Number="30" Volume="2006" Year="2008">
-      <Id>abe892ad-c887-41a4-8df5-86c686eb41dd</Id>
+      <Database Name="cv" Series="17990" Issue="138394" />
     </Book>
     <Book Series="Ms. Marvel" Number="31" Volume="2006" Year="2008">
-      <Id>cd0817e5-743c-44bc-9d1d-aeff29d79bc4</Id>
+      <Database Name="cv" Series="17990" Issue="139399" />
     </Book>
     <Book Series="Ms. Marvel" Number="32" Volume="2006" Year="2008">
-      <Id>2a669ed6-d50f-4665-b623-f16064ca6d69</Id>
+      <Database Name="cv" Series="17990" Issue="140940" />
     </Book>
     <Book Series="Ms. Marvel" Number="33" Volume="2006" Year="2009">
-      <Id>7979df56-53a8-4e1e-81b9-25eb1f5ce3d8</Id>
+      <Database Name="cv" Series="17990" Issue="144887" />
     </Book>
     <Book Series="Ms. Marvel" Number="34" Volume="2006" Year="2009">
-      <Id>1c158a98-aa72-45fc-9c4c-963750ef0ae0</Id>
+      <Database Name="cv" Series="17990" Issue="148638" />
     </Book>
     <Book Series="Ms. Marvel" Number="35" Volume="2006" Year="2009">
-      <Id>bed5890a-370d-4de8-b84a-3a5c43e60268</Id>
+      <Database Name="cv" Series="17990" Issue="150688" />
     </Book>
     <Book Series="Ms. Marvel" Number="36" Volume="2006" Year="2009">
-      <Id>1aa8f23a-a5fd-4453-9a45-b87626380e84</Id>
+      <Database Name="cv" Series="17990" Issue="152756" />
     </Book>
     <Book Series="Ms. Marvel" Number="37" Volume="2006" Year="2009">
-      <Id>d2a9c688-4321-4cf0-9b80-d2c2f92b6b7d</Id>
+      <Database Name="cv" Series="17990" Issue="153991" />
     </Book>
     <Book Series="Ms. Marvel" Number="38" Volume="2006" Year="2009">
-      <Id>def48da6-f0b2-4992-926e-48d2b02c50c0</Id>
+      <Database Name="cv" Series="17990" Issue="156119" />
     </Book>
     <Book Series="Ms. Marvel" Number="39" Volume="2006" Year="2009">
-      <Id>24065ee8-fe4b-4eb8-9c1d-d3754d13ea4b</Id>
+      <Database Name="cv" Series="17990" Issue="158779" />
     </Book>
     <Book Series="Ms. Marvel" Number="40" Volume="2006" Year="2009">
-      <Id>6c86b47e-7a36-4c99-b067-bde3b3d9ea55</Id>
+      <Database Name="cv" Series="17990" Issue="161727" />
     </Book>
     <Book Series="Ms. Marvel" Number="41" Volume="2006" Year="2009">
-      <Id>2ebfbeb1-c8c3-4b9a-b090-fa46384b1cf1</Id>
+      <Database Name="cv" Series="17990" Issue="163541" />
     </Book>
     <Book Series="Ms. Marvel" Number="42" Volume="2006" Year="2009">
-      <Id>d97b11ac-3f32-40b7-b3bc-20ed907c967d</Id>
+      <Database Name="cv" Series="17990" Issue="164960" />
     </Book>
     <Book Series="Ms. Marvel" Number="43" Volume="2006" Year="2009">
-      <Id>b50188fd-f9c0-41b6-9d06-18c7875e6573</Id>
+      <Database Name="cv" Series="17990" Issue="166836" />
     </Book>
     <Book Series="Ms. Marvel" Number="44" Volume="2006" Year="2009">
-      <Id>1fd7ca6f-9754-49c9-9826-09d931748df7</Id>
+      <Database Name="cv" Series="17990" Issue="168306" />
     </Book>
     <Book Series="Ms. Marvel" Number="45" Volume="2006" Year="2009">
-      <Id>dfac13d0-eeb1-427b-a7a3-64ef3f043741</Id>
+      <Database Name="cv" Series="17990" Issue="172379" />
     </Book>
     <Book Series="Ms. Marvel" Number="46" Volume="2006" Year="2009">
-      <Id>2eed2779-7060-459f-aec1-e94129cfc64a</Id>
+      <Database Name="cv" Series="17990" Issue="179194" />
     </Book>
     <Book Series="Ms. Marvel" Number="47" Volume="2006" Year="2010">
-      <Id>fdbe942e-ed89-47c6-a39a-991b301c4d4f</Id>
+      <Database Name="cv" Series="17990" Issue="184820" />
     </Book>
     <Book Series="Ms. Marvel" Number="48" Volume="2006" Year="2010">
-      <Id>2d4162e8-75ff-4b42-a0f5-5e27eb0aeb60</Id>
+      <Database Name="cv" Series="17990" Issue="187630" />
     </Book>
     <Book Series="Ms. Marvel" Number="49" Volume="2006" Year="2010">
-      <Id>66f8e6a3-7e35-44ca-b036-4df455498316</Id>
+      <Database Name="cv" Series="17990" Issue="194553" />
     </Book>
     <Book Series="Ms. Marvel" Number="50" Volume="2006" Year="2010">
-      <Id>a9c6136d-eae9-4cc9-93d7-06aac2e4f196</Id>
+      <Database Name="cv" Series="17990" Issue="198263" />
     </Book>
     <Book Series="Captain Marvel" Number="1" Volume="2012" Year="2012">
-      <Id>f347b8fe-e1eb-4f2e-baa3-38dca339178f</Id>
+      <Database Name="cv" Series="50575" Issue="346238" />
     </Book>
     <Book Series="Captain Marvel" Number="2" Volume="2012" Year="2012">
-      <Id>332b058e-3b1d-4033-b22e-a1475bf42868</Id>
+      <Database Name="cv" Series="50575" Issue="351087" />
     </Book>
     <Book Series="Captain Marvel" Number="3" Volume="2012" Year="2012">
-      <Id>97e2e192-4b6d-4fba-917e-6847d2d1c4e8</Id>
+      <Database Name="cv" Series="50575" Issue="354162" />
     </Book>
     <Book Series="Captain Marvel" Number="4" Volume="2012" Year="2012">
-      <Id>4d9d4e23-421f-45b5-90bf-ce0992f06b29</Id>
+      <Database Name="cv" Series="50575" Issue="358973" />
     </Book>
     <Book Series="Captain Marvel" Number="5" Volume="2012" Year="2012">
-      <Id>c7809011-a113-4c35-9f68-a48b25b64c09</Id>
+      <Database Name="cv" Series="50575" Issue="362179" />
     </Book>
     <Book Series="Captain Marvel" Number="6" Volume="2012" Year="2012">
-      <Id>58ab22a5-789c-4d15-92b2-76a9297a7d79</Id>
+      <Database Name="cv" Series="50575" Issue="364158" />
     </Book>
     <Book Series="Captain Marvel" Number="7" Volume="2012" Year="2013">
-      <Id>a5de72da-16ad-42f1-8a8d-5c2faf66de50</Id>
+      <Database Name="cv" Series="50575" Issue="369078" />
     </Book>
     <Book Series="Captain Marvel" Number="8" Volume="2012" Year="2013">
-      <Id>2f15c22a-d03a-40c5-be76-a082d8f649f3</Id>
+      <Database Name="cv" Series="50575" Issue="373299" />
     </Book>
     <Book Series="Captain Marvel" Number="9" Volume="2012" Year="2013">
-      <Id>fa593e2e-1833-4ea7-be4d-c2ab187b14a7</Id>
+      <Database Name="cv" Series="50575" Issue="380352" />
     </Book>
     <Book Series="Captain Marvel" Number="10" Volume="2012" Year="2013">
-      <Id>8c6c432a-f6b9-4600-8311-605d408b631c</Id>
+      <Database Name="cv" Series="50575" Issue="387254" />
     </Book>
     <Book Series="Captain Marvel" Number="11" Volume="2012" Year="2013">
-      <Id>73a9d039-21eb-4f94-b655-ce13d5e265bb</Id>
+      <Database Name="cv" Series="50575" Issue="394704" />
     </Book>
     <Book Series="Captain Marvel" Number="12" Volume="2012" Year="2013">
-      <Id>fb1f145b-085f-4c7e-b848-475af8b33394</Id>
+      <Database Name="cv" Series="50575" Issue="397543" />
     </Book>
     <Book Series="Captain Marvel" Number="13" Volume="2012" Year="2013">
-      <Id>be28f61e-81fb-4120-916d-45aa0d3f6028</Id>
+      <Database Name="cv" Series="50575" Issue="411827" />
     </Book>
     <Book Series="Captain Marvel" Number="14" Volume="2012" Year="2013">
-      <Id>23fa1e07-80de-47c7-b264-ba4ac88c1204</Id>
+      <Database Name="cv" Series="50575" Issue="419965" />
     </Book>
     <Book Series="Captain Marvel" Number="15" Volume="2012" Year="2013">
-      <Id>ee3b0838-53a2-4377-8ea7-4f010f4b080b</Id>
+      <Database Name="cv" Series="50575" Issue="423672" />
     </Book>
     <Book Series="Captain Marvel" Number="16" Volume="2012" Year="2013">
-      <Id>9311c504-a6c8-4e00-b8ae-7d89432376a2</Id>
+      <Database Name="cv" Series="50575" Issue="425931" />
     </Book>
     <Book Series="Captain Marvel" Number="17" Volume="2012" Year="2014">
-      <Id>674b6a2e-3d75-4ef5-948d-efb98730a76b</Id>
+      <Database Name="cv" Series="50575" Issue="432325" />
     </Book>
     <Book Series="Captain Marvel" Number="1" Volume="2014" Year="2014">
-      <Id>777bc9df-401c-4033-af80-699a9ef7c21d</Id>
+      <Database Name="cv" Series="72272" Issue="447507" />
     </Book>
     <Book Series="Captain Marvel" Number="2" Volume="2014" Year="2014">
-      <Id>79178597-c6c3-4d75-a5de-b43bdadd1732</Id>
+      <Database Name="cv" Series="72272" Issue="450071" />
     </Book>
     <Book Series="Captain Marvel" Number="3" Volume="2014" Year="2014">
-      <Id>59442960-4661-4e79-b8c4-0c1564c21f56</Id>
+      <Database Name="cv" Series="72272" Issue="452849" />
     </Book>
     <Book Series="Captain Marvel" Number="5" Volume="2014" Year="2014">
-      <Id>eb5c299a-1f11-433e-b0ce-6478373f3ae8</Id>
+      <Database Name="cv" Series="72272" Issue="459166" />
     </Book>
     <Book Series="Captain Marvel" Number="6" Volume="2014" Year="2014">
-      <Id>3f1dafb9-405d-4b65-b88d-1b21883888bd</Id>
+      <Database Name="cv" Series="72272" Issue="462247" />
     </Book>
     <Book Series="Captain Marvel" Number="7" Volume="2014" Year="2014">
-      <Id>817e83f1-d831-4a88-a69f-5fc165b389a7</Id>
+      <Database Name="cv" Series="72272" Issue="464976" />
     </Book>
     <Book Series="Captain Marvel" Number="8" Volume="2014" Year="2014">
-      <Id>5203229f-a3d6-409d-81cd-f39c12b7abc1</Id>
+      <Database Name="cv" Series="72272" Issue="467649" />
     </Book>
     <Book Series="Captain Marvel" Number="9" Volume="2014" Year="2015">
-      <Id>1dd9b034-94fb-4baa-902a-988d20e57443</Id>
+      <Database Name="cv" Series="72272" Issue="469830" />
     </Book>
     <Book Series="Captain Marvel" Number="10" Volume="2014" Year="2015">
-      <Id>c08b1661-6adb-4020-94b9-344aa9bf3479</Id>
+      <Database Name="cv" Series="72272" Issue="473643" />
     </Book>
     <Book Series="Captain Marvel" Number="11" Volume="2014" Year="2015">
-      <Id>c02cbf29-b63d-46ef-9e2a-58a69679de4a</Id>
+      <Database Name="cv" Series="72272" Issue="475933" />
     </Book>
     <Book Series="Captain Marvel" Number="12" Volume="2014" Year="2015">
-      <Id>09cbe2b2-7fe9-4d9b-8b93-b378def5338e</Id>
+      <Database Name="cv" Series="72272" Issue="479256" />
     </Book>
     <Book Series="Captain Marvel" Number="13" Volume="2014" Year="2015">
-      <Id>00039aa4-2d8e-4b2a-b316-354f49ce2c26</Id>
+      <Database Name="cv" Series="72272" Issue="482153" />
     </Book>
     <Book Series="Captain Marvel" Number="14" Volume="2014" Year="2015">
-      <Id>041ed1a3-eed4-45d4-a61d-a879bf0ab6fd</Id>
+      <Database Name="cv" Series="72272" Issue="485509" />
     </Book>
     <Book Series="Captain Marvel" Number="15" Volume="2014" Year="2015">
-      <Id>a686381e-dd3c-4baf-81df-e6e6c7ef2ffa</Id>
+      <Database Name="cv" Series="72272" Issue="488645" />
     </Book>
     <Book Series="Ms. Marvel" Number="1" Volume="2014" Year="2014">
-      <Id>11ad86e5-3f4e-47cb-b716-07bed1c02ae1</Id>
+      <Database Name="cv" Series="71457" Issue="444534" />
     </Book>
     <Book Series="Ms. Marvel" Number="2" Volume="2014" Year="2014">
-      <Id>335751d0-c1d2-4ae3-bd19-c410288567c2</Id>
+      <Database Name="cv" Series="71457" Issue="447998" />
     </Book>
     <Book Series="Ms. Marvel" Number="3" Volume="2014" Year="2014">
-      <Id>2bceb203-1ae6-481c-ba16-11c551b58092</Id>
+      <Database Name="cv" Series="71457" Issue="450552" />
     </Book>
     <Book Series="Ms. Marvel" Number="4" Volume="2014" Year="2014">
-      <Id>c80f4ac0-76c4-422e-80bf-0c83b305bba9</Id>
+      <Database Name="cv" Series="71457" Issue="454105" />
     </Book>
     <Book Series="Ms. Marvel" Number="5" Volume="2014" Year="2014">
-      <Id>5902518c-9270-4b0f-816b-51c39f72dbaa</Id>
+      <Database Name="cv" Series="71457" Issue="457643" />
     </Book>
     <Book Series="Ms. Marvel" Number="6" Volume="2014" Year="2014">
-      <Id>ff8f70ac-81d0-4847-9052-6b93cae97259</Id>
+      <Database Name="cv" Series="71457" Issue="459674" />
     </Book>
     <Book Series="Ms. Marvel" Number="7" Volume="2014" Year="2014">
-      <Id>3906331c-9ef0-4102-9a95-4ec81014fd98</Id>
+      <Database Name="cv" Series="71457" Issue="462895" />
     </Book>
     <Book Series="Ms. Marvel" Number="8" Volume="2014" Year="2014">
-      <Id>b8e26de4-2688-48eb-ac76-ee2e5bf6b679</Id>
+      <Database Name="cv" Series="71457" Issue="464986" />
     </Book>
     <Book Series="Ms. Marvel" Number="9" Volume="2014" Year="2014">
-      <Id>31b2c3da-9121-4521-a4f5-7a9066ea5447</Id>
+      <Database Name="cv" Series="71457" Issue="468083" />
     </Book>
     <Book Series="Ms. Marvel" Number="10" Volume="2014" Year="2015">
-      <Id>dfe0bd9f-233e-4e5e-839b-df4cbc096267</Id>
+      <Database Name="cv" Series="71457" Issue="473653" />
     </Book>
     <Book Series="Ms. Marvel" Number="11" Volume="2014" Year="2015">
-      <Id>36982b9b-a8fb-430e-b524-2f6721e80137</Id>
+      <Database Name="cv" Series="71457" Issue="478611" />
     </Book>
     <Book Series="Ms. Marvel" Number="12" Volume="2014" Year="2015">
-      <Id>95866dac-22e8-458e-9203-222a70deab35</Id>
+      <Database Name="cv" Series="71457" Issue="479978" />
     </Book>
     <Book Series="Ms. Marvel" Number="13" Volume="2014" Year="2015">
-      <Id>1139f916-d227-4a85-ad46-9dcbce2c5ab5</Id>
+      <Database Name="cv" Series="71457" Issue="482159" />
     </Book>
     <Book Series="Ms. Marvel" Number="14" Volume="2014" Year="2015">
-      <Id>279585b8-bf06-4913-b5ae-963052000c5b</Id>
+      <Database Name="cv" Series="71457" Issue="486151" />
     </Book>
     <Book Series="Ms. Marvel" Number="15" Volume="2014" Year="2015">
-      <Id>2fac0ffe-7bf5-4881-9913-9ddbda79fe1d</Id>
+      <Database Name="cv" Series="71457" Issue="488653" />
     </Book>
     <Book Series="Ms. Marvel" Number="16" Volume="2014" Year="2015">
-      <Id>55dbe83a-825d-4e47-b46f-8fdc009a433f</Id>
+      <Database Name="cv" Series="71457" Issue="492221" />
     </Book>
     <Book Series="Ms. Marvel" Number="17" Volume="2014" Year="2015">
-      <Id>75157c46-47ed-4593-881a-7a9b50c93294</Id>
+      <Database Name="cv" Series="71457" Issue="496886" />
     </Book>
     <Book Series="Ms. Marvel" Number="18" Volume="2014" Year="2015">
-      <Id>26be2bbe-13b3-4129-be84-1f47909f96ef</Id>
+      <Database Name="cv" Series="71457" Issue="499749" />
     </Book>
     <Book Series="Ms. Marvel" Number="19" Volume="2014" Year="2015">
-      <Id>fe620839-eb57-4df2-8451-ffd1997101c3</Id>
+      <Database Name="cv" Series="71457" Issue="502870" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Captain Marvel/Captain Marvel.cbl
+++ b/Marvel/Characters/unsorted/Captain Marvel/Captain Marvel.cbl
@@ -8,250 +8,250 @@
     <Book Series="Marvel Super-Heroes" Number="13" Volume="1967" Year="1968">
       <Id>25140366-e59e-4245-b44c-d5d089fe0fb3</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="1" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="Captain Marvel" Number="1" Volume="1968" Year="1968">
       <Id>51436de0-e07d-4318-a0e0-218a6cc61877</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="2" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="Captain Marvel" Number="2" Volume="1968" Year="1968">
       <Id>2273b3ff-2247-407b-b753-12ce7198f171</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="3" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="Captain Marvel" Number="3" Volume="1968" Year="1968">
       <Id>23eccdb6-1668-4a6c-8af8-9c9e9a52b226</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="4" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="Captain Marvel" Number="4" Volume="1968" Year="1968">
       <Id>5169f841-f744-4b92-9771-0def965b664f</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="5" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="Captain Marvel" Number="5" Volume="1968" Year="1968">
       <Id>b24678a6-2d34-4b06-adf4-87e8e6f86f42</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="6" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="Captain Marvel" Number="6" Volume="1968" Year="1968">
       <Id>ece6ec58-c4cf-41e2-8ef1-3db9d61580b9</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="7" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="Captain Marvel" Number="7" Volume="1968" Year="1968">
       <Id>c292aead-5a80-4ca5-99a1-eead6b8cb248</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="8" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="Captain Marvel" Number="8" Volume="1968" Year="1968">
       <Id>4153f503-6f2e-4f0d-a190-80a797a635c2</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="9" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="Captain Marvel" Number="9" Volume="1968" Year="1969">
       <Id>3bb0704c-bcac-4d66-9888-5cf2cfacaeb5</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="10" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="Captain Marvel" Number="10" Volume="1968" Year="1969">
       <Id>a339d5e2-b7e7-4255-af15-f8731533d250</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="11" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="Captain Marvel" Number="11" Volume="1968" Year="1969">
       <Id>3699236a-3ef6-4804-9a57-0a66fc4366a3</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="12" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="Captain Marvel" Number="12" Volume="1968" Year="1969">
       <Id>abfc9a8a-2df0-4585-8db8-9d68d0b2ba2e</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="13" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="Captain Marvel" Number="13" Volume="1968" Year="1969">
       <Id>c796b85f-bac4-4186-97e1-d04af8a59691</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="14" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="Captain Marvel" Number="14" Volume="1968" Year="1969">
       <Id>25463d88-ddd0-4131-9ff8-2489751bdca0</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="15" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="Captain Marvel" Number="15" Volume="1968" Year="1969">
       <Id>4a231b19-e7c0-4561-9181-867b31b94677</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="16" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="Captain Marvel" Number="16" Volume="1968" Year="1969">
       <Id>51d66256-87ef-43ed-8195-d735a6dfde79</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="17" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="Captain Marvel" Number="17" Volume="1968" Year="1969">
       <Id>821d7417-2ac3-4845-a890-f839f0783734</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="18" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="Captain Marvel" Number="18" Volume="1968" Year="1969">
       <Id>b7ae33cb-2169-4371-9d0b-fc96e5c7ce5d</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="19" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="Captain Marvel" Number="19" Volume="1968" Year="1969">
       <Id>186dac36-4f05-4e6f-b1cd-845724368c8d</Id>
     </Book>
-    <Book Series="The Avengers" Number="72" Volume="1963" Year="1970" Format="Main Series">
+    <Book Series="The Avengers" Number="72" Volume="1963" Year="1970">
       <Id>61f49a89-d8d8-45db-892a-253bd1048769</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="20" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="Captain Marvel" Number="20" Volume="1968" Year="1970">
       <Id>3810e3c2-cf67-4ef1-b4ab-044c7d993282</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="21" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="Captain Marvel" Number="21" Volume="1968" Year="1970">
       <Id>6243c9e2-a24e-4b0b-a4ea-5c992e6a0037</Id>
     </Book>
-    <Book Series="Iron Man" Number="55" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="Iron Man" Number="55" Volume="1968" Year="1973">
       <Id>caf69006-c97f-4c8e-9d86-aea0d67f0d4b</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="30" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="30" Volume="1968" Year="1970">
       <Id>6987c868-6051-4000-a2ef-ea3558e01eca</Id>
     </Book>
-    <Book Series="The Avengers" Number="89" Volume="1963" Year="1971" Format="Main Series">
+    <Book Series="The Avengers" Number="89" Volume="1963" Year="1971">
       <Id>2b86fcd6-c08b-436b-8840-c7aeacb3776b</Id>
     </Book>
-    <Book Series="The Avengers" Number="90" Volume="1963" Year="1971" Format="Main Series">
+    <Book Series="The Avengers" Number="90" Volume="1963" Year="1971">
       <Id>4fef8ed3-c5d5-41a7-ad93-a2b6313a8b6a</Id>
     </Book>
-    <Book Series="The Avengers" Number="91" Volume="1963" Year="1971" Format="Main Series">
+    <Book Series="The Avengers" Number="91" Volume="1963" Year="1971">
       <Id>8aaadfe0-f4a1-421f-b869-81d1a9d93e0e</Id>
     </Book>
-    <Book Series="The Avengers" Number="92" Volume="1963" Year="1971" Format="Main Series">
+    <Book Series="The Avengers" Number="92" Volume="1963" Year="1971">
       <Id>60a1e9c0-e7b3-4a53-b72a-ca211ccde05f</Id>
     </Book>
-    <Book Series="The Avengers" Number="93" Volume="1963" Year="1971" Format="Main Series">
+    <Book Series="The Avengers" Number="93" Volume="1963" Year="1971">
       <Id>fe5fcc09-5659-4feb-907a-6cdbc6b35cb9</Id>
     </Book>
-    <Book Series="The Avengers" Number="94" Volume="1963" Year="1971" Format="Main Series">
+    <Book Series="The Avengers" Number="94" Volume="1963" Year="1971">
       <Id>9f5eb565-f394-4f45-8723-5f5f0e9fe7f0</Id>
     </Book>
-    <Book Series="The Avengers" Number="95" Volume="1963" Year="1972" Format="Main Series">
+    <Book Series="The Avengers" Number="95" Volume="1963" Year="1972">
       <Id>7724d45b-83ca-40ab-bcf1-4cf54b8f6b08</Id>
     </Book>
-    <Book Series="The Avengers" Number="96" Volume="1963" Year="1972" Format="Main Series">
+    <Book Series="The Avengers" Number="96" Volume="1963" Year="1972">
       <Id>031957cd-7ff0-4489-8077-3957ca23a9bb</Id>
     </Book>
-    <Book Series="The Avengers" Number="97" Volume="1963" Year="1972" Format="Main Series">
+    <Book Series="The Avengers" Number="97" Volume="1963" Year="1972">
       <Id>fc09a34b-aa82-464f-bc62-767de1d877a9</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="22" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="Captain Marvel" Number="22" Volume="1968" Year="1972">
       <Id>01e77595-ad42-4a01-8c5e-f18d9522c012</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="23" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="Captain Marvel" Number="23" Volume="1968" Year="1972">
       <Id>57e545cc-ad69-4f62-8aed-b4e9e17677e8</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="24" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="Captain Marvel" Number="24" Volume="1968" Year="1973">
       <Id>a49f487b-9016-46cb-8c8c-bcf50da94c18</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="25" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="Captain Marvel" Number="25" Volume="1968" Year="1973">
       <Id>96914c7b-f6f8-4186-835e-7c582f8bd09f</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="26" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="Captain Marvel" Number="26" Volume="1968" Year="1973">
       <Id>55250504-d211-48ee-ab69-aa2ea1da26a1</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="27" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="Captain Marvel" Number="27" Volume="1968" Year="1973">
       <Id>a88e7531-075c-4468-a3d5-f7ebc2a8fdf7</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="28" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="Captain Marvel" Number="28" Volume="1968" Year="1973">
       <Id>4c8286a3-619a-42a7-a6e3-0d33514c254d</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="29" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="Captain Marvel" Number="29" Volume="1968" Year="1973">
       <Id>c4588694-ca54-4ace-9b2b-5b741ed4df0a</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="30" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="Captain Marvel" Number="30" Volume="1968" Year="1974">
       <Id>4552c428-162b-4f84-91b7-44f8ac53c37b</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="16" Volume="1972" Year="1973" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="16" Volume="1972" Year="1973">
       <Id>61fc3960-f82f-4b29-9ae1-b123ee13be41</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="17" Volume="1972" Year="1974" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="17" Volume="1972" Year="1974">
       <Id>1d20df12-2e90-4627-ab7f-daa6f1203168</Id>
     </Book>
-    <Book Series="Daredevil" Number="107" Volume="1964" Year="1974" Format="Main Series">
+    <Book Series="Daredevil" Number="107" Volume="1964" Year="1974">
       <Id>440da1ba-654d-45eb-9f33-61a9db690ecd</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="31" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="Captain Marvel" Number="31" Volume="1968" Year="1974">
       <Id>d6d468ec-b052-45b6-8993-9e9278628d12</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="32" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="Captain Marvel" Number="32" Volume="1968" Year="1974">
       <Id>8aa93bc6-7759-470e-aa39-ab309b24054e</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="33" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="Captain Marvel" Number="33" Volume="1968" Year="1974">
       <Id>b4bac5ad-b46c-4735-b048-84d0ba668e4f</Id>
     </Book>
-    <Book Series="The Avengers" Number="125" Volume="1963" Year="1974" Format="Main Series">
+    <Book Series="The Avengers" Number="125" Volume="1963" Year="1974">
       <Id>77c6aad0-fec8-491e-8afc-bb45ee458f2d</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="34" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="Captain Marvel" Number="34" Volume="1968" Year="1974">
       <Id>b7b964e2-00ec-424d-b0e2-a77890d47966</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="35" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="Captain Marvel" Number="35" Volume="1968" Year="1974">
       <Id>a50551b0-8dbe-42be-afb4-8aaa38c56e89</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="36" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="Captain Marvel" Number="36" Volume="1968" Year="1975">
       <Id>67f25840-e265-4a8e-b43c-e9fdcff2a331</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="37" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="Captain Marvel" Number="37" Volume="1968" Year="1975">
       <Id>0f8a5663-9979-4ec6-9d7c-1b4a5ae1229d</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="38" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="Captain Marvel" Number="38" Volume="1968" Year="1975">
       <Id>f37923c5-8dd4-4bb0-a747-a8ad4e6690ca</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="39" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="Captain Marvel" Number="39" Volume="1968" Year="1975">
       <Id>63695395-b78d-40d3-9f4e-dcd8a7fe1104</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="40" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="Captain Marvel" Number="40" Volume="1968" Year="1975">
       <Id>67668a0a-8d32-4e8f-b8a6-0c3fc7190a19</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="41" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="Captain Marvel" Number="41" Volume="1968" Year="1975">
       <Id>ae8881db-e650-42dd-a202-3c7b0c63e413</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="42" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="Captain Marvel" Number="42" Volume="1968" Year="1976">
       <Id>585a6f01-02ba-4cee-9bbe-a4fbf25e5cd5</Id>
     </Book>
-    <Book Series="Warlock" Number="10" Volume="1972" Year="1975" Format="Main Series">
+    <Book Series="Warlock" Number="10" Volume="1972" Year="1975">
       <Id>3a05c737-d565-4e76-babe-54ff594b37dd</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="43" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="Captain Marvel" Number="43" Volume="1968" Year="1976">
       <Id>b5b6042d-6337-4bef-bf90-86a944c9d64d</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="44" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="Captain Marvel" Number="44" Volume="1968" Year="1976">
       <Id>e963648c-f5b7-42e8-9896-dde494fc85b9</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="45" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="Captain Marvel" Number="45" Volume="1968" Year="1976">
       <Id>1c76bd65-2611-476b-8522-f4cb38114c25</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="46" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="Captain Marvel" Number="46" Volume="1968" Year="1976">
       <Id>d9065e43-92dd-4fff-8f8e-f8049f15161f</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="47" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="Captain Marvel" Number="47" Volume="1968" Year="1976">
       <Id>d9a7f90d-65c0-4c7d-81e0-b91277a454d8</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="48" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="Captain Marvel" Number="48" Volume="1968" Year="1977">
       <Id>9bd3dde0-f5d8-43f2-994b-e2d1a657d088</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="49" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="Captain Marvel" Number="49" Volume="1968" Year="1977">
       <Id>200d34c9-a252-4bfd-aeb1-aa35acf4515a</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="50" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="Captain Marvel" Number="50" Volume="1968" Year="1977">
       <Id>424c52b6-c304-4c81-90bd-c2edfcd285ef</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="51" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="Captain Marvel" Number="51" Volume="1968" Year="1977">
       <Id>23693453-8676-42eb-bb80-930e48263653</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="52" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="Captain Marvel" Number="52" Volume="1968" Year="1977">
       <Id>02dcb85f-568e-4323-a3e8-ec63c45d32af</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="53" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="Captain Marvel" Number="53" Volume="1968" Year="1977">
       <Id>500729af-5ebd-489f-81d9-e498c109151b</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="54" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="Captain Marvel" Number="54" Volume="1968" Year="1978">
       <Id>593ee455-8a98-4d78-923f-ba7cb41ef825</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="55" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="Captain Marvel" Number="55" Volume="1968" Year="1978">
       <Id>c2d78412-0606-4f47-9267-007f489ad4d4</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="56" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="Captain Marvel" Number="56" Volume="1968" Year="1978">
       <Id>a2ef7453-4a38-4edb-a074-8b248c5964a1</Id>
     </Book>
-    <Book Series="The Avengers Annual" Number="7" Volume="1967" Year="1977" Format="Annual">
+    <Book Series="The Avengers Annual" Number="7" Volume="1967" Year="1977">
       <Id>0aa90811-03da-40cd-8bd4-e8238a5f5597</Id>
     </Book>
-    <Book Series="Marvel Two-in-One Annual" Number="2" Volume="1976" Year="1977" Format="Annual">
+    <Book Series="Marvel Two-in-One Annual" Number="2" Volume="1976" Year="1977">
       <Id>2f77e350-ea10-40c6-9466-27ab677093e8</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="57" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="Captain Marvel" Number="57" Volume="1968" Year="1978">
       <Id>8b6ddae5-8b0c-4a7e-8eef-1b4f784a9119</Id>
     </Book>
-    <Book Series="Marvel Two-in-One" Number="45" Volume="1974" Year="1978" Format="Main Series">
+    <Book Series="Marvel Two-in-One" Number="45" Volume="1974" Year="1978">
       <Id>038fa77f-3f1c-4f4e-b02c-16b3c08e50ee</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="58" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="Captain Marvel" Number="58" Volume="1968" Year="1978">
       <Id>9c36b50a-1b5b-46f5-b37c-56523bb3392f</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="59" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="Captain Marvel" Number="59" Volume="1968" Year="1978">
       <Id>94c4f1e4-de29-4d16-8eff-caea1b77362d</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="60" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="Captain Marvel" Number="60" Volume="1968" Year="1979">
       <Id>a0385fc2-606f-4b25-827d-15d7b3cc71f4</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="61" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="Captain Marvel" Number="61" Volume="1968" Year="1979">
       <Id>52162ce1-cd2b-45f0-9eea-c07c193e5f17</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="62" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="Captain Marvel" Number="62" Volume="1968" Year="1979">
       <Id>62db833e-2919-48bb-a13b-198479f2f03f</Id>
     </Book>
     <Book Series="Marvel Spotlight" Number="1" Volume="1979" Year="1979">
@@ -266,655 +266,655 @@
     <Book Series="Marvel Spotlight" Number="4" Volume="1979" Year="1980">
       <Id>41920409-fcb5-40bc-a284-c770f58a9650</Id>
     </Book>
-    <Book Series="Marvel Two-in-One" Number="69" Volume="1974" Year="1980" Format="Main Series">
+    <Book Series="Marvel Two-in-One" Number="69" Volume="1974" Year="1980">
       <Id>effe2a8e-b559-4df0-8690-8f72a85614ce</Id>
     </Book>
     <Book Series="Marvel Spotlight" Number="8" Volume="1979" Year="1980">
       <Id>2721fc3e-49e4-4564-a715-01ad9b737db5</Id>
     </Book>
-    <Book Series="Marvel Graphic Novel" Number="1" Volume="1982" Year="1982" Format="One-Shot">
+    <Book Series="Marvel Graphic Novel" Number="1" Volume="1982" Year="1982">
       <Id>6655ec2d-c2c7-4ce1-a5e9-e39956983b3a</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="1" Volume="1977" Year="1977" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="1" Volume="1977" Year="1977">
       <Id>b8f60cc5-79b0-4508-891c-a312c3a2f5f7</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="2" Volume="1977" Year="1977" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="2" Volume="1977" Year="1977">
       <Id>4b5275d4-7f29-4832-8e7f-cb6b787c852f</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="3" Volume="1977" Year="1977" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="3" Volume="1977" Year="1977">
       <Id>bfb2f820-e8c2-4cdc-b3dc-8c16cda8c802</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="4" Volume="1977" Year="1977" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="4" Volume="1977" Year="1977">
       <Id>ec45ce30-07b3-4a68-b785-076292b0190c</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="5" Volume="1977" Year="1977" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="5" Volume="1977" Year="1977">
       <Id>f0fdf2bc-ebd2-4cc4-9db1-1f540e3a7ff1</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="6" Volume="1977" Year="1977" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="6" Volume="1977" Year="1977">
       <Id>bfb767ba-c24d-4e95-8884-7e47e0c2ff8d</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="7" Volume="1977" Year="1977" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="7" Volume="1977" Year="1977">
       <Id>c7be81d8-b781-4be8-afe1-9c0963b69d47</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="8" Volume="1977" Year="1977" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="8" Volume="1977" Year="1977">
       <Id>58f3c712-1c05-4249-90ec-8573113336c7</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="9" Volume="1977" Year="1977" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="9" Volume="1977" Year="1977">
       <Id>30caa3b5-afc7-404d-b6e2-460c561ca88f</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="10" Volume="1977" Year="1977" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="10" Volume="1977" Year="1977">
       <Id>615fd8d4-37c2-41ce-91b9-fa8decd6602b</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="61" Volume="1972" Year="1977" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="61" Volume="1972" Year="1977">
       <Id>4fb505ec-4d28-4e31-b10c-663b53c784e1</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="62" Volume="1972" Year="1977" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="62" Volume="1972" Year="1977">
       <Id>bf924923-901b-4796-a9fe-f3de78b6cee2</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="11" Volume="1977" Year="1977" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="11" Volume="1977" Year="1977">
       <Id>96e14d8d-22e1-454f-84f6-f1184d0b15f8</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="12" Volume="1977" Year="1977" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="12" Volume="1977" Year="1977">
       <Id>dfa0161b-b7d6-4576-8bf9-51ffba6a29b3</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="13" Volume="1977" Year="1978" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="13" Volume="1977" Year="1978">
       <Id>9e82d82a-cba9-45d5-88c3-6b91fcaa65d4</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="14" Volume="1977" Year="1978" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="14" Volume="1977" Year="1978">
       <Id>95160f93-3364-4847-8aef-62c531d6be97</Id>
     </Book>
-    <Book Series="The Defenders" Number="57" Volume="1972" Year="1978" Format="Main Series">
+    <Book Series="The Defenders" Number="57" Volume="1972" Year="1978">
       <Id>aacb64c0-2509-4522-a913-6242765b9f48</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="15" Volume="1977" Year="1978" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="15" Volume="1977" Year="1978">
       <Id>ffa14b74-e408-41e9-9025-3dc51fbc0025</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="16" Volume="1977" Year="1978" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="16" Volume="1977" Year="1978">
       <Id>43890636-55b5-4bb3-99a8-3c8c9e9b52cc</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="17" Volume="1977" Year="1978" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="17" Volume="1977" Year="1978">
       <Id>0614b984-5179-432e-a9b3-7923a2a2f70d</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="19" Volume="1977" Year="1978" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="19" Volume="1977" Year="1978">
       <Id>84069a59-92ee-4f60-8214-2bc6e2fc9986</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="18" Volume="1977" Year="1978" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="18" Volume="1977" Year="1978">
       <Id>bd03bd91-6bfb-4c26-a248-bb410ea245ea</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="20" Volume="1977" Year="1978" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="20" Volume="1977" Year="1978">
       <Id>decc950a-846b-4c10-a2fe-02b80687ffcb</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="21" Volume="1977" Year="1978" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="21" Volume="1977" Year="1978">
       <Id>219c245d-5466-4bc4-8a07-38f01d983f07</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="22" Volume="1977" Year="1979" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="22" Volume="1977" Year="1979">
       <Id>b1f53964-039c-4bb6-b8e8-ccf09d23ffd6</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="77" Volume="1972" Year="1979" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="77" Volume="1972" Year="1979">
       <Id>26a2d197-62f9-45e0-96e1-3bd61fe537dd</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="23" Volume="1977" Year="1979" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="23" Volume="1977" Year="1979">
       <Id>fe9a7db3-90a7-4f9c-9801-caf87f69170d</Id>
     </Book>
-    <Book Series="Marvel Two-in-One" Number="51" Volume="1974" Year="1979" Format="Main Series">
+    <Book Series="Marvel Two-in-One" Number="51" Volume="1974" Year="1979">
       <Id>d665e7c3-1736-41ea-913a-e50c1fafc7ce</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="24" Volume="1977" Year="1979" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="24" Volume="1977" Year="1979">
       <Id>4dd7106c-8b93-4c9d-b4a2-31af764e2c56</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="25" Volume="1977" Year="1979" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="25" Volume="1977" Year="1979">
       <Id>e6848c02-6ae6-4292-9b2f-841f2e633085</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="1" Volume="1989" Year="1989" Format="One-Shot">
+    <Book Series="Captain Marvel" Number="1" Volume="1989" Year="1989">
       <Id>6ce86e1c-7968-4f5a-8102-b142700dd70d</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="1" Volume="1994" Year="1994" Format="One-Shot">
+    <Book Series="Captain Marvel" Number="1" Volume="1994" Year="1994">
       <Id>774e93cd-293e-46ca-9377-efdcd0f308f6</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="1" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Captain Marvel" Number="1" Volume="1995" Year="1995">
       <Id>6b92b4d5-6171-41c6-851d-88eb3adfb1eb</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="2" Volume="1995" Year="1996" Format="Limited Series">
+    <Book Series="Captain Marvel" Number="2" Volume="1995" Year="1996">
       <Id>4a2151ab-6576-45e8-9970-6fe60fa7ee47</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="3" Volume="1995" Year="1996" Format="Limited Series">
+    <Book Series="Captain Marvel" Number="3" Volume="1995" Year="1996">
       <Id>23afa3eb-3cdc-4380-bca4-576256880909</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="4" Volume="1995" Year="1996" Format="Limited Series">
+    <Book Series="Captain Marvel" Number="4" Volume="1995" Year="1996">
       <Id>9ec9b023-db44-4f82-9ca8-25751576be0c</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="5" Volume="1995" Year="1996" Format="Limited Series">
+    <Book Series="Captain Marvel" Number="5" Volume="1995" Year="1996">
       <Id>2f1230e1-f295-4159-89ac-4fb3ad82d3dd</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="6" Volume="1995" Year="1996" Format="Limited Series">
+    <Book Series="Captain Marvel" Number="6" Volume="1995" Year="1996">
       <Id>34a2c325-bf91-48d0-aa43-8d816199e997</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="0" Volume="2000" Year="1999" Format="Main Series">
+    <Book Series="Captain Marvel" Number="0" Volume="2000" Year="1999">
       <Id>5323f4a0-07a9-4336-b96e-7da9daf089e3</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="1" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Captain Marvel" Number="1" Volume="2000" Year="2000">
       <Id>d1c84fc7-cb66-4924-b05e-7143c2ece5f4</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="2" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Captain Marvel" Number="2" Volume="2000" Year="2000">
       <Id>c9c92888-223a-43cd-8867-8a12bd807ed5</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="3" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Captain Marvel" Number="3" Volume="2000" Year="2000">
       <Id>3ec62eae-7af4-4818-9f26-c0025e564a0b</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="4" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Captain Marvel" Number="4" Volume="2000" Year="2000">
       <Id>2a841d27-d687-44c8-b9c6-ea90541531e4</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="5" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Captain Marvel" Number="5" Volume="2000" Year="2000">
       <Id>da7ebcda-03da-4d56-90b3-565df15506c9</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="6" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Captain Marvel" Number="6" Volume="2000" Year="2000">
       <Id>35ed5526-858d-4183-ae03-afa4bb5a8b4d</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="7" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Captain Marvel" Number="7" Volume="2000" Year="2000">
       <Id>fe635d83-e173-4a2e-8897-5b3c9b787b4e</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="8" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Captain Marvel" Number="8" Volume="2000" Year="2000">
       <Id>ab836853-ddef-45c4-9696-178df208e8fe</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="9" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Captain Marvel" Number="9" Volume="2000" Year="2000">
       <Id>0a3e2feb-e9e8-42f8-a6e2-d702ca2605f2</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="10" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Captain Marvel" Number="10" Volume="2000" Year="2000">
       <Id>6b1a8715-c310-4f75-812d-0c2c2c95967b</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="11" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Captain Marvel" Number="11" Volume="2000" Year="2000">
       <Id>1ba351df-5f94-456d-b529-5c5d47f9ebcd</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="12" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Captain Marvel" Number="12" Volume="2000" Year="2000">
       <Id>7272e1ce-e998-4571-a090-62ef6eded8ed</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="13" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Captain Marvel" Number="13" Volume="2000" Year="2001">
       <Id>c1874472-abe4-499e-bf85-f985e2780e7e</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="14" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Captain Marvel" Number="14" Volume="2000" Year="2001">
       <Id>14ffc486-bdf6-4455-b2ca-30960daa799d</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="15" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Captain Marvel" Number="15" Volume="2000" Year="2001">
       <Id>b249b95c-54ed-48df-b8b5-e278abd23cff</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="16" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Captain Marvel" Number="16" Volume="2000" Year="2001">
       <Id>dacb7686-b0e0-423d-b1b9-3c7bfc114c31</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="17" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Captain Marvel" Number="17" Volume="2000" Year="2001">
       <Id>fc09084c-6c11-453c-8fc6-18b4a00c0a17</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="18" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Captain Marvel" Number="18" Volume="2000" Year="2001">
       <Id>c3e92fe1-9e0e-451f-b62c-53ad86303fe9</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="19" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Captain Marvel" Number="19" Volume="2000" Year="2001">
       <Id>b295b9d3-32cb-4267-9a87-cde25d180be3</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="20" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Captain Marvel" Number="20" Volume="2000" Year="2001">
       <Id>0874e1c7-939b-423f-abd6-87f1c2448d9c</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="21" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Captain Marvel" Number="21" Volume="2000" Year="2001">
       <Id>59f0268b-c699-4538-a078-ed766a59035e</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="22" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Captain Marvel" Number="22" Volume="2000" Year="2001">
       <Id>3c0c505c-fff5-454e-b078-ee024d5fc83f</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="23" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Captain Marvel" Number="23" Volume="2000" Year="2001">
       <Id>f1b1cdd3-857b-4af8-97f3-2aff7090a299</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="24" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Captain Marvel" Number="24" Volume="2000" Year="2001">
       <Id>9a995ba3-e51f-49df-a25c-229efdd4bfa2</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="25" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Captain Marvel" Number="25" Volume="2000" Year="2002">
       <Id>90d42173-2960-47a2-8d14-dad90e599db6</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="26" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Captain Marvel" Number="26" Volume="2000" Year="2002">
       <Id>cfddb514-6657-4bb7-9fa9-af6215b78da8</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="27" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Captain Marvel" Number="27" Volume="2000" Year="2002">
       <Id>3bfbe80a-55c0-43c1-bf7f-6e41d076e2fc</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="28" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Captain Marvel" Number="28" Volume="2000" Year="2002">
       <Id>d2210fc0-53a6-48a3-963a-a6eaf9d0e721</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="29" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Captain Marvel" Number="29" Volume="2000" Year="2002">
       <Id>c71678e5-d680-47b3-8941-cb42f71ebce1</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="30" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Captain Marvel" Number="30" Volume="2000" Year="2002">
       <Id>1fc51db8-77ce-4467-9f8c-355a47d003fb</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="31" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Captain Marvel" Number="31" Volume="2000" Year="2002">
       <Id>8d3b2b97-869b-4d86-938c-3ff3f007e622</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="32" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Captain Marvel" Number="32" Volume="2000" Year="2002">
       <Id>3a3e5a75-01a2-4218-81d2-5a395f5955c8</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="33" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Captain Marvel" Number="33" Volume="2000" Year="2002">
       <Id>d04d3ee5-ca4a-42a8-9f00-bda771febd8a</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="34" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Captain Marvel" Number="34" Volume="2000" Year="2002">
       <Id>239f15b4-2c01-4d01-8a72-0c7d68967503</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="35" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Captain Marvel" Number="35" Volume="2000" Year="2002">
       <Id>a18fde17-5137-4c68-992a-fcf640d574cb</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="1" Volume="2002" Year="2002" Format="Main Series">
+    <Book Series="Captain Marvel" Number="1" Volume="2002" Year="2002">
       <Id>6deed2ba-9c8b-421c-9c29-82731d7ec874</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="2" Volume="2002" Year="2002" Format="Main Series">
+    <Book Series="Captain Marvel" Number="2" Volume="2002" Year="2002">
       <Id>d046f68d-fbaa-4c0a-85d2-c5a8f858ca6a</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="3" Volume="2002" Year="2003" Format="Main Series">
+    <Book Series="Captain Marvel" Number="3" Volume="2002" Year="2003">
       <Id>b1519a45-c260-46d3-901d-0be584defc59</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="4" Volume="2002" Year="2003" Format="Main Series">
+    <Book Series="Captain Marvel" Number="4" Volume="2002" Year="2003">
       <Id>44a4a458-2feb-4e60-b9ab-249eabdf3506</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="5" Volume="2002" Year="2003" Format="Main Series">
+    <Book Series="Captain Marvel" Number="5" Volume="2002" Year="2003">
       <Id>e2067224-01d7-4960-b767-e95b8028b307</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="6" Volume="2002" Year="2003" Format="Main Series">
+    <Book Series="Captain Marvel" Number="6" Volume="2002" Year="2003">
       <Id>9d816892-3490-4403-86ec-420f7c62c63f</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="7" Volume="2002" Year="2003" Format="Main Series">
+    <Book Series="Captain Marvel" Number="7" Volume="2002" Year="2003">
       <Id>33b9982d-c289-4fe4-b08f-adc5b3212a98</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="8" Volume="2002" Year="2003" Format="Main Series">
+    <Book Series="Captain Marvel" Number="8" Volume="2002" Year="2003">
       <Id>6159ff7f-2927-4836-9d21-b6787085e6ad</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="9" Volume="2002" Year="2003" Format="Main Series">
+    <Book Series="Captain Marvel" Number="9" Volume="2002" Year="2003">
       <Id>31936a53-1873-4789-a7dd-ff3cf1b025c9</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="10" Volume="2002" Year="2003" Format="Main Series">
+    <Book Series="Captain Marvel" Number="10" Volume="2002" Year="2003">
       <Id>10bcccfb-596f-4536-be09-4ecc5322e08b</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="11" Volume="2002" Year="2003" Format="Main Series">
+    <Book Series="Captain Marvel" Number="11" Volume="2002" Year="2003">
       <Id>41b36985-ad41-4328-9ea6-3b714fdf2cee</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="12" Volume="2002" Year="2003" Format="Main Series">
+    <Book Series="Captain Marvel" Number="12" Volume="2002" Year="2003">
       <Id>d4a7c073-2149-431d-93ee-19fef4d9ed40</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="13" Volume="2002" Year="2003" Format="Main Series">
+    <Book Series="Captain Marvel" Number="13" Volume="2002" Year="2003">
       <Id>1ebf151d-e588-4fc9-b236-b77f4885262c</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="14" Volume="2002" Year="2003" Format="Main Series">
+    <Book Series="Captain Marvel" Number="14" Volume="2002" Year="2003">
       <Id>c7cadb2e-563f-4e47-8983-d3c6ec90b5d9</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="15" Volume="2002" Year="2003" Format="Main Series">
+    <Book Series="Captain Marvel" Number="15" Volume="2002" Year="2003">
       <Id>0e4aec78-7efa-4ae1-998b-d4b6e292ffb0</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="16" Volume="2002" Year="2004" Format="Main Series">
+    <Book Series="Captain Marvel" Number="16" Volume="2002" Year="2004">
       <Id>2a96109a-c594-4767-b408-d5f39154cc28</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="17" Volume="2002" Year="2004" Format="Main Series">
+    <Book Series="Captain Marvel" Number="17" Volume="2002" Year="2004">
       <Id>d2dbb23f-f655-4ab7-bb2f-dcfd5a271e83</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="18" Volume="2002" Year="2004" Format="Main Series">
+    <Book Series="Captain Marvel" Number="18" Volume="2002" Year="2004">
       <Id>fa371130-ee66-4d7e-8909-3cc37a27106e</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="19" Volume="2002" Year="2004" Format="Main Series">
+    <Book Series="Captain Marvel" Number="19" Volume="2002" Year="2004">
       <Id>2c52277e-d09d-4a23-962d-732012da05d3</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="20" Volume="2002" Year="2004" Format="Main Series">
+    <Book Series="Captain Marvel" Number="20" Volume="2002" Year="2004">
       <Id>a4a81a5d-9096-48d2-94cf-c18485823951</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="21" Volume="2002" Year="2004" Format="Main Series">
+    <Book Series="Captain Marvel" Number="21" Volume="2002" Year="2004">
       <Id>e85aeef6-78c2-4125-8ac5-51b590d1cdfe</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="22" Volume="2002" Year="2004" Format="Main Series">
+    <Book Series="Captain Marvel" Number="22" Volume="2002" Year="2004">
       <Id>8b140dd5-b13c-46e9-8e2d-ac23333098ad</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="23" Volume="2002" Year="2004" Format="Main Series">
+    <Book Series="Captain Marvel" Number="23" Volume="2002" Year="2004">
       <Id>1cb818b1-6e72-401a-b4f6-3034b8c6573b</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="24" Volume="2002" Year="2004" Format="Main Series">
+    <Book Series="Captain Marvel" Number="24" Volume="2002" Year="2004">
       <Id>35b59b0c-512f-46dc-87cd-450397365cf6</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="25" Volume="2002" Year="2004" Format="Main Series">
+    <Book Series="Captain Marvel" Number="25" Volume="2002" Year="2004">
       <Id>2f95b539-7409-4486-a939-a76cfd3102c9</Id>
     </Book>
-    <Book Series="House of M" Number="1" Volume="2005" Year="2005" Format="Crossover">
+    <Book Series="House of M" Number="1" Volume="2005" Year="2005">
       <Id>87c12880-5952-4edd-87b2-17ca0f8a8412</Id>
     </Book>
-    <Book Series="House of M" Number="2" Volume="2005" Year="2005" Format="Crossover">
+    <Book Series="House of M" Number="2" Volume="2005" Year="2005">
       <Id>cd404553-6dd2-46e2-a706-b44501cceeb5</Id>
     </Book>
-    <Book Series="House of M" Number="3" Volume="2005" Year="2005" Format="Crossover">
+    <Book Series="House of M" Number="3" Volume="2005" Year="2005">
       <Id>52c3157a-6b7b-4a3f-93a3-5c65d8105904</Id>
     </Book>
-    <Book Series="House of M" Number="4" Volume="2005" Year="2005" Format="Crossover">
+    <Book Series="House of M" Number="4" Volume="2005" Year="2005">
       <Id>a9152579-cd4a-4fcf-a9fc-a28706d29844</Id>
     </Book>
-    <Book Series="House of M" Number="5" Volume="2005" Year="2005" Format="Crossover">
+    <Book Series="House of M" Number="5" Volume="2005" Year="2005">
       <Id>83190f73-884a-416f-968b-d52aaebeacf9</Id>
     </Book>
-    <Book Series="House of M" Number="6" Volume="2005" Year="2005" Format="Crossover">
+    <Book Series="House of M" Number="6" Volume="2005" Year="2005">
       <Id>4e3ef330-2fe0-4dbb-9f12-13b2c25ec7ae</Id>
     </Book>
-    <Book Series="House of M" Number="7" Volume="2005" Year="2005" Format="Crossover">
+    <Book Series="House of M" Number="7" Volume="2005" Year="2005">
       <Id>f0bdd681-2378-4e2d-a243-4b14799eb6ca</Id>
     </Book>
-    <Book Series="House of M" Number="8" Volume="2005" Year="2005" Format="Crossover">
+    <Book Series="House of M" Number="8" Volume="2005" Year="2005">
       <Id>8a2532e6-142d-45e2-ac8a-f8a8548d6e7b</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="1" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="1" Volume="2006" Year="2006">
       <Id>c5713eb0-b005-4621-aaec-c49bf52402c0</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="2" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="2" Volume="2006" Year="2006">
       <Id>d82b7a36-8e48-413f-b1b8-a51045e2cf02</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="3" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="3" Volume="2006" Year="2006">
       <Id>956884a0-1f0d-402f-9a87-78b123f0435f</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="4" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="4" Volume="2006" Year="2006">
       <Id>fde31705-e7a1-426d-af57-e8ed53f6cfa9</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="5" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="5" Volume="2006" Year="2006">
       <Id>1bb401c0-0595-4e66-b67b-af8288efed78</Id>
     </Book>
-    <Book Series="Giant-Size Ms. Marvel" Number="1" Volume="2006" Year="2006" Format="Giant Size">
+    <Book Series="Giant-Size Ms. Marvel" Number="1" Volume="2006" Year="2006">
       <Id>9a569040-5e2e-4349-8fc5-3a6adc7bbe4a</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="6" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="6" Volume="2006" Year="2006">
       <Id>26e11a93-16bd-49bd-a944-b1e157c7487c</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="7" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="7" Volume="2006" Year="2006">
       <Id>0c406573-f376-4d2f-9d9c-9aa86208af66</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="8" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="8" Volume="2006" Year="2006">
       <Id>1741658a-a67c-4d66-8fbd-7332373ca5d2</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="9" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="9" Volume="2006" Year="2007">
       <Id>96a41692-ee3b-4350-967c-e4e09b016a17</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="10" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="10" Volume="2006" Year="2007">
       <Id>fb940de6-d265-4b1f-9683-9914f7485233</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="11" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="11" Volume="2006" Year="2007">
       <Id>0f444614-9d40-4101-96fe-37f9ce8da080</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="12" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="12" Volume="2006" Year="2007">
       <Id>1a4ab880-fe7b-430e-aa01-aa2dc66e3070</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="13" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="13" Volume="2006" Year="2007">
       <Id>5cff6805-b961-4e27-aced-620807e41ddc</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="14" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="14" Volume="2006" Year="2007">
       <Id>a2225bc7-0154-4722-8c0d-c03a0ea95ca6</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="15" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="15" Volume="2006" Year="2007">
       <Id>634c83f4-26af-49e0-b437-28d0946b8862</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="16" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="16" Volume="2006" Year="2007">
       <Id>235504ba-3cd0-4f8b-8bac-da372ad61870</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="17" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="17" Volume="2006" Year="2007">
       <Id>39ac6bb7-d3d2-437b-bd2f-abafbc89e99b</Id>
     </Book>
-    <Book Series="Ms. Marvel Annual" Number="1" Volume="2008" Year="2008" Format="Annual">
+    <Book Series="Ms. Marvel Annual" Number="1" Volume="2008" Year="2008">
       <Id>107d3334-f68a-4381-923d-a2f15760f4cd</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="18" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="18" Volume="2006" Year="2007">
       <Id>a002ceef-54d8-434e-a1dd-6a4e330e2df6</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="19" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="19" Volume="2006" Year="2007">
       <Id>a6b50cdf-5080-4e82-849b-67b11313b91c</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="20" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="20" Volume="2006" Year="2007">
       <Id>dcc77139-6e51-4fbf-b3a0-a36c926cc9cb</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="21" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="21" Volume="2006" Year="2008">
       <Id>e66cecc8-3786-4494-9477-b6f1b157c902</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="22" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="22" Volume="2006" Year="2008">
       <Id>fa02e984-49ea-4d4d-8665-59a0d8180aca</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="23" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="23" Volume="2006" Year="2008">
       <Id>4505fa0b-fbfe-4ac4-b1b7-887b0aeb268a</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="24" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="24" Volume="2006" Year="2008">
       <Id>d2ac9271-7a05-4484-88b8-ed4c089de116</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="1" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="Captain Marvel" Number="1" Volume="2008" Year="2008">
       <Id>2c7a4e69-4afe-49ec-a810-77e3b1c41819</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="2" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="Captain Marvel" Number="2" Volume="2008" Year="2008">
       <Id>4d9aa056-361f-4ca8-8700-840cb870593a</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="3" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="Captain Marvel" Number="3" Volume="2008" Year="2008">
       <Id>1224c341-9cc5-4de4-9f49-ffc6c5c03614</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="4" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="Captain Marvel" Number="4" Volume="2008" Year="2008">
       <Id>7e3e92df-0f0b-4b82-8f32-e0061ca634a2</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="5" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="Captain Marvel" Number="5" Volume="2008" Year="2008">
       <Id>f13ef942-f9c3-4972-bce1-10ffb045cbd5</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="25" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="25" Volume="2006" Year="2008">
       <Id>2a9053d8-8fe5-4e2f-8553-e9ae6d866837</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="26" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="26" Volume="2006" Year="2008">
       <Id>2d14cd4f-fb37-4c5f-991f-f303e9b78815</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="27" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="27" Volume="2006" Year="2008">
       <Id>dffa203f-cb58-4704-84fa-d133068a7ba3</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="28" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="28" Volume="2006" Year="2008">
       <Id>272918e9-39fb-4756-99c0-2bbb5a4f1461</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="29" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="29" Volume="2006" Year="2008">
       <Id>8506058f-881b-4626-87d3-09e101405cb7</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="30" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="30" Volume="2006" Year="2008">
       <Id>abe892ad-c887-41a4-8df5-86c686eb41dd</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="31" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="31" Volume="2006" Year="2008">
       <Id>cd0817e5-743c-44bc-9d1d-aeff29d79bc4</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="32" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="32" Volume="2006" Year="2008">
       <Id>2a669ed6-d50f-4665-b623-f16064ca6d69</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="33" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="33" Volume="2006" Year="2009">
       <Id>7979df56-53a8-4e1e-81b9-25eb1f5ce3d8</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="34" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="34" Volume="2006" Year="2009">
       <Id>1c158a98-aa72-45fc-9c4c-963750ef0ae0</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="35" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="35" Volume="2006" Year="2009">
       <Id>bed5890a-370d-4de8-b84a-3a5c43e60268</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="36" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="36" Volume="2006" Year="2009">
       <Id>1aa8f23a-a5fd-4453-9a45-b87626380e84</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="37" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="37" Volume="2006" Year="2009">
       <Id>d2a9c688-4321-4cf0-9b80-d2c2f92b6b7d</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="38" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="38" Volume="2006" Year="2009">
       <Id>def48da6-f0b2-4992-926e-48d2b02c50c0</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="39" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="39" Volume="2006" Year="2009">
       <Id>24065ee8-fe4b-4eb8-9c1d-d3754d13ea4b</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="40" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="40" Volume="2006" Year="2009">
       <Id>6c86b47e-7a36-4c99-b067-bde3b3d9ea55</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="41" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="41" Volume="2006" Year="2009">
       <Id>2ebfbeb1-c8c3-4b9a-b090-fa46384b1cf1</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="42" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="42" Volume="2006" Year="2009">
       <Id>d97b11ac-3f32-40b7-b3bc-20ed907c967d</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="43" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="43" Volume="2006" Year="2009">
       <Id>b50188fd-f9c0-41b6-9d06-18c7875e6573</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="44" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="44" Volume="2006" Year="2009">
       <Id>1fd7ca6f-9754-49c9-9826-09d931748df7</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="45" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="45" Volume="2006" Year="2009">
       <Id>dfac13d0-eeb1-427b-a7a3-64ef3f043741</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="46" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="46" Volume="2006" Year="2009">
       <Id>2eed2779-7060-459f-aec1-e94129cfc64a</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="47" Volume="2006" Year="2010" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="47" Volume="2006" Year="2010">
       <Id>fdbe942e-ed89-47c6-a39a-991b301c4d4f</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="48" Volume="2006" Year="2010" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="48" Volume="2006" Year="2010">
       <Id>2d4162e8-75ff-4b42-a0f5-5e27eb0aeb60</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="49" Volume="2006" Year="2010" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="49" Volume="2006" Year="2010">
       <Id>66f8e6a3-7e35-44ca-b036-4df455498316</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="50" Volume="2006" Year="2010" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="50" Volume="2006" Year="2010">
       <Id>a9c6136d-eae9-4cc9-93d7-06aac2e4f196</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="1" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Captain Marvel" Number="1" Volume="2012" Year="2012">
       <Id>f347b8fe-e1eb-4f2e-baa3-38dca339178f</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="2" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Captain Marvel" Number="2" Volume="2012" Year="2012">
       <Id>332b058e-3b1d-4033-b22e-a1475bf42868</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="3" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Captain Marvel" Number="3" Volume="2012" Year="2012">
       <Id>97e2e192-4b6d-4fba-917e-6847d2d1c4e8</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="4" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Captain Marvel" Number="4" Volume="2012" Year="2012">
       <Id>4d9d4e23-421f-45b5-90bf-ce0992f06b29</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="5" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Captain Marvel" Number="5" Volume="2012" Year="2012">
       <Id>c7809011-a113-4c35-9f68-a48b25b64c09</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="6" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Captain Marvel" Number="6" Volume="2012" Year="2012">
       <Id>58ab22a5-789c-4d15-92b2-76a9297a7d79</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="7" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Captain Marvel" Number="7" Volume="2012" Year="2013">
       <Id>a5de72da-16ad-42f1-8a8d-5c2faf66de50</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="8" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Captain Marvel" Number="8" Volume="2012" Year="2013">
       <Id>2f15c22a-d03a-40c5-be76-a082d8f649f3</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="9" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Captain Marvel" Number="9" Volume="2012" Year="2013">
       <Id>fa593e2e-1833-4ea7-be4d-c2ab187b14a7</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="10" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Captain Marvel" Number="10" Volume="2012" Year="2013">
       <Id>8c6c432a-f6b9-4600-8311-605d408b631c</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="11" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Captain Marvel" Number="11" Volume="2012" Year="2013">
       <Id>73a9d039-21eb-4f94-b655-ce13d5e265bb</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="12" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Captain Marvel" Number="12" Volume="2012" Year="2013">
       <Id>fb1f145b-085f-4c7e-b848-475af8b33394</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="13" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Captain Marvel" Number="13" Volume="2012" Year="2013">
       <Id>be28f61e-81fb-4120-916d-45aa0d3f6028</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="14" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Captain Marvel" Number="14" Volume="2012" Year="2013">
       <Id>23fa1e07-80de-47c7-b264-ba4ac88c1204</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="15" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Captain Marvel" Number="15" Volume="2012" Year="2013">
       <Id>ee3b0838-53a2-4377-8ea7-4f010f4b080b</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="16" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Captain Marvel" Number="16" Volume="2012" Year="2013">
       <Id>9311c504-a6c8-4e00-b8ae-7d89432376a2</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="17" Volume="2012" Year="2014" Format="Main Series">
+    <Book Series="Captain Marvel" Number="17" Volume="2012" Year="2014">
       <Id>674b6a2e-3d75-4ef5-948d-efb98730a76b</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="1" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Captain Marvel" Number="1" Volume="2014" Year="2014">
       <Id>777bc9df-401c-4033-af80-699a9ef7c21d</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="2" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Captain Marvel" Number="2" Volume="2014" Year="2014">
       <Id>79178597-c6c3-4d75-a5de-b43bdadd1732</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="3" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Captain Marvel" Number="3" Volume="2014" Year="2014">
       <Id>59442960-4661-4e79-b8c4-0c1564c21f56</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="5" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Captain Marvel" Number="5" Volume="2014" Year="2014">
       <Id>eb5c299a-1f11-433e-b0ce-6478373f3ae8</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="6" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Captain Marvel" Number="6" Volume="2014" Year="2014">
       <Id>3f1dafb9-405d-4b65-b88d-1b21883888bd</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="7" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Captain Marvel" Number="7" Volume="2014" Year="2014">
       <Id>817e83f1-d831-4a88-a69f-5fc165b389a7</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="8" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Captain Marvel" Number="8" Volume="2014" Year="2014">
       <Id>5203229f-a3d6-409d-81cd-f39c12b7abc1</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="9" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Captain Marvel" Number="9" Volume="2014" Year="2015">
       <Id>1dd9b034-94fb-4baa-902a-988d20e57443</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="10" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Captain Marvel" Number="10" Volume="2014" Year="2015">
       <Id>c08b1661-6adb-4020-94b9-344aa9bf3479</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="11" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Captain Marvel" Number="11" Volume="2014" Year="2015">
       <Id>c02cbf29-b63d-46ef-9e2a-58a69679de4a</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="12" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Captain Marvel" Number="12" Volume="2014" Year="2015">
       <Id>09cbe2b2-7fe9-4d9b-8b93-b378def5338e</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="13" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Captain Marvel" Number="13" Volume="2014" Year="2015">
       <Id>00039aa4-2d8e-4b2a-b316-354f49ce2c26</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="14" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Captain Marvel" Number="14" Volume="2014" Year="2015">
       <Id>041ed1a3-eed4-45d4-a61d-a879bf0ab6fd</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="15" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Captain Marvel" Number="15" Volume="2014" Year="2015">
       <Id>a686381e-dd3c-4baf-81df-e6e6c7ef2ffa</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="1" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="1" Volume="2014" Year="2014">
       <Id>11ad86e5-3f4e-47cb-b716-07bed1c02ae1</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="2" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="2" Volume="2014" Year="2014">
       <Id>335751d0-c1d2-4ae3-bd19-c410288567c2</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="3" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="3" Volume="2014" Year="2014">
       <Id>2bceb203-1ae6-481c-ba16-11c551b58092</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="4" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="4" Volume="2014" Year="2014">
       <Id>c80f4ac0-76c4-422e-80bf-0c83b305bba9</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="5" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="5" Volume="2014" Year="2014">
       <Id>5902518c-9270-4b0f-816b-51c39f72dbaa</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="6" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="6" Volume="2014" Year="2014">
       <Id>ff8f70ac-81d0-4847-9052-6b93cae97259</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="7" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="7" Volume="2014" Year="2014">
       <Id>3906331c-9ef0-4102-9a95-4ec81014fd98</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="8" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="8" Volume="2014" Year="2014">
       <Id>b8e26de4-2688-48eb-ac76-ee2e5bf6b679</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="9" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="9" Volume="2014" Year="2014">
       <Id>31b2c3da-9121-4521-a4f5-7a9066ea5447</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="10" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="10" Volume="2014" Year="2015">
       <Id>dfe0bd9f-233e-4e5e-839b-df4cbc096267</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="11" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="11" Volume="2014" Year="2015">
       <Id>36982b9b-a8fb-430e-b524-2f6721e80137</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="12" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="12" Volume="2014" Year="2015">
       <Id>95866dac-22e8-458e-9203-222a70deab35</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="13" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="13" Volume="2014" Year="2015">
       <Id>1139f916-d227-4a85-ad46-9dcbce2c5ab5</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="14" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="14" Volume="2014" Year="2015">
       <Id>279585b8-bf06-4913-b5ae-963052000c5b</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="15" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="15" Volume="2014" Year="2015">
       <Id>2fac0ffe-7bf5-4881-9913-9ddbda79fe1d</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="16" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="16" Volume="2014" Year="2015">
       <Id>55dbe83a-825d-4e47-b46f-8fdc009a433f</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="17" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="17" Volume="2014" Year="2015">
       <Id>75157c46-47ed-4593-881a-7a9b50c93294</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="18" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="18" Volume="2014" Year="2015">
       <Id>26be2bbe-13b3-4129-be84-1f47909f96ef</Id>
     </Book>
-    <Book Series="Ms. Marvel" Number="19" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Ms. Marvel" Number="19" Volume="2014" Year="2015">
       <Id>fe620839-eb57-4df2-8451-ffd1997101c3</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Cosmic Ghost Rider/Cosmic Ghost Rider.cbl
+++ b/Marvel/Characters/unsorted/Cosmic Ghost Rider/Cosmic Ghost Rider.cbl
@@ -1,108 +1,109 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Cosmic Ghost Rider</Name>
+  <NumIssues>34</NumIssues>
   <Books>
     <Book Series="Thanos" Number="13" Volume="2016" Year="2018">
-      <Id>67bc8444-0f51-4efc-99a2-ca8609836c26</Id>
+      <Database Name="cv" Series="95750" Issue="641419" />
     </Book>
     <Book Series="Thanos" Number="14" Volume="2016" Year="2018">
-      <Id>2595260a-6fb0-4e9c-aa63-ebd03bfde76f</Id>
+      <Database Name="cv" Series="95750" Issue="649747" />
     </Book>
     <Book Series="Thanos" Number="15" Volume="2016" Year="2018">
-      <Id>0097dc11-4cd9-44fc-a488-fac842de039e</Id>
+      <Database Name="cv" Series="95750" Issue="655513" />
     </Book>
     <Book Series="Thanos" Number="16" Volume="2016" Year="2018">
-      <Id>fc35e4e8-5f2b-43b7-8ad4-878dc2fcb3df</Id>
+      <Database Name="cv" Series="95750" Issue="661162" />
     </Book>
     <Book Series="Thanos" Number="17" Volume="2016" Year="2018">
-      <Id>b22836a9-e4f1-4cff-9239-bd21fa1ec1eb</Id>
+      <Database Name="cv" Series="95750" Issue="663589" />
     </Book>
     <Book Series="Thanos" Number="18" Volume="2016" Year="2018">
-      <Id>b73abeac-0e0f-4e4e-8ba5-08b474dab8e9</Id>
+      <Database Name="cv" Series="95750" Issue="665923" />
     </Book>
-    <Book Series="Thanos Annual" Number="1" Volume="2016" Year="2018">
-      <Id>e2bbd371-970d-432c-a701-329417d9d8e1</Id>
+    <Book Series="Thanos Annual" Number="1" Volume="2018" Year="2018">
+      <Database Name="cv" Series="110119" Issue="667659" />
     </Book>
     <Book Series="Cosmic Ghost Rider" Number="1" Volume="2018" Year="2018">
-      <Id>5b92b042-1256-4d99-9f8a-656b5ce8a5d0</Id>
+      <Database Name="cv" Series="112031" Issue="675974" />
     </Book>
     <Book Series="Cosmic Ghost Rider" Number="2" Volume="2018" Year="2018">
-      <Id>6fbd5d76-c565-4045-80f5-dfb55d8f6a7f</Id>
+      <Database Name="cv" Series="112031" Issue="678530" />
     </Book>
     <Book Series="Cosmic Ghost Rider" Number="3" Volume="2018" Year="2018">
-      <Id>26161455-ba4b-4bc2-8865-9f406a1b1aa7</Id>
+      <Database Name="cv" Series="112031" Issue="683825" />
     </Book>
     <Book Series="Cosmic Ghost Rider" Number="4" Volume="2018" Year="2018">
-      <Id>ce23a675-47cb-4e09-a338-b3353b3bfdd8</Id>
+      <Database Name="cv" Series="112031" Issue="687007" />
     </Book>
     <Book Series="Cosmic Ghost Rider" Number="5" Volume="2018" Year="2019">
-      <Id>d6267841-c1ce-4cb6-b7d7-5f5e30b7ccf4</Id>
+      <Database Name="cv" Series="112031" Issue="692061" />
     </Book>
     <Book Series="Thanos Legacy" Number="1" Volume="2018" Year="2018">
-      <Id>0ce896bb-f333-49e7-b8ac-9d74dfb7e320</Id>
+      <Database Name="cv" Series="113264" Issue="683839" />
     </Book>
     <Book Series="Cosmic Ghost Rider Destroys Marvel History" Number="1" Volume="2019" Year="2019">
-      <Id>70862f6d-9b76-407e-906d-4740f2982c8d</Id>
+      <Database Name="cv" Series="117439" Issue="702460" />
     </Book>
     <Book Series="Cosmic Ghost Rider Destroys Marvel History" Number="2" Volume="2019" Year="2019">
-      <Id>a83f7c25-33ba-46f4-a415-c48148bd9cc8</Id>
+      <Database Name="cv" Series="117439" Issue="705471" />
     </Book>
     <Book Series="Cosmic Ghost Rider Destroys Marvel History" Number="3" Volume="2019" Year="2019">
-      <Id>e6b7b136-9293-43e6-bace-43b462f0b2a6</Id>
+      <Database Name="cv" Series="117439" Issue="707508" />
     </Book>
     <Book Series="Cosmic Ghost Rider Destroys Marvel History" Number="4" Volume="2019" Year="2019">
-      <Id>b0d023ca-3127-40ac-9651-0e10fc4ec1ed</Id>
+      <Database Name="cv" Series="117439" Issue="710676" />
     </Book>
     <Book Series="Cosmic Ghost Rider Destroys Marvel History" Number="5" Volume="2019" Year="2019">
-      <Id>79b52b9f-b764-4df3-967d-7c67d23a4635</Id>
+      <Database Name="cv" Series="117439" Issue="713068" />
     </Book>
     <Book Series="Cosmic Ghost Rider Destroys Marvel History" Number="6" Volume="2019" Year="2019">
-      <Id>2e6b87e9-ae41-4167-9283-f299738fbe93</Id>
+      <Database Name="cv" Series="117439" Issue="715302" />
     </Book>
     <Book Series="Guardians of the Galaxy" Number="1" Volume="2019" Year="2019">
-      <Id>23051421-9151-4c0e-bf5d-2550e2ea8bd6</Id>
+      <Database Name="cv" Series="116702" Issue="698605" />
     </Book>
     <Book Series="Guardians of the Galaxy" Number="2" Volume="2019" Year="2019">
-      <Id>7982e0c7-d74c-47bf-a671-77c9dd610748</Id>
+      <Database Name="cv" Series="116702" Issue="701312" />
     </Book>
     <Book Series="Guardians of the Galaxy" Number="3" Volume="2019" Year="2019">
-      <Id>c390c6aa-f9b4-44d3-bbfa-36327e6ce067</Id>
+      <Database Name="cv" Series="116702" Issue="703940" />
     </Book>
     <Book Series="Guardians of the Galaxy" Number="4" Volume="2019" Year="2019">
-      <Id>9318e8a3-610e-4079-9ce4-32f602b770fc</Id>
+      <Database Name="cv" Series="116702" Issue="706406" />
     </Book>
     <Book Series="Guardians of the Galaxy" Number="5" Volume="2019" Year="2019">
-      <Id>e3e3b6f4-3a7d-4b93-b068-8d4082e842ad</Id>
+      <Database Name="cv" Series="116702" Issue="709201" />
     </Book>
     <Book Series="Guardians of the Galaxy" Number="6" Volume="2019" Year="2019">
-      <Id>2c311b33-d491-4d63-afc8-a58de9eec532</Id>
+      <Database Name="cv" Series="116702" Issue="711947" />
     </Book>
     <Book Series="Avengers" Number="23" Volume="2018" Year="2019">
-      <Id>f553db5d-0693-4dca-9d0e-39cff17b6a77</Id>
+      <Database Name="cv" Series="110496" Issue="717513" />
     </Book>
     <Book Series="Avengers" Number="24" Volume="2018" Year="2019">
-      <Id>75e529e3-babb-412d-9b09-3846f7590469</Id>
+      <Database Name="cv" Series="110496" Issue="720157" />
     </Book>
     <Book Series="Avengers" Number="25" Volume="2018" Year="2019">
-      <Id>0f757194-f4db-4406-8a39-50bc00e9bac7</Id>
+      <Database Name="cv" Series="110496" Issue="723852" />
     </Book>
     <Book Series="Revenge of the Cosmic Ghost Rider" Number="1" Volume="2019" Year="2020">
-      <Id>bda24e41-003b-4e14-a61e-df5ecfefbdcc</Id>
+      <Database Name="cv" Series="123712" Issue="731523" />
     </Book>
     <Book Series="Revenge of the Cosmic Ghost Rider" Number="2" Volume="2019" Year="2020">
-      <Id>e0911f5c-5f13-474a-a6c8-56c262fe047f</Id>
+      <Database Name="cv" Series="123712" Issue="733826" />
     </Book>
     <Book Series="Revenge of the Cosmic Ghost Rider" Number="3" Volume="2019" Year="2020">
-      <Id>c64058d8-910f-4b4c-9393-45932b8b69d4</Id>
+      <Database Name="cv" Series="123712" Issue="737762" />
     </Book>
     <Book Series="Revenge of the Cosmic Ghost Rider" Number="4" Volume="2019" Year="2020">
-      <Id>ab98691b-a092-49e0-917f-7790b58ec97d</Id>
+      <Database Name="cv" Series="123712" Issue="743446" />
     </Book>
     <Book Series="Revenge of the Cosmic Ghost Rider" Number="5" Volume="2019" Year="2020">
-      <Id>63035781-1bd2-4cca-9af5-50f2e151b436</Id>
+      <Database Name="cv" Series="123712" Issue="766405" />
     </Book>
-    <Book Series="Wolverine: Black, White &amp; Blood" Number="3" Volume="2020" Year="2021">
-      <Id>ac677ce9-d8d7-4501-8853-6d3bfd0a424a</Id>
+    <Book Series="Wolverine: Black, White &#38; Blood" Number="3" Volume="2020" Year="2021">
+      <Database Name="cv" Series="131734" Issue="828199" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Cosmic Ghost Rider/Cosmic Ghost Rider.cbl
+++ b/Marvel/Characters/unsorted/Cosmic Ghost Rider/Cosmic Ghost Rider.cbl
@@ -20,7 +20,7 @@
     <Book Series="Thanos" Number="18" Volume="2016" Year="2018">
       <Id>b73abeac-0e0f-4e4e-8ba5-08b474dab8e9</Id>
     </Book>
-    <Book Series="Thanos Annual" Number="1" Volume="2016" Year="2018" Format="Annual">
+    <Book Series="Thanos Annual" Number="1" Volume="2016" Year="2018">
       <Id>e2bbd371-970d-432c-a701-329417d9d8e1</Id>
     </Book>
     <Book Series="Cosmic Ghost Rider" Number="1" Volume="2018" Year="2018">

--- a/Marvel/Characters/unsorted/Daredevil/Daredevil 001.cbl
+++ b/Marvel/Characters/unsorted/Daredevil/Daredevil 001.cbl
@@ -2,781 +2,781 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Daredevil 1</Name>
   <Books>
-    <Book Series="Daredevil" Number="1" Volume="1964" Year="1964" Format="Main Series">
+    <Book Series="Daredevil" Number="1" Volume="1964" Year="1964">
       <Id>5ec018c3-5dd7-4152-9808-866165026dc3</Id>
     </Book>
-    <Book Series="Daredevil" Number="2" Volume="1964" Year="1964" Format="Main Series">
+    <Book Series="Daredevil" Number="2" Volume="1964" Year="1964">
       <Id>94c3484f-da74-45ed-bc1b-732636b3eece</Id>
     </Book>
-    <Book Series="Daredevil" Number="3" Volume="1964" Year="1964" Format="Main Series">
+    <Book Series="Daredevil" Number="3" Volume="1964" Year="1964">
       <Id>94422450-3c5b-44e7-bc39-3f2d978efbc4</Id>
     </Book>
-    <Book Series="Daredevil" Number="4" Volume="1964" Year="1964" Format="Main Series">
+    <Book Series="Daredevil" Number="4" Volume="1964" Year="1964">
       <Id>ce483dbf-47da-41f4-b2ea-b78203f88343</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="16" Volume="1963" Year="1964" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="16" Volume="1963" Year="1964">
       <Id>500da22b-db48-424a-8472-e96fe24ca1e9</Id>
     </Book>
-    <Book Series="Daredevil" Number="5" Volume="1964" Year="1964" Format="Main Series">
+    <Book Series="Daredevil" Number="5" Volume="1964" Year="1964">
       <Id>444b30d4-3beb-46b7-b6e6-f908af30574f</Id>
     </Book>
-    <Book Series="Daredevil" Number="6" Volume="1964" Year="1965" Format="Main Series">
+    <Book Series="Daredevil" Number="6" Volume="1964" Year="1965">
       <Id>76361279-1180-421f-85e2-2d46ca61c4ca</Id>
     </Book>
-    <Book Series="Daredevil" Number="7" Volume="1964" Year="1965" Format="Main Series">
+    <Book Series="Daredevil" Number="7" Volume="1964" Year="1965">
       <Id>03394ce1-8c65-4fe4-8c6d-c72147b43da8</Id>
     </Book>
-    <Book Series="Daredevil" Number="8" Volume="1964" Year="1965" Format="Main Series">
+    <Book Series="Daredevil" Number="8" Volume="1964" Year="1965">
       <Id>72f35741-7c2d-4ccb-8c58-d4c31fd2cb75</Id>
     </Book>
-    <Book Series="Daredevil" Number="9" Volume="1964" Year="1965" Format="Main Series">
+    <Book Series="Daredevil" Number="9" Volume="1964" Year="1965">
       <Id>9b6d7246-bf61-409f-a506-ebccf0bb1362</Id>
     </Book>
-    <Book Series="Daredevil" Number="10" Volume="1964" Year="1965" Format="Main Series">
+    <Book Series="Daredevil" Number="10" Volume="1964" Year="1965">
       <Id>448a5794-fe0e-487e-9bce-4571d0e23ee1</Id>
     </Book>
-    <Book Series="Daredevil" Number="11" Volume="1964" Year="1965" Format="Main Series">
+    <Book Series="Daredevil" Number="11" Volume="1964" Year="1965">
       <Id>e77f79d1-3cbb-4703-ba98-788356275a3b</Id>
     </Book>
-    <Book Series="Daredevil" Number="12" Volume="1964" Year="1966" Format="Main Series">
+    <Book Series="Daredevil" Number="12" Volume="1964" Year="1966">
       <Id>47d10d36-374d-46c0-a552-66c9e4fdba00</Id>
     </Book>
-    <Book Series="Daredevil" Number="13" Volume="1964" Year="1966" Format="Main Series">
+    <Book Series="Daredevil" Number="13" Volume="1964" Year="1966">
       <Id>86146152-5b48-40ef-bb04-40f83ac67141</Id>
     </Book>
-    <Book Series="Daredevil" Number="14" Volume="1964" Year="1966" Format="Main Series">
+    <Book Series="Daredevil" Number="14" Volume="1964" Year="1966">
       <Id>57b8cb6e-e0cf-443f-b4ec-2ffbf5836236</Id>
     </Book>
-    <Book Series="Daredevil" Number="15" Volume="1964" Year="1966" Format="Main Series">
+    <Book Series="Daredevil" Number="15" Volume="1964" Year="1966">
       <Id>6ca881c0-8d42-4131-a0da-03618c9fd3af</Id>
     </Book>
-    <Book Series="Daredevil" Number="16" Volume="1964" Year="1966" Format="Main Series">
+    <Book Series="Daredevil" Number="16" Volume="1964" Year="1966">
       <Id>91233772-f8b7-4794-8fdf-dab6fea4bfee</Id>
     </Book>
-    <Book Series="Daredevil" Number="17" Volume="1964" Year="1966" Format="Main Series">
+    <Book Series="Daredevil" Number="17" Volume="1964" Year="1966">
       <Id>b800e2f7-6ef1-4074-bc4e-16a1a64b3a0d</Id>
     </Book>
-    <Book Series="Daredevil" Number="18" Volume="1964" Year="1966" Format="Main Series">
+    <Book Series="Daredevil" Number="18" Volume="1964" Year="1966">
       <Id>987362ed-53a8-481b-8c7f-f526cac98836</Id>
     </Book>
-    <Book Series="Daredevil" Number="19" Volume="1964" Year="1966" Format="Main Series">
+    <Book Series="Daredevil" Number="19" Volume="1964" Year="1966">
       <Id>2e88e434-672d-49e5-9529-0321bae05e1b</Id>
     </Book>
-    <Book Series="Daredevil" Number="20" Volume="1964" Year="1966" Format="Main Series">
+    <Book Series="Daredevil" Number="20" Volume="1964" Year="1966">
       <Id>a5a20a91-be80-44fc-a38f-d70ca7854ae5</Id>
     </Book>
-    <Book Series="Daredevil" Number="21" Volume="1964" Year="1966" Format="Main Series">
+    <Book Series="Daredevil" Number="21" Volume="1964" Year="1966">
       <Id>babb622e-b255-444b-b8b8-92a59327ceae</Id>
     </Book>
-    <Book Series="Daredevil" Number="22" Volume="1964" Year="1966" Format="Main Series">
+    <Book Series="Daredevil" Number="22" Volume="1964" Year="1966">
       <Id>1f3d3089-0d9d-43a4-bbc9-50c57d4850ab</Id>
     </Book>
-    <Book Series="Daredevil" Number="23" Volume="1964" Year="1966" Format="Main Series">
+    <Book Series="Daredevil" Number="23" Volume="1964" Year="1966">
       <Id>dd6a12b4-f444-4e00-98e6-2b76eaf14663</Id>
     </Book>
-    <Book Series="Daredevil" Number="24" Volume="1964" Year="1967" Format="Main Series">
+    <Book Series="Daredevil" Number="24" Volume="1964" Year="1967">
       <Id>dac69428-cdc4-42a5-a06b-53d05049c20e</Id>
     </Book>
-    <Book Series="Daredevil" Number="25" Volume="1964" Year="1967" Format="Main Series">
+    <Book Series="Daredevil" Number="25" Volume="1964" Year="1967">
       <Id>a7c7bbfd-2477-42d3-8ee2-55aa343d6282</Id>
     </Book>
-    <Book Series="Daredevil" Number="26" Volume="1964" Year="1967" Format="Main Series">
+    <Book Series="Daredevil" Number="26" Volume="1964" Year="1967">
       <Id>0ad14474-138d-4d5e-a9e0-620329be5940</Id>
     </Book>
-    <Book Series="Daredevil" Number="27" Volume="1964" Year="1967" Format="Main Series">
+    <Book Series="Daredevil" Number="27" Volume="1964" Year="1967">
       <Id>62387a45-27f1-4a30-943c-4baad7302163</Id>
     </Book>
-    <Book Series="Daredevil" Number="28" Volume="1964" Year="1967" Format="Main Series">
+    <Book Series="Daredevil" Number="28" Volume="1964" Year="1967">
       <Id>50804263-2e16-4cb1-a106-46ad2b83c93a</Id>
     </Book>
-    <Book Series="Daredevil" Number="29" Volume="1964" Year="1967" Format="Main Series">
+    <Book Series="Daredevil" Number="29" Volume="1964" Year="1967">
       <Id>5e565a88-d71a-4f66-bda0-10ebaa50157e</Id>
     </Book>
-    <Book Series="Daredevil" Number="30" Volume="1964" Year="1967" Format="Main Series">
+    <Book Series="Daredevil" Number="30" Volume="1964" Year="1967">
       <Id>5a815436-e396-4ecd-9154-22e333bd9a49</Id>
     </Book>
-    <Book Series="Daredevil" Number="31" Volume="1964" Year="1967" Format="Main Series">
+    <Book Series="Daredevil" Number="31" Volume="1964" Year="1967">
       <Id>92a1fdca-3b57-480e-8cc3-b5f3b2cce519</Id>
     </Book>
-    <Book Series="Daredevil" Number="32" Volume="1964" Year="1967" Format="Main Series">
+    <Book Series="Daredevil" Number="32" Volume="1964" Year="1967">
       <Id>b36cc26d-fd94-47d4-9e94-99f2b406e9a1</Id>
     </Book>
-    <Book Series="Daredevil" Number="33" Volume="1964" Year="1967" Format="Main Series">
+    <Book Series="Daredevil" Number="33" Volume="1964" Year="1967">
       <Id>ae3ead69-a436-4ff1-a154-8dbac675e1b9</Id>
     </Book>
-    <Book Series="Daredevil" Number="34" Volume="1964" Year="1967" Format="Main Series">
+    <Book Series="Daredevil" Number="34" Volume="1964" Year="1967">
       <Id>9d6fef26-9235-440d-a5ef-955f130f66d6</Id>
     </Book>
-    <Book Series="Daredevil Annual" Number="1" Volume="1967" Year="1967" Format="Annual">
+    <Book Series="Daredevil Annual" Number="1" Volume="1967" Year="1967">
       <Id>03fe91b5-018a-4908-93c2-cac8c6fd1898</Id>
     </Book>
-    <Book Series="Daredevil" Number="35" Volume="1964" Year="1967" Format="Main Series">
+    <Book Series="Daredevil" Number="35" Volume="1964" Year="1967">
       <Id>a2303256-55d0-463e-9bd7-d87b040e554d</Id>
     </Book>
-    <Book Series="Daredevil" Number="36" Volume="1964" Year="1968" Format="Main Series">
+    <Book Series="Daredevil" Number="36" Volume="1964" Year="1968">
       <Id>6a51fdb9-ff4c-489f-9194-e92cdb5d8ade</Id>
     </Book>
-    <Book Series="Daredevil" Number="37" Volume="1964" Year="1968" Format="Main Series">
+    <Book Series="Daredevil" Number="37" Volume="1964" Year="1968">
       <Id>846f8e23-9922-4007-9f92-43c4ddf5abf1</Id>
     </Book>
-    <Book Series="Daredevil" Number="38" Volume="1964" Year="1968" Format="Main Series">
+    <Book Series="Daredevil" Number="38" Volume="1964" Year="1968">
       <Id>673a103c-8a1d-404b-8879-6adb42a1dcbc</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="73" Volume="1961" Year="1968" Format="Main Series">
+    <Book Series="Fantastic Four" Number="73" Volume="1961" Year="1968">
       <Id>c7e81d19-e381-48b8-8b47-f23f3f8b631b</Id>
     </Book>
-    <Book Series="Daredevil" Number="39" Volume="1964" Year="1968" Format="Main Series">
+    <Book Series="Daredevil" Number="39" Volume="1964" Year="1968">
       <Id>74badd1a-1ed1-4339-81c7-7d0d3b332fc8</Id>
     </Book>
-    <Book Series="Daredevil" Number="40" Volume="1964" Year="1968" Format="Main Series">
+    <Book Series="Daredevil" Number="40" Volume="1964" Year="1968">
       <Id>74f9aa3b-3e9c-4d49-a70f-78a33b9b4367</Id>
     </Book>
-    <Book Series="Daredevil" Number="41" Volume="1964" Year="1968" Format="Main Series">
+    <Book Series="Daredevil" Number="41" Volume="1964" Year="1968">
       <Id>7a5bd9d2-0946-410f-98b1-23e75ab4be74</Id>
     </Book>
-    <Book Series="Daredevil" Number="42" Volume="1964" Year="1968" Format="Main Series">
+    <Book Series="Daredevil" Number="42" Volume="1964" Year="1968">
       <Id>fdb986d9-f5a2-461f-a38b-aefa42e73468</Id>
     </Book>
-    <Book Series="Daredevil" Number="43" Volume="1964" Year="1968" Format="Main Series">
+    <Book Series="Daredevil" Number="43" Volume="1964" Year="1968">
       <Id>f8ebe941-0b40-40d9-bc1e-4726629535dd</Id>
     </Book>
-    <Book Series="Daredevil" Number="44" Volume="1964" Year="1968" Format="Main Series">
+    <Book Series="Daredevil" Number="44" Volume="1964" Year="1968">
       <Id>a9e6f228-86e4-45c7-bff8-98fe261045fc</Id>
     </Book>
-    <Book Series="Daredevil" Number="45" Volume="1964" Year="1968" Format="Main Series">
+    <Book Series="Daredevil" Number="45" Volume="1964" Year="1968">
       <Id>77761a99-003d-41e6-9c3f-d7f6eb371c21</Id>
     </Book>
-    <Book Series="Daredevil" Number="46" Volume="1964" Year="1968" Format="Main Series">
+    <Book Series="Daredevil" Number="46" Volume="1964" Year="1968">
       <Id>41b7ae6b-ae31-4aea-ba11-7cf444694e2c</Id>
     </Book>
-    <Book Series="Daredevil" Number="47" Volume="1964" Year="1968" Format="Main Series">
+    <Book Series="Daredevil" Number="47" Volume="1964" Year="1968">
       <Id>04a9c5b7-5520-4996-a9cb-d725a103bbfc</Id>
     </Book>
-    <Book Series="Daredevil" Number="48" Volume="1964" Year="1969" Format="Main Series">
+    <Book Series="Daredevil" Number="48" Volume="1964" Year="1969">
       <Id>f4fc5aed-62ae-4784-857e-7064d7bbfed1</Id>
     </Book>
-    <Book Series="Daredevil" Number="49" Volume="1964" Year="1969" Format="Main Series">
+    <Book Series="Daredevil" Number="49" Volume="1964" Year="1969">
       <Id>94429be5-5be9-4799-a3bb-3823e5798f83</Id>
     </Book>
-    <Book Series="Daredevil" Number="50" Volume="1964" Year="1969" Format="Main Series">
+    <Book Series="Daredevil" Number="50" Volume="1964" Year="1969">
       <Id>6d40421a-4beb-4958-895f-915d602ee41d</Id>
     </Book>
-    <Book Series="Daredevil" Number="51" Volume="1964" Year="1969" Format="Main Series">
+    <Book Series="Daredevil" Number="51" Volume="1964" Year="1969">
       <Id>892d1e63-b7c9-4576-9747-1d0e90259293</Id>
     </Book>
-    <Book Series="Daredevil" Number="52" Volume="1964" Year="1969" Format="Main Series">
+    <Book Series="Daredevil" Number="52" Volume="1964" Year="1969">
       <Id>a67eb7e9-c9e1-45b6-94c1-a571be503834</Id>
     </Book>
-    <Book Series="Daredevil" Number="53" Volume="1964" Year="1969" Format="Main Series">
+    <Book Series="Daredevil" Number="53" Volume="1964" Year="1969">
       <Id>9f908374-07ab-4a0a-8df9-399df6ea2f30</Id>
     </Book>
-    <Book Series="Daredevil" Number="54" Volume="1964" Year="1969" Format="Main Series">
+    <Book Series="Daredevil" Number="54" Volume="1964" Year="1969">
       <Id>91178ef0-57e7-474e-b44c-369cfc0aca38</Id>
     </Book>
-    <Book Series="Daredevil" Number="55" Volume="1964" Year="1969" Format="Main Series">
+    <Book Series="Daredevil" Number="55" Volume="1964" Year="1969">
       <Id>94e131f5-3252-43cd-82a4-ea0bef1ce8fb</Id>
     </Book>
-    <Book Series="Daredevil" Number="56" Volume="1964" Year="1969" Format="Main Series">
+    <Book Series="Daredevil" Number="56" Volume="1964" Year="1969">
       <Id>13918ed9-6386-4e7f-be68-da9805dcf22b</Id>
     </Book>
-    <Book Series="Daredevil" Number="57" Volume="1964" Year="1969" Format="Main Series">
+    <Book Series="Daredevil" Number="57" Volume="1964" Year="1969">
       <Id>b06720b0-75aa-4c0e-b903-8a54e96167fe</Id>
     </Book>
-    <Book Series="Daredevil" Number="58" Volume="1964" Year="1969" Format="Main Series">
+    <Book Series="Daredevil" Number="58" Volume="1964" Year="1969">
       <Id>5b64ddd6-00b7-42e1-9094-0b1c376e7bfb</Id>
     </Book>
-    <Book Series="Daredevil" Number="59" Volume="1964" Year="1969" Format="Main Series">
+    <Book Series="Daredevil" Number="59" Volume="1964" Year="1969">
       <Id>01867e1d-5075-4158-b553-0b74d1368872</Id>
     </Book>
-    <Book Series="Daredevil" Number="60" Volume="1964" Year="1970" Format="Main Series">
+    <Book Series="Daredevil" Number="60" Volume="1964" Year="1970">
       <Id>9a65658f-a5c5-4e56-af54-1d24c7017afc</Id>
     </Book>
-    <Book Series="Daredevil" Number="61" Volume="1964" Year="1970" Format="Main Series">
+    <Book Series="Daredevil" Number="61" Volume="1964" Year="1970">
       <Id>6e886c2d-1119-4a69-856c-f48ee088b421</Id>
     </Book>
-    <Book Series="Daredevil" Number="62" Volume="1964" Year="1970" Format="Main Series">
+    <Book Series="Daredevil" Number="62" Volume="1964" Year="1970">
       <Id>a838c661-a097-46a3-9551-38a3bbce49e8</Id>
     </Book>
-    <Book Series="Daredevil" Number="63" Volume="1964" Year="1970" Format="Main Series">
+    <Book Series="Daredevil" Number="63" Volume="1964" Year="1970">
       <Id>f46b71f1-e629-4b4a-934a-8e7a18f91ced</Id>
     </Book>
-    <Book Series="Daredevil" Number="64" Volume="1964" Year="1970" Format="Main Series">
+    <Book Series="Daredevil" Number="64" Volume="1964" Year="1970">
       <Id>a01c4aee-917a-41c5-891c-08574496e557</Id>
     </Book>
-    <Book Series="Daredevil" Number="65" Volume="1964" Year="1970" Format="Main Series">
+    <Book Series="Daredevil" Number="65" Volume="1964" Year="1970">
       <Id>b4b12401-b031-4b3a-991f-3cd69b379a84</Id>
     </Book>
-    <Book Series="Daredevil" Number="66" Volume="1964" Year="1970" Format="Main Series">
+    <Book Series="Daredevil" Number="66" Volume="1964" Year="1970">
       <Id>421679cf-890d-4fc6-9544-cc59dc4952eb</Id>
     </Book>
-    <Book Series="Daredevil" Number="67" Volume="1964" Year="1970" Format="Main Series">
+    <Book Series="Daredevil" Number="67" Volume="1964" Year="1970">
       <Id>8de92212-7493-44b2-b722-3305f7136933</Id>
     </Book>
-    <Book Series="Daredevil" Number="68" Volume="1964" Year="1970" Format="Main Series">
+    <Book Series="Daredevil" Number="68" Volume="1964" Year="1970">
       <Id>3c6d2e6a-463d-4411-b495-e68f7be8cca1</Id>
     </Book>
-    <Book Series="Daredevil" Number="69" Volume="1964" Year="1970" Format="Main Series">
+    <Book Series="Daredevil" Number="69" Volume="1964" Year="1970">
       <Id>3dac609f-8b4e-41c8-a518-abcc9452ef8c</Id>
     </Book>
-    <Book Series="The Avengers" Number="82" Volume="1963" Year="1970" Format="Main Series">
+    <Book Series="The Avengers" Number="82" Volume="1963" Year="1970">
       <Id>c01a75fc-50a0-48b0-b211-9c62a7c2a312</Id>
     </Book>
-    <Book Series="Daredevil" Number="70" Volume="1964" Year="1970" Format="Main Series">
+    <Book Series="Daredevil" Number="70" Volume="1964" Year="1970">
       <Id>7e2bc93f-4a6a-4f1b-b348-dfd31c7468bc</Id>
     </Book>
-    <Book Series="Daredevil" Number="71" Volume="1964" Year="1970" Format="Main Series">
+    <Book Series="Daredevil" Number="71" Volume="1964" Year="1970">
       <Id>36b753b4-2698-4241-a1de-eb4ef554da50</Id>
     </Book>
-    <Book Series="Daredevil" Number="72" Volume="1964" Year="1971" Format="Main Series">
+    <Book Series="Daredevil" Number="72" Volume="1964" Year="1971">
       <Id>766fcf0d-9b66-4751-b54e-bdf5c7b505cb</Id>
     </Book>
-    <Book Series="Iron Man" Number="35" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Iron Man" Number="35" Volume="1968" Year="1971">
       <Id>71f473a9-d97d-4e0d-851d-dfc3b8467493</Id>
     </Book>
-    <Book Series="Daredevil" Number="73" Volume="1964" Year="1971" Format="Main Series">
+    <Book Series="Daredevil" Number="73" Volume="1964" Year="1971">
       <Id>ab76d5de-bdfe-463c-a029-4013aa17c004</Id>
     </Book>
-    <Book Series="Iron Man" Number="36" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Iron Man" Number="36" Volume="1968" Year="1971">
       <Id>85e94435-609b-48a3-b3f3-a3cf71df1780</Id>
     </Book>
-    <Book Series="Daredevil" Number="74" Volume="1964" Year="1971" Format="Main Series">
+    <Book Series="Daredevil" Number="74" Volume="1964" Year="1971">
       <Id>c558849a-3973-441f-a916-a902585ce980</Id>
     </Book>
-    <Book Series="Daredevil" Number="75" Volume="1964" Year="1971" Format="Main Series">
+    <Book Series="Daredevil" Number="75" Volume="1964" Year="1971">
       <Id>f25ed6be-09f8-4f4f-987f-889e58352d18</Id>
     </Book>
-    <Book Series="Daredevil" Number="76" Volume="1964" Year="1971" Format="Main Series">
+    <Book Series="Daredevil" Number="76" Volume="1964" Year="1971">
       <Id>32206752-702f-4620-a642-6864a1b9e30f</Id>
     </Book>
-    <Book Series="Daredevil" Number="77" Volume="1964" Year="1971" Format="Main Series">
+    <Book Series="Daredevil" Number="77" Volume="1964" Year="1971">
       <Id>b04cf0eb-e41c-4617-ab28-cf73bc10459a</Id>
     </Book>
-    <Book Series="Daredevil" Number="78" Volume="1964" Year="1971" Format="Main Series">
+    <Book Series="Daredevil" Number="78" Volume="1964" Year="1971">
       <Id>b0ba8012-5a5b-4660-bb3d-1be366385201</Id>
     </Book>
-    <Book Series="Daredevil" Number="79" Volume="1964" Year="1971" Format="Main Series">
+    <Book Series="Daredevil" Number="79" Volume="1964" Year="1971">
       <Id>ce251c7e-a5cb-44cb-ad9e-7dbcd9921a9a</Id>
     </Book>
-    <Book Series="Daredevil" Number="80" Volume="1964" Year="1971" Format="Main Series">
+    <Book Series="Daredevil" Number="80" Volume="1964" Year="1971">
       <Id>05bb5898-0797-4368-b4fd-c37f942f7c38</Id>
     </Book>
-    <Book Series="Daredevil" Number="81" Volume="1964" Year="1971" Format="Main Series">
+    <Book Series="Daredevil" Number="81" Volume="1964" Year="1971">
       <Id>99863980-9fc5-45b3-bfa6-b0d653dd2499</Id>
     </Book>
-    <Book Series="Daredevil" Number="82" Volume="1964" Year="1971" Format="Main Series">
+    <Book Series="Daredevil" Number="82" Volume="1964" Year="1971">
       <Id>bb6e30ee-1149-4e33-b17c-e9ed659c2a81</Id>
     </Book>
-    <Book Series="Daredevil" Number="83" Volume="1964" Year="1972" Format="Main Series">
+    <Book Series="Daredevil" Number="83" Volume="1964" Year="1972">
       <Id>3afa51f9-cba1-4a90-a5b8-bfefbbffe54d</Id>
     </Book>
-    <Book Series="Daredevil" Number="84" Volume="1964" Year="1972" Format="Main Series">
+    <Book Series="Daredevil" Number="84" Volume="1964" Year="1972">
       <Id>0ccaf7c2-c563-435e-8e9c-f7b4419ce182</Id>
     </Book>
-    <Book Series="Daredevil" Number="85" Volume="1964" Year="1972" Format="Main Series">
+    <Book Series="Daredevil" Number="85" Volume="1964" Year="1972">
       <Id>e11c30ba-4aa9-4ee1-ba3a-4ba11c5d795c</Id>
     </Book>
-    <Book Series="Daredevil" Number="86" Volume="1964" Year="1972" Format="Main Series">
+    <Book Series="Daredevil" Number="86" Volume="1964" Year="1972">
       <Id>130fa927-d8bc-4ab4-82c7-709eaa52810f</Id>
     </Book>
-    <Book Series="Daredevil" Number="87" Volume="1964" Year="1972" Format="Main Series">
+    <Book Series="Daredevil" Number="87" Volume="1964" Year="1972">
       <Id>81fa6b9d-b763-4f2c-8d81-742c58f5e338</Id>
     </Book>
-    <Book Series="Daredevil" Number="88" Volume="1964" Year="1972" Format="Main Series">
+    <Book Series="Daredevil" Number="88" Volume="1964" Year="1972">
       <Id>efefd854-ccdd-437e-a0cc-d07fcdcd7bb5</Id>
     </Book>
-    <Book Series="Daredevil" Number="89" Volume="1964" Year="1972" Format="Main Series">
+    <Book Series="Daredevil" Number="89" Volume="1964" Year="1972">
       <Id>02ea8360-cf7b-41ed-85c9-4eb60afd8672</Id>
     </Book>
-    <Book Series="Daredevil" Number="90" Volume="1964" Year="1972" Format="Main Series">
+    <Book Series="Daredevil" Number="90" Volume="1964" Year="1972">
       <Id>3f3b67ae-f1f1-4d24-b9d5-4f89ed7ae298</Id>
     </Book>
-    <Book Series="Daredevil" Number="91" Volume="1964" Year="1972" Format="Main Series">
+    <Book Series="Daredevil" Number="91" Volume="1964" Year="1972">
       <Id>c328cb0f-f4ee-4545-a62a-da46ee6c0c70</Id>
     </Book>
-    <Book Series="Daredevil" Number="92" Volume="1964" Year="1972" Format="Main Series">
+    <Book Series="Daredevil" Number="92" Volume="1964" Year="1972">
       <Id>21f68fda-146b-4346-86b3-ee385eb4a049</Id>
     </Book>
-    <Book Series="Daredevil" Number="93" Volume="1964" Year="1972" Format="Main Series">
+    <Book Series="Daredevil" Number="93" Volume="1964" Year="1972">
       <Id>be5582bb-6895-4845-bb08-cc2f82692005</Id>
     </Book>
-    <Book Series="Daredevil" Number="94" Volume="1964" Year="1972" Format="Main Series">
+    <Book Series="Daredevil" Number="94" Volume="1964" Year="1972">
       <Id>81fa9c80-0ec5-42bb-9c61-633833e3cadb</Id>
     </Book>
-    <Book Series="Daredevil" Number="95" Volume="1964" Year="1973" Format="Main Series">
+    <Book Series="Daredevil" Number="95" Volume="1964" Year="1973">
       <Id>48194391-86a2-4247-81b3-023ba2b0a02f</Id>
     </Book>
-    <Book Series="Daredevil" Number="96" Volume="1964" Year="1973" Format="Main Series">
+    <Book Series="Daredevil" Number="96" Volume="1964" Year="1973">
       <Id>a37f2eef-a397-47a1-a2f4-f3e7b8ebf02d</Id>
     </Book>
-    <Book Series="Daredevil" Number="97" Volume="1964" Year="1973" Format="Main Series">
+    <Book Series="Daredevil" Number="97" Volume="1964" Year="1973">
       <Id>61d398e8-b671-4d67-9b84-2c4f8baec0fd</Id>
     </Book>
-    <Book Series="Daredevil" Number="98" Volume="1964" Year="1973" Format="Main Series">
+    <Book Series="Daredevil" Number="98" Volume="1964" Year="1973">
       <Id>d21b2c0e-0518-4390-afd0-391133f14bef</Id>
     </Book>
-    <Book Series="Daredevil" Number="99" Volume="1964" Year="1973" Format="Main Series">
+    <Book Series="Daredevil" Number="99" Volume="1964" Year="1973">
       <Id>b452d7e2-b6a7-4762-9f3d-ba13bd0a2ab9</Id>
     </Book>
-    <Book Series="The Avengers" Number="100" Volume="1963" Year="1972" Format="Main Series">
+    <Book Series="The Avengers" Number="100" Volume="1963" Year="1972">
       <Id>cf95b160-d85b-469c-9069-3cbfcea767a7</Id>
     </Book>
-    <Book Series="Daredevil" Number="100" Volume="1964" Year="1973" Format="Main Series">
+    <Book Series="Daredevil" Number="100" Volume="1964" Year="1973">
       <Id>7428f17f-f5da-420d-8cd8-32f33d2ea9e1</Id>
     </Book>
-    <Book Series="Daredevil" Number="101" Volume="1964" Year="1973" Format="Main Series">
+    <Book Series="Daredevil" Number="101" Volume="1964" Year="1973">
       <Id>47333263-024b-4a41-a458-56c3494f726d</Id>
     </Book>
-    <Book Series="Daredevil" Number="102" Volume="1964" Year="1973" Format="Main Series">
+    <Book Series="Daredevil" Number="102" Volume="1964" Year="1973">
       <Id>bdbd9db8-3030-492e-af0b-7790446d2ad6</Id>
     </Book>
-    <Book Series="Daredevil" Number="103" Volume="1964" Year="1973" Format="Main Series">
+    <Book Series="Daredevil" Number="103" Volume="1964" Year="1973">
       <Id>39ea1acd-dd6a-4bf2-8c58-beecd4ebd043</Id>
     </Book>
-    <Book Series="Daredevil" Number="104" Volume="1964" Year="1973" Format="Main Series">
+    <Book Series="Daredevil" Number="104" Volume="1964" Year="1973">
       <Id>7764c0b6-9fc8-4864-b124-4f858e35478c</Id>
     </Book>
-    <Book Series="Daredevil" Number="105" Volume="1964" Year="1973" Format="Main Series">
+    <Book Series="Daredevil" Number="105" Volume="1964" Year="1973">
       <Id>ac0c4d79-1745-4fc6-9008-1589fb59cd02</Id>
     </Book>
-    <Book Series="Daredevil" Number="106" Volume="1964" Year="1973" Format="Main Series">
+    <Book Series="Daredevil" Number="106" Volume="1964" Year="1973">
       <Id>3827b091-5587-4955-baf6-8bfd86da10a0</Id>
     </Book>
-    <Book Series="Daredevil" Number="107" Volume="1964" Year="1974" Format="Main Series">
+    <Book Series="Daredevil" Number="107" Volume="1964" Year="1974">
       <Id>440da1ba-654d-45eb-9f33-61a9db690ecd</Id>
     </Book>
-    <Book Series="Daredevil" Number="108" Volume="1964" Year="1974" Format="Main Series">
+    <Book Series="Daredevil" Number="108" Volume="1964" Year="1974">
       <Id>cf5e4fee-7723-4071-93fd-993e7ec46da8</Id>
     </Book>
-    <Book Series="Daredevil" Number="109" Volume="1964" Year="1974" Format="Main Series">
+    <Book Series="Daredevil" Number="109" Volume="1964" Year="1974">
       <Id>63822677-f61d-4bbd-af21-10c0778daf32</Id>
     </Book>
-    <Book Series="Marvel Two-in-One" Number="3" Volume="1974" Year="1974" Format="Main Series">
+    <Book Series="Marvel Two-in-One" Number="3" Volume="1974" Year="1974">
       <Id>21a65fef-acef-4894-a6fa-ee5091f4dfa5</Id>
     </Book>
-    <Book Series="Daredevil" Number="110" Volume="1964" Year="1974" Format="Main Series">
+    <Book Series="Daredevil" Number="110" Volume="1964" Year="1974">
       <Id>915ecdee-d34a-4ac6-92f0-4eef67dc0c35</Id>
     </Book>
-    <Book Series="Daredevil" Number="111" Volume="1964" Year="1974" Format="Main Series">
+    <Book Series="Daredevil" Number="111" Volume="1964" Year="1974">
       <Id>ef4a59cd-94c9-436a-a887-b536a9e377cd</Id>
     </Book>
-    <Book Series="Daredevil" Number="112" Volume="1964" Year="1974" Format="Main Series">
+    <Book Series="Daredevil" Number="112" Volume="1964" Year="1974">
       <Id>9de2ed0a-ec8a-4b41-ad15-95cbb5a2a86c</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="25" Volume="1972" Year="1974" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="25" Volume="1972" Year="1974">
       <Id>ce92afb6-8465-41d7-95a0-5349bebfb531</Id>
     </Book>
-    <Book Series="Daredevil" Number="113" Volume="1964" Year="1974" Format="Main Series">
+    <Book Series="Daredevil" Number="113" Volume="1964" Year="1974">
       <Id>e71393cc-9669-4112-9eaf-9e202322207e</Id>
     </Book>
-    <Book Series="Daredevil" Number="114" Volume="1964" Year="1974" Format="Main Series">
+    <Book Series="Daredevil" Number="114" Volume="1964" Year="1974">
       <Id>a58c7dcd-9a94-40b7-8b9a-9757302b6a1c</Id>
     </Book>
-    <Book Series="Daredevil" Number="115" Volume="1964" Year="1974" Format="Main Series">
+    <Book Series="Daredevil" Number="115" Volume="1964" Year="1974">
       <Id>019f9149-913b-47f2-b44a-d18e08347d95</Id>
     </Book>
-    <Book Series="Daredevil" Number="116" Volume="1964" Year="1974" Format="Main Series">
+    <Book Series="Daredevil" Number="116" Volume="1964" Year="1974">
       <Id>23b30aca-b374-477f-b49c-e723ed5df0ba</Id>
     </Book>
-    <Book Series="Daredevil" Number="117" Volume="1964" Year="1975" Format="Main Series">
+    <Book Series="Daredevil" Number="117" Volume="1964" Year="1975">
       <Id>48ed2745-cd05-429a-9a43-26435f711737</Id>
     </Book>
-    <Book Series="Daredevil" Number="118" Volume="1964" Year="1975" Format="Main Series">
+    <Book Series="Daredevil" Number="118" Volume="1964" Year="1975">
       <Id>8d8a6798-b6e7-4a9e-b1c2-aa8cf63f84f0</Id>
     </Book>
-    <Book Series="Daredevil" Number="119" Volume="1964" Year="1975" Format="Main Series">
+    <Book Series="Daredevil" Number="119" Volume="1964" Year="1975">
       <Id>74c25796-fbe3-4607-901b-2b9b43db151b</Id>
     </Book>
-    <Book Series="Daredevil" Number="120" Volume="1964" Year="1975" Format="Main Series">
+    <Book Series="Daredevil" Number="120" Volume="1964" Year="1975">
       <Id>5104dd87-b9c9-4436-b76c-a899cf3f50da</Id>
     </Book>
-    <Book Series="Daredevil" Number="121" Volume="1964" Year="1975" Format="Main Series">
+    <Book Series="Daredevil" Number="121" Volume="1964" Year="1975">
       <Id>94c46402-aa3e-4801-943b-268140468ce3</Id>
     </Book>
-    <Book Series="Daredevil" Number="122" Volume="1964" Year="1975" Format="Main Series">
+    <Book Series="Daredevil" Number="122" Volume="1964" Year="1975">
       <Id>fb8ed937-edf9-4228-b208-ecf183102f2f</Id>
     </Book>
-    <Book Series="Daredevil" Number="123" Volume="1964" Year="1975" Format="Main Series">
+    <Book Series="Daredevil" Number="123" Volume="1964" Year="1975">
       <Id>6195ddd4-fab5-4c06-b09b-339dfb0ce384</Id>
     </Book>
-    <Book Series="Daredevil" Number="124" Volume="1964" Year="1975" Format="Main Series">
+    <Book Series="Daredevil" Number="124" Volume="1964" Year="1975">
       <Id>60e35865-8b35-4d6d-af3e-f8d8cf59491e</Id>
     </Book>
-    <Book Series="Daredevil" Number="125" Volume="1964" Year="1975" Format="Main Series">
+    <Book Series="Daredevil" Number="125" Volume="1964" Year="1975">
       <Id>5310eba1-c1ff-4740-b11d-e58df1c22a11</Id>
     </Book>
-    <Book Series="Daredevil" Number="126" Volume="1964" Year="1975" Format="Main Series">
+    <Book Series="Daredevil" Number="126" Volume="1964" Year="1975">
       <Id>5b081589-7674-4cb9-a58d-8f7d858a6c0b</Id>
     </Book>
-    <Book Series="Daredevil" Number="127" Volume="1964" Year="1975" Format="Main Series">
+    <Book Series="Daredevil" Number="127" Volume="1964" Year="1975">
       <Id>7abbf717-9302-4bc5-8ca5-03bda5786531</Id>
     </Book>
-    <Book Series="Daredevil" Number="128" Volume="1964" Year="1975" Format="Main Series">
+    <Book Series="Daredevil" Number="128" Volume="1964" Year="1975">
       <Id>0bfc804e-a453-44ae-bc92-07500143d5ab</Id>
     </Book>
-    <Book Series="Daredevil" Number="129" Volume="1964" Year="1976" Format="Main Series">
+    <Book Series="Daredevil" Number="129" Volume="1964" Year="1976">
       <Id>96a4cc3b-089c-48af-95ee-a7f3af450f9c</Id>
     </Book>
-    <Book Series="Daredevil" Number="130" Volume="1964" Year="1976" Format="Main Series">
+    <Book Series="Daredevil" Number="130" Volume="1964" Year="1976">
       <Id>45ea9e0a-492c-4dcd-9196-5044d0808753</Id>
     </Book>
-    <Book Series="Daredevil" Number="131" Volume="1964" Year="1976" Format="Main Series">
+    <Book Series="Daredevil" Number="131" Volume="1964" Year="1976">
       <Id>8203df8d-8b47-46b6-9997-deb97880439b</Id>
     </Book>
-    <Book Series="Daredevil" Number="132" Volume="1964" Year="1976" Format="Main Series">
+    <Book Series="Daredevil" Number="132" Volume="1964" Year="1976">
       <Id>2598117e-51dd-4a94-9ccc-b8e33f2b72a1</Id>
     </Book>
-    <Book Series="Daredevil" Number="133" Volume="1964" Year="1976" Format="Main Series">
+    <Book Series="Daredevil" Number="133" Volume="1964" Year="1976">
       <Id>251ef37d-af8f-41ef-988e-ef02b0f82759</Id>
     </Book>
-    <Book Series="Daredevil" Number="134" Volume="1964" Year="1976" Format="Main Series">
+    <Book Series="Daredevil" Number="134" Volume="1964" Year="1976">
       <Id>e8c8670c-5b33-4039-8f0d-a48a7a171a0e</Id>
     </Book>
-    <Book Series="Daredevil" Number="135" Volume="1964" Year="1976" Format="Main Series">
+    <Book Series="Daredevil" Number="135" Volume="1964" Year="1976">
       <Id>0b657291-5802-434c-91a1-e81bd90ae8e8</Id>
     </Book>
-    <Book Series="Daredevil" Number="136" Volume="1964" Year="1976" Format="Main Series">
+    <Book Series="Daredevil" Number="136" Volume="1964" Year="1976">
       <Id>8233ba50-9b60-4494-a45b-e5465bc76674</Id>
     </Book>
-    <Book Series="Daredevil" Number="137" Volume="1964" Year="1976" Format="Main Series">
+    <Book Series="Daredevil" Number="137" Volume="1964" Year="1976">
       <Id>2119b2ca-e40e-4d7e-858e-206bdfde7d22</Id>
     </Book>
-    <Book Series="Iron Man" Number="89" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="Iron Man" Number="89" Volume="1968" Year="1976">
       <Id>bbaabc23-0ead-4795-ab53-dde586b9c3e8</Id>
     </Book>
-    <Book Series="Daredevil" Number="139" Volume="1964" Year="1976" Format="Main Series">
+    <Book Series="Daredevil" Number="139" Volume="1964" Year="1976">
       <Id>dd33637e-29a3-4150-b06a-b1e918e79cdf</Id>
     </Book>
-    <Book Series="Daredevil Annual" Number="4" Volume="1967" Year="1976" Format="Annual">
+    <Book Series="Daredevil Annual" Number="4" Volume="1967" Year="1976">
       <Id>929c2b40-970a-4d16-99fc-ad1b0d4557d7</Id>
     </Book>
-    <Book Series="Daredevil" Number="140" Volume="1964" Year="1976" Format="Main Series">
+    <Book Series="Daredevil" Number="140" Volume="1964" Year="1976">
       <Id>8b15c841-8f69-4e44-9144-9d05330347ce</Id>
     </Book>
-    <Book Series="Daredevil" Number="141" Volume="1964" Year="1977" Format="Main Series">
+    <Book Series="Daredevil" Number="141" Volume="1964" Year="1977">
       <Id>d15e3e2e-021e-4f31-99cd-92ba1e3e1de4</Id>
     </Book>
-    <Book Series="Daredevil" Number="142" Volume="1964" Year="1977" Format="Main Series">
+    <Book Series="Daredevil" Number="142" Volume="1964" Year="1977">
       <Id>bc8f36ac-368d-43e8-ae1b-1797efc466b4</Id>
     </Book>
-    <Book Series="Daredevil" Number="143" Volume="1964" Year="1977" Format="Main Series">
+    <Book Series="Daredevil" Number="143" Volume="1964" Year="1977">
       <Id>03024178-9183-4127-a672-be5f7461996c</Id>
     </Book>
-    <Book Series="Daredevil" Number="144" Volume="1964" Year="1977" Format="Main Series">
+    <Book Series="Daredevil" Number="144" Volume="1964" Year="1977">
       <Id>074c3cb5-f28e-4bd1-b2f9-1b3356dc1a10</Id>
     </Book>
-    <Book Series="Daredevil" Number="145" Volume="1964" Year="1977" Format="Main Series">
+    <Book Series="Daredevil" Number="145" Volume="1964" Year="1977">
       <Id>6e44199b-7430-45b7-b0bd-9017a2787bfc</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="56" Volume="1972" Year="1977" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="56" Volume="1972" Year="1977">
       <Id>02a8392e-35cb-42e9-a030-7e67038108b4</Id>
     </Book>
-    <Book Series="Daredevil" Number="146" Volume="1964" Year="1977" Format="Main Series">
+    <Book Series="Daredevil" Number="146" Volume="1964" Year="1977">
       <Id>74365e66-7d2d-437b-9c09-e5c918f79859</Id>
     </Book>
-    <Book Series="Daredevil" Number="147" Volume="1964" Year="1977" Format="Main Series">
+    <Book Series="Daredevil" Number="147" Volume="1964" Year="1977">
       <Id>70cd32b1-e0f1-420e-9423-7bfe45e796ef</Id>
     </Book>
-    <Book Series="Daredevil" Number="148" Volume="1964" Year="1977" Format="Main Series">
+    <Book Series="Daredevil" Number="148" Volume="1964" Year="1977">
       <Id>8f869dd2-9287-49c1-9ca8-289a6642b4fc</Id>
     </Book>
-    <Book Series="Daredevil" Number="149" Volume="1964" Year="1977" Format="Main Series">
+    <Book Series="Daredevil" Number="149" Volume="1964" Year="1977">
       <Id>0eb089f9-5fa3-4f52-876e-339b7dabc5d9</Id>
     </Book>
-    <Book Series="Daredevil" Number="150" Volume="1964" Year="1978" Format="Main Series">
+    <Book Series="Daredevil" Number="150" Volume="1964" Year="1978">
       <Id>6500955d-bcfb-4091-b66d-a72cafc5ac5d</Id>
     </Book>
-    <Book Series="Daredevil" Number="151" Volume="1964" Year="1978" Format="Main Series">
+    <Book Series="Daredevil" Number="151" Volume="1964" Year="1978">
       <Id>84d9e925-54a1-4e0e-ba4e-0f079c930354</Id>
     </Book>
-    <Book Series="Daredevil" Number="152" Volume="1964" Year="1978" Format="Main Series">
+    <Book Series="Daredevil" Number="152" Volume="1964" Year="1978">
       <Id>af604070-c8ea-4a01-bc1c-7de9ccb3e1b7</Id>
     </Book>
-    <Book Series="Daredevil" Number="153" Volume="1964" Year="1978" Format="Main Series">
+    <Book Series="Daredevil" Number="153" Volume="1964" Year="1978">
       <Id>d7ff9a53-b42c-44d5-bacc-0663b0cb9717</Id>
     </Book>
-    <Book Series="Daredevil" Number="154" Volume="1964" Year="1978" Format="Main Series">
+    <Book Series="Daredevil" Number="154" Volume="1964" Year="1978">
       <Id>25c6be4d-2c9f-4d5f-ab4a-5758389d5660</Id>
     </Book>
-    <Book Series="Marvel Two-in-One" Number="37" Volume="1974" Year="1978" Format="Main Series">
+    <Book Series="Marvel Two-in-One" Number="37" Volume="1974" Year="1978">
       <Id>9861a0a3-81ca-4fd1-9116-9be5c166e0d4</Id>
     </Book>
-    <Book Series="Marvel Two-in-One" Number="38" Volume="1974" Year="1978" Format="Main Series">
+    <Book Series="Marvel Two-in-One" Number="38" Volume="1974" Year="1978">
       <Id>5e10a8d6-b1a5-4ec4-83c4-d330c98f278d</Id>
     </Book>
-    <Book Series="Marvel Two-in-One" Number="39" Volume="1974" Year="1978" Format="Main Series">
+    <Book Series="Marvel Two-in-One" Number="39" Volume="1974" Year="1978">
       <Id>f7f97792-44a2-406f-be71-a46774035c75</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="73" Volume="1972" Year="1978" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="73" Volume="1972" Year="1978">
       <Id>116b3e09-aae0-42d7-89cc-1d4fd2477695</Id>
     </Book>
-    <Book Series="Daredevil" Number="155" Volume="1964" Year="1978" Format="Main Series">
+    <Book Series="Daredevil" Number="155" Volume="1964" Year="1978">
       <Id>8bd71370-b8a4-4f8d-84ec-a842ccfdd570</Id>
     </Book>
-    <Book Series="Daredevil" Number="156" Volume="1964" Year="1979" Format="Main Series">
+    <Book Series="Daredevil" Number="156" Volume="1964" Year="1979">
       <Id>218e4147-fb7d-4c66-81f7-2863a21cb5c5</Id>
     </Book>
-    <Book Series="Daredevil" Number="157" Volume="1964" Year="1979" Format="Main Series">
+    <Book Series="Daredevil" Number="157" Volume="1964" Year="1979">
       <Id>3ea4a601-0d72-48cb-a931-1960f55a424d</Id>
     </Book>
-    <Book Series="Daredevil" Number="158" Volume="1964" Year="1979" Format="Main Series">
+    <Book Series="Daredevil" Number="158" Volume="1964" Year="1979">
       <Id>bbef3536-4f5b-4cac-937f-4d2b9ea12ec2</Id>
     </Book>
-    <Book Series="Daredevil" Number="159" Volume="1964" Year="1979" Format="Main Series">
+    <Book Series="Daredevil" Number="159" Volume="1964" Year="1979">
       <Id>008c3ac3-5c42-46b5-8b3d-4f7826756d2e</Id>
     </Book>
-    <Book Series="Daredevil" Number="160" Volume="1964" Year="1979" Format="Main Series">
+    <Book Series="Daredevil" Number="160" Volume="1964" Year="1979">
       <Id>4562f304-9628-4c0d-a8d6-d446971b9c0a</Id>
     </Book>
-    <Book Series="Daredevil" Number="161" Volume="1964" Year="1979" Format="Main Series">
+    <Book Series="Daredevil" Number="161" Volume="1964" Year="1979">
       <Id>e7c7b04f-d765-47b3-9c7b-8350e97797b6</Id>
     </Book>
-    <Book Series="Captain America" Number="234" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="Captain America" Number="234" Volume="1968" Year="1979">
       <Id>b5c1b853-6b82-4c95-9b96-81b59ddf36e6</Id>
     </Book>
-    <Book Series="Captain America" Number="235" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="Captain America" Number="235" Volume="1968" Year="1979">
       <Id>566f92dc-ebd9-411e-8f89-9e45475ccac1</Id>
     </Book>
-    <Book Series="Captain America" Number="236" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="Captain America" Number="236" Volume="1968" Year="1979">
       <Id>5b91914c-e885-43d1-a183-fb0b960a24d4</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="26" Volume="1976" Year="1979" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="26" Volume="1976" Year="1979">
       <Id>8e30f1a5-b3ec-4e98-887f-7ec7ce3f7bf9</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="27" Volume="1976" Year="1979" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="27" Volume="1976" Year="1979">
       <Id>9c1dd9c3-3a91-442d-9298-7375b659d1c6</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="28" Volume="1976" Year="1979" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="28" Volume="1976" Year="1979">
       <Id>6383f634-fb2d-4a6f-856a-916076ceea05</Id>
     </Book>
-    <Book Series="Daredevil" Number="162" Volume="1964" Year="1980" Format="Main Series">
+    <Book Series="Daredevil" Number="162" Volume="1964" Year="1980">
       <Id>11f83c00-681f-4161-bd83-98e75b04abbd</Id>
     </Book>
-    <Book Series="Daredevil" Number="163" Volume="1964" Year="1980" Format="Main Series">
+    <Book Series="Daredevil" Number="163" Volume="1964" Year="1980">
       <Id>2e028640-d8a2-4fed-a582-0d8e9e0b0e34</Id>
     </Book>
-    <Book Series="Daredevil" Number="164" Volume="1964" Year="1980" Format="Main Series">
+    <Book Series="Daredevil" Number="164" Volume="1964" Year="1980">
       <Id>1c70e29e-0161-439f-b10c-faa872f07da6</Id>
     </Book>
-    <Book Series="Daredevil" Number="165" Volume="1964" Year="1980" Format="Main Series">
+    <Book Series="Daredevil" Number="165" Volume="1964" Year="1980">
       <Id>b10c3a01-d9f6-471c-ade8-a54673ded961</Id>
     </Book>
-    <Book Series="Daredevil" Number="166" Volume="1964" Year="1980" Format="Main Series">
+    <Book Series="Daredevil" Number="166" Volume="1964" Year="1980">
       <Id>92d46541-4210-45a7-bdfe-50ee107fbddb</Id>
     </Book>
-    <Book Series="Daredevil" Number="167" Volume="1964" Year="1980" Format="Main Series">
+    <Book Series="Daredevil" Number="167" Volume="1964" Year="1980">
       <Id>aa5e8118-31c5-4470-a87f-7b8234580077</Id>
     </Book>
-    <Book Series="Daredevil" Number="168" Volume="1964" Year="1981" Format="Main Series">
+    <Book Series="Daredevil" Number="168" Volume="1964" Year="1981">
       <Id>f69ec81b-85c5-404c-ab89-1b75a062be52</Id>
     </Book>
-    <Book Series="Daredevil" Number="169" Volume="1964" Year="1981" Format="Main Series">
+    <Book Series="Daredevil" Number="169" Volume="1964" Year="1981">
       <Id>112d51df-6ade-432c-a553-8da49df8ae53</Id>
     </Book>
-    <Book Series="Daredevil" Number="170" Volume="1964" Year="1981" Format="Main Series">
+    <Book Series="Daredevil" Number="170" Volume="1964" Year="1981">
       <Id>7ce231e6-e0ba-4cc4-b294-cc19b460a8e2</Id>
     </Book>
-    <Book Series="Daredevil" Number="171" Volume="1964" Year="1981" Format="Main Series">
+    <Book Series="Daredevil" Number="171" Volume="1964" Year="1981">
       <Id>56928731-2c41-47ca-9db9-388b80d8f963</Id>
     </Book>
-    <Book Series="Daredevil" Number="172" Volume="1964" Year="1981" Format="Main Series">
+    <Book Series="Daredevil" Number="172" Volume="1964" Year="1981">
       <Id>fc19eb44-7e1b-47d7-ae04-b2056838359b</Id>
     </Book>
-    <Book Series="Daredevil" Number="173" Volume="1964" Year="1981" Format="Main Series">
+    <Book Series="Daredevil" Number="173" Volume="1964" Year="1981">
       <Id>dc7a21ba-12e9-43bb-b806-e26b12b4b8f2</Id>
     </Book>
-    <Book Series="Marvel Team-Up Annual" Number="4" Volume="1976" Year="1981" Format="Annual">
+    <Book Series="Marvel Team-Up Annual" Number="4" Volume="1976" Year="1981">
       <Id>4fc8be7e-5799-4337-9af8-614809746edc</Id>
     </Book>
-    <Book Series="Daredevil" Number="174" Volume="1964" Year="1981" Format="Main Series">
+    <Book Series="Daredevil" Number="174" Volume="1964" Year="1981">
       <Id>f0f6841c-6f08-46f7-abf4-34b191492b11</Id>
     </Book>
-    <Book Series="Daredevil" Number="175" Volume="1964" Year="1981" Format="Main Series">
+    <Book Series="Daredevil" Number="175" Volume="1964" Year="1981">
       <Id>ea1ba7c7-f3b7-4853-8d57-9da3844f9c2f</Id>
     </Book>
-    <Book Series="Daredevil" Number="176" Volume="1964" Year="1981" Format="Main Series">
+    <Book Series="Daredevil" Number="176" Volume="1964" Year="1981">
       <Id>b25718ce-9352-41c1-a703-3d51716a3773</Id>
     </Book>
-    <Book Series="Daredevil" Number="177" Volume="1964" Year="1981" Format="Main Series">
+    <Book Series="Daredevil" Number="177" Volume="1964" Year="1981">
       <Id>30cf3e28-05bf-4159-9c6c-856bc3307bdd</Id>
     </Book>
-    <Book Series="Daredevil" Number="178" Volume="1964" Year="1982" Format="Main Series">
+    <Book Series="Daredevil" Number="178" Volume="1964" Year="1982">
       <Id>7d9dda31-30bf-42d3-874d-de778cfebde5</Id>
     </Book>
-    <Book Series="Daredevil" Number="179" Volume="1964" Year="1982" Format="Main Series">
+    <Book Series="Daredevil" Number="179" Volume="1964" Year="1982">
       <Id>9e54a15d-a6e2-4937-941c-2c66da29b4d4</Id>
     </Book>
-    <Book Series="Daredevil" Number="180" Volume="1964" Year="1982" Format="Main Series">
+    <Book Series="Daredevil" Number="180" Volume="1964" Year="1982">
       <Id>588bd5e6-47e7-4ece-99a1-7c2065a7f2f8</Id>
     </Book>
-    <Book Series="Daredevil" Number="181" Volume="1964" Year="1982" Format="Main Series">
+    <Book Series="Daredevil" Number="181" Volume="1964" Year="1982">
       <Id>7ef23333-d5a5-40da-9b4c-fa4f355603c3</Id>
     </Book>
-    <Book Series="Daredevil" Number="182" Volume="1964" Year="1982" Format="Main Series">
+    <Book Series="Daredevil" Number="182" Volume="1964" Year="1982">
       <Id>20cb6cb1-8ed8-4609-8742-a6d7fba3cb77</Id>
     </Book>
-    <Book Series="Daredevil" Number="183" Volume="1964" Year="1982" Format="Main Series">
+    <Book Series="Daredevil" Number="183" Volume="1964" Year="1982">
       <Id>85bfd7a0-9615-41c9-bc4f-a144523228f0</Id>
     </Book>
-    <Book Series="Daredevil" Number="184" Volume="1964" Year="1982" Format="Main Series">
+    <Book Series="Daredevil" Number="184" Volume="1964" Year="1982">
       <Id>2a1a6621-8e4c-4fc3-96b7-26b0a7013f69</Id>
     </Book>
-    <Book Series="Daredevil" Number="185" Volume="1964" Year="1982" Format="Main Series">
+    <Book Series="Daredevil" Number="185" Volume="1964" Year="1982">
       <Id>91e73ff7-89a4-4b6f-b582-33395b055260</Id>
     </Book>
-    <Book Series="Marvel Super Hero Contest of Champions" Number="1" Volume="1982" Year="1982" Format="Crossover">
+    <Book Series="Marvel Super Hero Contest of Champions" Number="1" Volume="1982" Year="1982">
       <Id>97677479-2159-414c-ad99-39341e8f8d3a</Id>
     </Book>
-    <Book Series="Marvel Super Hero Contest of Champions" Number="2" Volume="1982" Year="1982" Format="Crossover">
+    <Book Series="Marvel Super Hero Contest of Champions" Number="2" Volume="1982" Year="1982">
       <Id>094492f8-7655-4691-a568-50a03bd8f014</Id>
     </Book>
-    <Book Series="Marvel Super Hero Contest of Champions" Number="3" Volume="1982" Year="1982" Format="Crossover">
+    <Book Series="Marvel Super Hero Contest of Champions" Number="3" Volume="1982" Year="1982">
       <Id>3c25c3a8-07d1-48cd-b6a7-ccb47c928f56</Id>
     </Book>
-    <Book Series="Daredevil" Number="186" Volume="1964" Year="1982" Format="Main Series">
+    <Book Series="Daredevil" Number="186" Volume="1964" Year="1982">
       <Id>6b8ad976-be29-4bb7-bf73-7fab2d5eaab1</Id>
     </Book>
-    <Book Series="Daredevil" Number="187" Volume="1964" Year="1982" Format="Main Series">
+    <Book Series="Daredevil" Number="187" Volume="1964" Year="1982">
       <Id>dbf01912-ced7-4beb-a383-260f37806160</Id>
     </Book>
-    <Book Series="Daredevil" Number="188" Volume="1964" Year="1982" Format="Main Series">
+    <Book Series="Daredevil" Number="188" Volume="1964" Year="1982">
       <Id>29aaebbd-a95f-4c59-964a-2c1d90fb055b</Id>
     </Book>
-    <Book Series="Daredevil" Number="189" Volume="1964" Year="1982" Format="Main Series">
+    <Book Series="Daredevil" Number="189" Volume="1964" Year="1982">
       <Id>cab7add3-0da7-4f90-b5ff-76b5121f9051</Id>
     </Book>
-    <Book Series="Daredevil" Number="190" Volume="1964" Year="1983" Format="Main Series">
+    <Book Series="Daredevil" Number="190" Volume="1964" Year="1983">
       <Id>45075381-cd42-4c95-8a69-04ac4aa381fa</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="123" Volume="1972" Year="1982" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="123" Volume="1972" Year="1982">
       <Id>beb4caf7-50f3-4a4f-893d-10990c4093a8</Id>
     </Book>
-    <Book Series="Daredevil" Number="191" Volume="1964" Year="1983" Format="Main Series">
+    <Book Series="Daredevil" Number="191" Volume="1964" Year="1983">
       <Id>c5ad78bd-3d99-43e4-9cad-1e339054333b</Id>
     </Book>
-    <Book Series="Daredevil" Number="192" Volume="1964" Year="1983" Format="Main Series">
+    <Book Series="Daredevil" Number="192" Volume="1964" Year="1983">
       <Id>4d90ab67-226b-4f90-b27f-1645c019f392</Id>
     </Book>
-    <Book Series="Daredevil" Number="193" Volume="1964" Year="1983" Format="Main Series">
+    <Book Series="Daredevil" Number="193" Volume="1964" Year="1983">
       <Id>f5b99545-d640-497e-b70b-b444d0fbc720</Id>
     </Book>
-    <Book Series="Daredevil" Number="194" Volume="1964" Year="1983" Format="Main Series">
+    <Book Series="Daredevil" Number="194" Volume="1964" Year="1983">
       <Id>6f699956-c6ac-4a8f-a6ac-7cf727bb8013</Id>
     </Book>
-    <Book Series="Daredevil" Number="195" Volume="1964" Year="1983" Format="Main Series">
+    <Book Series="Daredevil" Number="195" Volume="1964" Year="1983">
       <Id>5dd8926b-0842-4e2f-b47a-b92aa3471911</Id>
     </Book>
-    <Book Series="Daredevil" Number="196" Volume="1964" Year="1983" Format="Main Series">
+    <Book Series="Daredevil" Number="196" Volume="1964" Year="1983">
       <Id>0b8022d3-d8d4-4118-8fc0-766485c7b1f2</Id>
     </Book>
-    <Book Series="Daredevil" Number="197" Volume="1964" Year="1983" Format="Main Series">
+    <Book Series="Daredevil" Number="197" Volume="1964" Year="1983">
       <Id>6835b619-4dc3-48c8-bfd4-b0e11a75b949</Id>
     </Book>
-    <Book Series="Daredevil" Number="198" Volume="1964" Year="1983" Format="Main Series">
+    <Book Series="Daredevil" Number="198" Volume="1964" Year="1983">
       <Id>b1e6df20-3dd8-4723-a940-872bf99ceaf3</Id>
     </Book>
-    <Book Series="Daredevil" Number="199" Volume="1964" Year="1983" Format="Main Series">
+    <Book Series="Daredevil" Number="199" Volume="1964" Year="1983">
       <Id>8170b3bd-8858-4c6a-afe7-932c9b2d36e7</Id>
     </Book>
-    <Book Series="Daredevil" Number="200" Volume="1964" Year="1983" Format="Main Series">
+    <Book Series="Daredevil" Number="200" Volume="1964" Year="1983">
       <Id>a16837e9-3e8b-4eab-ab4b-302e099214e0</Id>
     </Book>
-    <Book Series="Daredevil" Number="201" Volume="1964" Year="1983" Format="Main Series">
+    <Book Series="Daredevil" Number="201" Volume="1964" Year="1983">
       <Id>70b91433-7788-4190-bcdd-6904894e660d</Id>
     </Book>
-    <Book Series="Daredevil" Number="202" Volume="1964" Year="1984" Format="Main Series">
+    <Book Series="Daredevil" Number="202" Volume="1964" Year="1984">
       <Id>697595b7-69ce-4c1a-81ad-d93770ea60cd</Id>
     </Book>
-    <Book Series="Daredevil" Number="203" Volume="1964" Year="1984" Format="Main Series">
+    <Book Series="Daredevil" Number="203" Volume="1964" Year="1984">
       <Id>3e0637f1-673d-44ff-a628-7dde9001a534</Id>
     </Book>
-    <Book Series="Daredevil" Number="204" Volume="1964" Year="1984" Format="Main Series">
+    <Book Series="Daredevil" Number="204" Volume="1964" Year="1984">
       <Id>5a9cef44-5619-48c8-b680-f3171890dfed</Id>
     </Book>
-    <Book Series="Daredevil" Number="205" Volume="1964" Year="1984" Format="Main Series">
+    <Book Series="Daredevil" Number="205" Volume="1964" Year="1984">
       <Id>4e58d02e-cf64-4656-99e1-b9fb732d7eef</Id>
     </Book>
-    <Book Series="Daredevil" Number="206" Volume="1964" Year="1984" Format="Main Series">
+    <Book Series="Daredevil" Number="206" Volume="1964" Year="1984">
       <Id>f4715600-6f30-4224-ba72-135501fac7d3</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="140" Volume="1972" Year="1984" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="140" Volume="1972" Year="1984">
       <Id>9db89044-a303-4dbe-89eb-b84dda7cccfb</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="141" Volume="1972" Year="1984" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="141" Volume="1972" Year="1984">
       <Id>b0b15eb4-131a-4947-a03f-4f7ae1cfd5a3</Id>
     </Book>
-    <Book Series="Daredevil" Number="207" Volume="1964" Year="1984" Format="Main Series">
+    <Book Series="Daredevil" Number="207" Volume="1964" Year="1984">
       <Id>5e63ac49-ee0b-494d-b3b2-32102a037d65</Id>
     </Book>
-    <Book Series="Daredevil" Number="208" Volume="1964" Year="1984" Format="Main Series">
+    <Book Series="Daredevil" Number="208" Volume="1964" Year="1984">
       <Id>07bb1251-f04d-4219-91fe-1ffee7a49596</Id>
     </Book>
-    <Book Series="Daredevil" Number="209" Volume="1964" Year="1984" Format="Main Series">
+    <Book Series="Daredevil" Number="209" Volume="1964" Year="1984">
       <Id>7b255cc2-e613-46ea-ac0f-958be388c155</Id>
     </Book>
-    <Book Series="Daredevil" Number="210" Volume="1964" Year="1984" Format="Main Series">
+    <Book Series="Daredevil" Number="210" Volume="1964" Year="1984">
       <Id>cac86695-8ea5-4875-ad39-8d9e12c12b73</Id>
     </Book>
-    <Book Series="Daredevil" Number="211" Volume="1964" Year="1984" Format="Main Series">
+    <Book Series="Daredevil" Number="211" Volume="1964" Year="1984">
       <Id>179a7774-a2de-4751-9e20-14a4318a8fe0</Id>
     </Book>
-    <Book Series="Daredevil" Number="212" Volume="1964" Year="1984" Format="Main Series">
+    <Book Series="Daredevil" Number="212" Volume="1964" Year="1984">
       <Id>1a85df8f-3e54-4dcc-bab2-c9d3a2355f64</Id>
     </Book>
-    <Book Series="Daredevil" Number="213" Volume="1964" Year="1984" Format="Main Series">
+    <Book Series="Daredevil" Number="213" Volume="1964" Year="1984">
       <Id>1ec147d3-9d8b-44ae-bcff-3f76897af3a3</Id>
     </Book>
-    <Book Series="Daredevil" Number="214" Volume="1964" Year="1985" Format="Main Series">
+    <Book Series="Daredevil" Number="214" Volume="1964" Year="1985">
       <Id>9b5083cc-6ecf-4b7b-bf2e-357832109f00</Id>
     </Book>
-    <Book Series="Daredevil" Number="215" Volume="1964" Year="1985" Format="Main Series">
+    <Book Series="Daredevil" Number="215" Volume="1964" Year="1985">
       <Id>e7288428-fba4-4f60-810a-aa0df118683d</Id>
     </Book>
-    <Book Series="Daredevil" Number="216" Volume="1964" Year="1985" Format="Main Series">
+    <Book Series="Daredevil" Number="216" Volume="1964" Year="1985">
       <Id>5a26c525-ec17-4ade-b89f-57b85379b168</Id>
     </Book>
-    <Book Series="Daredevil" Number="217" Volume="1964" Year="1985" Format="Main Series">
+    <Book Series="Daredevil" Number="217" Volume="1964" Year="1985">
       <Id>527e2609-0132-4bcf-979a-3235e22e89d1</Id>
     </Book>
-    <Book Series="Daredevil" Number="218" Volume="1964" Year="1985" Format="Main Series">
+    <Book Series="Daredevil" Number="218" Volume="1964" Year="1985">
       <Id>4ec9a452-2808-4e31-af75-3ca6ecc2100a</Id>
     </Book>
-    <Book Series="Daredevil" Number="219" Volume="1964" Year="1985" Format="Main Series">
+    <Book Series="Daredevil" Number="219" Volume="1964" Year="1985">
       <Id>85e31453-a726-480f-bc98-a2e5b7f1fff0</Id>
     </Book>
-    <Book Series="Daredevil" Number="220" Volume="1964" Year="1985" Format="Main Series">
+    <Book Series="Daredevil" Number="220" Volume="1964" Year="1985">
       <Id>28a1b476-bb92-4d84-b000-5e57fee3bbde</Id>
     </Book>
-    <Book Series="Daredevil" Number="221" Volume="1964" Year="1985" Format="Main Series">
+    <Book Series="Daredevil" Number="221" Volume="1964" Year="1985">
       <Id>0f666b4a-1275-4b06-a1da-c09d29b464db</Id>
     </Book>
-    <Book Series="Daredevil" Number="222" Volume="1964" Year="1985" Format="Main Series">
+    <Book Series="Daredevil" Number="222" Volume="1964" Year="1985">
       <Id>957a7443-4b8b-4c6d-9df8-1d871a8affd2</Id>
     </Book>
-    <Book Series="Secret Wars II" Number="3" Volume="1985" Year="1985" Format="Crossover">
+    <Book Series="Secret Wars II" Number="3" Volume="1985" Year="1985">
       <Id>e5b5030d-94e5-4db4-bee0-a76b4f865d95</Id>
     </Book>
-    <Book Series="Daredevil" Number="223" Volume="1964" Year="1985" Format="Main Series">
+    <Book Series="Daredevil" Number="223" Volume="1964" Year="1985">
       <Id>cf75c696-7188-4983-b0b8-4ef47db11244</Id>
     </Book>
-    <Book Series="Daredevil" Number="224" Volume="1964" Year="1985" Format="Main Series">
+    <Book Series="Daredevil" Number="224" Volume="1964" Year="1985">
       <Id>0d0e9083-0186-47c3-9c34-a2f2422c6896</Id>
     </Book>
-    <Book Series="Daredevil" Number="225" Volume="1964" Year="1985" Format="Main Series">
+    <Book Series="Daredevil" Number="225" Volume="1964" Year="1985">
       <Id>a682a921-7d9d-4b02-8166-820a19847613</Id>
     </Book>
-    <Book Series="Daredevil" Number="226" Volume="1964" Year="1986" Format="Main Series">
+    <Book Series="Daredevil" Number="226" Volume="1964" Year="1986">
       <Id>61983ed5-71a4-499b-813a-314010fbc2ac</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="107" Volume="1976" Year="1985" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="107" Volume="1976" Year="1985">
       <Id>d475b8d8-a6d5-4609-9f2e-0e85319e5e8e</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="108" Volume="1976" Year="1985" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="108" Volume="1976" Year="1985">
       <Id>98591799-7aa2-46fd-9437-08e7b210f39c</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="109" Volume="1976" Year="1985" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="109" Volume="1976" Year="1985">
       <Id>892c0b35-457f-4bca-b5f0-c63fdcfda040</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="110" Volume="1976" Year="1986" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="110" Volume="1976" Year="1986">
       <Id>44ded460-3a5f-45a4-82a1-cd3822453ca7</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Daredevil/Daredevil 001.cbl
+++ b/Marvel/Characters/unsorted/Daredevil/Daredevil 001.cbl
@@ -1,783 +1,784 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Daredevil 1</Name>
+  <Name>Daredevil 001</Name>
+  <NumIssues>259</NumIssues>
   <Books>
     <Book Series="Daredevil" Number="1" Volume="1964" Year="1964">
-      <Id>5ec018c3-5dd7-4152-9808-866165026dc3</Id>
+      <Database Name="cv" Series="2190" Issue="7067" />
     </Book>
     <Book Series="Daredevil" Number="2" Volume="1964" Year="1964">
-      <Id>94c3484f-da74-45ed-bc1b-732636b3eece</Id>
+      <Database Name="cv" Series="2190" Issue="7157" />
     </Book>
     <Book Series="Daredevil" Number="3" Volume="1964" Year="1964">
-      <Id>94422450-3c5b-44e7-bc39-3f2d978efbc4</Id>
+      <Database Name="cv" Series="2190" Issue="7255" />
     </Book>
     <Book Series="Daredevil" Number="4" Volume="1964" Year="1964">
-      <Id>ce483dbf-47da-41f4-b2ea-b78203f88343</Id>
+      <Database Name="cv" Series="2190" Issue="7372" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="16" Volume="1963" Year="1964">
-      <Id>500da22b-db48-424a-8472-e96fe24ca1e9</Id>
+      <Database Name="cv" Series="2127" Issue="7301" />
     </Book>
     <Book Series="Daredevil" Number="5" Volume="1964" Year="1964">
-      <Id>444b30d4-3beb-46b7-b6e6-f908af30574f</Id>
+      <Database Name="cv" Series="2190" Issue="7483" />
     </Book>
     <Book Series="Daredevil" Number="6" Volume="1964" Year="1965">
-      <Id>76361279-1180-421f-85e2-2d46ca61c4ca</Id>
+      <Database Name="cv" Series="2190" Issue="7609" />
     </Book>
     <Book Series="Daredevil" Number="7" Volume="1964" Year="1965">
-      <Id>03394ce1-8c65-4fe4-8c6d-c72147b43da8</Id>
+      <Database Name="cv" Series="2190" Issue="7725" />
     </Book>
     <Book Series="Daredevil" Number="8" Volume="1964" Year="1965">
-      <Id>72f35741-7c2d-4ccb-8c58-d4c31fd2cb75</Id>
+      <Database Name="cv" Series="2190" Issue="7836" />
     </Book>
     <Book Series="Daredevil" Number="9" Volume="1964" Year="1965">
-      <Id>9b6d7246-bf61-409f-a506-ebccf0bb1362</Id>
+      <Database Name="cv" Series="2190" Issue="7960" />
     </Book>
     <Book Series="Daredevil" Number="10" Volume="1964" Year="1965">
-      <Id>448a5794-fe0e-487e-9bce-4571d0e23ee1</Id>
+      <Database Name="cv" Series="2190" Issue="8102" />
     </Book>
     <Book Series="Daredevil" Number="11" Volume="1964" Year="1965">
-      <Id>e77f79d1-3cbb-4703-ba98-788356275a3b</Id>
+      <Database Name="cv" Series="2190" Issue="8230" />
     </Book>
     <Book Series="Daredevil" Number="12" Volume="1964" Year="1966">
-      <Id>47d10d36-374d-46c0-a552-66c9e4fdba00</Id>
+      <Database Name="cv" Series="2190" Issue="8307" />
     </Book>
     <Book Series="Daredevil" Number="13" Volume="1964" Year="1966">
-      <Id>86146152-5b48-40ef-bb04-40f83ac67141</Id>
+      <Database Name="cv" Series="2190" Issue="8366" />
     </Book>
     <Book Series="Daredevil" Number="14" Volume="1964" Year="1966">
-      <Id>57b8cb6e-e0cf-443f-b4ec-2ffbf5836236</Id>
+      <Database Name="cv" Series="2190" Issue="8427" />
     </Book>
     <Book Series="Daredevil" Number="15" Volume="1964" Year="1966">
-      <Id>6ca881c0-8d42-4131-a0da-03618c9fd3af</Id>
+      <Database Name="cv" Series="2190" Issue="8489" />
     </Book>
     <Book Series="Daredevil" Number="16" Volume="1964" Year="1966">
-      <Id>91233772-f8b7-4794-8fdf-dab6fea4bfee</Id>
+      <Database Name="cv" Series="2190" Issue="8545" />
     </Book>
     <Book Series="Daredevil" Number="17" Volume="1964" Year="1966">
-      <Id>b800e2f7-6ef1-4074-bc4e-16a1a64b3a0d</Id>
+      <Database Name="cv" Series="2190" Issue="8612" />
     </Book>
     <Book Series="Daredevil" Number="18" Volume="1964" Year="1966">
-      <Id>987362ed-53a8-481b-8c7f-f526cac98836</Id>
+      <Database Name="cv" Series="2190" Issue="8665" />
     </Book>
     <Book Series="Daredevil" Number="19" Volume="1964" Year="1966">
-      <Id>2e88e434-672d-49e5-9529-0321bae05e1b</Id>
+      <Database Name="cv" Series="2190" Issue="8731" />
     </Book>
     <Book Series="Daredevil" Number="20" Volume="1964" Year="1966">
-      <Id>a5a20a91-be80-44fc-a38f-d70ca7854ae5</Id>
+      <Database Name="cv" Series="2190" Issue="8809" />
     </Book>
     <Book Series="Daredevil" Number="21" Volume="1964" Year="1966">
-      <Id>babb622e-b255-444b-b8b8-92a59327ceae</Id>
+      <Database Name="cv" Series="2190" Issue="8875" />
     </Book>
     <Book Series="Daredevil" Number="22" Volume="1964" Year="1966">
-      <Id>1f3d3089-0d9d-43a4-bbc9-50c57d4850ab</Id>
+      <Database Name="cv" Series="2190" Issue="8942" />
     </Book>
     <Book Series="Daredevil" Number="23" Volume="1964" Year="1966">
-      <Id>dd6a12b4-f444-4e00-98e6-2b76eaf14663</Id>
+      <Database Name="cv" Series="2190" Issue="9016" />
     </Book>
     <Book Series="Daredevil" Number="24" Volume="1964" Year="1967">
-      <Id>dac69428-cdc4-42a5-a06b-53d05049c20e</Id>
+      <Database Name="cv" Series="2190" Issue="9089" />
     </Book>
     <Book Series="Daredevil" Number="25" Volume="1964" Year="1967">
-      <Id>a7c7bbfd-2477-42d3-8ee2-55aa343d6282</Id>
+      <Database Name="cv" Series="2190" Issue="9152" />
     </Book>
     <Book Series="Daredevil" Number="26" Volume="1964" Year="1967">
-      <Id>0ad14474-138d-4d5e-a9e0-620329be5940</Id>
+      <Database Name="cv" Series="2190" Issue="9225" />
     </Book>
     <Book Series="Daredevil" Number="27" Volume="1964" Year="1967">
-      <Id>62387a45-27f1-4a30-943c-4baad7302163</Id>
+      <Database Name="cv" Series="2190" Issue="9292" />
     </Book>
     <Book Series="Daredevil" Number="28" Volume="1964" Year="1967">
-      <Id>50804263-2e16-4cb1-a106-46ad2b83c93a</Id>
+      <Database Name="cv" Series="2190" Issue="9355" />
     </Book>
     <Book Series="Daredevil" Number="29" Volume="1964" Year="1967">
-      <Id>5e565a88-d71a-4f66-bda0-10ebaa50157e</Id>
+      <Database Name="cv" Series="2190" Issue="9425" />
     </Book>
     <Book Series="Daredevil" Number="30" Volume="1964" Year="1967">
-      <Id>5a815436-e396-4ecd-9154-22e333bd9a49</Id>
+      <Database Name="cv" Series="2190" Issue="9485" />
     </Book>
     <Book Series="Daredevil" Number="31" Volume="1964" Year="1967">
-      <Id>92a1fdca-3b57-480e-8cc3-b5f3b2cce519</Id>
+      <Database Name="cv" Series="2190" Issue="114011" />
     </Book>
     <Book Series="Daredevil" Number="32" Volume="1964" Year="1967">
-      <Id>b36cc26d-fd94-47d4-9e94-99f2b406e9a1</Id>
+      <Database Name="cv" Series="2190" Issue="9613" />
     </Book>
     <Book Series="Daredevil" Number="33" Volume="1964" Year="1967">
-      <Id>ae3ead69-a436-4ff1-a154-8dbac675e1b9</Id>
+      <Database Name="cv" Series="2190" Issue="9684" />
     </Book>
     <Book Series="Daredevil" Number="34" Volume="1964" Year="1967">
-      <Id>9d6fef26-9235-440d-a5ef-955f130f66d6</Id>
+      <Database Name="cv" Series="2190" Issue="9753" />
     </Book>
     <Book Series="Daredevil Annual" Number="1" Volume="1967" Year="1967">
-      <Id>03fe91b5-018a-4908-93c2-cac8c6fd1898</Id>
+      <Database Name="cv" Series="2351" Issue="9614" />
     </Book>
     <Book Series="Daredevil" Number="35" Volume="1964" Year="1967">
-      <Id>a2303256-55d0-463e-9bd7-d87b040e554d</Id>
+      <Database Name="cv" Series="2190" Issue="9815" />
     </Book>
     <Book Series="Daredevil" Number="36" Volume="1964" Year="1968">
-      <Id>6a51fdb9-ff4c-489f-9194-e92cdb5d8ade</Id>
+      <Database Name="cv" Series="2190" Issue="9879" />
     </Book>
     <Book Series="Daredevil" Number="37" Volume="1964" Year="1968">
-      <Id>846f8e23-9922-4007-9f92-43c4ddf5abf1</Id>
+      <Database Name="cv" Series="2190" Issue="9936" />
     </Book>
     <Book Series="Daredevil" Number="38" Volume="1964" Year="1968">
-      <Id>673a103c-8a1d-404b-8879-6adb42a1dcbc</Id>
+      <Database Name="cv" Series="2190" Issue="114012" />
     </Book>
     <Book Series="Fantastic Four" Number="73" Volume="1961" Year="1968">
-      <Id>c7e81d19-e381-48b8-8b47-f23f3f8b631b</Id>
+      <Database Name="cv" Series="2045" Issue="136901" />
     </Book>
     <Book Series="Daredevil" Number="39" Volume="1964" Year="1968">
-      <Id>74badd1a-1ed1-4339-81c7-7d0d3b332fc8</Id>
+      <Database Name="cv" Series="2190" Issue="114013" />
     </Book>
     <Book Series="Daredevil" Number="40" Volume="1964" Year="1968">
-      <Id>74f9aa3b-3e9c-4d49-a70f-78a33b9b4367</Id>
+      <Database Name="cv" Series="2190" Issue="114014" />
     </Book>
     <Book Series="Daredevil" Number="41" Volume="1964" Year="1968">
-      <Id>7a5bd9d2-0946-410f-98b1-23e75ab4be74</Id>
+      <Database Name="cv" Series="2190" Issue="114015" />
     </Book>
     <Book Series="Daredevil" Number="42" Volume="1964" Year="1968">
-      <Id>fdb986d9-f5a2-461f-a38b-aefa42e73468</Id>
+      <Database Name="cv" Series="2190" Issue="114016" />
     </Book>
     <Book Series="Daredevil" Number="43" Volume="1964" Year="1968">
-      <Id>f8ebe941-0b40-40d9-bc1e-4726629535dd</Id>
+      <Database Name="cv" Series="2190" Issue="114017" />
     </Book>
     <Book Series="Daredevil" Number="44" Volume="1964" Year="1968">
-      <Id>a9e6f228-86e4-45c7-bff8-98fe261045fc</Id>
+      <Database Name="cv" Series="2190" Issue="109518" />
     </Book>
     <Book Series="Daredevil" Number="45" Volume="1964" Year="1968">
-      <Id>77761a99-003d-41e6-9c3f-d7f6eb371c21</Id>
+      <Database Name="cv" Series="2190" Issue="114018" />
     </Book>
     <Book Series="Daredevil" Number="46" Volume="1964" Year="1968">
-      <Id>41b7ae6b-ae31-4aea-ba11-7cf444694e2c</Id>
+      <Database Name="cv" Series="2190" Issue="109563" />
     </Book>
     <Book Series="Daredevil" Number="47" Volume="1964" Year="1968">
-      <Id>04a9c5b7-5520-4996-a9cb-d725a103bbfc</Id>
+      <Database Name="cv" Series="2190" Issue="114019" />
     </Book>
     <Book Series="Daredevil" Number="48" Volume="1964" Year="1969">
-      <Id>f4fc5aed-62ae-4784-857e-7064d7bbfed1</Id>
+      <Database Name="cv" Series="2190" Issue="9991" />
     </Book>
     <Book Series="Daredevil" Number="49" Volume="1964" Year="1969">
-      <Id>94429be5-5be9-4799-a3bb-3823e5798f83</Id>
+      <Database Name="cv" Series="2190" Issue="10043" />
     </Book>
     <Book Series="Daredevil" Number="50" Volume="1964" Year="1969">
-      <Id>6d40421a-4beb-4958-895f-915d602ee41d</Id>
+      <Database Name="cv" Series="2190" Issue="10096" />
     </Book>
     <Book Series="Daredevil" Number="51" Volume="1964" Year="1969">
-      <Id>892d1e63-b7c9-4576-9747-1d0e90259293</Id>
+      <Database Name="cv" Series="2190" Issue="10151" />
     </Book>
     <Book Series="Daredevil" Number="52" Volume="1964" Year="1969">
-      <Id>a67eb7e9-c9e1-45b6-94c1-a571be503834</Id>
+      <Database Name="cv" Series="2190" Issue="10203" />
     </Book>
     <Book Series="Daredevil" Number="53" Volume="1964" Year="1969">
-      <Id>9f908374-07ab-4a0a-8df9-399df6ea2f30</Id>
+      <Database Name="cv" Series="2190" Issue="10260" />
     </Book>
     <Book Series="Daredevil" Number="54" Volume="1964" Year="1969">
-      <Id>91178ef0-57e7-474e-b44c-369cfc0aca38</Id>
+      <Database Name="cv" Series="2190" Issue="10307" />
     </Book>
     <Book Series="Daredevil" Number="55" Volume="1964" Year="1969">
-      <Id>94e131f5-3252-43cd-82a4-ea0bef1ce8fb</Id>
+      <Database Name="cv" Series="2190" Issue="10356" />
     </Book>
     <Book Series="Daredevil" Number="56" Volume="1964" Year="1969">
-      <Id>13918ed9-6386-4e7f-be68-da9805dcf22b</Id>
+      <Database Name="cv" Series="2190" Issue="114020" />
     </Book>
     <Book Series="Daredevil" Number="57" Volume="1964" Year="1969">
-      <Id>b06720b0-75aa-4c0e-b903-8a54e96167fe</Id>
+      <Database Name="cv" Series="2190" Issue="10466" />
     </Book>
     <Book Series="Daredevil" Number="58" Volume="1964" Year="1969">
-      <Id>5b64ddd6-00b7-42e1-9094-0b1c376e7bfb</Id>
+      <Database Name="cv" Series="2190" Issue="10511" />
     </Book>
     <Book Series="Daredevil" Number="59" Volume="1964" Year="1969">
-      <Id>01867e1d-5075-4158-b553-0b74d1368872</Id>
+      <Database Name="cv" Series="2190" Issue="114022" />
     </Book>
     <Book Series="Daredevil" Number="60" Volume="1964" Year="1970">
-      <Id>9a65658f-a5c5-4e56-af54-1d24c7017afc</Id>
+      <Database Name="cv" Series="2190" Issue="10620" />
     </Book>
     <Book Series="Daredevil" Number="61" Volume="1964" Year="1970">
-      <Id>6e886c2d-1119-4a69-856c-f48ee088b421</Id>
+      <Database Name="cv" Series="2190" Issue="10666" />
     </Book>
     <Book Series="Daredevil" Number="62" Volume="1964" Year="1970">
-      <Id>a838c661-a097-46a3-9551-38a3bbce49e8</Id>
+      <Database Name="cv" Series="2190" Issue="10711" />
     </Book>
     <Book Series="Daredevil" Number="63" Volume="1964" Year="1970">
-      <Id>f46b71f1-e629-4b4a-934a-8e7a18f91ced</Id>
+      <Database Name="cv" Series="2190" Issue="10757" />
     </Book>
     <Book Series="Daredevil" Number="64" Volume="1964" Year="1970">
-      <Id>a01c4aee-917a-41c5-891c-08574496e557</Id>
+      <Database Name="cv" Series="2190" Issue="10802" />
     </Book>
     <Book Series="Daredevil" Number="65" Volume="1964" Year="1970">
-      <Id>b4b12401-b031-4b3a-991f-3cd69b379a84</Id>
+      <Database Name="cv" Series="2190" Issue="10857" />
     </Book>
     <Book Series="Daredevil" Number="66" Volume="1964" Year="1970">
-      <Id>421679cf-890d-4fc6-9544-cc59dc4952eb</Id>
+      <Database Name="cv" Series="2190" Issue="10898" />
     </Book>
     <Book Series="Daredevil" Number="67" Volume="1964" Year="1970">
-      <Id>8de92212-7493-44b2-b722-3305f7136933</Id>
+      <Database Name="cv" Series="2190" Issue="114021" />
     </Book>
     <Book Series="Daredevil" Number="68" Volume="1964" Year="1970">
-      <Id>3c6d2e6a-463d-4411-b495-e68f7be8cca1</Id>
+      <Database Name="cv" Series="2190" Issue="11004" />
     </Book>
     <Book Series="Daredevil" Number="69" Volume="1964" Year="1970">
-      <Id>3dac609f-8b4e-41c8-a518-abcc9452ef8c</Id>
+      <Database Name="cv" Series="2190" Issue="11053" />
     </Book>
     <Book Series="The Avengers" Number="82" Volume="1963" Year="1970">
-      <Id>c01a75fc-50a0-48b0-b211-9c62a7c2a312</Id>
+      <Database Name="cv" Series="2128" Issue="11096" />
     </Book>
     <Book Series="Daredevil" Number="70" Volume="1964" Year="1970">
-      <Id>7e2bc93f-4a6a-4f1b-b348-dfd31c7468bc</Id>
+      <Database Name="cv" Series="2190" Issue="11098" />
     </Book>
     <Book Series="Daredevil" Number="71" Volume="1964" Year="1970">
-      <Id>36b753b4-2698-4241-a1de-eb4ef554da50</Id>
+      <Database Name="cv" Series="2190" Issue="11156" />
     </Book>
     <Book Series="Daredevil" Number="72" Volume="1964" Year="1971">
-      <Id>766fcf0d-9b66-4751-b54e-bdf5c7b505cb</Id>
+      <Database Name="cv" Series="2190" Issue="11219" />
     </Book>
     <Book Series="Iron Man" Number="35" Volume="1968" Year="1971">
-      <Id>71f473a9-d97d-4e0d-851d-dfc3b8467493</Id>
+      <Database Name="cv" Series="2407" Issue="11328" />
     </Book>
     <Book Series="Daredevil" Number="73" Volume="1964" Year="1971">
-      <Id>ab76d5de-bdfe-463c-a029-4013aa17c004</Id>
+      <Database Name="cv" Series="2190" Issue="11276" />
     </Book>
     <Book Series="Iron Man" Number="36" Volume="1968" Year="1971">
-      <Id>85e94435-609b-48a3-b3f3-a3cf71df1780</Id>
+      <Database Name="cv" Series="2407" Issue="11382" />
     </Book>
     <Book Series="Daredevil" Number="74" Volume="1964" Year="1971">
-      <Id>c558849a-3973-441f-a916-a902585ce980</Id>
+      <Database Name="cv" Series="2190" Issue="11324" />
     </Book>
     <Book Series="Daredevil" Number="75" Volume="1964" Year="1971">
-      <Id>f25ed6be-09f8-4f4f-987f-889e58352d18</Id>
+      <Database Name="cv" Series="2190" Issue="11379" />
     </Book>
     <Book Series="Daredevil" Number="76" Volume="1964" Year="1971">
-      <Id>32206752-702f-4620-a642-6864a1b9e30f</Id>
+      <Database Name="cv" Series="2190" Issue="11429" />
     </Book>
     <Book Series="Daredevil" Number="77" Volume="1964" Year="1971">
-      <Id>b04cf0eb-e41c-4617-ab28-cf73bc10459a</Id>
+      <Database Name="cv" Series="2190" Issue="11488" />
     </Book>
     <Book Series="Daredevil" Number="78" Volume="1964" Year="1971">
-      <Id>b0ba8012-5a5b-4660-bb3d-1be366385201</Id>
+      <Database Name="cv" Series="2190" Issue="11543" />
     </Book>
     <Book Series="Daredevil" Number="79" Volume="1964" Year="1971">
-      <Id>ce251c7e-a5cb-44cb-ad9e-7dbcd9921a9a</Id>
+      <Database Name="cv" Series="2190" Issue="11602" />
     </Book>
     <Book Series="Daredevil" Number="80" Volume="1964" Year="1971">
-      <Id>05bb5898-0797-4368-b4fd-c37f942f7c38</Id>
+      <Database Name="cv" Series="2190" Issue="11662" />
     </Book>
     <Book Series="Daredevil" Number="81" Volume="1964" Year="1971">
-      <Id>99863980-9fc5-45b3-bfa6-b0d653dd2499</Id>
+      <Database Name="cv" Series="2190" Issue="11781" />
     </Book>
     <Book Series="Daredevil" Number="82" Volume="1964" Year="1971">
-      <Id>bb6e30ee-1149-4e33-b17c-e9ed659c2a81</Id>
+      <Database Name="cv" Series="2190" Issue="11843" />
     </Book>
     <Book Series="Daredevil" Number="83" Volume="1964" Year="1972">
-      <Id>3afa51f9-cba1-4a90-a5b8-bfefbbffe54d</Id>
+      <Database Name="cv" Series="2190" Issue="11923" />
     </Book>
     <Book Series="Daredevil" Number="84" Volume="1964" Year="1972">
-      <Id>0ccaf7c2-c563-435e-8e9c-f7b4419ce182</Id>
+      <Database Name="cv" Series="2190" Issue="11991" />
     </Book>
     <Book Series="Daredevil" Number="85" Volume="1964" Year="1972">
-      <Id>e11c30ba-4aa9-4ee1-ba3a-4ba11c5d795c</Id>
+      <Database Name="cv" Series="2190" Issue="12052" />
     </Book>
     <Book Series="Daredevil" Number="86" Volume="1964" Year="1972">
-      <Id>130fa927-d8bc-4ab4-82c7-709eaa52810f</Id>
+      <Database Name="cv" Series="2190" Issue="12121" />
     </Book>
     <Book Series="Daredevil" Number="87" Volume="1964" Year="1972">
-      <Id>81fa6b9d-b763-4f2c-8d81-742c58f5e338</Id>
+      <Database Name="cv" Series="2190" Issue="12187" />
     </Book>
     <Book Series="Daredevil" Number="88" Volume="1964" Year="1972">
-      <Id>efefd854-ccdd-437e-a0cc-d07fcdcd7bb5</Id>
+      <Database Name="cv" Series="2190" Issue="12263" />
     </Book>
     <Book Series="Daredevil" Number="89" Volume="1964" Year="1972">
-      <Id>02ea8360-cf7b-41ed-85c9-4eb60afd8672</Id>
+      <Database Name="cv" Series="2190" Issue="12337" />
     </Book>
     <Book Series="Daredevil" Number="90" Volume="1964" Year="1972">
-      <Id>3f3b67ae-f1f1-4d24-b9d5-4f89ed7ae298</Id>
+      <Database Name="cv" Series="2190" Issue="12415" />
     </Book>
     <Book Series="Daredevil" Number="91" Volume="1964" Year="1972">
-      <Id>c328cb0f-f4ee-4545-a62a-da46ee6c0c70</Id>
+      <Database Name="cv" Series="2190" Issue="12479" />
     </Book>
     <Book Series="Daredevil" Number="92" Volume="1964" Year="1972">
-      <Id>21f68fda-146b-4346-86b3-ee385eb4a049</Id>
+      <Database Name="cv" Series="2190" Issue="12569" />
     </Book>
     <Book Series="Daredevil" Number="93" Volume="1964" Year="1972">
-      <Id>be5582bb-6895-4845-bb08-cc2f82692005</Id>
+      <Database Name="cv" Series="2190" Issue="12648" />
     </Book>
     <Book Series="Daredevil" Number="94" Volume="1964" Year="1972">
-      <Id>81fa9c80-0ec5-42bb-9c61-633833e3cadb</Id>
+      <Database Name="cv" Series="2190" Issue="12734" />
     </Book>
     <Book Series="Daredevil" Number="95" Volume="1964" Year="1973">
-      <Id>48194391-86a2-4247-81b3-023ba2b0a02f</Id>
+      <Database Name="cv" Series="2190" Issue="12830" />
     </Book>
     <Book Series="Daredevil" Number="96" Volume="1964" Year="1973">
-      <Id>a37f2eef-a397-47a1-a2f4-f3e7b8ebf02d</Id>
+      <Database Name="cv" Series="2190" Issue="12920" />
     </Book>
     <Book Series="Daredevil" Number="97" Volume="1964" Year="1973">
-      <Id>61d398e8-b671-4d67-9b84-2c4f8baec0fd</Id>
+      <Database Name="cv" Series="2190" Issue="13005" />
     </Book>
     <Book Series="Daredevil" Number="98" Volume="1964" Year="1973">
-      <Id>d21b2c0e-0518-4390-afd0-391133f14bef</Id>
+      <Database Name="cv" Series="2190" Issue="13103" />
     </Book>
     <Book Series="Daredevil" Number="99" Volume="1964" Year="1973">
-      <Id>b452d7e2-b6a7-4762-9f3d-ba13bd0a2ab9</Id>
+      <Database Name="cv" Series="2190" Issue="13176" />
     </Book>
     <Book Series="The Avengers" Number="100" Volume="1963" Year="1972">
-      <Id>cf95b160-d85b-469c-9069-3cbfcea767a7</Id>
+      <Database Name="cv" Series="2128" Issue="12260" />
     </Book>
     <Book Series="Daredevil" Number="100" Volume="1964" Year="1973">
-      <Id>7428f17f-f5da-420d-8cd8-32f33d2ea9e1</Id>
+      <Database Name="cv" Series="2190" Issue="13270" />
     </Book>
     <Book Series="Daredevil" Number="101" Volume="1964" Year="1973">
-      <Id>47333263-024b-4a41-a458-56c3494f726d</Id>
+      <Database Name="cv" Series="2190" Issue="13383" />
     </Book>
     <Book Series="Daredevil" Number="102" Volume="1964" Year="1973">
-      <Id>bdbd9db8-3030-492e-af0b-7790446d2ad6</Id>
+      <Database Name="cv" Series="2190" Issue="13473" />
     </Book>
     <Book Series="Daredevil" Number="103" Volume="1964" Year="1973">
-      <Id>39ea1acd-dd6a-4bf2-8c58-beecd4ebd043</Id>
+      <Database Name="cv" Series="2190" Issue="13572" />
     </Book>
     <Book Series="Daredevil" Number="104" Volume="1964" Year="1973">
-      <Id>7764c0b6-9fc8-4864-b124-4f858e35478c</Id>
+      <Database Name="cv" Series="2190" Issue="13687" />
     </Book>
     <Book Series="Daredevil" Number="105" Volume="1964" Year="1973">
-      <Id>ac0c4d79-1745-4fc6-9008-1589fb59cd02</Id>
+      <Database Name="cv" Series="2190" Issue="13789" />
     </Book>
     <Book Series="Daredevil" Number="106" Volume="1964" Year="1973">
-      <Id>3827b091-5587-4955-baf6-8bfd86da10a0</Id>
+      <Database Name="cv" Series="2190" Issue="13879" />
     </Book>
     <Book Series="Daredevil" Number="107" Volume="1964" Year="1974">
-      <Id>440da1ba-654d-45eb-9f33-61a9db690ecd</Id>
+      <Database Name="cv" Series="2190" Issue="13985" />
     </Book>
     <Book Series="Daredevil" Number="108" Volume="1964" Year="1974">
-      <Id>cf5e4fee-7723-4071-93fd-993e7ec46da8</Id>
+      <Database Name="cv" Series="2190" Issue="14123" />
     </Book>
     <Book Series="Daredevil" Number="109" Volume="1964" Year="1974">
-      <Id>63822677-f61d-4bbd-af21-10c0778daf32</Id>
+      <Database Name="cv" Series="2190" Issue="14260" />
     </Book>
     <Book Series="Marvel Two-in-One" Number="3" Volume="1974" Year="1974">
-      <Id>21a65fef-acef-4894-a6fa-ee5091f4dfa5</Id>
+      <Database Name="cv" Series="2696" Issue="14277" />
     </Book>
     <Book Series="Daredevil" Number="110" Volume="1964" Year="1974">
-      <Id>915ecdee-d34a-4ac6-92f0-4eef67dc0c35</Id>
+      <Database Name="cv" Series="2190" Issue="14332" />
     </Book>
     <Book Series="Daredevil" Number="111" Volume="1964" Year="1974">
-      <Id>ef4a59cd-94c9-436a-a887-b536a9e377cd</Id>
+      <Database Name="cv" Series="2190" Issue="14413" />
     </Book>
     <Book Series="Daredevil" Number="112" Volume="1964" Year="1974">
-      <Id>9de2ed0a-ec8a-4b41-ad15-95cbb5a2a86c</Id>
+      <Database Name="cv" Series="2190" Issue="14484" />
     </Book>
     <Book Series="Marvel Team-Up" Number="25" Volume="1972" Year="1974">
-      <Id>ce92afb6-8465-41d7-95a0-5349bebfb531</Id>
+      <Database Name="cv" Series="2576" Issue="14595" />
     </Book>
     <Book Series="Daredevil" Number="113" Volume="1964" Year="1974">
-      <Id>e71393cc-9669-4112-9eaf-9e202322207e</Id>
+      <Database Name="cv" Series="2190" Issue="14574" />
     </Book>
     <Book Series="Daredevil" Number="114" Volume="1964" Year="1974">
-      <Id>a58c7dcd-9a94-40b7-8b9a-9757302b6a1c</Id>
+      <Database Name="cv" Series="2190" Issue="14657" />
     </Book>
     <Book Series="Daredevil" Number="115" Volume="1964" Year="1974">
-      <Id>019f9149-913b-47f2-b44a-d18e08347d95</Id>
+      <Database Name="cv" Series="2190" Issue="14750" />
     </Book>
     <Book Series="Daredevil" Number="116" Volume="1964" Year="1974">
-      <Id>23b30aca-b374-477f-b49c-e723ed5df0ba</Id>
+      <Database Name="cv" Series="2190" Issue="14831" />
     </Book>
     <Book Series="Daredevil" Number="117" Volume="1964" Year="1975">
-      <Id>48ed2745-cd05-429a-9a43-26435f711737</Id>
+      <Database Name="cv" Series="2190" Issue="14958" />
     </Book>
     <Book Series="Daredevil" Number="118" Volume="1964" Year="1975">
-      <Id>8d8a6798-b6e7-4a9e-b1c2-aa8cf63f84f0</Id>
+      <Database Name="cv" Series="2190" Issue="15050" />
     </Book>
     <Book Series="Daredevil" Number="119" Volume="1964" Year="1975">
-      <Id>74c25796-fbe3-4607-901b-2b9b43db151b</Id>
+      <Database Name="cv" Series="2190" Issue="15142" />
     </Book>
     <Book Series="Daredevil" Number="120" Volume="1964" Year="1975">
-      <Id>5104dd87-b9c9-4436-b76c-a899cf3f50da</Id>
+      <Database Name="cv" Series="2190" Issue="114109" />
     </Book>
     <Book Series="Daredevil" Number="121" Volume="1964" Year="1975">
-      <Id>94c46402-aa3e-4801-943b-268140468ce3</Id>
+      <Database Name="cv" Series="2190" Issue="15175" />
     </Book>
     <Book Series="Daredevil" Number="122" Volume="1964" Year="1975">
-      <Id>fb8ed937-edf9-4228-b208-ecf183102f2f</Id>
+      <Database Name="cv" Series="2190" Issue="15263" />
     </Book>
     <Book Series="Daredevil" Number="123" Volume="1964" Year="1975">
-      <Id>6195ddd4-fab5-4c06-b09b-339dfb0ce384</Id>
+      <Database Name="cv" Series="2190" Issue="15369" />
     </Book>
     <Book Series="Daredevil" Number="124" Volume="1964" Year="1975">
-      <Id>60e35865-8b35-4d6d-af3e-f8d8cf59491e</Id>
+      <Database Name="cv" Series="2190" Issue="15473" />
     </Book>
     <Book Series="Daredevil" Number="125" Volume="1964" Year="1975">
-      <Id>5310eba1-c1ff-4740-b11d-e58df1c22a11</Id>
+      <Database Name="cv" Series="2190" Issue="15577" />
     </Book>
     <Book Series="Daredevil" Number="126" Volume="1964" Year="1975">
-      <Id>5b081589-7674-4cb9-a58d-8f7d858a6c0b</Id>
+      <Database Name="cv" Series="2190" Issue="15673" />
     </Book>
     <Book Series="Daredevil" Number="127" Volume="1964" Year="1975">
-      <Id>7abbf717-9302-4bc5-8ca5-03bda5786531</Id>
+      <Database Name="cv" Series="2190" Issue="15777" />
     </Book>
     <Book Series="Daredevil" Number="128" Volume="1964" Year="1975">
-      <Id>0bfc804e-a453-44ae-bc92-07500143d5ab</Id>
+      <Database Name="cv" Series="2190" Issue="15858" />
     </Book>
     <Book Series="Daredevil" Number="129" Volume="1964" Year="1976">
-      <Id>96a4cc3b-089c-48af-95ee-a7f3af450f9c</Id>
+      <Database Name="cv" Series="2190" Issue="15998" />
     </Book>
     <Book Series="Daredevil" Number="130" Volume="1964" Year="1976">
-      <Id>45ea9e0a-492c-4dcd-9196-5044d0808753</Id>
+      <Database Name="cv" Series="2190" Issue="16074" />
     </Book>
     <Book Series="Daredevil" Number="131" Volume="1964" Year="1976">
-      <Id>8203df8d-8b47-46b6-9997-deb97880439b</Id>
+      <Database Name="cv" Series="2190" Issue="16163" />
     </Book>
     <Book Series="Daredevil" Number="132" Volume="1964" Year="1976">
-      <Id>2598117e-51dd-4a94-9ccc-b8e33f2b72a1</Id>
+      <Database Name="cv" Series="2190" Issue="16249" />
     </Book>
     <Book Series="Daredevil" Number="133" Volume="1964" Year="1976">
-      <Id>251ef37d-af8f-41ef-988e-ef02b0f82759</Id>
+      <Database Name="cv" Series="2190" Issue="16336" />
     </Book>
     <Book Series="Daredevil" Number="134" Volume="1964" Year="1976">
-      <Id>e8c8670c-5b33-4039-8f0d-a48a7a171a0e</Id>
+      <Database Name="cv" Series="2190" Issue="16411" />
     </Book>
     <Book Series="Daredevil" Number="135" Volume="1964" Year="1976">
-      <Id>0b657291-5802-434c-91a1-e81bd90ae8e8</Id>
+      <Database Name="cv" Series="2190" Issue="16500" />
     </Book>
     <Book Series="Daredevil" Number="136" Volume="1964" Year="1976">
-      <Id>8233ba50-9b60-4494-a45b-e5465bc76674</Id>
+      <Database Name="cv" Series="2190" Issue="16589" />
     </Book>
     <Book Series="Daredevil" Number="137" Volume="1964" Year="1976">
-      <Id>2119b2ca-e40e-4d7e-858e-206bdfde7d22</Id>
+      <Database Name="cv" Series="2190" Issue="16677" />
     </Book>
     <Book Series="Iron Man" Number="89" Volume="1968" Year="1976">
-      <Id>bbaabc23-0ead-4795-ab53-dde586b9c3e8</Id>
+      <Database Name="cv" Series="2407" Issue="16599" />
     </Book>
     <Book Series="Daredevil" Number="139" Volume="1964" Year="1976">
-      <Id>dd33637e-29a3-4150-b06a-b1e918e79cdf</Id>
+      <Database Name="cv" Series="2190" Issue="16867" />
     </Book>
     <Book Series="Daredevil Annual" Number="4" Volume="1967" Year="1976">
-      <Id>929c2b40-970a-4d16-99fc-ad1b0d4557d7</Id>
+      <Database Name="cv" Series="2351" Issue="15924" />
     </Book>
     <Book Series="Daredevil" Number="140" Volume="1964" Year="1976">
-      <Id>8b15c841-8f69-4e44-9144-9d05330347ce</Id>
+      <Database Name="cv" Series="2190" Issue="16949" />
     </Book>
     <Book Series="Daredevil" Number="141" Volume="1964" Year="1977">
-      <Id>d15e3e2e-021e-4f31-99cd-92ba1e3e1de4</Id>
+      <Database Name="cv" Series="2190" Issue="17097" />
     </Book>
     <Book Series="Daredevil" Number="142" Volume="1964" Year="1977">
-      <Id>bc8f36ac-368d-43e8-ae1b-1797efc466b4</Id>
+      <Database Name="cv" Series="2190" Issue="17177" />
     </Book>
     <Book Series="Daredevil" Number="143" Volume="1964" Year="1977">
-      <Id>03024178-9183-4127-a672-be5f7461996c</Id>
+      <Database Name="cv" Series="2190" Issue="17266" />
     </Book>
     <Book Series="Daredevil" Number="144" Volume="1964" Year="1977">
-      <Id>074c3cb5-f28e-4bd1-b2f9-1b3356dc1a10</Id>
+      <Database Name="cv" Series="2190" Issue="17340" />
     </Book>
     <Book Series="Daredevil" Number="145" Volume="1964" Year="1977">
-      <Id>6e44199b-7430-45b7-b0bd-9017a2787bfc</Id>
+      <Database Name="cv" Series="2190" Issue="17429" />
     </Book>
     <Book Series="Marvel Team-Up" Number="56" Volume="1972" Year="1977">
-      <Id>02a8392e-35cb-42e9-a030-7e67038108b4</Id>
+      <Database Name="cv" Series="2576" Issue="17357" />
     </Book>
     <Book Series="Daredevil" Number="146" Volume="1964" Year="1977">
-      <Id>74365e66-7d2d-437b-9c09-e5c918f79859</Id>
+      <Database Name="cv" Series="2190" Issue="17496" />
     </Book>
     <Book Series="Daredevil" Number="147" Volume="1964" Year="1977">
-      <Id>70cd32b1-e0f1-420e-9423-7bfe45e796ef</Id>
+      <Database Name="cv" Series="2190" Issue="17596" />
     </Book>
     <Book Series="Daredevil" Number="148" Volume="1964" Year="1977">
-      <Id>8f869dd2-9287-49c1-9ca8-289a6642b4fc</Id>
+      <Database Name="cv" Series="2190" Issue="17774" />
     </Book>
     <Book Series="Daredevil" Number="149" Volume="1964" Year="1977">
-      <Id>0eb089f9-5fa3-4f52-876e-339b7dabc5d9</Id>
+      <Database Name="cv" Series="2190" Issue="17959" />
     </Book>
     <Book Series="Daredevil" Number="150" Volume="1964" Year="1978">
-      <Id>6500955d-bcfb-4091-b66d-a72cafc5ac5d</Id>
+      <Database Name="cv" Series="2190" Issue="18162" />
     </Book>
     <Book Series="Daredevil" Number="151" Volume="1964" Year="1978">
-      <Id>84d9e925-54a1-4e0e-ba4e-0f079c930354</Id>
+      <Database Name="cv" Series="2190" Issue="18324" />
     </Book>
     <Book Series="Daredevil" Number="152" Volume="1964" Year="1978">
-      <Id>af604070-c8ea-4a01-bc1c-7de9ccb3e1b7</Id>
+      <Database Name="cv" Series="2190" Issue="18493" />
     </Book>
     <Book Series="Daredevil" Number="153" Volume="1964" Year="1978">
-      <Id>d7ff9a53-b42c-44d5-bacc-0663b0cb9717</Id>
+      <Database Name="cv" Series="2190" Issue="18654" />
     </Book>
     <Book Series="Daredevil" Number="154" Volume="1964" Year="1978">
-      <Id>25c6be4d-2c9f-4d5f-ab4a-5758389d5660</Id>
+      <Database Name="cv" Series="2190" Issue="18814" />
     </Book>
     <Book Series="Marvel Two-in-One" Number="37" Volume="1974" Year="1978">
-      <Id>9861a0a3-81ca-4fd1-9116-9be5c166e0d4</Id>
+      <Database Name="cv" Series="2696" Issue="18334" />
     </Book>
     <Book Series="Marvel Two-in-One" Number="38" Volume="1974" Year="1978">
-      <Id>5e10a8d6-b1a5-4ec4-83c4-d330c98f278d</Id>
+      <Database Name="cv" Series="2696" Issue="18423" />
     </Book>
     <Book Series="Marvel Two-in-One" Number="39" Volume="1974" Year="1978">
-      <Id>f7f97792-44a2-406f-be71-a46774035c75</Id>
+      <Database Name="cv" Series="2696" Issue="18504" />
     </Book>
     <Book Series="Marvel Team-Up" Number="73" Volume="1972" Year="1978">
-      <Id>116b3e09-aae0-42d7-89cc-1d4fd2477695</Id>
+      <Database Name="cv" Series="2576" Issue="18824" />
     </Book>
     <Book Series="Daredevil" Number="155" Volume="1964" Year="1978">
-      <Id>8bd71370-b8a4-4f8d-84ec-a842ccfdd570</Id>
+      <Database Name="cv" Series="2190" Issue="18960" />
     </Book>
     <Book Series="Daredevil" Number="156" Volume="1964" Year="1979">
-      <Id>218e4147-fb7d-4c66-81f7-2863a21cb5c5</Id>
+      <Database Name="cv" Series="2190" Issue="19188" />
     </Book>
     <Book Series="Daredevil" Number="157" Volume="1964" Year="1979">
-      <Id>3ea4a601-0d72-48cb-a931-1960f55a424d</Id>
+      <Database Name="cv" Series="2190" Issue="19364" />
     </Book>
     <Book Series="Daredevil" Number="158" Volume="1964" Year="1979">
-      <Id>bbef3536-4f5b-4cac-937f-4d2b9ea12ec2</Id>
+      <Database Name="cv" Series="2190" Issue="19503" />
     </Book>
     <Book Series="Daredevil" Number="159" Volume="1964" Year="1979">
-      <Id>008c3ac3-5c42-46b5-8b3d-4f7826756d2e</Id>
+      <Database Name="cv" Series="2190" Issue="19638" />
     </Book>
     <Book Series="Daredevil" Number="160" Volume="1964" Year="1979">
-      <Id>4562f304-9628-4c0d-a8d6-d446971b9c0a</Id>
+      <Database Name="cv" Series="2190" Issue="19777" />
     </Book>
     <Book Series="Daredevil" Number="161" Volume="1964" Year="1979">
-      <Id>e7c7b04f-d765-47b3-9c7b-8350e97797b6</Id>
+      <Database Name="cv" Series="2190" Issue="19917" />
     </Book>
     <Book Series="Captain America" Number="234" Volume="1968" Year="1979">
-      <Id>b5c1b853-6b82-4c95-9b96-81b59ddf36e6</Id>
+      <Database Name="cv" Series="2400" Issue="19570" />
     </Book>
     <Book Series="Captain America" Number="235" Volume="1968" Year="1979">
-      <Id>566f92dc-ebd9-411e-8f89-9e45475ccac1</Id>
+      <Database Name="cv" Series="2400" Issue="19636" />
     </Book>
     <Book Series="Captain America" Number="236" Volume="1968" Year="1979">
-      <Id>5b91914c-e885-43d1-a183-fb0b960a24d4</Id>
+      <Database Name="cv" Series="2400" Issue="19700" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="26" Volume="1976" Year="1979">
-      <Id>8e30f1a5-b3ec-4e98-887f-7ec7ce3f7bf9</Id>
+      <Database Name="cv" Series="2870" Issue="19205" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="27" Volume="1976" Year="1979">
-      <Id>9c1dd9c3-3a91-442d-9298-7375b659d1c6</Id>
+      <Database Name="cv" Series="2870" Issue="19310" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="28" Volume="1976" Year="1979">
-      <Id>6383f634-fb2d-4a6f-856a-916076ceea05</Id>
+      <Database Name="cv" Series="2870" Issue="19381" />
     </Book>
     <Book Series="Daredevil" Number="162" Volume="1964" Year="1980">
-      <Id>11f83c00-681f-4161-bd83-98e75b04abbd</Id>
+      <Database Name="cv" Series="2190" Issue="20095" />
     </Book>
     <Book Series="Daredevil" Number="163" Volume="1964" Year="1980">
-      <Id>2e028640-d8a2-4fed-a582-0d8e9e0b0e34</Id>
+      <Database Name="cv" Series="2190" Issue="20237" />
     </Book>
     <Book Series="Daredevil" Number="164" Volume="1964" Year="1980">
-      <Id>1c70e29e-0161-439f-b10c-faa872f07da6</Id>
+      <Database Name="cv" Series="2190" Issue="20383" />
     </Book>
     <Book Series="Daredevil" Number="165" Volume="1964" Year="1980">
-      <Id>b10c3a01-d9f6-471c-ade8-a54673ded961</Id>
+      <Database Name="cv" Series="2190" Issue="20524" />
     </Book>
     <Book Series="Daredevil" Number="166" Volume="1964" Year="1980">
-      <Id>92d46541-4210-45a7-bdfe-50ee107fbddb</Id>
+      <Database Name="cv" Series="2190" Issue="20658" />
     </Book>
     <Book Series="Daredevil" Number="167" Volume="1964" Year="1980">
-      <Id>aa5e8118-31c5-4470-a87f-7b8234580077</Id>
+      <Database Name="cv" Series="2190" Issue="20791" />
     </Book>
     <Book Series="Daredevil" Number="168" Volume="1964" Year="1981">
-      <Id>f69ec81b-85c5-404c-ab89-1b75a062be52</Id>
+      <Database Name="cv" Series="2190" Issue="20965" />
     </Book>
     <Book Series="Daredevil" Number="169" Volume="1964" Year="1981">
-      <Id>112d51df-6ade-432c-a553-8da49df8ae53</Id>
+      <Database Name="cv" Series="2190" Issue="21105" />
     </Book>
     <Book Series="Daredevil" Number="170" Volume="1964" Year="1981">
-      <Id>7ce231e6-e0ba-4cc4-b294-cc19b460a8e2</Id>
+      <Database Name="cv" Series="2190" Issue="21237" />
     </Book>
     <Book Series="Daredevil" Number="171" Volume="1964" Year="1981">
-      <Id>56928731-2c41-47ca-9db9-388b80d8f963</Id>
+      <Database Name="cv" Series="2190" Issue="112180" />
     </Book>
     <Book Series="Daredevil" Number="172" Volume="1964" Year="1981">
-      <Id>fc19eb44-7e1b-47d7-ae04-b2056838359b</Id>
+      <Database Name="cv" Series="2190" Issue="21371" />
     </Book>
     <Book Series="Daredevil" Number="173" Volume="1964" Year="1981">
-      <Id>dc7a21ba-12e9-43bb-b806-e26b12b4b8f2</Id>
+      <Database Name="cv" Series="2190" Issue="21436" />
     </Book>
     <Book Series="Marvel Team-Up Annual" Number="4" Volume="1976" Year="1981">
-      <Id>4fc8be7e-5799-4337-9af8-614809746edc</Id>
+      <Database Name="cv" Series="2863" Issue="20904" />
     </Book>
     <Book Series="Daredevil" Number="174" Volume="1964" Year="1981">
-      <Id>f0f6841c-6f08-46f7-abf4-34b191492b11</Id>
+      <Database Name="cv" Series="2190" Issue="21508" />
     </Book>
     <Book Series="Daredevil" Number="175" Volume="1964" Year="1981">
-      <Id>ea1ba7c7-f3b7-4853-8d57-9da3844f9c2f</Id>
+      <Database Name="cv" Series="2190" Issue="21588" />
     </Book>
     <Book Series="Daredevil" Number="176" Volume="1964" Year="1981">
-      <Id>b25718ce-9352-41c1-a703-3d51716a3773</Id>
+      <Database Name="cv" Series="2190" Issue="21657" />
     </Book>
     <Book Series="Daredevil" Number="177" Volume="1964" Year="1981">
-      <Id>30cf3e28-05bf-4159-9c6c-856bc3307bdd</Id>
+      <Database Name="cv" Series="2190" Issue="21724" />
     </Book>
     <Book Series="Daredevil" Number="178" Volume="1964" Year="1982">
-      <Id>7d9dda31-30bf-42d3-874d-de778cfebde5</Id>
+      <Database Name="cv" Series="2190" Issue="21853" />
     </Book>
     <Book Series="Daredevil" Number="179" Volume="1964" Year="1982">
-      <Id>9e54a15d-a6e2-4937-941c-2c66da29b4d4</Id>
+      <Database Name="cv" Series="2190" Issue="21924" />
     </Book>
     <Book Series="Daredevil" Number="180" Volume="1964" Year="1982">
-      <Id>588bd5e6-47e7-4ece-99a1-7c2065a7f2f8</Id>
+      <Database Name="cv" Series="2190" Issue="22004" />
     </Book>
     <Book Series="Daredevil" Number="181" Volume="1964" Year="1982">
-      <Id>7ef23333-d5a5-40da-9b4c-fa4f355603c3</Id>
+      <Database Name="cv" Series="2190" Issue="22077" />
     </Book>
     <Book Series="Daredevil" Number="182" Volume="1964" Year="1982">
-      <Id>20cb6cb1-8ed8-4609-8742-a6d7fba3cb77</Id>
+      <Database Name="cv" Series="2190" Issue="22156" />
     </Book>
     <Book Series="Daredevil" Number="183" Volume="1964" Year="1982">
-      <Id>85bfd7a0-9615-41c9-bc4f-a144523228f0</Id>
+      <Database Name="cv" Series="2190" Issue="22225" />
     </Book>
     <Book Series="Daredevil" Number="184" Volume="1964" Year="1982">
-      <Id>2a1a6621-8e4c-4fc3-96b7-26b0a7013f69</Id>
+      <Database Name="cv" Series="2190" Issue="22296" />
     </Book>
     <Book Series="Daredevil" Number="185" Volume="1964" Year="1982">
-      <Id>91e73ff7-89a4-4b6f-b582-33395b055260</Id>
+      <Database Name="cv" Series="2190" Issue="22369" />
     </Book>
     <Book Series="Marvel Super Hero Contest of Champions" Number="1" Volume="1982" Year="1982">
-      <Id>97677479-2159-414c-ad99-39341e8f8d3a</Id>
+      <Database Name="cv" Series="3147" Issue="22234" />
     </Book>
     <Book Series="Marvel Super Hero Contest of Champions" Number="2" Volume="1982" Year="1982">
-      <Id>094492f8-7655-4691-a568-50a03bd8f014</Id>
+      <Database Name="cv" Series="3147" Issue="22304" />
     </Book>
     <Book Series="Marvel Super Hero Contest of Champions" Number="3" Volume="1982" Year="1982">
-      <Id>3c25c3a8-07d1-48cd-b6a7-ccb47c928f56</Id>
+      <Database Name="cv" Series="3147" Issue="22378" />
     </Book>
     <Book Series="Daredevil" Number="186" Volume="1964" Year="1982">
-      <Id>6b8ad976-be29-4bb7-bf73-7fab2d5eaab1</Id>
+      <Database Name="cv" Series="2190" Issue="22439" />
     </Book>
     <Book Series="Daredevil" Number="187" Volume="1964" Year="1982">
-      <Id>dbf01912-ced7-4beb-a383-260f37806160</Id>
+      <Database Name="cv" Series="2190" Issue="22513" />
     </Book>
     <Book Series="Daredevil" Number="188" Volume="1964" Year="1982">
-      <Id>29aaebbd-a95f-4c59-964a-2c1d90fb055b</Id>
+      <Database Name="cv" Series="2190" Issue="22587" />
     </Book>
     <Book Series="Daredevil" Number="189" Volume="1964" Year="1982">
-      <Id>cab7add3-0da7-4f90-b5ff-76b5121f9051</Id>
+      <Database Name="cv" Series="2190" Issue="22665" />
     </Book>
     <Book Series="Daredevil" Number="190" Volume="1964" Year="1983">
-      <Id>45075381-cd42-4c95-8a69-04ac4aa381fa</Id>
+      <Database Name="cv" Series="2190" Issue="22785" />
     </Book>
     <Book Series="Marvel Team-Up" Number="123" Volume="1972" Year="1982">
-      <Id>beb4caf7-50f3-4a4f-893d-10990c4093a8</Id>
+      <Database Name="cv" Series="2576" Issue="22599" />
     </Book>
     <Book Series="Daredevil" Number="191" Volume="1964" Year="1983">
-      <Id>c5ad78bd-3d99-43e4-9cad-1e339054333b</Id>
+      <Database Name="cv" Series="2190" Issue="22857" />
     </Book>
     <Book Series="Daredevil" Number="192" Volume="1964" Year="1983">
-      <Id>4d90ab67-226b-4f90-b27f-1645c019f392</Id>
+      <Database Name="cv" Series="2190" Issue="22943" />
     </Book>
     <Book Series="Daredevil" Number="193" Volume="1964" Year="1983">
-      <Id>f5b99545-d640-497e-b70b-b444d0fbc720</Id>
+      <Database Name="cv" Series="2190" Issue="23026" />
     </Book>
     <Book Series="Daredevil" Number="194" Volume="1964" Year="1983">
-      <Id>6f699956-c6ac-4a8f-a6ac-7cf727bb8013</Id>
+      <Database Name="cv" Series="2190" Issue="23113" />
     </Book>
     <Book Series="Daredevil" Number="195" Volume="1964" Year="1983">
-      <Id>5dd8926b-0842-4e2f-b47a-b92aa3471911</Id>
+      <Database Name="cv" Series="2190" Issue="23197" />
     </Book>
     <Book Series="Daredevil" Number="196" Volume="1964" Year="1983">
-      <Id>0b8022d3-d8d4-4118-8fc0-766485c7b1f2</Id>
+      <Database Name="cv" Series="2190" Issue="23284" />
     </Book>
     <Book Series="Daredevil" Number="197" Volume="1964" Year="1983">
-      <Id>6835b619-4dc3-48c8-bfd4-b0e11a75b949</Id>
+      <Database Name="cv" Series="2190" Issue="23366" />
     </Book>
     <Book Series="Daredevil" Number="198" Volume="1964" Year="1983">
-      <Id>b1e6df20-3dd8-4723-a940-872bf99ceaf3</Id>
+      <Database Name="cv" Series="2190" Issue="23446" />
     </Book>
     <Book Series="Daredevil" Number="199" Volume="1964" Year="1983">
-      <Id>8170b3bd-8858-4c6a-afe7-932c9b2d36e7</Id>
+      <Database Name="cv" Series="2190" Issue="23536" />
     </Book>
     <Book Series="Daredevil" Number="200" Volume="1964" Year="1983">
-      <Id>a16837e9-3e8b-4eab-ab4b-302e099214e0</Id>
+      <Database Name="cv" Series="2190" Issue="23619" />
     </Book>
     <Book Series="Daredevil" Number="201" Volume="1964" Year="1983">
-      <Id>70b91433-7788-4190-bcdd-6904894e660d</Id>
+      <Database Name="cv" Series="2190" Issue="114110" />
     </Book>
     <Book Series="Daredevil" Number="202" Volume="1964" Year="1984">
-      <Id>697595b7-69ce-4c1a-81ad-d93770ea60cd</Id>
+      <Database Name="cv" Series="2190" Issue="23869" />
     </Book>
     <Book Series="Daredevil" Number="203" Volume="1964" Year="1984">
-      <Id>3e0637f1-673d-44ff-a628-7dde9001a534</Id>
+      <Database Name="cv" Series="2190" Issue="23972" />
     </Book>
     <Book Series="Daredevil" Number="204" Volume="1964" Year="1984">
-      <Id>5a9cef44-5619-48c8-b680-f3171890dfed</Id>
+      <Database Name="cv" Series="2190" Issue="24089" />
     </Book>
     <Book Series="Daredevil" Number="205" Volume="1964" Year="1984">
-      <Id>4e58d02e-cf64-4656-99e1-b9fb732d7eef</Id>
+      <Database Name="cv" Series="2190" Issue="24195" />
     </Book>
     <Book Series="Daredevil" Number="206" Volume="1964" Year="1984">
-      <Id>f4715600-6f30-4224-ba72-135501fac7d3</Id>
+      <Database Name="cv" Series="2190" Issue="24300" />
     </Book>
     <Book Series="Marvel Team-Up" Number="140" Volume="1972" Year="1984">
-      <Id>9db89044-a303-4dbe-89eb-b84dda7cccfb</Id>
+      <Database Name="cv" Series="2576" Issue="24209" />
     </Book>
     <Book Series="Marvel Team-Up" Number="141" Volume="1972" Year="1984">
-      <Id>b0b15eb4-131a-4947-a03f-4f7ae1cfd5a3</Id>
+      <Database Name="cv" Series="2576" Issue="24313" />
     </Book>
     <Book Series="Daredevil" Number="207" Volume="1964" Year="1984">
-      <Id>5e63ac49-ee0b-494d-b3b2-32102a037d65</Id>
+      <Database Name="cv" Series="2190" Issue="24400" />
     </Book>
     <Book Series="Daredevil" Number="208" Volume="1964" Year="1984">
-      <Id>07bb1251-f04d-4219-91fe-1ffee7a49596</Id>
+      <Database Name="cv" Series="2190" Issue="24500" />
     </Book>
     <Book Series="Daredevil" Number="209" Volume="1964" Year="1984">
-      <Id>7b255cc2-e613-46ea-ac0f-958be388c155</Id>
+      <Database Name="cv" Series="2190" Issue="24596" />
     </Book>
     <Book Series="Daredevil" Number="210" Volume="1964" Year="1984">
-      <Id>cac86695-8ea5-4875-ad39-8d9e12c12b73</Id>
+      <Database Name="cv" Series="2190" Issue="24690" />
     </Book>
     <Book Series="Daredevil" Number="211" Volume="1964" Year="1984">
-      <Id>179a7774-a2de-4751-9e20-14a4318a8fe0</Id>
+      <Database Name="cv" Series="2190" Issue="24782" />
     </Book>
     <Book Series="Daredevil" Number="212" Volume="1964" Year="1984">
-      <Id>1a85df8f-3e54-4dcc-bab2-c9d3a2355f64</Id>
+      <Database Name="cv" Series="2190" Issue="24884" />
     </Book>
     <Book Series="Daredevil" Number="213" Volume="1964" Year="1984">
-      <Id>1ec147d3-9d8b-44ae-bcff-3f76897af3a3</Id>
+      <Database Name="cv" Series="2190" Issue="24987" />
     </Book>
     <Book Series="Daredevil" Number="214" Volume="1964" Year="1985">
-      <Id>9b5083cc-6ecf-4b7b-bf2e-357832109f00</Id>
+      <Database Name="cv" Series="2190" Issue="25160" />
     </Book>
     <Book Series="Daredevil" Number="215" Volume="1964" Year="1985">
-      <Id>e7288428-fba4-4f60-810a-aa0df118683d</Id>
+      <Database Name="cv" Series="2190" Issue="25255" />
     </Book>
     <Book Series="Daredevil" Number="216" Volume="1964" Year="1985">
-      <Id>5a26c525-ec17-4ade-b89f-57b85379b168</Id>
+      <Database Name="cv" Series="2190" Issue="114112" />
     </Book>
     <Book Series="Daredevil" Number="217" Volume="1964" Year="1985">
-      <Id>527e2609-0132-4bcf-979a-3235e22e89d1</Id>
+      <Database Name="cv" Series="2190" Issue="25384" />
     </Book>
     <Book Series="Daredevil" Number="218" Volume="1964" Year="1985">
-      <Id>4ec9a452-2808-4e31-af75-3ca6ecc2100a</Id>
+      <Database Name="cv" Series="2190" Issue="114111" />
     </Book>
     <Book Series="Daredevil" Number="219" Volume="1964" Year="1985">
-      <Id>85e31453-a726-480f-bc98-a2e5b7f1fff0</Id>
+      <Database Name="cv" Series="2190" Issue="25580" />
     </Book>
     <Book Series="Daredevil" Number="220" Volume="1964" Year="1985">
-      <Id>28a1b476-bb92-4d84-b000-5e57fee3bbde</Id>
+      <Database Name="cv" Series="2190" Issue="25679" />
     </Book>
     <Book Series="Daredevil" Number="221" Volume="1964" Year="1985">
-      <Id>0f666b4a-1275-4b06-a1da-c09d29b464db</Id>
+      <Database Name="cv" Series="2190" Issue="25780" />
     </Book>
     <Book Series="Daredevil" Number="222" Volume="1964" Year="1985">
-      <Id>957a7443-4b8b-4c6d-9df8-1d871a8affd2</Id>
+      <Database Name="cv" Series="2190" Issue="25873" />
     </Book>
     <Book Series="Secret Wars II" Number="3" Volume="1985" Year="1985">
-      <Id>e5b5030d-94e5-4db4-bee0-a76b4f865d95</Id>
+      <Database Name="cv" Series="3506" Issue="57517" />
     </Book>
     <Book Series="Daredevil" Number="223" Volume="1964" Year="1985">
-      <Id>cf75c696-7188-4983-b0b8-4ef47db11244</Id>
+      <Database Name="cv" Series="2190" Issue="25977" />
     </Book>
     <Book Series="Daredevil" Number="224" Volume="1964" Year="1985">
-      <Id>0d0e9083-0186-47c3-9c34-a2f2422c6896</Id>
+      <Database Name="cv" Series="2190" Issue="26080" />
     </Book>
     <Book Series="Daredevil" Number="225" Volume="1964" Year="1985">
-      <Id>a682a921-7d9d-4b02-8166-820a19847613</Id>
+      <Database Name="cv" Series="2190" Issue="26188" />
     </Book>
     <Book Series="Daredevil" Number="226" Volume="1964" Year="1986">
-      <Id>61983ed5-71a4-499b-813a-314010fbc2ac</Id>
+      <Database Name="cv" Series="2190" Issue="26394" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="107" Volume="1976" Year="1985">
-      <Id>d475b8d8-a6d5-4609-9f2e-0e85319e5e8e</Id>
+      <Database Name="cv" Series="2870" Issue="25993" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="108" Volume="1976" Year="1985">
-      <Id>98591799-7aa2-46fd-9437-08e7b210f39c</Id>
+      <Database Name="cv" Series="2870" Issue="26099" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="109" Volume="1976" Year="1985">
-      <Id>892c0b35-457f-4bca-b5f0-c63fdcfda040</Id>
+      <Database Name="cv" Series="2870" Issue="26205" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="110" Volume="1976" Year="1986">
-      <Id>44ded460-3a5f-45a4-82a1-cd3822453ca7</Id>
+      <Database Name="cv" Series="2870" Issue="26409" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Daredevil/Daredevil 002.cbl
+++ b/Marvel/Characters/unsorted/Daredevil/Daredevil 002.cbl
@@ -2,340 +2,340 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Daredevil 2</Name>
   <Books>
-    <Book Series="Daredevil" Number="227" Volume="1964" Year="1986" Format="Main Series">
+    <Book Series="Daredevil" Number="227" Volume="1964" Year="1986">
       <Id>28e479df-e730-4355-8177-e916ca256d92</Id>
     </Book>
-    <Book Series="Daredevil" Number="228" Volume="1964" Year="1986" Format="Main Series">
+    <Book Series="Daredevil" Number="228" Volume="1964" Year="1986">
       <Id>9a918774-4958-4572-aa14-67f16fd9b7e3</Id>
     </Book>
-    <Book Series="Daredevil" Number="229" Volume="1964" Year="1986" Format="Main Series">
+    <Book Series="Daredevil" Number="229" Volume="1964" Year="1986">
       <Id>c1464f77-9dcc-48ec-b211-212d06668c52</Id>
     </Book>
-    <Book Series="Daredevil" Number="230" Volume="1964" Year="1986" Format="Main Series">
+    <Book Series="Daredevil" Number="230" Volume="1964" Year="1986">
       <Id>442fb92a-547a-4f96-8270-faa6a4509a00</Id>
     </Book>
-    <Book Series="Daredevil" Number="231" Volume="1964" Year="1986" Format="Main Series">
+    <Book Series="Daredevil" Number="231" Volume="1964" Year="1986">
       <Id>76d51dc0-31d2-42b2-a265-f3e4e261b31c</Id>
     </Book>
-    <Book Series="Daredevil" Number="232" Volume="1964" Year="1986" Format="Main Series">
+    <Book Series="Daredevil" Number="232" Volume="1964" Year="1986">
       <Id>7e478fb3-fe44-4b37-b53b-2b70f0e6120c</Id>
     </Book>
-    <Book Series="Daredevil" Number="233" Volume="1964" Year="1986" Format="Main Series">
+    <Book Series="Daredevil" Number="233" Volume="1964" Year="1986">
       <Id>dcc25ebe-ab36-4be9-b4d3-9202f25f637d</Id>
     </Book>
     <Book Series="Marvel Fanfare" Number="27" Volume="1982" Year="1986">
       <Id>c9c59fde-fb82-4439-b657-d462dc61ecb2</Id>
     </Book>
-    <Book Series="Marvel Graphic Novel" Number="24" Volume="1982" Year="1986" Format="One-Shot">
+    <Book Series="Marvel Graphic Novel" Number="24" Volume="1982" Year="1986">
       <Id>60f5f691-13b2-433f-8edc-2dafc76c2561</Id>
     </Book>
-    <Book Series="Daredevil" Number="234" Volume="1964" Year="1986" Format="Main Series">
+    <Book Series="Daredevil" Number="234" Volume="1964" Year="1986">
       <Id>8ca3db95-5872-425f-988b-135561241bf2</Id>
     </Book>
-    <Book Series="Daredevil" Number="235" Volume="1964" Year="1986" Format="Main Series">
+    <Book Series="Daredevil" Number="235" Volume="1964" Year="1986">
       <Id>d5329737-5289-463f-b66a-44811a832699</Id>
     </Book>
-    <Book Series="Daredevil" Number="236" Volume="1964" Year="1986" Format="Main Series">
+    <Book Series="Daredevil" Number="236" Volume="1964" Year="1986">
       <Id>7900780d-cc7c-4429-97cb-bafdabcaa38e</Id>
     </Book>
-    <Book Series="Daredevil" Number="237" Volume="1964" Year="1986" Format="Main Series">
+    <Book Series="Daredevil" Number="237" Volume="1964" Year="1986">
       <Id>d369e315-ca38-4990-bbaa-b9227b4a77bc</Id>
     </Book>
-    <Book Series="Daredevil" Number="238" Volume="1964" Year="1987" Format="Main Series">
+    <Book Series="Daredevil" Number="238" Volume="1964" Year="1987">
       <Id>0c24cbcf-214a-4be7-82ba-bef9ef0e2a6d</Id>
     </Book>
-    <Book Series="Daredevil" Number="239" Volume="1964" Year="1987" Format="Main Series">
+    <Book Series="Daredevil" Number="239" Volume="1964" Year="1987">
       <Id>db669f00-abbe-4f0f-a647-d488b5057628</Id>
     </Book>
-    <Book Series="Daredevil" Number="240" Volume="1964" Year="1987" Format="Main Series">
+    <Book Series="Daredevil" Number="240" Volume="1964" Year="1987">
       <Id>98020efa-99f6-4b47-9c16-1af8583ba210</Id>
     </Book>
-    <Book Series="Daredevil" Number="241" Volume="1964" Year="1987" Format="Main Series">
+    <Book Series="Daredevil" Number="241" Volume="1964" Year="1987">
       <Id>351a618a-f5d2-49fc-91f9-59090722f69d</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="287" Volume="1963" Year="1987" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="287" Volume="1963" Year="1987">
       <Id>815e4524-32da-4639-8e54-8d356caceefe</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="288" Volume="1963" Year="1987" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="288" Volume="1963" Year="1987">
       <Id>0b0b8484-0ec4-4bde-a643-dab7e7da1090</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="128" Volume="1976" Year="1987" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="128" Volume="1976" Year="1987">
       <Id>bbb948f4-7d0d-4d51-a7a0-3e3de5da09e9</Id>
     </Book>
-    <Book Series="Daredevil" Number="242" Volume="1964" Year="1987" Format="Main Series">
+    <Book Series="Daredevil" Number="242" Volume="1964" Year="1987">
       <Id>c412b215-3143-44d6-a34f-4a2bf28fd97f</Id>
     </Book>
-    <Book Series="Daredevil" Number="243" Volume="1964" Year="1987" Format="Main Series">
+    <Book Series="Daredevil" Number="243" Volume="1964" Year="1987">
       <Id>f9c8b181-ccc0-4bc0-9c18-0a4619ee0908</Id>
     </Book>
-    <Book Series="Daredevil" Number="244" Volume="1964" Year="1987" Format="Main Series">
+    <Book Series="Daredevil" Number="244" Volume="1964" Year="1987">
       <Id>64ba2523-5f39-4824-afd5-3a189d84af45</Id>
     </Book>
-    <Book Series="Daredevil" Number="245" Volume="1964" Year="1987" Format="Main Series">
+    <Book Series="Daredevil" Number="245" Volume="1964" Year="1987">
       <Id>f310b3cb-8b82-479b-a7ac-f5793c0b4070</Id>
     </Book>
-    <Book Series="Daredevil" Number="246" Volume="1964" Year="1987" Format="Main Series">
+    <Book Series="Daredevil" Number="246" Volume="1964" Year="1987">
       <Id>de0a6c09-2e32-466f-a366-c4aa1f329c11</Id>
     </Book>
-    <Book Series="Daredevil" Number="247" Volume="1964" Year="1987" Format="Main Series">
+    <Book Series="Daredevil" Number="247" Volume="1964" Year="1987">
       <Id>88946a40-6e19-4521-8cf2-361c8f2eb505</Id>
     </Book>
-    <Book Series="Daredevil" Number="248" Volume="1964" Year="1987" Format="Main Series">
+    <Book Series="Daredevil" Number="248" Volume="1964" Year="1987">
       <Id>001c139a-b9a1-4e77-b85e-9cc5fee41839</Id>
     </Book>
-    <Book Series="Daredevil" Number="249" Volume="1964" Year="1987" Format="Main Series">
+    <Book Series="Daredevil" Number="249" Volume="1964" Year="1987">
       <Id>7541dd2c-f414-4a1a-990c-272c3a825dde</Id>
     </Book>
-    <Book Series="Daredevil" Number="250" Volume="1964" Year="1988" Format="Main Series">
+    <Book Series="Daredevil" Number="250" Volume="1964" Year="1988">
       <Id>1cfecb8a-1bfc-43c4-baec-b4a118e40bd9</Id>
     </Book>
-    <Book Series="Daredevil" Number="251" Volume="1964" Year="1988" Format="Main Series">
+    <Book Series="Daredevil" Number="251" Volume="1964" Year="1988">
       <Id>c2e89a89-561f-4fe6-a34d-b3a74d36bea0</Id>
     </Book>
-    <Book Series="Daredevil" Number="252" Volume="1964" Year="1988" Format="Main Series">
+    <Book Series="Daredevil" Number="252" Volume="1964" Year="1988">
       <Id>b7508bd7-3a0e-4255-ab62-0f54aa483253</Id>
     </Book>
-    <Book Series="Daredevil" Number="253" Volume="1964" Year="1988" Format="Main Series">
+    <Book Series="Daredevil" Number="253" Volume="1964" Year="1988">
       <Id>44bdf4d8-4e59-47d3-898f-a979d2615717</Id>
     </Book>
-    <Book Series="Daredevil" Number="254" Volume="1964" Year="1988" Format="Main Series">
+    <Book Series="Daredevil" Number="254" Volume="1964" Year="1988">
       <Id>3d4a419b-4600-413a-a6ff-9958bd20d016</Id>
     </Book>
-    <Book Series="Daredevil" Number="255" Volume="1964" Year="1988" Format="Main Series">
+    <Book Series="Daredevil" Number="255" Volume="1964" Year="1988">
       <Id>cebca0dc-df53-4edb-ab58-fd3d8cccdc7b</Id>
     </Book>
-    <Book Series="Daredevil" Number="256" Volume="1964" Year="1988" Format="Main Series">
+    <Book Series="Daredevil" Number="256" Volume="1964" Year="1988">
       <Id>e2c83e49-7efc-468b-8421-2e8b902546a2</Id>
     </Book>
-    <Book Series="The Punisher" Number="10" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="The Punisher" Number="10" Volume="2011" Year="2012">
       <Id>9c3c7981-7a95-49e0-8c72-af0b6dc04a9a</Id>
     </Book>
-    <Book Series="Daredevil" Number="257" Volume="1964" Year="1988" Format="Main Series">
+    <Book Series="Daredevil" Number="257" Volume="1964" Year="1988">
       <Id>a39a8830-1a21-465e-8a52-2444740eceec</Id>
     </Book>
-    <Book Series="Daredevil" Number="258" Volume="1964" Year="1988" Format="Main Series">
+    <Book Series="Daredevil" Number="258" Volume="1964" Year="1988">
       <Id>1a751706-18cb-47fd-93d2-7f22a4856d2e</Id>
     </Book>
-    <Book Series="Daredevil" Number="259" Volume="1964" Year="1988" Format="Main Series">
+    <Book Series="Daredevil" Number="259" Volume="1964" Year="1988">
       <Id>b573f2fd-7e58-423e-ab7c-61d14d544a64</Id>
     </Book>
-    <Book Series="Daredevil" Number="260" Volume="1964" Year="1988" Format="Main Series">
+    <Book Series="Daredevil" Number="260" Volume="1964" Year="1988">
       <Id>3195243d-9f00-4ea1-880c-bbd3a7d1ba5b</Id>
     </Book>
-    <Book Series="Daredevil" Number="261" Volume="1964" Year="1988" Format="Main Series">
+    <Book Series="Daredevil" Number="261" Volume="1964" Year="1988">
       <Id>240aa712-5cd1-4285-b256-b0b1dc383da6</Id>
     </Book>
-    <Book Series="Thor" Number="392" Volume="1966" Year="1988" Format="Main Series">
+    <Book Series="Thor" Number="392" Volume="1966" Year="1988">
       <Id>01577a89-aa3a-49a5-be27-cd7365d959d0</Id>
     </Book>
-    <Book Series="Thor" Number="393" Volume="1966" Year="1988" Format="Main Series">
+    <Book Series="Thor" Number="393" Volume="1966" Year="1988">
       <Id>dd9a624b-ee24-46d5-a9a0-2f53c94fc6b8</Id>
     </Book>
-    <Book Series="Thor" Number="395" Volume="1966" Year="1988" Format="Main Series">
+    <Book Series="Thor" Number="395" Volume="1966" Year="1988">
       <Id>bbe8a121-067e-4605-8795-f2714fa0ef3d</Id>
     </Book>
-    <Book Series="Thor" Number="396" Volume="1966" Year="1988" Format="Main Series">
+    <Book Series="Thor" Number="396" Volume="1966" Year="1988">
       <Id>c13d8f20-0b55-48aa-92b8-1e0f5e991fb1</Id>
     </Book>
-    <Book Series="Daredevil" Number="262" Volume="1964" Year="1989" Format="Main Series">
+    <Book Series="Daredevil" Number="262" Volume="1964" Year="1989">
       <Id>865d18e0-9f14-4dc7-b951-845a2c67f1ea</Id>
     </Book>
-    <Book Series="Daredevil" Number="263" Volume="1964" Year="1989" Format="Main Series">
+    <Book Series="Daredevil" Number="263" Volume="1964" Year="1989">
       <Id>db3e276f-1d53-4366-af96-b719f41cc5ce</Id>
     </Book>
-    <Book Series="Daredevil" Number="264" Volume="1964" Year="1989" Format="Main Series">
+    <Book Series="Daredevil" Number="264" Volume="1964" Year="1989">
       <Id>91a64da0-f462-47b5-8fce-da7b4faf5b58</Id>
     </Book>
-    <Book Series="Daredevil" Number="265" Volume="1964" Year="1989" Format="Main Series">
+    <Book Series="Daredevil" Number="265" Volume="1964" Year="1989">
       <Id>38da9e72-90bd-4633-b3f0-4e1694550d1c</Id>
     </Book>
-    <Book Series="Daredevil" Number="266" Volume="1964" Year="1989" Format="Main Series">
+    <Book Series="Daredevil" Number="266" Volume="1964" Year="1989">
       <Id>a5c9bf52-80bd-49b8-bea5-4338402ade32</Id>
     </Book>
-    <Book Series="Daredevil" Number="267" Volume="1964" Year="1989" Format="Main Series">
+    <Book Series="Daredevil" Number="267" Volume="1964" Year="1989">
       <Id>e26d276a-6efd-4ef3-a66d-96b12713d580</Id>
     </Book>
-    <Book Series="Daredevil" Number="268" Volume="1964" Year="1989" Format="Main Series">
+    <Book Series="Daredevil" Number="268" Volume="1964" Year="1989">
       <Id>2e214240-cbf9-41b3-873a-967c3db444cc</Id>
     </Book>
-    <Book Series="Daredevil" Number="269" Volume="1964" Year="1989" Format="Main Series">
+    <Book Series="Daredevil" Number="269" Volume="1964" Year="1989">
       <Id>143af90c-c51b-4b0b-bb5c-3fe0b3abad2e</Id>
     </Book>
-    <Book Series="Daredevil Annual" Number="5" Volume="1967" Year="1989" Format="Annual">
+    <Book Series="Daredevil Annual" Number="5" Volume="1967" Year="1989">
       <Id>62b27115-b3e5-4abd-bcf5-ce27c5734937</Id>
     </Book>
-    <Book Series="Daredevil" Number="270" Volume="1964" Year="1989" Format="Main Series">
+    <Book Series="Daredevil" Number="270" Volume="1964" Year="1989">
       <Id>4e1a3f11-9f71-43aa-b94b-85cce9eac2b4</Id>
     </Book>
-    <Book Series="Daredevil" Number="271" Volume="1964" Year="1989" Format="Main Series">
+    <Book Series="Daredevil" Number="271" Volume="1964" Year="1989">
       <Id>c3ed277e-0d78-46ff-abec-38bdbe143172</Id>
     </Book>
-    <Book Series="Daredevil" Number="272" Volume="1964" Year="1989" Format="Main Series">
+    <Book Series="Daredevil" Number="272" Volume="1964" Year="1989">
       <Id>75b40280-37b9-42c1-9b83-a8f5222d815a</Id>
     </Book>
-    <Book Series="Daredevil" Number="273" Volume="1964" Year="1989" Format="Main Series">
+    <Book Series="Daredevil" Number="273" Volume="1964" Year="1989">
       <Id>ec59e908-dd2a-4b24-ab33-e4210fffd186</Id>
     </Book>
-    <Book Series="Daredevil" Number="274" Volume="1964" Year="1989" Format="Main Series">
+    <Book Series="Daredevil" Number="274" Volume="1964" Year="1989">
       <Id>7e5f043c-7c9e-4613-b4f5-56c7af27d4b0</Id>
     </Book>
-    <Book Series="Daredevil" Number="275" Volume="1964" Year="1989" Format="Main Series">
+    <Book Series="Daredevil" Number="275" Volume="1964" Year="1989">
       <Id>956f2bb9-467f-409e-a5f8-2baad38ff84a</Id>
     </Book>
-    <Book Series="Daredevil" Number="276" Volume="1964" Year="1990" Format="Main Series">
+    <Book Series="Daredevil" Number="276" Volume="1964" Year="1990">
       <Id>90d56a2b-dbd4-49f8-b9e1-f7128e41d533</Id>
     </Book>
-    <Book Series="Daredevil" Number="277" Volume="1964" Year="1990" Format="Main Series">
+    <Book Series="Daredevil" Number="277" Volume="1964" Year="1990">
       <Id>7b05cf15-60b9-41f5-8986-fe71c9f037bd</Id>
     </Book>
-    <Book Series="Daredevil Annual" Number="6" Volume="1967" Year="1990" Format="Annual">
+    <Book Series="Daredevil Annual" Number="6" Volume="1967" Year="1990">
       <Id>30d05fd8-5ded-4a5c-a20d-edfefa8d1ceb</Id>
     </Book>
-    <Book Series="Daredevil" Number="278" Volume="1964" Year="1990" Format="Main Series">
+    <Book Series="Daredevil" Number="278" Volume="1964" Year="1990">
       <Id>5669dac7-77dd-4483-89a4-415f9f9a3598</Id>
     </Book>
-    <Book Series="Daredevil" Number="279" Volume="1964" Year="1990" Format="Main Series">
+    <Book Series="Daredevil" Number="279" Volume="1964" Year="1990">
       <Id>0dcddff9-f4c1-4e09-a964-0a0bf8f62513</Id>
     </Book>
-    <Book Series="Daredevil" Number="280" Volume="1964" Year="1990" Format="Main Series">
+    <Book Series="Daredevil" Number="280" Volume="1964" Year="1990">
       <Id>fd429878-6fd2-4f71-8165-253a3b546434</Id>
     </Book>
-    <Book Series="Daredevil" Number="281" Volume="1964" Year="1990" Format="Main Series">
+    <Book Series="Daredevil" Number="281" Volume="1964" Year="1990">
       <Id>46eaa884-273d-446a-a723-d98040ca151b</Id>
     </Book>
-    <Book Series="Daredevil" Number="282" Volume="1964" Year="1990" Format="Main Series">
+    <Book Series="Daredevil" Number="282" Volume="1964" Year="1990">
       <Id>3fad2685-fe23-4489-bc64-c1f2f24d8faa</Id>
     </Book>
-    <Book Series="Daredevil" Number="283" Volume="1964" Year="1990" Format="Main Series">
+    <Book Series="Daredevil" Number="283" Volume="1964" Year="1990">
       <Id>fb5290d8-839b-4a27-b7ec-c13aefbc5047</Id>
     </Book>
-    <Book Series="Daredevil" Number="284" Volume="1964" Year="1990" Format="Main Series">
+    <Book Series="Daredevil" Number="284" Volume="1964" Year="1990">
       <Id>7cc008f4-4b16-4d59-a47a-cf3a9078b75e</Id>
     </Book>
-    <Book Series="Daredevil" Number="285" Volume="1964" Year="1990" Format="Main Series">
+    <Book Series="Daredevil" Number="285" Volume="1964" Year="1990">
       <Id>48305a46-328f-43c4-985f-105fac86adf2</Id>
     </Book>
-    <Book Series="Daredevil" Number="286" Volume="1964" Year="1990" Format="Main Series">
+    <Book Series="Daredevil" Number="286" Volume="1964" Year="1990">
       <Id>534ed80b-986a-4d35-b381-4e920fcb36a2</Id>
     </Book>
-    <Book Series="Daredevil" Number="287" Volume="1964" Year="1990" Format="Main Series">
+    <Book Series="Daredevil" Number="287" Volume="1964" Year="1990">
       <Id>9ceb8970-b802-48db-9df8-3d945ae05648</Id>
     </Book>
-    <Book Series="Daredevil" Number="288" Volume="1964" Year="1991" Format="Main Series">
+    <Book Series="Daredevil" Number="288" Volume="1964" Year="1991">
       <Id>59264aee-c692-4c26-9887-bf20f6eff918</Id>
     </Book>
-    <Book Series="Daredevil" Number="289" Volume="1964" Year="1991" Format="Main Series">
+    <Book Series="Daredevil" Number="289" Volume="1964" Year="1991">
       <Id>a096e63a-a3f4-47ba-b2db-3c440d774eea</Id>
     </Book>
-    <Book Series="Daredevil" Number="290" Volume="1964" Year="1991" Format="Main Series">
+    <Book Series="Daredevil" Number="290" Volume="1964" Year="1991">
       <Id>047d0cde-7536-433f-b924-378b604b9145</Id>
     </Book>
-    <Book Series="Daredevil" Number="291" Volume="1964" Year="1991" Format="Main Series">
+    <Book Series="Daredevil" Number="291" Volume="1964" Year="1991">
       <Id>8cb68b08-72cf-443a-8203-efd72a05513e</Id>
     </Book>
-    <Book Series="Captain America" Number="375" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="Captain America" Number="375" Volume="1968" Year="1990">
       <Id>7a35ad5e-e6c9-4d9e-91b3-a9adb80949ed</Id>
     </Book>
-    <Book Series="Captain America" Number="376" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="Captain America" Number="376" Volume="1968" Year="1990">
       <Id>656973f8-25ea-4b18-8545-71407f21feee</Id>
     </Book>
-    <Book Series="Daredevil" Number="292" Volume="1964" Year="1991" Format="Main Series">
+    <Book Series="Daredevil" Number="292" Volume="1964" Year="1991">
       <Id>cf37275f-c3f7-47d0-ac9b-fc3cb0db3563</Id>
     </Book>
-    <Book Series="Daredevil" Number="293" Volume="1964" Year="1991" Format="Main Series">
+    <Book Series="Daredevil" Number="293" Volume="1964" Year="1991">
       <Id>01f4ad2c-a986-48e1-b130-b6dc152b17e1</Id>
     </Book>
-    <Book Series="Daredevil Annual" Number="7" Volume="1967" Year="1991" Format="Annual">
+    <Book Series="Daredevil Annual" Number="7" Volume="1967" Year="1991">
       <Id>782bea6d-c816-4e36-aa46-c92ca410df44</Id>
     </Book>
-    <Book Series="Daredevil" Number="294" Volume="1964" Year="1991" Format="Main Series">
+    <Book Series="Daredevil" Number="294" Volume="1964" Year="1991">
       <Id>19a8d2a6-120c-4361-8c47-4914a971a1eb</Id>
     </Book>
-    <Book Series="Daredevil" Number="295" Volume="1964" Year="1991" Format="Main Series">
+    <Book Series="Daredevil" Number="295" Volume="1964" Year="1991">
       <Id>48d49096-6d8a-45bc-926c-4c0e3d7edf6d</Id>
     </Book>
-    <Book Series="Daredevil" Number="296" Volume="1964" Year="1991" Format="Main Series">
+    <Book Series="Daredevil" Number="296" Volume="1964" Year="1991">
       <Id>e9b1e8b9-0ecc-479f-b0fd-2fca95d2e496</Id>
     </Book>
-    <Book Series="Daredevil" Number="297" Volume="1964" Year="1991" Format="Main Series">
+    <Book Series="Daredevil" Number="297" Volume="1964" Year="1991">
       <Id>37797c64-966b-4126-9810-0189aca994af</Id>
     </Book>
-    <Book Series="Daredevil" Number="298" Volume="1964" Year="1991" Format="Main Series">
+    <Book Series="Daredevil" Number="298" Volume="1964" Year="1991">
       <Id>2606520e-f0d1-4b9c-bff7-a69b4bb46a85</Id>
     </Book>
-    <Book Series="Daredevil" Number="299" Volume="1964" Year="1991" Format="Main Series">
+    <Book Series="Daredevil" Number="299" Volume="1964" Year="1991">
       <Id>352f7443-7ae6-4495-9246-d66d56c2d399</Id>
     </Book>
-    <Book Series="Daredevil" Number="300" Volume="1964" Year="1992" Format="Main Series">
+    <Book Series="Daredevil" Number="300" Volume="1964" Year="1992">
       <Id>35405290-c19a-4d24-a84c-4026f6b3ce7a</Id>
     </Book>
-    <Book Series="Daredevil" Number="301" Volume="1964" Year="1992" Format="Main Series">
+    <Book Series="Daredevil" Number="301" Volume="1964" Year="1992">
       <Id>3b41b228-f722-4bde-8f72-a73c8cc433dd</Id>
     </Book>
-    <Book Series="Daredevil" Number="302" Volume="1964" Year="1992" Format="Main Series">
+    <Book Series="Daredevil" Number="302" Volume="1964" Year="1992">
       <Id>abd74cb0-8093-451d-8e85-7c9be4c1696a</Id>
     </Book>
-    <Book Series="Daredevil" Number="303" Volume="1964" Year="1992" Format="Main Series">
+    <Book Series="Daredevil" Number="303" Volume="1964" Year="1992">
       <Id>75d73a3e-8ed2-4a1a-b7fd-9a67c328a6a2</Id>
     </Book>
-    <Book Series="Daredevil Annual" Number="8" Volume="1967" Year="1992" Format="Annual">
+    <Book Series="Daredevil Annual" Number="8" Volume="1967" Year="1992">
       <Id>5ed02090-3d6d-4b85-a1e0-c6e8ea31840e</Id>
     </Book>
-    <Book Series="Daredevil" Number="304" Volume="1964" Year="1992" Format="Main Series">
+    <Book Series="Daredevil" Number="304" Volume="1964" Year="1992">
       <Id>0ed60a72-24d9-4d80-af93-cf198efc964c</Id>
     </Book>
-    <Book Series="Daredevil" Number="305" Volume="1964" Year="1992" Format="Main Series">
+    <Book Series="Daredevil" Number="305" Volume="1964" Year="1992">
       <Id>b2d2f0a8-3862-4fb2-b59a-3682b5c81737</Id>
     </Book>
-    <Book Series="Daredevil" Number="306" Volume="1964" Year="1992" Format="Main Series">
+    <Book Series="Daredevil" Number="306" Volume="1964" Year="1992">
       <Id>11f93049-aaf9-4b06-9bb3-8a03702f5d71</Id>
     </Book>
-    <Book Series="Daredevil" Number="307" Volume="1964" Year="1992" Format="Main Series">
+    <Book Series="Daredevil" Number="307" Volume="1964" Year="1992">
       <Id>2ebb81bf-3b24-4f00-998d-0d8c3fb9d14c</Id>
     </Book>
-    <Book Series="Daredevil" Number="308" Volume="1964" Year="1992" Format="Main Series">
+    <Book Series="Daredevil" Number="308" Volume="1964" Year="1992">
       <Id>548489bf-858a-43b7-98bb-ba32935cafeb</Id>
     </Book>
-    <Book Series="Daredevil" Number="309" Volume="1964" Year="1992" Format="Main Series">
+    <Book Series="Daredevil" Number="309" Volume="1964" Year="1992">
       <Id>33afdaa4-d3e7-4d8a-8c01-aee85a5b8f93</Id>
     </Book>
-    <Book Series="Nomad" Number="6" Volume="1992" Year="1992" Format="Main Series">
+    <Book Series="Nomad" Number="6" Volume="1992" Year="1992">
       <Id>4c226921-2675-4237-bd32-a5fb8b67d23a</Id>
     </Book>
     <Book Series="The Punisher War Journal" Number="47" Volume="1988" Year="1992">
       <Id>feaadbe4-9de6-4694-897a-fa6b9d9eb422</Id>
     </Book>
-    <Book Series="Daredevil" Number="310" Volume="1964" Year="1992" Format="Main Series">
+    <Book Series="Daredevil" Number="310" Volume="1964" Year="1992">
       <Id>7e1bfa26-9e98-44da-9e4f-694e2f0d1db8</Id>
     </Book>
-    <Book Series="Spider-Man Special Edition" Number="1" Volume="1992" Year="1992" Format="One-Shot">
+    <Book Series="Spider-Man Special Edition" Number="1" Volume="1992" Year="1992">
       <Id>76a4b638-65da-4bb6-a6c6-9aea9742dcb6</Id>
     </Book>
-    <Book Series="Daredevil" Number="311" Volume="1964" Year="1992" Format="Main Series">
+    <Book Series="Daredevil" Number="311" Volume="1964" Year="1992">
       <Id>50a15e90-9ead-40b7-8bd8-93655d35b64e</Id>
     </Book>
-    <Book Series="Daredevil" Number="312" Volume="1964" Year="1993" Format="Main Series">
+    <Book Series="Daredevil" Number="312" Volume="1964" Year="1993">
       <Id>1dbdae38-de2d-484f-96d9-ad3f3259395c</Id>
     </Book>
-    <Book Series="Daredevil" Number="313" Volume="1964" Year="1993" Format="Main Series">
+    <Book Series="Daredevil" Number="313" Volume="1964" Year="1993">
       <Id>96713649-c532-45ba-bc3a-c6de59a4d95f</Id>
     </Book>
-    <Book Series="Daredevil" Number="314" Volume="1964" Year="1993" Format="Main Series">
+    <Book Series="Daredevil" Number="314" Volume="1964" Year="1993">
       <Id>6f340df4-aacf-4aa8-8c5f-586ccc7b7a5a</Id>
     </Book>
-    <Book Series="Daredevil" Number="315" Volume="1964" Year="1993" Format="Main Series">
+    <Book Series="Daredevil" Number="315" Volume="1964" Year="1993">
       <Id>6b8ab87c-1324-4fe9-8742-558f5a519d24</Id>
     </Book>
-    <Book Series="Daredevil" Number="316" Volume="1964" Year="1993" Format="Main Series">
+    <Book Series="Daredevil" Number="316" Volume="1964" Year="1993">
       <Id>4c3983d4-d987-4672-bfa6-ab91c6c8ea0d</Id>
     </Book>
-    <Book Series="Daredevil" Number="317" Volume="1964" Year="1993" Format="Main Series">
+    <Book Series="Daredevil" Number="317" Volume="1964" Year="1993">
       <Id>cb602ac5-4ba6-40b4-8321-04eab83ebbe6</Id>
     </Book>
-    <Book Series="Daredevil" Number="318" Volume="1964" Year="1993" Format="Main Series">
+    <Book Series="Daredevil" Number="318" Volume="1964" Year="1993">
       <Id>325c7f2f-84d0-480a-96cd-6e7dd81bbef5</Id>
     </Book>
-    <Book Series="Daredevil/Black Widow: Abattoir" Number="1" Volume="1993" Year="1993" Format="One-Shot">
+    <Book Series="Daredevil/Black Widow: Abattoir" Number="1" Volume="1993" Year="1993">
       <Id>e6ba88bc-12e7-4155-ba47-bb476635360c</Id>
     </Book>
     <Book Series="The Punisher War Journal" Number="57" Volume="1988" Year="1993">
@@ -344,214 +344,214 @@
     <Book Series="The Punisher War Journal" Number="58" Volume="1988" Year="1993">
       <Id>37dc32c1-e884-4a29-8bf5-dd7e2fa09dcb</Id>
     </Book>
-    <Book Series="Daredevil Annual" Number="9" Volume="1967" Year="1993" Format="Annual">
+    <Book Series="Daredevil Annual" Number="9" Volume="1967" Year="1993">
       <Id>a2a49093-52a2-4090-8c60-8a91aae28110</Id>
     </Book>
-    <Book Series="Daredevil" Number="319" Volume="1964" Year="1993" Format="Main Series">
+    <Book Series="Daredevil" Number="319" Volume="1964" Year="1993">
       <Id>58e5abd1-1352-4a4a-b699-67d782e4df56</Id>
     </Book>
-    <Book Series="Daredevil" Number="320" Volume="1964" Year="1993" Format="Main Series">
+    <Book Series="Daredevil" Number="320" Volume="1964" Year="1993">
       <Id>7429d9d8-380d-4c19-bcca-480d3a03adc3</Id>
     </Book>
-    <Book Series="Daredevil" Number="321" Volume="1964" Year="1993" Format="Main Series">
+    <Book Series="Daredevil" Number="321" Volume="1964" Year="1993">
       <Id>4f8e2de2-75f7-425b-a0f4-c9dd35f23580</Id>
     </Book>
-    <Book Series="Daredevil" Number="322" Volume="1964" Year="1993" Format="Main Series">
+    <Book Series="Daredevil" Number="322" Volume="1964" Year="1993">
       <Id>94591349-531a-4fee-8175-db34943ed5ec</Id>
     </Book>
-    <Book Series="Daredevil" Number="323" Volume="1964" Year="1993" Format="Main Series">
+    <Book Series="Daredevil" Number="323" Volume="1964" Year="1993">
       <Id>45371d22-a8b3-4528-8ca4-2ecbcf179b8b</Id>
     </Book>
-    <Book Series="Daredevil" Number="324" Volume="1964" Year="1994" Format="Main Series">
+    <Book Series="Daredevil" Number="324" Volume="1964" Year="1994">
       <Id>0a4e6684-e580-44b1-856c-6f654d86a2c6</Id>
     </Book>
-    <Book Series="Daredevil" Number="325" Volume="1964" Year="1994" Format="Main Series">
+    <Book Series="Daredevil" Number="325" Volume="1964" Year="1994">
       <Id>bd8191d1-3615-4d3d-8781-7a7210f3ba2a</Id>
     </Book>
-    <Book Series="Daredevil: The Man Without Fear" Number="1" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="Daredevil: The Man Without Fear" Number="1" Volume="1993" Year="1993">
       <Id>89fca584-a805-4a5e-944e-e9187de7875b</Id>
     </Book>
-    <Book Series="Daredevil: The Man Without Fear" Number="2" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="Daredevil: The Man Without Fear" Number="2" Volume="1993" Year="1993">
       <Id>71f4eb7c-bde5-4915-97bd-f4556bd483d6</Id>
     </Book>
-    <Book Series="Daredevil: The Man Without Fear" Number="3" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="Daredevil: The Man Without Fear" Number="3" Volume="1993" Year="1993">
       <Id>f31c99f4-31a9-4a7a-af55-7a8ec3924e11</Id>
     </Book>
-    <Book Series="Daredevil: The Man Without Fear" Number="4" Volume="1993" Year="1994" Format="Limited Series">
+    <Book Series="Daredevil: The Man Without Fear" Number="4" Volume="1993" Year="1994">
       <Id>ea4f4db3-99c6-452e-8c55-be64f80e9517</Id>
     </Book>
-    <Book Series="Daredevil: The Man Without Fear" Number="5" Volume="1993" Year="1994" Format="Limited Series">
+    <Book Series="Daredevil: The Man Without Fear" Number="5" Volume="1993" Year="1994">
       <Id>d5bc89f8-7400-4245-81a9-555f6b30ba42</Id>
     </Book>
-    <Book Series="Daredevil Annual" Number="10" Volume="1967" Year="1994" Format="Annual">
+    <Book Series="Daredevil Annual" Number="10" Volume="1967" Year="1994">
       <Id>7c445984-d195-4edc-8151-2af7a6e833b3</Id>
     </Book>
-    <Book Series="Daredevil" Number="326" Volume="1964" Year="1994" Format="Main Series">
+    <Book Series="Daredevil" Number="326" Volume="1964" Year="1994">
       <Id>99c29869-da53-429a-9465-81b768ea84dc</Id>
     </Book>
-    <Book Series="Daredevil" Number="327" Volume="1964" Year="1994" Format="Main Series">
+    <Book Series="Daredevil" Number="327" Volume="1964" Year="1994">
       <Id>110628ad-4ed4-4f0c-a5f1-49cfa05938dd</Id>
     </Book>
-    <Book Series="Daredevil" Number="328" Volume="1964" Year="1994" Format="Main Series">
+    <Book Series="Daredevil" Number="328" Volume="1964" Year="1994">
       <Id>3df693a0-76d6-4125-9607-ab3bd2176cf2</Id>
     </Book>
-    <Book Series="Daredevil" Number="329" Volume="1964" Year="1994" Format="Main Series">
+    <Book Series="Daredevil" Number="329" Volume="1964" Year="1994">
       <Id>70e0531e-335a-41fc-a931-c04b2ecd6101</Id>
     </Book>
-    <Book Series="Daredevil" Number="330" Volume="1964" Year="1994" Format="Main Series">
+    <Book Series="Daredevil" Number="330" Volume="1964" Year="1994">
       <Id>4bb7de3d-bb3c-4e96-a890-9550c7dc3fa3</Id>
     </Book>
-    <Book Series="Daredevil" Number="331" Volume="1964" Year="1994" Format="Main Series">
+    <Book Series="Daredevil" Number="331" Volume="1964" Year="1994">
       <Id>6e6c6524-a2b0-4404-ae75-f3986e9c4e92</Id>
     </Book>
-    <Book Series="Daredevil" Number="332" Volume="1964" Year="1994" Format="Main Series">
+    <Book Series="Daredevil" Number="332" Volume="1964" Year="1994">
       <Id>5b71a491-849e-404d-94bb-a362853c59fd</Id>
     </Book>
-    <Book Series="Daredevil" Number="333" Volume="1964" Year="1994" Format="Main Series">
+    <Book Series="Daredevil" Number="333" Volume="1964" Year="1994">
       <Id>0918f11c-a7b9-40ac-a4cd-face14326969</Id>
     </Book>
-    <Book Series="Daredevil" Number="334" Volume="1964" Year="1994" Format="Main Series">
+    <Book Series="Daredevil" Number="334" Volume="1964" Year="1994">
       <Id>99991de8-b545-4fb2-8ef8-e05fe2eb92a7</Id>
     </Book>
-    <Book Series="Daredevil" Number="335" Volume="1964" Year="1994" Format="Main Series">
+    <Book Series="Daredevil" Number="335" Volume="1964" Year="1994">
       <Id>fd4c736f-70d1-471f-84cb-faf531671fd0</Id>
     </Book>
-    <Book Series="Daredevil" Number="336" Volume="1964" Year="1995" Format="Main Series">
+    <Book Series="Daredevil" Number="336" Volume="1964" Year="1995">
       <Id>d3b31d6b-013e-4ac1-91db-14a10af5dff9</Id>
     </Book>
-    <Book Series="Daredevil" Number="337" Volume="1964" Year="1995" Format="Main Series">
+    <Book Series="Daredevil" Number="337" Volume="1964" Year="1995">
       <Id>186a1d3a-1b7b-4d4a-baa4-a757bee5d473</Id>
     </Book>
-    <Book Series="Daredevil" Number="338" Volume="1964" Year="1995" Format="Main Series">
+    <Book Series="Daredevil" Number="338" Volume="1964" Year="1995">
       <Id>7163cb25-6bb9-4e6c-ac46-7f8415934682</Id>
     </Book>
-    <Book Series="Daredevil" Number="339" Volume="1964" Year="1995" Format="Main Series">
+    <Book Series="Daredevil" Number="339" Volume="1964" Year="1995">
       <Id>93f553af-ef69-4d48-898a-734a42e7bef4</Id>
     </Book>
-    <Book Series="Daredevil" Number="340" Volume="1964" Year="1995" Format="Main Series">
+    <Book Series="Daredevil" Number="340" Volume="1964" Year="1995">
       <Id>d6c156fb-93e1-4f6a-ad1b-2d8c450f7240</Id>
     </Book>
-    <Book Series="Daredevil" Number="341" Volume="1964" Year="1995" Format="Main Series">
+    <Book Series="Daredevil" Number="341" Volume="1964" Year="1995">
       <Id>f4adb162-3780-42f0-bf08-405f168262b9</Id>
     </Book>
-    <Book Series="Daredevil" Number="342" Volume="1964" Year="1995" Format="Main Series">
+    <Book Series="Daredevil" Number="342" Volume="1964" Year="1995">
       <Id>5a5bfde4-7c61-4927-83e5-3e3ebf053297</Id>
     </Book>
-    <Book Series="Daredevil" Number="343" Volume="1964" Year="1995" Format="Main Series">
+    <Book Series="Daredevil" Number="343" Volume="1964" Year="1995">
       <Id>546caba6-5575-47b7-bda1-23569f155af2</Id>
     </Book>
-    <Book Series="Daredevil" Number="344" Volume="1964" Year="1995" Format="Main Series">
+    <Book Series="Daredevil" Number="344" Volume="1964" Year="1995">
       <Id>50ca3b03-6ee5-423a-b283-3721e8b79eb3</Id>
     </Book>
-    <Book Series="Daredevil" Number="345" Volume="1964" Year="1995" Format="Main Series">
+    <Book Series="Daredevil" Number="345" Volume="1964" Year="1995">
       <Id>360656ca-848f-4365-9e8f-72f2dab4f29a</Id>
     </Book>
-    <Book Series="Daredevil" Number="346" Volume="1964" Year="1995" Format="Main Series">
+    <Book Series="Daredevil" Number="346" Volume="1964" Year="1995">
       <Id>76b0decc-dc3c-4dd0-b20b-d9ecfa98beb4</Id>
     </Book>
-    <Book Series="Daredevil" Number="347" Volume="1964" Year="1995" Format="Main Series">
+    <Book Series="Daredevil" Number="347" Volume="1964" Year="1995">
       <Id>7e2c4b69-b5c5-4fa3-a845-a015bde79da9</Id>
     </Book>
-    <Book Series="Daredevil" Number="348" Volume="1964" Year="1996" Format="Main Series">
+    <Book Series="Daredevil" Number="348" Volume="1964" Year="1996">
       <Id>ca817bce-dc18-4362-8927-5aa5ee7ca796</Id>
     </Book>
-    <Book Series="Daredevil" Number="349" Volume="1964" Year="1996" Format="Main Series">
+    <Book Series="Daredevil" Number="349" Volume="1964" Year="1996">
       <Id>a8d622b9-9608-4cbc-8990-3c28a0f9fd53</Id>
     </Book>
-    <Book Series="Daredevil" Number="350" Volume="1964" Year="1996" Format="Main Series">
+    <Book Series="Daredevil" Number="350" Volume="1964" Year="1996">
       <Id>0f464c41-d8bb-4028-97b8-5a4a2477a34f</Id>
     </Book>
-    <Book Series="Daredevil" Number="351" Volume="1964" Year="1996" Format="Main Series">
+    <Book Series="Daredevil" Number="351" Volume="1964" Year="1996">
       <Id>d4e70f5d-f859-4759-9444-27092cf99a5e</Id>
     </Book>
-    <Book Series="Daredevil" Number="352" Volume="1964" Year="1996" Format="Main Series">
+    <Book Series="Daredevil" Number="352" Volume="1964" Year="1996">
       <Id>617ab307-8706-473b-9ef5-f10be439b249</Id>
     </Book>
-    <Book Series="Daredevil" Number="353" Volume="1964" Year="1996" Format="Main Series">
+    <Book Series="Daredevil" Number="353" Volume="1964" Year="1996">
       <Id>4d2ad4ce-dcd8-499d-8449-f1e55c60cbe7</Id>
     </Book>
-    <Book Series="Daredevil" Number="354" Volume="1964" Year="1996" Format="Main Series">
+    <Book Series="Daredevil" Number="354" Volume="1964" Year="1996">
       <Id>5f79f057-8ddb-44a5-9496-f5b4dcef0702</Id>
     </Book>
-    <Book Series="Daredevil" Number="355" Volume="1964" Year="1996" Format="Main Series">
+    <Book Series="Daredevil" Number="355" Volume="1964" Year="1996">
       <Id>de429cc3-1cea-4b10-ab58-22f67b69db2b</Id>
     </Book>
-    <Book Series="Daredevil" Number="356" Volume="1964" Year="1996" Format="Main Series">
+    <Book Series="Daredevil" Number="356" Volume="1964" Year="1996">
       <Id>0dbd9e71-0af7-469d-a261-929056c39dd9</Id>
     </Book>
-    <Book Series="Daredevil" Number="357" Volume="1964" Year="1996" Format="Main Series">
+    <Book Series="Daredevil" Number="357" Volume="1964" Year="1996">
       <Id>38d424de-de74-4260-a14c-e09703f1c3e3</Id>
     </Book>
-    <Book Series="Daredevil" Number="358" Volume="1964" Year="1996" Format="Main Series">
+    <Book Series="Daredevil" Number="358" Volume="1964" Year="1996">
       <Id>ed9fe99e-3c65-441a-a86b-8bea349f93bd</Id>
     </Book>
-    <Book Series="Daredevil" Number="359" Volume="1964" Year="1996" Format="Main Series">
+    <Book Series="Daredevil" Number="359" Volume="1964" Year="1996">
       <Id>a36552b1-629e-4429-b7f3-a0b17822778d</Id>
     </Book>
-    <Book Series="Daredevil" Number="360" Volume="1964" Year="1997" Format="Main Series">
+    <Book Series="Daredevil" Number="360" Volume="1964" Year="1997">
       <Id>a90bd84b-1642-49d1-96a0-0cc185902576</Id>
     </Book>
-    <Book Series="Daredevil" Number="361" Volume="1964" Year="1997" Format="Main Series">
+    <Book Series="Daredevil" Number="361" Volume="1964" Year="1997">
       <Id>a62e46df-8819-4ec8-9635-fdd9a794ea82</Id>
     </Book>
-    <Book Series="Daredevil" Number="362" Volume="1964" Year="1997" Format="Main Series">
+    <Book Series="Daredevil" Number="362" Volume="1964" Year="1997">
       <Id>583982e0-62bf-427b-9438-c871d125bb1a</Id>
     </Book>
-    <Book Series="Daredevil" Number="363" Volume="1964" Year="1997" Format="Main Series">
+    <Book Series="Daredevil" Number="363" Volume="1964" Year="1997">
       <Id>6b8ce822-06dc-4e7b-927f-e2efbc6a2563</Id>
     </Book>
-    <Book Series="Daredevil" Number="364" Volume="1964" Year="1997" Format="Main Series">
+    <Book Series="Daredevil" Number="364" Volume="1964" Year="1997">
       <Id>535f4c96-60dd-434e-b9ac-01b511eceef4</Id>
     </Book>
-    <Book Series="Daredevil / Deadpool Annual '97" Number="1" Volume="1997" Year="1997" Format="Annual">
+    <Book Series="Daredevil / Deadpool Annual '97" Number="1" Volume="1997" Year="1997">
       <Id>774f9935-fbdf-4ad1-bbad-3b3b2a80161c</Id>
     </Book>
-    <Book Series="Daredevil" Number="365" Volume="1964" Year="1997" Format="Main Series">
+    <Book Series="Daredevil" Number="365" Volume="1964" Year="1997">
       <Id>879111c2-8bc2-450b-b57e-53f56c4c63c7</Id>
     </Book>
-    <Book Series="Daredevil" Number="366" Volume="1964" Year="1997" Format="Main Series">
+    <Book Series="Daredevil" Number="366" Volume="1964" Year="1997">
       <Id>d367eac8-a607-4993-b6e2-b9cc402f08a2</Id>
     </Book>
-    <Book Series="Daredevil" Number="367" Volume="1964" Year="1997" Format="Main Series">
+    <Book Series="Daredevil" Number="367" Volume="1964" Year="1997">
       <Id>54c185e4-ca57-4b36-857d-a1b55b6bea36</Id>
     </Book>
-    <Book Series="Daredevil" Number="368" Volume="1964" Year="1997" Format="Main Series">
+    <Book Series="Daredevil" Number="368" Volume="1964" Year="1997">
       <Id>3362cd9a-1723-48b2-bddd-ef0e4756425d</Id>
     </Book>
-    <Book Series="Daredevil" Number="369" Volume="1964" Year="1997" Format="Main Series">
+    <Book Series="Daredevil" Number="369" Volume="1964" Year="1997">
       <Id>74797e95-8151-43ff-a038-154db17815d8</Id>
     </Book>
-    <Book Series="Daredevil" Number="370" Volume="1964" Year="1997" Format="Main Series">
+    <Book Series="Daredevil" Number="370" Volume="1964" Year="1997">
       <Id>de4134eb-346f-42cf-befb-a8eff1b44a99</Id>
     </Book>
-    <Book Series="Daredevil" Number="371" Volume="1964" Year="1998" Format="Main Series">
+    <Book Series="Daredevil" Number="371" Volume="1964" Year="1998">
       <Id>3e9ae233-9b57-4d2a-a4cc-a12ec268ef09</Id>
     </Book>
-    <Book Series="Daredevil" Number="372" Volume="1964" Year="1998" Format="Main Series">
+    <Book Series="Daredevil" Number="372" Volume="1964" Year="1998">
       <Id>7d85472b-c17f-4184-acce-63acfbf6d892</Id>
     </Book>
-    <Book Series="Daredevil" Number="373" Volume="1964" Year="1998" Format="Main Series">
+    <Book Series="Daredevil" Number="373" Volume="1964" Year="1998">
       <Id>3d10625e-1f4b-409a-aeeb-df88726f0ef3</Id>
     </Book>
-    <Book Series="Daredevil" Number="374" Volume="1964" Year="1998" Format="Main Series">
+    <Book Series="Daredevil" Number="374" Volume="1964" Year="1998">
       <Id>9fbff0ef-7fba-4953-8b7c-aeebbe9bc5cd</Id>
     </Book>
-    <Book Series="Daredevil" Number="375" Volume="1964" Year="1998" Format="Main Series">
+    <Book Series="Daredevil" Number="375" Volume="1964" Year="1998">
       <Id>49152766-e3fc-4b81-be09-4991f81fad94</Id>
     </Book>
-    <Book Series="Daredevil" Number="376" Volume="1964" Year="1998" Format="Main Series">
+    <Book Series="Daredevil" Number="376" Volume="1964" Year="1998">
       <Id>0b9cd55f-be1e-4994-8e66-7a5cd5935e77</Id>
     </Book>
-    <Book Series="Daredevil" Number="377" Volume="1964" Year="1998" Format="Main Series">
+    <Book Series="Daredevil" Number="377" Volume="1964" Year="1998">
       <Id>a30a6836-34d9-49f3-b87e-d570d818d067</Id>
     </Book>
-    <Book Series="Daredevil" Number="378" Volume="1964" Year="1998" Format="Main Series">
+    <Book Series="Daredevil" Number="378" Volume="1964" Year="1998">
       <Id>b37af97e-34c0-49c8-b0ab-812f015a391d</Id>
     </Book>
-    <Book Series="Daredevil" Number="379" Volume="1964" Year="1998" Format="Main Series">
+    <Book Series="Daredevil" Number="379" Volume="1964" Year="1998">
       <Id>e81f0c29-2cac-48bf-a29f-1602a027ff7a</Id>
     </Book>
-    <Book Series="Daredevil" Number="380" Volume="1964" Year="1998" Format="Main Series">
+    <Book Series="Daredevil" Number="380" Volume="1964" Year="1998">
       <Id>f079e4b7-1d00-4174-8853-191f386bf1a2</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Daredevil/Daredevil 002.cbl
+++ b/Marvel/Characters/unsorted/Daredevil/Daredevil 002.cbl
@@ -1,558 +1,559 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Daredevil 2</Name>
+  <Name>Daredevil 002</Name>
+  <NumIssues>184</NumIssues>
   <Books>
     <Book Series="Daredevil" Number="227" Volume="1964" Year="1986">
-      <Id>28e479df-e730-4355-8177-e916ca256d92</Id>
+      <Database Name="cv" Series="2190" Issue="26500" />
     </Book>
     <Book Series="Daredevil" Number="228" Volume="1964" Year="1986">
-      <Id>9a918774-4958-4572-aa14-67f16fd9b7e3</Id>
+      <Database Name="cv" Series="2190" Issue="26597" />
     </Book>
     <Book Series="Daredevil" Number="229" Volume="1964" Year="1986">
-      <Id>c1464f77-9dcc-48ec-b211-212d06668c52</Id>
+      <Database Name="cv" Series="2190" Issue="26695" />
     </Book>
     <Book Series="Daredevil" Number="230" Volume="1964" Year="1986">
-      <Id>442fb92a-547a-4f96-8270-faa6a4509a00</Id>
+      <Database Name="cv" Series="2190" Issue="26789" />
     </Book>
     <Book Series="Daredevil" Number="231" Volume="1964" Year="1986">
-      <Id>76d51dc0-31d2-42b2-a265-f3e4e261b31c</Id>
+      <Database Name="cv" Series="2190" Issue="26919" />
     </Book>
     <Book Series="Daredevil" Number="232" Volume="1964" Year="1986">
-      <Id>7e478fb3-fe44-4b37-b53b-2b70f0e6120c</Id>
+      <Database Name="cv" Series="2190" Issue="26987" />
     </Book>
     <Book Series="Daredevil" Number="233" Volume="1964" Year="1986">
-      <Id>dcc25ebe-ab36-4be9-b4d3-9202f25f637d</Id>
+      <Database Name="cv" Series="2190" Issue="27079" />
     </Book>
     <Book Series="Marvel Fanfare" Number="27" Volume="1982" Year="1986">
-      <Id>c9c59fde-fb82-4439-b657-d462dc61ecb2</Id>
+      <Database Name="cv" Series="3143" Issue="26991" />
     </Book>
     <Book Series="Marvel Graphic Novel" Number="24" Volume="1982" Year="1986">
-      <Id>60f5f691-13b2-433f-8edc-2dafc76c2561</Id>
+      <Database Name="cv" Series="3144" Issue="134231" />
     </Book>
     <Book Series="Daredevil" Number="234" Volume="1964" Year="1986">
-      <Id>8ca3db95-5872-425f-988b-135561241bf2</Id>
+      <Database Name="cv" Series="2190" Issue="27179" />
     </Book>
     <Book Series="Daredevil" Number="235" Volume="1964" Year="1986">
-      <Id>d5329737-5289-463f-b66a-44811a832699</Id>
+      <Database Name="cv" Series="2190" Issue="27273" />
     </Book>
     <Book Series="Daredevil" Number="236" Volume="1964" Year="1986">
-      <Id>7900780d-cc7c-4429-97cb-bafdabcaa38e</Id>
+      <Database Name="cv" Series="2190" Issue="27381" />
     </Book>
     <Book Series="Daredevil" Number="237" Volume="1964" Year="1986">
-      <Id>d369e315-ca38-4990-bbaa-b9227b4a77bc</Id>
+      <Database Name="cv" Series="2190" Issue="27485" />
     </Book>
     <Book Series="Daredevil" Number="238" Volume="1964" Year="1987">
-      <Id>0c24cbcf-214a-4be7-82ba-bef9ef0e2a6d</Id>
+      <Database Name="cv" Series="2190" Issue="27676" />
     </Book>
     <Book Series="Daredevil" Number="239" Volume="1964" Year="1987">
-      <Id>db669f00-abbe-4f0f-a647-d488b5057628</Id>
+      <Database Name="cv" Series="2190" Issue="27787" />
     </Book>
     <Book Series="Daredevil" Number="240" Volume="1964" Year="1987">
-      <Id>98020efa-99f6-4b47-9c16-1af8583ba210</Id>
+      <Database Name="cv" Series="2190" Issue="27898" />
     </Book>
     <Book Series="Daredevil" Number="241" Volume="1964" Year="1987">
-      <Id>351a618a-f5d2-49fc-91f9-59090722f69d</Id>
+      <Database Name="cv" Series="2190" Issue="28011" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="287" Volume="1963" Year="1987">
-      <Id>815e4524-32da-4639-8e54-8d356caceefe</Id>
+      <Database Name="cv" Series="2127" Issue="28007" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="288" Volume="1963" Year="1987">
-      <Id>0b0b8484-0ec4-4bde-a643-dab7e7da1090</Id>
+      <Database Name="cv" Series="2127" Issue="28108" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="128" Volume="1976" Year="1987">
-      <Id>bbb948f4-7d0d-4d51-a7a0-3e3de5da09e9</Id>
+      <Database Name="cv" Series="2870" Issue="28342" />
     </Book>
     <Book Series="Daredevil" Number="242" Volume="1964" Year="1987">
-      <Id>c412b215-3143-44d6-a34f-4a2bf28fd97f</Id>
+      <Database Name="cv" Series="2190" Issue="28112" />
     </Book>
     <Book Series="Daredevil" Number="243" Volume="1964" Year="1987">
-      <Id>f9c8b181-ccc0-4bc0-9c18-0a4619ee0908</Id>
+      <Database Name="cv" Series="2190" Issue="28222" />
     </Book>
     <Book Series="Daredevil" Number="244" Volume="1964" Year="1987">
-      <Id>64ba2523-5f39-4824-afd5-3a189d84af45</Id>
+      <Database Name="cv" Series="2190" Issue="28336" />
     </Book>
     <Book Series="Daredevil" Number="245" Volume="1964" Year="1987">
-      <Id>f310b3cb-8b82-479b-a7ac-f5793c0b4070</Id>
+      <Database Name="cv" Series="2190" Issue="28457" />
     </Book>
     <Book Series="Daredevil" Number="246" Volume="1964" Year="1987">
-      <Id>de0a6c09-2e32-466f-a366-c4aa1f329c11</Id>
+      <Database Name="cv" Series="2190" Issue="28564" />
     </Book>
     <Book Series="Daredevil" Number="247" Volume="1964" Year="1987">
-      <Id>88946a40-6e19-4521-8cf2-361c8f2eb505</Id>
+      <Database Name="cv" Series="2190" Issue="28686" />
     </Book>
     <Book Series="Daredevil" Number="248" Volume="1964" Year="1987">
-      <Id>001c139a-b9a1-4e77-b85e-9cc5fee41839</Id>
+      <Database Name="cv" Series="2190" Issue="28800" />
     </Book>
     <Book Series="Daredevil" Number="249" Volume="1964" Year="1987">
-      <Id>7541dd2c-f414-4a1a-990c-272c3a825dde</Id>
+      <Database Name="cv" Series="2190" Issue="28923" />
     </Book>
     <Book Series="Daredevil" Number="250" Volume="1964" Year="1988">
-      <Id>1cfecb8a-1bfc-43c4-baec-b4a118e40bd9</Id>
+      <Database Name="cv" Series="2190" Issue="29142" />
     </Book>
     <Book Series="Daredevil" Number="251" Volume="1964" Year="1988">
-      <Id>c2e89a89-561f-4fe6-a34d-b3a74d36bea0</Id>
+      <Database Name="cv" Series="2190" Issue="29260" />
     </Book>
     <Book Series="Daredevil" Number="252" Volume="1964" Year="1988">
-      <Id>b7508bd7-3a0e-4255-ab62-0f54aa483253</Id>
+      <Database Name="cv" Series="2190" Issue="29370" />
     </Book>
     <Book Series="Daredevil" Number="253" Volume="1964" Year="1988">
-      <Id>44bdf4d8-4e59-47d3-898f-a979d2615717</Id>
+      <Database Name="cv" Series="2190" Issue="29480" />
     </Book>
     <Book Series="Daredevil" Number="254" Volume="1964" Year="1988">
-      <Id>3d4a419b-4600-413a-a6ff-9958bd20d016</Id>
+      <Database Name="cv" Series="2190" Issue="29589" />
     </Book>
     <Book Series="Daredevil" Number="255" Volume="1964" Year="1988">
-      <Id>cebca0dc-df53-4edb-ab58-fd3d8cccdc7b</Id>
+      <Database Name="cv" Series="2190" Issue="29705" />
     </Book>
     <Book Series="Daredevil" Number="256" Volume="1964" Year="1988">
-      <Id>e2c83e49-7efc-468b-8421-2e8b902546a2</Id>
+      <Database Name="cv" Series="2190" Issue="29824" />
     </Book>
     <Book Series="The Punisher" Number="10" Volume="2011" Year="2012">
-      <Id>9c3c7981-7a95-49e0-8c72-af0b6dc04a9a</Id>
+      <Database Name="cv" Series="41758" Issue="331857" />
     </Book>
     <Book Series="Daredevil" Number="257" Volume="1964" Year="1988">
-      <Id>a39a8830-1a21-465e-8a52-2444740eceec</Id>
+      <Database Name="cv" Series="2190" Issue="29940" />
     </Book>
     <Book Series="Daredevil" Number="258" Volume="1964" Year="1988">
-      <Id>1a751706-18cb-47fd-93d2-7f22a4856d2e</Id>
+      <Database Name="cv" Series="2190" Issue="30054" />
     </Book>
     <Book Series="Daredevil" Number="259" Volume="1964" Year="1988">
-      <Id>b573f2fd-7e58-423e-ab7c-61d14d544a64</Id>
+      <Database Name="cv" Series="2190" Issue="114113" />
     </Book>
     <Book Series="Daredevil" Number="260" Volume="1964" Year="1988">
-      <Id>3195243d-9f00-4ea1-880c-bbd3a7d1ba5b</Id>
+      <Database Name="cv" Series="2190" Issue="30306" />
     </Book>
     <Book Series="Daredevil" Number="261" Volume="1964" Year="1988">
-      <Id>240aa712-5cd1-4285-b256-b0b1dc383da6</Id>
+      <Database Name="cv" Series="2190" Issue="30427" />
     </Book>
     <Book Series="Thor" Number="392" Volume="1966" Year="1988">
-      <Id>01577a89-aa3a-49a5-be27-cd7365d959d0</Id>
+      <Database Name="cv" Series="2294" Issue="29718" />
     </Book>
     <Book Series="Thor" Number="393" Volume="1966" Year="1988">
-      <Id>dd9a624b-ee24-46d5-a9a0-2f53c94fc6b8</Id>
+      <Database Name="cv" Series="2294" Issue="29837" />
     </Book>
     <Book Series="Thor" Number="395" Volume="1966" Year="1988">
-      <Id>bbe8a121-067e-4605-8795-f2714fa0ef3d</Id>
+      <Database Name="cv" Series="2294" Issue="30069" />
     </Book>
     <Book Series="Thor" Number="396" Volume="1966" Year="1988">
-      <Id>c13d8f20-0b55-48aa-92b8-1e0f5e991fb1</Id>
+      <Database Name="cv" Series="2294" Issue="30193" />
     </Book>
     <Book Series="Daredevil" Number="262" Volume="1964" Year="1989">
-      <Id>865d18e0-9f14-4dc7-b951-845a2c67f1ea</Id>
+      <Database Name="cv" Series="2190" Issue="30778" />
     </Book>
     <Book Series="Daredevil" Number="263" Volume="1964" Year="1989">
-      <Id>db3e276f-1d53-4366-af96-b719f41cc5ce</Id>
+      <Database Name="cv" Series="2190" Issue="30887" />
     </Book>
     <Book Series="Daredevil" Number="264" Volume="1964" Year="1989">
-      <Id>91a64da0-f462-47b5-8fce-da7b4faf5b58</Id>
+      <Database Name="cv" Series="2190" Issue="30987" />
     </Book>
     <Book Series="Daredevil" Number="265" Volume="1964" Year="1989">
-      <Id>38da9e72-90bd-4633-b3f0-4e1694550d1c</Id>
+      <Database Name="cv" Series="2190" Issue="31098" />
     </Book>
     <Book Series="Daredevil" Number="266" Volume="1964" Year="1989">
-      <Id>a5c9bf52-80bd-49b8-bea5-4338402ade32</Id>
+      <Database Name="cv" Series="2190" Issue="31212" />
     </Book>
     <Book Series="Daredevil" Number="267" Volume="1964" Year="1989">
-      <Id>e26d276a-6efd-4ef3-a66d-96b12713d580</Id>
+      <Database Name="cv" Series="2190" Issue="31321" />
     </Book>
     <Book Series="Daredevil" Number="268" Volume="1964" Year="1989">
-      <Id>2e214240-cbf9-41b3-873a-967c3db444cc</Id>
+      <Database Name="cv" Series="2190" Issue="31433" />
     </Book>
     <Book Series="Daredevil" Number="269" Volume="1964" Year="1989">
-      <Id>143af90c-c51b-4b0b-bb5c-3fe0b3abad2e</Id>
+      <Database Name="cv" Series="2190" Issue="31538" />
     </Book>
     <Book Series="Daredevil Annual" Number="5" Volume="1967" Year="1989">
-      <Id>62b27115-b3e5-4abd-bcf5-ce27c5734937</Id>
+      <Database Name="cv" Series="2351" Issue="30617" />
     </Book>
     <Book Series="Daredevil" Number="270" Volume="1964" Year="1989">
-      <Id>4e1a3f11-9f71-43aa-b94b-85cce9eac2b4</Id>
+      <Database Name="cv" Series="2190" Issue="31650" />
     </Book>
     <Book Series="Daredevil" Number="271" Volume="1964" Year="1989">
-      <Id>c3ed277e-0d78-46ff-abec-38bdbe143172</Id>
+      <Database Name="cv" Series="2190" Issue="31760" />
     </Book>
     <Book Series="Daredevil" Number="272" Volume="1964" Year="1989">
-      <Id>75b40280-37b9-42c1-9b83-a8f5222d815a</Id>
+      <Database Name="cv" Series="2190" Issue="31865" />
     </Book>
     <Book Series="Daredevil" Number="273" Volume="1964" Year="1989">
-      <Id>ec59e908-dd2a-4b24-ab33-e4210fffd186</Id>
+      <Database Name="cv" Series="2190" Issue="31920" />
     </Book>
     <Book Series="Daredevil" Number="274" Volume="1964" Year="1989">
-      <Id>7e5f043c-7c9e-4613-b4f5-56c7af27d4b0</Id>
+      <Database Name="cv" Series="2190" Issue="31995" />
     </Book>
     <Book Series="Daredevil" Number="275" Volume="1964" Year="1989">
-      <Id>956f2bb9-467f-409e-a5f8-2baad38ff84a</Id>
+      <Database Name="cv" Series="2190" Issue="32057" />
     </Book>
     <Book Series="Daredevil" Number="276" Volume="1964" Year="1990">
-      <Id>90d56a2b-dbd4-49f8-b9e1-f7128e41d533</Id>
+      <Database Name="cv" Series="2190" Issue="32318" />
     </Book>
     <Book Series="Daredevil" Number="277" Volume="1964" Year="1990">
-      <Id>7b05cf15-60b9-41f5-8986-fe71c9f037bd</Id>
+      <Database Name="cv" Series="2190" Issue="32416" />
     </Book>
     <Book Series="Daredevil Annual" Number="6" Volume="1967" Year="1990">
-      <Id>30d05fd8-5ded-4a5c-a20d-edfefa8d1ceb</Id>
+      <Database Name="cv" Series="2351" Issue="32180" />
     </Book>
     <Book Series="Daredevil" Number="278" Volume="1964" Year="1990">
-      <Id>5669dac7-77dd-4483-89a4-415f9f9a3598</Id>
+      <Database Name="cv" Series="2190" Issue="32517" />
     </Book>
     <Book Series="Daredevil" Number="279" Volume="1964" Year="1990">
-      <Id>0dcddff9-f4c1-4e09-a964-0a0bf8f62513</Id>
+      <Database Name="cv" Series="2190" Issue="32626" />
     </Book>
     <Book Series="Daredevil" Number="280" Volume="1964" Year="1990">
-      <Id>fd429878-6fd2-4f71-8165-253a3b546434</Id>
+      <Database Name="cv" Series="2190" Issue="32724" />
     </Book>
     <Book Series="Daredevil" Number="281" Volume="1964" Year="1990">
-      <Id>46eaa884-273d-446a-a723-d98040ca151b</Id>
+      <Database Name="cv" Series="2190" Issue="32835" />
     </Book>
     <Book Series="Daredevil" Number="282" Volume="1964" Year="1990">
-      <Id>3fad2685-fe23-4489-bc64-c1f2f24d8faa</Id>
+      <Database Name="cv" Series="2190" Issue="32961" />
     </Book>
     <Book Series="Daredevil" Number="283" Volume="1964" Year="1990">
-      <Id>fb5290d8-839b-4a27-b7ec-c13aefbc5047</Id>
+      <Database Name="cv" Series="2190" Issue="33075" />
     </Book>
     <Book Series="Daredevil" Number="284" Volume="1964" Year="1990">
-      <Id>7cc008f4-4b16-4d59-a47a-cf3a9078b75e</Id>
+      <Database Name="cv" Series="2190" Issue="33192" />
     </Book>
     <Book Series="Daredevil" Number="285" Volume="1964" Year="1990">
-      <Id>48305a46-328f-43c4-985f-105fac86adf2</Id>
+      <Database Name="cv" Series="2190" Issue="33310" />
     </Book>
     <Book Series="Daredevil" Number="286" Volume="1964" Year="1990">
-      <Id>534ed80b-986a-4d35-b381-4e920fcb36a2</Id>
+      <Database Name="cv" Series="2190" Issue="33422" />
     </Book>
     <Book Series="Daredevil" Number="287" Volume="1964" Year="1990">
-      <Id>9ceb8970-b802-48db-9df8-3d945ae05648</Id>
+      <Database Name="cv" Series="2190" Issue="33529" />
     </Book>
     <Book Series="Daredevil" Number="288" Volume="1964" Year="1991">
-      <Id>59264aee-c692-4c26-9887-bf20f6eff918</Id>
+      <Database Name="cv" Series="2190" Issue="33773" />
     </Book>
     <Book Series="Daredevil" Number="289" Volume="1964" Year="1991">
-      <Id>a096e63a-a3f4-47ba-b2db-3c440d774eea</Id>
+      <Database Name="cv" Series="2190" Issue="114114" />
     </Book>
     <Book Series="Daredevil" Number="290" Volume="1964" Year="1991">
-      <Id>047d0cde-7536-433f-b924-378b604b9145</Id>
+      <Database Name="cv" Series="2190" Issue="33988" />
     </Book>
     <Book Series="Daredevil" Number="291" Volume="1964" Year="1991">
-      <Id>8cb68b08-72cf-443a-8203-efd72a05513e</Id>
+      <Database Name="cv" Series="2190" Issue="34091" />
     </Book>
     <Book Series="Captain America" Number="375" Volume="1968" Year="1990">
-      <Id>7a35ad5e-e6c9-4d9e-91b3-a9adb80949ed</Id>
+      <Database Name="cv" Series="2400" Issue="33133" />
     </Book>
     <Book Series="Captain America" Number="376" Volume="1968" Year="1990">
-      <Id>656973f8-25ea-4b18-8545-71407f21feee</Id>
+      <Database Name="cv" Series="2400" Issue="33191" />
     </Book>
     <Book Series="Daredevil" Number="292" Volume="1964" Year="1991">
-      <Id>cf37275f-c3f7-47d0-ac9b-fc3cb0db3563</Id>
+      <Database Name="cv" Series="2190" Issue="34195" />
     </Book>
     <Book Series="Daredevil" Number="293" Volume="1964" Year="1991">
-      <Id>01f4ad2c-a986-48e1-b130-b6dc152b17e1</Id>
+      <Database Name="cv" Series="2190" Issue="34294" />
     </Book>
     <Book Series="Daredevil Annual" Number="7" Volume="1967" Year="1991">
-      <Id>782bea6d-c816-4e36-aa46-c92ca410df44</Id>
+      <Database Name="cv" Series="2351" Issue="99408" />
     </Book>
     <Book Series="Daredevil" Number="294" Volume="1964" Year="1991">
-      <Id>19a8d2a6-120c-4361-8c47-4914a971a1eb</Id>
+      <Database Name="cv" Series="2190" Issue="34409" />
     </Book>
     <Book Series="Daredevil" Number="295" Volume="1964" Year="1991">
-      <Id>48d49096-6d8a-45bc-926c-4c0e3d7edf6d</Id>
+      <Database Name="cv" Series="2190" Issue="34524" />
     </Book>
     <Book Series="Daredevil" Number="296" Volume="1964" Year="1991">
-      <Id>e9b1e8b9-0ecc-479f-b0fd-2fca95d2e496</Id>
+      <Database Name="cv" Series="2190" Issue="34642" />
     </Book>
     <Book Series="Daredevil" Number="297" Volume="1964" Year="1991">
-      <Id>37797c64-966b-4126-9810-0189aca994af</Id>
+      <Database Name="cv" Series="2190" Issue="34759" />
     </Book>
     <Book Series="Daredevil" Number="298" Volume="1964" Year="1991">
-      <Id>2606520e-f0d1-4b9c-bff7-a69b4bb46a85</Id>
+      <Database Name="cv" Series="2190" Issue="34875" />
     </Book>
     <Book Series="Daredevil" Number="299" Volume="1964" Year="1991">
-      <Id>352f7443-7ae6-4495-9246-d66d56c2d399</Id>
+      <Database Name="cv" Series="2190" Issue="34997" />
     </Book>
     <Book Series="Daredevil" Number="300" Volume="1964" Year="1992">
-      <Id>35405290-c19a-4d24-a84c-4026f6b3ce7a</Id>
+      <Database Name="cv" Series="2190" Issue="35256" />
     </Book>
     <Book Series="Daredevil" Number="301" Volume="1964" Year="1992">
-      <Id>3b41b228-f722-4bde-8f72-a73c8cc433dd</Id>
+      <Database Name="cv" Series="2190" Issue="35363" />
     </Book>
     <Book Series="Daredevil" Number="302" Volume="1964" Year="1992">
-      <Id>abd74cb0-8093-451d-8e85-7c9be4c1696a</Id>
+      <Database Name="cv" Series="2190" Issue="35468" />
     </Book>
     <Book Series="Daredevil" Number="303" Volume="1964" Year="1992">
-      <Id>75d73a3e-8ed2-4a1a-b7fd-9a67c328a6a2</Id>
+      <Database Name="cv" Series="2190" Issue="35572" />
     </Book>
     <Book Series="Daredevil Annual" Number="8" Volume="1967" Year="1992">
-      <Id>5ed02090-3d6d-4b85-a1e0-c6e8ea31840e</Id>
+      <Database Name="cv" Series="2351" Issue="35154" />
     </Book>
     <Book Series="Daredevil" Number="304" Volume="1964" Year="1992">
-      <Id>0ed60a72-24d9-4d80-af93-cf198efc964c</Id>
+      <Database Name="cv" Series="2190" Issue="35675" />
     </Book>
     <Book Series="Daredevil" Number="305" Volume="1964" Year="1992">
-      <Id>b2d2f0a8-3862-4fb2-b59a-3682b5c81737</Id>
+      <Database Name="cv" Series="2190" Issue="35780" />
     </Book>
     <Book Series="Daredevil" Number="306" Volume="1964" Year="1992">
-      <Id>11f93049-aaf9-4b06-9bb3-8a03702f5d71</Id>
+      <Database Name="cv" Series="2190" Issue="35903" />
     </Book>
     <Book Series="Daredevil" Number="307" Volume="1964" Year="1992">
-      <Id>2ebb81bf-3b24-4f00-998d-0d8c3fb9d14c</Id>
+      <Database Name="cv" Series="2190" Issue="107502" />
     </Book>
     <Book Series="Daredevil" Number="308" Volume="1964" Year="1992">
-      <Id>548489bf-858a-43b7-98bb-ba32935cafeb</Id>
+      <Database Name="cv" Series="2190" Issue="107496" />
     </Book>
     <Book Series="Daredevil" Number="309" Volume="1964" Year="1992">
-      <Id>33afdaa4-d3e7-4d8a-8c01-aee85a5b8f93</Id>
+      <Database Name="cv" Series="2190" Issue="36270" />
     </Book>
     <Book Series="Nomad" Number="6" Volume="1992" Year="1992">
-      <Id>4c226921-2675-4237-bd32-a5fb8b67d23a</Id>
+      <Database Name="cv" Series="4803" Issue="47837" />
     </Book>
     <Book Series="The Punisher War Journal" Number="47" Volume="1988" Year="1992">
-      <Id>feaadbe4-9de6-4694-897a-fa6b9d9eb422</Id>
+      <Database Name="cv" Series="4066" Issue="107493" />
     </Book>
     <Book Series="Daredevil" Number="310" Volume="1964" Year="1992">
-      <Id>7e1bfa26-9e98-44da-9e4f-694e2f0d1db8</Id>
+      <Database Name="cv" Series="2190" Issue="36395" />
     </Book>
     <Book Series="Spider-Man Special Edition" Number="1" Volume="1992" Year="1992">
-      <Id>76a4b638-65da-4bb6-a6c6-9aea9742dcb6</Id>
+      <Database Name="cv" Series="21781" Issue="131350" />
     </Book>
     <Book Series="Daredevil" Number="311" Volume="1964" Year="1992">
-      <Id>50a15e90-9ead-40b7-8bd8-93655d35b64e</Id>
+      <Database Name="cv" Series="2190" Issue="36510" />
     </Book>
     <Book Series="Daredevil" Number="312" Volume="1964" Year="1993">
-      <Id>1dbdae38-de2d-484f-96d9-ad3f3259395c</Id>
+      <Database Name="cv" Series="2190" Issue="36752" />
     </Book>
     <Book Series="Daredevil" Number="313" Volume="1964" Year="1993">
-      <Id>96713649-c532-45ba-bc3a-c6de59a4d95f</Id>
+      <Database Name="cv" Series="2190" Issue="36858" />
     </Book>
     <Book Series="Daredevil" Number="314" Volume="1964" Year="1993">
-      <Id>6f340df4-aacf-4aa8-8c5f-586ccc7b7a5a</Id>
+      <Database Name="cv" Series="2190" Issue="36969" />
     </Book>
     <Book Series="Daredevil" Number="315" Volume="1964" Year="1993">
-      <Id>6b8ab87c-1324-4fe9-8742-558f5a519d24</Id>
+      <Database Name="cv" Series="2190" Issue="37088" />
     </Book>
     <Book Series="Daredevil" Number="316" Volume="1964" Year="1993">
-      <Id>4c3983d4-d987-4672-bfa6-ab91c6c8ea0d</Id>
+      <Database Name="cv" Series="2190" Issue="37224" />
     </Book>
     <Book Series="Daredevil" Number="317" Volume="1964" Year="1993">
-      <Id>cb602ac5-4ba6-40b4-8321-04eab83ebbe6</Id>
+      <Database Name="cv" Series="2190" Issue="37359" />
     </Book>
     <Book Series="Daredevil" Number="318" Volume="1964" Year="1993">
-      <Id>325c7f2f-84d0-480a-96cd-6e7dd81bbef5</Id>
+      <Database Name="cv" Series="2190" Issue="37512" />
     </Book>
     <Book Series="Daredevil/Black Widow: Abattoir" Number="1" Volume="1993" Year="1993">
-      <Id>e6ba88bc-12e7-4155-ba47-bb476635360c</Id>
+      <Database Name="cv" Series="31673" Issue="198643" />
     </Book>
     <Book Series="The Punisher War Journal" Number="57" Volume="1988" Year="1993">
-      <Id>39392378-f6a2-406a-80d0-029bab2675c4</Id>
+      <Database Name="cv" Series="4066" Issue="77430" />
     </Book>
     <Book Series="The Punisher War Journal" Number="58" Volume="1988" Year="1993">
-      <Id>37dc32c1-e884-4a29-8bf5-dd7e2fa09dcb</Id>
+      <Database Name="cv" Series="4066" Issue="77431" />
     </Book>
     <Book Series="Daredevil Annual" Number="9" Volume="1967" Year="1993">
-      <Id>a2a49093-52a2-4090-8c60-8a91aae28110</Id>
+      <Database Name="cv" Series="2351" Issue="37513" />
     </Book>
     <Book Series="Daredevil" Number="319" Volume="1964" Year="1993">
-      <Id>58e5abd1-1352-4a4a-b699-67d782e4df56</Id>
+      <Database Name="cv" Series="2190" Issue="37654" />
     </Book>
     <Book Series="Daredevil" Number="320" Volume="1964" Year="1993">
-      <Id>7429d9d8-380d-4c19-bcca-480d3a03adc3</Id>
+      <Database Name="cv" Series="2190" Issue="37793" />
     </Book>
     <Book Series="Daredevil" Number="321" Volume="1964" Year="1993">
-      <Id>4f8e2de2-75f7-425b-a0f4-c9dd35f23580</Id>
+      <Database Name="cv" Series="2190" Issue="37945" />
     </Book>
     <Book Series="Daredevil" Number="322" Volume="1964" Year="1993">
-      <Id>94591349-531a-4fee-8175-db34943ed5ec</Id>
+      <Database Name="cv" Series="2190" Issue="38093" />
     </Book>
     <Book Series="Daredevil" Number="323" Volume="1964" Year="1993">
-      <Id>45371d22-a8b3-4528-8ca4-2ecbcf179b8b</Id>
+      <Database Name="cv" Series="2190" Issue="38251" />
     </Book>
     <Book Series="Daredevil" Number="324" Volume="1964" Year="1994">
-      <Id>0a4e6684-e580-44b1-856c-6f654d86a2c6</Id>
+      <Database Name="cv" Series="2190" Issue="38498" />
     </Book>
     <Book Series="Daredevil" Number="325" Volume="1964" Year="1994">
-      <Id>bd8191d1-3615-4d3d-8781-7a7210f3ba2a</Id>
+      <Database Name="cv" Series="2190" Issue="38647" />
     </Book>
     <Book Series="Daredevil: The Man Without Fear" Number="1" Volume="1993" Year="1993">
-      <Id>89fca584-a805-4a5e-944e-e9187de7875b</Id>
+      <Database Name="cv" Series="5000" Issue="37946" />
     </Book>
     <Book Series="Daredevil: The Man Without Fear" Number="2" Volume="1993" Year="1993">
-      <Id>71f4eb7c-bde5-4915-97bd-f4556bd483d6</Id>
+      <Database Name="cv" Series="5000" Issue="38094" />
     </Book>
     <Book Series="Daredevil: The Man Without Fear" Number="3" Volume="1993" Year="1993">
-      <Id>f31c99f4-31a9-4a7a-af55-7a8ec3924e11</Id>
+      <Database Name="cv" Series="5000" Issue="38252" />
     </Book>
     <Book Series="Daredevil: The Man Without Fear" Number="4" Volume="1993" Year="1994">
-      <Id>ea4f4db3-99c6-452e-8c55-be64f80e9517</Id>
+      <Database Name="cv" Series="5000" Issue="38499" />
     </Book>
     <Book Series="Daredevil: The Man Without Fear" Number="5" Volume="1993" Year="1994">
-      <Id>d5bc89f8-7400-4245-81a9-555f6b30ba42</Id>
+      <Database Name="cv" Series="5000" Issue="38648" />
     </Book>
     <Book Series="Daredevil Annual" Number="10" Volume="1967" Year="1994">
-      <Id>7c445984-d195-4edc-8151-2af7a6e833b3</Id>
+      <Database Name="cv" Series="2351" Issue="168482" />
     </Book>
     <Book Series="Daredevil" Number="326" Volume="1964" Year="1994">
-      <Id>99c29869-da53-429a-9465-81b768ea84dc</Id>
+      <Database Name="cv" Series="2190" Issue="38791" />
     </Book>
     <Book Series="Daredevil" Number="327" Volume="1964" Year="1994">
-      <Id>110628ad-4ed4-4f0c-a5f1-49cfa05938dd</Id>
+      <Database Name="cv" Series="2190" Issue="38938" />
     </Book>
     <Book Series="Daredevil" Number="328" Volume="1964" Year="1994">
-      <Id>3df693a0-76d6-4125-9607-ab3bd2176cf2</Id>
+      <Database Name="cv" Series="2190" Issue="39079" />
     </Book>
     <Book Series="Daredevil" Number="329" Volume="1964" Year="1994">
-      <Id>70e0531e-335a-41fc-a931-c04b2ecd6101</Id>
+      <Database Name="cv" Series="2190" Issue="39219" />
     </Book>
     <Book Series="Daredevil" Number="330" Volume="1964" Year="1994">
-      <Id>4bb7de3d-bb3c-4e96-a890-9550c7dc3fa3</Id>
+      <Database Name="cv" Series="2190" Issue="39368" />
     </Book>
     <Book Series="Daredevil" Number="331" Volume="1964" Year="1994">
-      <Id>6e6c6524-a2b0-4404-ae75-f3986e9c4e92</Id>
+      <Database Name="cv" Series="2190" Issue="39501" />
     </Book>
     <Book Series="Daredevil" Number="332" Volume="1964" Year="1994">
-      <Id>5b71a491-849e-404d-94bb-a362853c59fd</Id>
+      <Database Name="cv" Series="2190" Issue="39644" />
     </Book>
     <Book Series="Daredevil" Number="333" Volume="1964" Year="1994">
-      <Id>0918f11c-a7b9-40ac-a4cd-face14326969</Id>
+      <Database Name="cv" Series="2190" Issue="39789" />
     </Book>
     <Book Series="Daredevil" Number="334" Volume="1964" Year="1994">
-      <Id>99991de8-b545-4fb2-8ef8-e05fe2eb92a7</Id>
+      <Database Name="cv" Series="2190" Issue="39932" />
     </Book>
     <Book Series="Daredevil" Number="335" Volume="1964" Year="1994">
-      <Id>fd4c736f-70d1-471f-84cb-faf531671fd0</Id>
+      <Database Name="cv" Series="2190" Issue="40075" />
     </Book>
     <Book Series="Daredevil" Number="336" Volume="1964" Year="1995">
-      <Id>d3b31d6b-013e-4ac1-91db-14a10af5dff9</Id>
+      <Database Name="cv" Series="2190" Issue="40316" />
     </Book>
     <Book Series="Daredevil" Number="337" Volume="1964" Year="1995">
-      <Id>186a1d3a-1b7b-4d4a-baa4-a757bee5d473</Id>
+      <Database Name="cv" Series="2190" Issue="40454" />
     </Book>
     <Book Series="Daredevil" Number="338" Volume="1964" Year="1995">
-      <Id>7163cb25-6bb9-4e6c-ac46-7f8415934682</Id>
+      <Database Name="cv" Series="2190" Issue="40586" />
     </Book>
     <Book Series="Daredevil" Number="339" Volume="1964" Year="1995">
-      <Id>93f553af-ef69-4d48-898a-734a42e7bef4</Id>
+      <Database Name="cv" Series="2190" Issue="40725" />
     </Book>
     <Book Series="Daredevil" Number="340" Volume="1964" Year="1995">
-      <Id>d6c156fb-93e1-4f6a-ad1b-2d8c450f7240</Id>
+      <Database Name="cv" Series="2190" Issue="40849" />
     </Book>
     <Book Series="Daredevil" Number="341" Volume="1964" Year="1995">
-      <Id>f4adb162-3780-42f0-bf08-405f168262b9</Id>
+      <Database Name="cv" Series="2190" Issue="40972" />
     </Book>
     <Book Series="Daredevil" Number="342" Volume="1964" Year="1995">
-      <Id>5a5bfde4-7c61-4927-83e5-3e3ebf053297</Id>
+      <Database Name="cv" Series="2190" Issue="41111" />
     </Book>
     <Book Series="Daredevil" Number="343" Volume="1964" Year="1995">
-      <Id>546caba6-5575-47b7-bda1-23569f155af2</Id>
+      <Database Name="cv" Series="2190" Issue="41253" />
     </Book>
     <Book Series="Daredevil" Number="344" Volume="1964" Year="1995">
-      <Id>50ca3b03-6ee5-423a-b283-3721e8b79eb3</Id>
+      <Database Name="cv" Series="2190" Issue="41382" />
     </Book>
     <Book Series="Daredevil" Number="345" Volume="1964" Year="1995">
-      <Id>360656ca-848f-4365-9e8f-72f2dab4f29a</Id>
+      <Database Name="cv" Series="2190" Issue="41514" />
     </Book>
     <Book Series="Daredevil" Number="346" Volume="1964" Year="1995">
-      <Id>76b0decc-dc3c-4dd0-b20b-d9ecfa98beb4</Id>
+      <Database Name="cv" Series="2190" Issue="41640" />
     </Book>
     <Book Series="Daredevil" Number="347" Volume="1964" Year="1995">
-      <Id>7e2c4b69-b5c5-4fa3-a845-a015bde79da9</Id>
+      <Database Name="cv" Series="2190" Issue="41768" />
     </Book>
-    <Book Series="Daredevil" Number="348" Volume="1964" Year="1996">
-      <Id>ca817bce-dc18-4362-8927-5aa5ee7ca796</Id>
+    <Book Series="Daredevil" Number="348" Volume="1964" Year="1995">
+      <Database Name="cv" Series="2190" Issue="41987" />
     </Book>
     <Book Series="Daredevil" Number="349" Volume="1964" Year="1996">
-      <Id>a8d622b9-9608-4cbc-8990-3c28a0f9fd53</Id>
+      <Database Name="cv" Series="2190" Issue="42096" />
     </Book>
     <Book Series="Daredevil" Number="350" Volume="1964" Year="1996">
-      <Id>0f464c41-d8bb-4028-97b8-5a4a2477a34f</Id>
+      <Database Name="cv" Series="2190" Issue="42204" />
     </Book>
     <Book Series="Daredevil" Number="351" Volume="1964" Year="1996">
-      <Id>d4e70f5d-f859-4759-9444-27092cf99a5e</Id>
+      <Database Name="cv" Series="2190" Issue="42301" />
     </Book>
     <Book Series="Daredevil" Number="352" Volume="1964" Year="1996">
-      <Id>617ab307-8706-473b-9ef5-f10be439b249</Id>
+      <Database Name="cv" Series="2190" Issue="42397" />
     </Book>
     <Book Series="Daredevil" Number="353" Volume="1964" Year="1996">
-      <Id>4d2ad4ce-dcd8-499d-8449-f1e55c60cbe7</Id>
+      <Database Name="cv" Series="2190" Issue="42490" />
     </Book>
     <Book Series="Daredevil" Number="354" Volume="1964" Year="1996">
-      <Id>5f79f057-8ddb-44a5-9496-f5b4dcef0702</Id>
+      <Database Name="cv" Series="2190" Issue="42601" />
     </Book>
     <Book Series="Daredevil" Number="355" Volume="1964" Year="1996">
-      <Id>de429cc3-1cea-4b10-ab58-22f67b69db2b</Id>
+      <Database Name="cv" Series="2190" Issue="42699" />
     </Book>
     <Book Series="Daredevil" Number="356" Volume="1964" Year="1996">
-      <Id>0dbd9e71-0af7-469d-a261-929056c39dd9</Id>
+      <Database Name="cv" Series="2190" Issue="42793" />
     </Book>
     <Book Series="Daredevil" Number="357" Volume="1964" Year="1996">
-      <Id>38d424de-de74-4260-a14c-e09703f1c3e3</Id>
+      <Database Name="cv" Series="2190" Issue="42880" />
     </Book>
     <Book Series="Daredevil" Number="358" Volume="1964" Year="1996">
-      <Id>ed9fe99e-3c65-441a-a86b-8bea349f93bd</Id>
+      <Database Name="cv" Series="2190" Issue="42980" />
     </Book>
     <Book Series="Daredevil" Number="359" Volume="1964" Year="1996">
-      <Id>a36552b1-629e-4429-b7f3-a0b17822778d</Id>
+      <Database Name="cv" Series="2190" Issue="43074" />
     </Book>
     <Book Series="Daredevil" Number="360" Volume="1964" Year="1997">
-      <Id>a90bd84b-1642-49d1-96a0-0cc185902576</Id>
+      <Database Name="cv" Series="2190" Issue="43270" />
     </Book>
     <Book Series="Daredevil" Number="361" Volume="1964" Year="1997">
-      <Id>a62e46df-8819-4ec8-9635-fdd9a794ea82</Id>
+      <Database Name="cv" Series="2190" Issue="43380" />
     </Book>
     <Book Series="Daredevil" Number="362" Volume="1964" Year="1997">
-      <Id>583982e0-62bf-427b-9438-c871d125bb1a</Id>
+      <Database Name="cv" Series="2190" Issue="43479" />
     </Book>
     <Book Series="Daredevil" Number="363" Volume="1964" Year="1997">
-      <Id>6b8ce822-06dc-4e7b-927f-e2efbc6a2563</Id>
+      <Database Name="cv" Series="2190" Issue="43575" />
     </Book>
     <Book Series="Daredevil" Number="364" Volume="1964" Year="1997">
-      <Id>535f4c96-60dd-434e-b9ac-01b511eceef4</Id>
+      <Database Name="cv" Series="2190" Issue="43681" />
     </Book>
-    <Book Series="Daredevil / Deadpool Annual '97" Number="1" Volume="1997" Year="1997">
-      <Id>774f9935-fbdf-4ad1-bbad-3b3b2a80161c</Id>
+    <Book Series="Daredevil / Deadpool '97" Number="1" Volume="1997" Year="1997">
+      <Database Name="cv" Series="26448" Issue="157856" />
     </Book>
     <Book Series="Daredevil" Number="365" Volume="1964" Year="1997">
-      <Id>879111c2-8bc2-450b-b57e-53f56c4c63c7</Id>
+      <Database Name="cv" Series="2190" Issue="43771" />
     </Book>
     <Book Series="Daredevil" Number="366" Volume="1964" Year="1997">
-      <Id>d367eac8-a607-4993-b6e2-b9cc402f08a2</Id>
+      <Database Name="cv" Series="2190" Issue="43970" />
     </Book>
     <Book Series="Daredevil" Number="367" Volume="1964" Year="1997">
-      <Id>54c185e4-ca57-4b36-857d-a1b55b6bea36</Id>
+      <Database Name="cv" Series="2190" Issue="44106" />
     </Book>
     <Book Series="Daredevil" Number="368" Volume="1964" Year="1997">
-      <Id>3362cd9a-1723-48b2-bddd-ef0e4756425d</Id>
+      <Database Name="cv" Series="2190" Issue="44186" />
     </Book>
     <Book Series="Daredevil" Number="369" Volume="1964" Year="1997">
-      <Id>74797e95-8151-43ff-a038-154db17815d8</Id>
+      <Database Name="cv" Series="2190" Issue="44317" />
     </Book>
     <Book Series="Daredevil" Number="370" Volume="1964" Year="1997">
-      <Id>de4134eb-346f-42cf-befb-a8eff1b44a99</Id>
+      <Database Name="cv" Series="2190" Issue="44417" />
     </Book>
     <Book Series="Daredevil" Number="371" Volume="1964" Year="1998">
-      <Id>3e9ae233-9b57-4d2a-a4cc-a12ec268ef09</Id>
+      <Database Name="cv" Series="2190" Issue="44585" />
     </Book>
     <Book Series="Daredevil" Number="372" Volume="1964" Year="1998">
-      <Id>7d85472b-c17f-4184-acce-63acfbf6d892</Id>
+      <Database Name="cv" Series="2190" Issue="44694" />
     </Book>
     <Book Series="Daredevil" Number="373" Volume="1964" Year="1998">
-      <Id>3d10625e-1f4b-409a-aeeb-df88726f0ef3</Id>
+      <Database Name="cv" Series="2190" Issue="44788" />
     </Book>
     <Book Series="Daredevil" Number="374" Volume="1964" Year="1998">
-      <Id>9fbff0ef-7fba-4953-8b7c-aeebbe9bc5cd</Id>
+      <Database Name="cv" Series="2190" Issue="44858" />
     </Book>
     <Book Series="Daredevil" Number="375" Volume="1964" Year="1998">
-      <Id>49152766-e3fc-4b81-be09-4991f81fad94</Id>
+      <Database Name="cv" Series="2190" Issue="114115" />
     </Book>
     <Book Series="Daredevil" Number="376" Volume="1964" Year="1998">
-      <Id>0b9cd55f-be1e-4994-8e66-7a5cd5935e77</Id>
+      <Database Name="cv" Series="2190" Issue="136975" />
     </Book>
     <Book Series="Daredevil" Number="377" Volume="1964" Year="1998">
-      <Id>a30a6836-34d9-49f3-b87e-d570d818d067</Id>
+      <Database Name="cv" Series="2190" Issue="136974" />
     </Book>
     <Book Series="Daredevil" Number="378" Volume="1964" Year="1998">
-      <Id>b37af97e-34c0-49c8-b0ab-812f015a391d</Id>
+      <Database Name="cv" Series="2190" Issue="136973" />
     </Book>
     <Book Series="Daredevil" Number="379" Volume="1964" Year="1998">
-      <Id>e81f0c29-2cac-48bf-a29f-1602a027ff7a</Id>
+      <Database Name="cv" Series="2190" Issue="136972" />
     </Book>
     <Book Series="Daredevil" Number="380" Volume="1964" Year="1998">
-      <Id>f079e4b7-1d00-4174-8853-191f386bf1a2</Id>
+      <Database Name="cv" Series="2190" Issue="136969" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Daredevil/Daredevil 003.cbl
+++ b/Marvel/Characters/unsorted/Daredevil/Daredevil 003.cbl
@@ -1,759 +1,760 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Daredevil 3</Name>
+  <Name>Daredevil 003</Name>
+  <NumIssues>251</NumIssues>
   <Books>
     <Book Series="Daredevil" Number="½" Volume="1998" Year="1998">
-      <Id>04153c02-83d2-4625-a2dc-efc5856dcbb4</Id>
+      <Database Name="cv" Series="6209" Issue="126670" />
     </Book>
     <Book Series="Daredevil" Number="1" Volume="1998" Year="1998">
-      <Id>155f1484-6908-4e5a-9e8a-ec0393e51337</Id>
+      <Database Name="cv" Series="6209" Issue="45424" />
     </Book>
     <Book Series="Daredevil" Number="2" Volume="1998" Year="1998">
-      <Id>b32d5896-0a2c-4cd4-87f5-846b5cee6326</Id>
+      <Database Name="cv" Series="6209" Issue="45544" />
     </Book>
     <Book Series="Daredevil" Number="3" Volume="1998" Year="1999">
-      <Id>3c6436fb-ba43-48e5-a9d8-b687d8308453</Id>
+      <Database Name="cv" Series="6209" Issue="45634" />
     </Book>
     <Book Series="Daredevil" Number="4" Volume="1998" Year="1999">
-      <Id>63b273f3-9c19-4273-aaf3-e37027bbb0b9</Id>
+      <Database Name="cv" Series="6209" Issue="45653" />
     </Book>
     <Book Series="Daredevil" Number="5" Volume="1998" Year="1999">
-      <Id>412c7992-5ae7-4a0d-abb6-ad04535439b9</Id>
+      <Database Name="cv" Series="6209" Issue="45725" />
     </Book>
     <Book Series="Daredevil" Number="6" Volume="1998" Year="1999">
-      <Id>444615ba-6c62-457d-9b2a-729e71a663fc</Id>
+      <Database Name="cv" Series="6209" Issue="66255" />
     </Book>
     <Book Series="Daredevil" Number="7" Volume="1998" Year="1999">
-      <Id>1514e949-77e3-4594-b1df-76cb76c539c3</Id>
+      <Database Name="cv" Series="6209" Issue="66256" />
     </Book>
     <Book Series="Daredevil" Number="8" Volume="1998" Year="1999">
-      <Id>cb3d0520-44da-45a1-8e87-70b717bcdae6</Id>
+      <Database Name="cv" Series="6209" Issue="66257" />
     </Book>
     <Book Series="Daredevil" Number="9" Volume="1998" Year="1999">
-      <Id>cef906fd-c4ee-4c18-88d8-8c804c318055</Id>
+      <Database Name="cv" Series="6209" Issue="46149" />
     </Book>
     <Book Series="Daredevil" Number="10" Volume="1998" Year="2000">
-      <Id>711d8e8e-9da4-49d8-a379-344ad2d02fda</Id>
+      <Database Name="cv" Series="6209" Issue="66258" />
     </Book>
     <Book Series="Daredevil" Number="11" Volume="1998" Year="2000">
-      <Id>5c01b476-9787-4402-b05a-afde3572539d</Id>
+      <Database Name="cv" Series="6209" Issue="66259" />
     </Book>
     <Book Series="Daredevil" Number="12" Volume="1998" Year="2000">
-      <Id>dd0ef1a7-0e33-4386-bcad-7a1b53d573f8</Id>
+      <Database Name="cv" Series="6209" Issue="66260" />
     </Book>
     <Book Series="Daredevil" Number="13" Volume="1998" Year="2000">
-      <Id>7a5f66ce-b17c-4660-b854-860c3c9c2773</Id>
+      <Database Name="cv" Series="6209" Issue="66261" />
     </Book>
     <Book Series="Daredevil" Number="14" Volume="1998" Year="2001">
-      <Id>b331b7f5-ca95-4c85-9e8f-3c31bc1bbc25</Id>
+      <Database Name="cv" Series="6209" Issue="66262" />
     </Book>
     <Book Series="Daredevil" Number="15" Volume="1998" Year="2001">
-      <Id>159a33ed-c9f9-4ecf-9000-e6197623e688</Id>
+      <Database Name="cv" Series="6209" Issue="66263" />
     </Book>
     <Book Series="Daredevil/Spider-Man" Number="1" Volume="2001" Year="2001">
-      <Id>e30dab3a-999d-4076-9727-71aa2fca6a72</Id>
+      <Database Name="cv" Series="27657" Issue="169132" />
     </Book>
     <Book Series="Daredevil/Spider-Man" Number="2" Volume="2001" Year="2001">
-      <Id>bc4dbad5-b2d2-467b-965f-f44266895e86</Id>
+      <Database Name="cv" Series="27657" Issue="169136" />
     </Book>
     <Book Series="Daredevil/Spider-Man" Number="3" Volume="2001" Year="2001">
-      <Id>29ab8813-70b2-4871-bbbf-57ba8a9d4e0d</Id>
+      <Database Name="cv" Series="27657" Issue="169135" />
     </Book>
     <Book Series="Daredevil/Spider-Man" Number="4" Volume="2001" Year="2001">
-      <Id>ec06a0f1-2281-4791-9955-442cb1f8554e</Id>
+      <Database Name="cv" Series="27657" Issue="169134" />
     </Book>
     <Book Series="Daredevil: Ninja" Number="1" Volume="2000" Year="2000">
-      <Id>c52f56c3-67a5-49fd-9b18-d03ead986f8a</Id>
+      <Database Name="cv" Series="9540" Issue="80243" />
     </Book>
     <Book Series="Daredevil: Ninja" Number="2" Volume="2000" Year="2001">
-      <Id>d2f0b79a-e5b3-449b-be92-ca003d5fb567</Id>
+      <Database Name="cv" Series="9540" Issue="80244" />
     </Book>
     <Book Series="Daredevil: Ninja" Number="3" Volume="2000" Year="2001">
-      <Id>57f60bd4-7a1d-4d30-a7c3-64f2f3ff4279</Id>
+      <Database Name="cv" Series="9540" Issue="80245" />
     </Book>
     <Book Series="Daredevil" Number="16" Volume="1998" Year="2001">
-      <Id>a494f741-ee85-4e67-96da-391b80c5486c</Id>
+      <Database Name="cv" Series="6209" Issue="66264" />
     </Book>
     <Book Series="Daredevil" Number="17" Volume="1998" Year="2001">
-      <Id>ec75db13-7e0b-4946-b147-6761347d74f2</Id>
+      <Database Name="cv" Series="6209" Issue="66265" />
     </Book>
     <Book Series="Daredevil" Number="18" Volume="1998" Year="2001">
-      <Id>2e743a08-72e4-4097-abd6-25690277dc61</Id>
+      <Database Name="cv" Series="6209" Issue="66266" />
     </Book>
     <Book Series="Daredevil" Number="19" Volume="1998" Year="2001">
-      <Id>cd0a24c3-bfd6-461d-8dcc-530b2495a84f</Id>
+      <Database Name="cv" Series="6209" Issue="66267" />
     </Book>
     <Book Series="Daredevil: Yellow" Number="1" Volume="2001" Year="2001">
-      <Id>927bd2e5-33fb-42a2-af68-0b67a9b7d7cb</Id>
+      <Database Name="cv" Series="7513" Issue="55289" />
     </Book>
     <Book Series="Daredevil: Yellow" Number="2" Volume="2001" Year="2001">
-      <Id>6a52b549-89e3-4943-8dd8-1527810217ff</Id>
+      <Database Name="cv" Series="7513" Issue="55290" />
     </Book>
     <Book Series="Daredevil: Yellow" Number="3" Volume="2001" Year="2001">
-      <Id>21fafba8-cf53-47a0-bcd7-067d9b52f12d</Id>
+      <Database Name="cv" Series="7513" Issue="55291" />
     </Book>
     <Book Series="Daredevil: Yellow" Number="4" Volume="2001" Year="2001">
-      <Id>875cfb86-7884-41c9-83cb-586d8df84134</Id>
+      <Database Name="cv" Series="7513" Issue="55292" />
     </Book>
     <Book Series="Daredevil: Yellow" Number="5" Volume="2001" Year="2001">
-      <Id>492db08e-a8a0-4384-bbff-2eadfbcde0dd</Id>
+      <Database Name="cv" Series="7513" Issue="55293" />
     </Book>
     <Book Series="Daredevil: Yellow" Number="6" Volume="2001" Year="2002">
-      <Id>d4597064-b9b8-4573-926e-14e5dc28b2db</Id>
+      <Database Name="cv" Series="7513" Issue="55294" />
     </Book>
     <Book Series="Daredevil" Number="20" Volume="1998" Year="2001">
-      <Id>6bd0b2c9-f30f-408a-ada2-e4b996c3269f</Id>
+      <Database Name="cv" Series="6209" Issue="66268" />
     </Book>
     <Book Series="Daredevil" Number="21" Volume="1998" Year="2001">
-      <Id>7fd61e99-e930-433a-a04e-a92f51069488</Id>
+      <Database Name="cv" Series="6209" Issue="66269" />
     </Book>
     <Book Series="Daredevil" Number="22" Volume="1998" Year="2001">
-      <Id>19b202cc-2969-44cb-a0a0-0b01da5491e4</Id>
+      <Database Name="cv" Series="6209" Issue="66270" />
     </Book>
     <Book Series="Daredevil" Number="23" Volume="1998" Year="2001">
-      <Id>237fff1f-faed-43f5-aecd-c5c78f036c6c</Id>
+      <Database Name="cv" Series="6209" Issue="66271" />
     </Book>
     <Book Series="Daredevil" Number="24" Volume="1998" Year="2001">
-      <Id>385d7610-eff0-444c-bae0-018356cda923</Id>
+      <Database Name="cv" Series="6209" Issue="66272" />
     </Book>
     <Book Series="Daredevil" Number="25" Volume="1998" Year="2001">
-      <Id>6cea16c5-4700-4a4b-ac4d-600e9140931c</Id>
+      <Database Name="cv" Series="6209" Issue="66273" />
     </Book>
     <Book Series="Daredevil" Number="26" Volume="1998" Year="2001">
-      <Id>97532634-a746-4700-a3e4-59d17bcdd12d</Id>
+      <Database Name="cv" Series="6209" Issue="66274" />
     </Book>
     <Book Series="Daredevil" Number="27" Volume="1998" Year="2002">
-      <Id>8c43dc9f-c18f-4039-a091-6979bba7d7b3</Id>
+      <Database Name="cv" Series="6209" Issue="66275" />
     </Book>
     <Book Series="Daredevil" Number="28" Volume="1998" Year="2002">
-      <Id>cae3ca8b-28c8-498f-b281-1e444d2ecdeb</Id>
+      <Database Name="cv" Series="6209" Issue="66276" />
     </Book>
     <Book Series="Daredevil" Number="29" Volume="1998" Year="2002">
-      <Id>46aa52b0-97ec-4e66-bd3d-c46b133790e9</Id>
+      <Database Name="cv" Series="6209" Issue="66277" />
     </Book>
     <Book Series="Daredevil" Number="30" Volume="1998" Year="2002">
-      <Id>bcd27f78-314a-47b3-b666-8c4406b5b37e</Id>
+      <Database Name="cv" Series="6209" Issue="66278" />
     </Book>
     <Book Series="Daredevil" Number="31" Volume="1998" Year="2002">
-      <Id>69556e26-c1f0-435f-80d5-da4629a4791c</Id>
+      <Database Name="cv" Series="6209" Issue="66279" />
     </Book>
     <Book Series="Daredevil" Number="32" Volume="1998" Year="2002">
-      <Id>64e65447-2a02-406f-8d50-1849241956fe</Id>
+      <Database Name="cv" Series="6209" Issue="66280" />
     </Book>
     <Book Series="Daredevil" Number="33" Volume="1998" Year="2002">
-      <Id>613e9d4c-2e46-4331-ad71-472c7f0bdd57</Id>
+      <Database Name="cv" Series="6209" Issue="109984" />
     </Book>
     <Book Series="Daredevil" Number="34" Volume="1998" Year="2002">
-      <Id>60306b77-f47d-4410-b23d-09d6a7d7c772</Id>
+      <Database Name="cv" Series="6209" Issue="80279" />
     </Book>
     <Book Series="Daredevil" Number="35" Volume="1998" Year="2002">
-      <Id>43109af2-3629-49fa-a829-f3c6d041bb2f</Id>
+      <Database Name="cv" Series="6209" Issue="88708" />
     </Book>
     <Book Series="Daredevil" Number="36" Volume="1998" Year="2002">
-      <Id>02a06f72-64e7-4717-917c-da7281c84d93</Id>
+      <Database Name="cv" Series="6209" Issue="88710" />
     </Book>
     <Book Series="Daredevil" Number="37" Volume="1998" Year="2002">
-      <Id>3f2206ba-50f3-4f56-a111-6214fe667aa7</Id>
+      <Database Name="cv" Series="6209" Issue="109986" />
     </Book>
     <Book Series="Daredevil" Number="38" Volume="1998" Year="2002">
-      <Id>c4fd5b50-d474-47d2-bc6b-66974384482a</Id>
+      <Database Name="cv" Series="6209" Issue="109988" />
     </Book>
     <Book Series="Daredevil" Number="39" Volume="1998" Year="2003">
-      <Id>56fab634-0bc8-4e5d-941a-7795834f00ba</Id>
+      <Database Name="cv" Series="6209" Issue="110043" />
     </Book>
     <Book Series="Daredevil" Number="40" Volume="1998" Year="2003">
-      <Id>4f8dc94e-867e-40e4-9824-fc25782fdd48</Id>
+      <Database Name="cv" Series="6209" Issue="110107" />
     </Book>
     <Book Series="Daredevil" Number="41" Volume="1998" Year="2003">
-      <Id>c6d3b50a-2739-47ba-af9f-fc7973084876</Id>
+      <Database Name="cv" Series="6209" Issue="110108" />
     </Book>
     <Book Series="Daredevil" Number="42" Volume="1998" Year="2003">
-      <Id>59df28ed-6a3c-4acf-9e23-51db833ff01c</Id>
+      <Database Name="cv" Series="6209" Issue="110234" />
     </Book>
     <Book Series="Daredevil" Number="43" Volume="1998" Year="2003">
-      <Id>bbfdfbc8-78bf-426e-9557-b8aa68b772b5</Id>
+      <Database Name="cv" Series="6209" Issue="110235" />
     </Book>
     <Book Series="Daredevil" Number="44" Volume="1998" Year="2003">
-      <Id>33c78553-a302-4924-9611-7a0944f533f1</Id>
+      <Database Name="cv" Series="6209" Issue="110236" />
     </Book>
     <Book Series="Daredevil" Number="45" Volume="1998" Year="2003">
-      <Id>9de9d060-c5cd-4534-bd43-cd4adcc5aea8</Id>
+      <Database Name="cv" Series="6209" Issue="110237" />
     </Book>
     <Book Series="Daredevil" Number="46" Volume="1998" Year="2003">
-      <Id>edc4d100-d0ed-4ff1-a490-d3da623d78d8</Id>
+      <Database Name="cv" Series="6209" Issue="110238" />
     </Book>
     <Book Series="Daredevil" Number="47" Volume="1998" Year="2003">
-      <Id>147e2364-de76-47f0-bc24-67a51a628083</Id>
+      <Database Name="cv" Series="6209" Issue="93397" />
     </Book>
     <Book Series="Daredevil" Number="48" Volume="1998" Year="2003">
-      <Id>bb34c332-0853-44fd-89ea-df8bef0e30da</Id>
+      <Database Name="cv" Series="6209" Issue="93398" />
     </Book>
     <Book Series="Daredevil" Number="49" Volume="1998" Year="2003">
-      <Id>fd2985b7-5a5b-4467-8e75-a65d8863a68c</Id>
+      <Database Name="cv" Series="6209" Issue="93399" />
     </Book>
     <Book Series="Daredevil" Number="50" Volume="1998" Year="2003">
-      <Id>da4fc3fc-feb1-4e21-9e13-1235a5db20ae</Id>
+      <Database Name="cv" Series="6209" Issue="93400" />
     </Book>
     <Book Series="Daredevil" Number="51" Volume="1998" Year="2003">
-      <Id>849f83b7-f449-46a0-b122-903ce2cf2937</Id>
+      <Database Name="cv" Series="6209" Issue="93401" />
     </Book>
     <Book Series="Daredevil" Number="52" Volume="1998" Year="2003">
-      <Id>3719eff3-8a0d-4192-bd5f-746019ddc323</Id>
+      <Database Name="cv" Series="6209" Issue="93402" />
     </Book>
     <Book Series="Daredevil" Number="53" Volume="1998" Year="2003">
-      <Id>52a8ce23-c090-40d9-9c6e-aba7e74127f5</Id>
+      <Database Name="cv" Series="6209" Issue="93403" />
     </Book>
     <Book Series="Daredevil" Number="54" Volume="1998" Year="2004">
-      <Id>bc0d0678-a447-484d-8133-252d7b1da599</Id>
+      <Database Name="cv" Series="6209" Issue="93404" />
     </Book>
     <Book Series="Daredevil" Number="55" Volume="1998" Year="2004">
-      <Id>bac35397-ed2e-4af3-b4e7-f381a0b782c4</Id>
+      <Database Name="cv" Series="6209" Issue="93405" />
     </Book>
     <Book Series="Daredevil" Number="56" Volume="1998" Year="2004">
-      <Id>675ffc2f-574e-4c76-b4f0-cf481a19ca81</Id>
+      <Database Name="cv" Series="6209" Issue="93406" />
     </Book>
     <Book Series="Daredevil" Number="57" Volume="1998" Year="2004">
-      <Id>b4fc8b58-698f-4449-9631-8f7a67d74f35</Id>
+      <Database Name="cv" Series="6209" Issue="93407" />
     </Book>
     <Book Series="Daredevil" Number="58" Volume="1998" Year="2004">
-      <Id>c451c928-8be2-4e7e-94b0-0b69e263ee0f</Id>
+      <Database Name="cv" Series="6209" Issue="93408" />
     </Book>
     <Book Series="Daredevil" Number="59" Volume="1998" Year="2004">
-      <Id>ab122bd3-5d19-4664-8d88-f8c803df05aa</Id>
+      <Database Name="cv" Series="6209" Issue="93409" />
     </Book>
     <Book Series="Daredevil" Number="60" Volume="1998" Year="2004">
-      <Id>3a0c62d1-9b07-4614-9289-04538183530d</Id>
+      <Database Name="cv" Series="6209" Issue="93410" />
     </Book>
     <Book Series="Daredevil" Number="61" Volume="1998" Year="2004">
-      <Id>998acb47-e861-4bd4-b628-381b1a9e05f1</Id>
+      <Database Name="cv" Series="6209" Issue="93411" />
     </Book>
     <Book Series="Daredevil" Number="62" Volume="1998" Year="2004">
-      <Id>e8c82faa-9b36-40eb-95fc-b206f44f018b</Id>
+      <Database Name="cv" Series="6209" Issue="93412" />
     </Book>
     <Book Series="Daredevil" Number="63" Volume="1998" Year="2004">
-      <Id>eb57c6ac-fd34-4732-849c-684ecaa775ba</Id>
+      <Database Name="cv" Series="6209" Issue="93413" />
     </Book>
     <Book Series="Daredevil" Number="64" Volume="1998" Year="2004">
-      <Id>6cea13c7-2fc5-4894-ab93-84456bdf3cb0</Id>
+      <Database Name="cv" Series="6209" Issue="93414" />
     </Book>
     <Book Series="Daredevil" Number="65" Volume="1998" Year="2004">
-      <Id>9bbc5ea7-3d8d-4f0e-8351-1acb1cf3dafa</Id>
+      <Database Name="cv" Series="6209" Issue="94295" />
     </Book>
     <Book Series="Powerless" Number="1" Volume="2004" Year="2004">
-      <Id>f29b4301-1a51-4d54-aea6-7e4899945f1d</Id>
+      <Database Name="cv" Series="11364" Issue="99681" />
     </Book>
     <Book Series="Powerless" Number="2" Volume="2004" Year="2004">
-      <Id>b784ed70-3c65-4484-b2cf-6673ad441fa9</Id>
+      <Database Name="cv" Series="11364" Issue="99682" />
     </Book>
     <Book Series="Powerless" Number="3" Volume="2004" Year="2004">
-      <Id>a2636cea-a4a5-44d8-b386-3e8ceae6029e</Id>
+      <Database Name="cv" Series="11364" Issue="99683" />
     </Book>
     <Book Series="Powerless" Number="4" Volume="2004" Year="2004">
-      <Id>0c587da0-2894-4e83-a40d-104aecf774ea</Id>
+      <Database Name="cv" Series="11364" Issue="99684" />
     </Book>
     <Book Series="Powerless" Number="5" Volume="2004" Year="2004">
-      <Id>35c2c418-1c69-4039-b7bc-4aed7dbdd433</Id>
+      <Database Name="cv" Series="11364" Issue="99685" />
     </Book>
     <Book Series="Powerless" Number="6" Volume="2004" Year="2005">
-      <Id>3f293362-1694-45af-8645-a7a81873f99b</Id>
+      <Database Name="cv" Series="11364" Issue="99686" />
     </Book>
     <Book Series="Bullseye: Greatest Hits" Number="1" Volume="2004" Year="2004">
-      <Id>33d34045-5192-4c2e-895c-c432fdef4e0e</Id>
+      <Database Name="cv" Series="11341" Issue="99470" />
     </Book>
     <Book Series="Bullseye: Greatest Hits" Number="2" Volume="2004" Year="2004">
-      <Id>fe70abb5-19ed-43db-9f47-1f4ad2269066</Id>
+      <Database Name="cv" Series="11341" Issue="99471" />
     </Book>
     <Book Series="Bullseye: Greatest Hits" Number="3" Volume="2004" Year="2005">
-      <Id>94918110-5181-4cc3-80ac-92a0da19cc11</Id>
+      <Database Name="cv" Series="11341" Issue="99472" />
     </Book>
     <Book Series="Bullseye: Greatest Hits" Number="4" Volume="2004" Year="2005">
-      <Id>ac2e805d-0c65-4a99-b671-a027c2dd4162</Id>
+      <Database Name="cv" Series="11341" Issue="99473" />
     </Book>
     <Book Series="Bullseye: Greatest Hits" Number="5" Volume="2004" Year="2005">
-      <Id>22b159ba-8dd2-409d-a280-a476c88d08bd</Id>
+      <Database Name="cv" Series="11341" Issue="99474" />
     </Book>
     <Book Series="Daredevil" Number="66" Volume="1998" Year="2004">
-      <Id>a9b73edd-6c58-4701-958c-d9bad077d494</Id>
+      <Database Name="cv" Series="6209" Issue="94296" />
     </Book>
     <Book Series="Daredevil" Number="67" Volume="1998" Year="2005">
-      <Id>649ff179-a556-4481-9dc2-27739734a3f7</Id>
+      <Database Name="cv" Series="6209" Issue="97417" />
     </Book>
     <Book Series="Daredevil" Number="68" Volume="1998" Year="2005">
-      <Id>1d4bf476-1562-4ba6-b3b0-dbf7550adb8f</Id>
+      <Database Name="cv" Series="6209" Issue="97418" />
     </Book>
     <Book Series="Daredevil" Number="69" Volume="1998" Year="2005">
-      <Id>164808f9-c1fc-4e1d-8c52-ebc059ae7e23</Id>
+      <Database Name="cv" Series="6209" Issue="99468" />
     </Book>
     <Book Series="Daredevil" Number="70" Volume="1998" Year="2005">
-      <Id>c0e03d29-6a8e-4a30-9eaa-be32c827336f</Id>
+      <Database Name="cv" Series="6209" Issue="99469" />
     </Book>
     <Book Series="Daredevil: Redemption" Number="1" Volume="2005" Year="2005">
-      <Id>ddeabf60-614d-4337-aa22-c8bb7ae40de8</Id>
+      <Database Name="cv" Series="12001" Issue="104426" />
     </Book>
     <Book Series="Daredevil: Redemption" Number="2" Volume="2005" Year="2005">
-      <Id>5903c778-d886-4ac0-89f0-e551e861a898</Id>
+      <Database Name="cv" Series="12001" Issue="104427" />
     </Book>
     <Book Series="Daredevil: Redemption" Number="3" Volume="2005" Year="2005">
-      <Id>cc624e10-5a4d-4dfe-a6ca-992f779541fb</Id>
+      <Database Name="cv" Series="12001" Issue="104428" />
     </Book>
     <Book Series="Daredevil: Redemption" Number="4" Volume="2005" Year="2005">
-      <Id>4469f184-dffa-4038-88c8-a5e49f823a8d</Id>
+      <Database Name="cv" Series="12001" Issue="104429" />
     </Book>
     <Book Series="Daredevil: Redemption" Number="5" Volume="2005" Year="2005">
-      <Id>397cf24f-b584-4db1-b515-0e4733c11891</Id>
+      <Database Name="cv" Series="12001" Issue="104430" />
     </Book>
     <Book Series="Daredevil: Redemption" Number="6" Volume="2005" Year="2005">
-      <Id>b6eacff2-91a8-4e67-a873-b70720eb1b0b</Id>
+      <Database Name="cv" Series="12001" Issue="104431" />
     </Book>
     <Book Series="Daredevil" Number="71" Volume="1998" Year="2005">
-      <Id>1bf7f90d-97a8-4b07-a36e-0845dacd89f9</Id>
+      <Database Name="cv" Series="6209" Issue="101659" />
     </Book>
     <Book Series="Daredevil" Number="72" Volume="1998" Year="2005">
-      <Id>f4ce4c40-5ad9-42c3-9d81-22b6f2d7e97f</Id>
+      <Database Name="cv" Series="6209" Issue="101660" />
     </Book>
     <Book Series="Daredevil" Number="73" Volume="1998" Year="2005">
-      <Id>2ecf2e07-87eb-4674-9b1b-ae0a14e651f7</Id>
+      <Database Name="cv" Series="6209" Issue="110233" />
     </Book>
     <Book Series="Daredevil" Number="74" Volume="1998" Year="2005">
-      <Id>d34c8849-4a77-4033-b5e7-282581fb4750</Id>
+      <Database Name="cv" Series="6209" Issue="110239" />
     </Book>
     <Book Series="Daredevil" Number="75" Volume="1998" Year="2005">
-      <Id>e9e81d30-def5-4d08-924d-180be45dfc4f</Id>
+      <Database Name="cv" Series="6209" Issue="110240" />
     </Book>
     <Book Series="Daredevil Vs. Punisher" Number="1" Volume="2005" Year="2005">
-      <Id>039ebb03-7d56-4b07-ad26-370d1098fe5d</Id>
+      <Database Name="cv" Series="25438" Issue="150093" />
     </Book>
     <Book Series="Daredevil Vs. Punisher" Number="2" Volume="2005" Year="2005">
-      <Id>4b713325-8f5d-4362-b9ba-46d011888e46</Id>
+      <Database Name="cv" Series="25438" Issue="150094" />
     </Book>
     <Book Series="Daredevil Vs. Punisher" Number="3" Volume="2005" Year="2005">
-      <Id>caada2af-74d8-42b8-82d8-1818c093dcab</Id>
+      <Database Name="cv" Series="25438" Issue="150097" />
     </Book>
     <Book Series="Daredevil Vs. Punisher" Number="4" Volume="2005" Year="2005">
-      <Id>b9724383-f95a-4e00-b9c5-df3f72287123</Id>
+      <Database Name="cv" Series="25438" Issue="150133" />
     </Book>
     <Book Series="Daredevil Vs. Punisher" Number="5" Volume="2005" Year="2005">
-      <Id>8b35cd78-8e7a-48dc-9a12-f78b621be0b1</Id>
+      <Database Name="cv" Series="25438" Issue="150132" />
     </Book>
     <Book Series="Daredevil Vs. Punisher" Number="6" Volume="2005" Year="2006">
-      <Id>d56147ef-4d1c-4a8c-9c6f-1ef174595ed0</Id>
+      <Database Name="cv" Series="25438" Issue="150131" />
     </Book>
     <Book Series="Daredevil" Number="76" Volume="1998" Year="2005">
-      <Id>8850cf37-3720-40f0-9ea9-026f019741f6</Id>
+      <Database Name="cv" Series="6209" Issue="111423" />
     </Book>
     <Book Series="Daredevil" Number="77" Volume="1998" Year="2005">
-      <Id>3604e343-88bc-4608-97b3-bb942a36f874</Id>
+      <Database Name="cv" Series="6209" Issue="111425" />
     </Book>
     <Book Series="Daredevil" Number="78" Volume="1998" Year="2005">
-      <Id>83bf8cb6-83ec-4a1e-83f8-3c4fb98256fe</Id>
+      <Database Name="cv" Series="6209" Issue="111426" />
     </Book>
     <Book Series="Daredevil" Number="79" Volume="1998" Year="2006">
-      <Id>a34a6248-8c95-4bbd-b81c-3dd22dca7324</Id>
+      <Database Name="cv" Series="6209" Issue="111427" />
     </Book>
     <Book Series="Daredevil" Number="80" Volume="1998" Year="2006">
-      <Id>31f4a9c3-d507-4b4f-acdd-2b73f449dac9</Id>
+      <Database Name="cv" Series="6209" Issue="111428" />
     </Book>
     <Book Series="Daredevil" Number="81" Volume="1998" Year="2006">
-      <Id>c8862314-e2ec-4bfd-9174-fe49faf50ae9</Id>
+      <Database Name="cv" Series="6209" Issue="111429" />
     </Book>
     <Book Series="Daredevil" Number="82" Volume="1998" Year="2006">
-      <Id>772a2a8a-af82-48a0-82d0-d18e85e8f37e</Id>
+      <Database Name="cv" Series="6209" Issue="111430" />
     </Book>
     <Book Series="Daredevil" Number="83" Volume="1998" Year="2006">
-      <Id>d459414d-1794-4ee7-8222-375312561b9d</Id>
+      <Database Name="cv" Series="6209" Issue="111431" />
     </Book>
     <Book Series="Daredevil" Number="84" Volume="1998" Year="2006">
-      <Id>89c5d5f4-0722-4fb3-b8b1-25974564654f</Id>
+      <Database Name="cv" Series="6209" Issue="111432" />
     </Book>
     <Book Series="Daredevil" Number="85" Volume="1998" Year="2006">
-      <Id>fcb53bb3-8655-4c70-a15c-43abafdd3dd7</Id>
+      <Database Name="cv" Series="6209" Issue="111433" />
     </Book>
     <Book Series="Daredevil" Number="86" Volume="1998" Year="2006">
-      <Id>366bddd4-934e-4c30-9a83-245f597f70af</Id>
+      <Database Name="cv" Series="6209" Issue="111434" />
     </Book>
     <Book Series="Daredevil" Number="87" Volume="1998" Year="2006">
-      <Id>70f56bf6-a44d-4ee8-96b4-9d489c82d21a</Id>
+      <Database Name="cv" Series="6209" Issue="111435" />
     </Book>
     <Book Series="Daredevil: Father" Number="1" Volume="2004" Year="2004">
-      <Id>f128cb50-8973-4eb4-a168-3b3efa1fdf4a</Id>
+      <Database Name="cv" Series="21096" Issue="126668" />
     </Book>
     <Book Series="Daredevil: Father" Number="2" Volume="2004" Year="2005">
-      <Id>aa68d0a9-a9a1-4612-a85b-1095b25282a5</Id>
+      <Database Name="cv" Series="21096" Issue="126715" />
     </Book>
     <Book Series="Daredevil: Father" Number="3" Volume="2004" Year="2005">
-      <Id>08fa0451-36ad-4799-8917-b87f94e205bd</Id>
+      <Database Name="cv" Series="21096" Issue="126716" />
     </Book>
     <Book Series="Daredevil: Father" Number="4" Volume="2004" Year="2005">
-      <Id>c057a8c0-789c-455a-990b-f4ad4f6ac0d8</Id>
+      <Database Name="cv" Series="21096" Issue="126717" />
     </Book>
     <Book Series="Daredevil: Father" Number="5" Volume="2004" Year="2006">
-      <Id>15a5c589-7d63-4955-8327-192304677e09</Id>
+      <Database Name="cv" Series="21096" Issue="126719" />
     </Book>
     <Book Series="Daredevil: Father" Number="6" Volume="2004" Year="2006">
-      <Id>bb36232b-17e1-402b-9930-8cda0c8ba6a3</Id>
+      <Database Name="cv" Series="21096" Issue="126720" />
     </Book>
     <Book Series="Daredevil" Number="88" Volume="1998" Year="2006">
-      <Id>55952e6b-08b2-4ad5-a90c-7210178ae01d</Id>
+      <Database Name="cv" Series="6209" Issue="111436" />
     </Book>
     <Book Series="Daredevil" Number="89" Volume="1998" Year="2006">
-      <Id>8f7b7d48-d49a-42b4-aef4-35aad3ef1f81</Id>
+      <Database Name="cv" Series="6209" Issue="111437" />
     </Book>
     <Book Series="Daredevil" Number="90" Volume="1998" Year="2006">
-      <Id>04b2776c-9dce-4bd6-bea6-a178fffdda5a</Id>
+      <Database Name="cv" Series="6209" Issue="111438" />
     </Book>
     <Book Series="Daredevil" Number="91" Volume="1998" Year="2007">
-      <Id>bf0c1bf0-09bc-4696-a87a-c6c6834fbfb9</Id>
+      <Database Name="cv" Series="6209" Issue="108493" />
     </Book>
     <Book Series="Daredevil" Number="92" Volume="1998" Year="2007">
-      <Id>62571bc0-182c-40f7-8d94-878049707235</Id>
+      <Database Name="cv" Series="6209" Issue="108626" />
     </Book>
     <Book Series="Daredevil" Number="93" Volume="1998" Year="2007">
-      <Id>1591c9ec-f74c-4190-99d0-91545e7cb4f2</Id>
+      <Database Name="cv" Series="6209" Issue="106289" />
     </Book>
     <Book Series="Daredevil" Number="94" Volume="1998" Year="2007">
-      <Id>eb7f1b81-1f09-4923-bfb2-bcd52dc054f8</Id>
+      <Database Name="cv" Series="6209" Issue="106720" />
     </Book>
     <Book Series="Daredevil" Number="95" Volume="1998" Year="2007">
-      <Id>a27cfd0c-8b2d-4391-94d3-a0d22c8dcdb4</Id>
+      <Database Name="cv" Series="6209" Issue="107649" />
     </Book>
     <Book Series="Daredevil" Number="96" Volume="1998" Year="2007">
-      <Id>dc4061b3-2755-4846-b80e-0df2d3c1cbfa</Id>
+      <Database Name="cv" Series="6209" Issue="108760" />
     </Book>
     <Book Series="Daredevil" Number="97" Volume="1998" Year="2007">
-      <Id>c95246dd-7d5f-4cab-bec9-ee0730310114</Id>
+      <Database Name="cv" Series="6209" Issue="110054" />
     </Book>
     <Book Series="Daredevil" Number="98" Volume="1998" Year="2007">
-      <Id>351eac82-d184-4324-bb97-d7b55c264d80</Id>
+      <Database Name="cv" Series="6209" Issue="111104" />
     </Book>
     <Book Series="Daredevil" Number="99" Volume="1998" Year="2007">
-      <Id>a0303b63-9e3d-4b3b-8dcb-58b33497b27b</Id>
+      <Database Name="cv" Series="6209" Issue="113105" />
     </Book>
     <Book Series="Daredevil: Battlin' Jack Murdock" Number="1" Volume="2007" Year="2007">
-      <Id>acc100d2-43bf-4b39-9368-841455a94444</Id>
+      <Database Name="cv" Series="18672" Issue="110276" />
     </Book>
     <Book Series="Daredevil: Battlin' Jack Murdock" Number="2" Volume="2007" Year="2007">
-      <Id>1775c509-a9f1-4945-849b-84872ced75b9</Id>
+      <Database Name="cv" Series="18672" Issue="111444" />
     </Book>
     <Book Series="Daredevil: Battlin' Jack Murdock" Number="3" Volume="2007" Year="2007">
-      <Id>5b92a4b5-45fd-4074-b5f5-38504600c535</Id>
+      <Database Name="cv" Series="18672" Issue="113103" />
     </Book>
     <Book Series="Daredevil: Battlin' Jack Murdock" Number="4" Volume="2007" Year="2007">
-      <Id>abcf7c59-d881-45a2-b8de-7f19f07c27ad</Id>
+      <Database Name="cv" Series="18672" Issue="114242" />
     </Book>
     <Book Series="Daredevil" Number="100" Volume="1998" Year="2007">
-      <Id>754d94c5-701b-43e2-a509-8d7bb14fe6a7</Id>
+      <Database Name="cv" Series="6209" Issue="113577" />
     </Book>
     <Book Series="Daredevil" Number="101" Volume="1998" Year="2007">
-      <Id>d22d44a2-588d-4745-a7da-921a7ba77cf8</Id>
+      <Database Name="cv" Series="6209" Issue="115778" />
     </Book>
     <Book Series="Daredevil" Number="102" Volume="1998" Year="2008">
-      <Id>2f2a143e-e2f2-4b70-9cab-e7e9881c665f</Id>
+      <Database Name="cv" Series="6209" Issue="118613" />
     </Book>
     <Book Series="Daredevil" Number="103" Volume="1998" Year="2008">
-      <Id>3031a7d8-b6e4-489b-8970-0266f747257f</Id>
+      <Database Name="cv" Series="6209" Issue="120657" />
     </Book>
     <Book Series="Daredevil" Number="104" Volume="1998" Year="2008">
-      <Id>c38bc697-d378-46f7-8ece-2b917f378cdf</Id>
+      <Database Name="cv" Series="6209" Issue="122216" />
     </Book>
     <Book Series="Daredevil Annual" Number="1" Volume="2007" Year="2007">
-      <Id>b55384c9-ca07-446d-a6b5-a09798bd7ea5</Id>
+      <Database Name="cv" Series="19415" Issue="116339" />
     </Book>
     <Book Series="Daredevil" Number="106" Volume="1998" Year="2008">
-      <Id>cb8aaec0-2ce2-4f28-ae18-585954194976</Id>
+      <Database Name="cv" Series="6209" Issue="126028" />
     </Book>
     <Book Series="Daredevil" Number="107" Volume="1998" Year="2008">
-      <Id>5f084885-9563-4fd5-af8d-15604a36622d</Id>
+      <Database Name="cv" Series="6209" Issue="131016" />
     </Book>
     <Book Series="Daredevil" Number="108" Volume="1998" Year="2008">
-      <Id>cba7851f-c285-47ac-bd73-0af6e5c62475</Id>
+      <Database Name="cv" Series="6209" Issue="131833" />
     </Book>
     <Book Series="Daredevil" Number="109" Volume="1998" Year="2008">
-      <Id>588a8c96-b206-4f0d-9611-63306402fa42</Id>
+      <Database Name="cv" Series="6209" Issue="134092" />
     </Book>
     <Book Series="Daredevil" Number="110" Volume="1998" Year="2008">
-      <Id>dfa4f0dc-49f6-4103-a78a-d88dff864c5d</Id>
+      <Database Name="cv" Series="6209" Issue="136626" />
     </Book>
-    <Book Series="Daredevil &amp; Captain America: Dead On Arrival" Number="1" Volume="2009" Year="2009">
-      <Id>53e2274e-e01a-47db-b129-cfab9d6f9114</Id>
+    <Book Series="Daredevil &#38; Captain America: Dead On Arrival" Number="1" Volume="2009" Year="2009">
+      <Database Name="cv" Series="23671" Issue="141799" />
     </Book>
     <Book Series="Daredevil" Number="111" Volume="1998" Year="2008">
-      <Id>0e3825d4-c789-4795-8526-d90bd52c8e22</Id>
+      <Database Name="cv" Series="6209" Issue="139401" />
     </Book>
     <Book Series="Daredevil" Number="112" Volume="1998" Year="2008">
-      <Id>3be16b48-ad75-4fcf-98f7-a58e38299a50</Id>
+      <Database Name="cv" Series="6209" Issue="140814" />
     </Book>
     <Book Series="Daredevil" Number="113" Volume="1998" Year="2009">
-      <Id>c8517c18-c50a-47f4-9f4c-b58fe47973da</Id>
+      <Database Name="cv" Series="6209" Issue="143157" />
     </Book>
     <Book Series="Daredevil" Number="114" Volume="1998" Year="2009">
-      <Id>40ab95fc-5a74-43a4-bee5-716d1378bd4b</Id>
+      <Database Name="cv" Series="6209" Issue="148622" />
     </Book>
     <Book Series="Daredevil" Number="115" Volume="1998" Year="2009">
-      <Id>1305c524-3731-4e86-a624-f61dbe7898f9</Id>
+      <Database Name="cv" Series="6209" Issue="150705" />
     </Book>
     <Book Series="Daredevil Noir" Number="1" Volume="2009" Year="2009">
-      <Id>813f6610-8267-46fd-a7f2-993b1b4583ce</Id>
+      <Database Name="cv" Series="26164" Issue="155271" />
     </Book>
     <Book Series="Daredevil Noir" Number="2" Volume="2009" Year="2009">
-      <Id>4df776de-3bf3-4acf-a740-846ec3ab3277</Id>
+      <Database Name="cv" Series="26164" Issue="156671" />
     </Book>
     <Book Series="Daredevil Noir" Number="3" Volume="2009" Year="2009">
-      <Id>9b7c01fa-7411-41e1-8dfe-6a775cafb1eb</Id>
+      <Database Name="cv" Series="26164" Issue="159295" />
     </Book>
     <Book Series="Daredevil Noir" Number="4" Volume="2009" Year="2009">
-      <Id>680b9f30-46a1-412f-908d-694dcd9b7834</Id>
+      <Database Name="cv" Series="26164" Issue="162551" />
     </Book>
     <Book Series="Daredevil" Number="116" Volume="1998" Year="2009">
-      <Id>498a998b-1aad-4966-b1cb-23fbc9f83679</Id>
+      <Database Name="cv" Series="6209" Issue="153066" />
     </Book>
     <Book Series="Daredevil" Number="117" Volume="1998" Year="2009">
-      <Id>366d9a1f-9793-45f8-8772-f2563a0a764b</Id>
+      <Database Name="cv" Series="6209" Issue="153958" />
     </Book>
     <Book Series="Daredevil" Number="118" Volume="1998" Year="2009">
-      <Id>57003365-8a9d-42d3-aa8c-284959bdd991</Id>
+      <Database Name="cv" Series="6209" Issue="155781" />
     </Book>
     <Book Series="Daredevil" Number="119" Volume="1998" Year="2009">
-      <Id>4f5678a1-186d-4e14-8a39-e63b11a110fc</Id>
+      <Database Name="cv" Series="6209" Issue="161722" />
     </Book>
     <Book Series="Daredevil" Number="500" Volume="1998" Year="2009">
-      <Id>458e8392-06a3-4384-be4b-9d23de309778</Id>
+      <Database Name="cv" Series="6209" Issue="167610" />
     </Book>
     <Book Series="Black Widow: Deadly Origin" Number="1" Volume="2010" Year="2010">
-      <Id>52bddacf-6302-4e68-8c87-6db0b83d1e71</Id>
+      <Database Name="cv" Series="29302" Issue="181100" />
     </Book>
     <Book Series="Black Widow: Deadly Origin" Number="2" Volume="2010" Year="2010">
-      <Id>df6b8ed0-0bd9-43c6-9c0d-14ebcc4e2d8f</Id>
+      <Database Name="cv" Series="29302" Issue="186686" />
     </Book>
     <Book Series="Black Widow: Deadly Origin" Number="3" Volume="2010" Year="2010">
-      <Id>fd746e4c-d283-4785-a280-930bac6a64a1</Id>
+      <Database Name="cv" Series="29302" Issue="192623" />
     </Book>
     <Book Series="Black Widow: Deadly Origin" Number="4" Volume="2010" Year="2010">
-      <Id>d5ec5b80-5c57-4839-a0e2-b6dff29ad143</Id>
+      <Database Name="cv" Series="29302" Issue="197354" />
     </Book>
     <Book Series="Dark Reign: The List - Daredevil" Number="1" Volume="2009" Year="2009">
-      <Id>a72d4456-d3be-46e1-9837-cf402fe1df62</Id>
+      <Database Name="cv" Series="27953" Issue="171391" />
     </Book>
     <Book Series="Daredevil" Number="501" Volume="1998" Year="2009">
-      <Id>7dd97d2e-4593-487c-ac85-2d1e27cd828d</Id>
+      <Database Name="cv" Series="6209" Issue="175563" />
     </Book>
     <Book Series="Daredevil" Number="502" Volume="1998" Year="2010">
-      <Id>88bd6a40-562e-4175-a84d-ecc33b0e7e8d</Id>
+      <Database Name="cv" Series="6209" Issue="182581" />
     </Book>
     <Book Series="Daredevil" Number="503" Volume="1998" Year="2010">
-      <Id>23163b4b-7782-4ac7-84e1-31a97faf3776</Id>
+      <Database Name="cv" Series="6209" Issue="187670" />
     </Book>
     <Book Series="Daredevil" Number="504" Volume="1998" Year="2010">
-      <Id>3d047a21-7de2-4436-96b4-3ea98d31c512</Id>
+      <Database Name="cv" Series="6209" Issue="194806" />
     </Book>
     <Book Series="Daredevil" Number="505" Volume="1998" Year="2010">
-      <Id>73d8dfad-64d4-461e-b0c6-6782e1c319ae</Id>
+      <Database Name="cv" Series="6209" Issue="197598" />
     </Book>
     <Book Series="Daredevil" Number="506" Volume="1998" Year="2010">
-      <Id>5137608d-0c3e-4ed8-ab7f-2d05bba29826</Id>
+      <Database Name="cv" Series="6209" Issue="206679" />
     </Book>
     <Book Series="Daredevil" Number="507" Volume="1998" Year="2010">
-      <Id>815e5db0-1e7a-4831-b554-8f73155f9b1b</Id>
+      <Database Name="cv" Series="6209" Issue="218357" />
     </Book>
     <Book Series="Daredevil" Number="508" Volume="1998" Year="2010">
-      <Id>a40af5e0-cc3e-4052-8a7f-d584b894ef6e</Id>
+      <Database Name="cv" Series="6209" Issue="224616" />
     </Book>
     <Book Series="Daredevil" Number="509" Volume="1998" Year="2010">
-      <Id>d649d5df-3415-4929-bfa0-f58fb96f8c42</Id>
+      <Database Name="cv" Series="6209" Issue="228894" />
     </Book>
     <Book Series="Daredevil" Number="510" Volume="1998" Year="2010">
-      <Id>30067d2f-625a-48e0-8d37-3adc8081889b</Id>
+      <Database Name="cv" Series="6209" Issue="233759" />
     </Book>
     <Book Series="Daredevil" Number="511" Volume="1998" Year="2010">
-      <Id>518b764c-07a0-4ff6-9819-fff6e92d06a0</Id>
+      <Database Name="cv" Series="6209" Issue="239035" />
     </Book>
     <Book Series="Daredevil" Number="512" Volume="1998" Year="2011">
-      <Id>cc00e725-afc0-4eff-9d3e-a2b7f2ea3ea2</Id>
+      <Database Name="cv" Series="6209" Issue="247476" />
     </Book>
     <Book Series="Daredevil: Reborn" Number="1" Volume="2011" Year="2011">
-      <Id>630fd597-52f1-4328-ad28-f795f9be82fc</Id>
+      <Database Name="cv" Series="38237" Issue="255972" />
     </Book>
     <Book Series="Daredevil: Reborn" Number="2" Volume="2011" Year="2011">
-      <Id>5d243bee-3644-4bc6-ad73-c19d11b60643</Id>
+      <Database Name="cv" Series="38237" Issue="262645" />
     </Book>
     <Book Series="Daredevil: Reborn" Number="3" Volume="2011" Year="2011">
-      <Id>059a4d2b-be15-4f05-8af1-2d46b268b6ae</Id>
+      <Database Name="cv" Series="38237" Issue="266612" />
     </Book>
     <Book Series="Daredevil: Reborn" Number="4" Volume="2011" Year="2011">
-      <Id>d524e505-c02a-4ece-880b-f20a0171e876</Id>
+      <Database Name="cv" Series="38237" Issue="269833" />
     </Book>
     <Book Series="Daredevil" Number="1" Volume="2011" Year="2011">
-      <Id>6cfbd8b1-1328-4070-9b40-2edef3ea2b78</Id>
+      <Database Name="cv" Series="41410" Issue="280290" />
     </Book>
     <Book Series="Daredevil" Number="2" Volume="2011" Year="2011">
-      <Id>b4abe993-14ae-4fa9-85da-ce17c44e3e4d</Id>
+      <Database Name="cv" Series="41410" Issue="286916" />
     </Book>
     <Book Series="Daredevil" Number="3" Volume="2011" Year="2011">
-      <Id>6c645f73-65ee-4dc9-b9c3-a67a56ab75e1</Id>
+      <Database Name="cv" Series="41410" Issue="292615" />
     </Book>
     <Book Series="Daredevil" Number="4" Volume="2011" Year="2011">
-      <Id>cce1f817-867e-4117-8428-803182aec435</Id>
+      <Database Name="cv" Series="41410" Issue="293300" />
     </Book>
     <Book Series="Daredevil" Number="5" Volume="2011" Year="2011">
-      <Id>0235affb-06c9-4fa0-9097-965e176cf360</Id>
+      <Database Name="cv" Series="41410" Issue="299571" />
     </Book>
     <Book Series="Daredevil" Number="6" Volume="2011" Year="2012">
-      <Id>62000240-be84-4f16-b638-5457155c753e</Id>
+      <Database Name="cv" Series="41410" Issue="304471" />
     </Book>
     <Book Series="Daredevil" Number="7" Volume="2011" Year="2012">
-      <Id>32eb6154-a66a-4713-a42b-b89be686ea3d</Id>
+      <Database Name="cv" Series="41410" Issue="307448" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="677" Volume="1963" Year="2012">
-      <Id>8fe56df5-718a-411e-9664-0ba6030a62e9</Id>
+      <Database Name="cv" Series="2127" Issue="310913" />
     </Book>
     <Book Series="Daredevil" Number="8" Volume="2011" Year="2012">
-      <Id>ee8fd394-4cf9-4157-96f7-d009f78a18e2</Id>
+      <Database Name="cv" Series="41410" Issue="311671" />
     </Book>
     <Book Series="Daredevil" Number="9" Volume="2011" Year="2012">
-      <Id>97b2fd48-466c-4c43-b509-07b2793e4112</Id>
+      <Database Name="cv" Series="41410" Issue="315743" />
     </Book>
     <Book Series="Daredevil" Number="10" Volume="2011" Year="2012">
-      <Id>6d68e21c-fd41-42cd-bc4a-34961517fea8</Id>
+      <Database Name="cv" Series="41410" Issue="324976" />
     </Book>
     <Book Series="Daredevil" Number="10.1" Volume="2011" Year="2012">
-      <Id>af46bada-0eac-41b3-a39b-6fc12d8402eb</Id>
+      <Database Name="cv" Series="41410" Issue="326824" />
     </Book>
     <Book Series="Avenging Spider-Man" Number="6" Volume="2011" Year="2012">
-      <Id>f3f23314-2884-474f-b524-82fa084a21b2</Id>
+      <Database Name="cv" Series="43884" Issue="329213" />
     </Book>
     <Book Series="The Punisher" Number="10" Volume="2011" Year="2012">
-      <Id>9c3c7981-7a95-49e0-8c72-af0b6dc04a9a</Id>
+      <Database Name="cv" Series="41758" Issue="331857" />
     </Book>
     <Book Series="Daredevil" Number="11" Volume="2011" Year="2012">
-      <Id>174e76e0-8293-457a-90ee-ba967455527d</Id>
+      <Database Name="cv" Series="41410" Issue="333393" />
     </Book>
     <Book Series="Daredevil" Number="12" Volume="2011" Year="2012">
-      <Id>72489414-7cc1-4f8c-96a7-be6024f11910</Id>
+      <Database Name="cv" Series="41410" Issue="334213" />
     </Book>
     <Book Series="Daredevil" Number="13" Volume="2011" Year="2012">
-      <Id>d9fbd03f-f881-4112-ac31-c8312445de10</Id>
+      <Database Name="cv" Series="41410" Issue="335914" />
     </Book>
     <Book Series="Daredevil" Number="14" Volume="2011" Year="2012">
-      <Id>5d7b7d9d-e71f-4a09-82a6-2649b70a01a1</Id>
+      <Database Name="cv" Series="41410" Issue="341650" />
     </Book>
     <Book Series="Daredevil" Number="15" Volume="2011" Year="2012">
-      <Id>6ba37812-a946-4e85-8624-10adca268be5</Id>
+      <Database Name="cv" Series="41410" Issue="346239" />
     </Book>
     <Book Series="Daredevil" Number="16" Volume="2011" Year="2012">
-      <Id>425eeeca-3e06-4cd9-b3a3-211ab0524591</Id>
+      <Database Name="cv" Series="41410" Issue="348059" />
     </Book>
     <Book Series="Daredevil" Number="17" Volume="2011" Year="2012">
-      <Id>d9316ef0-c66b-4fa4-8fba-c616b7a732f2</Id>
+      <Database Name="cv" Series="41410" Issue="350914" />
     </Book>
     <Book Series="Daredevil Annual" Number="1" Volume="2012" Year="2012">
-      <Id>7ce3fbde-0a24-4516-bbc0-7c200f7d3df0</Id>
+      <Database Name="cv" Series="51109" Issue="349681" />
     </Book>
     <Book Series="Wolverine Annual" Number="1" Volume="2012" Year="2012">
-      <Id>13ffa23f-665f-4e83-8df5-c178bccc5ffc</Id>
+      <Database Name="cv" Series="51435" Issue="352699" />
     </Book>
     <Book Series="Daredevil" Number="18" Volume="2011" Year="2012">
-      <Id>bffa6482-d80b-45f4-b868-683b7e7e7610</Id>
+      <Database Name="cv" Series="41410" Issue="357702" />
     </Book>
     <Book Series="Daredevil" Number="19" Volume="2011" Year="2012">
-      <Id>a16cd9bf-0c84-45ae-888b-e96ef23fd76f</Id>
+      <Database Name="cv" Series="41410" Issue="362169" />
     </Book>
     <Book Series="Daredevil" Number="20" Volume="2011" Year="2013">
-      <Id>b9029ed8-bfa6-44a7-bd5c-d2aa735186dc</Id>
+      <Database Name="cv" Series="41410" Issue="369056" />
     </Book>
     <Book Series="Daredevil" Number="21" Volume="2011" Year="2013">
-      <Id>ed1030b2-3627-4d1d-ace1-baa1965f65b0</Id>
+      <Database Name="cv" Series="41410" Issue="373300" />
     </Book>
     <Book Series="Daredevil" Number="22" Volume="2011" Year="2013">
-      <Id>a00b9ca5-1370-418a-af47-1a6daa113d32</Id>
+      <Database Name="cv" Series="41410" Issue="380379" />
     </Book>
     <Book Series="Daredevil" Number="23" Volume="2011" Year="2013">
-      <Id>bb408aa8-37c7-4b47-8038-4dc85ca218ad</Id>
+      <Database Name="cv" Series="41410" Issue="387255" />
     </Book>
     <Book Series="Daredevil" Number="24" Volume="2011" Year="2013">
-      <Id>b2c3a2ff-92ad-447a-92fc-b8a48222264e</Id>
+      <Database Name="cv" Series="41410" Issue="394705" />
     </Book>
     <Book Series="Daredevil" Number="25" Volume="2011" Year="2013">
-      <Id>eb7c44a3-f044-4d15-9aac-72c5bf72218a</Id>
+      <Database Name="cv" Series="41410" Issue="397544" />
     </Book>
     <Book Series="Daredevil" Number="26" Volume="2011" Year="2013">
-      <Id>c1fbbbcb-fe3a-4e45-aec0-2b052de893e1</Id>
+      <Database Name="cv" Series="41410" Issue="404694" />
     </Book>
     <Book Series="Daredevil" Number="27" Volume="2011" Year="2013">
-      <Id>ea1e5708-63c5-4b3b-868c-e16c7e14af8b</Id>
+      <Database Name="cv" Series="41410" Issue="413655" />
     </Book>
     <Book Series="Daredevil" Number="28" Volume="2011" Year="2013">
-      <Id>b4040704-ede6-4d59-a64f-e5a372d60a32</Id>
+      <Database Name="cv" Series="41410" Issue="416916" />
     </Book>
     <Book Series="Daredevil" Number="29" Volume="2011" Year="2013">
-      <Id>1dd0a9c9-1fb6-46b2-b0ff-7facfa7f0206</Id>
+      <Database Name="cv" Series="41410" Issue="419966" />
     </Book>
     <Book Series="Daredevil" Number="30" Volume="2011" Year="2013">
-      <Id>1ff421d3-3872-48c1-a328-3d62ccad7cb8</Id>
+      <Database Name="cv" Series="41410" Issue="422496" />
     </Book>
     <Book Series="Daredevil" Number="31" Volume="2011" Year="2013">
-      <Id>d005b945-5277-4bd9-8657-eda4a2b7e557</Id>
+      <Database Name="cv" Series="41410" Issue="425932" />
     </Book>
     <Book Series="Daredevil" Number="32" Volume="2011" Year="2013">
-      <Id>d7aec916-67e0-4890-9044-91512fdb17c6</Id>
+      <Database Name="cv" Series="41410" Issue="430752" />
     </Book>
     <Book Series="Daredevil" Number="33" Volume="2011" Year="2014">
-      <Id>4ccf70f1-4458-4173-8c99-0a1970c0ed02</Id>
+      <Database Name="cv" Series="41410" Issue="433844" />
     </Book>
     <Book Series="Daredevil" Number="34" Volume="2011" Year="2014">
-      <Id>aee86f50-13a2-4f1e-95f2-ca176dd423ef</Id>
+      <Database Name="cv" Series="41410" Issue="437487" />
     </Book>
     <Book Series="Daredevil" Number="35" Volume="2011" Year="2014">
-      <Id>62e4b1fb-f338-483c-886e-5ac6b468873a</Id>
+      <Database Name="cv" Series="41410" Issue="442164" />
     </Book>
     <Book Series="Daredevil" Number="36" Volume="2011" Year="2014">
-      <Id>f9492fd6-072d-4568-8833-ff7e0bec9593</Id>
+      <Database Name="cv" Series="41410" Issue="445812" />
     </Book>
     <Book Series="Daredevil: Dark Nights" Number="1" Volume="2013" Year="2013">
-      <Id>4f71ce3b-13c3-42ac-8aa1-507a888946e4</Id>
+      <Database Name="cv" Series="62878" Issue="408993" />
     </Book>
     <Book Series="Daredevil: Dark Nights" Number="2" Volume="2013" Year="2013">
-      <Id>2a09d379-671c-401f-b527-8126ddca7f13</Id>
+      <Database Name="cv" Series="62878" Issue="415235" />
     </Book>
     <Book Series="Daredevil: Dark Nights" Number="3" Volume="2013" Year="2013">
-      <Id>89faebc9-0bbf-40ba-9205-d15d5cbb7fd1</Id>
+      <Database Name="cv" Series="62878" Issue="420638" />
     </Book>
     <Book Series="Daredevil: Dark Nights" Number="4" Volume="2013" Year="2013">
-      <Id>a260678d-23b7-479b-a403-d5e03f4549ca</Id>
+      <Database Name="cv" Series="62878" Issue="424530" />
     </Book>
     <Book Series="Daredevil: Dark Nights" Number="5" Volume="2013" Year="2013">
-      <Id>b1dedd85-92cb-4373-b206-c6c0b200b5cb</Id>
+      <Database Name="cv" Series="62878" Issue="427685" />
     </Book>
     <Book Series="Daredevil: Dark Nights" Number="6" Volume="2013" Year="2014">
-      <Id>4401fb1d-93ab-4a41-8e62-b887a50cf6ca</Id>
+      <Database Name="cv" Series="62878" Issue="432327" />
     </Book>
     <Book Series="Daredevil: Dark Nights" Number="7" Volume="2013" Year="2014">
-      <Id>930aef5d-9d6d-4c5b-92d4-de1992fc646e</Id>
+      <Database Name="cv" Series="62878" Issue="435577" />
     </Book>
     <Book Series="Daredevil: Dark Nights" Number="8" Volume="2013" Year="2014">
-      <Id>dc1c3317-e09e-41b5-9098-464853c7339e</Id>
+      <Database Name="cv" Series="62878" Issue="441411" />
     </Book>
     <Book Series="Daredevil: End of Days" Number="1" Volume="2012" Year="2012">
-      <Id>e51e877d-d272-4dd6-b878-6f68c21f861a</Id>
+      <Database Name="cv" Series="52640" Issue="359914" />
     </Book>
     <Book Series="Daredevil: End of Days" Number="2" Volume="2012" Year="2013">
-      <Id>3e98958e-0741-48dc-87e5-3f0164453971</Id>
+      <Database Name="cv" Series="52640" Issue="366186" />
     </Book>
     <Book Series="Daredevil: End of Days" Number="3" Volume="2012" Year="2013">
-      <Id>64284d02-6737-443c-b5cb-91d9cdc3e2e6</Id>
+      <Database Name="cv" Series="52640" Issue="371235" />
     </Book>
     <Book Series="Daredevil: End of Days" Number="4" Volume="2012" Year="2013">
-      <Id>340b8e67-622b-454b-b519-4a8967506b02</Id>
+      <Database Name="cv" Series="52640" Issue="376824" />
     </Book>
     <Book Series="Daredevil: End of Days" Number="5" Volume="2012" Year="2013">
-      <Id>fd157735-1c1f-4e41-9888-20c4962f83ba</Id>
+      <Database Name="cv" Series="52640" Issue="384955" />
     </Book>
     <Book Series="Daredevil: End of Days" Number="6" Volume="2012" Year="2013">
-      <Id>a3b951c7-6870-4a20-a314-007b92c723a0</Id>
+      <Database Name="cv" Series="52640" Issue="390446" />
     </Book>
     <Book Series="Daredevil: End of Days" Number="7" Volume="2012" Year="2013">
-      <Id>f1e6c1c1-3382-47de-97b3-a3b27131bbdd</Id>
+      <Database Name="cv" Series="52640" Issue="397545" />
     </Book>
     <Book Series="Daredevil: End of Days" Number="8" Volume="2012" Year="2013">
-      <Id>274fb14d-82e4-47a5-9b40-11b5ac08e767</Id>
+      <Database Name="cv" Series="52640" Issue="408994" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Daredevil/Daredevil 003.cbl
+++ b/Marvel/Characters/unsorted/Daredevil/Daredevil 003.cbl
@@ -2,757 +2,757 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Daredevil 3</Name>
   <Books>
-    <Book Series="Daredevil" Number="½" Volume="1998" Year="1998" Format="Main Series">
+    <Book Series="Daredevil" Number="½" Volume="1998" Year="1998">
       <Id>04153c02-83d2-4625-a2dc-efc5856dcbb4</Id>
     </Book>
-    <Book Series="Daredevil" Number="1" Volume="1998" Year="1998" Format="Main Series">
+    <Book Series="Daredevil" Number="1" Volume="1998" Year="1998">
       <Id>155f1484-6908-4e5a-9e8a-ec0393e51337</Id>
     </Book>
-    <Book Series="Daredevil" Number="2" Volume="1998" Year="1998" Format="Main Series">
+    <Book Series="Daredevil" Number="2" Volume="1998" Year="1998">
       <Id>b32d5896-0a2c-4cd4-87f5-846b5cee6326</Id>
     </Book>
-    <Book Series="Daredevil" Number="3" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Daredevil" Number="3" Volume="1998" Year="1999">
       <Id>3c6436fb-ba43-48e5-a9d8-b687d8308453</Id>
     </Book>
-    <Book Series="Daredevil" Number="4" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Daredevil" Number="4" Volume="1998" Year="1999">
       <Id>63b273f3-9c19-4273-aaf3-e37027bbb0b9</Id>
     </Book>
-    <Book Series="Daredevil" Number="5" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Daredevil" Number="5" Volume="1998" Year="1999">
       <Id>412c7992-5ae7-4a0d-abb6-ad04535439b9</Id>
     </Book>
-    <Book Series="Daredevil" Number="6" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Daredevil" Number="6" Volume="1998" Year="1999">
       <Id>444615ba-6c62-457d-9b2a-729e71a663fc</Id>
     </Book>
-    <Book Series="Daredevil" Number="7" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Daredevil" Number="7" Volume="1998" Year="1999">
       <Id>1514e949-77e3-4594-b1df-76cb76c539c3</Id>
     </Book>
-    <Book Series="Daredevil" Number="8" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Daredevil" Number="8" Volume="1998" Year="1999">
       <Id>cb3d0520-44da-45a1-8e87-70b717bcdae6</Id>
     </Book>
-    <Book Series="Daredevil" Number="9" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Daredevil" Number="9" Volume="1998" Year="1999">
       <Id>cef906fd-c4ee-4c18-88d8-8c804c318055</Id>
     </Book>
-    <Book Series="Daredevil" Number="10" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Daredevil" Number="10" Volume="1998" Year="2000">
       <Id>711d8e8e-9da4-49d8-a379-344ad2d02fda</Id>
     </Book>
-    <Book Series="Daredevil" Number="11" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Daredevil" Number="11" Volume="1998" Year="2000">
       <Id>5c01b476-9787-4402-b05a-afde3572539d</Id>
     </Book>
-    <Book Series="Daredevil" Number="12" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Daredevil" Number="12" Volume="1998" Year="2000">
       <Id>dd0ef1a7-0e33-4386-bcad-7a1b53d573f8</Id>
     </Book>
-    <Book Series="Daredevil" Number="13" Volume="1998" Year="2000" Format="Main Series">
+    <Book Series="Daredevil" Number="13" Volume="1998" Year="2000">
       <Id>7a5f66ce-b17c-4660-b854-860c3c9c2773</Id>
     </Book>
-    <Book Series="Daredevil" Number="14" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Daredevil" Number="14" Volume="1998" Year="2001">
       <Id>b331b7f5-ca95-4c85-9e8f-3c31bc1bbc25</Id>
     </Book>
-    <Book Series="Daredevil" Number="15" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Daredevil" Number="15" Volume="1998" Year="2001">
       <Id>159a33ed-c9f9-4ecf-9000-e6197623e688</Id>
     </Book>
-    <Book Series="Daredevil/Spider-Man" Number="1" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Daredevil/Spider-Man" Number="1" Volume="2001" Year="2001">
       <Id>e30dab3a-999d-4076-9727-71aa2fca6a72</Id>
     </Book>
-    <Book Series="Daredevil/Spider-Man" Number="2" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Daredevil/Spider-Man" Number="2" Volume="2001" Year="2001">
       <Id>bc4dbad5-b2d2-467b-965f-f44266895e86</Id>
     </Book>
-    <Book Series="Daredevil/Spider-Man" Number="3" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Daredevil/Spider-Man" Number="3" Volume="2001" Year="2001">
       <Id>29ab8813-70b2-4871-bbbf-57ba8a9d4e0d</Id>
     </Book>
-    <Book Series="Daredevil/Spider-Man" Number="4" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Daredevil/Spider-Man" Number="4" Volume="2001" Year="2001">
       <Id>ec06a0f1-2281-4791-9955-442cb1f8554e</Id>
     </Book>
-    <Book Series="Daredevil: Ninja" Number="1" Volume="2000" Year="2000" Format="Limited Series">
+    <Book Series="Daredevil: Ninja" Number="1" Volume="2000" Year="2000">
       <Id>c52f56c3-67a5-49fd-9b18-d03ead986f8a</Id>
     </Book>
-    <Book Series="Daredevil: Ninja" Number="2" Volume="2000" Year="2001" Format="Limited Series">
+    <Book Series="Daredevil: Ninja" Number="2" Volume="2000" Year="2001">
       <Id>d2f0b79a-e5b3-449b-be92-ca003d5fb567</Id>
     </Book>
-    <Book Series="Daredevil: Ninja" Number="3" Volume="2000" Year="2001" Format="Limited Series">
+    <Book Series="Daredevil: Ninja" Number="3" Volume="2000" Year="2001">
       <Id>57f60bd4-7a1d-4d30-a7c3-64f2f3ff4279</Id>
     </Book>
-    <Book Series="Daredevil" Number="16" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Daredevil" Number="16" Volume="1998" Year="2001">
       <Id>a494f741-ee85-4e67-96da-391b80c5486c</Id>
     </Book>
-    <Book Series="Daredevil" Number="17" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Daredevil" Number="17" Volume="1998" Year="2001">
       <Id>ec75db13-7e0b-4946-b147-6761347d74f2</Id>
     </Book>
-    <Book Series="Daredevil" Number="18" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Daredevil" Number="18" Volume="1998" Year="2001">
       <Id>2e743a08-72e4-4097-abd6-25690277dc61</Id>
     </Book>
-    <Book Series="Daredevil" Number="19" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Daredevil" Number="19" Volume="1998" Year="2001">
       <Id>cd0a24c3-bfd6-461d-8dcc-530b2495a84f</Id>
     </Book>
-    <Book Series="Daredevil: Yellow" Number="1" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Daredevil: Yellow" Number="1" Volume="2001" Year="2001">
       <Id>927bd2e5-33fb-42a2-af68-0b67a9b7d7cb</Id>
     </Book>
-    <Book Series="Daredevil: Yellow" Number="2" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Daredevil: Yellow" Number="2" Volume="2001" Year="2001">
       <Id>6a52b549-89e3-4943-8dd8-1527810217ff</Id>
     </Book>
-    <Book Series="Daredevil: Yellow" Number="3" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Daredevil: Yellow" Number="3" Volume="2001" Year="2001">
       <Id>21fafba8-cf53-47a0-bcd7-067d9b52f12d</Id>
     </Book>
-    <Book Series="Daredevil: Yellow" Number="4" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Daredevil: Yellow" Number="4" Volume="2001" Year="2001">
       <Id>875cfb86-7884-41c9-83cb-586d8df84134</Id>
     </Book>
-    <Book Series="Daredevil: Yellow" Number="5" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Daredevil: Yellow" Number="5" Volume="2001" Year="2001">
       <Id>492db08e-a8a0-4384-bbff-2eadfbcde0dd</Id>
     </Book>
-    <Book Series="Daredevil: Yellow" Number="6" Volume="2001" Year="2002" Format="Limited Series">
+    <Book Series="Daredevil: Yellow" Number="6" Volume="2001" Year="2002">
       <Id>d4597064-b9b8-4573-926e-14e5dc28b2db</Id>
     </Book>
-    <Book Series="Daredevil" Number="20" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Daredevil" Number="20" Volume="1998" Year="2001">
       <Id>6bd0b2c9-f30f-408a-ada2-e4b996c3269f</Id>
     </Book>
-    <Book Series="Daredevil" Number="21" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Daredevil" Number="21" Volume="1998" Year="2001">
       <Id>7fd61e99-e930-433a-a04e-a92f51069488</Id>
     </Book>
-    <Book Series="Daredevil" Number="22" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Daredevil" Number="22" Volume="1998" Year="2001">
       <Id>19b202cc-2969-44cb-a0a0-0b01da5491e4</Id>
     </Book>
-    <Book Series="Daredevil" Number="23" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Daredevil" Number="23" Volume="1998" Year="2001">
       <Id>237fff1f-faed-43f5-aecd-c5c78f036c6c</Id>
     </Book>
-    <Book Series="Daredevil" Number="24" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Daredevil" Number="24" Volume="1998" Year="2001">
       <Id>385d7610-eff0-444c-bae0-018356cda923</Id>
     </Book>
-    <Book Series="Daredevil" Number="25" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Daredevil" Number="25" Volume="1998" Year="2001">
       <Id>6cea16c5-4700-4a4b-ac4d-600e9140931c</Id>
     </Book>
-    <Book Series="Daredevil" Number="26" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Daredevil" Number="26" Volume="1998" Year="2001">
       <Id>97532634-a746-4700-a3e4-59d17bcdd12d</Id>
     </Book>
-    <Book Series="Daredevil" Number="27" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Daredevil" Number="27" Volume="1998" Year="2002">
       <Id>8c43dc9f-c18f-4039-a091-6979bba7d7b3</Id>
     </Book>
-    <Book Series="Daredevil" Number="28" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Daredevil" Number="28" Volume="1998" Year="2002">
       <Id>cae3ca8b-28c8-498f-b281-1e444d2ecdeb</Id>
     </Book>
-    <Book Series="Daredevil" Number="29" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Daredevil" Number="29" Volume="1998" Year="2002">
       <Id>46aa52b0-97ec-4e66-bd3d-c46b133790e9</Id>
     </Book>
-    <Book Series="Daredevil" Number="30" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Daredevil" Number="30" Volume="1998" Year="2002">
       <Id>bcd27f78-314a-47b3-b666-8c4406b5b37e</Id>
     </Book>
-    <Book Series="Daredevil" Number="31" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Daredevil" Number="31" Volume="1998" Year="2002">
       <Id>69556e26-c1f0-435f-80d5-da4629a4791c</Id>
     </Book>
-    <Book Series="Daredevil" Number="32" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Daredevil" Number="32" Volume="1998" Year="2002">
       <Id>64e65447-2a02-406f-8d50-1849241956fe</Id>
     </Book>
-    <Book Series="Daredevil" Number="33" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Daredevil" Number="33" Volume="1998" Year="2002">
       <Id>613e9d4c-2e46-4331-ad71-472c7f0bdd57</Id>
     </Book>
-    <Book Series="Daredevil" Number="34" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Daredevil" Number="34" Volume="1998" Year="2002">
       <Id>60306b77-f47d-4410-b23d-09d6a7d7c772</Id>
     </Book>
-    <Book Series="Daredevil" Number="35" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Daredevil" Number="35" Volume="1998" Year="2002">
       <Id>43109af2-3629-49fa-a829-f3c6d041bb2f</Id>
     </Book>
-    <Book Series="Daredevil" Number="36" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Daredevil" Number="36" Volume="1998" Year="2002">
       <Id>02a06f72-64e7-4717-917c-da7281c84d93</Id>
     </Book>
-    <Book Series="Daredevil" Number="37" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Daredevil" Number="37" Volume="1998" Year="2002">
       <Id>3f2206ba-50f3-4f56-a111-6214fe667aa7</Id>
     </Book>
-    <Book Series="Daredevil" Number="38" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Daredevil" Number="38" Volume="1998" Year="2002">
       <Id>c4fd5b50-d474-47d2-bc6b-66974384482a</Id>
     </Book>
-    <Book Series="Daredevil" Number="39" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Daredevil" Number="39" Volume="1998" Year="2003">
       <Id>56fab634-0bc8-4e5d-941a-7795834f00ba</Id>
     </Book>
-    <Book Series="Daredevil" Number="40" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Daredevil" Number="40" Volume="1998" Year="2003">
       <Id>4f8dc94e-867e-40e4-9824-fc25782fdd48</Id>
     </Book>
-    <Book Series="Daredevil" Number="41" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Daredevil" Number="41" Volume="1998" Year="2003">
       <Id>c6d3b50a-2739-47ba-af9f-fc7973084876</Id>
     </Book>
-    <Book Series="Daredevil" Number="42" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Daredevil" Number="42" Volume="1998" Year="2003">
       <Id>59df28ed-6a3c-4acf-9e23-51db833ff01c</Id>
     </Book>
-    <Book Series="Daredevil" Number="43" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Daredevil" Number="43" Volume="1998" Year="2003">
       <Id>bbfdfbc8-78bf-426e-9557-b8aa68b772b5</Id>
     </Book>
-    <Book Series="Daredevil" Number="44" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Daredevil" Number="44" Volume="1998" Year="2003">
       <Id>33c78553-a302-4924-9611-7a0944f533f1</Id>
     </Book>
-    <Book Series="Daredevil" Number="45" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Daredevil" Number="45" Volume="1998" Year="2003">
       <Id>9de9d060-c5cd-4534-bd43-cd4adcc5aea8</Id>
     </Book>
-    <Book Series="Daredevil" Number="46" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Daredevil" Number="46" Volume="1998" Year="2003">
       <Id>edc4d100-d0ed-4ff1-a490-d3da623d78d8</Id>
     </Book>
-    <Book Series="Daredevil" Number="47" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Daredevil" Number="47" Volume="1998" Year="2003">
       <Id>147e2364-de76-47f0-bc24-67a51a628083</Id>
     </Book>
-    <Book Series="Daredevil" Number="48" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Daredevil" Number="48" Volume="1998" Year="2003">
       <Id>bb34c332-0853-44fd-89ea-df8bef0e30da</Id>
     </Book>
-    <Book Series="Daredevil" Number="49" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Daredevil" Number="49" Volume="1998" Year="2003">
       <Id>fd2985b7-5a5b-4467-8e75-a65d8863a68c</Id>
     </Book>
-    <Book Series="Daredevil" Number="50" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Daredevil" Number="50" Volume="1998" Year="2003">
       <Id>da4fc3fc-feb1-4e21-9e13-1235a5db20ae</Id>
     </Book>
-    <Book Series="Daredevil" Number="51" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Daredevil" Number="51" Volume="1998" Year="2003">
       <Id>849f83b7-f449-46a0-b122-903ce2cf2937</Id>
     </Book>
-    <Book Series="Daredevil" Number="52" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Daredevil" Number="52" Volume="1998" Year="2003">
       <Id>3719eff3-8a0d-4192-bd5f-746019ddc323</Id>
     </Book>
-    <Book Series="Daredevil" Number="53" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Daredevil" Number="53" Volume="1998" Year="2003">
       <Id>52a8ce23-c090-40d9-9c6e-aba7e74127f5</Id>
     </Book>
-    <Book Series="Daredevil" Number="54" Volume="1998" Year="2004" Format="Main Series">
+    <Book Series="Daredevil" Number="54" Volume="1998" Year="2004">
       <Id>bc0d0678-a447-484d-8133-252d7b1da599</Id>
     </Book>
-    <Book Series="Daredevil" Number="55" Volume="1998" Year="2004" Format="Main Series">
+    <Book Series="Daredevil" Number="55" Volume="1998" Year="2004">
       <Id>bac35397-ed2e-4af3-b4e7-f381a0b782c4</Id>
     </Book>
-    <Book Series="Daredevil" Number="56" Volume="1998" Year="2004" Format="Main Series">
+    <Book Series="Daredevil" Number="56" Volume="1998" Year="2004">
       <Id>675ffc2f-574e-4c76-b4f0-cf481a19ca81</Id>
     </Book>
-    <Book Series="Daredevil" Number="57" Volume="1998" Year="2004" Format="Main Series">
+    <Book Series="Daredevil" Number="57" Volume="1998" Year="2004">
       <Id>b4fc8b58-698f-4449-9631-8f7a67d74f35</Id>
     </Book>
-    <Book Series="Daredevil" Number="58" Volume="1998" Year="2004" Format="Main Series">
+    <Book Series="Daredevil" Number="58" Volume="1998" Year="2004">
       <Id>c451c928-8be2-4e7e-94b0-0b69e263ee0f</Id>
     </Book>
-    <Book Series="Daredevil" Number="59" Volume="1998" Year="2004" Format="Main Series">
+    <Book Series="Daredevil" Number="59" Volume="1998" Year="2004">
       <Id>ab122bd3-5d19-4664-8d88-f8c803df05aa</Id>
     </Book>
-    <Book Series="Daredevil" Number="60" Volume="1998" Year="2004" Format="Main Series">
+    <Book Series="Daredevil" Number="60" Volume="1998" Year="2004">
       <Id>3a0c62d1-9b07-4614-9289-04538183530d</Id>
     </Book>
-    <Book Series="Daredevil" Number="61" Volume="1998" Year="2004" Format="Main Series">
+    <Book Series="Daredevil" Number="61" Volume="1998" Year="2004">
       <Id>998acb47-e861-4bd4-b628-381b1a9e05f1</Id>
     </Book>
-    <Book Series="Daredevil" Number="62" Volume="1998" Year="2004" Format="Main Series">
+    <Book Series="Daredevil" Number="62" Volume="1998" Year="2004">
       <Id>e8c82faa-9b36-40eb-95fc-b206f44f018b</Id>
     </Book>
-    <Book Series="Daredevil" Number="63" Volume="1998" Year="2004" Format="Main Series">
+    <Book Series="Daredevil" Number="63" Volume="1998" Year="2004">
       <Id>eb57c6ac-fd34-4732-849c-684ecaa775ba</Id>
     </Book>
-    <Book Series="Daredevil" Number="64" Volume="1998" Year="2004" Format="Main Series">
+    <Book Series="Daredevil" Number="64" Volume="1998" Year="2004">
       <Id>6cea13c7-2fc5-4894-ab93-84456bdf3cb0</Id>
     </Book>
-    <Book Series="Daredevil" Number="65" Volume="1998" Year="2004" Format="Main Series">
+    <Book Series="Daredevil" Number="65" Volume="1998" Year="2004">
       <Id>9bbc5ea7-3d8d-4f0e-8351-1acb1cf3dafa</Id>
     </Book>
-    <Book Series="Powerless" Number="1" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Powerless" Number="1" Volume="2004" Year="2004">
       <Id>f29b4301-1a51-4d54-aea6-7e4899945f1d</Id>
     </Book>
-    <Book Series="Powerless" Number="2" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Powerless" Number="2" Volume="2004" Year="2004">
       <Id>b784ed70-3c65-4484-b2cf-6673ad441fa9</Id>
     </Book>
-    <Book Series="Powerless" Number="3" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Powerless" Number="3" Volume="2004" Year="2004">
       <Id>a2636cea-a4a5-44d8-b386-3e8ceae6029e</Id>
     </Book>
-    <Book Series="Powerless" Number="4" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Powerless" Number="4" Volume="2004" Year="2004">
       <Id>0c587da0-2894-4e83-a40d-104aecf774ea</Id>
     </Book>
-    <Book Series="Powerless" Number="5" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Powerless" Number="5" Volume="2004" Year="2004">
       <Id>35c2c418-1c69-4039-b7bc-4aed7dbdd433</Id>
     </Book>
-    <Book Series="Powerless" Number="6" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="Powerless" Number="6" Volume="2004" Year="2005">
       <Id>3f293362-1694-45af-8645-a7a81873f99b</Id>
     </Book>
-    <Book Series="Bullseye: Greatest Hits" Number="1" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Bullseye: Greatest Hits" Number="1" Volume="2004" Year="2004">
       <Id>33d34045-5192-4c2e-895c-c432fdef4e0e</Id>
     </Book>
-    <Book Series="Bullseye: Greatest Hits" Number="2" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Bullseye: Greatest Hits" Number="2" Volume="2004" Year="2004">
       <Id>fe70abb5-19ed-43db-9f47-1f4ad2269066</Id>
     </Book>
-    <Book Series="Bullseye: Greatest Hits" Number="3" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="Bullseye: Greatest Hits" Number="3" Volume="2004" Year="2005">
       <Id>94918110-5181-4cc3-80ac-92a0da19cc11</Id>
     </Book>
-    <Book Series="Bullseye: Greatest Hits" Number="4" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="Bullseye: Greatest Hits" Number="4" Volume="2004" Year="2005">
       <Id>ac2e805d-0c65-4a99-b671-a027c2dd4162</Id>
     </Book>
-    <Book Series="Bullseye: Greatest Hits" Number="5" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="Bullseye: Greatest Hits" Number="5" Volume="2004" Year="2005">
       <Id>22b159ba-8dd2-409d-a280-a476c88d08bd</Id>
     </Book>
-    <Book Series="Daredevil" Number="66" Volume="1998" Year="2004" Format="Main Series">
+    <Book Series="Daredevil" Number="66" Volume="1998" Year="2004">
       <Id>a9b73edd-6c58-4701-958c-d9bad077d494</Id>
     </Book>
-    <Book Series="Daredevil" Number="67" Volume="1998" Year="2005" Format="Main Series">
+    <Book Series="Daredevil" Number="67" Volume="1998" Year="2005">
       <Id>649ff179-a556-4481-9dc2-27739734a3f7</Id>
     </Book>
-    <Book Series="Daredevil" Number="68" Volume="1998" Year="2005" Format="Main Series">
+    <Book Series="Daredevil" Number="68" Volume="1998" Year="2005">
       <Id>1d4bf476-1562-4ba6-b3b0-dbf7550adb8f</Id>
     </Book>
-    <Book Series="Daredevil" Number="69" Volume="1998" Year="2005" Format="Main Series">
+    <Book Series="Daredevil" Number="69" Volume="1998" Year="2005">
       <Id>164808f9-c1fc-4e1d-8c52-ebc059ae7e23</Id>
     </Book>
-    <Book Series="Daredevil" Number="70" Volume="1998" Year="2005" Format="Main Series">
+    <Book Series="Daredevil" Number="70" Volume="1998" Year="2005">
       <Id>c0e03d29-6a8e-4a30-9eaa-be32c827336f</Id>
     </Book>
-    <Book Series="Daredevil: Redemption" Number="1" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Daredevil: Redemption" Number="1" Volume="2005" Year="2005">
       <Id>ddeabf60-614d-4337-aa22-c8bb7ae40de8</Id>
     </Book>
-    <Book Series="Daredevil: Redemption" Number="2" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Daredevil: Redemption" Number="2" Volume="2005" Year="2005">
       <Id>5903c778-d886-4ac0-89f0-e551e861a898</Id>
     </Book>
-    <Book Series="Daredevil: Redemption" Number="3" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Daredevil: Redemption" Number="3" Volume="2005" Year="2005">
       <Id>cc624e10-5a4d-4dfe-a6ca-992f779541fb</Id>
     </Book>
-    <Book Series="Daredevil: Redemption" Number="4" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Daredevil: Redemption" Number="4" Volume="2005" Year="2005">
       <Id>4469f184-dffa-4038-88c8-a5e49f823a8d</Id>
     </Book>
-    <Book Series="Daredevil: Redemption" Number="5" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Daredevil: Redemption" Number="5" Volume="2005" Year="2005">
       <Id>397cf24f-b584-4db1-b515-0e4733c11891</Id>
     </Book>
-    <Book Series="Daredevil: Redemption" Number="6" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Daredevil: Redemption" Number="6" Volume="2005" Year="2005">
       <Id>b6eacff2-91a8-4e67-a873-b70720eb1b0b</Id>
     </Book>
-    <Book Series="Daredevil" Number="71" Volume="1998" Year="2005" Format="Main Series">
+    <Book Series="Daredevil" Number="71" Volume="1998" Year="2005">
       <Id>1bf7f90d-97a8-4b07-a36e-0845dacd89f9</Id>
     </Book>
-    <Book Series="Daredevil" Number="72" Volume="1998" Year="2005" Format="Main Series">
+    <Book Series="Daredevil" Number="72" Volume="1998" Year="2005">
       <Id>f4ce4c40-5ad9-42c3-9d81-22b6f2d7e97f</Id>
     </Book>
-    <Book Series="Daredevil" Number="73" Volume="1998" Year="2005" Format="Main Series">
+    <Book Series="Daredevil" Number="73" Volume="1998" Year="2005">
       <Id>2ecf2e07-87eb-4674-9b1b-ae0a14e651f7</Id>
     </Book>
-    <Book Series="Daredevil" Number="74" Volume="1998" Year="2005" Format="Main Series">
+    <Book Series="Daredevil" Number="74" Volume="1998" Year="2005">
       <Id>d34c8849-4a77-4033-b5e7-282581fb4750</Id>
     </Book>
-    <Book Series="Daredevil" Number="75" Volume="1998" Year="2005" Format="Main Series">
+    <Book Series="Daredevil" Number="75" Volume="1998" Year="2005">
       <Id>e9e81d30-def5-4d08-924d-180be45dfc4f</Id>
     </Book>
-    <Book Series="Daredevil Vs. Punisher" Number="1" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Daredevil Vs. Punisher" Number="1" Volume="2005" Year="2005">
       <Id>039ebb03-7d56-4b07-ad26-370d1098fe5d</Id>
     </Book>
-    <Book Series="Daredevil Vs. Punisher" Number="2" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Daredevil Vs. Punisher" Number="2" Volume="2005" Year="2005">
       <Id>4b713325-8f5d-4362-b9ba-46d011888e46</Id>
     </Book>
-    <Book Series="Daredevil Vs. Punisher" Number="3" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Daredevil Vs. Punisher" Number="3" Volume="2005" Year="2005">
       <Id>caada2af-74d8-42b8-82d8-1818c093dcab</Id>
     </Book>
-    <Book Series="Daredevil Vs. Punisher" Number="4" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Daredevil Vs. Punisher" Number="4" Volume="2005" Year="2005">
       <Id>b9724383-f95a-4e00-b9c5-df3f72287123</Id>
     </Book>
-    <Book Series="Daredevil Vs. Punisher" Number="5" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Daredevil Vs. Punisher" Number="5" Volume="2005" Year="2005">
       <Id>8b35cd78-8e7a-48dc-9a12-f78b621be0b1</Id>
     </Book>
-    <Book Series="Daredevil Vs. Punisher" Number="6" Volume="2005" Year="2006" Format="Limited Series">
+    <Book Series="Daredevil Vs. Punisher" Number="6" Volume="2005" Year="2006">
       <Id>d56147ef-4d1c-4a8c-9c6f-1ef174595ed0</Id>
     </Book>
-    <Book Series="Daredevil" Number="76" Volume="1998" Year="2005" Format="Main Series">
+    <Book Series="Daredevil" Number="76" Volume="1998" Year="2005">
       <Id>8850cf37-3720-40f0-9ea9-026f019741f6</Id>
     </Book>
-    <Book Series="Daredevil" Number="77" Volume="1998" Year="2005" Format="Main Series">
+    <Book Series="Daredevil" Number="77" Volume="1998" Year="2005">
       <Id>3604e343-88bc-4608-97b3-bb942a36f874</Id>
     </Book>
-    <Book Series="Daredevil" Number="78" Volume="1998" Year="2005" Format="Main Series">
+    <Book Series="Daredevil" Number="78" Volume="1998" Year="2005">
       <Id>83bf8cb6-83ec-4a1e-83f8-3c4fb98256fe</Id>
     </Book>
-    <Book Series="Daredevil" Number="79" Volume="1998" Year="2006" Format="Main Series">
+    <Book Series="Daredevil" Number="79" Volume="1998" Year="2006">
       <Id>a34a6248-8c95-4bbd-b81c-3dd22dca7324</Id>
     </Book>
-    <Book Series="Daredevil" Number="80" Volume="1998" Year="2006" Format="Main Series">
+    <Book Series="Daredevil" Number="80" Volume="1998" Year="2006">
       <Id>31f4a9c3-d507-4b4f-acdd-2b73f449dac9</Id>
     </Book>
-    <Book Series="Daredevil" Number="81" Volume="1998" Year="2006" Format="Main Series">
+    <Book Series="Daredevil" Number="81" Volume="1998" Year="2006">
       <Id>c8862314-e2ec-4bfd-9174-fe49faf50ae9</Id>
     </Book>
-    <Book Series="Daredevil" Number="82" Volume="1998" Year="2006" Format="Main Series">
+    <Book Series="Daredevil" Number="82" Volume="1998" Year="2006">
       <Id>772a2a8a-af82-48a0-82d0-d18e85e8f37e</Id>
     </Book>
-    <Book Series="Daredevil" Number="83" Volume="1998" Year="2006" Format="Main Series">
+    <Book Series="Daredevil" Number="83" Volume="1998" Year="2006">
       <Id>d459414d-1794-4ee7-8222-375312561b9d</Id>
     </Book>
-    <Book Series="Daredevil" Number="84" Volume="1998" Year="2006" Format="Main Series">
+    <Book Series="Daredevil" Number="84" Volume="1998" Year="2006">
       <Id>89c5d5f4-0722-4fb3-b8b1-25974564654f</Id>
     </Book>
-    <Book Series="Daredevil" Number="85" Volume="1998" Year="2006" Format="Main Series">
+    <Book Series="Daredevil" Number="85" Volume="1998" Year="2006">
       <Id>fcb53bb3-8655-4c70-a15c-43abafdd3dd7</Id>
     </Book>
-    <Book Series="Daredevil" Number="86" Volume="1998" Year="2006" Format="Main Series">
+    <Book Series="Daredevil" Number="86" Volume="1998" Year="2006">
       <Id>366bddd4-934e-4c30-9a83-245f597f70af</Id>
     </Book>
-    <Book Series="Daredevil" Number="87" Volume="1998" Year="2006" Format="Main Series">
+    <Book Series="Daredevil" Number="87" Volume="1998" Year="2006">
       <Id>70f56bf6-a44d-4ee8-96b4-9d489c82d21a</Id>
     </Book>
-    <Book Series="Daredevil: Father" Number="1" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Daredevil: Father" Number="1" Volume="2004" Year="2004">
       <Id>f128cb50-8973-4eb4-a168-3b3efa1fdf4a</Id>
     </Book>
-    <Book Series="Daredevil: Father" Number="2" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="Daredevil: Father" Number="2" Volume="2004" Year="2005">
       <Id>aa68d0a9-a9a1-4612-a85b-1095b25282a5</Id>
     </Book>
-    <Book Series="Daredevil: Father" Number="3" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="Daredevil: Father" Number="3" Volume="2004" Year="2005">
       <Id>08fa0451-36ad-4799-8917-b87f94e205bd</Id>
     </Book>
-    <Book Series="Daredevil: Father" Number="4" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="Daredevil: Father" Number="4" Volume="2004" Year="2005">
       <Id>c057a8c0-789c-455a-990b-f4ad4f6ac0d8</Id>
     </Book>
-    <Book Series="Daredevil: Father" Number="5" Volume="2004" Year="2006" Format="Limited Series">
+    <Book Series="Daredevil: Father" Number="5" Volume="2004" Year="2006">
       <Id>15a5c589-7d63-4955-8327-192304677e09</Id>
     </Book>
-    <Book Series="Daredevil: Father" Number="6" Volume="2004" Year="2006" Format="Limited Series">
+    <Book Series="Daredevil: Father" Number="6" Volume="2004" Year="2006">
       <Id>bb36232b-17e1-402b-9930-8cda0c8ba6a3</Id>
     </Book>
-    <Book Series="Daredevil" Number="88" Volume="1998" Year="2006" Format="Main Series">
+    <Book Series="Daredevil" Number="88" Volume="1998" Year="2006">
       <Id>55952e6b-08b2-4ad5-a90c-7210178ae01d</Id>
     </Book>
-    <Book Series="Daredevil" Number="89" Volume="1998" Year="2006" Format="Main Series">
+    <Book Series="Daredevil" Number="89" Volume="1998" Year="2006">
       <Id>8f7b7d48-d49a-42b4-aef4-35aad3ef1f81</Id>
     </Book>
-    <Book Series="Daredevil" Number="90" Volume="1998" Year="2006" Format="Main Series">
+    <Book Series="Daredevil" Number="90" Volume="1998" Year="2006">
       <Id>04b2776c-9dce-4bd6-bea6-a178fffdda5a</Id>
     </Book>
-    <Book Series="Daredevil" Number="91" Volume="1998" Year="2007" Format="Main Series">
+    <Book Series="Daredevil" Number="91" Volume="1998" Year="2007">
       <Id>bf0c1bf0-09bc-4696-a87a-c6c6834fbfb9</Id>
     </Book>
-    <Book Series="Daredevil" Number="92" Volume="1998" Year="2007" Format="Main Series">
+    <Book Series="Daredevil" Number="92" Volume="1998" Year="2007">
       <Id>62571bc0-182c-40f7-8d94-878049707235</Id>
     </Book>
-    <Book Series="Daredevil" Number="93" Volume="1998" Year="2007" Format="Main Series">
+    <Book Series="Daredevil" Number="93" Volume="1998" Year="2007">
       <Id>1591c9ec-f74c-4190-99d0-91545e7cb4f2</Id>
     </Book>
-    <Book Series="Daredevil" Number="94" Volume="1998" Year="2007" Format="Main Series">
+    <Book Series="Daredevil" Number="94" Volume="1998" Year="2007">
       <Id>eb7f1b81-1f09-4923-bfb2-bcd52dc054f8</Id>
     </Book>
-    <Book Series="Daredevil" Number="95" Volume="1998" Year="2007" Format="Main Series">
+    <Book Series="Daredevil" Number="95" Volume="1998" Year="2007">
       <Id>a27cfd0c-8b2d-4391-94d3-a0d22c8dcdb4</Id>
     </Book>
-    <Book Series="Daredevil" Number="96" Volume="1998" Year="2007" Format="Main Series">
+    <Book Series="Daredevil" Number="96" Volume="1998" Year="2007">
       <Id>dc4061b3-2755-4846-b80e-0df2d3c1cbfa</Id>
     </Book>
-    <Book Series="Daredevil" Number="97" Volume="1998" Year="2007" Format="Main Series">
+    <Book Series="Daredevil" Number="97" Volume="1998" Year="2007">
       <Id>c95246dd-7d5f-4cab-bec9-ee0730310114</Id>
     </Book>
-    <Book Series="Daredevil" Number="98" Volume="1998" Year="2007" Format="Main Series">
+    <Book Series="Daredevil" Number="98" Volume="1998" Year="2007">
       <Id>351eac82-d184-4324-bb97-d7b55c264d80</Id>
     </Book>
-    <Book Series="Daredevil" Number="99" Volume="1998" Year="2007" Format="Main Series">
+    <Book Series="Daredevil" Number="99" Volume="1998" Year="2007">
       <Id>a0303b63-9e3d-4b3b-8dcb-58b33497b27b</Id>
     </Book>
-    <Book Series="Daredevil: Battlin' Jack Murdock" Number="1" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="Daredevil: Battlin' Jack Murdock" Number="1" Volume="2007" Year="2007">
       <Id>acc100d2-43bf-4b39-9368-841455a94444</Id>
     </Book>
-    <Book Series="Daredevil: Battlin' Jack Murdock" Number="2" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="Daredevil: Battlin' Jack Murdock" Number="2" Volume="2007" Year="2007">
       <Id>1775c509-a9f1-4945-849b-84872ced75b9</Id>
     </Book>
-    <Book Series="Daredevil: Battlin' Jack Murdock" Number="3" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="Daredevil: Battlin' Jack Murdock" Number="3" Volume="2007" Year="2007">
       <Id>5b92a4b5-45fd-4074-b5f5-38504600c535</Id>
     </Book>
-    <Book Series="Daredevil: Battlin' Jack Murdock" Number="4" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="Daredevil: Battlin' Jack Murdock" Number="4" Volume="2007" Year="2007">
       <Id>abcf7c59-d881-45a2-b8de-7f19f07c27ad</Id>
     </Book>
-    <Book Series="Daredevil" Number="100" Volume="1998" Year="2007" Format="Main Series">
+    <Book Series="Daredevil" Number="100" Volume="1998" Year="2007">
       <Id>754d94c5-701b-43e2-a509-8d7bb14fe6a7</Id>
     </Book>
-    <Book Series="Daredevil" Number="101" Volume="1998" Year="2007" Format="Main Series">
+    <Book Series="Daredevil" Number="101" Volume="1998" Year="2007">
       <Id>d22d44a2-588d-4745-a7da-921a7ba77cf8</Id>
     </Book>
-    <Book Series="Daredevil" Number="102" Volume="1998" Year="2008" Format="Main Series">
+    <Book Series="Daredevil" Number="102" Volume="1998" Year="2008">
       <Id>2f2a143e-e2f2-4b70-9cab-e7e9881c665f</Id>
     </Book>
-    <Book Series="Daredevil" Number="103" Volume="1998" Year="2008" Format="Main Series">
+    <Book Series="Daredevil" Number="103" Volume="1998" Year="2008">
       <Id>3031a7d8-b6e4-489b-8970-0266f747257f</Id>
     </Book>
-    <Book Series="Daredevil" Number="104" Volume="1998" Year="2008" Format="Main Series">
+    <Book Series="Daredevil" Number="104" Volume="1998" Year="2008">
       <Id>c38bc697-d378-46f7-8ece-2b917f378cdf</Id>
     </Book>
-    <Book Series="Daredevil Annual" Number="1" Volume="2007" Year="2007" Format="Annual">
+    <Book Series="Daredevil Annual" Number="1" Volume="2007" Year="2007">
       <Id>b55384c9-ca07-446d-a6b5-a09798bd7ea5</Id>
     </Book>
-    <Book Series="Daredevil" Number="106" Volume="1998" Year="2008" Format="Main Series">
+    <Book Series="Daredevil" Number="106" Volume="1998" Year="2008">
       <Id>cb8aaec0-2ce2-4f28-ae18-585954194976</Id>
     </Book>
-    <Book Series="Daredevil" Number="107" Volume="1998" Year="2008" Format="Main Series">
+    <Book Series="Daredevil" Number="107" Volume="1998" Year="2008">
       <Id>5f084885-9563-4fd5-af8d-15604a36622d</Id>
     </Book>
-    <Book Series="Daredevil" Number="108" Volume="1998" Year="2008" Format="Main Series">
+    <Book Series="Daredevil" Number="108" Volume="1998" Year="2008">
       <Id>cba7851f-c285-47ac-bd73-0af6e5c62475</Id>
     </Book>
-    <Book Series="Daredevil" Number="109" Volume="1998" Year="2008" Format="Main Series">
+    <Book Series="Daredevil" Number="109" Volume="1998" Year="2008">
       <Id>588a8c96-b206-4f0d-9611-63306402fa42</Id>
     </Book>
-    <Book Series="Daredevil" Number="110" Volume="1998" Year="2008" Format="Main Series">
+    <Book Series="Daredevil" Number="110" Volume="1998" Year="2008">
       <Id>dfa4f0dc-49f6-4103-a78a-d88dff864c5d</Id>
     </Book>
-    <Book Series="Daredevil &amp; Captain America: Dead On Arrival" Number="1" Volume="2009" Year="2009" Format="One-Shot">
+    <Book Series="Daredevil &amp; Captain America: Dead On Arrival" Number="1" Volume="2009" Year="2009">
       <Id>53e2274e-e01a-47db-b129-cfab9d6f9114</Id>
     </Book>
-    <Book Series="Daredevil" Number="111" Volume="1998" Year="2008" Format="Main Series">
+    <Book Series="Daredevil" Number="111" Volume="1998" Year="2008">
       <Id>0e3825d4-c789-4795-8526-d90bd52c8e22</Id>
     </Book>
-    <Book Series="Daredevil" Number="112" Volume="1998" Year="2008" Format="Main Series">
+    <Book Series="Daredevil" Number="112" Volume="1998" Year="2008">
       <Id>3be16b48-ad75-4fcf-98f7-a58e38299a50</Id>
     </Book>
-    <Book Series="Daredevil" Number="113" Volume="1998" Year="2009" Format="Main Series">
+    <Book Series="Daredevil" Number="113" Volume="1998" Year="2009">
       <Id>c8517c18-c50a-47f4-9f4c-b58fe47973da</Id>
     </Book>
-    <Book Series="Daredevil" Number="114" Volume="1998" Year="2009" Format="Main Series">
+    <Book Series="Daredevil" Number="114" Volume="1998" Year="2009">
       <Id>40ab95fc-5a74-43a4-bee5-716d1378bd4b</Id>
     </Book>
-    <Book Series="Daredevil" Number="115" Volume="1998" Year="2009" Format="Main Series">
+    <Book Series="Daredevil" Number="115" Volume="1998" Year="2009">
       <Id>1305c524-3731-4e86-a624-f61dbe7898f9</Id>
     </Book>
-    <Book Series="Daredevil Noir" Number="1" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="Daredevil Noir" Number="1" Volume="2009" Year="2009">
       <Id>813f6610-8267-46fd-a7f2-993b1b4583ce</Id>
     </Book>
-    <Book Series="Daredevil Noir" Number="2" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="Daredevil Noir" Number="2" Volume="2009" Year="2009">
       <Id>4df776de-3bf3-4acf-a740-846ec3ab3277</Id>
     </Book>
-    <Book Series="Daredevil Noir" Number="3" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="Daredevil Noir" Number="3" Volume="2009" Year="2009">
       <Id>9b7c01fa-7411-41e1-8dfe-6a775cafb1eb</Id>
     </Book>
-    <Book Series="Daredevil Noir" Number="4" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="Daredevil Noir" Number="4" Volume="2009" Year="2009">
       <Id>680b9f30-46a1-412f-908d-694dcd9b7834</Id>
     </Book>
-    <Book Series="Daredevil" Number="116" Volume="1998" Year="2009" Format="Main Series">
+    <Book Series="Daredevil" Number="116" Volume="1998" Year="2009">
       <Id>498a998b-1aad-4966-b1cb-23fbc9f83679</Id>
     </Book>
-    <Book Series="Daredevil" Number="117" Volume="1998" Year="2009" Format="Main Series">
+    <Book Series="Daredevil" Number="117" Volume="1998" Year="2009">
       <Id>366d9a1f-9793-45f8-8772-f2563a0a764b</Id>
     </Book>
-    <Book Series="Daredevil" Number="118" Volume="1998" Year="2009" Format="Main Series">
+    <Book Series="Daredevil" Number="118" Volume="1998" Year="2009">
       <Id>57003365-8a9d-42d3-aa8c-284959bdd991</Id>
     </Book>
-    <Book Series="Daredevil" Number="119" Volume="1998" Year="2009" Format="Main Series">
+    <Book Series="Daredevil" Number="119" Volume="1998" Year="2009">
       <Id>4f5678a1-186d-4e14-8a39-e63b11a110fc</Id>
     </Book>
-    <Book Series="Daredevil" Number="500" Volume="1998" Year="2009" Format="Main Series">
+    <Book Series="Daredevil" Number="500" Volume="1998" Year="2009">
       <Id>458e8392-06a3-4384-be4b-9d23de309778</Id>
     </Book>
-    <Book Series="Black Widow: Deadly Origin" Number="1" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Black Widow: Deadly Origin" Number="1" Volume="2010" Year="2010">
       <Id>52bddacf-6302-4e68-8c87-6db0b83d1e71</Id>
     </Book>
-    <Book Series="Black Widow: Deadly Origin" Number="2" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Black Widow: Deadly Origin" Number="2" Volume="2010" Year="2010">
       <Id>df6b8ed0-0bd9-43c6-9c0d-14ebcc4e2d8f</Id>
     </Book>
-    <Book Series="Black Widow: Deadly Origin" Number="3" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Black Widow: Deadly Origin" Number="3" Volume="2010" Year="2010">
       <Id>fd746e4c-d283-4785-a280-930bac6a64a1</Id>
     </Book>
-    <Book Series="Black Widow: Deadly Origin" Number="4" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Black Widow: Deadly Origin" Number="4" Volume="2010" Year="2010">
       <Id>d5ec5b80-5c57-4839-a0e2-b6dff29ad143</Id>
     </Book>
-    <Book Series="Dark Reign: The List - Daredevil" Number="1" Volume="2009" Year="2009" Format="One-Shot">
+    <Book Series="Dark Reign: The List - Daredevil" Number="1" Volume="2009" Year="2009">
       <Id>a72d4456-d3be-46e1-9837-cf402fe1df62</Id>
     </Book>
-    <Book Series="Daredevil" Number="501" Volume="1998" Year="2009" Format="Main Series">
+    <Book Series="Daredevil" Number="501" Volume="1998" Year="2009">
       <Id>7dd97d2e-4593-487c-ac85-2d1e27cd828d</Id>
     </Book>
-    <Book Series="Daredevil" Number="502" Volume="1998" Year="2010" Format="Main Series">
+    <Book Series="Daredevil" Number="502" Volume="1998" Year="2010">
       <Id>88bd6a40-562e-4175-a84d-ecc33b0e7e8d</Id>
     </Book>
-    <Book Series="Daredevil" Number="503" Volume="1998" Year="2010" Format="Main Series">
+    <Book Series="Daredevil" Number="503" Volume="1998" Year="2010">
       <Id>23163b4b-7782-4ac7-84e1-31a97faf3776</Id>
     </Book>
-    <Book Series="Daredevil" Number="504" Volume="1998" Year="2010" Format="Main Series">
+    <Book Series="Daredevil" Number="504" Volume="1998" Year="2010">
       <Id>3d047a21-7de2-4436-96b4-3ea98d31c512</Id>
     </Book>
-    <Book Series="Daredevil" Number="505" Volume="1998" Year="2010" Format="Main Series">
+    <Book Series="Daredevil" Number="505" Volume="1998" Year="2010">
       <Id>73d8dfad-64d4-461e-b0c6-6782e1c319ae</Id>
     </Book>
-    <Book Series="Daredevil" Number="506" Volume="1998" Year="2010" Format="Main Series">
+    <Book Series="Daredevil" Number="506" Volume="1998" Year="2010">
       <Id>5137608d-0c3e-4ed8-ab7f-2d05bba29826</Id>
     </Book>
-    <Book Series="Daredevil" Number="507" Volume="1998" Year="2010" Format="Main Series">
+    <Book Series="Daredevil" Number="507" Volume="1998" Year="2010">
       <Id>815e5db0-1e7a-4831-b554-8f73155f9b1b</Id>
     </Book>
-    <Book Series="Daredevil" Number="508" Volume="1998" Year="2010" Format="Main Series">
+    <Book Series="Daredevil" Number="508" Volume="1998" Year="2010">
       <Id>a40af5e0-cc3e-4052-8a7f-d584b894ef6e</Id>
     </Book>
-    <Book Series="Daredevil" Number="509" Volume="1998" Year="2010" Format="Main Series">
+    <Book Series="Daredevil" Number="509" Volume="1998" Year="2010">
       <Id>d649d5df-3415-4929-bfa0-f58fb96f8c42</Id>
     </Book>
-    <Book Series="Daredevil" Number="510" Volume="1998" Year="2010" Format="Main Series">
+    <Book Series="Daredevil" Number="510" Volume="1998" Year="2010">
       <Id>30067d2f-625a-48e0-8d37-3adc8081889b</Id>
     </Book>
-    <Book Series="Daredevil" Number="511" Volume="1998" Year="2010" Format="Main Series">
+    <Book Series="Daredevil" Number="511" Volume="1998" Year="2010">
       <Id>518b764c-07a0-4ff6-9819-fff6e92d06a0</Id>
     </Book>
-    <Book Series="Daredevil" Number="512" Volume="1998" Year="2011" Format="Main Series">
+    <Book Series="Daredevil" Number="512" Volume="1998" Year="2011">
       <Id>cc00e725-afc0-4eff-9d3e-a2b7f2ea3ea2</Id>
     </Book>
-    <Book Series="Daredevil: Reborn" Number="1" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Daredevil: Reborn" Number="1" Volume="2011" Year="2011">
       <Id>630fd597-52f1-4328-ad28-f795f9be82fc</Id>
     </Book>
-    <Book Series="Daredevil: Reborn" Number="2" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Daredevil: Reborn" Number="2" Volume="2011" Year="2011">
       <Id>5d243bee-3644-4bc6-ad73-c19d11b60643</Id>
     </Book>
-    <Book Series="Daredevil: Reborn" Number="3" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Daredevil: Reborn" Number="3" Volume="2011" Year="2011">
       <Id>059a4d2b-be15-4f05-8af1-2d46b268b6ae</Id>
     </Book>
-    <Book Series="Daredevil: Reborn" Number="4" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Daredevil: Reborn" Number="4" Volume="2011" Year="2011">
       <Id>d524e505-c02a-4ece-880b-f20a0171e876</Id>
     </Book>
-    <Book Series="Daredevil" Number="1" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Daredevil" Number="1" Volume="2011" Year="2011">
       <Id>6cfbd8b1-1328-4070-9b40-2edef3ea2b78</Id>
     </Book>
-    <Book Series="Daredevil" Number="2" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Daredevil" Number="2" Volume="2011" Year="2011">
       <Id>b4abe993-14ae-4fa9-85da-ce17c44e3e4d</Id>
     </Book>
-    <Book Series="Daredevil" Number="3" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Daredevil" Number="3" Volume="2011" Year="2011">
       <Id>6c645f73-65ee-4dc9-b9c3-a67a56ab75e1</Id>
     </Book>
-    <Book Series="Daredevil" Number="4" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Daredevil" Number="4" Volume="2011" Year="2011">
       <Id>cce1f817-867e-4117-8428-803182aec435</Id>
     </Book>
-    <Book Series="Daredevil" Number="5" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Daredevil" Number="5" Volume="2011" Year="2011">
       <Id>0235affb-06c9-4fa0-9097-965e176cf360</Id>
     </Book>
-    <Book Series="Daredevil" Number="6" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Daredevil" Number="6" Volume="2011" Year="2012">
       <Id>62000240-be84-4f16-b638-5457155c753e</Id>
     </Book>
-    <Book Series="Daredevil" Number="7" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Daredevil" Number="7" Volume="2011" Year="2012">
       <Id>32eb6154-a66a-4713-a42b-b89be686ea3d</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="677" Volume="1963" Year="2012" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="677" Volume="1963" Year="2012">
       <Id>8fe56df5-718a-411e-9664-0ba6030a62e9</Id>
     </Book>
-    <Book Series="Daredevil" Number="8" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Daredevil" Number="8" Volume="2011" Year="2012">
       <Id>ee8fd394-4cf9-4157-96f7-d009f78a18e2</Id>
     </Book>
-    <Book Series="Daredevil" Number="9" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Daredevil" Number="9" Volume="2011" Year="2012">
       <Id>97b2fd48-466c-4c43-b509-07b2793e4112</Id>
     </Book>
-    <Book Series="Daredevil" Number="10" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Daredevil" Number="10" Volume="2011" Year="2012">
       <Id>6d68e21c-fd41-42cd-bc4a-34961517fea8</Id>
     </Book>
-    <Book Series="Daredevil" Number="10.1" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Daredevil" Number="10.1" Volume="2011" Year="2012">
       <Id>af46bada-0eac-41b3-a39b-6fc12d8402eb</Id>
     </Book>
-    <Book Series="Avenging Spider-Man" Number="6" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Avenging Spider-Man" Number="6" Volume="2011" Year="2012">
       <Id>f3f23314-2884-474f-b524-82fa084a21b2</Id>
     </Book>
-    <Book Series="The Punisher" Number="10" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="The Punisher" Number="10" Volume="2011" Year="2012">
       <Id>9c3c7981-7a95-49e0-8c72-af0b6dc04a9a</Id>
     </Book>
-    <Book Series="Daredevil" Number="11" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Daredevil" Number="11" Volume="2011" Year="2012">
       <Id>174e76e0-8293-457a-90ee-ba967455527d</Id>
     </Book>
-    <Book Series="Daredevil" Number="12" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Daredevil" Number="12" Volume="2011" Year="2012">
       <Id>72489414-7cc1-4f8c-96a7-be6024f11910</Id>
     </Book>
-    <Book Series="Daredevil" Number="13" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Daredevil" Number="13" Volume="2011" Year="2012">
       <Id>d9fbd03f-f881-4112-ac31-c8312445de10</Id>
     </Book>
-    <Book Series="Daredevil" Number="14" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Daredevil" Number="14" Volume="2011" Year="2012">
       <Id>5d7b7d9d-e71f-4a09-82a6-2649b70a01a1</Id>
     </Book>
-    <Book Series="Daredevil" Number="15" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Daredevil" Number="15" Volume="2011" Year="2012">
       <Id>6ba37812-a946-4e85-8624-10adca268be5</Id>
     </Book>
-    <Book Series="Daredevil" Number="16" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Daredevil" Number="16" Volume="2011" Year="2012">
       <Id>425eeeca-3e06-4cd9-b3a3-211ab0524591</Id>
     </Book>
-    <Book Series="Daredevil" Number="17" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Daredevil" Number="17" Volume="2011" Year="2012">
       <Id>d9316ef0-c66b-4fa4-8fba-c616b7a732f2</Id>
     </Book>
-    <Book Series="Daredevil Annual" Number="1" Volume="2012" Year="2012" Format="Annual">
+    <Book Series="Daredevil Annual" Number="1" Volume="2012" Year="2012">
       <Id>7ce3fbde-0a24-4516-bbc0-7c200f7d3df0</Id>
     </Book>
-    <Book Series="Wolverine Annual" Number="1" Volume="2012" Year="2012" Format="Annual">
+    <Book Series="Wolverine Annual" Number="1" Volume="2012" Year="2012">
       <Id>13ffa23f-665f-4e83-8df5-c178bccc5ffc</Id>
     </Book>
-    <Book Series="Daredevil" Number="18" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Daredevil" Number="18" Volume="2011" Year="2012">
       <Id>bffa6482-d80b-45f4-b868-683b7e7e7610</Id>
     </Book>
-    <Book Series="Daredevil" Number="19" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Daredevil" Number="19" Volume="2011" Year="2012">
       <Id>a16cd9bf-0c84-45ae-888b-e96ef23fd76f</Id>
     </Book>
-    <Book Series="Daredevil" Number="20" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Daredevil" Number="20" Volume="2011" Year="2013">
       <Id>b9029ed8-bfa6-44a7-bd5c-d2aa735186dc</Id>
     </Book>
-    <Book Series="Daredevil" Number="21" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Daredevil" Number="21" Volume="2011" Year="2013">
       <Id>ed1030b2-3627-4d1d-ace1-baa1965f65b0</Id>
     </Book>
-    <Book Series="Daredevil" Number="22" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Daredevil" Number="22" Volume="2011" Year="2013">
       <Id>a00b9ca5-1370-418a-af47-1a6daa113d32</Id>
     </Book>
-    <Book Series="Daredevil" Number="23" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Daredevil" Number="23" Volume="2011" Year="2013">
       <Id>bb408aa8-37c7-4b47-8038-4dc85ca218ad</Id>
     </Book>
-    <Book Series="Daredevil" Number="24" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Daredevil" Number="24" Volume="2011" Year="2013">
       <Id>b2c3a2ff-92ad-447a-92fc-b8a48222264e</Id>
     </Book>
-    <Book Series="Daredevil" Number="25" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Daredevil" Number="25" Volume="2011" Year="2013">
       <Id>eb7c44a3-f044-4d15-9aac-72c5bf72218a</Id>
     </Book>
-    <Book Series="Daredevil" Number="26" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Daredevil" Number="26" Volume="2011" Year="2013">
       <Id>c1fbbbcb-fe3a-4e45-aec0-2b052de893e1</Id>
     </Book>
-    <Book Series="Daredevil" Number="27" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Daredevil" Number="27" Volume="2011" Year="2013">
       <Id>ea1e5708-63c5-4b3b-868c-e16c7e14af8b</Id>
     </Book>
-    <Book Series="Daredevil" Number="28" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Daredevil" Number="28" Volume="2011" Year="2013">
       <Id>b4040704-ede6-4d59-a64f-e5a372d60a32</Id>
     </Book>
-    <Book Series="Daredevil" Number="29" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Daredevil" Number="29" Volume="2011" Year="2013">
       <Id>1dd0a9c9-1fb6-46b2-b0ff-7facfa7f0206</Id>
     </Book>
-    <Book Series="Daredevil" Number="30" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Daredevil" Number="30" Volume="2011" Year="2013">
       <Id>1ff421d3-3872-48c1-a328-3d62ccad7cb8</Id>
     </Book>
-    <Book Series="Daredevil" Number="31" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Daredevil" Number="31" Volume="2011" Year="2013">
       <Id>d005b945-5277-4bd9-8657-eda4a2b7e557</Id>
     </Book>
-    <Book Series="Daredevil" Number="32" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Daredevil" Number="32" Volume="2011" Year="2013">
       <Id>d7aec916-67e0-4890-9044-91512fdb17c6</Id>
     </Book>
-    <Book Series="Daredevil" Number="33" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Daredevil" Number="33" Volume="2011" Year="2014">
       <Id>4ccf70f1-4458-4173-8c99-0a1970c0ed02</Id>
     </Book>
-    <Book Series="Daredevil" Number="34" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Daredevil" Number="34" Volume="2011" Year="2014">
       <Id>aee86f50-13a2-4f1e-95f2-ca176dd423ef</Id>
     </Book>
-    <Book Series="Daredevil" Number="35" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Daredevil" Number="35" Volume="2011" Year="2014">
       <Id>62e4b1fb-f338-483c-886e-5ac6b468873a</Id>
     </Book>
-    <Book Series="Daredevil" Number="36" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Daredevil" Number="36" Volume="2011" Year="2014">
       <Id>f9492fd6-072d-4568-8833-ff7e0bec9593</Id>
     </Book>
-    <Book Series="Daredevil: Dark Nights" Number="1" Volume="2013" Year="2013" Format="Limited Series">
+    <Book Series="Daredevil: Dark Nights" Number="1" Volume="2013" Year="2013">
       <Id>4f71ce3b-13c3-42ac-8aa1-507a888946e4</Id>
     </Book>
-    <Book Series="Daredevil: Dark Nights" Number="2" Volume="2013" Year="2013" Format="Limited Series">
+    <Book Series="Daredevil: Dark Nights" Number="2" Volume="2013" Year="2013">
       <Id>2a09d379-671c-401f-b527-8126ddca7f13</Id>
     </Book>
-    <Book Series="Daredevil: Dark Nights" Number="3" Volume="2013" Year="2013" Format="Limited Series">
+    <Book Series="Daredevil: Dark Nights" Number="3" Volume="2013" Year="2013">
       <Id>89faebc9-0bbf-40ba-9205-d15d5cbb7fd1</Id>
     </Book>
-    <Book Series="Daredevil: Dark Nights" Number="4" Volume="2013" Year="2013" Format="Limited Series">
+    <Book Series="Daredevil: Dark Nights" Number="4" Volume="2013" Year="2013">
       <Id>a260678d-23b7-479b-a403-d5e03f4549ca</Id>
     </Book>
-    <Book Series="Daredevil: Dark Nights" Number="5" Volume="2013" Year="2013" Format="Limited Series">
+    <Book Series="Daredevil: Dark Nights" Number="5" Volume="2013" Year="2013">
       <Id>b1dedd85-92cb-4373-b206-c6c0b200b5cb</Id>
     </Book>
-    <Book Series="Daredevil: Dark Nights" Number="6" Volume="2013" Year="2014" Format="Limited Series">
+    <Book Series="Daredevil: Dark Nights" Number="6" Volume="2013" Year="2014">
       <Id>4401fb1d-93ab-4a41-8e62-b887a50cf6ca</Id>
     </Book>
-    <Book Series="Daredevil: Dark Nights" Number="7" Volume="2013" Year="2014" Format="Limited Series">
+    <Book Series="Daredevil: Dark Nights" Number="7" Volume="2013" Year="2014">
       <Id>930aef5d-9d6d-4c5b-92d4-de1992fc646e</Id>
     </Book>
-    <Book Series="Daredevil: Dark Nights" Number="8" Volume="2013" Year="2014" Format="Limited Series">
+    <Book Series="Daredevil: Dark Nights" Number="8" Volume="2013" Year="2014">
       <Id>dc1c3317-e09e-41b5-9098-464853c7339e</Id>
     </Book>
-    <Book Series="Daredevil: End of Days" Number="1" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Daredevil: End of Days" Number="1" Volume="2012" Year="2012">
       <Id>e51e877d-d272-4dd6-b878-6f68c21f861a</Id>
     </Book>
-    <Book Series="Daredevil: End of Days" Number="2" Volume="2012" Year="2013" Format="Limited Series">
+    <Book Series="Daredevil: End of Days" Number="2" Volume="2012" Year="2013">
       <Id>3e98958e-0741-48dc-87e5-3f0164453971</Id>
     </Book>
-    <Book Series="Daredevil: End of Days" Number="3" Volume="2012" Year="2013" Format="Limited Series">
+    <Book Series="Daredevil: End of Days" Number="3" Volume="2012" Year="2013">
       <Id>64284d02-6737-443c-b5cb-91d9cdc3e2e6</Id>
     </Book>
-    <Book Series="Daredevil: End of Days" Number="4" Volume="2012" Year="2013" Format="Limited Series">
+    <Book Series="Daredevil: End of Days" Number="4" Volume="2012" Year="2013">
       <Id>340b8e67-622b-454b-b519-4a8967506b02</Id>
     </Book>
-    <Book Series="Daredevil: End of Days" Number="5" Volume="2012" Year="2013" Format="Limited Series">
+    <Book Series="Daredevil: End of Days" Number="5" Volume="2012" Year="2013">
       <Id>fd157735-1c1f-4e41-9888-20c4962f83ba</Id>
     </Book>
-    <Book Series="Daredevil: End of Days" Number="6" Volume="2012" Year="2013" Format="Limited Series">
+    <Book Series="Daredevil: End of Days" Number="6" Volume="2012" Year="2013">
       <Id>a3b951c7-6870-4a20-a314-007b92c723a0</Id>
     </Book>
-    <Book Series="Daredevil: End of Days" Number="7" Volume="2012" Year="2013" Format="Limited Series">
+    <Book Series="Daredevil: End of Days" Number="7" Volume="2012" Year="2013">
       <Id>f1e6c1c1-3382-47de-97b3-a3b27131bbdd</Id>
     </Book>
-    <Book Series="Daredevil: End of Days" Number="8" Volume="2012" Year="2013" Format="Limited Series">
+    <Book Series="Daredevil: End of Days" Number="8" Volume="2012" Year="2013">
       <Id>274fb14d-82e4-47a5-9b40-11b5ac08e767</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Incredible Hulk/Incredible Hulk 001.cbl
+++ b/Marvel/Characters/unsorted/Incredible Hulk/Incredible Hulk 001.cbl
@@ -2,898 +2,898 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Incredible Hulk 1</Name>
   <Books>
-    <Book Series="The Incredible Hulk" Number="1" Volume="1962" Year="1962" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="1" Volume="1962" Year="1962">
       <Id>23324bc3-f45f-4226-a474-e51c9897d9f2</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="2" Volume="1962" Year="1962" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="2" Volume="1962" Year="1962">
       <Id>eb3d0b23-be06-4704-afc3-b2015b362b69</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="3" Volume="1962" Year="1962" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="3" Volume="1962" Year="1962">
       <Id>30f2265c-1c0a-4fbe-b9b2-fd9db3fba1b5</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="4" Volume="1962" Year="1962" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="4" Volume="1962" Year="1962">
       <Id>34a61208-2b86-483a-856c-3eb2e8133005</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="5" Volume="1962" Year="1963" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="5" Volume="1962" Year="1963">
       <Id>40260286-33f1-4342-b100-13a43937dc37</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="12" Volume="1961" Year="1963" Format="Main Series">
+    <Book Series="Fantastic Four" Number="12" Volume="1961" Year="1963">
       <Id>e757ee94-b229-4e42-b411-025e89e77adc</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="6" Volume="1962" Year="1963" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="6" Volume="1962" Year="1963">
       <Id>7238d383-a2c6-4b85-a13d-776113aa74e6</Id>
     </Book>
-    <Book Series="The Avengers" Number="1" Volume="1963" Year="1963" Format="Main Series">
+    <Book Series="The Avengers" Number="1" Volume="1963" Year="1963">
       <Id>8cf6b924-4620-4658-804f-a313c48d53b1</Id>
     </Book>
-    <Book Series="The Avengers" Number="2" Volume="1963" Year="1963" Format="Main Series">
+    <Book Series="The Avengers" Number="2" Volume="1963" Year="1963">
       <Id>4a9e07c7-cfe4-4a85-9733-9c991f8d0622</Id>
     </Book>
-    <Book Series="The Avengers" Number="3" Volume="1963" Year="1964" Format="Main Series">
+    <Book Series="The Avengers" Number="3" Volume="1963" Year="1964">
       <Id>1b1de360-7a6a-423a-aa77-a514d09ac1c7</Id>
     </Book>
-    <Book Series="The Avengers" Number="5" Volume="1963" Year="1964" Format="Main Series">
+    <Book Series="The Avengers" Number="5" Volume="1963" Year="1964">
       <Id>dd2a211b-788b-4e74-88ad-678df0e0874c</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="14" Volume="1963" Year="1964" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="14" Volume="1963" Year="1964">
       <Id>a1d3bd42-14dd-4721-b9b2-547f5f3d031e</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="25" Volume="1961" Year="1964" Format="Main Series">
+    <Book Series="Fantastic Four" Number="25" Volume="1961" Year="1964">
       <Id>74fe6185-a504-45d1-9a52-d0117f006406</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="26" Volume="1961" Year="1964" Format="Main Series">
+    <Book Series="Fantastic Four" Number="26" Volume="1961" Year="1964">
       <Id>dd149eaa-c799-49e0-9005-a4ccab14ec27</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="59" Volume="1959" Year="1964" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="59" Volume="1959" Year="1964">
       <Id>e4e2c373-a698-44eb-9ad6-a6b5bda2e634</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="60" Volume="1959" Year="1964" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="60" Volume="1959" Year="1964">
       <Id>2634b5bc-d359-42c9-bc38-738c5e959fca</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="61" Volume="1959" Year="1964" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="61" Volume="1959" Year="1964">
       <Id>cf0f4f6d-787d-43ab-a565-601c9ee4c3ab</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="62" Volume="1959" Year="1964" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="62" Volume="1959" Year="1964">
       <Id>8511ea55-3aa6-4b77-b282-0b91e2c63094</Id>
     </Book>
-    <Book Series="Journey into Mystery" Number="112" Volume="1952" Year="1965" Format="Main Series">
+    <Book Series="Journey into Mystery" Number="112" Volume="1952" Year="1965">
       <Id>56c2c848-0621-4c88-bbfa-c4d8cec3487f</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="63" Volume="1959" Year="1965" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="63" Volume="1959" Year="1965">
       <Id>e8513f4d-bca3-4dfd-9177-29db49f5f88d</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="64" Volume="1959" Year="1965" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="64" Volume="1959" Year="1965">
       <Id>738d2738-8fd1-4f71-af0e-64a02191bcf3</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="65" Volume="1959" Year="1965" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="65" Volume="1959" Year="1965">
       <Id>5ce08e79-cd8e-439b-8b7c-a7754ab35695</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="66" Volume="1959" Year="1965" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="66" Volume="1959" Year="1965">
       <Id>65d9b1ea-0bd1-4cd0-b54d-4f4b55bd50cb</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="67" Volume="1959" Year="1965" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="67" Volume="1959" Year="1965">
       <Id>05f11dc5-6755-4f98-9db4-c57a41efc4c5</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="68" Volume="1959" Year="1965" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="68" Volume="1959" Year="1965">
       <Id>4e96de9e-ad06-47ec-b017-8cd88747648d</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="69" Volume="1959" Year="1965" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="69" Volume="1959" Year="1965">
       <Id>58e96d60-571f-4297-98c3-d43330bbc555</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="70" Volume="1959" Year="1965" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="70" Volume="1959" Year="1965">
       <Id>1507ebe0-c0bc-414e-83dd-a815e768672e</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="71" Volume="1959" Year="1965" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="71" Volume="1959" Year="1965">
       <Id>7d9a74c4-abcd-4a73-a7c3-29723d182263</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="72" Volume="1959" Year="1965" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="72" Volume="1959" Year="1965">
       <Id>da144a45-d818-42d7-8966-b596767aa4f4</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="73" Volume="1959" Year="1965" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="73" Volume="1959" Year="1965">
       <Id>a5c09369-a098-46dc-92b3-0986da6eb90b</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="74" Volume="1959" Year="1965" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="74" Volume="1959" Year="1965">
       <Id>a141d8cb-c742-4707-84a8-2d2717693ded</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="75" Volume="1959" Year="1966" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="75" Volume="1959" Year="1966">
       <Id>1622118d-8b2c-4ee3-9d0e-16fe12616de6</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="76" Volume="1959" Year="1966" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="76" Volume="1959" Year="1966">
       <Id>7d31670c-53aa-452a-9467-1dbbd79979cb</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="77" Volume="1959" Year="1966" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="77" Volume="1959" Year="1966">
       <Id>ede92d12-9934-43b1-98c5-65ae3a3732b7</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="78" Volume="1959" Year="1966" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="78" Volume="1959" Year="1966">
       <Id>0db6c7ec-2ddf-4a65-b571-25b27b76bfff</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="79" Volume="1959" Year="1966" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="79" Volume="1959" Year="1966">
       <Id>2600f14d-8347-445e-9a86-f8db0e95e30f</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="80" Volume="1959" Year="1966" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="80" Volume="1959" Year="1966">
       <Id>d8009422-8ccb-4034-8201-6fedfe022a5c</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="81" Volume="1959" Year="1966" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="81" Volume="1959" Year="1966">
       <Id>6ef5e154-b4d2-4898-a5f9-68ea51cad881</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="82" Volume="1959" Year="1966" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="82" Volume="1959" Year="1966">
       <Id>28a11cbc-ffff-4a8f-b1e5-f18a41ca8a0b</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="83" Volume="1959" Year="1966" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="83" Volume="1959" Year="1966">
       <Id>0a0275c7-0f94-4f65-bf32-818827121599</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="84" Volume="1959" Year="1966" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="84" Volume="1959" Year="1966">
       <Id>38f39146-a6d4-40f6-9f5d-70d35f87bc45</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="3" Volume="1964" Year="1966" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="3" Volume="1964" Year="1966">
       <Id>a438f172-6f25-41e1-a578-e339113a02a4</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="85" Volume="1959" Year="1966" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="85" Volume="1959" Year="1966">
       <Id>7b31f726-16c8-4299-b458-bd6ba134d167</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="86" Volume="1959" Year="1966" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="86" Volume="1959" Year="1966">
       <Id>c22d9826-0e51-468b-8a7f-41920abb377b</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="87" Volume="1959" Year="1967" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="87" Volume="1959" Year="1967">
       <Id>7cfc2d71-9f08-49b2-9cf9-3e71f734a1bf</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="88" Volume="1959" Year="1967" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="88" Volume="1959" Year="1967">
       <Id>4bca007f-68b0-45a1-a169-c51bc31825b3</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="89" Volume="1959" Year="1967" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="89" Volume="1959" Year="1967">
       <Id>e4e90320-b10a-4fe9-b485-49d9cc4ff8ae</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="90" Volume="1959" Year="1967" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="90" Volume="1959" Year="1967">
       <Id>849fce13-ec31-4285-a791-e1aad2f0b30f</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="91" Volume="1959" Year="1967" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="91" Volume="1959" Year="1967">
       <Id>3386e6c6-8351-4f65-85d9-7b1ec2b83629</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="92" Volume="1959" Year="1967" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="92" Volume="1959" Year="1967">
       <Id>09747135-f117-4de6-875c-88d8c5783f5b</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="93" Volume="1959" Year="1967" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="93" Volume="1959" Year="1967">
       <Id>cc213d99-2bfd-4431-ba0e-7c9e56f5b21b</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="94" Volume="1959" Year="1967" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="94" Volume="1959" Year="1967">
       <Id>30977d6f-5f9d-474b-b6ea-b5fbd9b69959</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="95" Volume="1959" Year="1967" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="95" Volume="1959" Year="1967">
       <Id>090ce149-1d6c-4d27-8c5e-91fef8deea50</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="96" Volume="1959" Year="1967" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="96" Volume="1959" Year="1967">
       <Id>41127055-1c57-4792-882b-0779494a57b1</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="97" Volume="1959" Year="1967" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="97" Volume="1959" Year="1967">
       <Id>290e179d-e641-4f4d-9273-6b58faa094bd</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="98" Volume="1959" Year="1967" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="98" Volume="1959" Year="1967">
       <Id>8ef6b7fa-0e52-4777-9685-df3a84f0b83f</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="99" Volume="1959" Year="1968" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="99" Volume="1959" Year="1968">
       <Id>06588579-3c97-44f4-a51b-1d95c90c89a0</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="100" Volume="1959" Year="1968" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="100" Volume="1959" Year="1968">
       <Id>325b77e5-2801-4f6a-8a8f-af9d932c723f</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="101" Volume="1959" Year="1968" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="101" Volume="1959" Year="1968">
       <Id>c7449ddf-4132-40d5-894e-8b48caad94c7</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="102" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="102" Volume="1968" Year="1968">
       <Id>d65df262-f7ad-43a5-afe0-87ecf8752fd4</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="103" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="103" Volume="1968" Year="1968">
       <Id>72fdaa27-d090-43c5-83da-c934e4383bd3</Id>
     </Book>
-    <Book Series="Captain America" Number="110" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="Captain America" Number="110" Volume="1968" Year="1969">
       <Id>68a8ac5b-b3c8-433e-ba09-c38e05947f8e</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="104" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="104" Volume="1968" Year="1968">
       <Id>36469ffc-8390-47db-8267-10af835abf8c</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="105" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="105" Volume="1968" Year="1968">
       <Id>367ec05c-17ec-4d99-9cea-cf2f16dfea98</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="106" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="106" Volume="1968" Year="1968">
       <Id>d7dd0c82-5309-456b-b80c-c812a12531b1</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="107" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="107" Volume="1968" Year="1968">
       <Id>3ef77c9d-3619-4004-99db-325de257046d</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="108" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="108" Volume="1968" Year="1968">
       <Id>810b44bc-c183-4b98-b90c-a98bfdcdf001</Id>
     </Book>
-    <Book Series="The Incredible Hulk Annual" Number="1" Volume="1968" Year="1968" Format="Annual">
+    <Book Series="The Incredible Hulk Annual" Number="1" Volume="1968" Year="1968">
       <Id>2cf00c62-d9ab-4d40-bce8-cd7b7a04757d</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="109" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="109" Volume="1968" Year="1968">
       <Id>4f4b3b59-1b5e-4a06-83f8-29871dd711e7</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="110" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="110" Volume="1968" Year="1968">
       <Id>c9d974cc-b8c0-40ad-91cd-53c5798afb7a</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="111" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="111" Volume="1968" Year="1969">
       <Id>87907ce0-397a-4c0f-9e73-65fcc8e6abef</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="112" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="112" Volume="1968" Year="1969">
       <Id>7dcb6cf8-1726-49eb-bf65-e95985dc6ea9</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="113" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="113" Volume="1968" Year="1969">
       <Id>ac06ef30-2418-426c-be24-7f972c3f5184</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="114" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="114" Volume="1968" Year="1969">
       <Id>cba3a4cd-453a-49cd-b0d7-f9a0b1683882</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="115" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="115" Volume="1968" Year="1969">
       <Id>19f65128-8e6a-4a65-915b-504387ac67ad</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="116" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="116" Volume="1968" Year="1969">
       <Id>ab382904-7de1-4e3e-b113-ccaf76b2ef37</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="117" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="117" Volume="1968" Year="1969">
       <Id>12740da6-8716-4078-af16-0ef06e1370ce</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="118" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="118" Volume="1968" Year="1969">
       <Id>0b886f95-4ac5-47b6-854e-8510e0034bfd</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="119" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="119" Volume="1968" Year="1969">
       <Id>e65ef8d7-1288-4390-b29a-394fb005dd1f</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="120" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="120" Volume="1968" Year="1969">
       <Id>a5df4c2e-ab5e-4429-8f02-985949f9be02</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="121" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="121" Volume="1968" Year="1969">
       <Id>93f238a7-84f9-4f2b-b785-63e4d1bc7395</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="122" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="122" Volume="1968" Year="1969">
       <Id>ac646b31-a9ff-4e0c-9721-ad27607a5acb</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="123" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="123" Volume="1968" Year="1970">
       <Id>43fefa5a-aa34-4fdc-9941-c64ef4dd187c</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="124" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="124" Volume="1968" Year="1970">
       <Id>e6f63363-6863-472f-b167-21a779ece7e0</Id>
     </Book>
-    <Book Series="The X-Men" Number="66" Volume="1963" Year="1970" Format="Main Series">
+    <Book Series="The X-Men" Number="66" Volume="1963" Year="1970">
       <Id>34fa3055-7c14-4768-9693-07294ae449f6</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="125" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="125" Volume="1968" Year="1970">
       <Id>41d98e3a-2134-498b-b740-b93b36958e60</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="126" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="126" Volume="1968" Year="1970">
       <Id>72a72578-4682-4452-b92b-7d4cd29f61e2</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="127" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="127" Volume="1968" Year="1970">
       <Id>07059b00-36ee-4b20-8f58-a6a8581ec166</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="128" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="128" Volume="1968" Year="1970">
       <Id>6935e0c4-ccc8-4fc7-82b6-891c1d9ad416</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="129" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="129" Volume="1968" Year="1970">
       <Id>79005ee2-7476-41f2-a302-4fa83b654e0f</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="130" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="130" Volume="1968" Year="1970">
       <Id>17825155-76a1-4190-aff4-2b34cd2c4d7c</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="131" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="131" Volume="1968" Year="1970">
       <Id>d024a371-e0ab-48b2-af81-783f4929b2ba</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="132" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="132" Volume="1968" Year="1970">
       <Id>4845174f-3b8b-426a-a56b-4c6c58197316</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="133" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="133" Volume="1968" Year="1970">
       <Id>30fe927f-f3ef-41f6-b666-966e5e6b2a96</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="134" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="134" Volume="1968" Year="1970">
       <Id>3d8bc1c2-8777-453f-9793-e842b98d3276</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="135" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="135" Volume="1968" Year="1971">
       <Id>9d9b77e0-77bf-4133-a9c7-aa8d95b1db60</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="136" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="136" Volume="1968" Year="1971">
       <Id>41e0c86e-11cb-47c1-b570-59c6b08f1eb9</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="137" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="137" Volume="1968" Year="1971">
       <Id>bb3a927e-659f-4147-b02b-276f3841d881</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="138" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="138" Volume="1968" Year="1971">
       <Id>95d656d8-1bca-4771-bf27-ad54c4571222</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="34" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="34" Volume="1968" Year="1971">
       <Id>eab58567-b521-4025-b4bc-879a8d1235ab</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="35" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="35" Volume="1968" Year="1971">
       <Id>edb54501-068f-4cc8-93f5-66386c48f4ab</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="139" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="139" Volume="1968" Year="1971">
       <Id>cdd21ba9-978a-45d6-a191-6d1c5b488f86</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="111" Volume="1961" Year="1971" Format="Main Series">
+    <Book Series="Fantastic Four" Number="111" Volume="1961" Year="1971">
       <Id>4360b27c-11d3-456e-b801-28e7214aa305</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="112" Volume="1961" Year="1971" Format="Main Series">
+    <Book Series="Fantastic Four" Number="112" Volume="1961" Year="1971">
       <Id>1da1008e-cd52-4175-9f53-7d56b9663b7b</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="113" Volume="1961" Year="1971" Format="Main Series">
+    <Book Series="Fantastic Four" Number="113" Volume="1961" Year="1971">
       <Id>a3f11be1-8767-46fb-831c-b07ee59b09f4</Id>
     </Book>
-    <Book Series="Marvel Feature" Number="1" Volume="1971" Year="1971" Format="Main Series">
+    <Book Series="Marvel Feature" Number="1" Volume="1971" Year="1971">
       <Id>8e2d1684-3ad8-428c-a4c6-235d5b00a3bd</Id>
     </Book>
-    <Book Series="Marvel Feature" Number="2" Volume="1971" Year="1972" Format="Main Series">
+    <Book Series="Marvel Feature" Number="2" Volume="1971" Year="1972">
       <Id>16df5105-ef87-48bd-9562-e2326a5794d7</Id>
     </Book>
-    <Book Series="The Avengers" Number="88" Volume="1963" Year="1971" Format="Main Series">
+    <Book Series="The Avengers" Number="88" Volume="1963" Year="1971">
       <Id>83bd6468-38f7-4097-a5ae-81af499e8123</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="140" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="140" Volume="1968" Year="1971">
       <Id>99065bf5-13b9-4e1e-b296-15bde759a0b6</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="141" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="141" Volume="1968" Year="1971">
       <Id>b649c935-d0dd-448b-9c94-73265edc7263</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="142" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="142" Volume="1968" Year="1971">
       <Id>682701a3-fae4-43aa-8933-dd978f1c5a2f</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="143" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="143" Volume="1968" Year="1971">
       <Id>44d80e06-7686-4693-a9ab-f37ecd0924cb</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="144" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="144" Volume="1968" Year="1971">
       <Id>f52c6ed9-6449-4f82-b035-9cd7e8867b98</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="145" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="145" Volume="1968" Year="1971">
       <Id>488a9c53-b700-4167-804d-f2a3103366b5</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="146" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="146" Volume="1968" Year="1971">
       <Id>012665c7-d540-473b-a802-a6cb3da119d4</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="147" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="147" Volume="1968" Year="1972">
       <Id>45c6151b-e1c1-4abc-a809-64ec3bb554fe</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="148" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="148" Volume="1968" Year="1972">
       <Id>7af052da-e0f5-4a5b-8a8a-fe5479496e29</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="149" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="149" Volume="1968" Year="1972">
       <Id>068349cb-2a48-4d28-a295-8ccad83bf5d4</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="150" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="150" Volume="1968" Year="1972">
       <Id>8415cd8e-8f27-4cb4-905b-b46dbc5e79ac</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="151" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="151" Volume="1968" Year="1972">
       <Id>73b09d86-3c11-482a-ad1a-a763b45264e8</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="152" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="152" Volume="1968" Year="1972">
       <Id>a2a1d9cc-0c35-499e-b403-000f2dfb6733</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="153" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="153" Volume="1968" Year="1972">
       <Id>8290401a-0824-465b-91b2-461121f73739</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="154" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="154" Volume="1968" Year="1972">
       <Id>bb923bcc-45d8-44d4-98ce-6a13108a165d</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="155" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="155" Volume="1968" Year="1972">
       <Id>4dcf5652-4e1d-4604-8bcd-7a38e83b0e61</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="156" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="156" Volume="1968" Year="1972">
       <Id>afc47d39-6982-476f-8e42-5b294925c71a</Id>
     </Book>
-    <Book Series="Marvel Feature" Number="3" Volume="1971" Year="1972" Format="Main Series">
+    <Book Series="Marvel Feature" Number="3" Volume="1971" Year="1972">
       <Id>0c8f4ba0-5ec5-428a-a26b-0221ed3581d9</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="157" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="157" Volume="1968" Year="1972">
       <Id>fce72f7f-7d1a-47b7-bc06-5a0bdbd0cb01</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="158" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="158" Volume="1968" Year="1972">
       <Id>a4af3464-f739-4639-a354-34b9b5874378</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="159" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="159" Volume="1968" Year="1973">
       <Id>c442dcaa-93a8-42bb-bf3f-fbe5af9f2a31</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="160" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="160" Volume="1968" Year="1973">
       <Id>d2031d4a-6bc7-4c30-adba-888e7569a094</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="161" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="161" Volume="1968" Year="1973">
       <Id>e010b340-03af-48cb-b796-3bbd8f10ba00</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="162" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="162" Volume="1968" Year="1973">
       <Id>503d72dd-241e-4543-a2e6-15e90e844b4a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="119" Volume="1963" Year="1973" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="119" Volume="1963" Year="1973">
       <Id>a7915d7b-53f9-44b3-ad5b-68c019fe7720</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="120" Volume="1963" Year="1973" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="120" Volume="1963" Year="1973">
       <Id>fa8e8c9f-204b-4e99-b8dd-7a9b062f8cbc</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="163" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="163" Volume="1968" Year="1973">
       <Id>c8a16477-61ce-418e-944d-a9ebdf720fc7</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="164" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="164" Volume="1968" Year="1973">
       <Id>d6023d93-9f93-4aea-b635-0b0a559cda25</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="165" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="165" Volume="1968" Year="1973">
       <Id>adcf325f-a35b-4970-b900-a0e95e3eefc5</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="166" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="166" Volume="1968" Year="1973">
       <Id>a02c8aaf-b29a-464f-97d3-d53c20cb8f6b</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="167" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="167" Volume="1968" Year="1973">
       <Id>3ac32f42-a636-4981-83c3-649875cc048f</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="168" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="168" Volume="1968" Year="1973">
       <Id>4f4f68e6-9a2d-4fcd-a7f9-81821af73925</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="169" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="169" Volume="1968" Year="1973">
       <Id>4107ab1f-575e-4b71-92d2-b3bae4e70c58</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="170" Volume="1968" Year="1973" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="170" Volume="1968" Year="1973">
       <Id>8f296a66-911b-41b4-ae23-17c3c1b57b46</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="171" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="171" Volume="1968" Year="1974">
       <Id>dd685d14-9c12-4a05-8eb5-1bc03b48da5f</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="172" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="172" Volume="1968" Year="1974">
       <Id>ff0c65ac-0af7-454e-8678-0df36e794564</Id>
     </Book>
-    <Book Series="Marvel Feature" Number="11" Volume="1971" Year="1973" Format="Main Series">
+    <Book Series="Marvel Feature" Number="11" Volume="1971" Year="1973">
       <Id>ebf3c2f6-0bee-40c8-b144-57709145fbd4</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="18" Volume="1972" Year="1974" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="18" Volume="1972" Year="1974">
       <Id>dc1cf49f-b4f1-40df-9759-4ad1361fa231</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="173" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="173" Volume="1968" Year="1974">
       <Id>d384845f-6771-4fe1-b184-c51d7c02a7f3</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="174" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="174" Volume="1968" Year="1974">
       <Id>644622d4-108c-4213-a6a9-f7d7c28181a8</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="175" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="175" Volume="1968" Year="1974">
       <Id>72c49ee8-0f51-4f63-85ba-7fa415e7a285</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="176" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="176" Volume="1968" Year="1974">
       <Id>1d4b4e27-ca59-4e17-abab-35e8b1067738</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="177" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="177" Volume="1968" Year="1974">
       <Id>5d66fa1e-be25-4105-8054-1ba0e4b4e420</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="178" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="178" Volume="1968" Year="1974">
       <Id>ea6291ff-af57-4450-b86f-d9eee6074f87</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="179" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="179" Volume="1968" Year="1974">
       <Id>81bb60df-d00d-45a5-b803-4733a74eb884</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="180" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="180" Volume="1968" Year="1974">
       <Id>b2b7de8c-9315-422d-8218-7903d7bdc498</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="181" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="181" Volume="1968" Year="1974">
       <Id>ec40115a-0de9-4f78-ae31-56d426f3dfcb</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="182" Volume="1968" Year="1974" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="182" Volume="1968" Year="1974">
       <Id>5ab031d2-05a5-406f-a413-e1b1a9f718ef</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="183" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="183" Volume="1968" Year="1975">
       <Id>677bae72-8fe3-450c-8c7b-5a57f1d6e677</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="27" Volume="1972" Year="1974" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="27" Volume="1972" Year="1974">
       <Id>45145d7d-c730-482c-bddc-0a3614550518</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="184" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="184" Volume="1968" Year="1975">
       <Id>ebdc8534-06a7-4b1c-8546-dcc2266a53c8</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="185" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="185" Volume="1968" Year="1975">
       <Id>4cd4f954-da43-4ccb-8d2d-2ab8cf6a688c</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="186" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="186" Volume="1968" Year="1975">
       <Id>2f05e1f2-ade0-49cd-a4f7-144117524c66</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="187" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="187" Volume="1968" Year="1975">
       <Id>71d0199f-2226-4328-9d36-ae05cb0082b1</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="188" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="188" Volume="1968" Year="1975">
       <Id>1ca89615-d4f6-4d59-8642-4e608722f740</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="189" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="189" Volume="1968" Year="1975">
       <Id>e5602e8f-fb78-4ea4-8e0d-820d5d5e018f</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="190" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="190" Volume="1968" Year="1975">
       <Id>b33ac22e-01b7-41ce-9143-e7aa8cf5fbec</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="191" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="191" Volume="1968" Year="1975">
       <Id>530e84bf-0a1f-4d53-910a-46c6220aa203</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="192" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="192" Volume="1968" Year="1975">
       <Id>ca0ce35b-e021-452a-9f3b-4d71ac282b86</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="193" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="193" Volume="1968" Year="1975">
       <Id>bd88a3e6-046b-448d-81e6-ad5ab239ddfe</Id>
     </Book>
-    <Book Series="The Incredible Hulk Annual" Number="5" Volume="1968" Year="1976" Format="Annual">
+    <Book Series="The Incredible Hulk Annual" Number="5" Volume="1968" Year="1976">
       <Id>f8a02fcf-4191-4b04-b384-a814bfa5ad10</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="194" Volume="1968" Year="1975" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="194" Volume="1968" Year="1975">
       <Id>30aa3949-4e1e-4306-b0ae-3a6a4fc2d366</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="166" Volume="1961" Year="1976" Format="Main Series">
+    <Book Series="Fantastic Four" Number="166" Volume="1961" Year="1976">
       <Id>c97e99c3-86a3-4806-bf9e-38d788579d2f</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="167" Volume="1961" Year="1976" Format="Main Series">
+    <Book Series="Fantastic Four" Number="167" Volume="1961" Year="1976">
       <Id>58cc2c3b-9f69-4184-8957-2170f9d3e6aa</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="195" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="195" Volume="1968" Year="1976">
       <Id>7754108f-d3d5-45b4-a099-b1234786d3ed</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="196" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="196" Volume="1968" Year="1976">
       <Id>ab7449e3-2131-4276-9c84-e1223720ad75</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="197" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="197" Volume="1968" Year="1976">
       <Id>dfffa1af-5700-4dd1-83bf-53f1b1ec5aa6</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="198" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="198" Volume="1968" Year="1976">
       <Id>523ddc58-9a69-404f-9809-ddfcf3b20ce5</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="199" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="199" Volume="1968" Year="1976">
       <Id>935256e9-fec0-4b9e-88b2-3445e790f60c</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="200" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="200" Volume="1968" Year="1976">
       <Id>944e4f1c-7555-4679-b053-cfa44666acae</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="201" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="201" Volume="1968" Year="1976">
       <Id>b46e0a90-cd75-4b8a-a4fd-d4c89b83cd32</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="202" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="202" Volume="1968" Year="1976">
       <Id>a05c57b1-9963-4cf0-82f6-7c885801b0fe</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="203" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="203" Volume="1968" Year="1976">
       <Id>0ff8b2e5-f64a-40c8-a327-1d7b0c2a445c</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="204" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="204" Volume="1968" Year="1976">
       <Id>2c2b9bf7-131f-4034-b8af-20c56e0396b6</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="205" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="205" Volume="1968" Year="1976">
       <Id>c1fd4c67-f7b4-4052-9cde-92f3571d6d27</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="206" Volume="1968" Year="1976" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="206" Volume="1968" Year="1976">
       <Id>7c24dd6f-6593-4a5d-8563-2819989d0090</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="207" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="207" Volume="1968" Year="1977">
       <Id>08f46021-28bf-4d47-bc48-e509292ebec5</Id>
     </Book>
-    <Book Series="The Incredible Hulk Annual" Number="6" Volume="1968" Year="1977" Format="Annual">
+    <Book Series="The Incredible Hulk Annual" Number="6" Volume="1968" Year="1977">
       <Id>0e498a5b-2445-4192-ace1-9465f63f0695</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="53" Volume="1972" Year="1977" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="53" Volume="1972" Year="1977">
       <Id>d08363ed-9564-4f30-9b76-36e7924d1484</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="54" Volume="1972" Year="1977" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="54" Volume="1972" Year="1977">
       <Id>7fa6ed4c-5762-4dc0-a2ae-19dbe3e0b9e3</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="208" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="208" Volume="1968" Year="1977">
       <Id>186a44dc-94a4-46b1-bf40-938dfeccecbd</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="209" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="209" Volume="1968" Year="1977">
       <Id>0b148823-7a4e-4b0f-bc40-fffa7c129d11</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="210" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="210" Volume="1968" Year="1977">
       <Id>f757162f-45ff-42e2-b595-075800f51cdc</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="211" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="211" Volume="1968" Year="1977">
       <Id>6d52408c-58ad-49e6-b038-f6482c95c31d</Id>
     </Book>
-    <Book Series="Rampaging Hulk" Number="1" Volume="1977" Year="1977" Format="Main Series">
+    <Book Series="Rampaging Hulk" Number="1" Volume="1977" Year="1977">
       <Id>939cf9c3-d3d1-465e-bd0f-17eeab5540f1</Id>
     </Book>
-    <Book Series="Rampaging Hulk" Number="2" Volume="1977" Year="1977" Format="Main Series">
+    <Book Series="Rampaging Hulk" Number="2" Volume="1977" Year="1977">
       <Id>4664b559-1258-461b-a643-6857041b7c04</Id>
     </Book>
-    <Book Series="Rampaging Hulk" Number="3" Volume="1977" Year="1977" Format="Main Series">
+    <Book Series="Rampaging Hulk" Number="3" Volume="1977" Year="1977">
       <Id>54fec139-4791-435f-8888-5b28d94a280d</Id>
     </Book>
-    <Book Series="Rampaging Hulk" Number="4" Volume="1977" Year="1977" Format="Main Series">
+    <Book Series="Rampaging Hulk" Number="4" Volume="1977" Year="1977">
       <Id>c8b1f8d0-f293-4ed9-8764-1f729f886fc6</Id>
     </Book>
-    <Book Series="Rampaging Hulk" Number="5" Volume="1977" Year="1977" Format="Main Series">
+    <Book Series="Rampaging Hulk" Number="5" Volume="1977" Year="1977">
       <Id>5c1fca13-ac21-4cad-aa70-4a6c90bbe0c5</Id>
     </Book>
-    <Book Series="Rampaging Hulk" Number="6" Volume="1977" Year="1977" Format="Main Series">
+    <Book Series="Rampaging Hulk" Number="6" Volume="1977" Year="1977">
       <Id>12ec63ce-d682-42b9-b650-df455ad949c4</Id>
     </Book>
-    <Book Series="Rampaging Hulk" Number="7" Volume="1977" Year="1978" Format="Main Series">
+    <Book Series="Rampaging Hulk" Number="7" Volume="1977" Year="1978">
       <Id>0500ccbf-27ad-436b-ac5d-9ee0458e8844</Id>
     </Book>
-    <Book Series="Rampaging Hulk" Number="8" Volume="1977" Year="1978" Format="Main Series">
+    <Book Series="Rampaging Hulk" Number="8" Volume="1977" Year="1978">
       <Id>cd186198-2c54-432c-aa21-e692914d58a2</Id>
     </Book>
-    <Book Series="Rampaging Hulk" Number="9" Volume="1977" Year="1978" Format="Main Series">
+    <Book Series="Rampaging Hulk" Number="9" Volume="1977" Year="1978">
       <Id>eb3dae09-0ce3-482b-83ee-c7e289c5447c</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="212" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="212" Volume="1968" Year="1977">
       <Id>d0c6db77-4ce6-4533-a825-43321d84eaa3</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="213" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="213" Volume="1968" Year="1977">
       <Id>655276ce-0110-4ee9-812c-76cd27483f06</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="214" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="214" Volume="1968" Year="1977">
       <Id>9215311e-9ac4-4579-a4de-9d494c4cfd14</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="215" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="215" Volume="1968" Year="1977">
       <Id>ed62f4c6-ab6c-469c-8f06-7785a8496c65</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="216" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="216" Volume="1968" Year="1977">
       <Id>efc061fb-9d23-4097-bfc9-4ee9de7c0b4a</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="217" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="217" Volume="1968" Year="1977">
       <Id>0758d753-cf62-4f30-b5d4-0e1f048c42a9</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="218" Volume="1968" Year="1977" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="218" Volume="1968" Year="1977">
       <Id>4366d9db-ca5a-45a2-9fda-bebafdd1e204</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="219" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="219" Volume="1968" Year="1978">
       <Id>5fcc1174-61c7-4315-a771-b75c4c42e9c6</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="220" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="220" Volume="1968" Year="1978">
       <Id>415dca0c-276c-4265-8d32-406465127a62</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="221" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="221" Volume="1968" Year="1978">
       <Id>4e0e1d45-2c07-4d6b-9f73-5327c0268db6</Id>
     </Book>
-    <Book Series="The Inhumans" Number="12" Volume="1975" Year="1977" Format="Main Series">
+    <Book Series="The Inhumans" Number="12" Volume="1975" Year="1977">
       <Id>f297e8e6-f71c-49fa-b0dc-a2a4b8a055e3</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="222" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="222" Volume="1968" Year="1978">
       <Id>3b07bb8c-9828-49bb-90ee-671a87db2666</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="223" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="223" Volume="1968" Year="1978">
       <Id>6892d663-1904-4341-99dc-52f67a492d66</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="224" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="224" Volume="1968" Year="1978">
       <Id>10866e89-06de-4862-a140-e0710f2932ba</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="225" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="225" Volume="1968" Year="1978">
       <Id>a7bc5529-f4de-4dc9-8b43-83f472a45554</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="226" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="226" Volume="1968" Year="1978">
       <Id>b5a54274-b869-455c-ba42-cf465e504329</Id>
     </Book>
-    <Book Series="Marvel Two-in-One" Number="46" Volume="1974" Year="1978" Format="Main Series">
+    <Book Series="Marvel Two-in-One" Number="46" Volume="1974" Year="1978">
       <Id>200fd377-0bb3-421e-bd5f-90238a160b17</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="227" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="227" Volume="1968" Year="1978">
       <Id>f73813fd-0533-47ed-8eec-77de300b3109</Id>
     </Book>
-    <Book Series="The Incredible Hulk Annual" Number="7" Volume="1968" Year="1978" Format="Annual">
+    <Book Series="The Incredible Hulk Annual" Number="7" Volume="1968" Year="1978">
       <Id>179442a2-615c-4aab-90a0-102066ec6141</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="228" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="228" Volume="1968" Year="1978">
       <Id>2aef7fea-f0e7-4447-ab37-2e2a772a7a07</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="229" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="229" Volume="1968" Year="1978">
       <Id>cfcc7995-69dd-4653-b4cd-2ad6274aab0a</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="230" Volume="1968" Year="1978" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="230" Volume="1968" Year="1978">
       <Id>01a7536c-d592-4d39-b134-37385c29944c</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="231" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="231" Volume="1968" Year="1979">
       <Id>bbe14849-38b5-4304-a6eb-b4714c3b6bd4</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="232" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="232" Volume="1968" Year="1979">
       <Id>384f071f-28bd-4c15-aec7-271a448c4d70</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="233" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="233" Volume="1968" Year="1979">
       <Id>31f6f451-69d5-4e7a-a508-187fb69e26f0</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="234" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="234" Volume="1968" Year="1979">
       <Id>e142296b-fb67-4b19-bd8a-71d4c2ff003c</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="235" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="235" Volume="1968" Year="1979">
       <Id>2a0ff0ef-6afd-4b78-8d0b-d9514c1375e4</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="236" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="236" Volume="1968" Year="1979">
       <Id>c7a2465f-7251-4721-8285-36ba404f1334</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="237" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="237" Volume="1968" Year="1979">
       <Id>dfde8224-8259-4e30-b6ab-e3f6240c8aca</Id>
     </Book>
-    <Book Series="The Incredible Hulk Annual" Number="8" Volume="1968" Year="1979" Format="Annual">
+    <Book Series="The Incredible Hulk Annual" Number="8" Volume="1968" Year="1979">
       <Id>2e760ba6-8ed7-4033-af29-b38f604fbf2c</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="238" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="238" Volume="1968" Year="1979">
       <Id>a99af04e-81ac-4fdf-8834-4ece70931767</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="239" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="239" Volume="1968" Year="1979">
       <Id>3fcf2ccf-5f59-44a9-b4e6-42d1bac8e3ea</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="240" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="240" Volume="1968" Year="1979">
       <Id>611d698c-f4c0-4e6d-b4ea-62ec2799d487</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="241" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="241" Volume="1968" Year="1979">
       <Id>feffc5e6-842f-40f3-b5da-7cf579748a34</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="242" Volume="1968" Year="1979" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="242" Volume="1968" Year="1979">
       <Id>590f2c99-55cb-42b6-9a43-009f8eae8105</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="243" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="243" Volume="1968" Year="1980">
       <Id>4666ca3a-e064-4eda-b5f3-764ef5a28288</Id>
     </Book>
-    <Book Series="Hulk!" Number="10" Volume="1978" Year="1978" Format="Main Series">
+    <Book Series="Hulk!" Number="10" Volume="1978" Year="1978">
       <Id>0dd7464f-aebf-4634-92bc-ef11961587ee</Id>
     </Book>
-    <Book Series="Hulk!" Number="11" Volume="1978" Year="1978" Format="Main Series">
+    <Book Series="Hulk!" Number="11" Volume="1978" Year="1978">
       <Id>b1624f94-2501-4b93-9d2e-f2ba118c4b9e</Id>
     </Book>
-    <Book Series="Hulk!" Number="12" Volume="1978" Year="1978" Format="Main Series">
+    <Book Series="Hulk!" Number="12" Volume="1978" Year="1978">
       <Id>3ac3054c-96a6-4b63-bc0d-1ec867207c81</Id>
     </Book>
-    <Book Series="Hulk!" Number="13" Volume="1978" Year="1979" Format="Main Series">
+    <Book Series="Hulk!" Number="13" Volume="1978" Year="1979">
       <Id>587fffd5-37ad-4afb-bdde-5c11289e235a</Id>
     </Book>
-    <Book Series="Hulk!" Number="14" Volume="1978" Year="1979" Format="Main Series">
+    <Book Series="Hulk!" Number="14" Volume="1978" Year="1979">
       <Id>672cac4e-12f2-48dd-9f8e-bf4eb104d443</Id>
     </Book>
-    <Book Series="Hulk!" Number="15" Volume="1978" Year="1979" Format="Main Series">
+    <Book Series="Hulk!" Number="15" Volume="1978" Year="1979">
       <Id>f051777f-18ac-4940-aac0-f20b4ac2e388</Id>
     </Book>
-    <Book Series="Hulk!" Number="16" Volume="1978" Year="1979" Format="Main Series">
+    <Book Series="Hulk!" Number="16" Volume="1978" Year="1979">
       <Id>6b96874f-55fe-47ed-a627-27af1089d8bd</Id>
     </Book>
-    <Book Series="Hulk!" Number="17" Volume="1978" Year="1979" Format="Main Series">
+    <Book Series="Hulk!" Number="17" Volume="1978" Year="1979">
       <Id>c1789a70-4454-481d-97a8-1d0963db291f</Id>
     </Book>
-    <Book Series="Hulk!" Number="18" Volume="1978" Year="1979" Format="Main Series">
+    <Book Series="Hulk!" Number="18" Volume="1978" Year="1979">
       <Id>79361852-33eb-444f-8db0-baf25bbd7019</Id>
     </Book>
-    <Book Series="Hulk!" Number="19" Volume="1978" Year="1980" Format="Main Series">
+    <Book Series="Hulk!" Number="19" Volume="1978" Year="1980">
       <Id>496d69a3-39bb-40f2-90a1-7083ef0bb633</Id>
     </Book>
-    <Book Series="Hulk!" Number="20" Volume="1978" Year="1980" Format="Main Series">
+    <Book Series="Hulk!" Number="20" Volume="1978" Year="1980">
       <Id>dee8ab56-db3e-49e6-8b12-4d59632a2301</Id>
     </Book>
-    <Book Series="Marvel Team-Up Annual" Number="2" Volume="1976" Year="1979" Format="Annual">
+    <Book Series="Marvel Team-Up Annual" Number="2" Volume="1976" Year="1979">
       <Id>eb18a92d-4253-4f31-8118-76c5acd3ec7e</Id>
     </Book>
-    <Book Series="Daredevil" Number="163" Volume="1964" Year="1980" Format="Main Series">
+    <Book Series="Daredevil" Number="163" Volume="1964" Year="1980">
       <Id>2e028640-d8a2-4fed-a582-0d8e9e0b0e34</Id>
     </Book>
-    <Book Series="Iron Man" Number="131" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="Iron Man" Number="131" Volume="1968" Year="1980">
       <Id>30c569f7-a7a0-481c-ae7e-697287d12d8f</Id>
     </Book>
-    <Book Series="Iron Man" Number="132" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="Iron Man" Number="132" Volume="1968" Year="1980">
       <Id>6e1a7d95-f508-4714-9dd6-7c107eb011a7</Id>
     </Book>
-    <Book Series="Iron Man" Number="133" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="Iron Man" Number="133" Volume="1968" Year="1980">
       <Id>e3d3e01d-fc5d-431e-9562-412627f51224</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="244" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="244" Volume="1968" Year="1980">
       <Id>b3c3a8dd-aef2-4aa1-b035-9c3c75bb7fed</Id>
     </Book>
-    <Book Series="The Savage She-Hulk" Number="1" Volume="1980" Year="1980" Format="Main Series">
+    <Book Series="The Savage She-Hulk" Number="1" Volume="1980" Year="1980">
       <Id>f0b927d1-7272-4244-9a5d-930d48ee14ca</Id>
     </Book>
-    <Book Series="Marvel Treasury Edition" Number="25" Volume="1974" Year="1980" Format="Main Series">
+    <Book Series="Marvel Treasury Edition" Number="25" Volume="1974" Year="1980">
       <Id>d5aa470b-94e9-4446-af50-3451b54d52c2</Id>
     </Book>
-    <Book Series="Hulk!" Number="21" Volume="1978" Year="1980" Format="Main Series">
+    <Book Series="Hulk!" Number="21" Volume="1978" Year="1980">
       <Id>ab460b7a-df63-4643-a6d6-67e58eccdadb</Id>
     </Book>
-    <Book Series="Hulk!" Number="22" Volume="1978" Year="1980" Format="Main Series">
+    <Book Series="Hulk!" Number="22" Volume="1978" Year="1980">
       <Id>8ee75bdc-93da-4849-a222-729fc55dddad</Id>
     </Book>
-    <Book Series="Hulk!" Number="23" Volume="1978" Year="1980" Format="Main Series">
+    <Book Series="Hulk!" Number="23" Volume="1978" Year="1980">
       <Id>64e6fe6a-69b9-470c-91c7-82ab29c1b966</Id>
     </Book>
-    <Book Series="The Incredible Hulk Annual" Number="9" Volume="1968" Year="1980" Format="Annual">
+    <Book Series="The Incredible Hulk Annual" Number="9" Volume="1968" Year="1980">
       <Id>bcb3e352-c15d-49d7-8ff9-896cbf2c9e6d</Id>
     </Book>
-    <Book Series="Hulk!" Number="24" Volume="1978" Year="1980" Format="Main Series">
+    <Book Series="Hulk!" Number="24" Volume="1978" Year="1980">
       <Id>2aaad4ed-aba3-4406-97fd-146e267e12c7</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="245" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="245" Volume="1968" Year="1980">
       <Id>8d876c55-6aee-4e9a-9d35-ab41bbe3ad48</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="246" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="246" Volume="1968" Year="1980">
       <Id>92eaeed8-1fab-4980-b464-1f3a9bd9e204</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="247" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="247" Volume="1968" Year="1980">
       <Id>4a82c30f-1040-4a20-b3cd-b69f8bf2fe3e</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="248" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="248" Volume="1968" Year="1980">
       <Id>21e273d1-b870-4c80-af95-706cb598bb4e</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="249" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="249" Volume="1968" Year="1980">
       <Id>0394a5bc-a44d-44c6-85cf-ec25c503250b</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="250" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="250" Volume="1968" Year="1980">
       <Id>a1375c1f-59b8-42d2-b120-23efdbd7ae6f</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="251" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="251" Volume="1968" Year="1980">
       <Id>3143a4c7-4474-41cd-8290-c11648fd863b</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="252" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="252" Volume="1968" Year="1980">
       <Id>9a95b221-d276-4824-84bc-a283499aba27</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="253" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="253" Volume="1968" Year="1980">
       <Id>a7a45d58-42f2-4fba-9df3-4fd925613e9c</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="97" Volume="1972" Year="1980" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="97" Volume="1972" Year="1980">
       <Id>ba5ab60d-2880-4add-99a2-38497a57ded2</Id>
     </Book>
-    <Book Series="Hulk!" Number="25" Volume="1978" Year="1981" Format="Main Series">
+    <Book Series="Hulk!" Number="25" Volume="1978" Year="1981">
       <Id>cca195d6-26d3-42a6-898c-c697d58685a7</Id>
     </Book>
-    <Book Series="Marvel Team-Up Annual" Number="3" Volume="1976" Year="1980" Format="Annual">
+    <Book Series="Marvel Team-Up Annual" Number="3" Volume="1976" Year="1980">
       <Id>a5e5216d-a9fc-4afb-9635-d827b45934f2</Id>
     </Book>
-    <Book Series="Marvel Two-in-One Annual" Number="5" Volume="1976" Year="1980" Format="Annual">
+    <Book Series="Marvel Two-in-One Annual" Number="5" Volume="1976" Year="1980">
       <Id>bdb7ec56-f498-413a-8c38-9522abba2007</Id>
     </Book>
-    <Book Series="Hulk!" Number="26" Volume="1978" Year="1981" Format="Main Series">
+    <Book Series="Hulk!" Number="26" Volume="1978" Year="1981">
       <Id>62953f2d-64af-4d34-b405-433251297562</Id>
     </Book>
-    <Book Series="Hulk!" Number="27" Volume="1978" Year="1981" Format="Main Series">
+    <Book Series="Hulk!" Number="27" Volume="1978" Year="1981">
       <Id>37d4fcf5-a6b0-400a-adae-bebdbaf6a2a8</Id>
     </Book>
-    <Book Series="Captain America" Number="257" Volume="1968" Year="1981" Format="Main Series">
+    <Book Series="Captain America" Number="257" Volume="1968" Year="1981">
       <Id>a8abfa90-597c-47d2-8a33-0603583f2384</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="104" Volume="1972" Year="1981" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="104" Volume="1972" Year="1981">
       <Id>7e4ffb11-1897-40ab-b0f4-c6b7ad888807</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="105" Volume="1972" Year="1981" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="105" Volume="1972" Year="1981">
       <Id>42966bc2-e736-4c3b-8fc2-1d55c14281ce</Id>
     </Book>
-    <Book Series="Dazzler" Number="6" Volume="1981" Year="1981" Format="Main Series">
+    <Book Series="Dazzler" Number="6" Volume="1981" Year="1981">
       <Id>7a971c26-0218-4418-bb0e-1c627ce7bd1f</Id>
     </Book>
-    <Book Series="Dazzler" Number="7" Volume="1981" Year="1981" Format="Main Series">
+    <Book Series="Dazzler" Number="7" Volume="1981" Year="1981">
       <Id>93ab47e4-c2c4-458a-92b4-b6980a131dc8</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="254" Volume="1968" Year="1980" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="254" Volume="1968" Year="1980">
       <Id>ff5d181b-6464-4230-bc8b-6dff8281a11d</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="255" Volume="1968" Year="1981" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="255" Volume="1968" Year="1981">
       <Id>3ac92fe1-9f4b-4b1f-bb16-917710bf1be9</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="256" Volume="1968" Year="1981" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="256" Volume="1968" Year="1981">
       <Id>e9af5a39-4773-479d-a1c2-bdebcd870602</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="257" Volume="1968" Year="1981" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="257" Volume="1968" Year="1981">
       <Id>e634c198-9630-4f15-8261-579fafbe5b45</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="258" Volume="1968" Year="1981" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="258" Volume="1968" Year="1981">
       <Id>f56f5049-43a9-4bf8-91ad-68e6fc8ff3ee</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="259" Volume="1968" Year="1981" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="259" Volume="1968" Year="1981">
       <Id>d639ca89-e52a-4ace-89fa-1b8e191a331b</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="260" Volume="1968" Year="1981" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="260" Volume="1968" Year="1981">
       <Id>998c89f4-b5d0-4565-89d8-efdbd5f9e8f8</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="261" Volume="1968" Year="1981" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="261" Volume="1968" Year="1981">
       <Id>1a355b8d-6b71-4878-a895-b780506dca5b</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="262" Volume="1968" Year="1981" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="262" Volume="1968" Year="1981">
       <Id>5738530b-f866-43fe-9226-3b8be21c2cc2</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="263" Volume="1968" Year="1981" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="263" Volume="1968" Year="1981">
       <Id>457d38ef-c681-41cc-9a44-8978dfe46f4e</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="264" Volume="1968" Year="1981" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="264" Volume="1968" Year="1981">
       <Id>60f313a7-693a-4e83-8c21-02d0240e9222</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="265" Volume="1968" Year="1981" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="265" Volume="1968" Year="1981">
       <Id>9b017512-8617-4b17-b7ea-94176a7cc2a8</Id>
     </Book>
-    <Book Series="The Incredible Hulk Annual" Number="10" Volume="1968" Year="1981" Format="Annual">
+    <Book Series="The Incredible Hulk Annual" Number="10" Volume="1968" Year="1981">
       <Id>189746d9-9781-4a29-b262-53edd49157c1</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="266" Volume="1968" Year="1981" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="266" Volume="1968" Year="1981">
       <Id>eb6279d3-f835-4b94-83f0-f3f459ab0935</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="267" Volume="1968" Year="1982" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="267" Volume="1968" Year="1982">
       <Id>5986c293-5cdd-48e8-af5d-c323565e59e6</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="268" Volume="1968" Year="1982" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="268" Volume="1968" Year="1982">
       <Id>c1fac4c6-b57c-4214-b4b4-3e35e7f4c292</Id>
     </Book>
-    <Book Series="The Incredible Hulk Annual" Number="11" Volume="1968" Year="1982" Format="Annual">
+    <Book Series="The Incredible Hulk Annual" Number="11" Volume="1968" Year="1982">
       <Id>e4478d17-fd9d-45d0-b541-805da70eb0e4</Id>
     </Book>
     <Book Series="Marvel Fanfare" Number="7" Volume="1982" Year="1983">

--- a/Marvel/Characters/unsorted/Incredible Hulk/Incredible Hulk 001.cbl
+++ b/Marvel/Characters/unsorted/Incredible Hulk/Incredible Hulk 001.cbl
@@ -1,903 +1,904 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Incredible Hulk 1</Name>
+  <Name>Incredible Hulk 001</Name>
+  <NumIssues>299</NumIssues>
   <Books>
     <Book Series="The Incredible Hulk" Number="1" Volume="1962" Year="1962">
-      <Id>23324bc3-f45f-4226-a474-e51c9897d9f2</Id>
+      <Database Name="cv" Series="2077" Issue="5883" />
     </Book>
     <Book Series="The Incredible Hulk" Number="2" Volume="1962" Year="1962">
-      <Id>eb3d0b23-be06-4704-afc3-b2015b362b69</Id>
+      <Database Name="cv" Series="2077" Issue="5976" />
     </Book>
     <Book Series="The Incredible Hulk" Number="3" Volume="1962" Year="1962">
-      <Id>30f2265c-1c0a-4fbe-b9b2-fd9db3fba1b5</Id>
+      <Database Name="cv" Series="2077" Issue="6065" />
     </Book>
     <Book Series="The Incredible Hulk" Number="4" Volume="1962" Year="1962">
-      <Id>34a61208-2b86-483a-856c-3eb2e8133005</Id>
+      <Database Name="cv" Series="2077" Issue="6160" />
     </Book>
     <Book Series="The Incredible Hulk" Number="5" Volume="1962" Year="1963">
-      <Id>40260286-33f1-4342-b100-13a43937dc37</Id>
+      <Database Name="cv" Series="2077" Issue="6330" />
     </Book>
     <Book Series="Fantastic Four" Number="12" Volume="1961" Year="1963">
-      <Id>e757ee94-b229-4e42-b411-025e89e77adc</Id>
+      <Database Name="cv" Series="2045" Issue="6423" />
     </Book>
     <Book Series="The Incredible Hulk" Number="6" Volume="1962" Year="1963">
-      <Id>7238d383-a2c6-4b85-a13d-776113aa74e6</Id>
+      <Database Name="cv" Series="2077" Issue="6425" />
     </Book>
     <Book Series="The Avengers" Number="1" Volume="1963" Year="1963">
-      <Id>8cf6b924-4620-4658-804f-a313c48d53b1</Id>
+      <Database Name="cv" Series="2128" Issue="6686" />
     </Book>
     <Book Series="The Avengers" Number="2" Volume="1963" Year="1963">
-      <Id>4a9e07c7-cfe4-4a85-9733-9c991f8d0622</Id>
+      <Database Name="cv" Series="2128" Issue="6779" />
     </Book>
     <Book Series="The Avengers" Number="3" Volume="1963" Year="1964">
-      <Id>1b1de360-7a6a-423a-aa77-a514d09ac1c7</Id>
+      <Database Name="cv" Series="2128" Issue="6938" />
     </Book>
     <Book Series="The Avengers" Number="5" Volume="1963" Year="1964">
-      <Id>dd2a211b-788b-4e74-88ad-678df0e0874c</Id>
+      <Database Name="cv" Series="2128" Issue="7106" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="14" Volume="1963" Year="1964">
-      <Id>a1d3bd42-14dd-4721-b9b2-547f5f3d031e</Id>
+      <Database Name="cv" Series="2127" Issue="7198" />
     </Book>
     <Book Series="Fantastic Four" Number="25" Volume="1961" Year="1964">
-      <Id>74fe6185-a504-45d1-9a52-d0117f006406</Id>
+      <Database Name="cv" Series="2045" Issue="7068" />
     </Book>
     <Book Series="Fantastic Four" Number="26" Volume="1961" Year="1964">
-      <Id>dd149eaa-c799-49e0-9005-a4ccab14ec27</Id>
+      <Database Name="cv" Series="2045" Issue="7107" />
     </Book>
     <Book Series="Tales to Astonish" Number="59" Volume="1959" Year="1964">
-      <Id>e4e2c373-a698-44eb-9ad6-a6b5bda2e634</Id>
+      <Database Name="cv" Series="2008" Issue="7309" />
     </Book>
     <Book Series="Tales to Astonish" Number="60" Volume="1959" Year="1964">
-      <Id>2634b5bc-d359-42c9-bc38-738c5e959fca</Id>
+      <Database Name="cv" Series="2008" Issue="7378" />
     </Book>
     <Book Series="Tales to Astonish" Number="61" Volume="1959" Year="1964">
-      <Id>cf0f4f6d-787d-43ab-a565-601c9ee4c3ab</Id>
+      <Database Name="cv" Series="2008" Issue="7430" />
     </Book>
     <Book Series="Tales to Astonish" Number="62" Volume="1959" Year="1964">
-      <Id>8511ea55-3aa6-4b77-b282-0b91e2c63094</Id>
+      <Database Name="cv" Series="2008" Issue="7490" />
     </Book>
     <Book Series="Journey into Mystery" Number="112" Volume="1952" Year="1965">
-      <Id>56c2c848-0621-4c88-bbfa-c4d8cec3487f</Id>
+      <Database Name="cv" Series="1497" Issue="7553" />
     </Book>
     <Book Series="Tales to Astonish" Number="63" Volume="1959" Year="1965">
-      <Id>e8513f4d-bca3-4dfd-9177-29db49f5f88d</Id>
+      <Database Name="cv" Series="2008" Issue="7558" />
     </Book>
     <Book Series="Tales to Astonish" Number="64" Volume="1959" Year="1965">
-      <Id>738d2738-8fd1-4f71-af0e-64a02191bcf3</Id>
+      <Database Name="cv" Series="2008" Issue="7616" />
     </Book>
     <Book Series="Tales to Astonish" Number="65" Volume="1959" Year="1965">
-      <Id>5ce08e79-cd8e-439b-8b7c-a7754ab35695</Id>
+      <Database Name="cv" Series="2008" Issue="7673" />
     </Book>
     <Book Series="Tales to Astonish" Number="66" Volume="1959" Year="1965">
-      <Id>65d9b1ea-0bd1-4cd0-b54d-4f4b55bd50cb</Id>
+      <Database Name="cv" Series="2008" Issue="7732" />
     </Book>
     <Book Series="Tales to Astonish" Number="67" Volume="1959" Year="1965">
-      <Id>05f11dc5-6755-4f98-9db4-c57a41efc4c5</Id>
+      <Database Name="cv" Series="2008" Issue="7781" />
     </Book>
     <Book Series="Tales to Astonish" Number="68" Volume="1959" Year="1965">
-      <Id>4e96de9e-ad06-47ec-b017-8cd88747648d</Id>
+      <Database Name="cv" Series="2008" Issue="7843" />
     </Book>
     <Book Series="Tales to Astonish" Number="69" Volume="1959" Year="1965">
-      <Id>58e96d60-571f-4297-98c3-d43330bbc555</Id>
+      <Database Name="cv" Series="2008" Issue="7899" />
     </Book>
     <Book Series="Tales to Astonish" Number="70" Volume="1959" Year="1965">
-      <Id>1507ebe0-c0bc-414e-83dd-a815e768672e</Id>
+      <Database Name="cv" Series="2008" Issue="7967" />
     </Book>
     <Book Series="Tales to Astonish" Number="71" Volume="1959" Year="1965">
-      <Id>7d9a74c4-abcd-4a73-a7c3-29723d182263</Id>
+      <Database Name="cv" Series="2008" Issue="8036" />
     </Book>
     <Book Series="Tales to Astonish" Number="72" Volume="1959" Year="1965">
-      <Id>da144a45-d818-42d7-8966-b596767aa4f4</Id>
+      <Database Name="cv" Series="2008" Issue="8109" />
     </Book>
     <Book Series="Tales to Astonish" Number="73" Volume="1959" Year="1965">
-      <Id>a5c09369-a098-46dc-92b3-0986da6eb90b</Id>
+      <Database Name="cv" Series="2008" Issue="8169" />
     </Book>
     <Book Series="Tales to Astonish" Number="74" Volume="1959" Year="1965">
-      <Id>a141d8cb-c742-4707-84a8-2d2717693ded</Id>
+      <Database Name="cv" Series="2008" Issue="8237" />
     </Book>
     <Book Series="Tales to Astonish" Number="75" Volume="1959" Year="1966">
-      <Id>1622118d-8b2c-4ee3-9d0e-16fe12616de6</Id>
+      <Database Name="cv" Series="2008" Issue="8314" />
     </Book>
     <Book Series="Tales to Astonish" Number="76" Volume="1959" Year="1966">
-      <Id>7d31670c-53aa-452a-9467-1dbbd79979cb</Id>
+      <Database Name="cv" Series="2008" Issue="8374" />
     </Book>
     <Book Series="Tales to Astonish" Number="77" Volume="1959" Year="1966">
-      <Id>ede92d12-9934-43b1-98c5-65ae3a3732b7</Id>
+      <Database Name="cv" Series="2008" Issue="8433" />
     </Book>
     <Book Series="Tales to Astonish" Number="78" Volume="1959" Year="1966">
-      <Id>0db6c7ec-2ddf-4a65-b571-25b27b76bfff</Id>
+      <Database Name="cv" Series="2008" Issue="8496" />
     </Book>
     <Book Series="Tales to Astonish" Number="79" Volume="1959" Year="1966">
-      <Id>2600f14d-8347-445e-9a86-f8db0e95e30f</Id>
+      <Database Name="cv" Series="2008" Issue="8551" />
     </Book>
     <Book Series="Tales to Astonish" Number="80" Volume="1959" Year="1966">
-      <Id>d8009422-8ccb-4034-8201-6fedfe022a5c</Id>
+      <Database Name="cv" Series="2008" Issue="8619" />
     </Book>
     <Book Series="Tales to Astonish" Number="81" Volume="1959" Year="1966">
-      <Id>6ef5e154-b4d2-4898-a5f9-68ea51cad881</Id>
+      <Database Name="cv" Series="2008" Issue="8672" />
     </Book>
     <Book Series="Tales to Astonish" Number="82" Volume="1959" Year="1966">
-      <Id>28a11cbc-ffff-4a8f-b1e5-f18a41ca8a0b</Id>
+      <Database Name="cv" Series="2008" Issue="8738" />
     </Book>
     <Book Series="Tales to Astonish" Number="83" Volume="1959" Year="1966">
-      <Id>0a0275c7-0f94-4f65-bf32-818827121599</Id>
+      <Database Name="cv" Series="2008" Issue="8816" />
     </Book>
     <Book Series="Tales to Astonish" Number="84" Volume="1959" Year="1966">
-      <Id>38f39146-a6d4-40f6-9f5d-70d35f87bc45</Id>
+      <Database Name="cv" Series="2008" Issue="8883" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="3" Volume="1964" Year="1966">
-      <Id>a438f172-6f25-41e1-a578-e339113a02a4</Id>
+      <Database Name="cv" Series="2189" Issue="8905" />
     </Book>
     <Book Series="Tales to Astonish" Number="85" Volume="1959" Year="1966">
-      <Id>7b31f726-16c8-4299-b458-bd6ba134d167</Id>
+      <Database Name="cv" Series="2008" Issue="8949" />
     </Book>
     <Book Series="Tales to Astonish" Number="86" Volume="1959" Year="1966">
-      <Id>c22d9826-0e51-468b-8a7f-41920abb377b</Id>
+      <Database Name="cv" Series="2008" Issue="9023" />
     </Book>
     <Book Series="Tales to Astonish" Number="87" Volume="1959" Year="1967">
-      <Id>7cfc2d71-9f08-49b2-9cf9-3e71f734a1bf</Id>
+      <Database Name="cv" Series="2008" Issue="9096" />
     </Book>
     <Book Series="Tales to Astonish" Number="88" Volume="1959" Year="1967">
-      <Id>4bca007f-68b0-45a1-a169-c51bc31825b3</Id>
+      <Database Name="cv" Series="2008" Issue="9160" />
     </Book>
     <Book Series="Tales to Astonish" Number="89" Volume="1959" Year="1967">
-      <Id>e4e90320-b10a-4fe9-b485-49d9cc4ff8ae</Id>
+      <Database Name="cv" Series="2008" Issue="9232" />
     </Book>
     <Book Series="Tales to Astonish" Number="90" Volume="1959" Year="1967">
-      <Id>849fce13-ec31-4285-a791-e1aad2f0b30f</Id>
+      <Database Name="cv" Series="2008" Issue="9300" />
     </Book>
     <Book Series="Tales to Astonish" Number="91" Volume="1959" Year="1967">
-      <Id>3386e6c6-8351-4f65-85d9-7b1ec2b83629</Id>
+      <Database Name="cv" Series="2008" Issue="9362" />
     </Book>
     <Book Series="Tales to Astonish" Number="92" Volume="1959" Year="1967">
-      <Id>09747135-f117-4de6-875c-88d8c5783f5b</Id>
+      <Database Name="cv" Series="2008" Issue="9432" />
     </Book>
     <Book Series="Tales to Astonish" Number="93" Volume="1959" Year="1967">
-      <Id>cc213d99-2bfd-4431-ba0e-7c9e56f5b21b</Id>
+      <Database Name="cv" Series="2008" Issue="9491" />
     </Book>
     <Book Series="Tales to Astonish" Number="94" Volume="1959" Year="1967">
-      <Id>30977d6f-5f9d-474b-b6ea-b5fbd9b69959</Id>
+      <Database Name="cv" Series="2008" Issue="9563" />
     </Book>
     <Book Series="Tales to Astonish" Number="95" Volume="1959" Year="1967">
-      <Id>090ce149-1d6c-4d27-8c5e-91fef8deea50</Id>
+      <Database Name="cv" Series="2008" Issue="9623" />
     </Book>
     <Book Series="Tales to Astonish" Number="96" Volume="1959" Year="1967">
-      <Id>41127055-1c57-4792-882b-0779494a57b1</Id>
+      <Database Name="cv" Series="2008" Issue="9693" />
     </Book>
     <Book Series="Tales to Astonish" Number="97" Volume="1959" Year="1967">
-      <Id>290e179d-e641-4f4d-9273-6b58faa094bd</Id>
+      <Database Name="cv" Series="2008" Issue="9761" />
     </Book>
     <Book Series="Tales to Astonish" Number="98" Volume="1959" Year="1967">
-      <Id>8ef6b7fa-0e52-4777-9685-df3a84f0b83f</Id>
+      <Database Name="cv" Series="2008" Issue="9823" />
     </Book>
     <Book Series="Tales to Astonish" Number="99" Volume="1959" Year="1968">
-      <Id>06588579-3c97-44f4-a51b-1d95c90c89a0</Id>
+      <Database Name="cv" Series="2008" Issue="9886" />
     </Book>
     <Book Series="Tales to Astonish" Number="100" Volume="1959" Year="1968">
-      <Id>325b77e5-2801-4f6a-8a8f-af9d932c723f</Id>
+      <Database Name="cv" Series="2008" Issue="9943" />
     </Book>
     <Book Series="Tales to Astonish" Number="101" Volume="1959" Year="1968">
-      <Id>c7449ddf-4132-40d5-894e-8b48caad94c7</Id>
+      <Database Name="cv" Series="2008" Issue="108670" />
     </Book>
     <Book Series="The Incredible Hulk" Number="102" Volume="1968" Year="1968">
-      <Id>d65df262-f7ad-43a5-afe0-87ecf8752fd4</Id>
+      <Database Name="cv" Series="2406" Issue="111601" />
     </Book>
     <Book Series="The Incredible Hulk" Number="103" Volume="1968" Year="1968">
-      <Id>72fdaa27-d090-43c5-83da-c934e4383bd3</Id>
+      <Database Name="cv" Series="2406" Issue="111602" />
     </Book>
     <Book Series="Captain America" Number="110" Volume="1968" Year="1969">
-      <Id>68a8ac5b-b3c8-433e-ba09-c38e05947f8e</Id>
+      <Database Name="cv" Series="2400" Issue="10040" />
     </Book>
     <Book Series="The Incredible Hulk" Number="104" Volume="1968" Year="1968">
-      <Id>36469ffc-8390-47db-8267-10af835abf8c</Id>
+      <Database Name="cv" Series="2406" Issue="111603" />
     </Book>
     <Book Series="The Incredible Hulk" Number="105" Volume="1968" Year="1968">
-      <Id>367ec05c-17ec-4d99-9cea-cf2f16dfea98</Id>
+      <Database Name="cv" Series="2406" Issue="111620" />
     </Book>
     <Book Series="The Incredible Hulk" Number="106" Volume="1968" Year="1968">
-      <Id>d7dd0c82-5309-456b-b80c-c812a12531b1</Id>
+      <Database Name="cv" Series="2406" Issue="111619" />
     </Book>
     <Book Series="The Incredible Hulk" Number="107" Volume="1968" Year="1968">
-      <Id>3ef77c9d-3619-4004-99db-325de257046d</Id>
+      <Database Name="cv" Series="2406" Issue="111618" />
     </Book>
     <Book Series="The Incredible Hulk" Number="108" Volume="1968" Year="1968">
-      <Id>810b44bc-c183-4b98-b90c-a98bfdcdf001</Id>
+      <Database Name="cv" Series="2406" Issue="111614" />
     </Book>
     <Book Series="The Incredible Hulk Annual" Number="1" Volume="1968" Year="1968">
-      <Id>2cf00c62-d9ab-4d40-bce8-cd7b7a04757d</Id>
+      <Database Name="cv" Series="2860" Issue="138328" />
     </Book>
     <Book Series="The Incredible Hulk" Number="109" Volume="1968" Year="1968">
-      <Id>4f4b3b59-1b5e-4a06-83f8-29871dd711e7</Id>
+      <Database Name="cv" Series="2406" Issue="111613" />
     </Book>
     <Book Series="The Incredible Hulk" Number="110" Volume="1968" Year="1968">
-      <Id>c9d974cc-b8c0-40ad-91cd-53c5798afb7a</Id>
+      <Database Name="cv" Series="2406" Issue="111632" />
     </Book>
     <Book Series="The Incredible Hulk" Number="111" Volume="1968" Year="1969">
-      <Id>87907ce0-397a-4c0f-9e73-65fcc8e6abef</Id>
+      <Database Name="cv" Series="2406" Issue="9994" />
     </Book>
     <Book Series="The Incredible Hulk" Number="112" Volume="1968" Year="1969">
-      <Id>7dcb6cf8-1726-49eb-bf65-e95985dc6ea9</Id>
+      <Database Name="cv" Series="2406" Issue="10046" />
     </Book>
     <Book Series="The Incredible Hulk" Number="113" Volume="1968" Year="1969">
-      <Id>ac06ef30-2418-426c-be24-7f972c3f5184</Id>
+      <Database Name="cv" Series="2406" Issue="10099" />
     </Book>
     <Book Series="The Incredible Hulk" Number="114" Volume="1968" Year="1969">
-      <Id>cba3a4cd-453a-49cd-b0d7-f9a0b1683882</Id>
+      <Database Name="cv" Series="2406" Issue="10154" />
     </Book>
     <Book Series="The Incredible Hulk" Number="115" Volume="1968" Year="1969">
-      <Id>19f65128-8e6a-4a65-915b-504387ac67ad</Id>
+      <Database Name="cv" Series="2406" Issue="10206" />
     </Book>
     <Book Series="The Incredible Hulk" Number="116" Volume="1968" Year="1969">
-      <Id>ab382904-7de1-4e3e-b113-ccaf76b2ef37</Id>
+      <Database Name="cv" Series="2406" Issue="10262" />
     </Book>
     <Book Series="The Incredible Hulk" Number="117" Volume="1968" Year="1969">
-      <Id>12740da6-8716-4078-af16-0ef06e1370ce</Id>
+      <Database Name="cv" Series="2406" Issue="111621" />
     </Book>
     <Book Series="The Incredible Hulk" Number="118" Volume="1968" Year="1969">
-      <Id>0b886f95-4ac5-47b6-854e-8510e0034bfd</Id>
+      <Database Name="cv" Series="2406" Issue="10358" />
     </Book>
     <Book Series="The Incredible Hulk" Number="119" Volume="1968" Year="1969">
-      <Id>e65ef8d7-1288-4390-b29a-394fb005dd1f</Id>
+      <Database Name="cv" Series="2406" Issue="10407" />
     </Book>
     <Book Series="The Incredible Hulk" Number="120" Volume="1968" Year="1969">
-      <Id>a5df4c2e-ab5e-4429-8f02-985949f9be02</Id>
+      <Database Name="cv" Series="2406" Issue="10468" />
     </Book>
     <Book Series="The Incredible Hulk" Number="121" Volume="1968" Year="1969">
-      <Id>93f238a7-84f9-4f2b-b785-63e4d1bc7395</Id>
+      <Database Name="cv" Series="2406" Issue="10514" />
     </Book>
     <Book Series="The Incredible Hulk" Number="122" Volume="1968" Year="1969">
-      <Id>ac646b31-a9ff-4e0c-9721-ad27607a5acb</Id>
+      <Database Name="cv" Series="2406" Issue="10572" />
     </Book>
     <Book Series="The Incredible Hulk" Number="123" Volume="1968" Year="1970">
-      <Id>43fefa5a-aa34-4fdc-9941-c64ef4dd187c</Id>
+      <Database Name="cv" Series="2406" Issue="10622" />
     </Book>
     <Book Series="The Incredible Hulk" Number="124" Volume="1968" Year="1970">
-      <Id>e6f63363-6863-472f-b167-21a779ece7e0</Id>
+      <Database Name="cv" Series="2406" Issue="10668" />
     </Book>
     <Book Series="The X-Men" Number="66" Volume="1963" Year="1970">
-      <Id>34fa3055-7c14-4768-9693-07294ae449f6</Id>
+      <Database Name="cv" Series="2133" Issue="10724" />
     </Book>
     <Book Series="The Incredible Hulk" Number="125" Volume="1968" Year="1970">
-      <Id>41d98e3a-2134-498b-b740-b93b36958e60</Id>
+      <Database Name="cv" Series="2406" Issue="10713" />
     </Book>
     <Book Series="The Incredible Hulk" Number="126" Volume="1968" Year="1970">
-      <Id>72a72578-4682-4452-b92b-7d4cd29f61e2</Id>
+      <Database Name="cv" Series="2406" Issue="10759" />
     </Book>
     <Book Series="The Incredible Hulk" Number="127" Volume="1968" Year="1970">
-      <Id>07059b00-36ee-4b20-8f58-a6a8581ec166</Id>
+      <Database Name="cv" Series="2406" Issue="10804" />
     </Book>
     <Book Series="The Incredible Hulk" Number="128" Volume="1968" Year="1970">
-      <Id>6935e0c4-ccc8-4fc7-82b6-891c1d9ad416</Id>
+      <Database Name="cv" Series="2406" Issue="10859" />
     </Book>
     <Book Series="The Incredible Hulk" Number="129" Volume="1968" Year="1970">
-      <Id>79005ee2-7476-41f2-a302-4fa83b654e0f</Id>
+      <Database Name="cv" Series="2406" Issue="10900" />
     </Book>
     <Book Series="The Incredible Hulk" Number="130" Volume="1968" Year="1970">
-      <Id>17825155-76a1-4190-aff4-2b34cd2c4d7c</Id>
+      <Database Name="cv" Series="2406" Issue="10954" />
     </Book>
     <Book Series="The Incredible Hulk" Number="131" Volume="1968" Year="1970">
-      <Id>d024a371-e0ab-48b2-af81-783f4929b2ba</Id>
+      <Database Name="cv" Series="2406" Issue="11006" />
     </Book>
     <Book Series="The Incredible Hulk" Number="132" Volume="1968" Year="1970">
-      <Id>4845174f-3b8b-426a-a56b-4c6c58197316</Id>
+      <Database Name="cv" Series="2406" Issue="11055" />
     </Book>
     <Book Series="The Incredible Hulk" Number="133" Volume="1968" Year="1970">
-      <Id>30fe927f-f3ef-41f6-b666-966e5e6b2a96</Id>
+      <Database Name="cv" Series="2406" Issue="11101" />
     </Book>
     <Book Series="The Incredible Hulk" Number="134" Volume="1968" Year="1970">
-      <Id>3d8bc1c2-8777-453f-9793-e842b98d3276</Id>
+      <Database Name="cv" Series="2406" Issue="11158" />
     </Book>
     <Book Series="The Incredible Hulk" Number="135" Volume="1968" Year="1971">
-      <Id>9d9b77e0-77bf-4133-a9c7-aa8d95b1db60</Id>
+      <Database Name="cv" Series="2406" Issue="11221" />
     </Book>
     <Book Series="The Incredible Hulk" Number="136" Volume="1968" Year="1971">
-      <Id>41e0c86e-11cb-47c1-b570-59c6b08f1eb9</Id>
+      <Database Name="cv" Series="2406" Issue="11279" />
     </Book>
     <Book Series="The Incredible Hulk" Number="137" Volume="1968" Year="1971">
-      <Id>bb3a927e-659f-4147-b02b-276f3841d881</Id>
+      <Database Name="cv" Series="2406" Issue="11327" />
     </Book>
     <Book Series="The Incredible Hulk" Number="138" Volume="1968" Year="1971">
-      <Id>95d656d8-1bca-4771-bf27-ad54c4571222</Id>
+      <Database Name="cv" Series="2406" Issue="11381" />
     </Book>
     <Book Series="Sub-Mariner" Number="34" Volume="1968" Year="1971">
-      <Id>eab58567-b521-4025-b4bc-879a8d1235ab</Id>
+      <Database Name="cv" Series="2413" Issue="11285" />
     </Book>
     <Book Series="Sub-Mariner" Number="35" Volume="1968" Year="1971">
-      <Id>edb54501-068f-4cc8-93f5-66386c48f4ab</Id>
+      <Database Name="cv" Series="2413" Issue="11334" />
     </Book>
     <Book Series="The Incredible Hulk" Number="139" Volume="1968" Year="1971">
-      <Id>cdd21ba9-978a-45d6-a191-6d1c5b488f86</Id>
+      <Database Name="cv" Series="2406" Issue="11431" />
     </Book>
     <Book Series="Fantastic Four" Number="111" Volume="1961" Year="1971">
-      <Id>4360b27c-11d3-456e-b801-28e7214aa305</Id>
+      <Database Name="cv" Series="2045" Issue="11489" />
     </Book>
     <Book Series="Fantastic Four" Number="112" Volume="1961" Year="1971">
-      <Id>1da1008e-cd52-4175-9f53-7d56b9663b7b</Id>
+      <Database Name="cv" Series="2045" Issue="11544" />
     </Book>
     <Book Series="Fantastic Four" Number="113" Volume="1961" Year="1971">
-      <Id>a3f11be1-8767-46fb-831c-b07ee59b09f4</Id>
+      <Database Name="cv" Series="2045" Issue="11603" />
     </Book>
     <Book Series="Marvel Feature" Number="1" Volume="1971" Year="1971">
-      <Id>8e2d1684-3ad8-428c-a4c6-235d5b00a3bd</Id>
+      <Database Name="cv" Series="2515" Issue="11846" />
     </Book>
     <Book Series="Marvel Feature" Number="2" Volume="1971" Year="1972">
-      <Id>16df5105-ef87-48bd-9562-e2326a5794d7</Id>
+      <Database Name="cv" Series="2515" Issue="12057" />
     </Book>
     <Book Series="The Avengers" Number="88" Volume="1963" Year="1971">
-      <Id>83bd6468-38f7-4097-a5ae-81af499e8123</Id>
+      <Database Name="cv" Series="2128" Issue="11425" />
     </Book>
     <Book Series="The Incredible Hulk" Number="140" Volume="1968" Year="1971">
-      <Id>99065bf5-13b9-4e1e-b296-15bde759a0b6</Id>
+      <Database Name="cv" Series="2406" Issue="11490" />
     </Book>
     <Book Series="The Incredible Hulk" Number="141" Volume="1968" Year="1971">
-      <Id>b649c935-d0dd-448b-9c94-73265edc7263</Id>
+      <Database Name="cv" Series="2406" Issue="11546" />
     </Book>
     <Book Series="The Incredible Hulk" Number="142" Volume="1968" Year="1971">
-      <Id>682701a3-fae4-43aa-8933-dd978f1c5a2f</Id>
+      <Database Name="cv" Series="2406" Issue="11604" />
     </Book>
     <Book Series="The Incredible Hulk" Number="143" Volume="1968" Year="1971">
-      <Id>44d80e06-7686-4693-a9ab-f37ecd0924cb</Id>
+      <Database Name="cv" Series="2406" Issue="11664" />
     </Book>
     <Book Series="The Incredible Hulk" Number="144" Volume="1968" Year="1971">
-      <Id>f52c6ed9-6449-4f82-b035-9cd7e8867b98</Id>
+      <Database Name="cv" Series="2406" Issue="11722" />
     </Book>
     <Book Series="The Incredible Hulk" Number="145" Volume="1968" Year="1971">
-      <Id>488a9c53-b700-4167-804d-f2a3103366b5</Id>
+      <Database Name="cv" Series="2406" Issue="11784" />
     </Book>
     <Book Series="The Incredible Hulk" Number="146" Volume="1968" Year="1971">
-      <Id>012665c7-d540-473b-a802-a6cb3da119d4</Id>
+      <Database Name="cv" Series="2406" Issue="11845" />
     </Book>
     <Book Series="The Incredible Hulk" Number="147" Volume="1968" Year="1972">
-      <Id>45c6151b-e1c1-4abc-a809-64ec3bb554fe</Id>
+      <Database Name="cv" Series="2406" Issue="11926" />
     </Book>
     <Book Series="The Incredible Hulk" Number="148" Volume="1968" Year="1972">
-      <Id>7af052da-e0f5-4a5b-8a8a-fe5479496e29</Id>
+      <Database Name="cv" Series="2406" Issue="11994" />
     </Book>
     <Book Series="The Incredible Hulk" Number="149" Volume="1968" Year="1972">
-      <Id>068349cb-2a48-4d28-a295-8ccad83bf5d4</Id>
+      <Database Name="cv" Series="2406" Issue="12054" />
     </Book>
     <Book Series="The Incredible Hulk" Number="150" Volume="1968" Year="1972">
-      <Id>8415cd8e-8f27-4cb4-905b-b46dbc5e79ac</Id>
+      <Database Name="cv" Series="2406" Issue="12123" />
     </Book>
     <Book Series="The Incredible Hulk" Number="151" Volume="1968" Year="1972">
-      <Id>73b09d86-3c11-482a-ad1a-a763b45264e8</Id>
+      <Database Name="cv" Series="2406" Issue="12190" />
     </Book>
     <Book Series="The Incredible Hulk" Number="152" Volume="1968" Year="1972">
-      <Id>a2a1d9cc-0c35-499e-b403-000f2dfb6733</Id>
+      <Database Name="cv" Series="2406" Issue="12267" />
     </Book>
     <Book Series="The Incredible Hulk" Number="153" Volume="1968" Year="1972">
-      <Id>8290401a-0824-465b-91b2-461121f73739</Id>
+      <Database Name="cv" Series="2406" Issue="12339" />
     </Book>
     <Book Series="The Incredible Hulk" Number="154" Volume="1968" Year="1972">
-      <Id>bb923bcc-45d8-44d4-98ce-6a13108a165d</Id>
+      <Database Name="cv" Series="2406" Issue="12419" />
     </Book>
     <Book Series="The Incredible Hulk" Number="155" Volume="1968" Year="1972">
-      <Id>4dcf5652-4e1d-4604-8bcd-7a38e83b0e61</Id>
+      <Database Name="cv" Series="2406" Issue="12481" />
     </Book>
     <Book Series="The Incredible Hulk" Number="156" Volume="1968" Year="1972">
-      <Id>afc47d39-6982-476f-8e42-5b294925c71a</Id>
+      <Database Name="cv" Series="2406" Issue="12576" />
     </Book>
     <Book Series="Marvel Feature" Number="3" Volume="1971" Year="1972">
-      <Id>0c8f4ba0-5ec5-428a-a26b-0221ed3581d9</Id>
+      <Database Name="cv" Series="2515" Issue="12269" />
     </Book>
     <Book Series="The Incredible Hulk" Number="157" Volume="1968" Year="1972">
-      <Id>fce72f7f-7d1a-47b7-bc06-5a0bdbd0cb01</Id>
+      <Database Name="cv" Series="2406" Issue="12650" />
     </Book>
     <Book Series="The Incredible Hulk" Number="158" Volume="1968" Year="1972">
-      <Id>a4af3464-f739-4639-a354-34b9b5874378</Id>
+      <Database Name="cv" Series="2406" Issue="12741" />
     </Book>
     <Book Series="The Incredible Hulk" Number="159" Volume="1968" Year="1973">
-      <Id>c442dcaa-93a8-42bb-bf3f-fbe5af9f2a31</Id>
+      <Database Name="cv" Series="2406" Issue="12833" />
     </Book>
     <Book Series="The Incredible Hulk" Number="160" Volume="1968" Year="1973">
-      <Id>d2031d4a-6bc7-4c30-adba-888e7569a094</Id>
+      <Database Name="cv" Series="2406" Issue="12927" />
     </Book>
     <Book Series="The Incredible Hulk" Number="161" Volume="1968" Year="1973">
-      <Id>e010b340-03af-48cb-b796-3bbd8f10ba00</Id>
+      <Database Name="cv" Series="2406" Issue="13010" />
     </Book>
     <Book Series="The Incredible Hulk" Number="162" Volume="1968" Year="1973">
-      <Id>503d72dd-241e-4543-a2e6-15e90e844b4a</Id>
+      <Database Name="cv" Series="2406" Issue="13111" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="119" Volume="1963" Year="1973">
-      <Id>a7915d7b-53f9-44b3-ad5b-68c019fe7720</Id>
+      <Database Name="cv" Series="2127" Issue="13096" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="120" Volume="1963" Year="1973">
-      <Id>fa8e8c9f-204b-4e99-b8dd-7a9b062f8cbc</Id>
+      <Database Name="cv" Series="2127" Issue="13169" />
     </Book>
     <Book Series="The Incredible Hulk" Number="163" Volume="1968" Year="1973">
-      <Id>c8a16477-61ce-418e-944d-a9ebdf720fc7</Id>
+      <Database Name="cv" Series="2406" Issue="13179" />
     </Book>
     <Book Series="The Incredible Hulk" Number="164" Volume="1968" Year="1973">
-      <Id>d6023d93-9f93-4aea-b635-0b0a559cda25</Id>
+      <Database Name="cv" Series="2406" Issue="13279" />
     </Book>
     <Book Series="The Incredible Hulk" Number="165" Volume="1968" Year="1973">
-      <Id>adcf325f-a35b-4970-b900-a0e95e3eefc5</Id>
+      <Database Name="cv" Series="2406" Issue="13387" />
     </Book>
     <Book Series="The Incredible Hulk" Number="166" Volume="1968" Year="1973">
-      <Id>a02c8aaf-b29a-464f-97d3-d53c20cb8f6b</Id>
+      <Database Name="cv" Series="2406" Issue="13480" />
     </Book>
     <Book Series="The Incredible Hulk" Number="167" Volume="1968" Year="1973">
-      <Id>3ac32f42-a636-4981-83c3-649875cc048f</Id>
+      <Database Name="cv" Series="2406" Issue="13579" />
     </Book>
     <Book Series="The Incredible Hulk" Number="168" Volume="1968" Year="1973">
-      <Id>4f4f68e6-9a2d-4fcd-a7f9-81821af73925</Id>
+      <Database Name="cv" Series="2406" Issue="13697" />
     </Book>
     <Book Series="The Incredible Hulk" Number="169" Volume="1968" Year="1973">
-      <Id>4107ab1f-575e-4b71-92d2-b3bae4e70c58</Id>
+      <Database Name="cv" Series="2406" Issue="13795" />
     </Book>
     <Book Series="The Incredible Hulk" Number="170" Volume="1968" Year="1973">
-      <Id>8f296a66-911b-41b4-ae23-17c3c1b57b46</Id>
+      <Database Name="cv" Series="2406" Issue="13885" />
     </Book>
     <Book Series="The Incredible Hulk" Number="171" Volume="1968" Year="1974">
-      <Id>dd685d14-9c12-4a05-8eb5-1bc03b48da5f</Id>
+      <Database Name="cv" Series="2406" Issue="13990" />
     </Book>
     <Book Series="The Incredible Hulk" Number="172" Volume="1968" Year="1974">
-      <Id>ff0c65ac-0af7-454e-8678-0df36e794564</Id>
+      <Database Name="cv" Series="2406" Issue="14059" />
     </Book>
     <Book Series="Marvel Feature" Number="11" Volume="1971" Year="1973">
-      <Id>ebf3c2f6-0bee-40c8-b144-57709145fbd4</Id>
+      <Database Name="cv" Series="2515" Issue="13584" />
     </Book>
     <Book Series="Marvel Team-Up" Number="18" Volume="1972" Year="1974">
-      <Id>dc1cf49f-b4f1-40df-9759-4ad1361fa231</Id>
+      <Database Name="cv" Series="2576" Issue="14066" />
     </Book>
     <Book Series="The Incredible Hulk" Number="173" Volume="1968" Year="1974">
-      <Id>d384845f-6771-4fe1-b184-c51d7c02a7f3</Id>
+      <Database Name="cv" Series="2406" Issue="14127" />
     </Book>
     <Book Series="The Incredible Hulk" Number="174" Volume="1968" Year="1974">
-      <Id>644622d4-108c-4213-a6a9-f7d7c28181a8</Id>
+      <Database Name="cv" Series="2406" Issue="14196" />
     </Book>
     <Book Series="The Incredible Hulk" Number="175" Volume="1968" Year="1974">
-      <Id>72c49ee8-0f51-4f63-85ba-7fa415e7a285</Id>
+      <Database Name="cv" Series="2406" Issue="14267" />
     </Book>
     <Book Series="The Incredible Hulk" Number="176" Volume="1968" Year="1974">
-      <Id>1d4b4e27-ca59-4e17-abab-35e8b1067738</Id>
+      <Database Name="cv" Series="2406" Issue="14340" />
     </Book>
     <Book Series="The Incredible Hulk" Number="177" Volume="1968" Year="1974">
-      <Id>5d66fa1e-be25-4105-8054-1ba0e4b4e420</Id>
+      <Database Name="cv" Series="2406" Issue="14423" />
     </Book>
     <Book Series="The Incredible Hulk" Number="178" Volume="1968" Year="1974">
-      <Id>ea6291ff-af57-4450-b86f-d9eee6074f87</Id>
+      <Database Name="cv" Series="2406" Issue="14493" />
     </Book>
     <Book Series="The Incredible Hulk" Number="179" Volume="1968" Year="1974">
-      <Id>81bb60df-d00d-45a5-b803-4733a74eb884</Id>
+      <Database Name="cv" Series="2406" Issue="14584" />
     </Book>
     <Book Series="The Incredible Hulk" Number="180" Volume="1968" Year="1974">
-      <Id>b2b7de8c-9315-422d-8218-7903d7bdc498</Id>
+      <Database Name="cv" Series="2406" Issue="14667" />
     </Book>
     <Book Series="The Incredible Hulk" Number="181" Volume="1968" Year="1974">
-      <Id>ec40115a-0de9-4f78-ae31-56d426f3dfcb</Id>
+      <Database Name="cv" Series="2406" Issue="14760" />
     </Book>
     <Book Series="The Incredible Hulk" Number="182" Volume="1968" Year="1974">
-      <Id>5ab031d2-05a5-406f-a413-e1b1a9f718ef</Id>
+      <Database Name="cv" Series="2406" Issue="14841" />
     </Book>
     <Book Series="The Incredible Hulk" Number="183" Volume="1968" Year="1975">
-      <Id>677bae72-8fe3-450c-8c7b-5a57f1d6e677</Id>
+      <Database Name="cv" Series="2406" Issue="14970" />
     </Book>
     <Book Series="Marvel Team-Up" Number="27" Volume="1972" Year="1974">
-      <Id>45145d7d-c730-482c-bddc-0a3614550518</Id>
+      <Database Name="cv" Series="2576" Issue="14770" />
     </Book>
     <Book Series="The Incredible Hulk" Number="184" Volume="1968" Year="1975">
-      <Id>ebdc8534-06a7-4b1c-8546-dcc2266a53c8</Id>
+      <Database Name="cv" Series="2406" Issue="15060" />
     </Book>
     <Book Series="The Incredible Hulk" Number="185" Volume="1968" Year="1975">
-      <Id>4cd4f954-da43-4ccb-8d2d-2ab8cf6a688c</Id>
+      <Database Name="cv" Series="2406" Issue="15151" />
     </Book>
     <Book Series="The Incredible Hulk" Number="186" Volume="1968" Year="1975">
-      <Id>2f05e1f2-ade0-49cd-a4f7-144117524c66</Id>
+      <Database Name="cv" Series="2406" Issue="134872" />
     </Book>
     <Book Series="The Incredible Hulk" Number="187" Volume="1968" Year="1975">
-      <Id>71d0199f-2226-4328-9d36-ae05cb0082b1</Id>
+      <Database Name="cv" Series="2406" Issue="15184" />
     </Book>
     <Book Series="The Incredible Hulk" Number="188" Volume="1968" Year="1975">
-      <Id>1ca89615-d4f6-4d59-8642-4e608722f740</Id>
+      <Database Name="cv" Series="2406" Issue="15276" />
     </Book>
     <Book Series="The Incredible Hulk" Number="189" Volume="1968" Year="1975">
-      <Id>e5602e8f-fb78-4ea4-8e0d-820d5d5e018f</Id>
+      <Database Name="cv" Series="2406" Issue="15381" />
     </Book>
     <Book Series="The Incredible Hulk" Number="190" Volume="1968" Year="1975">
-      <Id>b33ac22e-01b7-41ce-9143-e7aa8cf5fbec</Id>
+      <Database Name="cv" Series="2406" Issue="15483" />
     </Book>
     <Book Series="The Incredible Hulk" Number="191" Volume="1968" Year="1975">
-      <Id>530e84bf-0a1f-4d53-910a-46c6220aa203</Id>
+      <Database Name="cv" Series="2406" Issue="15583" />
     </Book>
     <Book Series="The Incredible Hulk" Number="192" Volume="1968" Year="1975">
-      <Id>ca0ce35b-e021-452a-9f3b-4d71ac282b86</Id>
+      <Database Name="cv" Series="2406" Issue="15683" />
     </Book>
     <Book Series="The Incredible Hulk" Number="193" Volume="1968" Year="1975">
-      <Id>bd88a3e6-046b-448d-81e6-ad5ab239ddfe</Id>
+      <Database Name="cv" Series="2406" Issue="15782" />
     </Book>
     <Book Series="The Incredible Hulk Annual" Number="5" Volume="1968" Year="1976">
-      <Id>f8a02fcf-4191-4b04-b384-a814bfa5ad10</Id>
+      <Database Name="cv" Series="2860" Issue="16775" />
     </Book>
     <Book Series="The Incredible Hulk" Number="194" Volume="1968" Year="1975">
-      <Id>30aa3949-4e1e-4306-b0ae-3a6a4fc2d366</Id>
+      <Database Name="cv" Series="2406" Issue="15865" />
     </Book>
     <Book Series="Fantastic Four" Number="166" Volume="1961" Year="1976">
-      <Id>c97e99c3-86a3-4806-bf9e-38d788579d2f</Id>
+      <Database Name="cv" Series="2045" Issue="16002" />
     </Book>
     <Book Series="Fantastic Four" Number="167" Volume="1961" Year="1976">
-      <Id>58cc2c3b-9f69-4184-8957-2170f9d3e6aa</Id>
+      <Database Name="cv" Series="2045" Issue="16078" />
     </Book>
     <Book Series="The Incredible Hulk" Number="195" Volume="1968" Year="1976">
-      <Id>7754108f-d3d5-45b4-a099-b1234786d3ed</Id>
+      <Database Name="cv" Series="2406" Issue="16003" />
     </Book>
     <Book Series="The Incredible Hulk" Number="196" Volume="1968" Year="1976">
-      <Id>ab7449e3-2131-4276-9c84-e1223720ad75</Id>
+      <Database Name="cv" Series="2406" Issue="16080" />
     </Book>
     <Book Series="The Incredible Hulk" Number="197" Volume="1968" Year="1976">
-      <Id>dfffa1af-5700-4dd1-83bf-53f1b1ec5aa6</Id>
+      <Database Name="cv" Series="2406" Issue="16167" />
     </Book>
     <Book Series="The Incredible Hulk" Number="198" Volume="1968" Year="1976">
-      <Id>523ddc58-9a69-404f-9809-ddfcf3b20ce5</Id>
+      <Database Name="cv" Series="2406" Issue="16256" />
     </Book>
     <Book Series="The Incredible Hulk" Number="199" Volume="1968" Year="1976">
-      <Id>935256e9-fec0-4b9e-88b2-3445e790f60c</Id>
+      <Database Name="cv" Series="2406" Issue="16341" />
     </Book>
     <Book Series="The Incredible Hulk" Number="200" Volume="1968" Year="1976">
-      <Id>944e4f1c-7555-4679-b053-cfa44666acae</Id>
+      <Database Name="cv" Series="2406" Issue="16417" />
     </Book>
     <Book Series="The Incredible Hulk" Number="201" Volume="1968" Year="1976">
-      <Id>b46e0a90-cd75-4b8a-a4fd-d4c89b83cd32</Id>
+      <Database Name="cv" Series="2406" Issue="16507" />
     </Book>
     <Book Series="The Incredible Hulk" Number="202" Volume="1968" Year="1976">
-      <Id>a05c57b1-9963-4cf0-82f6-7c885801b0fe</Id>
+      <Database Name="cv" Series="2406" Issue="16596" />
     </Book>
     <Book Series="The Incredible Hulk" Number="203" Volume="1968" Year="1976">
-      <Id>0ff8b2e5-f64a-40c8-a327-1d7b0c2a445c</Id>
+      <Database Name="cv" Series="2406" Issue="16683" />
     </Book>
     <Book Series="The Incredible Hulk" Number="204" Volume="1968" Year="1976">
-      <Id>2c2b9bf7-131f-4034-b8af-20c56e0396b6</Id>
+      <Database Name="cv" Series="2406" Issue="16776" />
     </Book>
     <Book Series="The Incredible Hulk" Number="205" Volume="1968" Year="1976">
-      <Id>c1fd4c67-f7b4-4052-9cde-92f3571d6d27</Id>
+      <Database Name="cv" Series="2406" Issue="16872" />
     </Book>
     <Book Series="The Incredible Hulk" Number="206" Volume="1968" Year="1976">
-      <Id>7c24dd6f-6593-4a5d-8563-2819989d0090</Id>
+      <Database Name="cv" Series="2406" Issue="16956" />
     </Book>
     <Book Series="The Incredible Hulk" Number="207" Volume="1968" Year="1977">
-      <Id>08f46021-28bf-4d47-bc48-e509292ebec5</Id>
+      <Database Name="cv" Series="2406" Issue="17103" />
     </Book>
     <Book Series="The Incredible Hulk Annual" Number="6" Volume="1968" Year="1977">
-      <Id>0e498a5b-2445-4192-ace1-9465f63f0695</Id>
+      <Database Name="cv" Series="2860" Issue="17965" />
     </Book>
     <Book Series="Marvel Team-Up" Number="53" Volume="1972" Year="1977">
-      <Id>d08363ed-9564-4f30-9b76-36e7924d1484</Id>
+      <Database Name="cv" Series="2576" Issue="17108" />
     </Book>
     <Book Series="Marvel Team-Up" Number="54" Volume="1972" Year="1977">
-      <Id>7fa6ed4c-5762-4dc0-a2ae-19dbe3e0b9e3</Id>
+      <Database Name="cv" Series="2576" Issue="17195" />
     </Book>
     <Book Series="The Incredible Hulk" Number="208" Volume="1968" Year="1977">
-      <Id>186a44dc-94a4-46b1-bf40-938dfeccecbd</Id>
+      <Database Name="cv" Series="2406" Issue="17184" />
     </Book>
     <Book Series="The Incredible Hulk" Number="209" Volume="1968" Year="1977">
-      <Id>0b148823-7a4e-4b0f-bc40-fffa7c129d11</Id>
+      <Database Name="cv" Series="2406" Issue="17270" />
     </Book>
     <Book Series="The Incredible Hulk" Number="210" Volume="1968" Year="1977">
-      <Id>f757162f-45ff-42e2-b595-075800f51cdc</Id>
+      <Database Name="cv" Series="2406" Issue="17347" />
     </Book>
     <Book Series="The Incredible Hulk" Number="211" Volume="1968" Year="1977">
-      <Id>6d52408c-58ad-49e6-b038-f6482c95c31d</Id>
+      <Database Name="cv" Series="2406" Issue="17433" />
     </Book>
     <Book Series="Rampaging Hulk" Number="1" Volume="1977" Year="1977">
-      <Id>939cf9c3-d3d1-465e-bd0f-17eeab5540f1</Id>
+      <Database Name="cv" Series="2911" Issue="17116" />
     </Book>
     <Book Series="Rampaging Hulk" Number="2" Volume="1977" Year="1977">
-      <Id>4664b559-1258-461b-a643-6857041b7c04</Id>
+      <Database Name="cv" Series="2911" Issue="17363" />
     </Book>
     <Book Series="Rampaging Hulk" Number="3" Volume="1977" Year="1977">
-      <Id>54fec139-4791-435f-8888-5b28d94a280d</Id>
+      <Database Name="cv" Series="2911" Issue="17518" />
     </Book>
     <Book Series="Rampaging Hulk" Number="4" Volume="1977" Year="1977">
-      <Id>c8b1f8d0-f293-4ed9-8764-1f729f886fc6</Id>
+      <Database Name="cv" Series="2911" Issue="17698" />
     </Book>
     <Book Series="Rampaging Hulk" Number="5" Volume="1977" Year="1977">
-      <Id>5c1fca13-ac21-4cad-aa70-4a6c90bbe0c5</Id>
+      <Database Name="cv" Series="2911" Issue="17887" />
     </Book>
     <Book Series="Rampaging Hulk" Number="6" Volume="1977" Year="1977">
-      <Id>12ec63ce-d682-42b9-b650-df455ad949c4</Id>
+      <Database Name="cv" Series="2911" Issue="18057" />
     </Book>
     <Book Series="Rampaging Hulk" Number="7" Volume="1977" Year="1978">
-      <Id>0500ccbf-27ad-436b-ac5d-9ee0458e8844</Id>
+      <Database Name="cv" Series="2911" Issue="18261" />
     </Book>
     <Book Series="Rampaging Hulk" Number="8" Volume="1977" Year="1978">
-      <Id>cd186198-2c54-432c-aa21-e692914d58a2</Id>
+      <Database Name="cv" Series="2911" Issue="18427" />
     </Book>
     <Book Series="Rampaging Hulk" Number="9" Volume="1977" Year="1978">
-      <Id>eb3dae09-0ce3-482b-83ee-c7e289c5447c</Id>
+      <Database Name="cv" Series="2911" Issue="18591" />
     </Book>
     <Book Series="The Incredible Hulk" Number="212" Volume="1968" Year="1977">
-      <Id>d0c6db77-4ce6-4533-a825-43321d84eaa3</Id>
+      <Database Name="cv" Series="2406" Issue="17502" />
     </Book>
     <Book Series="The Incredible Hulk" Number="213" Volume="1968" Year="1977">
-      <Id>655276ce-0110-4ee9-812c-76cd27483f06</Id>
+      <Database Name="cv" Series="2406" Issue="17600" />
     </Book>
     <Book Series="The Incredible Hulk" Number="214" Volume="1968" Year="1977">
-      <Id>9215311e-9ac4-4579-a4de-9d494c4cfd14</Id>
+      <Database Name="cv" Series="2406" Issue="17682" />
     </Book>
     <Book Series="The Incredible Hulk" Number="215" Volume="1968" Year="1977">
-      <Id>ed62f4c6-ab6c-469c-8f06-7785a8496c65</Id>
+      <Database Name="cv" Series="2406" Issue="17780" />
     </Book>
     <Book Series="The Incredible Hulk" Number="216" Volume="1968" Year="1977">
-      <Id>efc061fb-9d23-4097-bfc9-4ee9de7c0b4a</Id>
+      <Database Name="cv" Series="2406" Issue="17873" />
     </Book>
     <Book Series="The Incredible Hulk" Number="217" Volume="1968" Year="1977">
-      <Id>0758d753-cf62-4f30-b5d4-0e1f048c42a9</Id>
+      <Database Name="cv" Series="2406" Issue="17966" />
     </Book>
     <Book Series="The Incredible Hulk" Number="218" Volume="1968" Year="1977">
-      <Id>4366d9db-ca5a-45a2-9fda-bebafdd1e204</Id>
+      <Database Name="cv" Series="2406" Issue="18044" />
     </Book>
     <Book Series="The Incredible Hulk" Number="219" Volume="1968" Year="1978">
-      <Id>5fcc1174-61c7-4315-a771-b75c4c42e9c6</Id>
+      <Database Name="cv" Series="2406" Issue="18168" />
     </Book>
     <Book Series="The Incredible Hulk" Number="220" Volume="1968" Year="1978">
-      <Id>415dca0c-276c-4265-8d32-406465127a62</Id>
+      <Database Name="cv" Series="2406" Issue="18248" />
     </Book>
     <Book Series="The Incredible Hulk" Number="221" Volume="1968" Year="1978">
-      <Id>4e0e1d45-2c07-4d6b-9f73-5327c0268db6</Id>
+      <Database Name="cv" Series="2406" Issue="18329" />
     </Book>
     <Book Series="The Inhumans" Number="12" Volume="1975" Year="1977">
-      <Id>f297e8e6-f71c-49fa-b0dc-a2a4b8a055e3</Id>
+      <Database Name="cv" Series="2764" Issue="17683" />
     </Book>
     <Book Series="The Incredible Hulk" Number="222" Volume="1968" Year="1978">
-      <Id>3b07bb8c-9828-49bb-90ee-671a87db2666</Id>
+      <Database Name="cv" Series="2406" Issue="18413" />
     </Book>
     <Book Series="The Incredible Hulk" Number="223" Volume="1968" Year="1978">
-      <Id>6892d663-1904-4341-99dc-52f67a492d66</Id>
+      <Database Name="cv" Series="2406" Issue="18498" />
     </Book>
     <Book Series="The Incredible Hulk" Number="224" Volume="1968" Year="1978">
-      <Id>10866e89-06de-4862-a140-e0710f2932ba</Id>
+      <Database Name="cv" Series="2406" Issue="18578" />
     </Book>
     <Book Series="The Incredible Hulk" Number="225" Volume="1968" Year="1978">
-      <Id>a7bc5529-f4de-4dc9-8b43-83f472a45554</Id>
+      <Database Name="cv" Series="2406" Issue="18659" />
     </Book>
     <Book Series="The Incredible Hulk" Number="226" Volume="1968" Year="1978">
-      <Id>b5a54274-b869-455c-ba42-cf465e504329</Id>
+      <Database Name="cv" Series="2406" Issue="18737" />
     </Book>
     <Book Series="Marvel Two-in-One" Number="46" Volume="1974" Year="1978">
-      <Id>200fd377-0bb3-421e-bd5f-90238a160b17</Id>
+      <Database Name="cv" Series="2696" Issue="19049" />
     </Book>
     <Book Series="The Incredible Hulk" Number="227" Volume="1968" Year="1978">
-      <Id>f73813fd-0533-47ed-8eec-77de300b3109</Id>
+      <Database Name="cv" Series="2406" Issue="18819" />
     </Book>
     <Book Series="The Incredible Hulk Annual" Number="7" Volume="1968" Year="1978">
-      <Id>179442a2-615c-4aab-90a0-102066ec6141</Id>
+      <Database Name="cv" Series="2860" Issue="19039" />
     </Book>
     <Book Series="The Incredible Hulk" Number="228" Volume="1968" Year="1978">
-      <Id>2aef7fea-f0e7-4447-ab37-2e2a772a7a07</Id>
+      <Database Name="cv" Series="2406" Issue="18895" />
     </Book>
     <Book Series="The Incredible Hulk" Number="229" Volume="1968" Year="1978">
-      <Id>cfcc7995-69dd-4653-b4cd-2ad6274aab0a</Id>
+      <Database Name="cv" Series="2406" Issue="18965" />
     </Book>
     <Book Series="The Incredible Hulk" Number="230" Volume="1968" Year="1978">
-      <Id>01a7536c-d592-4d39-b134-37385c29944c</Id>
+      <Database Name="cv" Series="2406" Issue="19040" />
     </Book>
     <Book Series="The Incredible Hulk" Number="231" Volume="1968" Year="1979">
-      <Id>bbe14849-38b5-4304-a6eb-b4714c3b6bd4</Id>
+      <Database Name="cv" Series="2406" Issue="19193" />
     </Book>
     <Book Series="The Incredible Hulk" Number="232" Volume="1968" Year="1979">
-      <Id>384f071f-28bd-4c15-aec7-271a448c4d70</Id>
+      <Database Name="cv" Series="2406" Issue="19295" />
     </Book>
     <Book Series="The Incredible Hulk" Number="233" Volume="1968" Year="1979">
-      <Id>31f6f451-69d5-4e7a-a508-187fb69e26f0</Id>
+      <Database Name="cv" Series="2406" Issue="19369" />
     </Book>
     <Book Series="The Incredible Hulk" Number="234" Volume="1968" Year="1979">
-      <Id>e142296b-fb67-4b19-bd8a-71d4c2ff003c</Id>
+      <Database Name="cv" Series="2406" Issue="19432" />
     </Book>
     <Book Series="The Incredible Hulk" Number="235" Volume="1968" Year="1979">
-      <Id>2a0ff0ef-6afd-4b78-8d0b-d9514c1375e4</Id>
+      <Database Name="cv" Series="2406" Issue="19507" />
     </Book>
     <Book Series="The Incredible Hulk" Number="236" Volume="1968" Year="1979">
-      <Id>c7a2465f-7251-4721-8285-36ba404f1334</Id>
+      <Database Name="cv" Series="2406" Issue="19578" />
     </Book>
     <Book Series="The Incredible Hulk" Number="237" Volume="1968" Year="1979">
-      <Id>dfde8224-8259-4e30-b6ab-e3f6240c8aca</Id>
+      <Database Name="cv" Series="2406" Issue="19642" />
     </Book>
     <Book Series="The Incredible Hulk Annual" Number="8" Volume="1968" Year="1979">
-      <Id>2e760ba6-8ed7-4033-af29-b38f604fbf2c</Id>
+      <Database Name="cv" Series="2860" Issue="19985" />
     </Book>
     <Book Series="The Incredible Hulk" Number="238" Volume="1968" Year="1979">
-      <Id>a99af04e-81ac-4fdf-8834-4ece70931767</Id>
+      <Database Name="cv" Series="2406" Issue="19707" />
     </Book>
     <Book Series="The Incredible Hulk" Number="239" Volume="1968" Year="1979">
-      <Id>3fcf2ccf-5f59-44a9-b4e6-42d1bac8e3ea</Id>
+      <Database Name="cv" Series="2406" Issue="153062" />
     </Book>
     <Book Series="The Incredible Hulk" Number="240" Volume="1968" Year="1979">
-      <Id>611d698c-f4c0-4e6d-b4ea-62ec2799d487</Id>
+      <Database Name="cv" Series="2406" Issue="19845" />
     </Book>
     <Book Series="The Incredible Hulk" Number="241" Volume="1968" Year="1979">
-      <Id>feffc5e6-842f-40f3-b5da-7cf579748a34</Id>
+      <Database Name="cv" Series="2406" Issue="19920" />
     </Book>
     <Book Series="The Incredible Hulk" Number="242" Volume="1968" Year="1979">
-      <Id>590f2c99-55cb-42b6-9a43-009f8eae8105</Id>
+      <Database Name="cv" Series="2406" Issue="19986" />
     </Book>
     <Book Series="The Incredible Hulk" Number="243" Volume="1968" Year="1980">
-      <Id>4666ca3a-e064-4eda-b5f3-764ef5a28288</Id>
+      <Database Name="cv" Series="2406" Issue="20099" />
     </Book>
     <Book Series="Hulk!" Number="10" Volume="1978" Year="1978">
-      <Id>0dd7464f-aebf-4634-92bc-ef11961587ee</Id>
+      <Database Name="cv" Series="2954" Issue="18735" />
     </Book>
     <Book Series="Hulk!" Number="11" Volume="1978" Year="1978">
-      <Id>b1624f94-2501-4b93-9d2e-f2ba118c4b9e</Id>
+      <Database Name="cv" Series="2954" Issue="18893" />
     </Book>
     <Book Series="Hulk!" Number="12" Volume="1978" Year="1978">
-      <Id>3ac3054c-96a6-4b63-bc0d-1ec867207c81</Id>
+      <Database Name="cv" Series="2954" Issue="19037" />
     </Book>
     <Book Series="Hulk!" Number="13" Volume="1978" Year="1979">
-      <Id>587fffd5-37ad-4afb-bdde-5c11289e235a</Id>
+      <Database Name="cv" Series="2954" Issue="19293" />
     </Book>
     <Book Series="Hulk!" Number="14" Volume="1978" Year="1979">
-      <Id>672cac4e-12f2-48dd-9f8e-bf4eb104d443</Id>
+      <Database Name="cv" Series="2954" Issue="19431" />
     </Book>
     <Book Series="Hulk!" Number="15" Volume="1978" Year="1979">
-      <Id>f051777f-18ac-4940-aac0-f20b4ac2e388</Id>
+      <Database Name="cv" Series="2954" Issue="19577" />
     </Book>
     <Book Series="Hulk!" Number="16" Volume="1978" Year="1979">
-      <Id>6b96874f-55fe-47ed-a627-27af1089d8bd</Id>
+      <Database Name="cv" Series="2954" Issue="19706" />
     </Book>
     <Book Series="Hulk!" Number="17" Volume="1978" Year="1979">
-      <Id>c1789a70-4454-481d-97a8-1d0963db291f</Id>
+      <Database Name="cv" Series="2954" Issue="19844" />
     </Book>
     <Book Series="Hulk!" Number="18" Volume="1978" Year="1979">
-      <Id>79361852-33eb-444f-8db0-baf25bbd7019</Id>
+      <Database Name="cv" Series="2954" Issue="19984" />
     </Book>
     <Book Series="Hulk!" Number="19" Volume="1978" Year="1980">
-      <Id>496d69a3-39bb-40f2-90a1-7083ef0bb633</Id>
+      <Database Name="cv" Series="2954" Issue="20166" />
     </Book>
     <Book Series="Hulk!" Number="20" Volume="1978" Year="1980">
-      <Id>dee8ab56-db3e-49e6-8b12-4d59632a2301</Id>
+      <Database Name="cv" Series="2954" Issue="20310" />
     </Book>
     <Book Series="Marvel Team-Up Annual" Number="2" Volume="1976" Year="1979">
-      <Id>eb18a92d-4253-4f31-8118-76c5acd3ec7e</Id>
+      <Database Name="cv" Series="2863" Issue="19085" />
     </Book>
     <Book Series="Daredevil" Number="163" Volume="1964" Year="1980">
-      <Id>2e028640-d8a2-4fed-a582-0d8e9e0b0e34</Id>
+      <Database Name="cv" Series="2190" Issue="20237" />
     </Book>
     <Book Series="Iron Man" Number="131" Volume="1968" Year="1980">
-      <Id>30c569f7-a7a0-481c-ae7e-697287d12d8f</Id>
+      <Database Name="cv" Series="2407" Issue="20168" />
     </Book>
     <Book Series="Iron Man" Number="132" Volume="1968" Year="1980">
-      <Id>6e1a7d95-f508-4714-9dd6-7c107eb011a7</Id>
+      <Database Name="cv" Series="2407" Issue="20243" />
     </Book>
     <Book Series="Iron Man" Number="133" Volume="1968" Year="1980">
-      <Id>e3d3e01d-fc5d-431e-9562-412627f51224</Id>
+      <Database Name="cv" Series="2407" Issue="20312" />
     </Book>
     <Book Series="The Incredible Hulk" Number="244" Volume="1968" Year="1980">
-      <Id>b3c3a8dd-aef2-4aa1-b035-9c3c75bb7fed</Id>
+      <Database Name="cv" Series="2406" Issue="20167" />
     </Book>
     <Book Series="The Savage She-Hulk" Number="1" Volume="1980" Year="1980">
-      <Id>f0b927d1-7272-4244-9a5d-930d48ee14ca</Id>
+      <Database Name="cv" Series="3053" Issue="20177" />
     </Book>
     <Book Series="Marvel Treasury Edition" Number="25" Volume="1974" Year="1980">
-      <Id>d5aa470b-94e9-4446-af50-3451b54d52c2</Id>
+      <Database Name="cv" Series="2694" Issue="20054" />
     </Book>
     <Book Series="Hulk!" Number="21" Volume="1978" Year="1980">
-      <Id>ab460b7a-df63-4643-a6d6-67e58eccdadb</Id>
+      <Database Name="cv" Series="2954" Issue="20454" />
     </Book>
     <Book Series="Hulk!" Number="22" Volume="1978" Year="1980">
-      <Id>8ee75bdc-93da-4849-a222-729fc55dddad</Id>
+      <Database Name="cv" Series="2954" Issue="20591" />
     </Book>
     <Book Series="Hulk!" Number="23" Volume="1978" Year="1980">
-      <Id>64e6fe6a-69b9-470c-91c7-82ab29c1b966</Id>
+      <Database Name="cv" Series="2954" Issue="20730" />
     </Book>
     <Book Series="The Incredible Hulk Annual" Number="9" Volume="1968" Year="1980">
-      <Id>bcb3e352-c15d-49d7-8ff9-896cbf2c9e6d</Id>
+      <Database Name="cv" Series="2860" Issue="20663" />
     </Book>
     <Book Series="Hulk!" Number="24" Volume="1978" Year="1980">
-      <Id>2aaad4ed-aba3-4406-97fd-146e267e12c7</Id>
+      <Database Name="cv" Series="2954" Issue="20860" />
     </Book>
     <Book Series="The Incredible Hulk" Number="245" Volume="1968" Year="1980">
-      <Id>8d876c55-6aee-4e9a-9d35-ab41bbe3ad48</Id>
+      <Database Name="cv" Series="2406" Issue="20242" />
     </Book>
     <Book Series="The Incredible Hulk" Number="246" Volume="1968" Year="1980">
-      <Id>92eaeed8-1fab-4980-b464-1f3a9bd9e204</Id>
+      <Database Name="cv" Series="2406" Issue="20311" />
     </Book>
     <Book Series="The Incredible Hulk" Number="247" Volume="1968" Year="1980">
-      <Id>4a82c30f-1040-4a20-b3cd-b69f8bf2fe3e</Id>
+      <Database Name="cv" Series="2406" Issue="20387" />
     </Book>
     <Book Series="The Incredible Hulk" Number="248" Volume="1968" Year="1980">
-      <Id>21e273d1-b870-4c80-af95-706cb598bb4e</Id>
+      <Database Name="cv" Series="2406" Issue="20455" />
     </Book>
     <Book Series="The Incredible Hulk" Number="249" Volume="1968" Year="1980">
-      <Id>0394a5bc-a44d-44c6-85cf-ec25c503250b</Id>
+      <Database Name="cv" Series="2406" Issue="20528" />
     </Book>
     <Book Series="The Incredible Hulk" Number="250" Volume="1968" Year="1980">
-      <Id>a1375c1f-59b8-42d2-b120-23efdbd7ae6f</Id>
+      <Database Name="cv" Series="2406" Issue="20592" />
     </Book>
     <Book Series="The Incredible Hulk" Number="251" Volume="1968" Year="1980">
-      <Id>3143a4c7-4474-41cd-8290-c11648fd863b</Id>
+      <Database Name="cv" Series="2406" Issue="20664" />
     </Book>
     <Book Series="The Incredible Hulk" Number="252" Volume="1968" Year="1980">
-      <Id>9a95b221-d276-4824-84bc-a283499aba27</Id>
+      <Database Name="cv" Series="2406" Issue="20731" />
     </Book>
     <Book Series="The Incredible Hulk" Number="253" Volume="1968" Year="1980">
-      <Id>a7a45d58-42f2-4fba-9df3-4fd925613e9c</Id>
+      <Database Name="cv" Series="2406" Issue="20795" />
     </Book>
     <Book Series="Marvel Team-Up" Number="97" Volume="1972" Year="1980">
-      <Id>ba5ab60d-2880-4add-99a2-38497a57ded2</Id>
+      <Database Name="cv" Series="2576" Issue="20669" />
     </Book>
     <Book Series="Hulk!" Number="25" Volume="1978" Year="1981">
-      <Id>cca195d6-26d3-42a6-898c-c697d58685a7</Id>
+      <Database Name="cv" Series="2954" Issue="21036" />
     </Book>
     <Book Series="Marvel Team-Up Annual" Number="3" Volume="1976" Year="1980">
-      <Id>a5e5216d-a9fc-4afb-9635-d827b45934f2</Id>
+      <Database Name="cv" Series="2863" Issue="20036" />
     </Book>
     <Book Series="Marvel Two-in-One Annual" Number="5" Volume="1976" Year="1980">
-      <Id>bdb7ec56-f498-413a-8c38-9522abba2007</Id>
+      <Database Name="cv" Series="2865" Issue="20039" />
     </Book>
     <Book Series="Hulk!" Number="26" Volume="1978" Year="1981">
-      <Id>62953f2d-64af-4d34-b405-433251297562</Id>
+      <Database Name="cv" Series="2954" Issue="21177" />
     </Book>
     <Book Series="Hulk!" Number="27" Volume="1978" Year="1981">
-      <Id>37d4fcf5-a6b0-400a-adae-bebdbaf6a2a8</Id>
+      <Database Name="cv" Series="2954" Issue="21301" />
     </Book>
     <Book Series="Captain America" Number="257" Volume="1968" Year="1981">
-      <Id>a8abfa90-597c-47d2-8a33-0603583f2384</Id>
+      <Database Name="cv" Series="2400" Issue="21235" />
     </Book>
     <Book Series="Marvel Team-Up" Number="104" Volume="1972" Year="1981">
-      <Id>7e4ffb11-1897-40ab-b0f4-c6b7ad888807</Id>
+      <Database Name="cv" Series="2576" Issue="21182" />
     </Book>
     <Book Series="Marvel Team-Up" Number="105" Volume="1972" Year="1981">
-      <Id>42966bc2-e736-4c3b-8fc2-1d55c14281ce</Id>
+      <Database Name="cv" Series="2576" Issue="21246" />
     </Book>
     <Book Series="Dazzler" Number="6" Volume="1981" Year="1981">
-      <Id>7a971c26-0218-4418-bb0e-1c627ce7bd1f</Id>
+      <Database Name="cv" Series="3083" Issue="108338" />
     </Book>
     <Book Series="Dazzler" Number="7" Volume="1981" Year="1981">
-      <Id>93ab47e4-c2c4-458a-92b4-b6980a131dc8</Id>
+      <Database Name="cv" Series="3083" Issue="108339" />
     </Book>
     <Book Series="The Incredible Hulk" Number="254" Volume="1968" Year="1980">
-      <Id>ff5d181b-6464-4230-bc8b-6dff8281a11d</Id>
+      <Database Name="cv" Series="2406" Issue="20861" />
     </Book>
     <Book Series="The Incredible Hulk" Number="255" Volume="1968" Year="1981">
-      <Id>3ac92fe1-9f4b-4b1f-bb16-917710bf1be9</Id>
+      <Database Name="cv" Series="2406" Issue="20969" />
     </Book>
     <Book Series="The Incredible Hulk" Number="256" Volume="1968" Year="1981">
-      <Id>e9af5a39-4773-479d-a1c2-bdebcd870602</Id>
+      <Database Name="cv" Series="2406" Issue="21037" />
     </Book>
     <Book Series="The Incredible Hulk" Number="257" Volume="1968" Year="1981">
-      <Id>e634c198-9630-4f15-8261-579fafbe5b45</Id>
+      <Database Name="cv" Series="2406" Issue="21109" />
     </Book>
     <Book Series="The Incredible Hulk" Number="258" Volume="1968" Year="1981">
-      <Id>f56f5049-43a9-4bf8-91ad-68e6fc8ff3ee</Id>
+      <Database Name="cv" Series="2406" Issue="21178" />
     </Book>
     <Book Series="The Incredible Hulk" Number="259" Volume="1968" Year="1981">
-      <Id>d639ca89-e52a-4ace-89fa-1b8e191a331b</Id>
+      <Database Name="cv" Series="2406" Issue="21242" />
     </Book>
     <Book Series="The Incredible Hulk" Number="260" Volume="1968" Year="1981">
-      <Id>998c89f4-b5d0-4565-89d8-efdbd5f9e8f8</Id>
+      <Database Name="cv" Series="2406" Issue="21302" />
     </Book>
     <Book Series="The Incredible Hulk" Number="261" Volume="1968" Year="1981">
-      <Id>1a355b8d-6b71-4878-a895-b780506dca5b</Id>
+      <Database Name="cv" Series="2406" Issue="21376" />
     </Book>
     <Book Series="The Incredible Hulk" Number="262" Volume="1968" Year="1981">
-      <Id>5738530b-f866-43fe-9226-3b8be21c2cc2</Id>
+      <Database Name="cv" Series="2406" Issue="21442" />
     </Book>
     <Book Series="The Incredible Hulk" Number="263" Volume="1968" Year="1981">
-      <Id>457d38ef-c681-41cc-9a44-8978dfe46f4e</Id>
+      <Database Name="cv" Series="2406" Issue="21513" />
     </Book>
     <Book Series="The Incredible Hulk" Number="264" Volume="1968" Year="1981">
-      <Id>60f313a7-693a-4e83-8c21-02d0240e9222</Id>
+      <Database Name="cv" Series="2406" Issue="21595" />
     </Book>
     <Book Series="The Incredible Hulk" Number="265" Volume="1968" Year="1981">
-      <Id>9b017512-8617-4b17-b7ea-94176a7cc2a8</Id>
+      <Database Name="cv" Series="2406" Issue="21662" />
     </Book>
     <Book Series="The Incredible Hulk Annual" Number="10" Volume="1968" Year="1981">
-      <Id>189746d9-9781-4a29-b262-53edd49157c1</Id>
+      <Database Name="cv" Series="2860" Issue="21512" />
     </Book>
     <Book Series="The Incredible Hulk" Number="266" Volume="1968" Year="1981">
-      <Id>eb6279d3-f835-4b94-83f0-f3f459ab0935</Id>
+      <Database Name="cv" Series="2406" Issue="21731" />
     </Book>
     <Book Series="The Incredible Hulk" Number="267" Volume="1968" Year="1982">
-      <Id>5986c293-5cdd-48e8-af5d-c323565e59e6</Id>
+      <Database Name="cv" Series="2406" Issue="21858" />
     </Book>
     <Book Series="The Incredible Hulk" Number="268" Volume="1968" Year="1982">
-      <Id>c1fac4c6-b57c-4214-b4b4-3e35e7f4c292</Id>
+      <Database Name="cv" Series="2406" Issue="21931" />
     </Book>
     <Book Series="The Incredible Hulk Annual" Number="11" Volume="1968" Year="1982">
-      <Id>e4478d17-fd9d-45d0-b541-805da70eb0e4</Id>
+      <Database Name="cv" Series="2860" Issue="22521" />
     </Book>
     <Book Series="Marvel Fanfare" Number="7" Volume="1982" Year="1983">
-      <Id>734bcba4-8282-4ffc-8867-ade174765c9e</Id>
+      <Database Name="cv" Series="3143" Issue="22954" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Incredible Hulk/Incredible Hulk 002.cbl
+++ b/Marvel/Characters/unsorted/Incredible Hulk/Incredible Hulk 002.cbl
@@ -2,880 +2,880 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Incredible Hulk 2</Name>
   <Books>
-    <Book Series="The Incredible Hulk" Number="269" Volume="1968" Year="1982" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="269" Volume="1968" Year="1982">
       <Id>69b523c4-8c1c-42dd-9b0c-a1aa252afd12</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="270" Volume="1968" Year="1982" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="270" Volume="1968" Year="1982">
       <Id>03c22e87-894c-4bfd-b8cd-dcac9e7e97da</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="271" Volume="1968" Year="1982" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="271" Volume="1968" Year="1982">
       <Id>09e57932-8c08-4aa9-9d96-e45e8ad9590b</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="272" Volume="1968" Year="1982" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="272" Volume="1968" Year="1982">
       <Id>12d3e016-ccf0-4130-af6f-099f52b160f3</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="273" Volume="1968" Year="1982" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="273" Volume="1968" Year="1982">
       <Id>cbcbee85-44f8-4c3d-85c3-00c2a4c15273</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="274" Volume="1968" Year="1982" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="274" Volume="1968" Year="1982">
       <Id>a20b3659-765c-498a-a9cb-b521001ecb2d</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="275" Volume="1968" Year="1982" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="275" Volume="1968" Year="1982">
       <Id>bd9088fe-b3ed-4f20-992b-15f007f3617a</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="276" Volume="1968" Year="1982" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="276" Volume="1968" Year="1982">
       <Id>5e853439-7a80-49d2-aa7c-8d153a6494d3</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="277" Volume="1968" Year="1982" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="277" Volume="1968" Year="1982">
       <Id>77a35246-7938-47bc-96dc-4f34f46a536e</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="278" Volume="1968" Year="1982" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="278" Volume="1968" Year="1982">
       <Id>dadb6303-0596-42b6-8908-609105b0ca98</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="279" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="279" Volume="1968" Year="1983">
       <Id>cc3d1cb9-8f0a-4792-816b-4d42d68b6500</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="280" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="280" Volume="1968" Year="1983">
       <Id>41450bf1-94c7-4039-9ee1-f1601e648f48</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="281" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="281" Volume="1968" Year="1983">
       <Id>400f2b6e-abe6-4000-80cd-ee86c0df4c0a</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="282" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="282" Volume="1968" Year="1983">
       <Id>e88c93a7-7055-451c-9fc9-f6b7816b34a9</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="283" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="283" Volume="1968" Year="1983">
       <Id>2677a0e4-6e8c-46ee-9733-8b41fef3e50d</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="284" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="284" Volume="1968" Year="1983">
       <Id>db726a3d-10d6-40e3-be4d-f10386b1cf5f</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="126" Volume="1972" Year="1983" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="126" Volume="1972" Year="1983">
       <Id>226582a0-44ca-4518-92c6-d734aa486570</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="285" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="285" Volume="1968" Year="1983">
       <Id>19c2d3ca-ee13-4e6b-b5a2-5b9003a74ec2</Id>
     </Book>
-    <Book Series="The Incredible Hulk Annual" Number="12" Volume="1968" Year="1983" Format="Annual">
+    <Book Series="The Incredible Hulk Annual" Number="12" Volume="1968" Year="1983">
       <Id>74a78ac2-9654-4d2b-be2d-283580607497</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="286" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="286" Volume="1968" Year="1983">
       <Id>f18a17dc-69e8-440c-adbe-8803fd41ce9a</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="287" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="287" Volume="1968" Year="1983">
       <Id>0fdb72ed-b489-42f2-b910-108a1f52272f</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="288" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="288" Volume="1968" Year="1983">
       <Id>a51c6c3d-ed24-4c69-81f3-8eb783fc02af</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="289" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="289" Volume="1968" Year="1983">
       <Id>8c39e70f-6628-4bac-8b82-022a52189d73</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="290" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="290" Volume="1968" Year="1983">
       <Id>524ccc8f-03a8-4fda-96fa-8a08d7a6c673</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="291" Volume="1968" Year="1984" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="291" Volume="1968" Year="1984">
       <Id>2c06f24d-9f81-46df-baae-d62883cc74c7</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="292" Volume="1968" Year="1984" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="292" Volume="1968" Year="1984">
       <Id>da93f45d-8808-4c87-b167-02902415f876</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="293" Volume="1968" Year="1984" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="293" Volume="1968" Year="1984">
       <Id>75cace92-ea6c-4dc4-ac48-e2045b5d7add</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="294" Volume="1968" Year="1984" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="294" Volume="1968" Year="1984">
       <Id>7d205f83-0170-4aa8-9b84-8d03251522e9</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="1" Volume="1984" Year="1984" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="1" Volume="1984" Year="1984">
       <Id>8cca6608-ad5c-4934-835c-22b03be105b7</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="2" Volume="1984" Year="1984" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="2" Volume="1984" Year="1984">
       <Id>26b8b46b-2789-4c5c-8783-81336cc9cddb</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="3" Volume="1984" Year="1984" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="3" Volume="1984" Year="1984">
       <Id>c7e233c8-fb62-44e1-874d-40da0a2bdd1e</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="4" Volume="1984" Year="1984" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="4" Volume="1984" Year="1984">
       <Id>88b8416d-9788-40d2-9885-53e208c46cbd</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="5" Volume="1984" Year="1984" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="5" Volume="1984" Year="1984">
       <Id>996c2542-1459-4d0e-8588-71fedeb17283</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="6" Volume="1984" Year="1984" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="6" Volume="1984" Year="1984">
       <Id>dff7685a-da38-4375-af65-12e8f68be23e</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="7" Volume="1984" Year="1984" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="7" Volume="1984" Year="1984">
       <Id>0a7b085a-3499-40cb-b0cd-fe7729986bcc</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="8" Volume="1984" Year="1984" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="8" Volume="1984" Year="1984">
       <Id>725f3771-5867-4f54-8fc6-8e14a70128bf</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="9" Volume="1984" Year="1985" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="9" Volume="1984" Year="1985">
       <Id>758f01d8-5db5-4d9e-85cc-6ab5e2fc9cf1</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="10" Volume="1984" Year="1985" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="10" Volume="1984" Year="1985">
       <Id>7f658ccd-cd23-48dc-8200-98dbf5878d23</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="11" Volume="1984" Year="1985" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="11" Volume="1984" Year="1985">
       <Id>65d2beab-745a-40da-aa31-e0f2a9f21965</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="12" Volume="1984" Year="1985" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="12" Volume="1984" Year="1985">
       <Id>b3a0a236-200e-4b07-b75a-c5d00841e516</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="295" Volume="1968" Year="1984" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="295" Volume="1968" Year="1984">
       <Id>215c734d-93c5-49f1-a063-eb0a6a268c1d</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="296" Volume="1968" Year="1984" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="296" Volume="1968" Year="1984">
       <Id>2b11dfbd-8995-4d05-9bab-d9e5a216a4de</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="297" Volume="1968" Year="1984" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="297" Volume="1968" Year="1984">
       <Id>3072b95a-3a10-4b9e-9c60-c587bcc4abd6</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="298" Volume="1968" Year="1984" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="298" Volume="1968" Year="1984">
       <Id>18f58b66-f543-4ac9-a059-7928452788c4</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="299" Volume="1968" Year="1984" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="299" Volume="1968" Year="1984">
       <Id>6336a232-0eaf-4b08-89cf-09e316d4d965</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="300" Volume="1968" Year="1984" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="300" Volume="1968" Year="1984">
       <Id>6f9146d1-285a-4106-85d6-30ebf9680731</Id>
     </Book>
-    <Book Series="The Avengers Annual" Number="13" Volume="1967" Year="1984" Format="Annual">
+    <Book Series="The Avengers Annual" Number="13" Volume="1967" Year="1984">
       <Id>a5e1ad45-09e0-44fe-99ff-c1d0c81c62d9</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="301" Volume="1968" Year="1984" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="301" Volume="1968" Year="1984">
       <Id>e4cf7fc3-ac8f-4217-8f3d-724968f76661</Id>
     </Book>
-    <Book Series="The Incredible Hulk Annual" Number="13" Volume="1968" Year="1984" Format="Annual">
+    <Book Series="The Incredible Hulk Annual" Number="13" Volume="1968" Year="1984">
       <Id>2ba9ab87-3df9-4d6b-8d91-d5fff2ceb96d</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="302" Volume="1968" Year="1984" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="302" Volume="1968" Year="1984">
       <Id>385d86e3-8eff-48eb-afdd-8d2cbb47ebb3</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="303" Volume="1968" Year="1985" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="303" Volume="1968" Year="1985">
       <Id>492f839b-6457-403a-a2aa-0b5d3e5a6c43</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="304" Volume="1968" Year="1985" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="304" Volume="1968" Year="1985">
       <Id>33126366-9d53-46dc-85b2-b0799e6b6124</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="305" Volume="1968" Year="1985" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="305" Volume="1968" Year="1985">
       <Id>e7ccc58f-ae2d-4416-b176-fa507c7c1596</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="306" Volume="1968" Year="1985" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="306" Volume="1968" Year="1985">
       <Id>f525dcd1-7c79-420f-bdb9-2155cf99dc12</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="307" Volume="1968" Year="1985" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="307" Volume="1968" Year="1985">
       <Id>68078cf8-ab95-4803-bb55-f37d32260b71</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="308" Volume="1968" Year="1985" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="308" Volume="1968" Year="1985">
       <Id>edb39dd4-113c-4c6f-93bf-65d91aa65529</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="309" Volume="1968" Year="1985" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="309" Volume="1968" Year="1985">
       <Id>2de00b80-9836-4eb8-a943-43ed0fa8100b</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="310" Volume="1968" Year="1985" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="310" Volume="1968" Year="1985">
       <Id>57f546a7-cd63-4a65-8982-9a06fd558c29</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="311" Volume="1968" Year="1985" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="311" Volume="1968" Year="1985">
       <Id>ad1a9873-d100-4a6b-af36-2b16108c5601</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="312" Volume="1968" Year="1985" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="312" Volume="1968" Year="1985">
       <Id>5a4dc460-a440-4802-941d-b17bfa462587</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="28" Volume="1983" Year="1985" Format="Main Series">
+    <Book Series="Alpha Flight" Number="28" Volume="1983" Year="1985">
       <Id>dbb60a3b-3c80-44e1-a6bd-8965304f0a87</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="313" Volume="1968" Year="1985" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="313" Volume="1968" Year="1985">
       <Id>d72d6126-245c-4b0d-8004-5e82185ab146</Id>
     </Book>
-    <Book Series="Alpha Flight" Number="29" Volume="1983" Year="1985" Format="Main Series">
+    <Book Series="Alpha Flight" Number="29" Volume="1983" Year="1985">
       <Id>25200fd2-4689-4169-b3eb-8fee85e653af</Id>
     </Book>
-    <Book Series="The Incredible Hulk Annual" Number="14" Volume="1968" Year="1985" Format="Annual">
+    <Book Series="The Incredible Hulk Annual" Number="14" Volume="1968" Year="1985">
       <Id>fe59a600-fe1f-4a2f-85d1-402170487c90</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="314" Volume="1968" Year="1985" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="314" Volume="1968" Year="1985">
       <Id>1676f7dc-7c52-4c7d-a7ef-d7e7d4c2dca0</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="315" Volume="1968" Year="1986" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="315" Volume="1968" Year="1986">
       <Id>1068aa8b-1959-4a6a-be76-1f9834a4f8bb</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="316" Volume="1968" Year="1986" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="316" Volume="1968" Year="1986">
       <Id>4bb563a9-191b-4310-9b8b-4fc48f921175</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="317" Volume="1968" Year="1986" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="317" Volume="1968" Year="1986">
       <Id>8ebeb78b-c263-4bed-8ae7-e4b25b1fcb91</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="318" Volume="1968" Year="1986" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="318" Volume="1968" Year="1986">
       <Id>12bfb6c5-ab7b-45cf-980f-5229596a147b</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="319" Volume="1968" Year="1986" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="319" Volume="1968" Year="1986">
       <Id>75b0062f-39f1-465b-9f1a-dea1df4d3acd</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="320" Volume="1968" Year="1986" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="320" Volume="1968" Year="1986">
       <Id>a62bdac3-096a-41e0-9b3f-f1d59a0be678</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="321" Volume="1968" Year="1986" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="321" Volume="1968" Year="1986">
       <Id>dcc343dd-065a-47b0-a5b1-63c190c58a51</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="322" Volume="1968" Year="1986" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="322" Volume="1968" Year="1986">
       <Id>a52ae23b-ba2b-4dca-90a1-80c7cbe32aa5</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="323" Volume="1968" Year="1986" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="323" Volume="1968" Year="1986">
       <Id>8699054a-6758-4fc7-a349-79adf2c1f277</Id>
     </Book>
-    <Book Series="The Avengers" Number="267" Volume="1963" Year="1986" Format="Main Series">
+    <Book Series="The Avengers" Number="267" Volume="1963" Year="1986">
       <Id>e470921b-a9bc-4d8a-8f95-8baaba985229</Id>
     </Book>
     <Book Series="Marvel Fanfare" Number="29" Volume="1982" Year="1986">
       <Id>40fa8824-35fc-48e3-845d-624d147126e0</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="324" Volume="1968" Year="1986" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="324" Volume="1968" Year="1986">
       <Id>ca4c12ab-6ed2-4eb5-90b9-f3e0b0513268</Id>
     </Book>
-    <Book Series="The Incredible Hulk Annual" Number="15" Volume="1968" Year="1986" Format="Annual">
+    <Book Series="The Incredible Hulk Annual" Number="15" Volume="1968" Year="1986">
       <Id>fe1c24a2-c70d-4c1e-a902-c0108d4c6c73</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="325" Volume="1968" Year="1986" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="325" Volume="1968" Year="1986">
       <Id>ed54b5c3-774b-4e4e-90ac-25f73b100348</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="326" Volume="1968" Year="1986" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="326" Volume="1968" Year="1986">
       <Id>408a2961-0fd8-4f7c-8932-a6b164a47eb0</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="327" Volume="1968" Year="1987" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="327" Volume="1968" Year="1987">
       <Id>3d0e3af3-799d-46ae-b53d-70ae6253c4c2</Id>
     </Book>
-    <Book Series="Marvel Graphic Novel" Number="29" Volume="1982" Year="1987" Format="One-Shot">
+    <Book Series="Marvel Graphic Novel" Number="29" Volume="1982" Year="1987">
       <Id>8001d8e8-7da4-4b64-9292-900dc6e9599b</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="328" Volume="1968" Year="1987" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="328" Volume="1968" Year="1987">
       <Id>ba12cff3-19ff-4c16-8d66-6e14117c7fab</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="329" Volume="1968" Year="1987" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="329" Volume="1968" Year="1987">
       <Id>bef08413-97ae-4349-abed-0879875b2052</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="330" Volume="1968" Year="1987" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="330" Volume="1968" Year="1987">
       <Id>2d08cdcc-e380-453b-aef0-a00fedf00897</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="331" Volume="1968" Year="1987" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="331" Volume="1968" Year="1987">
       <Id>d80dbff9-c3ef-4f3f-93cf-b7135c07272e</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="332" Volume="1968" Year="1987" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="332" Volume="1968" Year="1987">
       <Id>0318f2a4-c878-4927-ac27-ff0d19b4b3eb</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="333" Volume="1968" Year="1987" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="333" Volume="1968" Year="1987">
       <Id>348917d8-17e1-4dd6-868d-5a0e640e9973</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="334" Volume="1968" Year="1987" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="334" Volume="1968" Year="1987">
       <Id>2fbf5091-903e-4440-a55e-2907912067ff</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="335" Volume="1968" Year="1987" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="335" Volume="1968" Year="1987">
       <Id>64c17a77-b2e3-4dba-8265-4c768a1cd339</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="336" Volume="1968" Year="1987" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="336" Volume="1968" Year="1987">
       <Id>7a95fecb-ad50-47df-bc29-9c81db3aa589</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="337" Volume="1968" Year="1987" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="337" Volume="1968" Year="1987">
       <Id>4888e8f9-8d6c-4bea-88b3-238dc3d873d8</Id>
     </Book>
-    <Book Series="Thor" Number="385" Volume="1966" Year="1987" Format="Main Series">
+    <Book Series="Thor" Number="385" Volume="1966" Year="1987">
       <Id>5b4bdb9a-1a73-430c-bf31-e52e897d0fbb</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="338" Volume="1968" Year="1987" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="338" Volume="1968" Year="1987">
       <Id>d25a0f40-720c-4b19-b1a7-09e97c921e4d</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="339" Volume="1968" Year="1988" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="339" Volume="1968" Year="1988">
       <Id>c8a9c642-1921-444b-a589-7029a91a20ea</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="340" Volume="1968" Year="1988" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="340" Volume="1968" Year="1988">
       <Id>f77b4acd-e2e8-465a-bae5-a0bc88615276</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="341" Volume="1968" Year="1988" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="341" Volume="1968" Year="1988">
       <Id>0fd3eaed-de74-4fea-9754-c6cd5c09977a</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="342" Volume="1968" Year="1988" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="342" Volume="1968" Year="1988">
       <Id>3f160c93-8886-4899-a6ba-0a11e7dc1417</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="343" Volume="1968" Year="1988" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="343" Volume="1968" Year="1988">
       <Id>9d6533e9-8212-495e-8923-d7d0239e7dfd</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="344" Volume="1968" Year="1988" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="344" Volume="1968" Year="1988">
       <Id>531c3209-5497-4129-bf40-ba959812d648</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="345" Volume="1968" Year="1988" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="345" Volume="1968" Year="1988">
       <Id>b60e7ad3-9b01-44b8-9b68-9fb001957fd2</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="346" Volume="1968" Year="1988" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="346" Volume="1968" Year="1988">
       <Id>a7bb24de-bef1-446f-94ae-29ade6837c79</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="347" Volume="1968" Year="1988" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="347" Volume="1968" Year="1988">
       <Id>9cdbd23b-5f1c-4fb0-8fba-2e976b64a3e3</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="348" Volume="1968" Year="1988" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="348" Volume="1968" Year="1988">
       <Id>25e400b7-24a0-496c-98ec-783e9013a70f</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="44" Volume="1985" Year="1988" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="44" Volume="1985" Year="1988">
       <Id>32340d79-4ef4-464a-89f4-76ae96f0e6cf</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="349" Volume="1968" Year="1988" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="349" Volume="1968" Year="1988">
       <Id>064119b8-a2bf-4afa-a3a2-e2daeabf6f59</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="320" Volume="1961" Year="1988" Format="Main Series">
+    <Book Series="Fantastic Four" Number="320" Volume="1961" Year="1988">
       <Id>d7d903ef-dc25-490e-9823-df1473771be1</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="350" Volume="1968" Year="1988" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="350" Volume="1968" Year="1988">
       <Id>5f52636a-b02d-4cad-916b-92ecf4759530</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="351" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="351" Volume="1968" Year="1989">
       <Id>cc0c022b-10ea-48b3-a254-8bba575b3c31</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="352" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="352" Volume="1968" Year="1989">
       <Id>edb84433-0d33-42ba-b0b9-2463b2a55db5</Id>
     </Book>
-    <Book Series="Wolverine" Number="7" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Wolverine" Number="7" Volume="1988" Year="1989">
       <Id>32a28c09-83b5-4885-81f1-1934141d2184</Id>
     </Book>
-    <Book Series="Wolverine" Number="8" Volume="1988" Year="1989" Format="Main Series">
+    <Book Series="Wolverine" Number="8" Volume="1988" Year="1989">
       <Id>65af2951-9170-487c-92ee-9edcca672081</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="353" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="353" Volume="1968" Year="1989">
       <Id>8aed585e-3d8a-4a1c-b0b9-ee55fa99aed7</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="354" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="354" Volume="1968" Year="1989">
       <Id>dc4b5228-a88d-4348-b3e2-800f02b4bf79</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="355" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="355" Volume="1968" Year="1989">
       <Id>e018454f-1202-4ff6-8a55-69ea738339ce</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="356" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="356" Volume="1968" Year="1989">
       <Id>e4bf2acb-9bbc-4702-bc79-efd0d40973c3</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="357" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="357" Volume="1968" Year="1989">
       <Id>2c84057e-6a86-4b41-b019-7aece3b68e35</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="358" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="358" Volume="1968" Year="1989">
       <Id>548ab466-7ca8-4f21-a88a-f7d6cc617310</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="359" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="359" Volume="1968" Year="1989">
       <Id>707ff5a7-b248-4614-89d9-c46601d1f56b</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="360" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="360" Volume="1968" Year="1989">
       <Id>53801dfe-4dc9-4ab9-a116-341527176052</Id>
     </Book>
-    <Book Series="Iron Man" Number="247" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="Iron Man" Number="247" Volume="1968" Year="1989">
       <Id>170cffc3-0f80-47ad-8d89-0af4c508e494</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="361" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="361" Volume="1968" Year="1989">
       <Id>e3b4290f-4fbe-492a-9558-86ad84cb7886</Id>
     </Book>
     <Book Series="Marvel Fanfare" Number="47" Volume="1982" Year="1989">
       <Id>9db338db-5f33-4116-b9e9-ffdb8704ecfd</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="363" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="363" Volume="1968" Year="1989">
       <Id>182ef0e7-2c31-4e13-aef7-a89e27bd749c</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="364" Volume="1968" Year="1989" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="364" Volume="1968" Year="1989">
       <Id>d581a44d-8080-4421-ba0c-d32a63643ef7</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="365" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="365" Volume="1968" Year="1990">
       <Id>26360d76-691d-431c-aa17-837cc91d422d</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="366" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="366" Volume="1968" Year="1990">
       <Id>ba28b0ac-4b8f-44da-9b04-7f97c8231dae</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="367" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="367" Volume="1968" Year="1990">
       <Id>a2b27868-c531-4e7d-b416-6a18b0e46875</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="328" Volume="1963" Year="1990" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="328" Volume="1963" Year="1990">
       <Id>2030fc16-b582-46d8-b53a-b13a36dcdc00</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="368" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="368" Volume="1968" Year="1990">
       <Id>7a0f198a-c6e6-4603-8198-2f89315a6529</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="369" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="369" Volume="1968" Year="1990">
       <Id>992115f4-f83a-40fa-bd9f-a8c8fde92a92</Id>
     </Book>
-    <Book Series="The Incredible Hulk Annual" Number="16" Volume="1968" Year="1990" Format="Annual">
+    <Book Series="The Incredible Hulk Annual" Number="16" Volume="1968" Year="1990">
       <Id>175b70e9-bcfd-4899-a489-837f81a76e24</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="370" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="370" Volume="1968" Year="1990">
       <Id>234cba18-9e9c-4e2a-bf80-1734eebaabc7</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="371" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="371" Volume="1968" Year="1990">
       <Id>57e3de43-d04b-4757-939f-e4c7e1e99626</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="52" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="52" Volume="1988" Year="1990">
       <Id>eae784cf-8243-43e5-baf2-1049f3a2636a</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="53" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="53" Volume="1988" Year="1990">
       <Id>1e7ed635-8f16-4078-b87c-f506b8dc296a</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="54" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="54" Volume="1988" Year="1990">
       <Id>42f6ae9b-06ca-42b0-82d6-a0e8b90fde95</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="55" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="55" Volume="1988" Year="1990">
       <Id>fe2e468f-9428-45b3-b124-937cae97acab</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="56" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="56" Volume="1988" Year="1990">
       <Id>c7fa864b-7722-4178-a7d6-0a6878787bf0</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="57" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="57" Volume="1988" Year="1990">
       <Id>01ecf45f-33ff-4e52-bbc1-0feb813033e8</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="58" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="58" Volume="1988" Year="1990">
       <Id>6d5a5486-2af4-4761-a00e-2c0ca2dc40e5</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="59" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="59" Volume="1988" Year="1990">
       <Id>0903b682-ac6e-4c22-a9fa-38e4e339be2e</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="60" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="60" Volume="1988" Year="1990">
       <Id>d2d645ad-7a6e-4022-afb4-af14fc567c86</Id>
     </Book>
-    <Book Series="Marvel Comics Presents" Number="61" Volume="1988" Year="1990" Format="Main Series">
+    <Book Series="Marvel Comics Presents" Number="61" Volume="1988" Year="1990">
       <Id>91fc4fed-c949-444a-b9de-2ac5201a1370</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="372" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="372" Volume="1968" Year="1990">
       <Id>33c3da64-48d6-42bb-af26-b1bb2c0692ad</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="373" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="373" Volume="1968" Year="1990">
       <Id>e83c9032-89a8-4cab-bd03-057f61088e65</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="374" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="374" Volume="1968" Year="1990">
       <Id>c78973c9-7df3-4091-8b91-fb3877a42d40</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="375" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="375" Volume="1968" Year="1990">
       <Id>d884d974-d886-4f7a-87db-f33694a57119</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="69" Volume="1985" Year="1990" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="69" Volume="1985" Year="1990">
       <Id>6b0dff06-f375-494d-8fa6-d1e304629eb0</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="376" Volume="1968" Year="1990" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="376" Volume="1968" Year="1990">
       <Id>048087fa-0840-4ece-8274-f2e14a99a414</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="377" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="377" Volume="1968" Year="1991">
       <Id>9e456287-e40a-4236-acfd-f82303625c17</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="347" Volume="1961" Year="1990" Format="Main Series">
+    <Book Series="Fantastic Four" Number="347" Volume="1961" Year="1990">
       <Id>f81cac5e-8ad0-442e-a6a1-039f88a3d43d</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="348" Volume="1961" Year="1991" Format="Main Series">
+    <Book Series="Fantastic Four" Number="348" Volume="1961" Year="1991">
       <Id>8cf9919f-4249-4d15-9b06-3877f75d47f1</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="349" Volume="1961" Year="1991" Format="Main Series">
+    <Book Series="Fantastic Four" Number="349" Volume="1961" Year="1991">
       <Id>c7ddb595-8c6f-45ec-873f-667d4df2765e</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="378" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="378" Volume="1968" Year="1991">
       <Id>7dd030b1-8dca-4572-af27-6d96c97f79a6</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="379" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="379" Volume="1968" Year="1991">
       <Id>e3ccec52-305b-4a13-be14-ad80723694e1</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="380" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="380" Volume="1968" Year="1991">
       <Id>eb385a13-97b7-43e3-85d4-858e4129eedb</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="381" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="381" Volume="1968" Year="1991">
       <Id>635452d6-d36e-4c21-b032-54e7aa95c0c4</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="382" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="382" Volume="1968" Year="1991">
       <Id>1a35c2fa-7bdc-4c73-b5b9-21f78f69fbdc</Id>
     </Book>
-    <Book Series="The Incredible Hulk Annual" Number="17" Volume="1968" Year="1991" Format="Annual">
+    <Book Series="The Incredible Hulk Annual" Number="17" Volume="1968" Year="1991">
       <Id>7533e764-174b-4eb7-aa73-f516e65e7015</Id>
     </Book>
-    <Book Series="The Infinity Gauntlet" Number="1" Volume="1991" Year="1991" Format="Crossover">
+    <Book Series="The Infinity Gauntlet" Number="1" Volume="1991" Year="1991">
       <Id>2f23b825-4c7d-4ecb-b84d-4b6681197cc4</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="383" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="383" Volume="1968" Year="1991">
       <Id>a1f3343b-595e-4d34-8cfa-38a8a8af6cde</Id>
     </Book>
-    <Book Series="The Infinity Gauntlet" Number="3" Volume="1991" Year="1991" Format="Crossover">
+    <Book Series="The Infinity Gauntlet" Number="3" Volume="1991" Year="1991">
       <Id>692b2852-59a3-48d7-9e16-d24e4fbe7c89</Id>
     </Book>
-    <Book Series="The Infinity Gauntlet" Number="4" Volume="1991" Year="1991" Format="Crossover">
+    <Book Series="The Infinity Gauntlet" Number="4" Volume="1991" Year="1991">
       <Id>964ff388-35dd-4666-8c7f-281e2be065d4</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="384" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="384" Volume="1968" Year="1991">
       <Id>2e101605-645c-40aa-850c-446776b1ce41</Id>
     </Book>
-    <Book Series="The Infinity Gauntlet" Number="5" Volume="1991" Year="1991" Format="Crossover">
+    <Book Series="The Infinity Gauntlet" Number="5" Volume="1991" Year="1991">
       <Id>f5a11a17-4854-4bba-9702-dd482bc009cc</Id>
     </Book>
-    <Book Series="The Infinity Gauntlet" Number="6" Volume="1991" Year="1991" Format="Crossover">
+    <Book Series="The Infinity Gauntlet" Number="6" Volume="1991" Year="1991">
       <Id>01e38e6c-6b68-4d69-acff-be79c486f01d</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="385" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="385" Volume="1968" Year="1991">
       <Id>762f343f-0090-45ad-93fe-c80887ee10c0</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="386" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="386" Volume="1968" Year="1991">
       <Id>e552d76c-918c-473f-8245-14fe5166374e</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="387" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="387" Volume="1968" Year="1991">
       <Id>a8a75916-a861-460a-b954-adca93ed37d5</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="388" Volume="1968" Year="1991" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="388" Volume="1968" Year="1991">
       <Id>a686bf5f-300d-4666-9a14-cafb6d6ee34b</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="389" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="389" Volume="1968" Year="1992">
       <Id>e408b95e-87f7-4758-be7e-587d38c46b7b</Id>
     </Book>
-    <Book Series="Spider-Man" Number="18" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Spider-Man" Number="18" Volume="1990" Year="1992">
       <Id>110562f4-5117-4472-9401-5bd737f0c5e4</Id>
     </Book>
-    <Book Series="Spider-Man" Number="19" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Spider-Man" Number="19" Volume="1990" Year="1992">
       <Id>1cbbf730-87ad-44bd-a20a-995288540842</Id>
     </Book>
-    <Book Series="Spider-Man" Number="20" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Spider-Man" Number="20" Volume="1990" Year="1992">
       <Id>158ac9ef-05d1-4c72-a91b-34b5a5bfff3a</Id>
     </Book>
-    <Book Series="Spider-Man" Number="22" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Spider-Man" Number="22" Volume="1990" Year="1992">
       <Id>381cd4dd-439b-4ea9-b3ce-3d2f804ff3c2</Id>
     </Book>
-    <Book Series="Spider-Man" Number="23" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Spider-Man" Number="23" Volume="1990" Year="1992">
       <Id>0d5c4cfd-74e6-46ac-89f4-70490f6337ab</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="390" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="390" Volume="1968" Year="1992">
       <Id>8d57f0d8-66bd-41d7-82f8-530d52c08035</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="391" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="391" Volume="1968" Year="1992">
       <Id>f55090a9-0477-4396-a05b-f5b15634ddd8</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="392" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="392" Volume="1968" Year="1992">
       <Id>46b0ce66-099c-4976-8e47-fe2365c6c273</Id>
     </Book>
-    <Book Series="The Incredible Hulk Annual" Number="18" Volume="1968" Year="1992" Format="Annual">
+    <Book Series="The Incredible Hulk Annual" Number="18" Volume="1968" Year="1992">
       <Id>e6a353fc-b49e-4bb6-874d-7c74936ae603</Id>
     </Book>
-    <Book Series="Namor, The Sub-Mariner Annual" Number="2" Volume="1991" Year="1992" Format="Annual">
+    <Book Series="Namor, The Sub-Mariner Annual" Number="2" Volume="1991" Year="1992">
       <Id>e4e2878a-1a83-4f4d-b56a-70b43f15a648</Id>
     </Book>
-    <Book Series="Silver Surfer Annual" Number="5" Volume="1988" Year="1992" Format="Annual">
+    <Book Series="Silver Surfer Annual" Number="5" Volume="1988" Year="1992">
       <Id>b781b373-060d-4f2c-bcad-f49f4c8fa14e</Id>
     </Book>
-    <Book Series="Doctor Strange, Sorcerer Supreme Annual" Number="2" Volume="1976" Year="1992" Format="Annual">
+    <Book Series="Doctor Strange, Sorcerer Supreme Annual" Number="2" Volume="1976" Year="1992">
       <Id>afb5c9b8-9b6f-485a-a80f-2133b976a009</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="393" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="393" Volume="1968" Year="1992">
       <Id>4b3df239-4f9d-4dec-946d-4013b8364ec7</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="394" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="394" Volume="1968" Year="1992">
       <Id>aa3572ea-cac4-4ef9-9356-43d5b9efab00</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="395" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="395" Volume="1968" Year="1992">
       <Id>8e4b2eb6-d7ea-4939-ad56-b75f938879a2</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="396" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="396" Volume="1968" Year="1992">
       <Id>93eabc44-3585-4753-bdde-19272d133c7d</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="397" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="397" Volume="1968" Year="1992">
       <Id>4eac47cf-b564-4199-b14e-600547ce03b8</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="398" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="398" Volume="1968" Year="1992">
       <Id>0c2feb61-bc75-4bcc-b127-6dbd774224cf</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="399" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="399" Volume="1968" Year="1992">
       <Id>12d7bdc7-19a7-43e2-987f-8f6ce3cd8ea8</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="400" Volume="1968" Year="1992" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="400" Volume="1968" Year="1992">
       <Id>7250e46e-6cc1-45d5-826c-db76ea84c03f</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="401" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="401" Volume="1968" Year="1993">
       <Id>b1c3940c-b8e4-4dd3-ac94-31420f2e2a1c</Id>
     </Book>
-    <Book Series="Cage" Number="9" Volume="1992" Year="1992" Format="Main Series">
+    <Book Series="Cage" Number="9" Volume="1992" Year="1992">
       <Id>85a8ba48-5d91-4daf-be3b-2df6d0898609</Id>
     </Book>
-    <Book Series="Cage" Number="10" Volume="1992" Year="1993" Format="Main Series">
+    <Book Series="Cage" Number="10" Volume="1992" Year="1993">
       <Id>029c56a8-dae0-46b8-9121-e4d6ccacff2b</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="402" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="402" Volume="1968" Year="1993">
       <Id>a9830e24-176e-4b0a-9c5d-b710c1318011</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="403" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="403" Volume="1968" Year="1993">
       <Id>fb077806-70f5-4871-ae2e-7b49f19aa9a6</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="404" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="404" Volume="1968" Year="1993">
       <Id>251695e8-8ff4-430d-ae2b-441e2a39cfcd</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="56" Volume="1989" Year="1993" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="56" Volume="1989" Year="1993">
       <Id>eee4f908-96b1-4d0f-8c19-e8b16253f6c3</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="57" Volume="1989" Year="1993" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="57" Volume="1989" Year="1993">
       <Id>bf423288-efad-45e9-a9a0-f198e97e448a</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="374" Volume="1961" Year="1993" Format="Main Series">
+    <Book Series="Fantastic Four" Number="374" Volume="1961" Year="1993">
       <Id>1d3e5377-27fc-4654-8037-e9e931841e60</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="405" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="405" Volume="1968" Year="1993">
       <Id>5aa44ee3-6e2a-448c-9964-f585eb188a3e</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="406" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="406" Volume="1968" Year="1993">
       <Id>59d4dcb3-e1e6-4b75-ad9b-459d5408f80f</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="407" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="407" Volume="1968" Year="1993">
       <Id>760703d2-2aa3-4151-afd4-f3175a2654eb</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="408" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="408" Volume="1968" Year="1993">
       <Id>602cba93-02a6-48c4-8755-6d6a0ab3e62d</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="409" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="409" Volume="1968" Year="1993">
       <Id>bda8f2b5-4e24-4407-8b9d-297e30ab039a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="381" Volume="1963" Year="1993" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="381" Volume="1963" Year="1993">
       <Id>fa5f0bdc-628c-48a5-aba5-8b4d45abf453</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="382" Volume="1963" Year="1993" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="382" Volume="1963" Year="1993">
       <Id>82d644e2-cc70-4fba-9a1f-53c67c48b9e0</Id>
     </Book>
-    <Book Series="The Incredible Hulk Annual" Number="19" Volume="1968" Year="1993" Format="Annual">
+    <Book Series="The Incredible Hulk Annual" Number="19" Volume="1968" Year="1993">
       <Id>14ce45a5-307b-4634-bf60-1e2670e63309</Id>
     </Book>
-    <Book Series="Wonder Man" Number="26" Volume="1991" Year="1993" Format="Main Series">
+    <Book Series="Wonder Man" Number="26" Volume="1991" Year="1993">
       <Id>ba523d12-d58e-4dea-a119-8b900d2069cf</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="410" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="410" Volume="1968" Year="1993">
       <Id>087d0769-22ad-4f99-a786-7488d0c75f60</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="411" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="411" Volume="1968" Year="1993">
       <Id>5929c616-1d4a-4e99-bc13-a176a7652492</Id>
     </Book>
-    <Book Series="Wonder Man" Number="27" Volume="1991" Year="1993" Format="Main Series">
+    <Book Series="Wonder Man" Number="27" Volume="1991" Year="1993">
       <Id>936352ec-b974-4d1e-9989-8cb6eb646df2</Id>
     </Book>
-    <Book Series="Fantastic Four Unlimited" Number="4" Volume="1993" Year="1993" Format="Main Series">
+    <Book Series="Fantastic Four Unlimited" Number="4" Volume="1993" Year="1993">
       <Id>aef86759-5682-42a8-9f69-4bc8fee4efee</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="412" Volume="1968" Year="1993" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="412" Volume="1968" Year="1993">
       <Id>184cf402-39af-48e2-b3ec-a7a3a130f6a0</Id>
     </Book>
-    <Book Series="Fantastic Four Unlimited" Number="5" Volume="1993" Year="1994" Format="Main Series">
+    <Book Series="Fantastic Four Unlimited" Number="5" Volume="1993" Year="1994">
       <Id>410df40e-bbcc-460a-ae95-d99461e2e0b9</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="413" Volume="1968" Year="1994" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="413" Volume="1968" Year="1994">
       <Id>16881639-febd-4ba8-ba80-2b208f4d5bc8</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="414" Volume="1968" Year="1994" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="414" Volume="1968" Year="1994">
       <Id>b224cc25-7bfe-440d-a136-5f1654a65664</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="415" Volume="1968" Year="1994" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="415" Volume="1968" Year="1994">
       <Id>0c951b36-7420-4689-afc3-99a6e42ee0f7</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="416" Volume="1968" Year="1994" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="416" Volume="1968" Year="1994">
       <Id>c332dd2e-ff32-46d8-8352-68dd80623846</Id>
     </Book>
-    <Book Series="Hulk: Future Imperfect" Number="1" Volume="1992" Year="1992" Format="Limited Series">
+    <Book Series="Hulk: Future Imperfect" Number="1" Volume="1992" Year="1992">
       <Id>6b797f3d-feb7-4303-853e-fb2786c048a2</Id>
     </Book>
-    <Book Series="Hulk: Future Imperfect" Number="2" Volume="1992" Year="1993" Format="Limited Series">
+    <Book Series="Hulk: Future Imperfect" Number="2" Volume="1992" Year="1993">
       <Id>4e683588-f0b9-446f-8d17-ff85a12b6080</Id>
     </Book>
-    <Book Series="Ghost Rider" Number="49" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="Ghost Rider" Number="49" Volume="1990" Year="1994">
       <Id>3b8d959d-4882-4bca-8555-e991ec559bb6</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="417" Volume="1968" Year="1994" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="417" Volume="1968" Year="1994">
       <Id>930a21b4-2717-41ea-8597-7606edd96da3</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="418" Volume="1968" Year="1994" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="418" Volume="1968" Year="1994">
       <Id>d9a9d22f-a3f6-4b83-911c-87e799336c4d</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="419" Volume="1968" Year="1994" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="419" Volume="1968" Year="1994">
       <Id>bf951002-0e60-464d-a3d4-d3f2cc6c6b09</Id>
     </Book>
-    <Book Series="The Incredible Hulk Annual" Number="20" Volume="1968" Year="1994" Format="Annual">
+    <Book Series="The Incredible Hulk Annual" Number="20" Volume="1968" Year="1994">
       <Id>6468a946-e735-47ff-a308-c89f75b6534d</Id>
     </Book>
-    <Book Series="Iron Man" Number="304" Volume="1968" Year="1994" Format="Main Series">
+    <Book Series="Iron Man" Number="304" Volume="1968" Year="1994">
       <Id>ddee2d88-7798-4ae4-9a26-71cbdb8df10a</Id>
     </Book>
-    <Book Series="Iron Man" Number="305" Volume="1968" Year="1994" Format="Main Series">
+    <Book Series="Iron Man" Number="305" Volume="1968" Year="1994">
       <Id>6cb46438-7b73-42c2-bdd3-06ce0ad385a3</Id>
     </Book>
-    <Book Series="Incredible Hulk vs. Venom" Number="1" Volume="1993" Year="1994" Format="One-Shot">
+    <Book Series="Incredible Hulk vs. Venom" Number="1" Volume="1993" Year="1994">
       <Id>9bda0c3c-e1d2-48fe-8abc-4b2978c6e627</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="1" Volume="1994" Year="1994" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="1" Volume="1994" Year="1994">
       <Id>0eaa5cfa-249b-4f77-9230-bc80e569d107</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="420" Volume="1968" Year="1994" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="420" Volume="1968" Year="1994">
       <Id>cac9c625-5d5a-4e90-bb3d-dd1033235b0f</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="421" Volume="1968" Year="1994" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="421" Volume="1968" Year="1994">
       <Id>2462eb9f-b6a6-4bb3-af85-5b9522cefb23</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="422" Volume="1968" Year="1994" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="422" Volume="1968" Year="1994">
       <Id>281d925d-b041-432e-9364-f0dd2e26b1c2</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="423" Volume="1968" Year="1994" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="423" Volume="1968" Year="1994">
       <Id>a2bc26da-bebe-47d1-9c41-afef29676ccd</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="424" Volume="1968" Year="1994" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="424" Volume="1968" Year="1994">
       <Id>0fa09ad9-23e7-4c9d-8924-054c0b567fd4</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="425" Volume="1968" Year="1995" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="425" Volume="1968" Year="1995">
       <Id>aaa64d8d-2ea0-4ba8-8dc8-4a62c86d55ae</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="426" Volume="1968" Year="1995" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="426" Volume="1968" Year="1995">
       <Id>c2887fbf-ab5b-44bb-9347-62db5377e738</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="427" Volume="1968" Year="1995" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="427" Volume="1968" Year="1995">
       <Id>b17dfe52-ec64-47b1-92c2-ec67b6c2d859</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="428" Volume="1968" Year="1995" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="428" Volume="1968" Year="1995">
       <Id>79e6f34a-6ebf-43f5-a6e8-2acc419feef0</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="429" Volume="1968" Year="1995" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="429" Volume="1968" Year="1995">
       <Id>5952a9b8-1ed8-4045-b839-9c68934e336e</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="430" Volume="1968" Year="1995" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="430" Volume="1968" Year="1995">
       <Id>4a946d6d-c763-4812-8086-178124881f53</Id>
     </Book>
-    <Book Series="The Mighty Thor" Number="488" Volume="1989" Year="1995" Format="Main Series">
+    <Book Series="The Mighty Thor" Number="488" Volume="1989" Year="1995">
       <Id>063f3260-b145-4528-9a28-3a4dbd2ea37e</Id>
     </Book>
-    <Book Series="The Mighty Thor" Number="489" Volume="1989" Year="1995" Format="Main Series">
+    <Book Series="The Mighty Thor" Number="489" Volume="1989" Year="1995">
       <Id>bdcca08e-4f31-4c50-a334-5ab499428d01</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="431" Volume="1968" Year="1995" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="431" Volume="1968" Year="1995">
       <Id>cb938bc7-aaa2-42fc-aba4-5a3aaef6ca14</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="432" Volume="1968" Year="1995" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="432" Volume="1968" Year="1995">
       <Id>605326b5-16d1-43d6-9d39-357f0d4b9ceb</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="433" Volume="1968" Year="1995" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="433" Volume="1968" Year="1995">
       <Id>c9a854fe-c6ce-4191-8891-b661c96bc6ab</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="434" Volume="1968" Year="1995" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="434" Volume="1968" Year="1995">
       <Id>7a0b5dbd-9417-4e5d-b148-dbab6c3b6c81</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="435" Volume="1968" Year="1995" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="435" Volume="1968" Year="1995">
       <Id>a53e5c86-7577-4023-b73e-8486c63cfdf5</Id>
     </Book>
-    <Book Series="Cutting Edge" Number="1" Volume="1995" Year="1995" Format="One-Shot">
+    <Book Series="Cutting Edge" Number="1" Volume="1995" Year="1995">
       <Id>24cfaf3a-3921-42f5-ae40-45a77cca1dbf</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="436" Volume="1968" Year="1995" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="436" Volume="1968" Year="1995">
       <Id>fee27fe8-7dc0-443f-872f-278f9006f3dd</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="437" Volume="1968" Year="1996" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="437" Volume="1968" Year="1996">
       <Id>fa126cb2-169a-42ea-9af3-08ae3a75ab27</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="438" Volume="1968" Year="1996" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="438" Volume="1968" Year="1996">
       <Id>94bcc494-eb63-4be6-9370-038e50f6d127</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="439" Volume="1968" Year="1996" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="439" Volume="1968" Year="1996">
       <Id>bd9109be-ea83-46e9-864f-3c22e7fbb8e7</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="440" Volume="1968" Year="1996" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="440" Volume="1968" Year="1996">
       <Id>2cbab535-c33b-48ce-9869-712d9a3cafa0</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="441" Volume="1968" Year="1996" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="441" Volume="1968" Year="1996">
       <Id>8a0ca7e2-99ba-476f-ad8f-8067ac6d4689</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="442" Volume="1968" Year="1996" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="442" Volume="1968" Year="1996">
       <Id>260f2ce7-f24c-4f03-b742-e026cf9bb72d</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="443" Volume="1968" Year="1996" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="443" Volume="1968" Year="1996">
       <Id>464bb52e-0c0b-4325-9ed2-eea4730ad40f</Id>
     </Book>
-    <Book Series="Cable" Number="34" Volume="1993" Year="1996" Format="Main Series">
+    <Book Series="Cable" Number="34" Volume="1993" Year="1996">
       <Id>390f7bee-febf-402b-8e4c-6137bf0ddcdd</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="444" Volume="1968" Year="1996" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="444" Volume="1968" Year="1996">
       <Id>6d825348-441a-46f6-8e5e-d83096ea4ec6</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="445" Volume="1968" Year="1996" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="445" Volume="1968" Year="1996">
       <Id>6d7277a8-e8b0-408e-88e3-772b54095e72</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="446" Volume="1968" Year="1996" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="446" Volume="1968" Year="1996">
       <Id>8ecb7a86-5bc5-4c12-876f-f5e8512b2786</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="447" Volume="1968" Year="1996" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="447" Volume="1968" Year="1996">
       <Id>d45cbf50-087b-4a59-ac16-47f66f0f417e</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="448" Volume="1968" Year="1996" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="448" Volume="1968" Year="1996">
       <Id>d91cd8f7-f749-473a-9308-63dd25134230</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="449" Volume="1968" Year="1997" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="449" Volume="1968" Year="1997">
       <Id>075f9856-27d3-4136-a389-85d1e88c5732</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="450" Volume="1968" Year="1997" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="450" Volume="1968" Year="1997">
       <Id>c3fa786f-2c3e-4f6a-a74c-52b988e91b85</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="451" Volume="1968" Year="1997" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="451" Volume="1968" Year="1997">
       <Id>a345af5e-4867-46f9-91c2-68347b5c2ee9</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="452" Volume="1968" Year="1997" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="452" Volume="1968" Year="1997">
       <Id>3b50f792-ce58-4307-990c-368b6f28ee94</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="453" Volume="1968" Year="1997" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="453" Volume="1968" Year="1997">
       <Id>8e567c26-099b-4f1f-bf10-c9fe63840b75</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="454" Volume="1968" Year="1997" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="454" Volume="1968" Year="1997">
       <Id>0e9a44de-d53b-47d4-b2d9-1756f490fb99</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="455" Volume="1968" Year="1997" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="455" Volume="1968" Year="1997">
       <Id>94f3dc30-4372-41bb-bb5c-e9586ec25334</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="456" Volume="1968" Year="1997" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="456" Volume="1968" Year="1997">
       <Id>01ea1b6a-24ec-404f-bb4a-1d3eaa42d2c3</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="457" Volume="1968" Year="1997" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="457" Volume="1968" Year="1997">
       <Id>2ad6dd03-680c-4f6b-9261-648417d89007</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="458" Volume="1968" Year="1997" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="458" Volume="1968" Year="1997">
       <Id>ffa4f061-77dd-4193-a8a6-ade9169f3dd6</Id>
     </Book>
-    <Book Series="The Incredible Hulk Annual '97" Number="1" Volume="1997" Year="1997" Format="Annual">
+    <Book Series="The Incredible Hulk Annual '97" Number="1" Volume="1997" Year="1997">
       <Id>b5b93282-0139-4365-b522-4b739d6bdbb1</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="459" Volume="1968" Year="1997" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="459" Volume="1968" Year="1997">
       <Id>6a006a49-34bb-4737-bd51-bb95aa7518f2</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="460" Volume="1968" Year="1998" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="460" Volume="1968" Year="1998">
       <Id>72ca1d02-2f56-44b1-840a-10c5c38db2e2</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="461" Volume="1968" Year="1998" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="461" Volume="1968" Year="1998">
       <Id>a820765c-6e3c-4668-b1b0-f7b9cd9a13dd</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="462" Volume="1968" Year="1998" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="462" Volume="1968" Year="1998">
       <Id>0efef52e-94aa-4ef6-9aaa-7dfa4bba35ed</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="463" Volume="1968" Year="1998" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="463" Volume="1968" Year="1998">
       <Id>043e6bb7-85ed-426f-8560-a451691cbc27</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="464" Volume="1968" Year="1998" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="464" Volume="1968" Year="1998">
       <Id>7971c2d4-01f8-4772-91bc-cb0d8a741242</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="465" Volume="1968" Year="1998" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="465" Volume="1968" Year="1998">
       <Id>e15cfcc8-e879-42f2-a354-fbe7a7e49098</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="466" Volume="1968" Year="1998" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="466" Volume="1968" Year="1998">
       <Id>fbaa2662-fd68-4a47-8a2a-e7df4e5c37bd</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="467" Volume="1968" Year="1998" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="467" Volume="1968" Year="1998">
       <Id>a0312bc6-94ae-400e-9960-c34d9afd0d2c</Id>
     </Book>
-    <Book Series="Hulk / Sub-Mariner Annual '98" Number="1" Volume="1998" Year="1998" Format="Annual">
+    <Book Series="Hulk / Sub-Mariner Annual '98" Number="1" Volume="1998" Year="1998">
       <Id>bf950a0d-bd49-4e68-bf6c-affc7ea41828</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="468" Volume="1968" Year="1998" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="468" Volume="1968" Year="1998">
       <Id>73b5df18-5a46-48a4-96d5-cdd1ca9a1963</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="469" Volume="1968" Year="1998" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="469" Volume="1968" Year="1998">
       <Id>fd9ae566-1357-49ba-afd9-505194471a61</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="470" Volume="1968" Year="1998" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="470" Volume="1968" Year="1998">
       <Id>907aa6d1-cf0f-491c-8787-5b9bb6beea2e</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="471" Volume="1968" Year="1998" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="471" Volume="1968" Year="1998">
       <Id>b851e740-121d-4271-88a0-31508a98fd76</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="472" Volume="1968" Year="1999" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="472" Volume="1968" Year="1999">
       <Id>68afa272-0c0d-4bac-9787-174faf976c21</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="473" Volume="1968" Year="1999" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="473" Volume="1968" Year="1999">
       <Id>b78e6248-9ca6-40a6-8e9d-c6388d658a1d</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="474" Volume="1968" Year="1999" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="474" Volume="1968" Year="1999">
       <Id>b7817421-00e7-4a83-81b2-ffef57dfe5f0</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Incredible Hulk/Incredible Hulk 002.cbl
+++ b/Marvel/Characters/unsorted/Incredible Hulk/Incredible Hulk 002.cbl
@@ -1,882 +1,883 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Incredible Hulk 2</Name>
+  <Name>Incredible Hulk 002</Name>
+  <NumIssues>292</NumIssues>
   <Books>
     <Book Series="The Incredible Hulk" Number="269" Volume="1968" Year="1982">
-      <Id>69b523c4-8c1c-42dd-9b0c-a1aa252afd12</Id>
+      <Database Name="cv" Series="2406" Issue="22009" />
     </Book>
     <Book Series="The Incredible Hulk" Number="270" Volume="1968" Year="1982">
-      <Id>03c22e87-894c-4bfd-b8cd-dcac9e7e97da</Id>
+      <Database Name="cv" Series="2406" Issue="22084" />
     </Book>
     <Book Series="The Incredible Hulk" Number="271" Volume="1968" Year="1982">
-      <Id>09e57932-8c08-4aa9-9d96-e45e8ad9590b</Id>
+      <Database Name="cv" Series="2406" Issue="22162" />
     </Book>
     <Book Series="The Incredible Hulk" Number="272" Volume="1968" Year="1982">
-      <Id>12d3e016-ccf0-4130-af6f-099f52b160f3</Id>
+      <Database Name="cv" Series="2406" Issue="22232" />
     </Book>
     <Book Series="The Incredible Hulk" Number="273" Volume="1968" Year="1982">
-      <Id>cbcbee85-44f8-4c3d-85c3-00c2a4c15273</Id>
+      <Database Name="cv" Series="2406" Issue="22301" />
     </Book>
     <Book Series="The Incredible Hulk" Number="274" Volume="1968" Year="1982">
-      <Id>a20b3659-765c-498a-a9cb-b521001ecb2d</Id>
+      <Database Name="cv" Series="2406" Issue="22376" />
     </Book>
     <Book Series="The Incredible Hulk" Number="275" Volume="1968" Year="1982">
-      <Id>bd9088fe-b3ed-4f20-992b-15f007f3617a</Id>
+      <Database Name="cv" Series="2406" Issue="22445" />
     </Book>
     <Book Series="The Incredible Hulk" Number="276" Volume="1968" Year="1982">
-      <Id>5e853439-7a80-49d2-aa7c-8d153a6494d3</Id>
+      <Database Name="cv" Series="2406" Issue="22522" />
     </Book>
     <Book Series="The Incredible Hulk" Number="277" Volume="1968" Year="1982">
-      <Id>77a35246-7938-47bc-96dc-4f34f46a536e</Id>
+      <Database Name="cv" Series="2406" Issue="22593" />
     </Book>
     <Book Series="The Incredible Hulk" Number="278" Volume="1968" Year="1982">
-      <Id>dadb6303-0596-42b6-8908-609105b0ca98</Id>
+      <Database Name="cv" Series="2406" Issue="22673" />
     </Book>
     <Book Series="The Incredible Hulk" Number="279" Volume="1968" Year="1983">
-      <Id>cc3d1cb9-8f0a-4792-816b-4d42d68b6500</Id>
+      <Database Name="cv" Series="2406" Issue="22792" />
     </Book>
     <Book Series="The Incredible Hulk" Number="280" Volume="1968" Year="1983">
-      <Id>41450bf1-94c7-4039-9ee1-f1601e648f48</Id>
+      <Database Name="cv" Series="2406" Issue="22865" />
     </Book>
     <Book Series="The Incredible Hulk" Number="281" Volume="1968" Year="1983">
-      <Id>400f2b6e-abe6-4000-80cd-ee86c0df4c0a</Id>
+      <Database Name="cv" Series="2406" Issue="22950" />
     </Book>
     <Book Series="The Incredible Hulk" Number="282" Volume="1968" Year="1983">
-      <Id>e88c93a7-7055-451c-9fc9-f6b7816b34a9</Id>
+      <Database Name="cv" Series="2406" Issue="23034" />
     </Book>
     <Book Series="The Incredible Hulk" Number="283" Volume="1968" Year="1983">
-      <Id>2677a0e4-6e8c-46ee-9733-8b41fef3e50d</Id>
+      <Database Name="cv" Series="2406" Issue="23120" />
     </Book>
     <Book Series="The Incredible Hulk" Number="284" Volume="1968" Year="1983">
-      <Id>db726a3d-10d6-40e3-be4d-f10386b1cf5f</Id>
+      <Database Name="cv" Series="2406" Issue="23205" />
     </Book>
     <Book Series="Marvel Team-Up" Number="126" Volume="1972" Year="1983">
-      <Id>226582a0-44ca-4518-92c6-d734aa486570</Id>
+      <Database Name="cv" Series="2576" Issue="22868" />
     </Book>
     <Book Series="The Incredible Hulk" Number="285" Volume="1968" Year="1983">
-      <Id>19c2d3ca-ee13-4e6b-b5a2-5b9003a74ec2</Id>
+      <Database Name="cv" Series="2406" Issue="23291" />
     </Book>
     <Book Series="The Incredible Hulk Annual" Number="12" Volume="1968" Year="1983">
-      <Id>74a78ac2-9654-4d2b-be2d-283580607497</Id>
+      <Database Name="cv" Series="2860" Issue="23373" />
     </Book>
     <Book Series="The Incredible Hulk" Number="286" Volume="1968" Year="1983">
-      <Id>f18a17dc-69e8-440c-adbe-8803fd41ce9a</Id>
+      <Database Name="cv" Series="2406" Issue="23374" />
     </Book>
     <Book Series="The Incredible Hulk" Number="287" Volume="1968" Year="1983">
-      <Id>0fdb72ed-b489-42f2-b910-108a1f52272f</Id>
+      <Database Name="cv" Series="2406" Issue="23454" />
     </Book>
     <Book Series="The Incredible Hulk" Number="288" Volume="1968" Year="1983">
-      <Id>a51c6c3d-ed24-4c69-81f3-8eb783fc02af</Id>
+      <Database Name="cv" Series="2406" Issue="23543" />
     </Book>
     <Book Series="The Incredible Hulk" Number="289" Volume="1968" Year="1983">
-      <Id>8c39e70f-6628-4bac-8b82-022a52189d73</Id>
+      <Database Name="cv" Series="2406" Issue="23628" />
     </Book>
     <Book Series="The Incredible Hulk" Number="290" Volume="1968" Year="1983">
-      <Id>524ccc8f-03a8-4fda-96fa-8a08d7a6c673</Id>
+      <Database Name="cv" Series="2406" Issue="23727" />
     </Book>
     <Book Series="The Incredible Hulk" Number="291" Volume="1968" Year="1984">
-      <Id>2c06f24d-9f81-46df-baae-d62883cc74c7</Id>
+      <Database Name="cv" Series="2406" Issue="23876" />
     </Book>
     <Book Series="The Incredible Hulk" Number="292" Volume="1968" Year="1984">
-      <Id>da93f45d-8808-4c87-b167-02902415f876</Id>
+      <Database Name="cv" Series="2406" Issue="23980" />
     </Book>
     <Book Series="The Incredible Hulk" Number="293" Volume="1968" Year="1984">
-      <Id>75cace92-ea6c-4dc4-ac48-e2045b5d7add</Id>
+      <Database Name="cv" Series="2406" Issue="24097" />
     </Book>
     <Book Series="The Incredible Hulk" Number="294" Volume="1968" Year="1984">
-      <Id>7d205f83-0170-4aa8-9b84-8d03251522e9</Id>
+      <Database Name="cv" Series="2406" Issue="24205" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="1" Volume="1984" Year="1984">
-      <Id>8cca6608-ad5c-4934-835c-22b03be105b7</Id>
+      <Database Name="cv" Series="3352" Issue="57504" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="2" Volume="1984" Year="1984">
-      <Id>26b8b46b-2789-4c5c-8783-81336cc9cddb</Id>
+      <Database Name="cv" Series="3352" Issue="57505" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="3" Volume="1984" Year="1984">
-      <Id>c7e233c8-fb62-44e1-874d-40da0a2bdd1e</Id>
+      <Database Name="cv" Series="3352" Issue="57506" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="4" Volume="1984" Year="1984">
-      <Id>88b8416d-9788-40d2-9885-53e208c46cbd</Id>
+      <Database Name="cv" Series="3352" Issue="57507" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="5" Volume="1984" Year="1984">
-      <Id>996c2542-1459-4d0e-8588-71fedeb17283</Id>
+      <Database Name="cv" Series="3352" Issue="57508" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="6" Volume="1984" Year="1984">
-      <Id>dff7685a-da38-4375-af65-12e8f68be23e</Id>
+      <Database Name="cv" Series="3352" Issue="57509" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="7" Volume="1984" Year="1984">
-      <Id>0a7b085a-3499-40cb-b0cd-fe7729986bcc</Id>
+      <Database Name="cv" Series="3352" Issue="57510" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="8" Volume="1984" Year="1984">
-      <Id>725f3771-5867-4f54-8fc6-8e14a70128bf</Id>
+      <Database Name="cv" Series="3352" Issue="57511" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="9" Volume="1984" Year="1985">
-      <Id>758f01d8-5db5-4d9e-85cc-6ab5e2fc9cf1</Id>
+      <Database Name="cv" Series="3352" Issue="57512" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="10" Volume="1984" Year="1985">
-      <Id>7f658ccd-cd23-48dc-8200-98dbf5878d23</Id>
+      <Database Name="cv" Series="3352" Issue="57513" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="11" Volume="1984" Year="1985">
-      <Id>65d2beab-745a-40da-aa31-e0f2a9f21965</Id>
+      <Database Name="cv" Series="3352" Issue="57514" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="12" Volume="1984" Year="1985">
-      <Id>b3a0a236-200e-4b07-b75a-c5d00841e516</Id>
+      <Database Name="cv" Series="3352" Issue="57515" />
     </Book>
     <Book Series="The Incredible Hulk" Number="295" Volume="1968" Year="1984">
-      <Id>215c734d-93c5-49f1-a063-eb0a6a268c1d</Id>
+      <Database Name="cv" Series="2406" Issue="24308" />
     </Book>
     <Book Series="The Incredible Hulk" Number="296" Volume="1968" Year="1984">
-      <Id>2b11dfbd-8995-4d05-9bab-d9e5a216a4de</Id>
+      <Database Name="cv" Series="2406" Issue="24409" />
     </Book>
     <Book Series="The Incredible Hulk" Number="297" Volume="1968" Year="1984">
-      <Id>3072b95a-3a10-4b9e-9c60-c587bcc4abd6</Id>
+      <Database Name="cv" Series="2406" Issue="24505" />
     </Book>
     <Book Series="The Incredible Hulk" Number="298" Volume="1968" Year="1984">
-      <Id>18f58b66-f543-4ac9-a059-7928452788c4</Id>
+      <Database Name="cv" Series="2406" Issue="24603" />
     </Book>
     <Book Series="The Incredible Hulk" Number="299" Volume="1968" Year="1984">
-      <Id>6336a232-0eaf-4b08-89cf-09e316d4d965</Id>
+      <Database Name="cv" Series="2406" Issue="24694" />
     </Book>
     <Book Series="The Incredible Hulk" Number="300" Volume="1968" Year="1984">
-      <Id>6f9146d1-285a-4106-85d6-30ebf9680731</Id>
+      <Database Name="cv" Series="2406" Issue="24789" />
     </Book>
     <Book Series="The Avengers Annual" Number="13" Volume="1967" Year="1984">
-      <Id>a5e1ad45-09e0-44fe-99ff-c1d0c81c62d9</Id>
+      <Database Name="cv" Series="2350" Issue="23800" />
     </Book>
     <Book Series="The Incredible Hulk" Number="301" Volume="1968" Year="1984">
-      <Id>e4cf7fc3-ac8f-4217-8f3d-724968f76661</Id>
+      <Database Name="cv" Series="2406" Issue="24890" />
     </Book>
     <Book Series="The Incredible Hulk Annual" Number="13" Volume="1968" Year="1984">
-      <Id>2ba9ab87-3df9-4d6b-8d91-d5fff2ceb96d</Id>
+      <Database Name="cv" Series="2860" Issue="24889" />
     </Book>
     <Book Series="The Incredible Hulk" Number="302" Volume="1968" Year="1984">
-      <Id>385d86e3-8eff-48eb-afdd-8d2cbb47ebb3</Id>
+      <Database Name="cv" Series="2406" Issue="24994" />
     </Book>
     <Book Series="The Incredible Hulk" Number="303" Volume="1968" Year="1985">
-      <Id>492f839b-6457-403a-a2aa-0b5d3e5a6c43</Id>
+      <Database Name="cv" Series="2406" Issue="25164" />
     </Book>
     <Book Series="The Incredible Hulk" Number="304" Volume="1968" Year="1985">
-      <Id>33126366-9d53-46dc-85b2-b0799e6b6124</Id>
+      <Database Name="cv" Series="2406" Issue="25262" />
     </Book>
     <Book Series="The Incredible Hulk" Number="305" Volume="1968" Year="1985">
-      <Id>e7ccc58f-ae2d-4416-b176-fa507c7c1596</Id>
+      <Database Name="cv" Series="2406" Issue="25288" />
     </Book>
     <Book Series="The Incredible Hulk" Number="306" Volume="1968" Year="1985">
-      <Id>f525dcd1-7c79-420f-bdb9-2155cf99dc12</Id>
+      <Database Name="cv" Series="2406" Issue="25391" />
     </Book>
     <Book Series="The Incredible Hulk" Number="307" Volume="1968" Year="1985">
-      <Id>68078cf8-ab95-4803-bb55-f37d32260b71</Id>
+      <Database Name="cv" Series="2406" Issue="25487" />
     </Book>
     <Book Series="The Incredible Hulk" Number="308" Volume="1968" Year="1985">
-      <Id>edb39dd4-113c-4c6f-93bf-65d91aa65529</Id>
+      <Database Name="cv" Series="2406" Issue="25588" />
     </Book>
     <Book Series="The Incredible Hulk" Number="309" Volume="1968" Year="1985">
-      <Id>2de00b80-9836-4eb8-a943-43ed0fa8100b</Id>
+      <Database Name="cv" Series="2406" Issue="25686" />
     </Book>
     <Book Series="The Incredible Hulk" Number="310" Volume="1968" Year="1985">
-      <Id>57f546a7-cd63-4a65-8982-9a06fd558c29</Id>
+      <Database Name="cv" Series="2406" Issue="25787" />
     </Book>
     <Book Series="The Incredible Hulk" Number="311" Volume="1968" Year="1985">
-      <Id>ad1a9873-d100-4a6b-af36-2b16108c5601</Id>
+      <Database Name="cv" Series="2406" Issue="25880" />
     </Book>
     <Book Series="The Incredible Hulk" Number="312" Volume="1968" Year="1985">
-      <Id>5a4dc460-a440-4802-941d-b17bfa462587</Id>
+      <Database Name="cv" Series="2406" Issue="25984" />
     </Book>
     <Book Series="Alpha Flight" Number="28" Volume="1983" Year="1985">
-      <Id>dbb60a3b-3c80-44e1-a6bd-8965304f0a87</Id>
+      <Database Name="cv" Series="3217" Issue="26070" />
     </Book>
     <Book Series="The Incredible Hulk" Number="313" Volume="1968" Year="1985">
-      <Id>d72d6126-245c-4b0d-8004-5e82185ab146</Id>
+      <Database Name="cv" Series="2406" Issue="26086" />
     </Book>
     <Book Series="Alpha Flight" Number="29" Volume="1983" Year="1985">
-      <Id>25200fd2-4689-4169-b3eb-8fee85e653af</Id>
+      <Database Name="cv" Series="3217" Issue="26182" />
     </Book>
     <Book Series="The Incredible Hulk Annual" Number="14" Volume="1968" Year="1985">
-      <Id>fe59a600-fe1f-4a2f-85d1-402170487c90</Id>
+      <Database Name="cv" Series="2860" Issue="26196" />
     </Book>
     <Book Series="The Incredible Hulk" Number="314" Volume="1968" Year="1985">
-      <Id>1676f7dc-7c52-4c7d-a7ef-d7e7d4c2dca0</Id>
+      <Database Name="cv" Series="2406" Issue="26197" />
     </Book>
     <Book Series="The Incredible Hulk" Number="315" Volume="1968" Year="1986">
-      <Id>1068aa8b-1959-4a6a-be76-1f9834a4f8bb</Id>
+      <Database Name="cv" Series="2406" Issue="26399" />
     </Book>
     <Book Series="The Incredible Hulk" Number="316" Volume="1968" Year="1986">
-      <Id>4bb563a9-191b-4310-9b8b-4fc48f921175</Id>
+      <Database Name="cv" Series="2406" Issue="26506" />
     </Book>
     <Book Series="The Incredible Hulk" Number="317" Volume="1968" Year="1986">
-      <Id>8ebeb78b-c263-4bed-8ae7-e4b25b1fcb91</Id>
+      <Database Name="cv" Series="2406" Issue="26601" />
     </Book>
     <Book Series="The Incredible Hulk" Number="318" Volume="1968" Year="1986">
-      <Id>12bfb6c5-ab7b-45cf-980f-5229596a147b</Id>
+      <Database Name="cv" Series="2406" Issue="26700" />
     </Book>
     <Book Series="The Incredible Hulk" Number="319" Volume="1968" Year="1986">
-      <Id>75b0062f-39f1-465b-9f1a-dea1df4d3acd</Id>
+      <Database Name="cv" Series="2406" Issue="26792" />
     </Book>
     <Book Series="The Incredible Hulk" Number="320" Volume="1968" Year="1986">
-      <Id>a62bdac3-096a-41e0-9b3f-f1d59a0be678</Id>
+      <Database Name="cv" Series="2406" Issue="26891" />
     </Book>
     <Book Series="The Incredible Hulk" Number="321" Volume="1968" Year="1986">
-      <Id>dcc343dd-065a-47b0-a5b1-63c190c58a51</Id>
+      <Database Name="cv" Series="2406" Issue="26989" />
     </Book>
     <Book Series="The Incredible Hulk" Number="322" Volume="1968" Year="1986">
-      <Id>a52ae23b-ba2b-4dca-90a1-80c7cbe32aa5</Id>
+      <Database Name="cv" Series="2406" Issue="27084" />
     </Book>
     <Book Series="The Incredible Hulk" Number="323" Volume="1968" Year="1986">
-      <Id>8699054a-6758-4fc7-a349-79adf2c1f277</Id>
+      <Database Name="cv" Series="2406" Issue="27183" />
     </Book>
     <Book Series="The Avengers" Number="267" Volume="1963" Year="1986">
-      <Id>e470921b-a9bc-4d8a-8f95-8baaba985229</Id>
+      <Database Name="cv" Series="2128" Issue="26784" />
     </Book>
     <Book Series="Marvel Fanfare" Number="29" Volume="1982" Year="1986">
-      <Id>40fa8824-35fc-48e3-845d-624d147126e0</Id>
+      <Database Name="cv" Series="3143" Issue="27391" />
     </Book>
     <Book Series="The Incredible Hulk" Number="324" Volume="1968" Year="1986">
-      <Id>ca4c12ab-6ed2-4eb5-90b9-f3e0b0513268</Id>
+      <Database Name="cv" Series="2406" Issue="27278" />
     </Book>
     <Book Series="The Incredible Hulk Annual" Number="15" Volume="1968" Year="1986">
-      <Id>fe1c24a2-c70d-4c1e-a902-c0108d4c6c73</Id>
+      <Database Name="cv" Series="2860" Issue="27277" />
     </Book>
     <Book Series="The Incredible Hulk" Number="325" Volume="1968" Year="1986">
-      <Id>ed54b5c3-774b-4e4e-90ac-25f73b100348</Id>
+      <Database Name="cv" Series="2406" Issue="27385" />
     </Book>
     <Book Series="The Incredible Hulk" Number="326" Volume="1968" Year="1986">
-      <Id>408a2961-0fd8-4f7c-8932-a6b164a47eb0</Id>
+      <Database Name="cv" Series="2406" Issue="27490" />
     </Book>
     <Book Series="The Incredible Hulk" Number="327" Volume="1968" Year="1987">
-      <Id>3d0e3af3-799d-46ae-b53d-70ae6253c4c2</Id>
+      <Database Name="cv" Series="2406" Issue="27680" />
     </Book>
     <Book Series="Marvel Graphic Novel" Number="29" Volume="1982" Year="1987">
-      <Id>8001d8e8-7da4-4b64-9292-900dc6e9599b</Id>
+      <Database Name="cv" Series="3144" Issue="134234" />
     </Book>
     <Book Series="The Incredible Hulk" Number="328" Volume="1968" Year="1987">
-      <Id>ba12cff3-19ff-4c16-8d66-6e14117c7fab</Id>
+      <Database Name="cv" Series="2406" Issue="27793" />
     </Book>
     <Book Series="The Incredible Hulk" Number="329" Volume="1968" Year="1987">
-      <Id>bef08413-97ae-4349-abed-0879875b2052</Id>
+      <Database Name="cv" Series="2406" Issue="27902" />
     </Book>
     <Book Series="The Incredible Hulk" Number="330" Volume="1968" Year="1987">
-      <Id>2d08cdcc-e380-453b-aef0-a00fedf00897</Id>
+      <Database Name="cv" Series="2406" Issue="28014" />
     </Book>
     <Book Series="The Incredible Hulk" Number="331" Volume="1968" Year="1987">
-      <Id>d80dbff9-c3ef-4f3f-93cf-b7135c07272e</Id>
+      <Database Name="cv" Series="2406" Issue="28114" />
     </Book>
     <Book Series="The Incredible Hulk" Number="332" Volume="1968" Year="1987">
-      <Id>0318f2a4-c878-4927-ac27-ff0d19b4b3eb</Id>
+      <Database Name="cv" Series="2406" Issue="28225" />
     </Book>
     <Book Series="The Incredible Hulk" Number="333" Volume="1968" Year="1987">
-      <Id>348917d8-17e1-4dd6-868d-5a0e640e9973</Id>
+      <Database Name="cv" Series="2406" Issue="28338" />
     </Book>
     <Book Series="The Incredible Hulk" Number="334" Volume="1968" Year="1987">
-      <Id>2fbf5091-903e-4440-a55e-2907912067ff</Id>
+      <Database Name="cv" Series="2406" Issue="28459" />
     </Book>
     <Book Series="The Incredible Hulk" Number="335" Volume="1968" Year="1987">
-      <Id>64c17a77-b2e3-4dba-8265-4c768a1cd339</Id>
+      <Database Name="cv" Series="2406" Issue="28566" />
     </Book>
     <Book Series="The Incredible Hulk" Number="336" Volume="1968" Year="1987">
-      <Id>7a95fecb-ad50-47df-bc29-9c81db3aa589</Id>
+      <Database Name="cv" Series="2406" Issue="28688" />
     </Book>
     <Book Series="The Incredible Hulk" Number="337" Volume="1968" Year="1987">
-      <Id>4888e8f9-8d6c-4bea-88b3-238dc3d873d8</Id>
+      <Database Name="cv" Series="2406" Issue="28802" />
     </Book>
     <Book Series="Thor" Number="385" Volume="1966" Year="1987">
-      <Id>5b4bdb9a-1a73-430c-bf31-e52e897d0fbb</Id>
+      <Database Name="cv" Series="2294" Issue="28815" />
     </Book>
     <Book Series="The Incredible Hulk" Number="338" Volume="1968" Year="1987">
-      <Id>d25a0f40-720c-4b19-b1a7-09e97c921e4d</Id>
+      <Database Name="cv" Series="2406" Issue="28925" />
     </Book>
     <Book Series="The Incredible Hulk" Number="339" Volume="1968" Year="1988">
-      <Id>c8a9c642-1921-444b-a589-7029a91a20ea</Id>
+      <Database Name="cv" Series="2406" Issue="29144" />
     </Book>
     <Book Series="The Incredible Hulk" Number="340" Volume="1968" Year="1988">
-      <Id>f77b4acd-e2e8-465a-bae5-a0bc88615276</Id>
+      <Database Name="cv" Series="2406" Issue="29262" />
     </Book>
     <Book Series="The Incredible Hulk" Number="341" Volume="1968" Year="1988">
-      <Id>0fd3eaed-de74-4fea-9754-c6cd5c09977a</Id>
+      <Database Name="cv" Series="2406" Issue="29372" />
     </Book>
     <Book Series="The Incredible Hulk" Number="342" Volume="1968" Year="1988">
-      <Id>3f160c93-8886-4899-a6ba-0a11e7dc1417</Id>
+      <Database Name="cv" Series="2406" Issue="29483" />
     </Book>
     <Book Series="The Incredible Hulk" Number="343" Volume="1968" Year="1988">
-      <Id>9d6533e9-8212-495e-8923-d7d0239e7dfd</Id>
+      <Database Name="cv" Series="2406" Issue="29591" />
     </Book>
     <Book Series="The Incredible Hulk" Number="344" Volume="1968" Year="1988">
-      <Id>531c3209-5497-4129-bf40-ba959812d648</Id>
+      <Database Name="cv" Series="2406" Issue="29708" />
     </Book>
     <Book Series="The Incredible Hulk" Number="345" Volume="1968" Year="1988">
-      <Id>b60e7ad3-9b01-44b8-9b68-9fb001957fd2</Id>
+      <Database Name="cv" Series="2406" Issue="29827" />
     </Book>
     <Book Series="The Incredible Hulk" Number="346" Volume="1968" Year="1988">
-      <Id>a7bb24de-bef1-446f-94ae-29ade6837c79</Id>
+      <Database Name="cv" Series="2406" Issue="29943" />
     </Book>
     <Book Series="The Incredible Hulk" Number="347" Volume="1968" Year="1988">
-      <Id>9cdbd23b-5f1c-4fb0-8fba-2e976b64a3e3</Id>
+      <Database Name="cv" Series="2406" Issue="30056" />
     </Book>
     <Book Series="The Incredible Hulk" Number="348" Volume="1968" Year="1988">
-      <Id>25e400b7-24a0-496c-98ec-783e9013a70f</Id>
+      <Database Name="cv" Series="2406" Issue="30180" />
     </Book>
     <Book Series="Web of Spider-Man" Number="44" Volume="1985" Year="1988">
-      <Id>32340d79-4ef4-464a-89f4-76ae96f0e6cf</Id>
+      <Database Name="cv" Series="3519" Issue="30327" />
     </Book>
     <Book Series="The Incredible Hulk" Number="349" Volume="1968" Year="1988">
-      <Id>064119b8-a2bf-4afa-a3a2-e2daeabf6f59</Id>
+      <Database Name="cv" Series="2406" Issue="30310" />
     </Book>
     <Book Series="Fantastic Four" Number="320" Volume="1961" Year="1988">
-      <Id>d7d903ef-dc25-490e-9823-df1473771be1</Id>
+      <Database Name="cv" Series="2045" Issue="30309" />
     </Book>
     <Book Series="The Incredible Hulk" Number="350" Volume="1968" Year="1988">
-      <Id>5f52636a-b02d-4cad-916b-92ecf4759530</Id>
+      <Database Name="cv" Series="2406" Issue="30431" />
     </Book>
     <Book Series="The Incredible Hulk" Number="351" Volume="1968" Year="1989">
-      <Id>cc0c022b-10ea-48b3-a254-8bba575b3c31</Id>
+      <Database Name="cv" Series="2406" Issue="30781" />
     </Book>
     <Book Series="The Incredible Hulk" Number="352" Volume="1968" Year="1989">
-      <Id>edb84433-0d33-42ba-b0b9-2463b2a55db5</Id>
+      <Database Name="cv" Series="2406" Issue="30890" />
     </Book>
     <Book Series="Wolverine" Number="7" Volume="1988" Year="1989">
-      <Id>32a28c09-83b5-4885-81f1-1934141d2184</Id>
+      <Database Name="cv" Series="4250" Issue="64272" />
     </Book>
     <Book Series="Wolverine" Number="8" Volume="1988" Year="1989">
-      <Id>65af2951-9170-487c-92ee-9edcca672081</Id>
+      <Database Name="cv" Series="4250" Issue="64273" />
     </Book>
     <Book Series="The Incredible Hulk" Number="353" Volume="1968" Year="1989">
-      <Id>8aed585e-3d8a-4a1c-b0b9-ee55fa99aed7</Id>
+      <Database Name="cv" Series="2406" Issue="30991" />
     </Book>
     <Book Series="The Incredible Hulk" Number="354" Volume="1968" Year="1989">
-      <Id>dc4b5228-a88d-4348-b3e2-800f02b4bf79</Id>
+      <Database Name="cv" Series="2406" Issue="31102" />
     </Book>
     <Book Series="The Incredible Hulk" Number="355" Volume="1968" Year="1989">
-      <Id>e018454f-1202-4ff6-8a55-69ea738339ce</Id>
+      <Database Name="cv" Series="2406" Issue="31214" />
     </Book>
     <Book Series="The Incredible Hulk" Number="356" Volume="1968" Year="1989">
-      <Id>e4bf2acb-9bbc-4702-bc79-efd0d40973c3</Id>
+      <Database Name="cv" Series="2406" Issue="31325" />
     </Book>
     <Book Series="The Incredible Hulk" Number="357" Volume="1968" Year="1989">
-      <Id>2c84057e-6a86-4b41-b019-7aece3b68e35</Id>
+      <Database Name="cv" Series="2406" Issue="31436" />
     </Book>
     <Book Series="The Incredible Hulk" Number="358" Volume="1968" Year="1989">
-      <Id>548ab466-7ca8-4f21-a88a-f7d6cc617310</Id>
+      <Database Name="cv" Series="2406" Issue="31540" />
     </Book>
     <Book Series="The Incredible Hulk" Number="359" Volume="1968" Year="1989">
-      <Id>707ff5a7-b248-4614-89d9-c46601d1f56b</Id>
+      <Database Name="cv" Series="2406" Issue="31653" />
     </Book>
     <Book Series="The Incredible Hulk" Number="360" Volume="1968" Year="1989">
-      <Id>53801dfe-4dc9-4ab9-a116-341527176052</Id>
+      <Database Name="cv" Series="2406" Issue="31763" />
     </Book>
     <Book Series="Iron Man" Number="247" Volume="1968" Year="1989">
-      <Id>170cffc3-0f80-47ad-8d89-0af4c508e494</Id>
+      <Database Name="cv" Series="2407" Issue="31764" />
     </Book>
     <Book Series="The Incredible Hulk" Number="361" Volume="1968" Year="1989">
-      <Id>e3b4290f-4fbe-492a-9558-86ad84cb7886</Id>
+      <Database Name="cv" Series="2406" Issue="31868" />
     </Book>
     <Book Series="Marvel Fanfare" Number="47" Volume="1982" Year="1989">
-      <Id>9db338db-5f33-4116-b9e9-ffdb8704ecfd</Id>
+      <Database Name="cv" Series="3143" Issue="31872" />
     </Book>
     <Book Series="The Incredible Hulk" Number="363" Volume="1968" Year="1989">
-      <Id>182ef0e7-2c31-4e13-aef7-a89e27bd749c</Id>
+      <Database Name="cv" Series="2406" Issue="31999" />
     </Book>
     <Book Series="The Incredible Hulk" Number="364" Volume="1968" Year="1989">
-      <Id>d581a44d-8080-4421-ba0c-d32a63643ef7</Id>
+      <Database Name="cv" Series="2406" Issue="32059" />
     </Book>
     <Book Series="The Incredible Hulk" Number="365" Volume="1968" Year="1990">
-      <Id>26360d76-691d-431c-aa17-837cc91d422d</Id>
+      <Database Name="cv" Series="2406" Issue="32320" />
     </Book>
     <Book Series="The Incredible Hulk" Number="366" Volume="1968" Year="1990">
-      <Id>ba28b0ac-4b8f-44da-9b04-7f97c8231dae</Id>
+      <Database Name="cv" Series="2406" Issue="32419" />
     </Book>
     <Book Series="The Incredible Hulk" Number="367" Volume="1968" Year="1990">
-      <Id>a2b27868-c531-4e7d-b416-6a18b0e46875</Id>
+      <Database Name="cv" Series="2406" Issue="32519" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="328" Volume="1963" Year="1990">
-      <Id>2030fc16-b582-46d8-b53a-b13a36dcdc00</Id>
+      <Database Name="cv" Series="2127" Issue="113265" />
     </Book>
     <Book Series="The Incredible Hulk" Number="368" Volume="1968" Year="1990">
-      <Id>7a0f198a-c6e6-4603-8198-2f89315a6529</Id>
+      <Database Name="cv" Series="2406" Issue="32628" />
     </Book>
     <Book Series="The Incredible Hulk" Number="369" Volume="1968" Year="1990">
-      <Id>992115f4-f83a-40fa-bd9f-a8c8fde92a92</Id>
+      <Database Name="cv" Series="2406" Issue="32726" />
     </Book>
     <Book Series="The Incredible Hulk Annual" Number="16" Volume="1968" Year="1990">
-      <Id>175b70e9-bcfd-4899-a489-837f81a76e24</Id>
+      <Database Name="cv" Series="2860" Issue="32839" />
     </Book>
     <Book Series="The Incredible Hulk" Number="370" Volume="1968" Year="1990">
-      <Id>234cba18-9e9c-4e2a-bf80-1734eebaabc7</Id>
+      <Database Name="cv" Series="2406" Issue="32840" />
     </Book>
     <Book Series="The Incredible Hulk" Number="371" Volume="1968" Year="1990">
-      <Id>57e3de43-d04b-4757-939f-e4c7e1e99626</Id>
+      <Database Name="cv" Series="2406" Issue="32965" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="52" Volume="1988" Year="1990">
-      <Id>eae784cf-8243-43e5-baf2-1049f3a2636a</Id>
+      <Database Name="cv" Series="4058" Issue="32895" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="53" Volume="1988" Year="1990">
-      <Id>1e7ed635-8f16-4078-b87c-f506b8dc296a</Id>
+      <Database Name="cv" Series="4058" Issue="32968" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="54" Volume="1988" Year="1990">
-      <Id>42f6ae9b-06ca-42b0-82d6-a0e8b90fde95</Id>
+      <Database Name="cv" Series="4058" Issue="33014" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="55" Volume="1988" Year="1990">
-      <Id>fe2e468f-9428-45b3-b124-937cae97acab</Id>
+      <Database Name="cv" Series="4058" Issue="33016" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="56" Volume="1988" Year="1990">
-      <Id>c7fa864b-7722-4178-a7d6-0a6878787bf0</Id>
+      <Database Name="cv" Series="4058" Issue="33082" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="57" Volume="1988" Year="1990">
-      <Id>01ecf45f-33ff-4e52-bbc1-0feb813033e8</Id>
+      <Database Name="cv" Series="4058" Issue="33134" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="58" Volume="1988" Year="1990">
-      <Id>6d5a5486-2af4-4761-a00e-2c0ca2dc40e5</Id>
+      <Database Name="cv" Series="4058" Issue="33199" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="59" Volume="1988" Year="1990">
-      <Id>0903b682-ac6e-4c22-a9fa-38e4e339be2e</Id>
+      <Database Name="cv" Series="4058" Issue="33253" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="60" Volume="1988" Year="1990">
-      <Id>d2d645ad-7a6e-4022-afb4-af14fc567c86</Id>
+      <Database Name="cv" Series="4058" Issue="33319" />
     </Book>
     <Book Series="Marvel Comics Presents" Number="61" Volume="1988" Year="1990">
-      <Id>91fc4fed-c949-444a-b9de-2ac5201a1370</Id>
+      <Database Name="cv" Series="4058" Issue="33365" />
     </Book>
     <Book Series="The Incredible Hulk" Number="372" Volume="1968" Year="1990">
-      <Id>33c3da64-48d6-42bb-af26-b1bb2c0692ad</Id>
+      <Database Name="cv" Series="2406" Issue="33079" />
     </Book>
     <Book Series="The Incredible Hulk" Number="373" Volume="1968" Year="1990">
-      <Id>e83c9032-89a8-4cab-bd03-057f61088e65</Id>
+      <Database Name="cv" Series="2406" Issue="33195" />
     </Book>
     <Book Series="The Incredible Hulk" Number="374" Volume="1968" Year="1990">
-      <Id>c78973c9-7df3-4091-8b91-fb3877a42d40</Id>
+      <Database Name="cv" Series="2406" Issue="33316" />
     </Book>
     <Book Series="The Incredible Hulk" Number="375" Volume="1968" Year="1990">
-      <Id>d884d974-d886-4f7a-87db-f33694a57119</Id>
+      <Database Name="cv" Series="2406" Issue="33427" />
     </Book>
     <Book Series="Web of Spider-Man" Number="69" Volume="1985" Year="1990">
-      <Id>6b0dff06-f375-494d-8fa6-d1e304629eb0</Id>
+      <Database Name="cv" Series="3519" Issue="33335" />
     </Book>
     <Book Series="The Incredible Hulk" Number="376" Volume="1968" Year="1990">
-      <Id>048087fa-0840-4ece-8274-f2e14a99a414</Id>
+      <Database Name="cv" Series="2406" Issue="33533" />
     </Book>
     <Book Series="The Incredible Hulk" Number="377" Volume="1968" Year="1991">
-      <Id>9e456287-e40a-4236-acfd-f82303625c17</Id>
+      <Database Name="cv" Series="2406" Issue="33777" />
     </Book>
     <Book Series="Fantastic Four" Number="347" Volume="1961" Year="1990">
-      <Id>f81cac5e-8ad0-442e-a6a1-039f88a3d43d</Id>
+      <Database Name="cv" Series="2045" Issue="33871" />
     </Book>
     <Book Series="Fantastic Four" Number="348" Volume="1961" Year="1991">
-      <Id>8cf9919f-4249-4d15-9b06-3877f75d47f1</Id>
+      <Database Name="cv" Series="2045" Issue="33989" />
     </Book>
     <Book Series="Fantastic Four" Number="349" Volume="1961" Year="1991">
-      <Id>c7ddb595-8c6f-45ec-873f-667d4df2765e</Id>
+      <Database Name="cv" Series="2045" Issue="34092" />
     </Book>
     <Book Series="The Incredible Hulk" Number="378" Volume="1968" Year="1991">
-      <Id>7dd030b1-8dca-4572-af27-6d96c97f79a6</Id>
+      <Database Name="cv" Series="2406" Issue="33875" />
     </Book>
     <Book Series="The Incredible Hulk" Number="379" Volume="1968" Year="1991">
-      <Id>e3ccec52-305b-4a13-be14-ad80723694e1</Id>
+      <Database Name="cv" Series="2406" Issue="33992" />
     </Book>
     <Book Series="The Incredible Hulk" Number="380" Volume="1968" Year="1991">
-      <Id>eb385a13-97b7-43e3-85d4-858e4129eedb</Id>
+      <Database Name="cv" Series="2406" Issue="34096" />
     </Book>
     <Book Series="The Incredible Hulk" Number="381" Volume="1968" Year="1991">
-      <Id>635452d6-d36e-4c21-b032-54e7aa95c0c4</Id>
+      <Database Name="cv" Series="2406" Issue="34200" />
     </Book>
     <Book Series="The Incredible Hulk" Number="382" Volume="1968" Year="1991">
-      <Id>1a35c2fa-7bdc-4c73-b5b9-21f78f69fbdc</Id>
+      <Database Name="cv" Series="2406" Issue="34298" />
     </Book>
     <Book Series="The Incredible Hulk Annual" Number="17" Volume="1968" Year="1991">
-      <Id>7533e764-174b-4eb7-aa73-f516e65e7015</Id>
+      <Database Name="cv" Series="2860" Issue="34527" />
     </Book>
     <Book Series="The Infinity Gauntlet" Number="1" Volume="1991" Year="1991">
-      <Id>2f23b825-4c7d-4ecb-b84d-4b6681197cc4</Id>
+      <Database Name="cv" Series="4596" Issue="34415" />
     </Book>
     <Book Series="The Incredible Hulk" Number="383" Volume="1968" Year="1991">
-      <Id>a1f3343b-595e-4d34-8cfa-38a8a8af6cde</Id>
+      <Database Name="cv" Series="2406" Issue="34414" />
     </Book>
     <Book Series="The Infinity Gauntlet" Number="3" Volume="1991" Year="1991">
-      <Id>692b2852-59a3-48d7-9e16-d24e4fbe7c89</Id>
+      <Database Name="cv" Series="4596" Issue="34647" />
     </Book>
     <Book Series="The Infinity Gauntlet" Number="4" Volume="1991" Year="1991">
-      <Id>964ff388-35dd-4666-8c7f-281e2be065d4</Id>
+      <Database Name="cv" Series="4596" Issue="34764" />
     </Book>
     <Book Series="The Incredible Hulk" Number="384" Volume="1968" Year="1991">
-      <Id>2e101605-645c-40aa-850c-446776b1ce41</Id>
+      <Database Name="cv" Series="2406" Issue="34528" />
     </Book>
     <Book Series="The Infinity Gauntlet" Number="5" Volume="1991" Year="1991">
-      <Id>f5a11a17-4854-4bba-9702-dd482bc009cc</Id>
+      <Database Name="cv" Series="4596" Issue="34880" />
     </Book>
     <Book Series="The Infinity Gauntlet" Number="6" Volume="1991" Year="1991">
-      <Id>01e38e6c-6b68-4d69-acff-be79c486f01d</Id>
+      <Database Name="cv" Series="4596" Issue="35000" />
     </Book>
     <Book Series="The Incredible Hulk" Number="385" Volume="1968" Year="1991">
-      <Id>762f343f-0090-45ad-93fe-c80887ee10c0</Id>
+      <Database Name="cv" Series="2406" Issue="34646" />
     </Book>
     <Book Series="The Incredible Hulk" Number="386" Volume="1968" Year="1991">
-      <Id>e552d76c-918c-473f-8245-14fe5166374e</Id>
+      <Database Name="cv" Series="2406" Issue="34763" />
     </Book>
     <Book Series="The Incredible Hulk" Number="387" Volume="1968" Year="1991">
-      <Id>a8a75916-a861-460a-b954-adca93ed37d5</Id>
+      <Database Name="cv" Series="2406" Issue="34879" />
     </Book>
     <Book Series="The Incredible Hulk" Number="388" Volume="1968" Year="1991">
-      <Id>a686bf5f-300d-4666-9a14-cafb6d6ee34b</Id>
+      <Database Name="cv" Series="2406" Issue="34999" />
     </Book>
     <Book Series="The Incredible Hulk" Number="389" Volume="1968" Year="1992">
-      <Id>e408b95e-87f7-4758-be7e-587d38c46b7b</Id>
+      <Database Name="cv" Series="2406" Issue="35259" />
     </Book>
     <Book Series="Spider-Man" Number="18" Volume="1990" Year="1992">
-      <Id>110562f4-5117-4472-9401-5bd737f0c5e4</Id>
+      <Database Name="cv" Series="4421" Issue="64620" />
     </Book>
     <Book Series="Spider-Man" Number="19" Volume="1990" Year="1992">
-      <Id>1cbbf730-87ad-44bd-a20a-995288540842</Id>
+      <Database Name="cv" Series="4421" Issue="64621" />
     </Book>
     <Book Series="Spider-Man" Number="20" Volume="1990" Year="1992">
-      <Id>158ac9ef-05d1-4c72-a91b-34b5a5bfff3a</Id>
+      <Database Name="cv" Series="4421" Issue="64622" />
     </Book>
     <Book Series="Spider-Man" Number="22" Volume="1990" Year="1992">
-      <Id>381cd4dd-439b-4ea9-b3ce-3d2f804ff3c2</Id>
+      <Database Name="cv" Series="4421" Issue="64624" />
     </Book>
     <Book Series="Spider-Man" Number="23" Volume="1990" Year="1992">
-      <Id>0d5c4cfd-74e6-46ac-89f4-70490f6337ab</Id>
+      <Database Name="cv" Series="4421" Issue="64625" />
     </Book>
     <Book Series="The Incredible Hulk" Number="390" Volume="1968" Year="1992">
-      <Id>8d57f0d8-66bd-41d7-82f8-530d52c08035</Id>
+      <Database Name="cv" Series="2406" Issue="35366" />
     </Book>
     <Book Series="The Incredible Hulk" Number="391" Volume="1968" Year="1992">
-      <Id>f55090a9-0477-4396-a05b-f5b15634ddd8</Id>
+      <Database Name="cv" Series="2406" Issue="35471" />
     </Book>
     <Book Series="The Incredible Hulk" Number="392" Volume="1968" Year="1992">
-      <Id>46b0ce66-099c-4976-8e47-fe2365c6c273</Id>
+      <Database Name="cv" Series="2406" Issue="35575" />
     </Book>
     <Book Series="The Incredible Hulk Annual" Number="18" Volume="1968" Year="1992">
-      <Id>e6a353fc-b49e-4bb6-874d-7c74936ae603</Id>
+      <Database Name="cv" Series="2860" Issue="35173" />
     </Book>
     <Book Series="Namor, The Sub-Mariner Annual" Number="2" Volume="1991" Year="1992">
-      <Id>e4e2878a-1a83-4f4d-b56a-70b43f15a648</Id>
+      <Database Name="cv" Series="9432" Issue="77412" />
     </Book>
     <Book Series="Silver Surfer Annual" Number="5" Volume="1988" Year="1992">
-      <Id>b781b373-060d-4f2c-bcad-f49f4c8fa14e</Id>
+      <Database Name="cv" Series="4069" Issue="35144" />
     </Book>
-    <Book Series="Doctor Strange, Sorcerer Supreme Annual" Number="2" Volume="1976" Year="1992">
-      <Id>afb5c9b8-9b6f-485a-a80f-2133b976a009</Id>
+    <Book Series="Doctor Strange, Sorcerer Supreme Annual" Number="2" Volume="1975" Year="1992">
+      <Database Name="cv" Series="4786" Issue="35128" />
     </Book>
     <Book Series="The Incredible Hulk" Number="393" Volume="1968" Year="1992">
-      <Id>4b3df239-4f9d-4dec-946d-4013b8364ec7</Id>
+      <Database Name="cv" Series="2406" Issue="35678" />
     </Book>
     <Book Series="The Incredible Hulk" Number="394" Volume="1968" Year="1992">
-      <Id>aa3572ea-cac4-4ef9-9356-43d5b9efab00</Id>
+      <Database Name="cv" Series="2406" Issue="35782" />
     </Book>
     <Book Series="The Incredible Hulk" Number="395" Volume="1968" Year="1992">
-      <Id>8e4b2eb6-d7ea-4939-ad56-b75f938879a2</Id>
+      <Database Name="cv" Series="2406" Issue="35906" />
     </Book>
     <Book Series="The Incredible Hulk" Number="396" Volume="1968" Year="1992">
-      <Id>93eabc44-3585-4753-bdde-19272d133c7d</Id>
+      <Database Name="cv" Series="2406" Issue="36024" />
     </Book>
     <Book Series="The Incredible Hulk" Number="397" Volume="1968" Year="1992">
-      <Id>4eac47cf-b564-4199-b14e-600547ce03b8</Id>
+      <Database Name="cv" Series="2406" Issue="36151" />
     </Book>
     <Book Series="The Incredible Hulk" Number="398" Volume="1968" Year="1992">
-      <Id>0c2feb61-bc75-4bcc-b127-6dbd774224cf</Id>
+      <Database Name="cv" Series="2406" Issue="36275" />
     </Book>
     <Book Series="The Incredible Hulk" Number="399" Volume="1968" Year="1992">
-      <Id>12d7bdc7-19a7-43e2-987f-8f6ce3cd8ea8</Id>
+      <Database Name="cv" Series="2406" Issue="36399" />
     </Book>
     <Book Series="The Incredible Hulk" Number="400" Volume="1968" Year="1992">
-      <Id>7250e46e-6cc1-45d5-826c-db76ea84c03f</Id>
+      <Database Name="cv" Series="2406" Issue="36514" />
     </Book>
     <Book Series="The Incredible Hulk" Number="401" Volume="1968" Year="1993">
-      <Id>b1c3940c-b8e4-4dd3-ac94-31420f2e2a1c</Id>
+      <Database Name="cv" Series="2406" Issue="36756" />
     </Book>
     <Book Series="Cage" Number="9" Volume="1992" Year="1992">
-      <Id>85a8ba48-5d91-4daf-be3b-2df6d0898609</Id>
+      <Database Name="cv" Series="4779" Issue="101645" />
     </Book>
     <Book Series="Cage" Number="10" Volume="1992" Year="1993">
-      <Id>029c56a8-dae0-46b8-9121-e4d6ccacff2b</Id>
+      <Database Name="cv" Series="4779" Issue="101646" />
     </Book>
     <Book Series="The Incredible Hulk" Number="402" Volume="1968" Year="1993">
-      <Id>a9830e24-176e-4b0a-9c5d-b710c1318011</Id>
+      <Database Name="cv" Series="2406" Issue="36861" />
     </Book>
     <Book Series="The Incredible Hulk" Number="403" Volume="1968" Year="1993">
-      <Id>fb077806-70f5-4871-ae2e-7b49f19aa9a6</Id>
+      <Database Name="cv" Series="2406" Issue="36972" />
     </Book>
     <Book Series="The Incredible Hulk" Number="404" Volume="1968" Year="1993">
-      <Id>251695e8-8ff4-430d-ae2b-441e2a39cfcd</Id>
+      <Database Name="cv" Series="2406" Issue="37090" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="56" Volume="1989" Year="1993">
-      <Id>eee4f908-96b1-4d0f-8c19-e8b16253f6c3</Id>
+      <Database Name="cv" Series="4243" Issue="73824" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="57" Volume="1989" Year="1993">
-      <Id>bf423288-efad-45e9-a9a0-f198e97e448a</Id>
+      <Database Name="cv" Series="4243" Issue="73825" />
     </Book>
     <Book Series="Fantastic Four" Number="374" Volume="1961" Year="1993">
-      <Id>1d3e5377-27fc-4654-8037-e9e931841e60</Id>
+      <Database Name="cv" Series="2045" Issue="77551" />
     </Book>
     <Book Series="The Incredible Hulk" Number="405" Volume="1968" Year="1993">
-      <Id>5aa44ee3-6e2a-448c-9964-f585eb188a3e</Id>
+      <Database Name="cv" Series="2406" Issue="37227" />
     </Book>
     <Book Series="The Incredible Hulk" Number="406" Volume="1968" Year="1993">
-      <Id>59d4dcb3-e1e6-4b75-ad9b-459d5408f80f</Id>
+      <Database Name="cv" Series="2406" Issue="37363" />
     </Book>
     <Book Series="The Incredible Hulk" Number="407" Volume="1968" Year="1993">
-      <Id>760703d2-2aa3-4151-afd4-f3175a2654eb</Id>
+      <Database Name="cv" Series="2406" Issue="37516" />
     </Book>
     <Book Series="The Incredible Hulk" Number="408" Volume="1968" Year="1993">
-      <Id>602cba93-02a6-48c4-8755-6d6a0ab3e62d</Id>
+      <Database Name="cv" Series="2406" Issue="37657" />
     </Book>
     <Book Series="The Incredible Hulk" Number="409" Volume="1968" Year="1993">
-      <Id>bda8f2b5-4e24-4407-8b9d-297e30ab039a</Id>
+      <Database Name="cv" Series="2406" Issue="37796" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="381" Volume="1963" Year="1993">
-      <Id>fa5f0bdc-628c-48a5-aba5-8b4d45abf453</Id>
+      <Database Name="cv" Series="2127" Issue="37789" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="382" Volume="1963" Year="1993">
-      <Id>82d644e2-cc70-4fba-9a1f-53c67c48b9e0</Id>
+      <Database Name="cv" Series="2127" Issue="37988" />
     </Book>
     <Book Series="The Incredible Hulk Annual" Number="19" Volume="1968" Year="1993">
-      <Id>14ce45a5-307b-4634-bf60-1e2670e63309</Id>
+      <Database Name="cv" Series="2860" Issue="138332" />
     </Book>
     <Book Series="Wonder Man" Number="26" Volume="1991" Year="1993">
-      <Id>ba523d12-d58e-4dea-a119-8b900d2069cf</Id>
+      <Database Name="cv" Series="4603" Issue="136868" />
     </Book>
     <Book Series="The Incredible Hulk" Number="410" Volume="1968" Year="1993">
-      <Id>087d0769-22ad-4f99-a786-7488d0c75f60</Id>
+      <Database Name="cv" Series="2406" Issue="37949" />
     </Book>
     <Book Series="The Incredible Hulk" Number="411" Volume="1968" Year="1993">
-      <Id>5929c616-1d4a-4e99-bc13-a176a7652492</Id>
+      <Database Name="cv" Series="2406" Issue="38097" />
     </Book>
     <Book Series="Wonder Man" Number="27" Volume="1991" Year="1993">
-      <Id>936352ec-b974-4d1e-9989-8cb6eb646df2</Id>
+      <Database Name="cv" Series="4603" Issue="136869" />
     </Book>
     <Book Series="Fantastic Four Unlimited" Number="4" Volume="1993" Year="1993">
-      <Id>aef86759-5682-42a8-9f69-4bc8fee4efee</Id>
+      <Database Name="cv" Series="5009" Issue="48957" />
     </Book>
     <Book Series="The Incredible Hulk" Number="412" Volume="1968" Year="1993">
-      <Id>184cf402-39af-48e2-b3ec-a7a3a130f6a0</Id>
+      <Database Name="cv" Series="2406" Issue="38255" />
     </Book>
     <Book Series="Fantastic Four Unlimited" Number="5" Volume="1993" Year="1994">
-      <Id>410df40e-bbcc-460a-ae95-d99461e2e0b9</Id>
+      <Database Name="cv" Series="5009" Issue="48958" />
     </Book>
     <Book Series="The Incredible Hulk" Number="413" Volume="1968" Year="1994">
-      <Id>16881639-febd-4ba8-ba80-2b208f4d5bc8</Id>
+      <Database Name="cv" Series="2406" Issue="38502" />
     </Book>
     <Book Series="The Incredible Hulk" Number="414" Volume="1968" Year="1994">
-      <Id>b224cc25-7bfe-440d-a136-5f1654a65664</Id>
+      <Database Name="cv" Series="2406" Issue="38651" />
     </Book>
     <Book Series="The Incredible Hulk" Number="415" Volume="1968" Year="1994">
-      <Id>0c951b36-7420-4689-afc3-99a6e42ee0f7</Id>
+      <Database Name="cv" Series="2406" Issue="38796" />
     </Book>
     <Book Series="The Incredible Hulk" Number="416" Volume="1968" Year="1994">
-      <Id>c332dd2e-ff32-46d8-8352-68dd80623846</Id>
+      <Database Name="cv" Series="2406" Issue="38940" />
     </Book>
     <Book Series="Hulk: Future Imperfect" Number="1" Volume="1992" Year="1992">
-      <Id>6b797f3d-feb7-4303-853e-fb2786c048a2</Id>
+      <Database Name="cv" Series="4793" Issue="94708" />
     </Book>
     <Book Series="Hulk: Future Imperfect" Number="2" Volume="1992" Year="1993">
-      <Id>4e683588-f0b9-446f-8d17-ff85a12b6080</Id>
+      <Database Name="cv" Series="4793" Issue="94709" />
     </Book>
     <Book Series="Ghost Rider" Number="49" Volume="1990" Year="1994">
-      <Id>3b8d959d-4882-4bca-8555-e991ec559bb6</Id>
+      <Database Name="cv" Series="4397" Issue="66464" />
     </Book>
     <Book Series="The Incredible Hulk" Number="417" Volume="1968" Year="1994">
-      <Id>930a21b4-2717-41ea-8597-7606edd96da3</Id>
+      <Database Name="cv" Series="2406" Issue="39081" />
     </Book>
     <Book Series="The Incredible Hulk" Number="418" Volume="1968" Year="1994">
-      <Id>d9a9d22f-a3f6-4b83-911c-87e799336c4d</Id>
+      <Database Name="cv" Series="2406" Issue="39221" />
     </Book>
     <Book Series="The Incredible Hulk" Number="419" Volume="1968" Year="1994">
-      <Id>bf951002-0e60-464d-a3d4-d3f2cc6c6b09</Id>
+      <Database Name="cv" Series="2406" Issue="39371" />
     </Book>
     <Book Series="The Incredible Hulk Annual" Number="20" Volume="1968" Year="1994">
-      <Id>6468a946-e735-47ff-a308-c89f75b6534d</Id>
+      <Database Name="cv" Series="2860" Issue="138334" />
     </Book>
     <Book Series="Iron Man" Number="304" Volume="1968" Year="1994">
-      <Id>ddee2d88-7798-4ae4-9a26-71cbdb8df10a</Id>
+      <Database Name="cv" Series="2407" Issue="134810" />
     </Book>
     <Book Series="Iron Man" Number="305" Volume="1968" Year="1994">
-      <Id>6cb46438-7b73-42c2-bdd3-06ce0ad385a3</Id>
+      <Database Name="cv" Series="2407" Issue="134811" />
     </Book>
     <Book Series="Incredible Hulk vs. Venom" Number="1" Volume="1993" Year="1994">
-      <Id>9bda0c3c-e1d2-48fe-8abc-4b2978c6e627</Id>
+      <Database Name="cv" Series="18771" Issue="110894" />
     </Book>
     <Book Series="Tales to Astonish" Number="1" Volume="1994" Year="1994">
-      <Id>0eaa5cfa-249b-4f77-9230-bc80e569d107</Id>
+      <Database Name="cv" Series="18578" Issue="109463" />
     </Book>
     <Book Series="The Incredible Hulk" Number="420" Volume="1968" Year="1994">
-      <Id>cac9c625-5d5a-4e90-bb3d-dd1033235b0f</Id>
+      <Database Name="cv" Series="2406" Issue="39504" />
     </Book>
     <Book Series="The Incredible Hulk" Number="421" Volume="1968" Year="1994">
-      <Id>2462eb9f-b6a6-4bb3-af85-5b9522cefb23</Id>
+      <Database Name="cv" Series="2406" Issue="39647" />
     </Book>
     <Book Series="The Incredible Hulk" Number="422" Volume="1968" Year="1994">
-      <Id>281d925d-b041-432e-9364-f0dd2e26b1c2</Id>
+      <Database Name="cv" Series="2406" Issue="39793" />
     </Book>
     <Book Series="The Incredible Hulk" Number="423" Volume="1968" Year="1994">
-      <Id>a2bc26da-bebe-47d1-9c41-afef29676ccd</Id>
+      <Database Name="cv" Series="2406" Issue="39936" />
     </Book>
     <Book Series="The Incredible Hulk" Number="424" Volume="1968" Year="1994">
-      <Id>0fa09ad9-23e7-4c9d-8924-054c0b567fd4</Id>
+      <Database Name="cv" Series="2406" Issue="40078" />
     </Book>
     <Book Series="The Incredible Hulk" Number="425" Volume="1968" Year="1995">
-      <Id>aaa64d8d-2ea0-4ba8-8dc8-4a62c86d55ae</Id>
+      <Database Name="cv" Series="2406" Issue="40319" />
     </Book>
     <Book Series="The Incredible Hulk" Number="426" Volume="1968" Year="1995">
-      <Id>c2887fbf-ab5b-44bb-9347-62db5377e738</Id>
+      <Database Name="cv" Series="2406" Issue="40456" />
     </Book>
     <Book Series="The Incredible Hulk" Number="427" Volume="1968" Year="1995">
-      <Id>b17dfe52-ec64-47b1-92c2-ec67b6c2d859</Id>
+      <Database Name="cv" Series="2406" Issue="40590" />
     </Book>
     <Book Series="The Incredible Hulk" Number="428" Volume="1968" Year="1995">
-      <Id>79e6f34a-6ebf-43f5-a6e8-2acc419feef0</Id>
+      <Database Name="cv" Series="2406" Issue="40730" />
     </Book>
     <Book Series="The Incredible Hulk" Number="429" Volume="1968" Year="1995">
-      <Id>5952a9b8-1ed8-4045-b839-9c68934e336e</Id>
+      <Database Name="cv" Series="2406" Issue="40855" />
     </Book>
     <Book Series="The Incredible Hulk" Number="430" Volume="1968" Year="1995">
-      <Id>4a946d6d-c763-4812-8086-178124881f53</Id>
+      <Database Name="cv" Series="2406" Issue="40978" />
     </Book>
     <Book Series="The Mighty Thor" Number="488" Volume="1989" Year="1995">
-      <Id>063f3260-b145-4528-9a28-3a4dbd2ea37e</Id>
+      <Database Name="cv" Series="61213" Issue="41118" />
     </Book>
     <Book Series="The Mighty Thor" Number="489" Volume="1989" Year="1995">
-      <Id>bdcca08e-4f31-4c50-a334-5ab499428d01</Id>
+      <Database Name="cv" Series="61213" Issue="41258" />
     </Book>
     <Book Series="The Incredible Hulk" Number="431" Volume="1968" Year="1995">
-      <Id>cb938bc7-aaa2-42fc-aba4-5a3aaef6ca14</Id>
+      <Database Name="cv" Series="2406" Issue="41115" />
     </Book>
     <Book Series="The Incredible Hulk" Number="432" Volume="1968" Year="1995">
-      <Id>605326b5-16d1-43d6-9d39-357f0d4b9ceb</Id>
+      <Database Name="cv" Series="2406" Issue="41255" />
     </Book>
     <Book Series="The Incredible Hulk" Number="433" Volume="1968" Year="1995">
-      <Id>c9a854fe-c6ce-4191-8891-b661c96bc6ab</Id>
+      <Database Name="cv" Series="2406" Issue="41385" />
     </Book>
     <Book Series="The Incredible Hulk" Number="434" Volume="1968" Year="1995">
-      <Id>7a0b5dbd-9417-4e5d-b148-dbab6c3b6c81</Id>
+      <Database Name="cv" Series="2406" Issue="41516" />
     </Book>
     <Book Series="The Incredible Hulk" Number="435" Volume="1968" Year="1995">
-      <Id>a53e5c86-7577-4023-b73e-8486c63cfdf5</Id>
+      <Database Name="cv" Series="2406" Issue="41643" />
     </Book>
     <Book Series="Cutting Edge" Number="1" Volume="1995" Year="1995">
-      <Id>24cfaf3a-3921-42f5-ae40-45a77cca1dbf</Id>
+      <Database Name="cv" Series="27167" Issue="165115" />
     </Book>
     <Book Series="The Incredible Hulk" Number="436" Volume="1968" Year="1995">
-      <Id>fee27fe8-7dc0-443f-872f-278f9006f3dd</Id>
+      <Database Name="cv" Series="2406" Issue="41770" />
     </Book>
     <Book Series="The Incredible Hulk" Number="437" Volume="1968" Year="1996">
-      <Id>fa126cb2-169a-42ea-9af3-08ae3a75ab27</Id>
+      <Database Name="cv" Series="2406" Issue="41989" />
     </Book>
     <Book Series="The Incredible Hulk" Number="438" Volume="1968" Year="1996">
-      <Id>94bcc494-eb63-4be6-9370-038e50f6d127</Id>
+      <Database Name="cv" Series="2406" Issue="42097" />
     </Book>
     <Book Series="The Incredible Hulk" Number="439" Volume="1968" Year="1996">
-      <Id>bd9109be-ea83-46e9-864f-3c22e7fbb8e7</Id>
+      <Database Name="cv" Series="2406" Issue="42207" />
     </Book>
     <Book Series="The Incredible Hulk" Number="440" Volume="1968" Year="1996">
-      <Id>2cbab535-c33b-48ce-9869-712d9a3cafa0</Id>
+      <Database Name="cv" Series="2406" Issue="42303" />
     </Book>
     <Book Series="The Incredible Hulk" Number="441" Volume="1968" Year="1996">
-      <Id>8a0ca7e2-99ba-476f-ad8f-8067ac6d4689</Id>
+      <Database Name="cv" Series="2406" Issue="42399" />
     </Book>
     <Book Series="The Incredible Hulk" Number="442" Volume="1968" Year="1996">
-      <Id>260f2ce7-f24c-4f03-b742-e026cf9bb72d</Id>
+      <Database Name="cv" Series="2406" Issue="42492" />
     </Book>
     <Book Series="The Incredible Hulk" Number="443" Volume="1968" Year="1996">
-      <Id>464bb52e-0c0b-4325-9ed2-eea4730ad40f</Id>
+      <Database Name="cv" Series="2406" Issue="42603" />
     </Book>
     <Book Series="Cable" Number="34" Volume="1993" Year="1996">
-      <Id>390f7bee-febf-402b-8e4c-6137bf0ddcdd</Id>
+      <Database Name="cv" Series="4993" Issue="42721" />
     </Book>
     <Book Series="The Incredible Hulk" Number="444" Volume="1968" Year="1996">
-      <Id>6d825348-441a-46f6-8e5e-d83096ea4ec6</Id>
+      <Database Name="cv" Series="2406" Issue="42701" />
     </Book>
     <Book Series="The Incredible Hulk" Number="445" Volume="1968" Year="1996">
-      <Id>6d7277a8-e8b0-408e-88e3-772b54095e72</Id>
+      <Database Name="cv" Series="2406" Issue="42795" />
     </Book>
     <Book Series="The Incredible Hulk" Number="446" Volume="1968" Year="1996">
-      <Id>8ecb7a86-5bc5-4c12-876f-f5e8512b2786</Id>
+      <Database Name="cv" Series="2406" Issue="42883" />
     </Book>
     <Book Series="The Incredible Hulk" Number="447" Volume="1968" Year="1996">
-      <Id>d45cbf50-087b-4a59-ac16-47f66f0f417e</Id>
+      <Database Name="cv" Series="2406" Issue="42984" />
     </Book>
     <Book Series="The Incredible Hulk" Number="448" Volume="1968" Year="1996">
-      <Id>d91cd8f7-f749-473a-9308-63dd25134230</Id>
+      <Database Name="cv" Series="2406" Issue="43078" />
     </Book>
     <Book Series="The Incredible Hulk" Number="449" Volume="1968" Year="1997">
-      <Id>075f9856-27d3-4136-a389-85d1e88c5732</Id>
+      <Database Name="cv" Series="2406" Issue="43273" />
     </Book>
     <Book Series="The Incredible Hulk" Number="450" Volume="1968" Year="1997">
-      <Id>c3fa786f-2c3e-4f6a-a74c-52b988e91b85</Id>
+      <Database Name="cv" Series="2406" Issue="43384" />
     </Book>
     <Book Series="The Incredible Hulk" Number="451" Volume="1968" Year="1997">
-      <Id>a345af5e-4867-46f9-91c2-68347b5c2ee9</Id>
+      <Database Name="cv" Series="2406" Issue="43483" />
     </Book>
     <Book Series="The Incredible Hulk" Number="452" Volume="1968" Year="1997">
-      <Id>3b50f792-ce58-4307-990c-368b6f28ee94</Id>
+      <Database Name="cv" Series="2406" Issue="43579" />
     </Book>
     <Book Series="The Incredible Hulk" Number="453" Volume="1968" Year="1997">
-      <Id>8e567c26-099b-4f1f-bf10-c9fe63840b75</Id>
+      <Database Name="cv" Series="2406" Issue="43684" />
     </Book>
     <Book Series="The Incredible Hulk" Number="454" Volume="1968" Year="1997">
-      <Id>0e9a44de-d53b-47d4-b2d9-1756f490fb99</Id>
+      <Database Name="cv" Series="2406" Issue="51679" />
     </Book>
     <Book Series="The Incredible Hulk" Number="455" Volume="1968" Year="1997">
-      <Id>94f3dc30-4372-41bb-bb5c-e9586ec25334</Id>
+      <Database Name="cv" Series="2406" Issue="43973" />
     </Book>
     <Book Series="The Incredible Hulk" Number="456" Volume="1968" Year="1997">
-      <Id>01ea1b6a-24ec-404f-bb4a-1d3eaa42d2c3</Id>
+      <Database Name="cv" Series="2406" Issue="44083" />
     </Book>
     <Book Series="The Incredible Hulk" Number="457" Volume="1968" Year="1997">
-      <Id>2ad6dd03-680c-4f6b-9261-648417d89007</Id>
+      <Database Name="cv" Series="2406" Issue="44188" />
     </Book>
     <Book Series="The Incredible Hulk" Number="458" Volume="1968" Year="1997">
-      <Id>ffa4f061-77dd-4193-a8a6-ade9169f3dd6</Id>
+      <Database Name="cv" Series="2406" Issue="44295" />
     </Book>
-    <Book Series="The Incredible Hulk Annual '97" Number="1" Volume="1997" Year="1997">
-      <Id>b5b93282-0139-4365-b522-4b739d6bdbb1</Id>
+    <Book Series="The Incredible Hulk '97" Number="1" Volume="1997" Year="1997">
+      <Database Name="cv" Series="60432" Issue="138335" />
     </Book>
     <Book Series="The Incredible Hulk" Number="459" Volume="1968" Year="1997">
-      <Id>6a006a49-34bb-4737-bd51-bb95aa7518f2</Id>
+      <Database Name="cv" Series="2406" Issue="80802" />
     </Book>
     <Book Series="The Incredible Hulk" Number="460" Volume="1968" Year="1998">
-      <Id>72ca1d02-2f56-44b1-840a-10c5c38db2e2</Id>
+      <Database Name="cv" Series="2406" Issue="80803" />
     </Book>
     <Book Series="The Incredible Hulk" Number="461" Volume="1968" Year="1998">
-      <Id>a820765c-6e3c-4668-b1b0-f7b9cd9a13dd</Id>
+      <Database Name="cv" Series="2406" Issue="80804" />
     </Book>
     <Book Series="The Incredible Hulk" Number="462" Volume="1968" Year="1998">
-      <Id>0efef52e-94aa-4ef6-9aaa-7dfa4bba35ed</Id>
+      <Database Name="cv" Series="2406" Issue="80805" />
     </Book>
     <Book Series="The Incredible Hulk" Number="463" Volume="1968" Year="1998">
-      <Id>043e6bb7-85ed-426f-8560-a451691cbc27</Id>
+      <Database Name="cv" Series="2406" Issue="80806" />
     </Book>
     <Book Series="The Incredible Hulk" Number="464" Volume="1968" Year="1998">
-      <Id>7971c2d4-01f8-4772-91bc-cb0d8a741242</Id>
+      <Database Name="cv" Series="2406" Issue="80807" />
     </Book>
     <Book Series="The Incredible Hulk" Number="465" Volume="1968" Year="1998">
-      <Id>e15cfcc8-e879-42f2-a354-fbe7a7e49098</Id>
+      <Database Name="cv" Series="2406" Issue="80808" />
     </Book>
     <Book Series="The Incredible Hulk" Number="466" Volume="1968" Year="1998">
-      <Id>fbaa2662-fd68-4a47-8a2a-e7df4e5c37bd</Id>
+      <Database Name="cv" Series="2406" Issue="132144" />
     </Book>
     <Book Series="The Incredible Hulk" Number="467" Volume="1968" Year="1998">
-      <Id>a0312bc6-94ae-400e-9960-c34d9afd0d2c</Id>
+      <Database Name="cv" Series="2406" Issue="152728" />
     </Book>
-    <Book Series="Hulk / Sub-Mariner Annual '98" Number="1" Volume="1998" Year="1998">
-      <Id>bf950a0d-bd49-4e68-bf6c-affc7ea41828</Id>
+    <Book Series="Hulk / Sub-Mariner '98" Number="1" Volume="1998" Year="1998">
+      <Database Name="cv" Series="60434" Issue="138336" />
     </Book>
     <Book Series="The Incredible Hulk" Number="468" Volume="1968" Year="1998">
-      <Id>73b5df18-5a46-48a4-96d5-cdd1ca9a1963</Id>
+      <Database Name="cv" Series="2406" Issue="80809" />
     </Book>
     <Book Series="The Incredible Hulk" Number="469" Volume="1968" Year="1998">
-      <Id>fd9ae566-1357-49ba-afd9-505194471a61</Id>
+      <Database Name="cv" Series="2406" Issue="80811" />
     </Book>
     <Book Series="The Incredible Hulk" Number="470" Volume="1968" Year="1998">
-      <Id>907aa6d1-cf0f-491c-8787-5b9bb6beea2e</Id>
+      <Database Name="cv" Series="2406" Issue="132145" />
     </Book>
     <Book Series="The Incredible Hulk" Number="471" Volume="1968" Year="1998">
-      <Id>b851e740-121d-4271-88a0-31508a98fd76</Id>
+      <Database Name="cv" Series="2406" Issue="80812" />
     </Book>
     <Book Series="The Incredible Hulk" Number="472" Volume="1968" Year="1999">
-      <Id>68afa272-0c0d-4bac-9787-174faf976c21</Id>
+      <Database Name="cv" Series="2406" Issue="132147" />
     </Book>
     <Book Series="The Incredible Hulk" Number="473" Volume="1968" Year="1999">
-      <Id>b78e6248-9ca6-40a6-8e9d-c6388d658a1d</Id>
+      <Database Name="cv" Series="2406" Issue="80815" />
     </Book>
     <Book Series="The Incredible Hulk" Number="474" Volume="1968" Year="1999">
-      <Id>b7817421-00e7-4a83-81b2-ffef57dfe5f0</Id>
+      <Database Name="cv" Series="2406" Issue="80818" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Incredible Hulk/Incredible Hulk 003.cbl
+++ b/Marvel/Characters/unsorted/Incredible Hulk/Incredible Hulk 003.cbl
@@ -2,895 +2,895 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Incredible Hulk 3</Name>
   <Books>
-    <Book Series="Hulk" Number="1" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Hulk" Number="1" Volume="1999" Year="1999">
       <Id>934562b5-dee2-489b-b443-79dc1bc6fbf3</Id>
     </Book>
-    <Book Series="Hulk" Number="2" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Hulk" Number="2" Volume="1999" Year="1999">
       <Id>9cb8b66e-9446-46f9-bc6e-db996e5e5b8f</Id>
     </Book>
-    <Book Series="Hulk" Number="3" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Hulk" Number="3" Volume="1999" Year="1999">
       <Id>f71c4320-3366-483d-83c4-d49c4bc4e9c0</Id>
     </Book>
-    <Book Series="Hulk" Number="4" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Hulk" Number="4" Volume="1999" Year="1999">
       <Id>e3f9c949-f360-43fb-a9a8-a55b796b6be0</Id>
     </Book>
-    <Book Series="Hulk" Number="5" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Hulk" Number="5" Volume="1999" Year="1999">
       <Id>0843d6b1-d98e-4752-8a49-380c3f7b40b3</Id>
     </Book>
-    <Book Series="Hulk" Number="6" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Hulk" Number="6" Volume="1999" Year="1999">
       <Id>65347e63-8fc5-4433-8bd3-edbf9c5530d8</Id>
     </Book>
-    <Book Series="Hulk" Number="7" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Hulk" Number="7" Volume="1999" Year="1999">
       <Id>0525b749-1a2f-403d-9406-f8997acee384</Id>
     </Book>
-    <Book Series="Hulk" Number="8" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Hulk" Number="8" Volume="1999" Year="1999">
       <Id>462a9f32-3c35-4290-b5a4-da5fefe32c5a</Id>
     </Book>
-    <Book Series="Wolverine" Number="145" Volume="1988" Year="1999" Format="Main Series">
+    <Book Series="Wolverine" Number="145" Volume="1988" Year="1999">
       <Id>0195f75f-bfdf-43f3-ae2f-464b99b79767</Id>
     </Book>
-    <Book Series="Hulk" Number="9" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Hulk" Number="9" Volume="1999" Year="1999">
       <Id>c2373a82-b202-4fac-abbb-87ce03ebc279</Id>
     </Book>
-    <Book Series="Hulk" Number="10" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Hulk" Number="10" Volume="1999" Year="2000">
       <Id>96018f6f-d5bb-42f6-8369-4c48b290dcbb</Id>
     </Book>
-    <Book Series="Hulk" Number="½" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Hulk" Number="½" Volume="1999" Year="1999">
       <Id>d6d2e476-71c1-462a-90f6-ac5755490f1b</Id>
     </Book>
-    <Book Series="Hulk" Number="11" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Hulk" Number="11" Volume="1999" Year="2000">
       <Id>c7fb88e8-377b-4a9c-8b97-d4af92386369</Id>
     </Book>
-    <Book Series="Thunderbolts" Number="34" Volume="1997" Year="2000" Format="Main Series">
+    <Book Series="Thunderbolts" Number="34" Volume="1997" Year="2000">
       <Id>4a29497f-6448-4321-b789-440b529a9846</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="14" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="14" Volume="1999" Year="2000">
       <Id>7b6277a5-edc5-46df-9cd9-7ea449c2222f</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="2" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Captain Marvel" Number="2" Volume="2000" Year="2000">
       <Id>c9c92888-223a-43cd-8867-8a12bd807ed5</Id>
     </Book>
-    <Book Series="Captain Marvel" Number="3" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Captain Marvel" Number="3" Volume="2000" Year="2000">
       <Id>3ec62eae-7af4-4818-9f26-c0025e564a0b</Id>
     </Book>
-    <Book Series="Hulk Annual 1999" Number="1" Volume="1999" Year="1999" Format="Annual">
+    <Book Series="Hulk Annual 1999" Number="1" Volume="1999" Year="1999">
       <Id>4a945410-08cd-47ae-a01a-c3919a6c3772</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="12" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="12" Volume="2000" Year="2000">
       <Id>8487abf2-bd9b-425a-82b3-664fff584fc8</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="13" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="13" Volume="2000" Year="2000">
       <Id>53746df5-5017-403c-b62b-075af9869b46</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="14" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="14" Volume="2000" Year="2000">
       <Id>539b1243-d2de-480a-934c-dbd4ba0779a9</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="15" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="15" Volume="2000" Year="2000">
       <Id>8a01b371-bd36-4a9e-99ed-7b0ac1887de0</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="16" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="16" Volume="2000" Year="2000">
       <Id>ece009f4-5800-4049-8146-481ebc75dfd6</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="17" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="17" Volume="2000" Year="2000">
       <Id>b68b4564-4943-4ad9-8eb1-48d40bc02fda</Id>
     </Book>
-    <Book Series="Hulk Smash" Number="1" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Hulk Smash" Number="1" Volume="2001" Year="2001">
       <Id>559453a8-e975-4daf-b00a-6f0f654f6c84</Id>
     </Book>
-    <Book Series="Hulk Smash" Number="2" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Hulk Smash" Number="2" Volume="2001" Year="2001">
       <Id>75c59e1f-ccb0-44a2-ad09-02f5dc6d5d8c</Id>
     </Book>
-    <Book Series="Hulk Annual 2000" Number="1" Volume="2000" Year="2000" Format="Annual">
+    <Book Series="Hulk Annual 2000" Number="1" Volume="2000" Year="2000">
       <Id>868291e4-53bc-4209-8816-26a76b4a13e7</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="18" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="18" Volume="2000" Year="2000">
       <Id>7d0dd3ad-0352-435c-9b4c-ba06b7c4cdd7</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="19" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="19" Volume="2000" Year="2000">
       <Id>f2f1a288-09aa-4900-a597-ccf0ac46ddce</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="20" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="20" Volume="2000" Year="2000">
       <Id>02dfc60a-bf1c-4480-978e-92fa95f99322</Id>
     </Book>
-    <Book Series="Sentry/Hulk" Number="1" Volume="2001" Year="2001" Format="One-Shot">
+    <Book Series="Sentry/Hulk" Number="1" Volume="2001" Year="2001">
       <Id>1314531f-2d4e-40db-aabb-feacc58e8b9f</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="21" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="21" Volume="2000" Year="2000">
       <Id>4292db15-e601-41e9-9d43-4129fb41a741</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="22" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="22" Volume="2000" Year="2001">
       <Id>53ea5489-f375-452f-98a8-4a25334dd05b</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="23" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="23" Volume="2000" Year="2001">
       <Id>9205442a-ef9e-4d32-8bb6-435cb1582f54</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="24" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="24" Volume="2000" Year="2001">
       <Id>90491ac0-90cb-4476-8b67-ef542258471d</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="25" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="25" Volume="2000" Year="2001">
       <Id>b08f325c-42fb-4685-96df-113920735816</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="26" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="26" Volume="2000" Year="2001">
       <Id>9f7a46bc-c867-4686-b57d-08ab1a9259bd</Id>
     </Book>
-    <Book Series="Avengers" Number="39" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Avengers" Number="39" Volume="1998" Year="2001">
       <Id>68566dad-bbb2-4d75-b815-396ed43deab9</Id>
     </Book>
-    <Book Series="Avengers" Number="40" Volume="1998" Year="2001" Format="Main Series">
+    <Book Series="Avengers" Number="40" Volume="1998" Year="2001">
       <Id>1d685eb3-ce98-4471-825d-3264f63c5d96</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="27" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="27" Volume="2000" Year="2001">
       <Id>2aa2c63e-c8db-4a41-9716-2547b4b45da1</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="28" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="28" Volume="2000" Year="2001">
       <Id>b85b4f4a-9ca5-4ecc-91b7-92a6536c48b4</Id>
     </Book>
-    <Book Series="Incredible Hulk Annual 2001" Number="1" Volume="2001" Year="2001" Format="Annual">
+    <Book Series="Incredible Hulk Annual 2001" Number="1" Volume="2001" Year="2001">
       <Id>8d33e45a-4902-4bd3-9cd2-4dd3a70eb645</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="29" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="29" Volume="2000" Year="2001">
       <Id>9676a2f7-f0f1-4f9f-89fa-3829f4a75c38</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="30" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="30" Volume="2000" Year="2001">
       <Id>3aa0188b-f881-4fa2-9280-05022777965d</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="31" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="31" Volume="2000" Year="2001">
       <Id>fcfacd23-2ed1-46c8-bffa-c86e371d6f12</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="32" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="32" Volume="2000" Year="2001">
       <Id>f5ce4d5c-c675-411f-b30d-4428524952b5</Id>
     </Book>
-    <Book Series="The Order" Number="1" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="The Order" Number="1" Volume="2002" Year="2002">
       <Id>ee9f9db9-0e76-4f5a-af25-b1f5c9343c85</Id>
     </Book>
-    <Book Series="The Order" Number="2" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="The Order" Number="2" Volume="2002" Year="2002">
       <Id>ac5eb691-f5d3-4975-93f5-cbc9430cc61c</Id>
     </Book>
-    <Book Series="The Order" Number="3" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="The Order" Number="3" Volume="2002" Year="2002">
       <Id>99e63d04-ac07-4baf-b6c0-d6ea52b1dbc7</Id>
     </Book>
-    <Book Series="The Order" Number="4" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="The Order" Number="4" Volume="2002" Year="2002">
       <Id>cebec8ea-97dc-4732-9ba9-160c6d105bc8</Id>
     </Book>
-    <Book Series="The Order" Number="5" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="The Order" Number="5" Volume="2002" Year="2002">
       <Id>b34cc60f-bd21-4222-8ba1-ad64619140e2</Id>
     </Book>
-    <Book Series="The Order" Number="6" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="The Order" Number="6" Volume="2002" Year="2002">
       <Id>f36cc04f-dde3-4104-bd26-9fc02a2fbf80</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="33" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="33" Volume="2000" Year="2001">
       <Id>8a3c58dd-9400-41d6-88c7-86a2ddb0e676</Id>
     </Book>
-    <Book Series="Wolverine/Hulk" Number="1" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="Wolverine/Hulk" Number="1" Volume="2002" Year="2002">
       <Id>3f63b295-d8c1-491f-b0b3-cc910e5b2dc7</Id>
     </Book>
-    <Book Series="Wolverine/Hulk" Number="2" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="Wolverine/Hulk" Number="2" Volume="2002" Year="2002">
       <Id>8e03cb38-4385-4842-82ed-9843f2429ece</Id>
     </Book>
-    <Book Series="Wolverine/Hulk" Number="3" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="Wolverine/Hulk" Number="3" Volume="2002" Year="2002">
       <Id>e6031199-0335-4495-b501-ca2ad9037ef5</Id>
     </Book>
-    <Book Series="Wolverine/Hulk" Number="4" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="Wolverine/Hulk" Number="4" Volume="2002" Year="2002">
       <Id>36552a21-1aff-43e5-a0b4-3bd82747f291</Id>
     </Book>
-    <Book Series="Hulk: Gray" Number="1" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Hulk: Gray" Number="1" Volume="2003" Year="2003">
       <Id>e39c8eac-3eff-4407-a473-94132b46fa03</Id>
     </Book>
-    <Book Series="Hulk: Gray" Number="2" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Hulk: Gray" Number="2" Volume="2003" Year="2003">
       <Id>a8e74048-798c-494f-8073-d5eaba343aa3</Id>
     </Book>
-    <Book Series="Hulk: Gray" Number="3" Volume="2003" Year="2004" Format="Limited Series">
+    <Book Series="Hulk: Gray" Number="3" Volume="2003" Year="2004">
       <Id>b67c78a1-273a-4399-b07a-33fcc651e66e</Id>
     </Book>
-    <Book Series="Hulk: Gray" Number="4" Volume="2003" Year="2004" Format="Limited Series">
+    <Book Series="Hulk: Gray" Number="4" Volume="2003" Year="2004">
       <Id>ff293bb5-eb96-43f5-889b-26fe374f2c27</Id>
     </Book>
-    <Book Series="Hulk: Gray" Number="5" Volume="2003" Year="2004" Format="Limited Series">
+    <Book Series="Hulk: Gray" Number="5" Volume="2003" Year="2004">
       <Id>dcb2485a-0658-408c-9195-0347612c5a6d</Id>
     </Book>
-    <Book Series="Hulk: Gray" Number="6" Volume="2003" Year="2004" Format="Limited Series">
+    <Book Series="Hulk: Gray" Number="6" Volume="2003" Year="2004">
       <Id>b086fa6a-f38d-4a56-a1be-b19afb2eb6ba</Id>
     </Book>
-    <Book Series="Hulk: Nightmerica" Number="1" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Hulk: Nightmerica" Number="1" Volume="2003" Year="2003">
       <Id>ec4a609c-048e-432d-b0e4-2197e58f30db</Id>
     </Book>
-    <Book Series="Hulk: Nightmerica" Number="2" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Hulk: Nightmerica" Number="2" Volume="2003" Year="2003">
       <Id>f8ad5077-57a4-4820-a5ac-c7e3b2752580</Id>
     </Book>
-    <Book Series="Hulk: Nightmerica" Number="3" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Hulk: Nightmerica" Number="3" Volume="2003" Year="2003">
       <Id>9ceb3a0b-b9b1-464c-9491-4ac08af19e7c</Id>
     </Book>
-    <Book Series="Hulk: Nightmerica" Number="4" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Hulk: Nightmerica" Number="4" Volume="2003" Year="2003">
       <Id>7fba9f7b-ce12-4cdb-8676-c53dea4bcc57</Id>
     </Book>
-    <Book Series="Hulk: Nightmerica" Number="5" Volume="2003" Year="2004" Format="Limited Series">
+    <Book Series="Hulk: Nightmerica" Number="5" Volume="2003" Year="2004">
       <Id>e47cafd3-1d80-4eed-a5ae-4662899b2b94</Id>
     </Book>
-    <Book Series="Hulk: Nightmerica" Number="6" Volume="2003" Year="2004" Format="Limited Series">
+    <Book Series="Hulk: Nightmerica" Number="6" Volume="2003" Year="2004">
       <Id>d71c59cc-62de-49d4-ab50-5ca9dac5e9cb</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="34" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="34" Volume="2000" Year="2002">
       <Id>00718076-bdae-4cee-91a8-152e36cb622d</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="35" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="35" Volume="2000" Year="2002">
       <Id>3ff9ab79-965f-4932-845d-9188c5ba75e1</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="36" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="36" Volume="2000" Year="2002">
       <Id>985086da-1415-4737-b11f-a62af47dd5f7</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="37" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="37" Volume="2000" Year="2002">
       <Id>65905d73-8428-4d76-97c0-5ad0ad7a17e9</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="38" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="38" Volume="2000" Year="2002">
       <Id>1f089de2-423f-47e8-9e52-68aa2325a8da</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="39" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="39" Volume="2000" Year="2002">
       <Id>9612df96-2dac-4d34-8b2e-0f799fa70b42</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="40" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="40" Volume="2000" Year="2002">
       <Id>cd27a4a4-b608-4981-bba0-7192e5895cac</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="41" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="41" Volume="2000" Year="2002">
       <Id>2f5c9f66-2ce5-4028-b5e2-a03225264bc3</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="42" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="42" Volume="2000" Year="2002">
       <Id>feadf3d3-63e7-409e-9818-e09ecd179d9b</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="43" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="43" Volume="2000" Year="2002">
       <Id>bfe73529-7c5f-411e-aa13-884a2e4b8256</Id>
     </Book>
-    <Book Series="Startling Stories: Banner" Number="1" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Startling Stories: Banner" Number="1" Volume="2001" Year="2001">
       <Id>93792022-5f62-4fe8-bd33-2ca468a2748d</Id>
     </Book>
-    <Book Series="Startling Stories: Banner" Number="2" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Startling Stories: Banner" Number="2" Volume="2001" Year="2001">
       <Id>6187a1b1-c56f-4980-bcaf-c6cf8fd3c16f</Id>
     </Book>
-    <Book Series="Startling Stories: Banner" Number="3" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Startling Stories: Banner" Number="3" Volume="2001" Year="2001">
       <Id>54bc6152-063c-43c5-a3dc-55c9641d80bb</Id>
     </Book>
-    <Book Series="Startling Stories: Banner" Number="4" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Startling Stories: Banner" Number="4" Volume="2001" Year="2001">
       <Id>7a9ddea9-e21e-4d8e-a276-8b17f0f38d37</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="44" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="44" Volume="2000" Year="2002">
       <Id>152e9754-5a85-4987-9d45-d88ab6396a52</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="45" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="45" Volume="2000" Year="2002">
       <Id>a27e92b4-6181-44d8-b535-773cea40d94e</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="46" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="46" Volume="2000" Year="2002">
       <Id>c2c98b35-43cc-484a-9fe4-118acee41725</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="47" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="47" Volume="2000" Year="2003">
       <Id>7167ec42-2cfe-4610-b9dc-1c7ca05982cf</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="48" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="48" Volume="2000" Year="2003">
       <Id>06501b3c-1087-43b7-a90b-bc29caa07a9d</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="49" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="49" Volume="2000" Year="2003">
       <Id>62e7151e-253c-40ff-b6d0-248df15ef0c2</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="50" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="50" Volume="2000" Year="2003">
       <Id>51e5dcdd-b186-4d0f-b801-19e840cba3ad</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="51" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="51" Volume="2000" Year="2003">
       <Id>474405e0-5d41-4a9a-9da3-b5ed33ea8f93</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="52" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="52" Volume="2000" Year="2003">
       <Id>3e9430d0-6f01-4ff5-991f-5dde053df3a1</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="53" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="53" Volume="2000" Year="2003">
       <Id>aa936ec6-7e68-44da-8d1d-f1d744e2b75d</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="54" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="54" Volume="2000" Year="2003">
       <Id>5be7e7ba-5b96-4e3f-8484-0264806a2bf7</Id>
     </Book>
-    <Book Series="Hulk/Wolverine: 6 Hours" Number="1" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Hulk/Wolverine: 6 Hours" Number="1" Volume="2003" Year="2003">
       <Id>48154efb-f9ff-4dca-a36a-a21ee1fd2056</Id>
     </Book>
-    <Book Series="Hulk/Wolverine: 6 Hours" Number="2" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Hulk/Wolverine: 6 Hours" Number="2" Volume="2003" Year="2003">
       <Id>4d1dd650-8134-4bed-8e7a-4ee177c4de7a</Id>
     </Book>
-    <Book Series="Hulk/Wolverine: 6 Hours" Number="3" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Hulk/Wolverine: 6 Hours" Number="3" Volume="2003" Year="2003">
       <Id>3ee69bdf-460a-456c-8ae6-44ee56cf7a4f</Id>
     </Book>
-    <Book Series="Hulk/Wolverine: 6 Hours" Number="4" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Hulk/Wolverine: 6 Hours" Number="4" Volume="2003" Year="2003">
       <Id>9206a11f-b71b-4564-b411-0eb2c1f34db4</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="55" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="55" Volume="2000" Year="2003">
       <Id>b5445ac8-6d98-427c-bf26-4f61505b0075</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="56" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="56" Volume="2000" Year="2003">
       <Id>b767dbde-251b-4963-9d99-85c2773a8bb7</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="57" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="57" Volume="2000" Year="2003">
       <Id>f9e99278-201a-435a-9c9b-14e83d2caea6</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="58" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="58" Volume="2000" Year="2003">
       <Id>2085c6c1-1bb0-4684-9d56-79d7f642e0f4</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="59" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="59" Volume="2000" Year="2003">
       <Id>a467f5ec-ca21-4bbb-9573-f65f25ffd0c2</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="60" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="60" Volume="2000" Year="2003">
       <Id>9f41cb00-681f-49e6-9338-814dad79c521</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="61" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="61" Volume="2000" Year="2003">
       <Id>2d7a64af-2561-4481-8cc6-d97353d715d1</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="62" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="62" Volume="2000" Year="2003">
       <Id>506ec2f2-c4ca-45e6-a1cc-6afdc437d07e</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="63" Volume="2000" Year="2004" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="63" Volume="2000" Year="2004">
       <Id>451d5ca8-e81a-4454-87c3-2f97806bb58e</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="64" Volume="2000" Year="2004" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="64" Volume="2000" Year="2004">
       <Id>4d8848ae-d93d-4a13-bd6e-39b7cdd65f7d</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="65" Volume="2000" Year="2004" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="65" Volume="2000" Year="2004">
       <Id>779c7fa0-7499-47b1-a823-d14eb2eb5952</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="66" Volume="2000" Year="2004" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="66" Volume="2000" Year="2004">
       <Id>748f2f65-bec4-445e-94a7-040c75cef5c6</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="67" Volume="2000" Year="2004" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="67" Volume="2000" Year="2004">
       <Id>ded82282-2994-42b0-8c91-da6b2e7578cc</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="68" Volume="2000" Year="2004" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="68" Volume="2000" Year="2004">
       <Id>26fb0eed-cdb5-497e-b437-7f0ab5eea9cf</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="69" Volume="2000" Year="2004" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="69" Volume="2000" Year="2004">
       <Id>6f7c1cf5-7a3a-49a2-848f-87a1ce26d6e3</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="70" Volume="2000" Year="2004" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="70" Volume="2000" Year="2004">
       <Id>953acbe0-addb-41da-9fcf-42d95345a4ff</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="71" Volume="2000" Year="2004" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="71" Volume="2000" Year="2004">
       <Id>a6a1aca8-13ac-49ba-8bf7-076c2811ff5e</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="72" Volume="2000" Year="2004" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="72" Volume="2000" Year="2004">
       <Id>9054f86c-f8d2-4b5e-b7b4-c636aae6d3e8</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="73" Volume="2000" Year="2004" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="73" Volume="2000" Year="2004">
       <Id>22fb4fb7-5083-4fd4-a4c1-70e170ed7e5c</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="74" Volume="2000" Year="2004" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="74" Volume="2000" Year="2004">
       <Id>3221721f-22e6-46f8-9cc2-97fd4fe14fd1</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="75" Volume="2000" Year="2004" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="75" Volume="2000" Year="2004">
       <Id>613e32ef-f2be-433f-af50-851737e1ddbd</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="76" Volume="2000" Year="2004" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="76" Volume="2000" Year="2004">
       <Id>3e8d870d-a50b-412a-9367-489f89cca191</Id>
     </Book>
-    <Book Series="Hulk &amp; Thing: Hard Knocks" Number="1" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Hulk &amp; Thing: Hard Knocks" Number="1" Volume="2004" Year="2004">
       <Id>ec2f7997-a8cd-429f-bca2-128244960651</Id>
     </Book>
-    <Book Series="Hulk &amp; Thing: Hard Knocks" Number="2" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Hulk &amp; Thing: Hard Knocks" Number="2" Volume="2004" Year="2004">
       <Id>0fd5dc1a-1414-465a-aa4e-155a967e2389</Id>
     </Book>
-    <Book Series="Hulk &amp; Thing: Hard Knocks" Number="3" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="Hulk &amp; Thing: Hard Knocks" Number="3" Volume="2004" Year="2005">
       <Id>a445c6dd-8b82-49f5-b805-1eace2e92bda</Id>
     </Book>
-    <Book Series="Hulk &amp; Thing: Hard Knocks" Number="4" Volume="2004" Year="2005" Format="Limited Series">
+    <Book Series="Hulk &amp; Thing: Hard Knocks" Number="4" Volume="2004" Year="2005">
       <Id>6d627230-16bf-4ba6-b4a2-1851b34e3332</Id>
     </Book>
-    <Book Series="Avengers" Number="74" Volume="1998" Year="2004" Format="Main Series">
+    <Book Series="Avengers" Number="74" Volume="1998" Year="2004">
       <Id>1346fa28-ecda-49da-a235-2f8b1cf0c27d</Id>
     </Book>
-    <Book Series="Avengers" Number="75" Volume="1998" Year="2004" Format="Main Series">
+    <Book Series="Avengers" Number="75" Volume="1998" Year="2004">
       <Id>5826d0b8-4c4e-4731-b7b1-6f28d8746d38</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="3" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="3" Volume="2005" Year="2005">
       <Id>c8c1e351-6929-428e-8360-75f42d37f98e</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="4" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="4" Volume="2005" Year="2005">
       <Id>9632409f-2b7e-44fe-b867-f9acece4b343</Id>
     </Book>
-    <Book Series="Captain Universe / Hulk" Number="1" Volume="2006" Year="2006" Format="One-Shot">
+    <Book Series="Captain Universe / Hulk" Number="1" Volume="2006" Year="2006">
       <Id>cc51f943-b5cf-4115-818e-c0f228dce754</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="77" Volume="2000" Year="2005" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="77" Volume="2000" Year="2005">
       <Id>e600cda0-fe2e-4a83-9f51-9bb045e8192a</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="78" Volume="2000" Year="2005" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="78" Volume="2000" Year="2005">
       <Id>06ff6611-d219-40c5-8637-667459b556f2</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="79" Volume="2000" Year="2005" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="79" Volume="2000" Year="2005">
       <Id>41b260c6-b449-48d7-bd87-152e69d44404</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="80" Volume="2000" Year="2005" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="80" Volume="2000" Year="2005">
       <Id>41ff8a8e-34f7-42ed-a726-fa3136b42734</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="81" Volume="2000" Year="2005" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="81" Volume="2000" Year="2005">
       <Id>f98ee36a-10ab-4d79-b6f8-33e722632cf6</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="82" Volume="2000" Year="2005" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="82" Volume="2000" Year="2005">
       <Id>1aaf336b-38ec-4e47-99f1-091a25eb7940</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="83" Volume="2000" Year="2005" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="83" Volume="2000" Year="2005">
       <Id>b8483192-5552-4f5e-9667-e5b12c154297</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="84" Volume="2000" Year="2005" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="84" Volume="2000" Year="2005">
       <Id>7dcbaffa-94b7-4ea0-b704-0b5ab323118d</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="85" Volume="2000" Year="2005" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="85" Volume="2000" Year="2005">
       <Id>7c809f32-7e78-474a-bb6a-8635ae66f1ab</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="86" Volume="2000" Year="2005" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="86" Volume="2000" Year="2005">
       <Id>0a4b761c-10b7-48ba-82cd-321fdcbe0b73</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="87" Volume="2000" Year="2005" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="87" Volume="2000" Year="2005">
       <Id>639abfa7-4f0b-4eab-a29e-42d475e7232b</Id>
     </Book>
-    <Book Series="Hulk: Destruction" Number="1" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Hulk: Destruction" Number="1" Volume="2005" Year="2005">
       <Id>c05c3852-8e01-41a3-8472-abe0e18f1113</Id>
     </Book>
-    <Book Series="Hulk: Destruction" Number="2" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Hulk: Destruction" Number="2" Volume="2005" Year="2005">
       <Id>34865475-4eaa-4344-8911-0ef44c5fc113</Id>
     </Book>
-    <Book Series="Hulk: Destruction" Number="3" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Hulk: Destruction" Number="3" Volume="2005" Year="2005">
       <Id>910ceeaf-f9c2-4f06-8d40-89b7f1cdff9d</Id>
     </Book>
-    <Book Series="Hulk: Destruction" Number="4" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Hulk: Destruction" Number="4" Volume="2005" Year="2005">
       <Id>531525d9-7df3-46d7-8794-c41798c5b160</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="533" Volume="1998" Year="2006" Format="Main Series">
+    <Book Series="Fantastic Four" Number="533" Volume="1998" Year="2006">
       <Id>b978e1ac-673a-4450-aa3b-19208b6cc7b5</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="534" Volume="1998" Year="2006" Format="Main Series">
+    <Book Series="Fantastic Four" Number="534" Volume="1998" Year="2006">
       <Id>5c2a9109-be64-45aa-8287-aa0ff50932e9</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="535" Volume="1998" Year="2006" Format="Main Series">
+    <Book Series="Fantastic Four" Number="535" Volume="1998" Year="2006">
       <Id>445654ea-bc6c-4316-adcf-efc17e800bdd</Id>
     </Book>
-    <Book Series="The New Avengers: Illuminati" Number="1" Volume="2006" Year="2006" Format="One-Shot">
+    <Book Series="The New Avengers: Illuminati" Number="1" Volume="2006" Year="2006">
       <Id>c570c47d-1e2a-4a69-b920-0724f45b327b</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="88" Volume="2000" Year="2006" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="88" Volume="2000" Year="2006">
       <Id>4780b227-a3b3-4504-bbae-34a33cd9b4e3</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="89" Volume="2000" Year="2006" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="89" Volume="2000" Year="2006">
       <Id>e7e71134-22a1-42b2-86d4-104a61de17bf</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="90" Volume="2000" Year="2006" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="90" Volume="2000" Year="2006">
       <Id>988816f4-492a-4a69-977b-e134dcd7ae03</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="91" Volume="2000" Year="2006" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="91" Volume="2000" Year="2006">
       <Id>65bdb09e-c84b-45dc-b092-8785714c381c</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="92" Volume="2000" Year="2006" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="92" Volume="2000" Year="2006">
       <Id>786e7ba6-411e-4c47-9e29-2eff8bbc207d</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="93" Volume="2000" Year="2006" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="93" Volume="2000" Year="2006">
       <Id>3bf6a469-9d75-4bdc-aea7-82e6740f51f2</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="94" Volume="2000" Year="2006" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="94" Volume="2000" Year="2006">
       <Id>9d53d7cc-8d52-47f9-9ab5-7e1d342fdcea</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="95" Volume="2000" Year="2006" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="95" Volume="2000" Year="2006">
       <Id>d582f94e-2b68-4acd-ade3-54ec197ad53f</Id>
     </Book>
-    <Book Series="Giant-Size Hulk" Number="1" Volume="2006" Year="2006" Format="Giant Size">
+    <Book Series="Giant-Size Hulk" Number="1" Volume="2006" Year="2006">
       <Id>046a25db-c3a3-4b94-9dcb-110133ed3e9d</Id>
     </Book>
-    <Book Series="Planet Hulk: Gladiator Guidebook" Number="1" Volume="2006" Year="2006" Format="One-Shot">
+    <Book Series="Planet Hulk: Gladiator Guidebook" Number="1" Volume="2006" Year="2006">
       <Id>697329e2-5b3a-4a8c-b30b-8c110f3303ce</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="96" Volume="2000" Year="2006" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="96" Volume="2000" Year="2006">
       <Id>c0074ac3-fbc8-4bf9-8e20-1282ae45d11f</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="97" Volume="2000" Year="2006" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="97" Volume="2000" Year="2006">
       <Id>950fe046-1579-4070-bf25-5e820b40cd48</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="98" Volume="2000" Year="2006" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="98" Volume="2000" Year="2006">
       <Id>e5c7d29b-bde7-43a7-81b1-1f997ddafb42</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="99" Volume="2000" Year="2006" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="99" Volume="2000" Year="2006">
       <Id>c9892c99-af1a-4c36-93b6-0ea2581e8778</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="100" Volume="2000" Year="2007" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="100" Volume="2000" Year="2007">
       <Id>feaf2460-3635-4704-9613-188b32afd21d</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="101" Volume="2000" Year="2007" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="101" Volume="2000" Year="2007">
       <Id>6525101c-1b66-48af-a00b-8e2b05f33e78</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="102" Volume="2000" Year="2007" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="102" Volume="2000" Year="2007">
       <Id>6d411752-07cb-44a2-ac5f-2e7cb2294d91</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="103" Volume="2000" Year="2007" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="103" Volume="2000" Year="2007">
       <Id>01c8e6f3-b631-4938-8eac-67c50d712aff</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="104" Volume="2000" Year="2007" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="104" Volume="2000" Year="2007">
       <Id>dad48f06-1c2a-48fe-8f88-f44297cd7ed6</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="105" Volume="2000" Year="2007" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="105" Volume="2000" Year="2007">
       <Id>49f477da-5d46-4f98-94ea-d30507bcf399</Id>
     </Book>
-    <Book Series="World War Hulk Prologue: World Breaker" Number="1" Volume="2007" Year="2007" Format="Crossover">
+    <Book Series="World War Hulk Prologue: World Breaker" Number="1" Volume="2007" Year="2007">
       <Id>c0629644-6e20-434c-b745-17b5c841b5d5</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="106" Volume="2000" Year="2007" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="106" Volume="2000" Year="2007">
       <Id>abad0944-ab19-4324-bcc8-20d221171785</Id>
     </Book>
-    <Book Series="World War Hulk" Number="1" Volume="2007" Year="2007" Format="Crossover">
+    <Book Series="World War Hulk" Number="1" Volume="2007" Year="2007">
       <Id>3960db97-4174-4f10-aa1e-728dd6be66a9</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="107" Volume="2000" Year="2007" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="107" Volume="2000" Year="2007">
       <Id>a8b3d2df-cd75-419e-bd3f-c4032f205c1c</Id>
     </Book>
-    <Book Series="Iron Man" Number="19" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Iron Man" Number="19" Volume="2005" Year="2007">
       <Id>a9e477ed-e523-4fe3-b32c-7382c33fe8e6</Id>
     </Book>
-    <Book Series="Ghost Rider" Number="12" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Ghost Rider" Number="12" Volume="2006" Year="2007">
       <Id>45b85ba2-5bab-4eaa-b104-2b12bdf08446</Id>
     </Book>
-    <Book Series="Heroes for Hire" Number="11" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Heroes for Hire" Number="11" Volume="2006" Year="2007">
       <Id>434b0142-4394-42b2-ac6f-8091e1f0fb25</Id>
     </Book>
-    <Book Series="World War Hulk: X-Men" Number="1" Volume="2007" Year="2007" Format="Crossover">
+    <Book Series="World War Hulk: X-Men" Number="1" Volume="2007" Year="2007">
       <Id>b94d41f6-4ecd-42a8-87ca-818684ed49a3</Id>
     </Book>
-    <Book Series="World War Hulk: Front Line" Number="1" Volume="2007" Year="2007" Format="Crossover">
+    <Book Series="World War Hulk: Front Line" Number="1" Volume="2007" Year="2007">
       <Id>400e2265-9f39-4089-8298-52e99c380a9b</Id>
     </Book>
-    <Book Series="The Irredeemable Ant-Man" Number="10" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="The Irredeemable Ant-Man" Number="10" Volume="2006" Year="2007">
       <Id>cb0ba897-23d2-4a31-a127-bba3c3c0efbf</Id>
     </Book>
-    <Book Series="World War Hulk: Gamma Corps" Number="1" Volume="2007" Year="2007" Format="Crossover">
+    <Book Series="World War Hulk: Gamma Corps" Number="1" Volume="2007" Year="2007">
       <Id>e4d01747-20d8-4316-8f0a-8a0ff5830f0c</Id>
     </Book>
-    <Book Series="World War Hulk" Number="2" Volume="2007" Year="2007" Format="Crossover">
+    <Book Series="World War Hulk" Number="2" Volume="2007" Year="2007">
       <Id>72641fe2-0417-4bee-a67e-e873cc88a4ee</Id>
     </Book>
-    <Book Series="World War Hulk: X-Men" Number="2" Volume="2007" Year="2007" Format="Crossover">
+    <Book Series="World War Hulk: X-Men" Number="2" Volume="2007" Year="2007">
       <Id>f4ec563b-aed7-4343-a58b-653424703ddf</Id>
     </Book>
-    <Book Series="World War Hulk: Front Line" Number="2" Volume="2007" Year="2007" Format="Crossover">
+    <Book Series="World War Hulk: Front Line" Number="2" Volume="2007" Year="2007">
       <Id>5195c49c-3220-47f4-914e-0ad37b222ee5</Id>
     </Book>
-    <Book Series="Avengers: The Initiative" Number="4" Volume="2007" Year="2007" Format="Main Series">
+    <Book Series="Avengers: The Initiative" Number="4" Volume="2007" Year="2007">
       <Id>6409a098-fbc1-4049-b949-274ac25f3a7e</Id>
     </Book>
-    <Book Series="Ghost Rider" Number="13" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Ghost Rider" Number="13" Volume="2006" Year="2007">
       <Id>5f86ba13-e398-438e-8f5f-48c470ffefbc</Id>
     </Book>
-    <Book Series="Iron Man" Number="20" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Iron Man" Number="20" Volume="2005" Year="2007">
       <Id>00ed08a6-42dd-4410-b0e3-06a929555912</Id>
     </Book>
-    <Book Series="Heroes for Hire" Number="12" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Heroes for Hire" Number="12" Volume="2006" Year="2007">
       <Id>e0bc0c4d-3f10-43bb-9e3f-50e4e5567026</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="108" Volume="2000" Year="2007" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="108" Volume="2000" Year="2007">
       <Id>5fecd249-3268-4318-829b-1c2f060fc9fb</Id>
     </Book>
-    <Book Series="World War Hulk" Number="3" Volume="2007" Year="2007" Format="Crossover">
+    <Book Series="World War Hulk" Number="3" Volume="2007" Year="2007">
       <Id>6da401c2-91ac-479f-b752-35e9ad8a26df</Id>
     </Book>
-    <Book Series="World War Hulk: Front Line" Number="3" Volume="2007" Year="2007" Format="Crossover">
+    <Book Series="World War Hulk: Front Line" Number="3" Volume="2007" Year="2007">
       <Id>3e753cff-35e2-4d0d-9d40-94c1b91c84ed</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="109" Volume="2000" Year="2007" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="109" Volume="2000" Year="2007">
       <Id>6dd09093-fd08-413c-be62-e701e0441f9a</Id>
     </Book>
-    <Book Series="Avengers: The Initiative" Number="5" Volume="2007" Year="2007" Format="Main Series">
+    <Book Series="Avengers: The Initiative" Number="5" Volume="2007" Year="2007">
       <Id>31298d45-35d2-41b9-8c80-fb28110975b8</Id>
     </Book>
-    <Book Series="World War Hulk: Gamma Corps" Number="2" Volume="2007" Year="2007" Format="Crossover">
+    <Book Series="World War Hulk: Gamma Corps" Number="2" Volume="2007" Year="2007">
       <Id>983ef8a3-54d5-468a-ae96-b57fedc14939</Id>
     </Book>
-    <Book Series="World War Hulk: Gamma Files" Number="1" Volume="2007" Year="2007" Format="Crossover">
+    <Book Series="World War Hulk: Gamma Files" Number="1" Volume="2007" Year="2007">
       <Id>2003a58b-3010-45b5-9efe-a23920ac11b0</Id>
     </Book>
-    <Book Series="World War Hulk: X-Men" Number="3" Volume="2007" Year="2007" Format="Crossover">
+    <Book Series="World War Hulk: X-Men" Number="3" Volume="2007" Year="2007">
       <Id>efe752bb-f6e7-489e-be14-7c5e1ae6ae71</Id>
     </Book>
-    <Book Series="World War Hulk: Front Line" Number="4" Volume="2007" Year="2007" Format="Crossover">
+    <Book Series="World War Hulk: Front Line" Number="4" Volume="2007" Year="2007">
       <Id>954d920e-04c3-412f-8b3f-cf916256c576</Id>
     </Book>
-    <Book Series="Heroes for Hire" Number="13" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Heroes for Hire" Number="13" Volume="2006" Year="2007">
       <Id>6b6e47fc-f1a4-4dad-be67-36171e6c47d1</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="110" Volume="2000" Year="2007" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="110" Volume="2000" Year="2007">
       <Id>960fddf4-b6a5-4476-858f-75ef21f956ce</Id>
     </Book>
-    <Book Series="World War Hulk" Number="4" Volume="2007" Year="2007" Format="Crossover">
+    <Book Series="World War Hulk" Number="4" Volume="2007" Year="2007">
       <Id>76ea018a-a1bf-4d9b-be27-b0de2f0efdb9</Id>
     </Book>
-    <Book Series="World War Hulk: Gamma Corps" Number="3" Volume="2007" Year="2007" Format="Crossover">
+    <Book Series="World War Hulk: Gamma Corps" Number="3" Volume="2007" Year="2007">
       <Id>8da3c8ae-8cfa-4011-866a-5c3ec1f954d2</Id>
     </Book>
-    <Book Series="World War Hulk: Front Line" Number="5" Volume="2007" Year="2007" Format="Crossover">
+    <Book Series="World War Hulk: Front Line" Number="5" Volume="2007" Year="2007">
       <Id>46dafb5d-ec2c-498e-b3ad-3d8e98e7b1a1</Id>
     </Book>
-    <Book Series="Heroes for Hire" Number="14" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Heroes for Hire" Number="14" Volume="2006" Year="2007">
       <Id>1e248a4f-d095-4806-82fd-70e211fe3e3d</Id>
     </Book>
-    <Book Series="World War Hulk: Gamma Corps" Number="4" Volume="2007" Year="2008" Format="Crossover">
+    <Book Series="World War Hulk: Gamma Corps" Number="4" Volume="2007" Year="2008">
       <Id>6122145b-84f6-4768-9035-1552e280878d</Id>
     </Book>
-    <Book Series="World War Hulk" Number="5" Volume="2007" Year="2008" Format="Crossover">
+    <Book Series="World War Hulk" Number="5" Volume="2007" Year="2008">
       <Id>3e0de482-4511-47d3-b6fd-c5efd9215833</Id>
     </Book>
-    <Book Series="Punisher War Journal" Number="12" Volume="2007" Year="2007" Format="Main Series">
+    <Book Series="Punisher War Journal" Number="12" Volume="2007" Year="2007">
       <Id>18661d5e-38d2-4ecd-8f9e-86ea20bb1cd1</Id>
     </Book>
-    <Book Series="World War Hulk: Front Line" Number="6" Volume="2007" Year="2007" Format="Crossover">
+    <Book Series="World War Hulk: Front Line" Number="6" Volume="2007" Year="2007">
       <Id>8013dca8-e6fb-439b-9ed4-cd923cedcc0f</Id>
     </Book>
-    <Book Series="Heroes for Hire" Number="15" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Heroes for Hire" Number="15" Volume="2006" Year="2007">
       <Id>8b953d51-93c6-4d71-8f7b-b85c098d6a95</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="111" Volume="2000" Year="2007" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="111" Volume="2000" Year="2007">
       <Id>b5755963-9925-471c-8f59-a13f66c0c9ad</Id>
     </Book>
-    <Book Series="Hulk and Power Pack" Number="1" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="Hulk and Power Pack" Number="1" Volume="2007" Year="2007">
       <Id>bbed6cf7-9bf2-4f81-a78f-afa43b6ab464</Id>
     </Book>
-    <Book Series="Hulk and Power Pack" Number="2" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="Hulk and Power Pack" Number="2" Volume="2007" Year="2007">
       <Id>24170401-ac02-4904-851e-4ba678e783bf</Id>
     </Book>
-    <Book Series="Hulk and Power Pack" Number="3" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="Hulk and Power Pack" Number="3" Volume="2007" Year="2007">
       <Id>a37b5c3b-ce2f-464b-a121-44354128d066</Id>
     </Book>
-    <Book Series="Hulk and Power Pack" Number="4" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="Hulk and Power Pack" Number="4" Volume="2007" Year="2007">
       <Id>ed66f192-b218-4d91-9021-49a45360abc3</Id>
     </Book>
-    <Book Series="Mythos: Hulk" Number="1" Volume="2006" Year="2006" Format="One-Shot">
+    <Book Series="Mythos: Hulk" Number="1" Volume="2006" Year="2006">
       <Id>c6524e66-913f-4575-8706-1e9e87a3089f</Id>
     </Book>
-    <Book Series="Hulk" Number="1" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="Hulk" Number="1" Volume="2008" Year="2008">
       <Id>55631c83-7a28-42bf-bd6c-c9607ad4e2e4</Id>
     </Book>
-    <Book Series="Hulk" Number="2" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="Hulk" Number="2" Volume="2008" Year="2008">
       <Id>bda59ad1-ee2c-475a-9829-554b6977a282</Id>
     </Book>
-    <Book Series="Hulk" Number="3" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="Hulk" Number="3" Volume="2008" Year="2008">
       <Id>54dbf5d6-e01e-4a41-a6b7-dbd1bb9f5fa4</Id>
     </Book>
-    <Book Series="Hulk" Number="4" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="Hulk" Number="4" Volume="2008" Year="2008">
       <Id>2f8d8828-797d-4096-80c5-0d5d38c2f205</Id>
     </Book>
-    <Book Series="Hulk" Number="5" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="Hulk" Number="5" Volume="2008" Year="2008">
       <Id>d7fc68fa-c83a-4c55-b020-da65ee60c9b7</Id>
     </Book>
-    <Book Series="Hulk" Number="6" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="Hulk" Number="6" Volume="2008" Year="2008">
       <Id>cb7acc41-621d-41d6-8363-834be0328f82</Id>
     </Book>
-    <Book Series="Hulk" Number="7" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="Hulk" Number="7" Volume="2008" Year="2008">
       <Id>c4b00b98-e27b-4330-9478-ce8857c2d04a</Id>
     </Book>
-    <Book Series="Hulk" Number="8" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Hulk" Number="8" Volume="2008" Year="2009">
       <Id>b46e63a6-2579-4ced-a1db-8ff6d5247663</Id>
     </Book>
-    <Book Series="Hulk" Number="9" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Hulk" Number="9" Volume="2008" Year="2009">
       <Id>9473a640-60ae-45ce-8074-6628a6008887</Id>
     </Book>
-    <Book Series="King-Size Hulk" Number="1" Volume="2008" Year="2008" Format="One-Shot">
+    <Book Series="King-Size Hulk" Number="1" Volume="2008" Year="2008">
       <Id>1ba68136-a0e6-4ee9-843e-73aa3bb97716</Id>
     </Book>
-    <Book Series="Hulk Monster-Size Special" Number="1" Volume="2008" Year="2008" Format="One-Shot">
+    <Book Series="Hulk Monster-Size Special" Number="1" Volume="2008" Year="2008">
       <Id>0ed75062-6730-4c82-8214-364ef53113dd</Id>
     </Book>
-    <Book Series="Hulk: Raging Thunder" Number="1" Volume="2008" Year="2008" Format="One-Shot">
+    <Book Series="Hulk: Raging Thunder" Number="1" Volume="2008" Year="2008">
       <Id>5b804f8b-9302-415a-bfbf-e14dcf7c2a91</Id>
     </Book>
-    <Book Series="Hulk" Number="10" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Hulk" Number="10" Volume="2008" Year="2009">
       <Id>9648da5a-da82-4f09-98ab-75bfaa7e17c0</Id>
     </Book>
-    <Book Series="Hulk" Number="11" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Hulk" Number="11" Volume="2008" Year="2009">
       <Id>bf491eab-95ef-4c23-81ae-3c0751fc7af8</Id>
     </Book>
-    <Book Series="Hulk" Number="12" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Hulk" Number="12" Volume="2008" Year="2009">
       <Id>154d58fd-1bbb-49c3-95fd-da99572f4beb</Id>
     </Book>
-    <Book Series="Hulk" Number="13" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Hulk" Number="13" Volume="2008" Year="2009">
       <Id>9336ff5a-ad07-4e26-b18f-53bea26aba9e</Id>
     </Book>
-    <Book Series="Hulk" Number="14" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Hulk" Number="14" Volume="2008" Year="2009">
       <Id>c5049ef6-3a22-4128-a990-5bcb4b7bb427</Id>
     </Book>
-    <Book Series="Hulk" Number="15" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Hulk" Number="15" Volume="2008" Year="2009">
       <Id>f26a4b2f-ab50-4777-b387-63dc2fb88222</Id>
     </Book>
-    <Book Series="Hulk" Number="16" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Hulk" Number="16" Volume="2008" Year="2009">
       <Id>07067507-a8df-45e8-8b7e-4fbc35f9af11</Id>
     </Book>
-    <Book Series="Hulk" Number="17" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="Hulk" Number="17" Volume="2008" Year="2010">
       <Id>fbbf71bb-3cb6-4386-ac9f-016fe5d92844</Id>
     </Book>
-    <Book Series="Hulk" Number="18" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="Hulk" Number="18" Volume="2008" Year="2010">
       <Id>d5f5097a-7cf0-4605-b454-9235459d4f5c</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="600" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="600" Volume="2009" Year="2009">
       <Id>9d3400fe-1e8b-414f-95ef-2c6f638f39c6</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="601" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="601" Volume="2009" Year="2009">
       <Id>302eaa74-7787-468e-8e10-50e4e5285b70</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="602" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="602" Volume="2009" Year="2009">
       <Id>af075fab-3722-4a59-b466-aded57a1509c</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="603" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="603" Volume="2009" Year="2009">
       <Id>e4022aef-0618-4a44-804c-21075cd2d895</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="604" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="604" Volume="2009" Year="2010">
       <Id>c83d6851-546b-492e-b6c5-0d420a033958</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="605" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="605" Volume="2009" Year="2010">
       <Id>3894de43-62f4-4d09-8b78-44923087dc3c</Id>
     </Book>
-    <Book Series="Hulk Team-Up" Number="1" Volume="2009" Year="2009" Format="One-Shot">
+    <Book Series="Hulk Team-Up" Number="1" Volume="2009" Year="2009">
       <Id>135f4776-40b8-4ea9-b44a-e2323c0e5209</Id>
     </Book>
-    <Book Series="Dark Reign: The List - Hulk" Number="1" Volume="2009" Year="2009" Format="One-Shot">
+    <Book Series="Dark Reign: The List - Hulk" Number="1" Volume="2009" Year="2009">
       <Id>daa371a6-ebed-4f26-8d18-cbe9a033e4b1</Id>
     </Book>
-    <Book Series="Fall of the Hulks: Alpha" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="Fall of the Hulks: Alpha" Number="1" Volume="2010" Year="2010">
       <Id>062e36b5-0231-4d8f-9478-5b50d08dcbe9</Id>
     </Book>
-    <Book Series="Fall of the Hulks: Gamma" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="Fall of the Hulks: Gamma" Number="1" Volume="2010" Year="2010">
       <Id>84cbf3fb-32e6-483f-a755-20862fc4c354</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="606" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="606" Volume="2009" Year="2010">
       <Id>6dd584c5-dcd3-49cb-9481-80e74ce8e4f9</Id>
     </Book>
-    <Book Series="Hulk" Number="19" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="Hulk" Number="19" Volume="2008" Year="2010">
       <Id>766142ec-f4d2-43db-84e4-bf4c0679ed15</Id>
     </Book>
-    <Book Series="Fall of the Hulks: Red Hulk" Number="1" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Fall of the Hulks: Red Hulk" Number="1" Volume="2010" Year="2010">
       <Id>52f31eb9-b7b1-4d31-b351-f531c8c8de74</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="607" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="607" Volume="2009" Year="2010">
       <Id>2413714f-f972-4c50-95bb-f0a92b8ee74e</Id>
     </Book>
-    <Book Series="Hulk" Number="20" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="Hulk" Number="20" Volume="2008" Year="2010">
       <Id>c3e43fac-25ae-48bd-babf-62cc1a462226</Id>
     </Book>
-    <Book Series="Fall of the Hulks: Red Hulk" Number="2" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Fall of the Hulks: Red Hulk" Number="2" Volume="2010" Year="2010">
       <Id>893cb520-8ce9-40ae-a7a9-accfb9b3680d</Id>
     </Book>
-    <Book Series="Fall of the Hulks: The Savage She-Hulks" Number="1" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Fall of the Hulks: The Savage She-Hulks" Number="1" Volume="2010" Year="2010">
       <Id>55b51039-bda9-4feb-8cb1-c38b9ddf7df5</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="608" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="608" Volume="2009" Year="2010">
       <Id>f229549e-f4ef-4032-a029-c55575c9120d</Id>
     </Book>
-    <Book Series="Hulk" Number="21" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="Hulk" Number="21" Volume="2008" Year="2010">
       <Id>22caf5e1-e684-4782-b971-3e7dcc9fb41a</Id>
     </Book>
-    <Book Series="Fall of the Hulks: Red Hulk" Number="3" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Fall of the Hulks: Red Hulk" Number="3" Volume="2010" Year="2010">
       <Id>f3978aa2-9d28-4fb5-9cf9-727fec4e71b7</Id>
     </Book>
-    <Book Series="Fall of the Hulks: The Savage She-Hulks" Number="2" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Fall of the Hulks: The Savage She-Hulks" Number="2" Volume="2010" Year="2010">
       <Id>38656409-830f-4b8d-933d-b6f23d8a6527</Id>
     </Book>
-    <Book Series="Fall of the Hulks: Red Hulk" Number="4" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Fall of the Hulks: Red Hulk" Number="4" Volume="2010" Year="2010">
       <Id>8297ab43-d50f-44fc-991c-af89cede7be0</Id>
     </Book>
-    <Book Series="Fall of the Hulks: The Savage She-Hulks" Number="3" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Fall of the Hulks: The Savage She-Hulks" Number="3" Volume="2010" Year="2010">
       <Id>0e5cd3b4-c208-4bb3-9587-fe85d63148f6</Id>
     </Book>
-    <Book Series="Skaar: Son of Hulk" Number="1" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="Skaar: Son of Hulk" Number="1" Volume="2008" Year="2008">
       <Id>2ed87283-720d-40f6-a037-42f831448a82</Id>
     </Book>
-    <Book Series="Skaar: Son of Hulk" Number="2" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="Skaar: Son of Hulk" Number="2" Volume="2008" Year="2008">
       <Id>1dac5e8c-34bf-4d72-b87d-00b119b0d308</Id>
     </Book>
-    <Book Series="Skaar: Son of Hulk" Number="3" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="Skaar: Son of Hulk" Number="3" Volume="2008" Year="2008">
       <Id>443fd459-7444-461c-a7f0-c598550c198d</Id>
     </Book>
-    <Book Series="Skaar: Son of Hulk" Number="4" Volume="2008" Year="2008" Format="Main Series">
+    <Book Series="Skaar: Son of Hulk" Number="4" Volume="2008" Year="2008">
       <Id>1271acab-eefa-47f2-a620-13f1e91804e9</Id>
     </Book>
-    <Book Series="Skaar: Son of Hulk" Number="5" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Skaar: Son of Hulk" Number="5" Volume="2008" Year="2009">
       <Id>0d8f187a-f9a5-461c-a1cb-c842fa28f09d</Id>
     </Book>
-    <Book Series="Skaar: Son of Hulk" Number="6" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Skaar: Son of Hulk" Number="6" Volume="2008" Year="2009">
       <Id>6959d592-04ba-4fd2-85f9-58b229124633</Id>
     </Book>
-    <Book Series="Skaar: Son of Hulk Presents - Savage World of Sakaar" Number="1" Volume="2008" Year="2008" Format="One-Shot">
+    <Book Series="Skaar: Son of Hulk Presents - Savage World of Sakaar" Number="1" Volume="2008" Year="2008">
       <Id>9685e876-91fc-4f4f-9e59-accd1c11eb8e</Id>
     </Book>
-    <Book Series="Skaar: Son of Hulk" Number="7" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Skaar: Son of Hulk" Number="7" Volume="2008" Year="2009">
       <Id>784d272e-d20d-4a08-90a5-11a2297d90bd</Id>
     </Book>
-    <Book Series="Skaar: Son of Hulk" Number="8" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Skaar: Son of Hulk" Number="8" Volume="2008" Year="2009">
       <Id>5b0f8b6f-cb89-4bbf-a99d-30f29c40ff20</Id>
     </Book>
-    <Book Series="Skaar: Son of Hulk" Number="9" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Skaar: Son of Hulk" Number="9" Volume="2008" Year="2009">
       <Id>1a9de837-1a88-4957-ac5a-84e7ad7f1044</Id>
     </Book>
-    <Book Series="Skaar: Son of Hulk" Number="10" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Skaar: Son of Hulk" Number="10" Volume="2008" Year="2009">
       <Id>e4f02a47-7bef-49d1-acab-85c813587660</Id>
     </Book>
-    <Book Series="Skaar: Son of Hulk" Number="11" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Skaar: Son of Hulk" Number="11" Volume="2008" Year="2009">
       <Id>56f88d80-9f54-44f9-bfdf-3fc3760a3af8</Id>
     </Book>
-    <Book Series="Skaar: Son of Hulk" Number="12" Volume="2008" Year="2009" Format="Main Series">
+    <Book Series="Skaar: Son of Hulk" Number="12" Volume="2008" Year="2009">
       <Id>ba49e2b3-bd5e-48ad-bab2-a599e8d7bc62</Id>
     </Book>
-    <Book Series="Hulked-Out Heroes" Number="1" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Hulked-Out Heroes" Number="1" Volume="2010" Year="2010">
       <Id>8e460827-d34c-4033-9ac0-c0bb9021da1d</Id>
     </Book>
-    <Book Series="Hulked-Out Heroes" Number="2" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Hulked-Out Heroes" Number="2" Volume="2010" Year="2010">
       <Id>61083c5f-8221-484d-a83b-cdc1403ed62a</Id>
     </Book>
-    <Book Series="World War Hulks" Number="1" Volume="2010" Year="2010" Format="Crossover">
+    <Book Series="World War Hulks" Number="1" Volume="2010" Year="2010">
       <Id>0e146154-c5cd-443c-bca0-3845d586e18d</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="609" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="609" Volume="2009" Year="2010">
       <Id>255da2d6-4b2c-45fc-954f-cb34f226ea1c</Id>
     </Book>
-    <Book Series="Hulk" Number="22" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="Hulk" Number="22" Volume="2008" Year="2010">
       <Id>b93c7189-510c-4411-adb4-e0c039b670a0</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="610" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="610" Volume="2009" Year="2010">
       <Id>67497b25-e783-432d-a088-5de24becb3f2</Id>
     </Book>
-    <Book Series="Hulk" Number="23" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="Hulk" Number="23" Volume="2008" Year="2010">
       <Id>1c662cb0-d83c-4727-8ce0-e3d5ae3cc512</Id>
     </Book>
-    <Book Series="World War Hulks: Captain America vs. Wolverine" Number="1" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="World War Hulks: Captain America vs. Wolverine" Number="1" Volume="2010" Year="2010">
       <Id>0922cd9c-0ca5-4797-838a-7c8f1661196c</Id>
     </Book>
-    <Book Series="World War Hulks: Captain America vs. Wolverine" Number="2" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="World War Hulks: Captain America vs. Wolverine" Number="2" Volume="2010" Year="2010">
       <Id>c7aa8b69-a8bf-410b-9597-00376fb8c015</Id>
     </Book>
-    <Book Series="World War Hulks: Spider-Man vs. Thor" Number="1" Volume="2010" Year="2010" Format="Crossover">
+    <Book Series="World War Hulks: Spider-Man vs. Thor" Number="1" Volume="2010" Year="2010">
       <Id>3a41b1f9-dc65-4687-84c5-5d3b4a431341</Id>
     </Book>
-    <Book Series="World War Hulks: Spider-Man vs. Thor" Number="2" Volume="2010" Year="2010" Format="Crossover">
+    <Book Series="World War Hulks: Spider-Man vs. Thor" Number="2" Volume="2010" Year="2010">
       <Id>06883713-153c-4553-aafe-e8921de1c423</Id>
     </Book>
-    <Book Series="Hulk" Number="24" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="Hulk" Number="24" Volume="2008" Year="2010">
       <Id>9e489e51-32bc-4569-abaa-4aca05061a5a</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="611" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="611" Volume="2009" Year="2010">
       <Id>fc9881f5-e1ee-4d22-b8e4-05a83bae7dc1</Id>
     </Book>
-    <Book Series="Son of Hulk" Number="13" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Son of Hulk" Number="13" Volume="2009" Year="2009">
       <Id>270e4140-8ca9-4381-89d4-e1845f382023</Id>
     </Book>
-    <Book Series="Son of Hulk" Number="14" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Son of Hulk" Number="14" Volume="2009" Year="2009">
       <Id>9727397b-37cc-4ed7-9b34-91a7740ef80c</Id>
     </Book>
-    <Book Series="Son of Hulk" Number="15" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Son of Hulk" Number="15" Volume="2009" Year="2009">
       <Id>24bf5685-b89d-4cd4-bfa8-4cc02b7e7fc5</Id>
     </Book>
-    <Book Series="Son of Hulk" Number="16" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Son of Hulk" Number="16" Volume="2009" Year="2009">
       <Id>6defbf3d-21ae-44e6-a8f3-0dbc537f0d23</Id>
     </Book>
-    <Book Series="Son of Hulk" Number="17" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Son of Hulk" Number="17" Volume="2009" Year="2010">
       <Id>1e1f7347-60a5-47ac-bd94-04f17eb9b9af</Id>
     </Book>
-    <Book Series="All-New Savage She-Hulk" Number="1" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="All-New Savage She-Hulk" Number="1" Volume="2009" Year="2009">
       <Id>e323bae7-839f-4015-a885-1850cefe8643</Id>
     </Book>
-    <Book Series="All-New Savage She-Hulk" Number="2" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="All-New Savage She-Hulk" Number="2" Volume="2009" Year="2009">
       <Id>40ecbeb0-de27-4de9-ad3c-b331be334dac</Id>
     </Book>
-    <Book Series="All-New Savage She-Hulk" Number="3" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="All-New Savage She-Hulk" Number="3" Volume="2009" Year="2009">
       <Id>dbaaaf70-b55f-4f28-8a06-90bcb06052e7</Id>
     </Book>
-    <Book Series="All-New Savage She-Hulk" Number="4" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="All-New Savage She-Hulk" Number="4" Volume="2009" Year="2009">
       <Id>b7fd5315-5710-4def-9bf9-a20dbb5a0e62</Id>
     </Book>
-    <Book Series="Incredible Hulks" Number="612" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="Incredible Hulks" Number="612" Volume="2010" Year="2010">
       <Id>5c628620-c23f-4912-a99c-22b68ea39387</Id>
     </Book>
-    <Book Series="Incredible Hulks" Number="613" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="Incredible Hulks" Number="613" Volume="2010" Year="2010">
       <Id>b3bf33f7-7990-425a-bc62-6f0fbba586db</Id>
     </Book>
-    <Book Series="Incredible Hulks" Number="614" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="Incredible Hulks" Number="614" Volume="2010" Year="2010">
       <Id>c4d13b74-6571-4829-a722-55dcbc224807</Id>
     </Book>
-    <Book Series="Incredible Hulks" Number="615" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="Incredible Hulks" Number="615" Volume="2010" Year="2010">
       <Id>7aaf48c3-1617-4bbb-8a09-2fb0951c6f05</Id>
     </Book>
-    <Book Series="Incredible Hulks" Number="616" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Incredible Hulks" Number="616" Volume="2010" Year="2011">
       <Id>e74d91c8-cde7-44f0-980a-6ae6aafc65ad</Id>
     </Book>
-    <Book Series="Incredible Hulks" Number="617" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Incredible Hulks" Number="617" Volume="2010" Year="2011">
       <Id>634deefa-cfb2-48c9-a6ef-bed9d99163ef</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Incredible Hulk/Incredible Hulk 003.cbl
+++ b/Marvel/Characters/unsorted/Incredible Hulk/Incredible Hulk 003.cbl
@@ -1,897 +1,898 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Incredible Hulk 3</Name>
+  <Name>Incredible Hulk 003</Name>
+  <NumIssues>297</NumIssues>
   <Books>
     <Book Series="Hulk" Number="1" Volume="1999" Year="1999">
-      <Id>934562b5-dee2-489b-b443-79dc1bc6fbf3</Id>
+      <Database Name="cv" Series="6779" Issue="48380" />
     </Book>
     <Book Series="Hulk" Number="2" Volume="1999" Year="1999">
-      <Id>9cb8b66e-9446-46f9-bc6e-db996e5e5b8f</Id>
+      <Database Name="cv" Series="6779" Issue="48381" />
     </Book>
     <Book Series="Hulk" Number="3" Volume="1999" Year="1999">
-      <Id>f71c4320-3366-483d-83c4-d49c4bc4e9c0</Id>
+      <Database Name="cv" Series="6779" Issue="48382" />
     </Book>
     <Book Series="Hulk" Number="4" Volume="1999" Year="1999">
-      <Id>e3f9c949-f360-43fb-a9a8-a55b796b6be0</Id>
+      <Database Name="cv" Series="6779" Issue="48383" />
     </Book>
     <Book Series="Hulk" Number="5" Volume="1999" Year="1999">
-      <Id>0843d6b1-d98e-4752-8a49-380c3f7b40b3</Id>
+      <Database Name="cv" Series="6779" Issue="48384" />
     </Book>
     <Book Series="Hulk" Number="6" Volume="1999" Year="1999">
-      <Id>65347e63-8fc5-4433-8bd3-edbf9c5530d8</Id>
+      <Database Name="cv" Series="6779" Issue="48385" />
     </Book>
     <Book Series="Hulk" Number="7" Volume="1999" Year="1999">
-      <Id>0525b749-1a2f-403d-9406-f8997acee384</Id>
+      <Database Name="cv" Series="6779" Issue="48386" />
     </Book>
     <Book Series="Hulk" Number="8" Volume="1999" Year="1999">
-      <Id>462a9f32-3c35-4290-b5a4-da5fefe32c5a</Id>
+      <Database Name="cv" Series="6779" Issue="48387" />
     </Book>
     <Book Series="Wolverine" Number="145" Volume="1988" Year="1999">
-      <Id>0195f75f-bfdf-43f3-ae2f-464b99b79767</Id>
+      <Database Name="cv" Series="4250" Issue="51212" />
     </Book>
     <Book Series="Hulk" Number="9" Volume="1999" Year="1999">
-      <Id>c2373a82-b202-4fac-abbb-87ce03ebc279</Id>
+      <Database Name="cv" Series="6779" Issue="48388" />
     </Book>
     <Book Series="Hulk" Number="10" Volume="1999" Year="2000">
-      <Id>96018f6f-d5bb-42f6-8369-4c48b290dcbb</Id>
+      <Database Name="cv" Series="6779" Issue="48389" />
     </Book>
     <Book Series="Hulk" Number="½" Volume="1999" Year="1999">
-      <Id>d6d2e476-71c1-462a-90f6-ac5755490f1b</Id>
+      <Database Name="cv" Series="6779" Issue="194641" />
     </Book>
     <Book Series="Hulk" Number="11" Volume="1999" Year="2000">
-      <Id>c7fb88e8-377b-4a9c-8b97-d4af92386369</Id>
+      <Database Name="cv" Series="6779" Issue="48390" />
     </Book>
     <Book Series="Thunderbolts" Number="34" Volume="1997" Year="2000">
-      <Id>4a29497f-6448-4321-b789-440b529a9846</Id>
+      <Database Name="cv" Series="6020" Issue="46230" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="14" Volume="1999" Year="2000">
-      <Id>7b6277a5-edc5-46df-9cd9-7ea449c2222f</Id>
+      <Database Name="cv" Series="9142" Issue="68491" />
     </Book>
     <Book Series="Captain Marvel" Number="2" Volume="2000" Year="2000">
-      <Id>c9c92888-223a-43cd-8867-8a12bd807ed5</Id>
+      <Database Name="cv" Series="6458" Issue="46250" />
     </Book>
     <Book Series="Captain Marvel" Number="3" Volume="2000" Year="2000">
-      <Id>3ec62eae-7af4-4818-9f26-c0025e564a0b</Id>
+      <Database Name="cv" Series="6458" Issue="65844" />
     </Book>
-    <Book Series="Hulk Annual 1999" Number="1" Volume="1999" Year="1999">
-      <Id>4a945410-08cd-47ae-a01a-c3919a6c3772</Id>
+    <Book Series="Hulk 1999" Number="1" Volume="1999" Year="1999">
+      <Database Name="cv" Series="58522" Issue="138338" />
     </Book>
     <Book Series="Incredible Hulk" Number="12" Volume="2000" Year="2000">
-      <Id>8487abf2-bd9b-425a-82b3-664fff584fc8</Id>
+      <Database Name="cv" Series="6558" Issue="46831" />
     </Book>
     <Book Series="Incredible Hulk" Number="13" Volume="2000" Year="2000">
-      <Id>53746df5-5017-403c-b62b-075af9869b46</Id>
+      <Database Name="cv" Series="6558" Issue="46832" />
     </Book>
     <Book Series="Incredible Hulk" Number="14" Volume="2000" Year="2000">
-      <Id>539b1243-d2de-480a-934c-dbd4ba0779a9</Id>
+      <Database Name="cv" Series="6558" Issue="46833" />
     </Book>
     <Book Series="Incredible Hulk" Number="15" Volume="2000" Year="2000">
-      <Id>8a01b371-bd36-4a9e-99ed-7b0ac1887de0</Id>
+      <Database Name="cv" Series="6558" Issue="46834" />
     </Book>
     <Book Series="Incredible Hulk" Number="16" Volume="2000" Year="2000">
-      <Id>ece009f4-5800-4049-8146-481ebc75dfd6</Id>
+      <Database Name="cv" Series="6558" Issue="46835" />
     </Book>
     <Book Series="Incredible Hulk" Number="17" Volume="2000" Year="2000">
-      <Id>b68b4564-4943-4ad9-8eb1-48d40bc02fda</Id>
+      <Database Name="cv" Series="6558" Issue="46836" />
     </Book>
     <Book Series="Hulk Smash" Number="1" Volume="2001" Year="2001">
-      <Id>559453a8-e975-4daf-b00a-6f0f654f6c84</Id>
+      <Database Name="cv" Series="6654" Issue="47560" />
     </Book>
     <Book Series="Hulk Smash" Number="2" Volume="2001" Year="2001">
-      <Id>75c59e1f-ccb0-44a2-ad09-02f5dc6d5d8c</Id>
+      <Database Name="cv" Series="6654" Issue="47561" />
     </Book>
-    <Book Series="Hulk Annual 2000" Number="1" Volume="2000" Year="2000">
-      <Id>868291e4-53bc-4209-8816-26a76b4a13e7</Id>
+    <Book Series="Hulk 2000" Number="1" Volume="2000" Year="2000">
+      <Database Name="cv" Series="60435" Issue="138339" />
     </Book>
     <Book Series="Incredible Hulk" Number="18" Volume="2000" Year="2000">
-      <Id>7d0dd3ad-0352-435c-9b4c-ba06b7c4cdd7</Id>
+      <Database Name="cv" Series="6558" Issue="46837" />
     </Book>
     <Book Series="Incredible Hulk" Number="19" Volume="2000" Year="2000">
-      <Id>f2f1a288-09aa-4900-a597-ccf0ac46ddce</Id>
+      <Database Name="cv" Series="6558" Issue="46838" />
     </Book>
     <Book Series="Incredible Hulk" Number="20" Volume="2000" Year="2000">
-      <Id>02dfc60a-bf1c-4480-978e-92fa95f99322</Id>
+      <Database Name="cv" Series="6558" Issue="46839" />
     </Book>
     <Book Series="Sentry/Hulk" Number="1" Volume="2001" Year="2001">
-      <Id>1314531f-2d4e-40db-aabb-feacc58e8b9f</Id>
+      <Database Name="cv" Series="20453" Issue="122435" />
     </Book>
     <Book Series="Incredible Hulk" Number="21" Volume="2000" Year="2000">
-      <Id>4292db15-e601-41e9-9d43-4129fb41a741</Id>
+      <Database Name="cv" Series="6558" Issue="46840" />
     </Book>
     <Book Series="Incredible Hulk" Number="22" Volume="2000" Year="2001">
-      <Id>53ea5489-f375-452f-98a8-4a25334dd05b</Id>
+      <Database Name="cv" Series="6558" Issue="46841" />
     </Book>
     <Book Series="Incredible Hulk" Number="23" Volume="2000" Year="2001">
-      <Id>9205442a-ef9e-4d32-8bb6-435cb1582f54</Id>
+      <Database Name="cv" Series="6558" Issue="46842" />
     </Book>
     <Book Series="Incredible Hulk" Number="24" Volume="2000" Year="2001">
-      <Id>90491ac0-90cb-4476-8b67-ef542258471d</Id>
+      <Database Name="cv" Series="6558" Issue="46843" />
     </Book>
     <Book Series="Incredible Hulk" Number="25" Volume="2000" Year="2001">
-      <Id>b08f325c-42fb-4685-96df-113920735816</Id>
+      <Database Name="cv" Series="6558" Issue="46844" />
     </Book>
     <Book Series="Incredible Hulk" Number="26" Volume="2000" Year="2001">
-      <Id>9f7a46bc-c867-4686-b57d-08ab1a9259bd</Id>
+      <Database Name="cv" Series="6558" Issue="76542" />
     </Book>
     <Book Series="Avengers" Number="39" Volume="1998" Year="2001">
-      <Id>68566dad-bbb2-4d75-b815-396ed43deab9</Id>
+      <Database Name="cv" Series="7084" Issue="50798" />
     </Book>
     <Book Series="Avengers" Number="40" Volume="1998" Year="2001">
-      <Id>1d685eb3-ce98-4471-825d-3264f63c5d96</Id>
+      <Database Name="cv" Series="7084" Issue="50799" />
     </Book>
     <Book Series="Incredible Hulk" Number="27" Volume="2000" Year="2001">
-      <Id>2aa2c63e-c8db-4a41-9716-2547b4b45da1</Id>
+      <Database Name="cv" Series="6558" Issue="76543" />
     </Book>
     <Book Series="Incredible Hulk" Number="28" Volume="2000" Year="2001">
-      <Id>b85b4f4a-9ca5-4ecc-91b7-92a6536c48b4</Id>
+      <Database Name="cv" Series="6558" Issue="76544" />
     </Book>
-    <Book Series="Incredible Hulk Annual 2001" Number="1" Volume="2001" Year="2001">
-      <Id>8d33e45a-4902-4bd3-9cd2-4dd3a70eb645</Id>
+    <Book Series="Incredible Hulk 2001" Number="1" Volume="2001" Year="2001">
+      <Database Name="cv" Series="39930" Issue="269296" />
     </Book>
     <Book Series="Incredible Hulk" Number="29" Volume="2000" Year="2001">
-      <Id>9676a2f7-f0f1-4f9f-89fa-3829f4a75c38</Id>
+      <Database Name="cv" Series="6558" Issue="76545" />
     </Book>
     <Book Series="Incredible Hulk" Number="30" Volume="2000" Year="2001">
-      <Id>3aa0188b-f881-4fa2-9280-05022777965d</Id>
+      <Database Name="cv" Series="6558" Issue="107138" />
     </Book>
     <Book Series="Incredible Hulk" Number="31" Volume="2000" Year="2001">
-      <Id>fcfacd23-2ed1-46c8-bffa-c86e371d6f12</Id>
+      <Database Name="cv" Series="6558" Issue="107139" />
     </Book>
     <Book Series="Incredible Hulk" Number="32" Volume="2000" Year="2001">
-      <Id>f5ce4d5c-c675-411f-b30d-4428524952b5</Id>
+      <Database Name="cv" Series="6558" Issue="112787" />
     </Book>
     <Book Series="The Order" Number="1" Volume="2002" Year="2002">
-      <Id>ee9f9db9-0e76-4f5a-af25-b1f5c9343c85</Id>
+      <Database Name="cv" Series="9496" Issue="78208" />
     </Book>
     <Book Series="The Order" Number="2" Volume="2002" Year="2002">
-      <Id>ac5eb691-f5d3-4975-93f5-cbc9430cc61c</Id>
+      <Database Name="cv" Series="9496" Issue="78209" />
     </Book>
     <Book Series="The Order" Number="3" Volume="2002" Year="2002">
-      <Id>99e63d04-ac07-4baf-b6c0-d6ea52b1dbc7</Id>
+      <Database Name="cv" Series="9496" Issue="78210" />
     </Book>
     <Book Series="The Order" Number="4" Volume="2002" Year="2002">
-      <Id>cebec8ea-97dc-4732-9ba9-160c6d105bc8</Id>
+      <Database Name="cv" Series="9496" Issue="78211" />
     </Book>
     <Book Series="The Order" Number="5" Volume="2002" Year="2002">
-      <Id>b34cc60f-bd21-4222-8ba1-ad64619140e2</Id>
+      <Database Name="cv" Series="9496" Issue="78212" />
     </Book>
     <Book Series="The Order" Number="6" Volume="2002" Year="2002">
-      <Id>f36cc04f-dde3-4104-bd26-9fc02a2fbf80</Id>
+      <Database Name="cv" Series="9496" Issue="78213" />
     </Book>
     <Book Series="Incredible Hulk" Number="33" Volume="2000" Year="2001">
-      <Id>8a3c58dd-9400-41d6-88c7-86a2ddb0e676</Id>
+      <Database Name="cv" Series="6558" Issue="112786" />
     </Book>
     <Book Series="Wolverine/Hulk" Number="1" Volume="2002" Year="2002">
-      <Id>3f63b295-d8c1-491f-b0b3-cc910e5b2dc7</Id>
+      <Database Name="cv" Series="18569" Issue="109438" />
     </Book>
     <Book Series="Wolverine/Hulk" Number="2" Volume="2002" Year="2002">
-      <Id>8e03cb38-4385-4842-82ed-9843f2429ece</Id>
+      <Database Name="cv" Series="18569" Issue="109654" />
     </Book>
     <Book Series="Wolverine/Hulk" Number="3" Volume="2002" Year="2002">
-      <Id>e6031199-0335-4495-b501-ca2ad9037ef5</Id>
+      <Database Name="cv" Series="18569" Issue="109655" />
     </Book>
     <Book Series="Wolverine/Hulk" Number="4" Volume="2002" Year="2002">
-      <Id>36552a21-1aff-43e5-a0b4-3bd82747f291</Id>
+      <Database Name="cv" Series="18569" Issue="109656" />
     </Book>
     <Book Series="Hulk: Gray" Number="1" Volume="2003" Year="2003">
-      <Id>e39c8eac-3eff-4407-a473-94132b46fa03</Id>
+      <Database Name="cv" Series="21637" Issue="130629" />
     </Book>
     <Book Series="Hulk: Gray" Number="2" Volume="2003" Year="2003">
-      <Id>a8e74048-798c-494f-8073-d5eaba343aa3</Id>
+      <Database Name="cv" Series="21637" Issue="130645" />
     </Book>
     <Book Series="Hulk: Gray" Number="3" Volume="2003" Year="2004">
-      <Id>b67c78a1-273a-4399-b07a-33fcc651e66e</Id>
+      <Database Name="cv" Series="21637" Issue="130646" />
     </Book>
     <Book Series="Hulk: Gray" Number="4" Volume="2003" Year="2004">
-      <Id>ff293bb5-eb96-43f5-889b-26fe374f2c27</Id>
+      <Database Name="cv" Series="21637" Issue="130647" />
     </Book>
     <Book Series="Hulk: Gray" Number="5" Volume="2003" Year="2004">
-      <Id>dcb2485a-0658-408c-9195-0347612c5a6d</Id>
+      <Database Name="cv" Series="21637" Issue="130644" />
     </Book>
     <Book Series="Hulk: Gray" Number="6" Volume="2003" Year="2004">
-      <Id>b086fa6a-f38d-4a56-a1be-b19afb2eb6ba</Id>
+      <Database Name="cv" Series="21637" Issue="130649" />
     </Book>
     <Book Series="Hulk: Nightmerica" Number="1" Volume="2003" Year="2003">
-      <Id>ec4a609c-048e-432d-b0e4-2197e58f30db</Id>
+      <Database Name="cv" Series="19184" Issue="114858" />
     </Book>
     <Book Series="Hulk: Nightmerica" Number="2" Volume="2003" Year="2003">
-      <Id>f8ad5077-57a4-4820-a5ac-c7e3b2752580</Id>
+      <Database Name="cv" Series="19184" Issue="115046" />
     </Book>
     <Book Series="Hulk: Nightmerica" Number="3" Volume="2003" Year="2003">
-      <Id>9ceb3a0b-b9b1-464c-9491-4ac08af19e7c</Id>
+      <Database Name="cv" Series="19184" Issue="115047" />
     </Book>
     <Book Series="Hulk: Nightmerica" Number="4" Volume="2003" Year="2003">
-      <Id>7fba9f7b-ce12-4cdb-8676-c53dea4bcc57</Id>
+      <Database Name="cv" Series="19184" Issue="115048" />
     </Book>
     <Book Series="Hulk: Nightmerica" Number="5" Volume="2003" Year="2004">
-      <Id>e47cafd3-1d80-4eed-a5ae-4662899b2b94</Id>
+      <Database Name="cv" Series="19184" Issue="115049" />
     </Book>
     <Book Series="Hulk: Nightmerica" Number="6" Volume="2003" Year="2004">
-      <Id>d71c59cc-62de-49d4-ab50-5ca9dac5e9cb</Id>
+      <Database Name="cv" Series="19184" Issue="115050" />
     </Book>
     <Book Series="Incredible Hulk" Number="34" Volume="2000" Year="2002">
-      <Id>00718076-bdae-4cee-91a8-152e36cb622d</Id>
+      <Database Name="cv" Series="6558" Issue="112788" />
     </Book>
     <Book Series="Incredible Hulk" Number="35" Volume="2000" Year="2002">
-      <Id>3ff9ab79-965f-4932-845d-9188c5ba75e1</Id>
+      <Database Name="cv" Series="6558" Issue="112785" />
     </Book>
     <Book Series="Incredible Hulk" Number="36" Volume="2000" Year="2002">
-      <Id>985086da-1415-4737-b11f-a62af47dd5f7</Id>
+      <Database Name="cv" Series="6558" Issue="112789" />
     </Book>
     <Book Series="Incredible Hulk" Number="37" Volume="2000" Year="2002">
-      <Id>65905d73-8428-4d76-97c0-5ad0ad7a17e9</Id>
+      <Database Name="cv" Series="6558" Issue="112790" />
     </Book>
     <Book Series="Incredible Hulk" Number="38" Volume="2000" Year="2002">
-      <Id>1f089de2-423f-47e8-9e52-68aa2325a8da</Id>
+      <Database Name="cv" Series="6558" Issue="112791" />
     </Book>
     <Book Series="Incredible Hulk" Number="39" Volume="2000" Year="2002">
-      <Id>9612df96-2dac-4d34-8b2e-0f799fa70b42</Id>
+      <Database Name="cv" Series="6558" Issue="112792" />
     </Book>
     <Book Series="Incredible Hulk" Number="40" Volume="2000" Year="2002">
-      <Id>cd27a4a4-b608-4981-bba0-7192e5895cac</Id>
+      <Database Name="cv" Series="6558" Issue="76556" />
     </Book>
     <Book Series="Incredible Hulk" Number="41" Volume="2000" Year="2002">
-      <Id>2f5c9f66-2ce5-4028-b5e2-a03225264bc3</Id>
+      <Database Name="cv" Series="6558" Issue="76557" />
     </Book>
     <Book Series="Incredible Hulk" Number="42" Volume="2000" Year="2002">
-      <Id>feadf3d3-63e7-409e-9818-e09ecd179d9b</Id>
+      <Database Name="cv" Series="6558" Issue="80227" />
     </Book>
     <Book Series="Incredible Hulk" Number="43" Volume="2000" Year="2002">
-      <Id>bfe73529-7c5f-411e-aa13-884a2e4b8256</Id>
+      <Database Name="cv" Series="6558" Issue="89231" />
     </Book>
     <Book Series="Startling Stories: Banner" Number="1" Volume="2001" Year="2001">
-      <Id>93792022-5f62-4fe8-bd33-2ca468a2748d</Id>
+      <Database Name="cv" Series="9471" Issue="77965" />
     </Book>
     <Book Series="Startling Stories: Banner" Number="2" Volume="2001" Year="2001">
-      <Id>6187a1b1-c56f-4980-bcaf-c6cf8fd3c16f</Id>
+      <Database Name="cv" Series="9471" Issue="77966" />
     </Book>
     <Book Series="Startling Stories: Banner" Number="3" Volume="2001" Year="2001">
-      <Id>54bc6152-063c-43c5-a3dc-55c9641d80bb</Id>
+      <Database Name="cv" Series="9471" Issue="77967" />
     </Book>
     <Book Series="Startling Stories: Banner" Number="4" Volume="2001" Year="2001">
-      <Id>7a9ddea9-e21e-4d8e-a276-8b17f0f38d37</Id>
+      <Database Name="cv" Series="9471" Issue="77968" />
     </Book>
     <Book Series="Incredible Hulk" Number="44" Volume="2000" Year="2002">
-      <Id>152e9754-5a85-4987-9d45-d88ab6396a52</Id>
+      <Database Name="cv" Series="6558" Issue="112793" />
     </Book>
     <Book Series="Incredible Hulk" Number="45" Volume="2000" Year="2002">
-      <Id>a27e92b4-6181-44d8-b535-773cea40d94e</Id>
+      <Database Name="cv" Series="6558" Issue="121622" />
     </Book>
     <Book Series="Incredible Hulk" Number="46" Volume="2000" Year="2002">
-      <Id>c2c98b35-43cc-484a-9fe4-118acee41725</Id>
+      <Database Name="cv" Series="6558" Issue="131570" />
     </Book>
     <Book Series="Incredible Hulk" Number="47" Volume="2000" Year="2003">
-      <Id>7167ec42-2cfe-4610-b9dc-1c7ca05982cf</Id>
+      <Database Name="cv" Series="6558" Issue="131571" />
     </Book>
     <Book Series="Incredible Hulk" Number="48" Volume="2000" Year="2003">
-      <Id>06501b3c-1087-43b7-a90b-bc29caa07a9d</Id>
+      <Database Name="cv" Series="6558" Issue="131572" />
     </Book>
     <Book Series="Incredible Hulk" Number="49" Volume="2000" Year="2003">
-      <Id>62e7151e-253c-40ff-b6d0-248df15ef0c2</Id>
+      <Database Name="cv" Series="6558" Issue="131573" />
     </Book>
     <Book Series="Incredible Hulk" Number="50" Volume="2000" Year="2003">
-      <Id>51e5dcdd-b186-4d0f-b801-19e840cba3ad</Id>
+      <Database Name="cv" Series="6558" Issue="131574" />
     </Book>
     <Book Series="Incredible Hulk" Number="51" Volume="2000" Year="2003">
-      <Id>474405e0-5d41-4a9a-9da3-b5ed33ea8f93</Id>
+      <Database Name="cv" Series="6558" Issue="131575" />
     </Book>
     <Book Series="Incredible Hulk" Number="52" Volume="2000" Year="2003">
-      <Id>3e9430d0-6f01-4ff5-991f-5dde053df3a1</Id>
+      <Database Name="cv" Series="6558" Issue="131576" />
     </Book>
     <Book Series="Incredible Hulk" Number="53" Volume="2000" Year="2003">
-      <Id>aa936ec6-7e68-44da-8d1d-f1d744e2b75d</Id>
+      <Database Name="cv" Series="6558" Issue="131577" />
     </Book>
     <Book Series="Incredible Hulk" Number="54" Volume="2000" Year="2003">
-      <Id>5be7e7ba-5b96-4e3f-8484-0264806a2bf7</Id>
+      <Database Name="cv" Series="6558" Issue="131578" />
     </Book>
     <Book Series="Hulk/Wolverine: 6 Hours" Number="1" Volume="2003" Year="2003">
-      <Id>48154efb-f9ff-4dca-a36a-a21ee1fd2056</Id>
+      <Database Name="cv" Series="11379" Issue="99759" />
     </Book>
     <Book Series="Hulk/Wolverine: 6 Hours" Number="2" Volume="2003" Year="2003">
-      <Id>4d1dd650-8134-4bed-8e7a-4ee177c4de7a</Id>
+      <Database Name="cv" Series="11379" Issue="99760" />
     </Book>
     <Book Series="Hulk/Wolverine: 6 Hours" Number="3" Volume="2003" Year="2003">
-      <Id>3ee69bdf-460a-456c-8ae6-44ee56cf7a4f</Id>
+      <Database Name="cv" Series="11379" Issue="99761" />
     </Book>
     <Book Series="Hulk/Wolverine: 6 Hours" Number="4" Volume="2003" Year="2003">
-      <Id>9206a11f-b71b-4564-b411-0eb2c1f34db4</Id>
+      <Database Name="cv" Series="11379" Issue="99762" />
     </Book>
     <Book Series="Incredible Hulk" Number="55" Volume="2000" Year="2003">
-      <Id>b5445ac8-6d98-427c-bf26-4f61505b0075</Id>
+      <Database Name="cv" Series="6558" Issue="131579" />
     </Book>
     <Book Series="Incredible Hulk" Number="56" Volume="2000" Year="2003">
-      <Id>b767dbde-251b-4963-9d99-85c2773a8bb7</Id>
+      <Database Name="cv" Series="6558" Issue="99120" />
     </Book>
     <Book Series="Incredible Hulk" Number="57" Volume="2000" Year="2003">
-      <Id>f9e99278-201a-435a-9c9b-14e83d2caea6</Id>
+      <Database Name="cv" Series="6558" Issue="99121" />
     </Book>
     <Book Series="Incredible Hulk" Number="58" Volume="2000" Year="2003">
-      <Id>2085c6c1-1bb0-4684-9d56-79d7f642e0f4</Id>
+      <Database Name="cv" Series="6558" Issue="99122" />
     </Book>
     <Book Series="Incredible Hulk" Number="59" Volume="2000" Year="2003">
-      <Id>a467f5ec-ca21-4bbb-9573-f65f25ffd0c2</Id>
+      <Database Name="cv" Series="6558" Issue="99123" />
     </Book>
     <Book Series="Incredible Hulk" Number="60" Volume="2000" Year="2003">
-      <Id>9f41cb00-681f-49e6-9338-814dad79c521</Id>
+      <Database Name="cv" Series="6558" Issue="99124" />
     </Book>
     <Book Series="Incredible Hulk" Number="61" Volume="2000" Year="2003">
-      <Id>2d7a64af-2561-4481-8cc6-d97353d715d1</Id>
+      <Database Name="cv" Series="6558" Issue="99125" />
     </Book>
     <Book Series="Incredible Hulk" Number="62" Volume="2000" Year="2003">
-      <Id>506ec2f2-c4ca-45e6-a1cc-6afdc437d07e</Id>
+      <Database Name="cv" Series="6558" Issue="99126" />
     </Book>
     <Book Series="Incredible Hulk" Number="63" Volume="2000" Year="2004">
-      <Id>451d5ca8-e81a-4454-87c3-2f97806bb58e</Id>
+      <Database Name="cv" Series="6558" Issue="99127" />
     </Book>
     <Book Series="Incredible Hulk" Number="64" Volume="2000" Year="2004">
-      <Id>4d8848ae-d93d-4a13-bd6e-39b7cdd65f7d</Id>
+      <Database Name="cv" Series="6558" Issue="99128" />
     </Book>
     <Book Series="Incredible Hulk" Number="65" Volume="2000" Year="2004">
-      <Id>779c7fa0-7499-47b1-a823-d14eb2eb5952</Id>
+      <Database Name="cv" Series="6558" Issue="99129" />
     </Book>
     <Book Series="Incredible Hulk" Number="66" Volume="2000" Year="2004">
-      <Id>748f2f65-bec4-445e-94a7-040c75cef5c6</Id>
+      <Database Name="cv" Series="6558" Issue="99130" />
     </Book>
     <Book Series="Incredible Hulk" Number="67" Volume="2000" Year="2004">
-      <Id>ded82282-2994-42b0-8c91-da6b2e7578cc</Id>
+      <Database Name="cv" Series="6558" Issue="99131" />
     </Book>
     <Book Series="Incredible Hulk" Number="68" Volume="2000" Year="2004">
-      <Id>26fb0eed-cdb5-497e-b437-7f0ab5eea9cf</Id>
+      <Database Name="cv" Series="6558" Issue="99132" />
     </Book>
     <Book Series="Incredible Hulk" Number="69" Volume="2000" Year="2004">
-      <Id>6f7c1cf5-7a3a-49a2-848f-87a1ce26d6e3</Id>
+      <Database Name="cv" Series="6558" Issue="99133" />
     </Book>
     <Book Series="Incredible Hulk" Number="70" Volume="2000" Year="2004">
-      <Id>953acbe0-addb-41da-9fcf-42d95345a4ff</Id>
+      <Database Name="cv" Series="6558" Issue="99134" />
     </Book>
     <Book Series="Incredible Hulk" Number="71" Volume="2000" Year="2004">
-      <Id>a6a1aca8-13ac-49ba-8bf7-076c2811ff5e</Id>
+      <Database Name="cv" Series="6558" Issue="99135" />
     </Book>
     <Book Series="Incredible Hulk" Number="72" Volume="2000" Year="2004">
-      <Id>9054f86c-f8d2-4b5e-b7b4-c636aae6d3e8</Id>
+      <Database Name="cv" Series="6558" Issue="99136" />
     </Book>
     <Book Series="Incredible Hulk" Number="73" Volume="2000" Year="2004">
-      <Id>22fb4fb7-5083-4fd4-a4c1-70e170ed7e5c</Id>
+      <Database Name="cv" Series="6558" Issue="99137" />
     </Book>
     <Book Series="Incredible Hulk" Number="74" Volume="2000" Year="2004">
-      <Id>3221721f-22e6-46f8-9cc2-97fd4fe14fd1</Id>
+      <Database Name="cv" Series="6558" Issue="99138" />
     </Book>
     <Book Series="Incredible Hulk" Number="75" Volume="2000" Year="2004">
-      <Id>613e32ef-f2be-433f-af50-851737e1ddbd</Id>
+      <Database Name="cv" Series="6558" Issue="99139" />
     </Book>
     <Book Series="Incredible Hulk" Number="76" Volume="2000" Year="2004">
-      <Id>3e8d870d-a50b-412a-9367-489f89cca191</Id>
+      <Database Name="cv" Series="6558" Issue="99140" />
     </Book>
-    <Book Series="Hulk &amp; Thing: Hard Knocks" Number="1" Volume="2004" Year="2004">
-      <Id>ec2f7997-a8cd-429f-bca2-128244960651</Id>
+    <Book Series="Hulk &#38; Thing: Hard Knocks" Number="1" Volume="2004" Year="2004">
+      <Database Name="cv" Series="23574" Issue="141434" />
     </Book>
-    <Book Series="Hulk &amp; Thing: Hard Knocks" Number="2" Volume="2004" Year="2004">
-      <Id>0fd5dc1a-1414-465a-aa4e-155a967e2389</Id>
+    <Book Series="Hulk &#38; Thing: Hard Knocks" Number="2" Volume="2004" Year="2004">
+      <Database Name="cv" Series="23574" Issue="176055" />
     </Book>
-    <Book Series="Hulk &amp; Thing: Hard Knocks" Number="3" Volume="2004" Year="2005">
-      <Id>a445c6dd-8b82-49f5-b805-1eace2e92bda</Id>
+    <Book Series="Hulk &#38; Thing: Hard Knocks" Number="3" Volume="2004" Year="2005">
+      <Database Name="cv" Series="23574" Issue="176054" />
     </Book>
-    <Book Series="Hulk &amp; Thing: Hard Knocks" Number="4" Volume="2004" Year="2005">
-      <Id>6d627230-16bf-4ba6-b4a2-1851b34e3332</Id>
+    <Book Series="Hulk &#38; Thing: Hard Knocks" Number="4" Volume="2004" Year="2005">
+      <Database Name="cv" Series="23574" Issue="176053" />
     </Book>
     <Book Series="Avengers" Number="74" Volume="1998" Year="2004">
-      <Id>1346fa28-ecda-49da-a235-2f8b1cf0c27d</Id>
+      <Database Name="cv" Series="7084" Issue="114478" />
     </Book>
     <Book Series="Avengers" Number="75" Volume="1998" Year="2004">
-      <Id>5826d0b8-4c4e-4731-b7b1-6f28d8746d38</Id>
+      <Database Name="cv" Series="7084" Issue="114479" />
     </Book>
-    <Book Series="Marvel Team-Up" Number="3" Volume="2005" Year="2005">
-      <Id>c8c1e351-6929-428e-8360-75f42d37f98e</Id>
+    <Book Series="Marvel Team-Up" Number="3" Volume="2004" Year="2005">
+      <Database Name="cv" Series="18024" Issue="105569" />
     </Book>
-    <Book Series="Marvel Team-Up" Number="4" Volume="2005" Year="2005">
-      <Id>9632409f-2b7e-44fe-b867-f9acece4b343</Id>
+    <Book Series="Marvel Team-Up" Number="4" Volume="2004" Year="2005">
+      <Database Name="cv" Series="18024" Issue="105631" />
     </Book>
-    <Book Series="Captain Universe / Hulk" Number="1" Volume="2006" Year="2006">
-      <Id>cc51f943-b5cf-4115-818e-c0f228dce754</Id>
+    <Book Series="Captain Universe / The Incredible Hulk" Number="1" Volume="2006" Year="2006">
+      <Database Name="cv" Series="18633" Issue="109911" />
     </Book>
     <Book Series="Incredible Hulk" Number="77" Volume="2000" Year="2005">
-      <Id>e600cda0-fe2e-4a83-9f51-9bb045e8192a</Id>
+      <Database Name="cv" Series="6558" Issue="99141" />
     </Book>
     <Book Series="Incredible Hulk" Number="78" Volume="2000" Year="2005">
-      <Id>06ff6611-d219-40c5-8637-667459b556f2</Id>
+      <Database Name="cv" Series="6558" Issue="101161" />
     </Book>
     <Book Series="Incredible Hulk" Number="79" Volume="2000" Year="2005">
-      <Id>41b260c6-b449-48d7-bd87-152e69d44404</Id>
+      <Database Name="cv" Series="6558" Issue="101162" />
     </Book>
     <Book Series="Incredible Hulk" Number="80" Volume="2000" Year="2005">
-      <Id>41ff8a8e-34f7-42ed-a726-fa3136b42734</Id>
+      <Database Name="cv" Series="6558" Issue="101163" />
     </Book>
     <Book Series="Incredible Hulk" Number="81" Volume="2000" Year="2005">
-      <Id>f98ee36a-10ab-4d79-b6f8-33e722632cf6</Id>
+      <Database Name="cv" Series="6558" Issue="112745" />
     </Book>
     <Book Series="Incredible Hulk" Number="82" Volume="2000" Year="2005">
-      <Id>1aaf336b-38ec-4e47-99f1-091a25eb7940</Id>
+      <Database Name="cv" Series="6558" Issue="133260" />
     </Book>
     <Book Series="Incredible Hulk" Number="83" Volume="2000" Year="2005">
-      <Id>b8483192-5552-4f5e-9667-e5b12c154297</Id>
+      <Database Name="cv" Series="6558" Issue="117046" />
     </Book>
     <Book Series="Incredible Hulk" Number="84" Volume="2000" Year="2005">
-      <Id>7dcbaffa-94b7-4ea0-b704-0b5ab323118d</Id>
+      <Database Name="cv" Series="6558" Issue="117044" />
     </Book>
     <Book Series="Incredible Hulk" Number="85" Volume="2000" Year="2005">
-      <Id>7c809f32-7e78-474a-bb6a-8635ae66f1ab</Id>
+      <Database Name="cv" Series="6558" Issue="117041" />
     </Book>
     <Book Series="Incredible Hulk" Number="86" Volume="2000" Year="2005">
-      <Id>0a4b761c-10b7-48ba-82cd-321fdcbe0b73</Id>
+      <Database Name="cv" Series="6558" Issue="117039" />
     </Book>
     <Book Series="Incredible Hulk" Number="87" Volume="2000" Year="2005">
-      <Id>639abfa7-4f0b-4eab-a29e-42d475e7232b</Id>
+      <Database Name="cv" Series="6558" Issue="117038" />
     </Book>
     <Book Series="Hulk: Destruction" Number="1" Volume="2005" Year="2005">
-      <Id>c05c3852-8e01-41a3-8472-abe0e18f1113</Id>
+      <Database Name="cv" Series="19185" Issue="114859" />
     </Book>
     <Book Series="Hulk: Destruction" Number="2" Volume="2005" Year="2005">
-      <Id>34865475-4eaa-4344-8911-0ef44c5fc113</Id>
+      <Database Name="cv" Series="19185" Issue="115017" />
     </Book>
     <Book Series="Hulk: Destruction" Number="3" Volume="2005" Year="2005">
-      <Id>910ceeaf-f9c2-4f06-8d40-89b7f1cdff9d</Id>
+      <Database Name="cv" Series="19185" Issue="115018" />
     </Book>
     <Book Series="Hulk: Destruction" Number="4" Volume="2005" Year="2005">
-      <Id>531525d9-7df3-46d7-8794-c41798c5b160</Id>
+      <Database Name="cv" Series="19185" Issue="115045" />
     </Book>
     <Book Series="Fantastic Four" Number="533" Volume="1998" Year="2006">
-      <Id>b978e1ac-673a-4450-aa3b-19208b6cc7b5</Id>
+      <Database Name="cv" Series="6211" Issue="151579" />
     </Book>
     <Book Series="Fantastic Four" Number="534" Volume="1998" Year="2006">
-      <Id>5c2a9109-be64-45aa-8287-aa0ff50932e9</Id>
+      <Database Name="cv" Series="6211" Issue="151580" />
     </Book>
     <Book Series="Fantastic Four" Number="535" Volume="1998" Year="2006">
-      <Id>445654ea-bc6c-4316-adcf-efc17e800bdd</Id>
+      <Database Name="cv" Series="6211" Issue="151582" />
     </Book>
     <Book Series="The New Avengers: Illuminati" Number="1" Volume="2006" Year="2006">
-      <Id>c570c47d-1e2a-4a69-b920-0724f45b327b</Id>
+      <Database Name="cv" Series="18180" Issue="106482" />
     </Book>
     <Book Series="Incredible Hulk" Number="88" Volume="2000" Year="2006">
-      <Id>4780b227-a3b3-4504-bbae-34a33cd9b4e3</Id>
+      <Database Name="cv" Series="6558" Issue="151586" />
     </Book>
     <Book Series="Incredible Hulk" Number="89" Volume="2000" Year="2006">
-      <Id>e7e71134-22a1-42b2-86d4-104a61de17bf</Id>
+      <Database Name="cv" Series="6558" Issue="151587" />
     </Book>
     <Book Series="Incredible Hulk" Number="90" Volume="2000" Year="2006">
-      <Id>988816f4-492a-4a69-977b-e134dcd7ae03</Id>
+      <Database Name="cv" Series="6558" Issue="117037" />
     </Book>
     <Book Series="Incredible Hulk" Number="91" Volume="2000" Year="2006">
-      <Id>65bdb09e-c84b-45dc-b092-8785714c381c</Id>
+      <Database Name="cv" Series="6558" Issue="112741" />
     </Book>
     <Book Series="Incredible Hulk" Number="92" Volume="2000" Year="2006">
-      <Id>786e7ba6-411e-4c47-9e29-2eff8bbc207d</Id>
+      <Database Name="cv" Series="6558" Issue="108947" />
     </Book>
     <Book Series="Incredible Hulk" Number="93" Volume="2000" Year="2006">
-      <Id>3bf6a469-9d75-4bdc-aea7-82e6740f51f2</Id>
+      <Database Name="cv" Series="6558" Issue="113692" />
     </Book>
     <Book Series="Incredible Hulk" Number="94" Volume="2000" Year="2006">
-      <Id>9d53d7cc-8d52-47f9-9ab5-7e1d342fdcea</Id>
+      <Database Name="cv" Series="6558" Issue="112742" />
     </Book>
     <Book Series="Incredible Hulk" Number="95" Volume="2000" Year="2006">
-      <Id>d582f94e-2b68-4acd-ade3-54ec197ad53f</Id>
+      <Database Name="cv" Series="6558" Issue="112743" />
     </Book>
     <Book Series="Giant-Size Hulk" Number="1" Volume="2006" Year="2006">
-      <Id>046a25db-c3a3-4b94-9dcb-110133ed3e9d</Id>
+      <Database Name="cv" Series="18222" Issue="106733" />
     </Book>
     <Book Series="Planet Hulk: Gladiator Guidebook" Number="1" Volume="2006" Year="2006">
-      <Id>697329e2-5b3a-4a8c-b30b-8c110f3303ce</Id>
+      <Database Name="cv" Series="20839" Issue="124921" />
     </Book>
     <Book Series="Incredible Hulk" Number="96" Volume="2000" Year="2006">
-      <Id>c0074ac3-fbc8-4bf9-8e20-1282ae45d11f</Id>
+      <Database Name="cv" Series="6558" Issue="112744" />
     </Book>
     <Book Series="Incredible Hulk" Number="97" Volume="2000" Year="2006">
-      <Id>950fe046-1579-4070-bf25-5e820b40cd48</Id>
+      <Database Name="cv" Series="6558" Issue="106736" />
     </Book>
     <Book Series="Incredible Hulk" Number="98" Volume="2000" Year="2006">
-      <Id>e5c7d29b-bde7-43a7-81b1-1f997ddafb42</Id>
+      <Database Name="cv" Series="6558" Issue="113724" />
     </Book>
     <Book Series="Incredible Hulk" Number="99" Volume="2000" Year="2006">
-      <Id>c9892c99-af1a-4c36-93b6-0ea2581e8778</Id>
+      <Database Name="cv" Series="6558" Issue="113725" />
     </Book>
     <Book Series="Incredible Hulk" Number="100" Volume="2000" Year="2007">
-      <Id>feaf2460-3635-4704-9613-188b32afd21d</Id>
+      <Database Name="cv" Series="6558" Issue="112746" />
     </Book>
     <Book Series="Incredible Hulk" Number="101" Volume="2000" Year="2007">
-      <Id>6525101c-1b66-48af-a00b-8e2b05f33e78</Id>
+      <Database Name="cv" Series="6558" Issue="106399" />
     </Book>
     <Book Series="Incredible Hulk" Number="102" Volume="2000" Year="2007">
-      <Id>6d411752-07cb-44a2-ac5f-2e7cb2294d91</Id>
+      <Database Name="cv" Series="6558" Issue="112747" />
     </Book>
     <Book Series="Incredible Hulk" Number="103" Volume="2000" Year="2007">
-      <Id>01c8e6f3-b631-4938-8eac-67c50d712aff</Id>
+      <Database Name="cv" Series="6558" Issue="106416" />
     </Book>
     <Book Series="Incredible Hulk" Number="104" Volume="2000" Year="2007">
-      <Id>dad48f06-1c2a-48fe-8f88-f44297cd7ed6</Id>
+      <Database Name="cv" Series="6558" Issue="106796" />
     </Book>
     <Book Series="Incredible Hulk" Number="105" Volume="2000" Year="2007">
-      <Id>49f477da-5d46-4f98-94ea-d30507bcf399</Id>
+      <Database Name="cv" Series="6558" Issue="108001" />
     </Book>
     <Book Series="World War Hulk Prologue: World Breaker" Number="1" Volume="2007" Year="2007">
-      <Id>c0629644-6e20-434c-b745-17b5c841b5d5</Id>
+      <Database Name="cv" Series="18537" Issue="108929" />
     </Book>
     <Book Series="Incredible Hulk" Number="106" Volume="2000" Year="2007">
-      <Id>abad0944-ab19-4324-bcc8-20d221171785</Id>
+      <Database Name="cv" Series="6558" Issue="108922" />
     </Book>
     <Book Series="World War Hulk" Number="1" Volume="2007" Year="2007">
-      <Id>3960db97-4174-4f10-aa1e-728dd6be66a9</Id>
+      <Database Name="cv" Series="18686" Issue="110435" />
     </Book>
     <Book Series="Incredible Hulk" Number="107" Volume="2000" Year="2007">
-      <Id>a8b3d2df-cd75-419e-bd3f-c4032f205c1c</Id>
+      <Database Name="cv" Series="6558" Issue="110665" />
     </Book>
-    <Book Series="Iron Man" Number="19" Volume="2005" Year="2007">
-      <Id>a9e477ed-e523-4fe3-b32c-7382c33fe8e6</Id>
+    <Book Series="Iron Man" Number="19" Volume="2004" Year="2007">
+      <Database Name="cv" Series="18220" Issue="110667" />
     </Book>
     <Book Series="Ghost Rider" Number="12" Volume="2006" Year="2007">
-      <Id>45b85ba2-5bab-4eaa-b104-2b12bdf08446</Id>
+      <Database Name="cv" Series="18138" Issue="110671" />
     </Book>
     <Book Series="Heroes for Hire" Number="11" Volume="2006" Year="2007">
-      <Id>434b0142-4394-42b2-ac6f-8091e1f0fb25</Id>
+      <Database Name="cv" Series="18102" Issue="110674" />
     </Book>
     <Book Series="World War Hulk: X-Men" Number="1" Volume="2007" Year="2007">
-      <Id>b94d41f6-4ecd-42a8-87ca-818684ed49a3</Id>
+      <Database Name="cv" Series="18786" Issue="111036" />
     </Book>
     <Book Series="World War Hulk: Front Line" Number="1" Volume="2007" Year="2007">
-      <Id>400e2265-9f39-4089-8298-52e99c380a9b</Id>
+      <Database Name="cv" Series="18793" Issue="111078" />
     </Book>
     <Book Series="The Irredeemable Ant-Man" Number="10" Volume="2006" Year="2007">
-      <Id>cb0ba897-23d2-4a31-a127-bba3c3c0efbf</Id>
+      <Database Name="cv" Series="18227" Issue="111374" />
     </Book>
     <Book Series="World War Hulk: Gamma Corps" Number="1" Volume="2007" Year="2007">
-      <Id>e4d01747-20d8-4316-8f0a-8a0ff5830f0c</Id>
+      <Database Name="cv" Series="18903" Issue="111703" />
     </Book>
     <Book Series="World War Hulk" Number="2" Volume="2007" Year="2007">
-      <Id>72641fe2-0417-4bee-a67e-e873cc88a4ee</Id>
+      <Database Name="cv" Series="18686" Issue="111670" />
     </Book>
     <Book Series="World War Hulk: X-Men" Number="2" Volume="2007" Year="2007">
-      <Id>f4ec563b-aed7-4343-a58b-653424703ddf</Id>
+      <Database Name="cv" Series="18786" Issue="111708" />
     </Book>
     <Book Series="World War Hulk: Front Line" Number="2" Volume="2007" Year="2007">
-      <Id>5195c49c-3220-47f4-914e-0ad37b222ee5</Id>
+      <Database Name="cv" Series="18793" Issue="111727" />
     </Book>
     <Book Series="Avengers: The Initiative" Number="4" Volume="2007" Year="2007">
-      <Id>6409a098-fbc1-4049-b949-274ac25f3a7e</Id>
+      <Database Name="cv" Series="18419" Issue="111663" />
     </Book>
     <Book Series="Ghost Rider" Number="13" Volume="2006" Year="2007">
-      <Id>5f86ba13-e398-438e-8f5f-48c470ffefbc</Id>
+      <Database Name="cv" Series="18138" Issue="111669" />
     </Book>
-    <Book Series="Iron Man" Number="20" Volume="2005" Year="2007">
-      <Id>00ed08a6-42dd-4410-b0e3-06a929555912</Id>
+    <Book Series="Iron Man" Number="20" Volume="2004" Year="2007">
+      <Database Name="cv" Series="18220" Issue="111936" />
     </Book>
     <Book Series="Heroes for Hire" Number="12" Volume="2006" Year="2007">
-      <Id>e0bc0c4d-3f10-43bb-9e3f-50e4e5567026</Id>
+      <Database Name="cv" Series="18102" Issue="111934" />
     </Book>
     <Book Series="Incredible Hulk" Number="108" Volume="2000" Year="2007">
-      <Id>5fecd249-3268-4318-829b-1c2f060fc9fb</Id>
+      <Database Name="cv" Series="6558" Issue="111938" />
     </Book>
     <Book Series="World War Hulk" Number="3" Volume="2007" Year="2007">
-      <Id>6da401c2-91ac-479f-b752-35e9ad8a26df</Id>
+      <Database Name="cv" Series="18686" Issue="112280" />
     </Book>
     <Book Series="World War Hulk: Front Line" Number="3" Volume="2007" Year="2007">
-      <Id>3e753cff-35e2-4d0d-9d40-94c1b91c84ed</Id>
+      <Database Name="cv" Series="18793" Issue="112958" />
     </Book>
     <Book Series="Incredible Hulk" Number="109" Volume="2000" Year="2007">
-      <Id>6dd09093-fd08-413c-be62-e701e0441f9a</Id>
+      <Database Name="cv" Series="6558" Issue="112986" />
     </Book>
     <Book Series="Avengers: The Initiative" Number="5" Volume="2007" Year="2007">
-      <Id>31298d45-35d2-41b9-8c80-fb28110975b8</Id>
+      <Database Name="cv" Series="18419" Issue="113956" />
     </Book>
     <Book Series="World War Hulk: Gamma Corps" Number="2" Volume="2007" Year="2007">
-      <Id>983ef8a3-54d5-468a-ae96-b57fedc14939</Id>
+      <Database Name="cv" Series="18903" Issue="113778" />
     </Book>
     <Book Series="World War Hulk: Gamma Files" Number="1" Volume="2007" Year="2007">
-      <Id>2003a58b-3010-45b5-9efe-a23920ac11b0</Id>
+      <Database Name="cv" Series="19050" Issue="113742" />
     </Book>
     <Book Series="World War Hulk: X-Men" Number="3" Volume="2007" Year="2007">
-      <Id>efe752bb-f6e7-489e-be14-7c5e1ae6ae71</Id>
+      <Database Name="cv" Series="18786" Issue="113957" />
     </Book>
     <Book Series="World War Hulk: Front Line" Number="4" Volume="2007" Year="2007">
-      <Id>954d920e-04c3-412f-8b3f-cf916256c576</Id>
+      <Database Name="cv" Series="18793" Issue="114625" />
     </Book>
     <Book Series="Heroes for Hire" Number="13" Volume="2006" Year="2007">
-      <Id>6b6e47fc-f1a4-4dad-be67-36171e6c47d1</Id>
+      <Database Name="cv" Series="18102" Issue="114431" />
     </Book>
     <Book Series="Incredible Hulk" Number="110" Volume="2000" Year="2007">
-      <Id>960fddf4-b6a5-4476-858f-75ef21f956ce</Id>
+      <Database Name="cv" Series="6558" Issue="114203" />
     </Book>
     <Book Series="World War Hulk" Number="4" Volume="2007" Year="2007">
-      <Id>76ea018a-a1bf-4d9b-be27-b0de2f0efdb9</Id>
+      <Database Name="cv" Series="18686" Issue="114624" />
     </Book>
     <Book Series="World War Hulk: Gamma Corps" Number="3" Volume="2007" Year="2007">
-      <Id>8da3c8ae-8cfa-4011-866a-5c3ec1f954d2</Id>
+      <Database Name="cv" Series="18903" Issue="114667" />
     </Book>
     <Book Series="World War Hulk: Front Line" Number="5" Volume="2007" Year="2007">
-      <Id>46dafb5d-ec2c-498e-b3ad-3d8e98e7b1a1</Id>
+      <Database Name="cv" Series="18793" Issue="115396" />
     </Book>
     <Book Series="Heroes for Hire" Number="14" Volume="2006" Year="2007">
-      <Id>1e248a4f-d095-4806-82fd-70e211fe3e3d</Id>
+      <Database Name="cv" Series="18102" Issue="115799" />
     </Book>
     <Book Series="World War Hulk: Gamma Corps" Number="4" Volume="2007" Year="2008">
-      <Id>6122145b-84f6-4768-9035-1552e280878d</Id>
+      <Database Name="cv" Series="18903" Issue="117844" />
     </Book>
     <Book Series="World War Hulk" Number="5" Volume="2007" Year="2008">
-      <Id>3e0de482-4511-47d3-b6fd-c5efd9215833</Id>
+      <Database Name="cv" Series="18686" Issue="117746" />
     </Book>
     <Book Series="Punisher War Journal" Number="12" Volume="2007" Year="2007">
-      <Id>18661d5e-38d2-4ecd-8f9e-86ea20bb1cd1</Id>
+      <Database Name="cv" Series="18152" Issue="115853" />
     </Book>
     <Book Series="World War Hulk: Front Line" Number="6" Volume="2007" Year="2007">
-      <Id>8013dca8-e6fb-439b-9ed4-cd923cedcc0f</Id>
+      <Database Name="cv" Series="18793" Issue="118696" />
     </Book>
     <Book Series="Heroes for Hire" Number="15" Volume="2006" Year="2007">
-      <Id>8b953d51-93c6-4d71-8f7b-b85c098d6a95</Id>
+      <Database Name="cv" Series="18102" Issue="120321" />
     </Book>
     <Book Series="Incredible Hulk" Number="111" Volume="2000" Year="2007">
-      <Id>b5755963-9925-471c-8f59-a13f66c0c9ad</Id>
+      <Database Name="cv" Series="6558" Issue="118078" />
     </Book>
     <Book Series="Hulk and Power Pack" Number="1" Volume="2007" Year="2007">
-      <Id>bbed6cf7-9bf2-4f81-a78f-afa43b6ab464</Id>
+      <Database Name="cv" Series="18694" Issue="118353" />
     </Book>
     <Book Series="Hulk and Power Pack" Number="2" Volume="2007" Year="2007">
-      <Id>24170401-ac02-4904-851e-4ba678e783bf</Id>
+      <Database Name="cv" Series="18694" Issue="124526" />
     </Book>
     <Book Series="Hulk and Power Pack" Number="3" Volume="2007" Year="2007">
-      <Id>a37b5c3b-ce2f-464b-a121-44354128d066</Id>
+      <Database Name="cv" Series="18694" Issue="110516" />
     </Book>
     <Book Series="Hulk and Power Pack" Number="4" Volume="2007" Year="2007">
-      <Id>ed66f192-b218-4d91-9021-49a45360abc3</Id>
+      <Database Name="cv" Series="18694" Issue="141478" />
     </Book>
     <Book Series="Mythos: Hulk" Number="1" Volume="2006" Year="2006">
-      <Id>c6524e66-913f-4575-8706-1e9e87a3089f</Id>
+      <Database Name="cv" Series="33157" Issue="214263" />
     </Book>
     <Book Series="Hulk" Number="1" Volume="2008" Year="2008">
-      <Id>55631c83-7a28-42bf-bd6c-c9607ad4e2e4</Id>
+      <Database Name="cv" Series="20291" Issue="121093" />
     </Book>
     <Book Series="Hulk" Number="2" Volume="2008" Year="2008">
-      <Id>bda59ad1-ee2c-475a-9829-554b6977a282</Id>
+      <Database Name="cv" Series="20291" Issue="123374" />
     </Book>
     <Book Series="Hulk" Number="3" Volume="2008" Year="2008">
-      <Id>54dbf5d6-e01e-4a41-a6b7-dbd1bb9f5fa4</Id>
+      <Database Name="cv" Series="20291" Issue="128216" />
     </Book>
     <Book Series="Hulk" Number="4" Volume="2008" Year="2008">
-      <Id>2f8d8828-797d-4096-80c5-0d5d38c2f205</Id>
+      <Database Name="cv" Series="20291" Issue="131852" />
     </Book>
     <Book Series="Hulk" Number="5" Volume="2008" Year="2008">
-      <Id>d7fc68fa-c83a-4c55-b020-da65ee60c9b7</Id>
+      <Database Name="cv" Series="20291" Issue="135069" />
     </Book>
     <Book Series="Hulk" Number="6" Volume="2008" Year="2008">
-      <Id>cb7acc41-621d-41d6-8363-834be0328f82</Id>
+      <Database Name="cv" Series="20291" Issue="139368" />
     </Book>
     <Book Series="Hulk" Number="7" Volume="2008" Year="2008">
-      <Id>c4b00b98-e27b-4330-9478-ce8857c2d04a</Id>
+      <Database Name="cv" Series="20291" Issue="140858" />
     </Book>
     <Book Series="Hulk" Number="8" Volume="2008" Year="2009">
-      <Id>b46e63a6-2579-4ced-a1db-8ff6d5247663</Id>
+      <Database Name="cv" Series="20291" Issue="143159" />
     </Book>
     <Book Series="Hulk" Number="9" Volume="2008" Year="2009">
-      <Id>9473a640-60ae-45ce-8074-6628a6008887</Id>
+      <Database Name="cv" Series="20291" Issue="148630" />
     </Book>
     <Book Series="King-Size Hulk" Number="1" Volume="2008" Year="2008">
-      <Id>1ba68136-a0e6-4ee9-843e-73aa3bb97716</Id>
+      <Database Name="cv" Series="21721" Issue="131018" />
     </Book>
     <Book Series="Hulk Monster-Size Special" Number="1" Volume="2008" Year="2008">
-      <Id>0ed75062-6730-4c82-8214-364ef53113dd</Id>
+      <Database Name="cv" Series="23418" Issue="140461" />
     </Book>
     <Book Series="Hulk: Raging Thunder" Number="1" Volume="2008" Year="2008">
-      <Id>5b804f8b-9302-415a-bfbf-e14dcf7c2a91</Id>
+      <Database Name="cv" Series="22153" Issue="133276" />
     </Book>
     <Book Series="Hulk" Number="10" Volume="2008" Year="2009">
-      <Id>9648da5a-da82-4f09-98ab-75bfaa7e17c0</Id>
+      <Database Name="cv" Series="20291" Issue="152710" />
     </Book>
     <Book Series="Hulk" Number="11" Volume="2008" Year="2009">
-      <Id>bf491eab-95ef-4c23-81ae-3c0751fc7af8</Id>
+      <Database Name="cv" Series="20291" Issue="155776" />
     </Book>
     <Book Series="Hulk" Number="12" Volume="2008" Year="2009">
-      <Id>154d58fd-1bbb-49c3-95fd-da99572f4beb</Id>
+      <Database Name="cv" Series="20291" Issue="157780" />
     </Book>
     <Book Series="Hulk" Number="13" Volume="2008" Year="2009">
-      <Id>9336ff5a-ad07-4e26-b18f-53bea26aba9e</Id>
+      <Database Name="cv" Series="20291" Issue="166266" />
     </Book>
     <Book Series="Hulk" Number="14" Volume="2008" Year="2009">
-      <Id>c5049ef6-3a22-4128-a990-5bcb4b7bb427</Id>
+      <Database Name="cv" Series="20291" Issue="168325" />
     </Book>
     <Book Series="Hulk" Number="15" Volume="2008" Year="2009">
-      <Id>f26a4b2f-ab50-4777-b387-63dc2fb88222</Id>
+      <Database Name="cv" Series="20291" Issue="173682" />
     </Book>
     <Book Series="Hulk" Number="16" Volume="2008" Year="2009">
-      <Id>07067507-a8df-45e8-8b7e-4fbc35f9af11</Id>
+      <Database Name="cv" Series="20291" Issue="179032" />
     </Book>
     <Book Series="Hulk" Number="17" Volume="2008" Year="2010">
-      <Id>fbbf71bb-3cb6-4386-ac9f-016fe5d92844</Id>
+      <Database Name="cv" Series="20291" Issue="184822" />
     </Book>
     <Book Series="Hulk" Number="18" Volume="2008" Year="2010">
-      <Id>d5f5097a-7cf0-4605-b454-9235459d4f5c</Id>
+      <Database Name="cv" Series="20291" Issue="187739" />
     </Book>
     <Book Series="Incredible Hulk" Number="600" Volume="2009" Year="2009">
-      <Id>9d3400fe-1e8b-414f-95ef-2c6f638f39c6</Id>
+      <Database Name="cv" Series="24715" Issue="165068" />
     </Book>
     <Book Series="Incredible Hulk" Number="601" Volume="2009" Year="2009">
-      <Id>302eaa74-7787-468e-8e10-50e4e5285b70</Id>
+      <Database Name="cv" Series="24715" Issue="168304" />
     </Book>
     <Book Series="Incredible Hulk" Number="602" Volume="2009" Year="2009">
-      <Id>af075fab-3722-4a59-b466-aded57a1509c</Id>
+      <Database Name="cv" Series="24715" Issue="172437" />
     </Book>
     <Book Series="Incredible Hulk" Number="603" Volume="2009" Year="2009">
-      <Id>e4022aef-0618-4a44-804c-21075cd2d895</Id>
+      <Database Name="cv" Series="24715" Issue="176845" />
     </Book>
     <Book Series="Incredible Hulk" Number="604" Volume="2009" Year="2010">
-      <Id>c83d6851-546b-492e-b6c5-0d420a033958</Id>
+      <Database Name="cv" Series="24715" Issue="183869" />
     </Book>
     <Book Series="Incredible Hulk" Number="605" Volume="2009" Year="2010">
-      <Id>3894de43-62f4-4d09-8b78-44923087dc3c</Id>
+      <Database Name="cv" Series="24715" Issue="186768" />
     </Book>
     <Book Series="Hulk Team-Up" Number="1" Volume="2009" Year="2009">
-      <Id>135f4776-40b8-4ea9-b44a-e2323c0e5209</Id>
+      <Database Name="cv" Series="28067" Issue="172315" />
     </Book>
     <Book Series="Dark Reign: The List - Hulk" Number="1" Volume="2009" Year="2009">
-      <Id>daa371a6-ebed-4f26-8d18-cbe9a033e4b1</Id>
+      <Database Name="cv" Series="28715" Issue="176842" />
     </Book>
     <Book Series="Fall of the Hulks: Alpha" Number="1" Volume="2010" Year="2010">
-      <Id>062e36b5-0231-4d8f-9478-5b50d08dcbe9</Id>
+      <Database Name="cv" Series="30188" Issue="186112" />
     </Book>
     <Book Series="Fall of the Hulks: Gamma" Number="1" Volume="2010" Year="2010">
-      <Id>84cbf3fb-32e6-483f-a755-20862fc4c354</Id>
+      <Database Name="cv" Series="30681" Issue="189503" />
     </Book>
     <Book Series="Incredible Hulk" Number="606" Volume="2009" Year="2010">
-      <Id>6dd584c5-dcd3-49cb-9481-80e74ce8e4f9</Id>
+      <Database Name="cv" Series="24715" Issue="193351" />
     </Book>
     <Book Series="Hulk" Number="19" Volume="2008" Year="2010">
-      <Id>766142ec-f4d2-43db-84e4-bf4c0679ed15</Id>
+      <Database Name="cv" Series="20291" Issue="193347" />
     </Book>
     <Book Series="Fall of the Hulks: Red Hulk" Number="1" Volume="2010" Year="2010">
-      <Id>52f31eb9-b7b1-4d31-b351-f531c8c8de74</Id>
+      <Database Name="cv" Series="31254" Issue="194439" />
     </Book>
     <Book Series="Incredible Hulk" Number="607" Volume="2009" Year="2010">
-      <Id>2413714f-f972-4c50-95bb-f0a92b8ee74e</Id>
+      <Database Name="cv" Series="24715" Issue="197521" />
     </Book>
     <Book Series="Hulk" Number="20" Volume="2008" Year="2010">
-      <Id>c3e43fac-25ae-48bd-babf-62cc1a462226</Id>
+      <Database Name="cv" Series="20291" Issue="197524" />
     </Book>
     <Book Series="Fall of the Hulks: Red Hulk" Number="2" Volume="2010" Year="2010">
-      <Id>893cb520-8ce9-40ae-a7a9-accfb9b3680d</Id>
+      <Database Name="cv" Series="31254" Issue="198372" />
     </Book>
     <Book Series="Fall of the Hulks: The Savage She-Hulks" Number="1" Volume="2010" Year="2010">
-      <Id>55b51039-bda9-4feb-8cb1-c38b9ddf7df5</Id>
+      <Database Name="cv" Series="31734" Issue="198873" />
     </Book>
     <Book Series="Incredible Hulk" Number="608" Volume="2009" Year="2010">
-      <Id>f229549e-f4ef-4032-a029-c55575c9120d</Id>
+      <Database Name="cv" Series="24715" Issue="201038" />
     </Book>
     <Book Series="Hulk" Number="21" Volume="2008" Year="2010">
-      <Id>22caf5e1-e684-4782-b971-3e7dcc9fb41a</Id>
+      <Database Name="cv" Series="20291" Issue="201037" />
     </Book>
     <Book Series="Fall of the Hulks: Red Hulk" Number="3" Volume="2010" Year="2010">
-      <Id>f3978aa2-9d28-4fb5-9cf9-727fec4e71b7</Id>
+      <Database Name="cv" Series="31254" Issue="201886" />
     </Book>
     <Book Series="Fall of the Hulks: The Savage She-Hulks" Number="2" Volume="2010" Year="2010">
-      <Id>38656409-830f-4b8d-933d-b6f23d8a6527</Id>
+      <Database Name="cv" Series="31734" Issue="208680" />
     </Book>
     <Book Series="Fall of the Hulks: Red Hulk" Number="4" Volume="2010" Year="2010">
-      <Id>8297ab43-d50f-44fc-991c-af89cede7be0</Id>
+      <Database Name="cv" Series="31254" Issue="210698" />
     </Book>
     <Book Series="Fall of the Hulks: The Savage She-Hulks" Number="3" Volume="2010" Year="2010">
-      <Id>0e5cd3b4-c208-4bb3-9587-fe85d63148f6</Id>
+      <Database Name="cv" Series="31734" Issue="216204" />
     </Book>
     <Book Series="Skaar: Son of Hulk" Number="1" Volume="2008" Year="2008">
-      <Id>2ed87283-720d-40f6-a037-42f831448a82</Id>
+      <Database Name="cv" Series="21791" Issue="131394" />
     </Book>
     <Book Series="Skaar: Son of Hulk" Number="2" Volume="2008" Year="2008">
-      <Id>1dac5e8c-34bf-4d72-b87d-00b119b0d308</Id>
+      <Database Name="cv" Series="21791" Issue="134596" />
     </Book>
     <Book Series="Skaar: Son of Hulk" Number="3" Volume="2008" Year="2008">
-      <Id>443fd459-7444-461c-a7f0-c598550c198d</Id>
+      <Database Name="cv" Series="21791" Issue="136636" />
     </Book>
     <Book Series="Skaar: Son of Hulk" Number="4" Volume="2008" Year="2008">
-      <Id>1271acab-eefa-47f2-a620-13f1e91804e9</Id>
+      <Database Name="cv" Series="21791" Issue="141326" />
     </Book>
     <Book Series="Skaar: Son of Hulk" Number="5" Volume="2008" Year="2009">
-      <Id>0d8f187a-f9a5-461c-a1cb-c842fa28f09d</Id>
+      <Database Name="cv" Series="21791" Issue="143644" />
     </Book>
     <Book Series="Skaar: Son of Hulk" Number="6" Volume="2008" Year="2009">
-      <Id>6959d592-04ba-4fd2-85f9-58b229124633</Id>
+      <Database Name="cv" Series="21791" Issue="148698" />
     </Book>
     <Book Series="Skaar: Son of Hulk Presents - Savage World of Sakaar" Number="1" Volume="2008" Year="2008">
-      <Id>9685e876-91fc-4f4f-9e59-accd1c11eb8e</Id>
+      <Database Name="cv" Series="23172" Issue="139486" />
     </Book>
     <Book Series="Skaar: Son of Hulk" Number="7" Volume="2008" Year="2009">
-      <Id>784d272e-d20d-4a08-90a5-11a2297d90bd</Id>
+      <Database Name="cv" Series="21791" Issue="150602" />
     </Book>
     <Book Series="Skaar: Son of Hulk" Number="8" Volume="2008" Year="2009">
-      <Id>5b0f8b6f-cb89-4bbf-a99d-30f29c40ff20</Id>
+      <Database Name="cv" Series="21791" Issue="152818" />
     </Book>
     <Book Series="Skaar: Son of Hulk" Number="9" Volume="2008" Year="2009">
-      <Id>1a9de837-1a88-4957-ac5a-84e7ad7f1044</Id>
+      <Database Name="cv" Series="21791" Issue="153976" />
     </Book>
     <Book Series="Skaar: Son of Hulk" Number="10" Volume="2008" Year="2009">
-      <Id>e4f02a47-7bef-49d1-acab-85c813587660</Id>
+      <Database Name="cv" Series="21791" Issue="157593" />
     </Book>
     <Book Series="Skaar: Son of Hulk" Number="11" Volume="2008" Year="2009">
-      <Id>56f88d80-9f54-44f9-bfdf-3fc3760a3af8</Id>
+      <Database Name="cv" Series="21791" Issue="159266" />
     </Book>
     <Book Series="Skaar: Son of Hulk" Number="12" Volume="2008" Year="2009">
-      <Id>ba49e2b3-bd5e-48ad-bab2-a599e8d7bc62</Id>
+      <Database Name="cv" Series="21791" Issue="161763" />
     </Book>
     <Book Series="Hulked-Out Heroes" Number="1" Volume="2010" Year="2010">
-      <Id>8e460827-d34c-4033-9ac0-c0bb9021da1d</Id>
+      <Database Name="cv" Series="32593" Issue="206853" />
     </Book>
     <Book Series="Hulked-Out Heroes" Number="2" Volume="2010" Year="2010">
-      <Id>61083c5f-8221-484d-a83b-cdc1403ed62a</Id>
+      <Database Name="cv" Series="32593" Issue="210889" />
     </Book>
     <Book Series="World War Hulks" Number="1" Volume="2010" Year="2010">
-      <Id>0e146154-c5cd-443c-bca0-3845d586e18d</Id>
+      <Database Name="cv" Series="32449" Issue="204631" />
     </Book>
     <Book Series="Incredible Hulk" Number="609" Volume="2009" Year="2010">
-      <Id>255da2d6-4b2c-45fc-954f-cb34f226ea1c</Id>
+      <Database Name="cv" Series="24715" Issue="213470" />
     </Book>
     <Book Series="Hulk" Number="22" Volume="2008" Year="2010">
-      <Id>b93c7189-510c-4411-adb4-e0c039b670a0</Id>
+      <Database Name="cv" Series="20291" Issue="213441" />
     </Book>
     <Book Series="Incredible Hulk" Number="610" Volume="2009" Year="2010">
-      <Id>67497b25-e783-432d-a088-5de24becb3f2</Id>
+      <Database Name="cv" Series="24715" Issue="219571" />
     </Book>
     <Book Series="Hulk" Number="23" Volume="2008" Year="2010">
-      <Id>1c662cb0-d83c-4727-8ce0-e3d5ae3cc512</Id>
+      <Database Name="cv" Series="20291" Issue="220729" />
     </Book>
     <Book Series="World War Hulks: Captain America vs. Wolverine" Number="1" Volume="2010" Year="2010">
-      <Id>0922cd9c-0ca5-4797-838a-7c8f1661196c</Id>
+      <Database Name="cv" Series="34414" Issue="224633" />
     </Book>
     <Book Series="World War Hulks: Captain America vs. Wolverine" Number="2" Volume="2010" Year="2010">
-      <Id>c7aa8b69-a8bf-410b-9597-00376fb8c015</Id>
+      <Database Name="cv" Series="34414" Issue="227127" />
     </Book>
     <Book Series="World War Hulks: Spider-Man vs. Thor" Number="1" Volume="2010" Year="2010">
-      <Id>3a41b1f9-dc65-4687-84c5-5d3b4a431341</Id>
+      <Database Name="cv" Series="34435" Issue="224825" />
     </Book>
     <Book Series="World War Hulks: Spider-Man vs. Thor" Number="2" Volume="2010" Year="2010">
-      <Id>06883713-153c-4553-aafe-e8921de1c423</Id>
+      <Database Name="cv" Series="34435" Issue="227103" />
     </Book>
     <Book Series="Hulk" Number="24" Volume="2008" Year="2010">
-      <Id>9e489e51-32bc-4569-abaa-4aca05061a5a</Id>
+      <Database Name="cv" Series="20291" Issue="230321" />
     </Book>
     <Book Series="Incredible Hulk" Number="611" Volume="2009" Year="2010">
-      <Id>fc9881f5-e1ee-4d22-b8e4-05a83bae7dc1</Id>
+      <Database Name="cv" Series="24715" Issue="228986" />
     </Book>
     <Book Series="Son of Hulk" Number="13" Volume="2009" Year="2009">
-      <Id>270e4140-8ca9-4381-89d4-e1845f382023</Id>
+      <Database Name="cv" Series="50762" Issue="347248" />
     </Book>
     <Book Series="Son of Hulk" Number="14" Volume="2009" Year="2009">
-      <Id>9727397b-37cc-4ed7-9b34-91a7740ef80c</Id>
+      <Database Name="cv" Series="50762" Issue="347249" />
     </Book>
     <Book Series="Son of Hulk" Number="15" Volume="2009" Year="2009">
-      <Id>24bf5685-b89d-4cd4-bfa8-4cc02b7e7fc5</Id>
+      <Database Name="cv" Series="50762" Issue="347256" />
     </Book>
     <Book Series="Son of Hulk" Number="16" Volume="2009" Year="2009">
-      <Id>6defbf3d-21ae-44e6-a8f3-0dbc537f0d23</Id>
+      <Database Name="cv" Series="50762" Issue="347257" />
     </Book>
     <Book Series="Son of Hulk" Number="17" Volume="2009" Year="2010">
-      <Id>1e1f7347-60a5-47ac-bd94-04f17eb9b9af</Id>
+      <Database Name="cv" Series="50762" Issue="347258" />
     </Book>
     <Book Series="All-New Savage She-Hulk" Number="1" Volume="2009" Year="2009">
-      <Id>e323bae7-839f-4015-a885-1850cefe8643</Id>
+      <Database Name="cv" Series="26151" Issue="155152" />
     </Book>
     <Book Series="All-New Savage She-Hulk" Number="2" Volume="2009" Year="2009">
-      <Id>40ecbeb0-de27-4de9-ad3c-b331be334dac</Id>
+      <Database Name="cv" Series="26151" Issue="157367" />
     </Book>
     <Book Series="All-New Savage She-Hulk" Number="3" Volume="2009" Year="2009">
-      <Id>dbaaaf70-b55f-4f28-8a06-90bcb06052e7</Id>
+      <Database Name="cv" Series="26151" Issue="160413" />
     </Book>
     <Book Series="All-New Savage She-Hulk" Number="4" Volume="2009" Year="2009">
-      <Id>b7fd5315-5710-4def-9bf9-a20dbb5a0e62</Id>
+      <Database Name="cv" Series="26151" Issue="164815" />
     </Book>
     <Book Series="Incredible Hulks" Number="612" Volume="2010" Year="2010">
-      <Id>5c628620-c23f-4912-a99c-22b68ea39387</Id>
+      <Database Name="cv" Series="35303" Issue="232749" />
     </Book>
     <Book Series="Incredible Hulks" Number="613" Volume="2010" Year="2010">
-      <Id>b3bf33f7-7990-425a-bc62-6f0fbba586db</Id>
+      <Database Name="cv" Series="35303" Issue="234681" />
     </Book>
     <Book Series="Incredible Hulks" Number="614" Volume="2010" Year="2010">
-      <Id>c4d13b74-6571-4829-a722-55dcbc224807</Id>
+      <Database Name="cv" Series="35303" Issue="238256" />
     </Book>
     <Book Series="Incredible Hulks" Number="615" Volume="2010" Year="2010">
-      <Id>7aaf48c3-1617-4bbb-8a09-2fb0951c6f05</Id>
+      <Database Name="cv" Series="35303" Issue="239983" />
     </Book>
     <Book Series="Incredible Hulks" Number="616" Volume="2010" Year="2011">
-      <Id>e74d91c8-cde7-44f0-980a-6ae6aafc65ad</Id>
+      <Database Name="cv" Series="35303" Issue="242148" />
     </Book>
     <Book Series="Incredible Hulks" Number="617" Volume="2010" Year="2011">
-      <Id>634deefa-cfb2-48c9-a6ef-bed9d99163ef</Id>
+      <Database Name="cv" Series="35303" Issue="246467" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Incredible Hulk/Incredible Hulk 004.cbl
+++ b/Marvel/Characters/unsorted/Incredible Hulk/Incredible Hulk 004.cbl
@@ -1,363 +1,364 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Incredible Hulk 4</Name>
+  <Name>Incredible Hulk 004</Name>
+  <NumIssues>119</NumIssues>
   <Books>
     <Book Series="Hulk" Number="25" Volume="2008" Year="2010">
-      <Id>b9ea6065-623d-4352-9489-a68573211141</Id>
+      <Database Name="cv" Series="20291" Issue="235401" />
     </Book>
     <Book Series="Hulk" Number="26" Volume="2008" Year="2010">
-      <Id>6e164162-d352-47be-b8a8-7f0e4b56c1ad</Id>
+      <Database Name="cv" Series="20291" Issue="239276" />
     </Book>
     <Book Series="Hulk" Number="27" Volume="2008" Year="2011">
-      <Id>285c5c9b-088e-47d8-808a-d9d2b27456de</Id>
+      <Database Name="cv" Series="20291" Issue="244933" />
     </Book>
     <Book Series="Hulk" Number="28" Volume="2008" Year="2011">
-      <Id>8cc0de10-4074-43e9-85b1-7768256162e7</Id>
+      <Database Name="cv" Series="20291" Issue="253000" />
     </Book>
     <Book Series="Hulk" Number="29" Volume="2008" Year="2011">
-      <Id>a1258809-748d-4982-9d43-54b34ba02c9d</Id>
+      <Database Name="cv" Series="20291" Issue="259999" />
     </Book>
     <Book Series="Hulk" Number="30" Volume="2008" Year="2011">
-      <Id>8e851a19-89e0-4f41-9d1e-2def75d71e0b</Id>
+      <Database Name="cv" Series="20291" Issue="262614" />
     </Book>
     <Book Series="Incredible Hulks" Number="618" Volume="2010" Year="2011">
-      <Id>db29e233-9b30-4b6f-904d-7540edaa399e</Id>
+      <Database Name="cv" Series="35303" Issue="248499" />
     </Book>
     <Book Series="Incredible Hulks" Number="619" Volume="2010" Year="2011">
-      <Id>6bbda978-9604-4299-bf86-2ce2a0a29b98</Id>
+      <Database Name="cv" Series="35303" Issue="250621" />
     </Book>
     <Book Series="Incredible Hulks" Number="620" Volume="2010" Year="2011">
-      <Id>9672a878-5fb3-43a8-955c-db4ae488573b</Id>
+      <Database Name="cv" Series="35303" Issue="255919" />
     </Book>
     <Book Series="Incredible Hulks" Number="621" Volume="2010" Year="2011">
-      <Id>bdb15d72-6a36-49ff-ba72-c6067548befb</Id>
+      <Database Name="cv" Series="35303" Issue="259128" />
     </Book>
     <Book Series="Incredible Hulks" Number="622" Volume="2010" Year="2011">
-      <Id>3292dd39-3a37-4e6e-b4d5-b09390a7bc7c</Id>
+      <Database Name="cv" Series="35303" Issue="261241" />
     </Book>
     <Book Series="Hulk" Number="30.1" Volume="2008" Year="2011">
-      <Id>38b1dd15-06f3-4e71-8d36-4be83a45130e</Id>
+      <Database Name="cv" Series="20291" Issue="266043" />
     </Book>
     <Book Series="Hulk" Number="31" Volume="2008" Year="2011">
-      <Id>881a6e33-473f-4697-af8e-5ec7f8c19f25</Id>
+      <Database Name="cv" Series="20291" Issue="266523" />
     </Book>
     <Book Series="Hulk" Number="32" Volume="2008" Year="2011">
-      <Id>fddb1a9b-f441-4865-a9cd-22649cfe8fb9</Id>
+      <Database Name="cv" Series="20291" Issue="268764" />
     </Book>
     <Book Series="Hulk" Number="33" Volume="2008" Year="2011">
-      <Id>fbe8e948-119e-4fe7-ae89-f57f48e94289</Id>
+      <Database Name="cv" Series="20291" Issue="270463" />
     </Book>
     <Book Series="Hulk" Number="34" Volume="2008" Year="2011">
-      <Id>36087d05-b056-41b4-b891-888144e66d2c</Id>
+      <Database Name="cv" Series="20291" Issue="272434" />
     </Book>
     <Book Series="Hulk" Number="35" Volume="2008" Year="2011">
-      <Id>0004691d-58e2-4654-9086-7ea5cfae9e58</Id>
+      <Database Name="cv" Series="20291" Issue="274549" />
     </Book>
     <Book Series="Hulk" Number="36" Volume="2008" Year="2011">
-      <Id>e3c77c66-4444-4f60-b163-5140533bba8e</Id>
+      <Database Name="cv" Series="20291" Issue="277684" />
     </Book>
     <Book Series="Incredible Hulks" Number="623" Volume="2010" Year="2011">
-      <Id>4a38bae0-20f9-449f-908a-5b44687d9ae2</Id>
+      <Database Name="cv" Series="35303" Issue="263745" />
     </Book>
     <Book Series="Incredible Hulks" Number="624" Volume="2010" Year="2011">
-      <Id>c4572ada-1bae-4437-9c82-d1e12d4c475c</Id>
+      <Database Name="cv" Series="35303" Issue="265513" />
     </Book>
     <Book Series="Incredible Hulks" Number="625" Volume="2010" Year="2011">
-      <Id>45c16e15-5d4e-4ea7-bde4-786fcf2cda6e</Id>
+      <Database Name="cv" Series="35303" Issue="267091" />
     </Book>
     <Book Series="Incredible Hulks" Number="626" Volume="2010" Year="2011">
-      <Id>ddd0c1a0-d20a-4f0b-8b4c-7abcbc83cea2</Id>
+      <Database Name="cv" Series="35303" Issue="268226" />
     </Book>
     <Book Series="Incredible Hulks" Number="627" Volume="2010" Year="2011">
-      <Id>ba9bcb0a-07f5-49e1-97da-595074bde5fe</Id>
+      <Database Name="cv" Series="35303" Issue="269066" />
     </Book>
     <Book Series="Incredible Hulks" Number="628" Volume="2010" Year="2011">
-      <Id>5556557c-7ca5-4796-9957-3f5d0165895e</Id>
+      <Database Name="cv" Series="35303" Issue="269834" />
     </Book>
     <Book Series="Incredible Hulks" Number="629" Volume="2010" Year="2011">
-      <Id>c107d8da-e2a1-4d63-95aa-23a0862cdb5e</Id>
+      <Database Name="cv" Series="35303" Issue="271637" />
     </Book>
     <Book Series="She-Hulks" Number="1" Volume="2011" Year="2011">
-      <Id>73fc8850-95d4-479f-aa3d-335f515fc09d</Id>
+      <Database Name="cv" Series="36561" Issue="242167" />
     </Book>
     <Book Series="She-Hulks" Number="2" Volume="2011" Year="2011">
-      <Id>79d0ea43-cb10-45e5-abd5-ff51574bd4ff</Id>
+      <Database Name="cv" Series="36561" Issue="247312" />
     </Book>
     <Book Series="She-Hulks" Number="3" Volume="2011" Year="2011">
-      <Id>c09d947b-a968-4004-9c67-eb94273fa9cb</Id>
+      <Database Name="cv" Series="36561" Issue="254574" />
     </Book>
     <Book Series="She-Hulks" Number="4" Volume="2011" Year="2011">
-      <Id>1ad05b37-a6aa-408d-80ee-14491cdd326a</Id>
+      <Database Name="cv" Series="36561" Issue="260032" />
     </Book>
     <Book Series="Incredible Hulks" Number="630" Volume="2010" Year="2011">
-      <Id>05f2e550-17c2-4076-8410-dda0a7a6c64e</Id>
+      <Database Name="cv" Series="35303" Issue="273109" />
     </Book>
     <Book Series="Incredible Hulks" Number="631" Volume="2010" Year="2011">
-      <Id>622f370b-934c-4424-8305-c6bd076a4d95</Id>
+      <Database Name="cv" Series="35303" Issue="275809" />
     </Book>
     <Book Series="Incredible Hulks" Number="632" Volume="2010" Year="2011">
-      <Id>89468e14-067a-4392-b0da-94f82d3b598c</Id>
+      <Database Name="cv" Series="35303" Issue="278716" />
     </Book>
     <Book Series="Incredible Hulks" Number="633" Volume="2010" Year="2011">
-      <Id>1a02b555-a477-4e32-84a4-5976c58ad67b</Id>
+      <Database Name="cv" Series="35303" Issue="281834" />
     </Book>
     <Book Series="Incredible Hulks" Number="634" Volume="2010" Year="2011">
-      <Id>fdb36e9a-c95c-440d-b680-b3141c3bc615</Id>
+      <Database Name="cv" Series="35303" Issue="285561" />
     </Book>
     <Book Series="Incredible Hulks" Number="635" Volume="2010" Year="2011">
-      <Id>5e8d607b-a2de-4ee3-b86e-6b45b7201917</Id>
+      <Database Name="cv" Series="35303" Issue="290675" />
     </Book>
     <Book Series="Fear Itself: Hulk vs. Dracula" Number="1" Volume="2011" Year="2011">
-      <Id>a0812dc4-11d5-4962-9ac9-3257fa9e871a</Id>
+      <Database Name="cv" Series="42899" Issue="293095" />
     </Book>
     <Book Series="Fear Itself: Hulk vs. Dracula" Number="2" Volume="2011" Year="2011">
-      <Id>10a50f95-14d9-4d96-92cf-df0e82926e67</Id>
+      <Database Name="cv" Series="42899" Issue="293801" />
     </Book>
     <Book Series="Fear Itself: Hulk vs. Dracula" Number="3" Volume="2011" Year="2011">
-      <Id>206f96a3-5a79-4c39-89d4-43a27ee801c0</Id>
+      <Database Name="cv" Series="42899" Issue="295919" />
     </Book>
     <Book Series="Hulk" Number="37" Volume="2008" Year="2011">
-      <Id>2b79af2d-4afe-4026-94ad-40a116e327f1</Id>
+      <Database Name="cv" Series="20291" Issue="280351" />
     </Book>
     <Book Series="Hulk" Number="38" Volume="2008" Year="2011">
-      <Id>732d7981-64e0-4e27-86a2-421bd121daa1</Id>
+      <Database Name="cv" Series="20291" Issue="283860" />
     </Book>
     <Book Series="Hulk" Number="39" Volume="2008" Year="2011">
-      <Id>ada30568-d5b4-40de-a84a-1d7382c2c8bd</Id>
+      <Database Name="cv" Series="20291" Issue="286964" />
     </Book>
     <Book Series="Hulk" Number="40" Volume="2008" Year="2011">
-      <Id>bb2b8d3c-a5bc-427e-baac-38290be4db12</Id>
+      <Database Name="cv" Series="20291" Issue="291604" />
     </Book>
     <Book Series="Hulk" Number="41" Volume="2008" Year="2011">
-      <Id>7177c465-cc23-4ca7-87ad-3afd9c6a2a06</Id>
+      <Database Name="cv" Series="20291" Issue="293357" />
     </Book>
     <Book Series="Incredible Hulk" Number="1" Volume="2011" Year="2011">
-      <Id>dc6e422f-6a98-4958-a28b-45fd4050919c</Id>
+      <Database Name="cv" Series="43516" Issue="299245" />
     </Book>
     <Book Series="Incredible Hulk" Number="2" Volume="2011" Year="2012">
-      <Id>28a3f374-ab2d-4580-9122-e63cd3c11d14</Id>
+      <Database Name="cv" Series="43516" Issue="301811" />
     </Book>
     <Book Series="Incredible Hulk" Number="3" Volume="2011" Year="2012">
-      <Id>c82420a5-1815-4f38-9fd3-86dbb82ec78e</Id>
+      <Database Name="cv" Series="43516" Issue="307475" />
     </Book>
     <Book Series="Incredible Hulk" Number="4" Volume="2011" Year="2012">
-      <Id>7cd1838b-567c-4c7c-82bd-a115b208ee5d</Id>
+      <Database Name="cv" Series="43516" Issue="310918" />
     </Book>
     <Book Series="Incredible Hulk" Number="5" Volume="2011" Year="2012">
-      <Id>5db14dad-32d1-46d5-acde-00d4cc510ee3</Id>
+      <Database Name="cv" Series="43516" Issue="315103" />
     </Book>
     <Book Series="Incredible Hulk" Number="6" Volume="2011" Year="2012">
-      <Id>35feac24-d330-488c-897f-b75069d8043e</Id>
+      <Database Name="cv" Series="43516" Issue="321308" />
     </Book>
     <Book Series="Incredible Hulk" Number="7" Volume="2011" Year="2012">
-      <Id>b30c73d0-f6d0-4795-9811-099539a5f175</Id>
+      <Database Name="cv" Series="43516" Issue="331860" />
     </Book>
     <Book Series="Avengers: X-Sanction" Number="1" Volume="2012" Year="2012">
-      <Id>c83bc85f-783c-4e16-b7b9-f3d91e435bb9</Id>
+      <Database Name="cv" Series="44477" Issue="306478" />
     </Book>
     <Book Series="Avengers: X-Sanction" Number="2" Volume="2012" Year="2012">
-      <Id>4d4a684b-c77d-4adf-b93e-5d5c55adc17b</Id>
+      <Database Name="cv" Series="44477" Issue="309396" />
     </Book>
     <Book Series="Avengers: X-Sanction" Number="3" Volume="2012" Year="2012">
-      <Id>0550b34e-e235-45b3-81d2-368d0ccd9601</Id>
+      <Database Name="cv" Series="44477" Issue="313883" />
     </Book>
     <Book Series="Avengers: X-Sanction" Number="4" Volume="2012" Year="2012">
-      <Id>04a79481-a1da-4ee9-94f1-c3956688eb01</Id>
+      <Database Name="cv" Series="44477" Issue="322751" />
     </Book>
     <Book Series="Venom" Number="13" Volume="2011" Year="2012">
-      <Id>ad56161f-d8c8-4aeb-b790-7e43dcbe6856</Id>
+      <Database Name="cv" Series="39301" Issue="313844" />
     </Book>
     <Book Series="Venom" Number="13.1" Volume="2011" Year="2012">
-      <Id>16de70ae-2dba-442a-81c0-541a8d9ff0c2</Id>
+      <Database Name="cv" Series="39301" Issue="315124" />
     </Book>
     <Book Series="Venom" Number="13.2" Volume="2011" Year="2012">
-      <Id>9b21806b-bbe2-490e-977d-dd2c29f15b42</Id>
+      <Database Name="cv" Series="39301" Issue="315751" />
     </Book>
     <Book Series="Venom" Number="13.3" Volume="2011" Year="2012">
-      <Id>d391b6cd-6988-49fc-963e-10853eee5fc6</Id>
+      <Database Name="cv" Series="39301" Issue="316684" />
     </Book>
     <Book Series="Venom" Number="13.4" Volume="2011" Year="2012">
-      <Id>f634687d-886a-4230-94c8-731daa0bc6bd</Id>
+      <Database Name="cv" Series="39301" Issue="317938" />
     </Book>
     <Book Series="Venom" Number="14" Volume="2011" Year="2012">
-      <Id>b18aa01a-5661-4c0b-8796-940abcb14093</Id>
+      <Database Name="cv" Series="39301" Issue="319364" />
     </Book>
     <Book Series="Hulk" Number="47" Volume="2008" Year="2012">
-      <Id>b7833b6e-91cf-43ba-a056-1b9bf0fd22ca</Id>
+      <Database Name="cv" Series="20291" Issue="309587" />
     </Book>
     <Book Series="Hulk" Number="48" Volume="2008" Year="2012">
-      <Id>c3a6a1c4-2db4-4e53-ad22-dc8e5fb7ffe0</Id>
+      <Database Name="cv" Series="20291" Issue="313922" />
     </Book>
     <Book Series="Hulk" Number="49" Volume="2008" Year="2012">
-      <Id>d40ded46-2cab-45d8-a57b-34ee0ae194f1</Id>
+      <Database Name="cv" Series="20291" Issue="319375" />
     </Book>
     <Book Series="Hulk" Number="50" Volume="2008" Year="2012">
-      <Id>458daf90-d653-4b48-a6b8-8923227d7833</Id>
+      <Database Name="cv" Series="20291" Issue="326871" />
     </Book>
     <Book Series="Hulk" Number="51" Volume="2008" Year="2012">
-      <Id>9c470b43-e4d1-46c7-85d6-962223a81479</Id>
+      <Database Name="cv" Series="20291" Issue="335250" />
     </Book>
     <Book Series="Hulk" Number="52" Volume="2008" Year="2012">
-      <Id>68dcf6f0-9239-401a-ae60-97d5ccda7abf</Id>
+      <Database Name="cv" Series="20291" Issue="336596" />
     </Book>
     <Book Series="Hulk" Number="53" Volume="2008" Year="2012">
-      <Id>1a73cf8c-45fb-47f2-8c37-cf7cad475d21</Id>
+      <Database Name="cv" Series="20291" Issue="338513" />
     </Book>
     <Book Series="Hulk" Number="54" Volume="2008" Year="2012">
-      <Id>dbaaba39-974e-4229-8c2d-62ff8584e217</Id>
+      <Database Name="cv" Series="20291" Issue="341712" />
     </Book>
     <Book Series="Hulk" Number="55" Volume="2008" Year="2012">
-      <Id>e8ea4a36-60d8-4e49-af1c-c3eb5a879547</Id>
+      <Database Name="cv" Series="20291" Issue="344079" />
     </Book>
     <Book Series="Hulk" Number="56" Volume="2008" Year="2012">
-      <Id>f80b1d0a-f0df-4587-867d-694ed9fc688b</Id>
+      <Database Name="cv" Series="20291" Issue="351086" />
     </Book>
     <Book Series="Hulk" Number="57" Volume="2008" Year="2012">
-      <Id>5107a604-0d2c-4d25-b42d-5e8829307b3d</Id>
+      <Database Name="cv" Series="20291" Issue="354182" />
     </Book>
     <Book Series="Incredible Hulk" Number="7.1" Volume="2011" Year="2012">
-      <Id>a079a434-a9e0-4452-9136-1ac70a93063a</Id>
+      <Database Name="cv" Series="43516" Issue="335917" />
     </Book>
     <Book Series="Incredible Hulk" Number="8" Volume="2011" Year="2012">
-      <Id>5b216122-b0fd-4f46-926a-74dcb9fa2051</Id>
+      <Database Name="cv" Series="43516" Issue="337504" />
     </Book>
     <Book Series="Incredible Hulk" Number="9" Volume="2011" Year="2012">
-      <Id>816131f1-7776-47b9-8be7-a82e8516aed3</Id>
+      <Database Name="cv" Series="43516" Issue="340178" />
     </Book>
     <Book Series="Incredible Hulk" Number="10" Volume="2011" Year="2012">
-      <Id>3c965a1e-3ff2-4a45-8e4c-d81cc676f039</Id>
+      <Database Name="cv" Series="43516" Issue="342846" />
     </Book>
     <Book Series="Incredible Hulk" Number="11" Volume="2011" Year="2012">
-      <Id>fa618261-594d-494e-bd01-de2e51e4fd83</Id>
+      <Database Name="cv" Series="43516" Issue="347207" />
     </Book>
     <Book Series="Incredible Hulk" Number="12" Volume="2011" Year="2012">
-      <Id>c8d8d899-78ec-4be0-a5e9-a342bb347b3d</Id>
+      <Database Name="cv" Series="43516" Issue="349641" />
     </Book>
     <Book Series="Incredible Hulk" Number="13" Volume="2011" Year="2012">
-      <Id>11063e44-b1d8-4383-9448-e4dc716fbca2</Id>
+      <Database Name="cv" Series="43516" Issue="356769" />
     </Book>
     <Book Series="Incredible Hulk" Number="14" Volume="2011" Year="2012">
-      <Id>fc143076-21f0-41bf-9787-7bfe995777c9</Id>
+      <Database Name="cv" Series="43516" Issue="358955" />
     </Book>
     <Book Series="Incredible Hulk" Number="15" Volume="2011" Year="2012">
-      <Id>73b1c621-3d71-42f3-a655-9a5e1251f76a</Id>
+      <Database Name="cv" Series="43516" Issue="363079" />
     </Book>
     <Book Series="Hulk Smash Avengers" Number="1" Volume="2012" Year="2012">
-      <Id>e007b590-5dfd-4050-adc6-462bec1071e6</Id>
+      <Database Name="cv" Series="48554" Issue="334323" />
     </Book>
     <Book Series="Hulk Smash Avengers" Number="2" Volume="2012" Year="2012">
-      <Id>e66ef5de-9c0b-47b0-80b6-35932bf62b8e</Id>
+      <Database Name="cv" Series="48554" Issue="335251" />
     </Book>
     <Book Series="Hulk Smash Avengers" Number="3" Volume="2012" Year="2012">
-      <Id>3bb5931e-18db-471d-8edc-ffc79e4cb5c9</Id>
+      <Database Name="cv" Series="48554" Issue="335950" />
     </Book>
     <Book Series="Hulk Smash Avengers" Number="4" Volume="2012" Year="2012">
-      <Id>b91c238b-2f4d-4ae6-9b25-0cf827c2abf5</Id>
+      <Database Name="cv" Series="48554" Issue="336599" />
     </Book>
     <Book Series="Hulk Smash Avengers" Number="5" Volume="2012" Year="2012">
-      <Id>b15ea4f0-7e30-4484-af92-6da91a849619</Id>
+      <Database Name="cv" Series="48554" Issue="337508" />
     </Book>
-    <Book Series="Indestructible Hulk" Number="1" Volume="2012" Year="2012">
-      <Id>d8c29058-2eff-4bff-ab49-867fcf18833e</Id>
+    <Book Series="Indestructible Hulk" Number="1" Volume="2012" Year="2013">
+      <Database Name="cv" Series="54112" Issue="369012" />
     </Book>
-    <Book Series="Indestructible Hulk" Number="2" Volume="2012" Year="2012">
-      <Id>3902f4d5-1b26-4688-a793-bff7b24acfa7</Id>
+    <Book Series="Indestructible Hulk" Number="2" Volume="2012" Year="2013">
+      <Database Name="cv" Series="54112" Issue="373303" />
     </Book>
     <Book Series="Indestructible Hulk" Number="3" Volume="2012" Year="2013">
-      <Id>b793d6a3-e913-4f96-96ae-4cb98a7f0102</Id>
+      <Database Name="cv" Series="54112" Issue="380354" />
     </Book>
     <Book Series="Indestructible Hulk" Number="4" Volume="2012" Year="2013">
-      <Id>4736bc66-f0d6-4695-81b9-0ee4d6b32af0</Id>
+      <Database Name="cv" Series="54112" Issue="387258" />
     </Book>
     <Book Series="Indestructible Hulk" Number="5" Volume="2012" Year="2013">
-      <Id>ad00ee5f-9fcc-4a75-8876-013c3964ffa9</Id>
+      <Database Name="cv" Series="54112" Issue="394708" />
     </Book>
     <Book Series="Red She-Hulk" Number="58" Volume="2012" Year="2012">
-      <Id>e56aeb9c-4249-41bf-9746-865e489dad18</Id>
+      <Database Name="cv" Series="52884" Issue="360902" />
     </Book>
     <Book Series="Red She-Hulk" Number="59" Volume="2012" Year="2013">
-      <Id>892254c6-88aa-4e06-9217-0f8755227187</Id>
+      <Database Name="cv" Series="52884" Issue="367784" />
     </Book>
     <Book Series="Red She-Hulk" Number="60" Volume="2012" Year="2013">
-      <Id>73eee3e1-1c24-4747-bd83-f150ec9e5943</Id>
+      <Database Name="cv" Series="52884" Issue="371259" />
     </Book>
     <Book Series="Red She-Hulk" Number="61" Volume="2012" Year="2013">
-      <Id>8c5286ee-de3c-4ad4-b3ee-a9231eaed5c8</Id>
+      <Database Name="cv" Series="52884" Issue="376660" />
     </Book>
     <Book Series="Red She-Hulk" Number="62" Volume="2012" Year="2013">
-      <Id>780ecbcf-81eb-4240-84d8-3d4e544bb486</Id>
+      <Database Name="cv" Series="52884" Issue="384961" />
     </Book>
     <Book Series="Red She-Hulk" Number="63" Volume="2012" Year="2013">
-      <Id>e213028a-c9a7-4f65-92c9-16a2af3d9dce</Id>
+      <Database Name="cv" Series="52884" Issue="390451" />
     </Book>
     <Book Series="Red She-Hulk" Number="64" Volume="2012" Year="2013">
-      <Id>15490f0e-805b-419c-acde-ffb729e04028</Id>
+      <Database Name="cv" Series="52884" Issue="395703" />
     </Book>
     <Book Series="Red She-Hulk" Number="65" Volume="2012" Year="2013">
-      <Id>8187cf6d-dc86-47aa-a384-597a9e2852db</Id>
+      <Database Name="cv" Series="52884" Issue="400151" />
     </Book>
     <Book Series="Red She-Hulk" Number="66" Volume="2012" Year="2013">
-      <Id>1c0fabe4-30e8-4980-b7ae-459d5e48ac0e</Id>
+      <Database Name="cv" Series="52884" Issue="408998" />
     </Book>
     <Book Series="Red She-Hulk" Number="67" Volume="2012" Year="2013">
-      <Id>54ac5670-65b8-4011-87f4-ac8c023d7665</Id>
+      <Database Name="cv" Series="52884" Issue="415240" />
     </Book>
     <Book Series="Indestructible Hulk" Number="6" Volume="2012" Year="2013">
-      <Id>944c0b2d-0d75-41c8-8fa3-be8fab660721</Id>
+      <Database Name="cv" Series="54112" Issue="395702" />
     </Book>
     <Book Series="Indestructible Hulk" Number="7" Volume="2012" Year="2013">
-      <Id>aec564f2-a425-42eb-8e98-c92f316c568a</Id>
+      <Database Name="cv" Series="54112" Issue="400147" />
     </Book>
     <Book Series="Indestructible Hulk" Number="8" Volume="2012" Year="2013">
-      <Id>97b66057-3caa-4459-aafd-5a78631496e1</Id>
+      <Database Name="cv" Series="54112" Issue="406975" />
     </Book>
     <Book Series="Indestructible Hulk" Number="9" Volume="2012" Year="2013">
-      <Id>6457dd24-ecb2-4a93-b8a8-dcd0f9156574</Id>
+      <Database Name="cv" Series="54112" Issue="411829" />
     </Book>
     <Book Series="Indestructible Hulk" Number="10" Volume="2012" Year="2013">
-      <Id>547fb0c5-70a6-4bd5-ab56-1afbfa533b9c</Id>
+      <Database Name="cv" Series="54112" Issue="416944" />
     </Book>
     <Book Series="Indestructible Hulk" Number="11" Volume="2012" Year="2013">
-      <Id>1a5a80f7-d1af-4ef8-a90b-175401d9b0a4</Id>
+      <Database Name="cv" Series="54112" Issue="419970" />
     </Book>
     <Book Series="Indestructible Hulk" Number="12" Volume="2012" Year="2013">
-      <Id>1458bdc8-a94f-4a85-ae83-a01b3a29d653</Id>
+      <Database Name="cv" Series="54112" Issue="422498" />
     </Book>
     <Book Series="Indestructible Hulk" Number="13" Volume="2012" Year="2013">
-      <Id>1b34c803-0621-4f9e-8afe-8549b03d1560</Id>
+      <Database Name="cv" Series="54112" Issue="425028" />
     </Book>
     <Book Series="Indestructible Hulk" Number="14" Volume="2012" Year="2013">
-      <Id>535ff481-67e9-4de9-a9bb-04620c412777</Id>
+      <Database Name="cv" Series="54112" Issue="430754" />
     </Book>
     <Book Series="Indestructible Hulk" Number="15" Volume="2012" Year="2014">
-      <Id>a919ccf9-a929-4d40-977c-41204c345816</Id>
+      <Database Name="cv" Series="54112" Issue="433846" />
     </Book>
     <Book Series="Indestructible Hulk Special" Number="1" Volume="2013" Year="2013">
-      <Id>eb738a1d-ad79-42db-b9d1-1d15d8bfab91</Id>
+      <Database Name="cv" Series="68320" Issue="428862" />
     </Book>
     <Book Series="Indestructible Hulk Annual" Number="1" Volume="2013" Year="2014">
-      <Id>b1992c60-824f-45d9-bd07-76c982754ed2</Id>
+      <Database Name="cv" Series="69687" Issue="435582" />
     </Book>
     <Book Series="Indestructible Hulk" Number="16" Volume="2012" Year="2014">
-      <Id>1704b687-5f08-4f45-afd4-70855817f51e</Id>
+      <Database Name="cv" Series="54112" Issue="435054" />
     </Book>
     <Book Series="Indestructible Hulk" Number="17" Volume="2012" Year="2014">
-      <Id>dde8e390-c3c5-4329-a028-e79f7a78a4db</Id>
+      <Database Name="cv" Series="54112" Issue="437491" />
     </Book>
     <Book Series="Indestructible Hulk" Number="18" Volume="2012" Year="2014">
-      <Id>85a1081b-68c3-4c2f-964a-e71401d04417</Id>
+      <Database Name="cv" Series="54112" Issue="442922" />
     </Book>
     <Book Series="Indestructible Hulk" Number="19" Volume="2012" Year="2014">
-      <Id>4ae7c7a1-de32-4b19-b993-a9a7f5d8b1c6</Id>
+      <Database Name="cv" Series="54112" Issue="446484" />
     </Book>
     <Book Series="Indestructible Hulk" Number="20" Volume="2012" Year="2014">
-      <Id>123c5096-a7ce-4e5e-8724-285dbe2fa91b</Id>
+      <Database Name="cv" Series="54112" Issue="448969" />
     </Book>
     <Book Series="Hulk" Number="1" Volume="2014" Year="2014">
-      <Id>1e1fd701-3dc2-4228-853f-dc5f010f13e7</Id>
+      <Database Name="cv" Series="73100" Issue="450551" />
     </Book>
     <Book Series="Hulk" Number="2" Volume="2014" Year="2014">
-      <Id>b6e05c14-8f78-4e30-8444-109bd4bdd04a</Id>
+      <Database Name="cv" Series="73100" Issue="451769" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Incredible Hulk/Incredible Hulk 004.cbl
+++ b/Marvel/Characters/unsorted/Incredible Hulk/Incredible Hulk 004.cbl
@@ -2,361 +2,361 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Incredible Hulk 4</Name>
   <Books>
-    <Book Series="Hulk" Number="25" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="Hulk" Number="25" Volume="2008" Year="2010">
       <Id>b9ea6065-623d-4352-9489-a68573211141</Id>
     </Book>
-    <Book Series="Hulk" Number="26" Volume="2008" Year="2010" Format="Main Series">
+    <Book Series="Hulk" Number="26" Volume="2008" Year="2010">
       <Id>6e164162-d352-47be-b8a8-7f0e4b56c1ad</Id>
     </Book>
-    <Book Series="Hulk" Number="27" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="Hulk" Number="27" Volume="2008" Year="2011">
       <Id>285c5c9b-088e-47d8-808a-d9d2b27456de</Id>
     </Book>
-    <Book Series="Hulk" Number="28" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="Hulk" Number="28" Volume="2008" Year="2011">
       <Id>8cc0de10-4074-43e9-85b1-7768256162e7</Id>
     </Book>
-    <Book Series="Hulk" Number="29" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="Hulk" Number="29" Volume="2008" Year="2011">
       <Id>a1258809-748d-4982-9d43-54b34ba02c9d</Id>
     </Book>
-    <Book Series="Hulk" Number="30" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="Hulk" Number="30" Volume="2008" Year="2011">
       <Id>8e851a19-89e0-4f41-9d1e-2def75d71e0b</Id>
     </Book>
-    <Book Series="Incredible Hulks" Number="618" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Incredible Hulks" Number="618" Volume="2010" Year="2011">
       <Id>db29e233-9b30-4b6f-904d-7540edaa399e</Id>
     </Book>
-    <Book Series="Incredible Hulks" Number="619" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Incredible Hulks" Number="619" Volume="2010" Year="2011">
       <Id>6bbda978-9604-4299-bf86-2ce2a0a29b98</Id>
     </Book>
-    <Book Series="Incredible Hulks" Number="620" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Incredible Hulks" Number="620" Volume="2010" Year="2011">
       <Id>9672a878-5fb3-43a8-955c-db4ae488573b</Id>
     </Book>
-    <Book Series="Incredible Hulks" Number="621" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Incredible Hulks" Number="621" Volume="2010" Year="2011">
       <Id>bdb15d72-6a36-49ff-ba72-c6067548befb</Id>
     </Book>
-    <Book Series="Incredible Hulks" Number="622" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Incredible Hulks" Number="622" Volume="2010" Year="2011">
       <Id>3292dd39-3a37-4e6e-b4d5-b09390a7bc7c</Id>
     </Book>
-    <Book Series="Hulk" Number="30.1" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="Hulk" Number="30.1" Volume="2008" Year="2011">
       <Id>38b1dd15-06f3-4e71-8d36-4be83a45130e</Id>
     </Book>
-    <Book Series="Hulk" Number="31" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="Hulk" Number="31" Volume="2008" Year="2011">
       <Id>881a6e33-473f-4697-af8e-5ec7f8c19f25</Id>
     </Book>
-    <Book Series="Hulk" Number="32" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="Hulk" Number="32" Volume="2008" Year="2011">
       <Id>fddb1a9b-f441-4865-a9cd-22649cfe8fb9</Id>
     </Book>
-    <Book Series="Hulk" Number="33" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="Hulk" Number="33" Volume="2008" Year="2011">
       <Id>fbe8e948-119e-4fe7-ae89-f57f48e94289</Id>
     </Book>
-    <Book Series="Hulk" Number="34" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="Hulk" Number="34" Volume="2008" Year="2011">
       <Id>36087d05-b056-41b4-b891-888144e66d2c</Id>
     </Book>
-    <Book Series="Hulk" Number="35" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="Hulk" Number="35" Volume="2008" Year="2011">
       <Id>0004691d-58e2-4654-9086-7ea5cfae9e58</Id>
     </Book>
-    <Book Series="Hulk" Number="36" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="Hulk" Number="36" Volume="2008" Year="2011">
       <Id>e3c77c66-4444-4f60-b163-5140533bba8e</Id>
     </Book>
-    <Book Series="Incredible Hulks" Number="623" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Incredible Hulks" Number="623" Volume="2010" Year="2011">
       <Id>4a38bae0-20f9-449f-908a-5b44687d9ae2</Id>
     </Book>
-    <Book Series="Incredible Hulks" Number="624" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Incredible Hulks" Number="624" Volume="2010" Year="2011">
       <Id>c4572ada-1bae-4437-9c82-d1e12d4c475c</Id>
     </Book>
-    <Book Series="Incredible Hulks" Number="625" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Incredible Hulks" Number="625" Volume="2010" Year="2011">
       <Id>45c16e15-5d4e-4ea7-bde4-786fcf2cda6e</Id>
     </Book>
-    <Book Series="Incredible Hulks" Number="626" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Incredible Hulks" Number="626" Volume="2010" Year="2011">
       <Id>ddd0c1a0-d20a-4f0b-8b4c-7abcbc83cea2</Id>
     </Book>
-    <Book Series="Incredible Hulks" Number="627" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Incredible Hulks" Number="627" Volume="2010" Year="2011">
       <Id>ba9bcb0a-07f5-49e1-97da-595074bde5fe</Id>
     </Book>
-    <Book Series="Incredible Hulks" Number="628" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Incredible Hulks" Number="628" Volume="2010" Year="2011">
       <Id>5556557c-7ca5-4796-9957-3f5d0165895e</Id>
     </Book>
-    <Book Series="Incredible Hulks" Number="629" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Incredible Hulks" Number="629" Volume="2010" Year="2011">
       <Id>c107d8da-e2a1-4d63-95aa-23a0862cdb5e</Id>
     </Book>
-    <Book Series="She-Hulks" Number="1" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="She-Hulks" Number="1" Volume="2011" Year="2011">
       <Id>73fc8850-95d4-479f-aa3d-335f515fc09d</Id>
     </Book>
-    <Book Series="She-Hulks" Number="2" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="She-Hulks" Number="2" Volume="2011" Year="2011">
       <Id>79d0ea43-cb10-45e5-abd5-ff51574bd4ff</Id>
     </Book>
-    <Book Series="She-Hulks" Number="3" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="She-Hulks" Number="3" Volume="2011" Year="2011">
       <Id>c09d947b-a968-4004-9c67-eb94273fa9cb</Id>
     </Book>
-    <Book Series="She-Hulks" Number="4" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="She-Hulks" Number="4" Volume="2011" Year="2011">
       <Id>1ad05b37-a6aa-408d-80ee-14491cdd326a</Id>
     </Book>
-    <Book Series="Incredible Hulks" Number="630" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Incredible Hulks" Number="630" Volume="2010" Year="2011">
       <Id>05f2e550-17c2-4076-8410-dda0a7a6c64e</Id>
     </Book>
-    <Book Series="Incredible Hulks" Number="631" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Incredible Hulks" Number="631" Volume="2010" Year="2011">
       <Id>622f370b-934c-4424-8305-c6bd076a4d95</Id>
     </Book>
-    <Book Series="Incredible Hulks" Number="632" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Incredible Hulks" Number="632" Volume="2010" Year="2011">
       <Id>89468e14-067a-4392-b0da-94f82d3b598c</Id>
     </Book>
-    <Book Series="Incredible Hulks" Number="633" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Incredible Hulks" Number="633" Volume="2010" Year="2011">
       <Id>1a02b555-a477-4e32-84a4-5976c58ad67b</Id>
     </Book>
-    <Book Series="Incredible Hulks" Number="634" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Incredible Hulks" Number="634" Volume="2010" Year="2011">
       <Id>fdb36e9a-c95c-440d-b680-b3141c3bc615</Id>
     </Book>
-    <Book Series="Incredible Hulks" Number="635" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Incredible Hulks" Number="635" Volume="2010" Year="2011">
       <Id>5e8d607b-a2de-4ee3-b86e-6b45b7201917</Id>
     </Book>
-    <Book Series="Fear Itself: Hulk vs. Dracula" Number="1" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Fear Itself: Hulk vs. Dracula" Number="1" Volume="2011" Year="2011">
       <Id>a0812dc4-11d5-4962-9ac9-3257fa9e871a</Id>
     </Book>
-    <Book Series="Fear Itself: Hulk vs. Dracula" Number="2" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Fear Itself: Hulk vs. Dracula" Number="2" Volume="2011" Year="2011">
       <Id>10a50f95-14d9-4d96-92cf-df0e82926e67</Id>
     </Book>
-    <Book Series="Fear Itself: Hulk vs. Dracula" Number="3" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Fear Itself: Hulk vs. Dracula" Number="3" Volume="2011" Year="2011">
       <Id>206f96a3-5a79-4c39-89d4-43a27ee801c0</Id>
     </Book>
-    <Book Series="Hulk" Number="37" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="Hulk" Number="37" Volume="2008" Year="2011">
       <Id>2b79af2d-4afe-4026-94ad-40a116e327f1</Id>
     </Book>
-    <Book Series="Hulk" Number="38" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="Hulk" Number="38" Volume="2008" Year="2011">
       <Id>732d7981-64e0-4e27-86a2-421bd121daa1</Id>
     </Book>
-    <Book Series="Hulk" Number="39" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="Hulk" Number="39" Volume="2008" Year="2011">
       <Id>ada30568-d5b4-40de-a84a-1d7382c2c8bd</Id>
     </Book>
-    <Book Series="Hulk" Number="40" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="Hulk" Number="40" Volume="2008" Year="2011">
       <Id>bb2b8d3c-a5bc-427e-baac-38290be4db12</Id>
     </Book>
-    <Book Series="Hulk" Number="41" Volume="2008" Year="2011" Format="Main Series">
+    <Book Series="Hulk" Number="41" Volume="2008" Year="2011">
       <Id>7177c465-cc23-4ca7-87ad-3afd9c6a2a06</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="1" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="1" Volume="2011" Year="2011">
       <Id>dc6e422f-6a98-4958-a28b-45fd4050919c</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="2" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="2" Volume="2011" Year="2012">
       <Id>28a3f374-ab2d-4580-9122-e63cd3c11d14</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="3" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="3" Volume="2011" Year="2012">
       <Id>c82420a5-1815-4f38-9fd3-86dbb82ec78e</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="4" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="4" Volume="2011" Year="2012">
       <Id>7cd1838b-567c-4c7c-82bd-a115b208ee5d</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="5" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="5" Volume="2011" Year="2012">
       <Id>5db14dad-32d1-46d5-acde-00d4cc510ee3</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="6" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="6" Volume="2011" Year="2012">
       <Id>35feac24-d330-488c-897f-b75069d8043e</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="7" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="7" Volume="2011" Year="2012">
       <Id>b30c73d0-f6d0-4795-9811-099539a5f175</Id>
     </Book>
-    <Book Series="Avengers: X-Sanction" Number="1" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Avengers: X-Sanction" Number="1" Volume="2012" Year="2012">
       <Id>c83bc85f-783c-4e16-b7b9-f3d91e435bb9</Id>
     </Book>
-    <Book Series="Avengers: X-Sanction" Number="2" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Avengers: X-Sanction" Number="2" Volume="2012" Year="2012">
       <Id>4d4a684b-c77d-4adf-b93e-5d5c55adc17b</Id>
     </Book>
-    <Book Series="Avengers: X-Sanction" Number="3" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Avengers: X-Sanction" Number="3" Volume="2012" Year="2012">
       <Id>0550b34e-e235-45b3-81d2-368d0ccd9601</Id>
     </Book>
-    <Book Series="Avengers: X-Sanction" Number="4" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Avengers: X-Sanction" Number="4" Volume="2012" Year="2012">
       <Id>04a79481-a1da-4ee9-94f1-c3956688eb01</Id>
     </Book>
-    <Book Series="Venom" Number="13" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Venom" Number="13" Volume="2011" Year="2012">
       <Id>ad56161f-d8c8-4aeb-b790-7e43dcbe6856</Id>
     </Book>
-    <Book Series="Venom" Number="13.1" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Venom" Number="13.1" Volume="2011" Year="2012">
       <Id>16de70ae-2dba-442a-81c0-541a8d9ff0c2</Id>
     </Book>
-    <Book Series="Venom" Number="13.2" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Venom" Number="13.2" Volume="2011" Year="2012">
       <Id>9b21806b-bbe2-490e-977d-dd2c29f15b42</Id>
     </Book>
-    <Book Series="Venom" Number="13.3" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Venom" Number="13.3" Volume="2011" Year="2012">
       <Id>d391b6cd-6988-49fc-963e-10853eee5fc6</Id>
     </Book>
-    <Book Series="Venom" Number="13.4" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Venom" Number="13.4" Volume="2011" Year="2012">
       <Id>f634687d-886a-4230-94c8-731daa0bc6bd</Id>
     </Book>
-    <Book Series="Venom" Number="14" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Venom" Number="14" Volume="2011" Year="2012">
       <Id>b18aa01a-5661-4c0b-8796-940abcb14093</Id>
     </Book>
-    <Book Series="Hulk" Number="47" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="Hulk" Number="47" Volume="2008" Year="2012">
       <Id>b7833b6e-91cf-43ba-a056-1b9bf0fd22ca</Id>
     </Book>
-    <Book Series="Hulk" Number="48" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="Hulk" Number="48" Volume="2008" Year="2012">
       <Id>c3a6a1c4-2db4-4e53-ad22-dc8e5fb7ffe0</Id>
     </Book>
-    <Book Series="Hulk" Number="49" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="Hulk" Number="49" Volume="2008" Year="2012">
       <Id>d40ded46-2cab-45d8-a57b-34ee0ae194f1</Id>
     </Book>
-    <Book Series="Hulk" Number="50" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="Hulk" Number="50" Volume="2008" Year="2012">
       <Id>458daf90-d653-4b48-a6b8-8923227d7833</Id>
     </Book>
-    <Book Series="Hulk" Number="51" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="Hulk" Number="51" Volume="2008" Year="2012">
       <Id>9c470b43-e4d1-46c7-85d6-962223a81479</Id>
     </Book>
-    <Book Series="Hulk" Number="52" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="Hulk" Number="52" Volume="2008" Year="2012">
       <Id>68dcf6f0-9239-401a-ae60-97d5ccda7abf</Id>
     </Book>
-    <Book Series="Hulk" Number="53" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="Hulk" Number="53" Volume="2008" Year="2012">
       <Id>1a73cf8c-45fb-47f2-8c37-cf7cad475d21</Id>
     </Book>
-    <Book Series="Hulk" Number="54" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="Hulk" Number="54" Volume="2008" Year="2012">
       <Id>dbaaba39-974e-4229-8c2d-62ff8584e217</Id>
     </Book>
-    <Book Series="Hulk" Number="55" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="Hulk" Number="55" Volume="2008" Year="2012">
       <Id>e8ea4a36-60d8-4e49-af1c-c3eb5a879547</Id>
     </Book>
-    <Book Series="Hulk" Number="56" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="Hulk" Number="56" Volume="2008" Year="2012">
       <Id>f80b1d0a-f0df-4587-867d-694ed9fc688b</Id>
     </Book>
-    <Book Series="Hulk" Number="57" Volume="2008" Year="2012" Format="Main Series">
+    <Book Series="Hulk" Number="57" Volume="2008" Year="2012">
       <Id>5107a604-0d2c-4d25-b42d-5e8829307b3d</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="7.1" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="7.1" Volume="2011" Year="2012">
       <Id>a079a434-a9e0-4452-9136-1ac70a93063a</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="8" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="8" Volume="2011" Year="2012">
       <Id>5b216122-b0fd-4f46-926a-74dcb9fa2051</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="9" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="9" Volume="2011" Year="2012">
       <Id>816131f1-7776-47b9-8be7-a82e8516aed3</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="10" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="10" Volume="2011" Year="2012">
       <Id>3c965a1e-3ff2-4a45-8e4c-d81cc676f039</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="11" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="11" Volume="2011" Year="2012">
       <Id>fa618261-594d-494e-bd01-de2e51e4fd83</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="12" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="12" Volume="2011" Year="2012">
       <Id>c8d8d899-78ec-4be0-a5e9-a342bb347b3d</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="13" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="13" Volume="2011" Year="2012">
       <Id>11063e44-b1d8-4383-9448-e4dc716fbca2</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="14" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="14" Volume="2011" Year="2012">
       <Id>fc143076-21f0-41bf-9787-7bfe995777c9</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="15" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="15" Volume="2011" Year="2012">
       <Id>73b1c621-3d71-42f3-a655-9a5e1251f76a</Id>
     </Book>
-    <Book Series="Hulk Smash Avengers" Number="1" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Hulk Smash Avengers" Number="1" Volume="2012" Year="2012">
       <Id>e007b590-5dfd-4050-adc6-462bec1071e6</Id>
     </Book>
-    <Book Series="Hulk Smash Avengers" Number="2" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Hulk Smash Avengers" Number="2" Volume="2012" Year="2012">
       <Id>e66ef5de-9c0b-47b0-80b6-35932bf62b8e</Id>
     </Book>
-    <Book Series="Hulk Smash Avengers" Number="3" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Hulk Smash Avengers" Number="3" Volume="2012" Year="2012">
       <Id>3bb5931e-18db-471d-8edc-ffc79e4cb5c9</Id>
     </Book>
-    <Book Series="Hulk Smash Avengers" Number="4" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Hulk Smash Avengers" Number="4" Volume="2012" Year="2012">
       <Id>b91c238b-2f4d-4ae6-9b25-0cf827c2abf5</Id>
     </Book>
-    <Book Series="Hulk Smash Avengers" Number="5" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Hulk Smash Avengers" Number="5" Volume="2012" Year="2012">
       <Id>b15ea4f0-7e30-4484-af92-6da91a849619</Id>
     </Book>
-    <Book Series="Indestructible Hulk" Number="1" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Indestructible Hulk" Number="1" Volume="2012" Year="2012">
       <Id>d8c29058-2eff-4bff-ab49-867fcf18833e</Id>
     </Book>
-    <Book Series="Indestructible Hulk" Number="2" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Indestructible Hulk" Number="2" Volume="2012" Year="2012">
       <Id>3902f4d5-1b26-4688-a793-bff7b24acfa7</Id>
     </Book>
-    <Book Series="Indestructible Hulk" Number="3" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Indestructible Hulk" Number="3" Volume="2012" Year="2013">
       <Id>b793d6a3-e913-4f96-96ae-4cb98a7f0102</Id>
     </Book>
-    <Book Series="Indestructible Hulk" Number="4" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Indestructible Hulk" Number="4" Volume="2012" Year="2013">
       <Id>4736bc66-f0d6-4695-81b9-0ee4d6b32af0</Id>
     </Book>
-    <Book Series="Indestructible Hulk" Number="5" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Indestructible Hulk" Number="5" Volume="2012" Year="2013">
       <Id>ad00ee5f-9fcc-4a75-8876-013c3964ffa9</Id>
     </Book>
-    <Book Series="Red She-Hulk" Number="58" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Red She-Hulk" Number="58" Volume="2012" Year="2012">
       <Id>e56aeb9c-4249-41bf-9746-865e489dad18</Id>
     </Book>
-    <Book Series="Red She-Hulk" Number="59" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Red She-Hulk" Number="59" Volume="2012" Year="2013">
       <Id>892254c6-88aa-4e06-9217-0f8755227187</Id>
     </Book>
-    <Book Series="Red She-Hulk" Number="60" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Red She-Hulk" Number="60" Volume="2012" Year="2013">
       <Id>73eee3e1-1c24-4747-bd83-f150ec9e5943</Id>
     </Book>
-    <Book Series="Red She-Hulk" Number="61" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Red She-Hulk" Number="61" Volume="2012" Year="2013">
       <Id>8c5286ee-de3c-4ad4-b3ee-a9231eaed5c8</Id>
     </Book>
-    <Book Series="Red She-Hulk" Number="62" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Red She-Hulk" Number="62" Volume="2012" Year="2013">
       <Id>780ecbcf-81eb-4240-84d8-3d4e544bb486</Id>
     </Book>
-    <Book Series="Red She-Hulk" Number="63" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Red She-Hulk" Number="63" Volume="2012" Year="2013">
       <Id>e213028a-c9a7-4f65-92c9-16a2af3d9dce</Id>
     </Book>
-    <Book Series="Red She-Hulk" Number="64" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Red She-Hulk" Number="64" Volume="2012" Year="2013">
       <Id>15490f0e-805b-419c-acde-ffb729e04028</Id>
     </Book>
-    <Book Series="Red She-Hulk" Number="65" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Red She-Hulk" Number="65" Volume="2012" Year="2013">
       <Id>8187cf6d-dc86-47aa-a384-597a9e2852db</Id>
     </Book>
-    <Book Series="Red She-Hulk" Number="66" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Red She-Hulk" Number="66" Volume="2012" Year="2013">
       <Id>1c0fabe4-30e8-4980-b7ae-459d5e48ac0e</Id>
     </Book>
-    <Book Series="Red She-Hulk" Number="67" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Red She-Hulk" Number="67" Volume="2012" Year="2013">
       <Id>54ac5670-65b8-4011-87f4-ac8c023d7665</Id>
     </Book>
-    <Book Series="Indestructible Hulk" Number="6" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Indestructible Hulk" Number="6" Volume="2012" Year="2013">
       <Id>944c0b2d-0d75-41c8-8fa3-be8fab660721</Id>
     </Book>
-    <Book Series="Indestructible Hulk" Number="7" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Indestructible Hulk" Number="7" Volume="2012" Year="2013">
       <Id>aec564f2-a425-42eb-8e98-c92f316c568a</Id>
     </Book>
-    <Book Series="Indestructible Hulk" Number="8" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Indestructible Hulk" Number="8" Volume="2012" Year="2013">
       <Id>97b66057-3caa-4459-aafd-5a78631496e1</Id>
     </Book>
-    <Book Series="Indestructible Hulk" Number="9" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Indestructible Hulk" Number="9" Volume="2012" Year="2013">
       <Id>6457dd24-ecb2-4a93-b8a8-dcd0f9156574</Id>
     </Book>
-    <Book Series="Indestructible Hulk" Number="10" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Indestructible Hulk" Number="10" Volume="2012" Year="2013">
       <Id>547fb0c5-70a6-4bd5-ab56-1afbfa533b9c</Id>
     </Book>
-    <Book Series="Indestructible Hulk" Number="11" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Indestructible Hulk" Number="11" Volume="2012" Year="2013">
       <Id>1a5a80f7-d1af-4ef8-a90b-175401d9b0a4</Id>
     </Book>
-    <Book Series="Indestructible Hulk" Number="12" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Indestructible Hulk" Number="12" Volume="2012" Year="2013">
       <Id>1458bdc8-a94f-4a85-ae83-a01b3a29d653</Id>
     </Book>
-    <Book Series="Indestructible Hulk" Number="13" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Indestructible Hulk" Number="13" Volume="2012" Year="2013">
       <Id>1b34c803-0621-4f9e-8afe-8549b03d1560</Id>
     </Book>
-    <Book Series="Indestructible Hulk" Number="14" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Indestructible Hulk" Number="14" Volume="2012" Year="2013">
       <Id>535ff481-67e9-4de9-a9bb-04620c412777</Id>
     </Book>
-    <Book Series="Indestructible Hulk" Number="15" Volume="2012" Year="2014" Format="Main Series">
+    <Book Series="Indestructible Hulk" Number="15" Volume="2012" Year="2014">
       <Id>a919ccf9-a929-4d40-977c-41204c345816</Id>
     </Book>
-    <Book Series="Indestructible Hulk Special" Number="1" Volume="2013" Year="2013" Format="One-Shot">
+    <Book Series="Indestructible Hulk Special" Number="1" Volume="2013" Year="2013">
       <Id>eb738a1d-ad79-42db-b9d1-1d15d8bfab91</Id>
     </Book>
-    <Book Series="Indestructible Hulk Annual" Number="1" Volume="2013" Year="2014" Format="Annual">
+    <Book Series="Indestructible Hulk Annual" Number="1" Volume="2013" Year="2014">
       <Id>b1992c60-824f-45d9-bd07-76c982754ed2</Id>
     </Book>
-    <Book Series="Indestructible Hulk" Number="16" Volume="2012" Year="2014" Format="Main Series">
+    <Book Series="Indestructible Hulk" Number="16" Volume="2012" Year="2014">
       <Id>1704b687-5f08-4f45-afd4-70855817f51e</Id>
     </Book>
-    <Book Series="Indestructible Hulk" Number="17" Volume="2012" Year="2014" Format="Main Series">
+    <Book Series="Indestructible Hulk" Number="17" Volume="2012" Year="2014">
       <Id>dde8e390-c3c5-4329-a028-e79f7a78a4db</Id>
     </Book>
-    <Book Series="Indestructible Hulk" Number="18" Volume="2012" Year="2014" Format="Main Series">
+    <Book Series="Indestructible Hulk" Number="18" Volume="2012" Year="2014">
       <Id>85a1081b-68c3-4c2f-964a-e71401d04417</Id>
     </Book>
-    <Book Series="Indestructible Hulk" Number="19" Volume="2012" Year="2014" Format="Main Series">
+    <Book Series="Indestructible Hulk" Number="19" Volume="2012" Year="2014">
       <Id>4ae7c7a1-de32-4b19-b993-a9a7f5d8b1c6</Id>
     </Book>
-    <Book Series="Indestructible Hulk" Number="20" Volume="2012" Year="2014" Format="Main Series">
+    <Book Series="Indestructible Hulk" Number="20" Volume="2012" Year="2014">
       <Id>123c5096-a7ce-4e5e-8724-285dbe2fa91b</Id>
     </Book>
-    <Book Series="Hulk" Number="1" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Hulk" Number="1" Volume="2014" Year="2014">
       <Id>1e1fd701-3dc2-4228-853f-dc5f010f13e7</Id>
     </Book>
-    <Book Series="Hulk" Number="2" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Hulk" Number="2" Volume="2014" Year="2014">
       <Id>b6e05c14-8f78-4e30-8444-109bd4bdd04a</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Micronauts/The Micronauts.cbl
+++ b/Marvel/Characters/unsorted/Micronauts/The Micronauts.cbl
@@ -1,363 +1,292 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>The Micronauts</Name>
+  <NumIssues>95</NumIssues>
   <Books>
     <Book Series="Micronauts" Number="1" Volume="1979" Year="1979">
-      <Id>851abc12-8090-4455-8589-cf0e39a55636</Id>
+      <Database Name="cv" Series="3008" Issue="19203" />
     </Book>
     <Book Series="Micronauts" Number="2" Volume="1979" Year="1979">
-      <Id>ab9cf4b4-81ca-418b-8601-27325af1395a</Id>
+      <Database Name="cv" Series="3008" Issue="19305" />
     </Book>
     <Book Series="Micronauts" Number="3" Volume="1979" Year="1979">
-      <Id>159cf417-b808-4abd-83d3-1b71633ee590</Id>
+      <Database Name="cv" Series="3008" Issue="19377" />
     </Book>
     <Book Series="Micronauts" Number="4" Volume="1979" Year="1979">
-      <Id>c111ef7d-9829-434a-acea-4af835704b75</Id>
+      <Database Name="cv" Series="3008" Issue="19443" />
     </Book>
     <Book Series="Micronauts" Number="5" Volume="1979" Year="1979">
-      <Id>bcdf721c-ce3f-475e-a592-84700ca80f06</Id>
+      <Database Name="cv" Series="3008" Issue="19516" />
     </Book>
     <Book Series="Micronauts" Number="6" Volume="1979" Year="1979">
-      <Id>653a379f-126d-48f6-844d-51935dd2db86</Id>
+      <Database Name="cv" Series="3008" Issue="19583" />
     </Book>
     <Book Series="Micronauts" Number="7" Volume="1979" Year="1979">
-      <Id>f3fec1d9-8306-4dc2-8919-af684f8db39d</Id>
+      <Database Name="cv" Series="3008" Issue="19651" />
     </Book>
     <Book Series="Micronauts" Number="8" Volume="1979" Year="1979">
-      <Id>131a97e0-a9e2-433d-af29-f0fe1b6127a2</Id>
+      <Database Name="cv" Series="3008" Issue="19715" />
     </Book>
     <Book Series="Micronauts" Number="9" Volume="1979" Year="1979">
-      <Id>03cd6661-58ab-4ab5-8428-ee9ba33b54b5</Id>
+      <Database Name="cv" Series="3008" Issue="19787" />
     </Book>
     <Book Series="Micronauts" Number="10" Volume="1979" Year="1979">
-      <Id>add26860-008b-4875-bee3-4ec062ade65a</Id>
+      <Database Name="cv" Series="3008" Issue="19854" />
     </Book>
     <Book Series="Micronauts" Number="11" Volume="1979" Year="1979">
-      <Id>c2c734cd-11d9-4640-9403-fe41470b6465</Id>
+      <Database Name="cv" Series="3008" Issue="19928" />
     </Book>
     <Book Series="Micronauts Annual" Number="1" Volume="1979" Year="1979">
-      <Id>698cd8bb-ebdd-4b1b-ad76-c35e245a9aea</Id>
+      <Database Name="cv" Series="3009" Issue="19995" />
     </Book>
     <Book Series="Micronauts" Number="12" Volume="1979" Year="1979">
-      <Id>34290f06-7dfe-46c3-b496-c9fcbb434397</Id>
+      <Database Name="cv" Series="3008" Issue="19994" />
     </Book>
     <Book Series="Micronauts" Number="13" Volume="1979" Year="1980">
-      <Id>fe2e8006-4036-41f7-b29e-8eafe35db317</Id>
+      <Database Name="cv" Series="3008" Issue="20107" />
     </Book>
     <Book Series="Micronauts" Number="14" Volume="1979" Year="1980">
-      <Id>8942a8f5-2c8b-49e1-a222-6704ce6a9667</Id>
+      <Database Name="cv" Series="3008" Issue="20174" />
     </Book>
     <Book Series="Micronauts" Number="15" Volume="1979" Year="1980">
-      <Id>0f255c0b-d147-437d-b799-794a0493160e</Id>
+      <Database Name="cv" Series="3008" Issue="20250" />
     </Book>
     <Book Series="Micronauts" Number="16" Volume="1979" Year="1980">
-      <Id>0c72e06d-7912-460d-8221-25bf5226e00f</Id>
+      <Database Name="cv" Series="3008" Issue="20320" />
     </Book>
     <Book Series="Micronauts" Number="17" Volume="1979" Year="1980">
-      <Id>e2ad693c-d02b-4e8b-bf27-e5aae3b7b97a</Id>
+      <Database Name="cv" Series="3008" Issue="20394" />
     </Book>
     <Book Series="Micronauts" Number="18" Volume="1979" Year="1980">
-      <Id>f64df85a-53b6-44bf-9d1d-72dc6ba3e14c</Id>
+      <Database Name="cv" Series="3008" Issue="20463" />
     </Book>
     <Book Series="Micronauts" Number="19" Volume="1979" Year="1980">
-      <Id>bfc7835b-1e31-470f-82af-57d5ab154681</Id>
+      <Database Name="cv" Series="3008" Issue="20537" />
     </Book>
     <Book Series="Micronauts" Number="20" Volume="1979" Year="1980">
-      <Id>1fca113f-3440-4ad6-8a1e-ac52e3a4354f</Id>
+      <Database Name="cv" Series="3008" Issue="20599" />
     </Book>
     <Book Series="Micronauts" Number="21" Volume="1979" Year="1980">
-      <Id>eadeccc8-094a-4b6e-b5e9-53d1155be494</Id>
+      <Database Name="cv" Series="3008" Issue="20672" />
     </Book>
     <Book Series="Micronauts" Number="22" Volume="1979" Year="1980">
-      <Id>d7c661dc-ad70-4ea1-bd5b-d7481fc6a656</Id>
+      <Database Name="cv" Series="3008" Issue="20739" />
     </Book>
     <Book Series="Micronauts" Number="23" Volume="1979" Year="1980">
-      <Id>4bec974b-b6de-45c0-baa1-17f3bbc7619b</Id>
+      <Database Name="cv" Series="3008" Issue="20802" />
     </Book>
     <Book Series="Micronauts Annual" Number="2" Volume="1979" Year="1980">
-      <Id>8c8831db-ccf6-41ea-838a-cc743c242536</Id>
+      <Database Name="cv" Series="3009" Issue="20870" />
     </Book>
     <Book Series="Micronauts" Number="25" Volume="1979" Year="1981">
-      <Id>a7016839-ce0d-4b85-b418-3c2eef154375</Id>
+      <Database Name="cv" Series="3008" Issue="20978" />
     </Book>
     <Book Series="Micronauts" Number="26" Volume="1979" Year="1981">
-      <Id>c0a5acd9-8518-49d3-acbe-4c16de636d63</Id>
+      <Database Name="cv" Series="3008" Issue="21045" />
     </Book>
     <Book Series="Micronauts" Number="27" Volume="1979" Year="1981">
-      <Id>57ba1bcf-7576-4d95-a6a8-c7626bab60af</Id>
+      <Database Name="cv" Series="3008" Issue="21118" />
     </Book>
     <Book Series="Micronauts" Number="28" Volume="1979" Year="1981">
-      <Id>e7fc0c89-9a0d-4c49-9f5e-efd87711a511</Id>
+      <Database Name="cv" Series="3008" Issue="21185" />
     </Book>
     <Book Series="Micronauts" Number="29" Volume="1979" Year="1981">
-      <Id>d9a9709e-d5d5-49bd-bc8c-5122f04d6f2e</Id>
+      <Database Name="cv" Series="3008" Issue="21249" />
     </Book>
     <Book Series="Micronauts" Number="30" Volume="1979" Year="1981">
-      <Id>19240e25-c24b-49dc-af42-701cd3791ac7</Id>
+      <Database Name="cv" Series="3008" Issue="21309" />
     </Book>
     <Book Series="Micronauts" Number="31" Volume="1979" Year="1981">
-      <Id>9f12d6a8-46ba-4059-9be3-5ffd485709c4</Id>
+      <Database Name="cv" Series="3008" Issue="21383" />
     </Book>
     <Book Series="Micronauts" Number="32" Volume="1979" Year="1981">
-      <Id>ff2feb73-655b-4ffd-9d77-97deee56f5ba</Id>
+      <Database Name="cv" Series="3008" Issue="21449" />
     </Book>
     <Book Series="Micronauts" Number="33" Volume="1979" Year="1981">
-      <Id>cf098f67-58ff-4c70-8754-97117e3ad3e5</Id>
+      <Database Name="cv" Series="3008" Issue="21521" />
     </Book>
     <Book Series="Micronauts" Number="34" Volume="1979" Year="1981">
-      <Id>baf014da-bcea-49d8-bfc1-33aa68b456d2</Id>
+      <Database Name="cv" Series="3008" Issue="21603" />
     </Book>
     <Book Series="Micronauts" Number="35" Volume="1979" Year="1981">
-      <Id>2751e483-b716-4ce5-9826-40760b3d1d28</Id>
+      <Database Name="cv" Series="3008" Issue="21670" />
     </Book>
     <Book Series="Micronauts" Number="36" Volume="1979" Year="1981">
-      <Id>57025c11-450c-408d-af6b-e59ef2723d65</Id>
+      <Database Name="cv" Series="3008" Issue="21740" />
     </Book>
     <Book Series="Micronauts" Number="37" Volume="1979" Year="1982">
-      <Id>f8fe7ab4-05ca-46cf-b135-e4b44fb2509e</Id>
+      <Database Name="cv" Series="3008" Issue="21866" />
     </Book>
     <Book Series="Micronauts" Number="38" Volume="1979" Year="1982">
-      <Id>482e3fd3-ccb7-4c0b-8a20-7532479f8455</Id>
+      <Database Name="cv" Series="3008" Issue="21939" />
     </Book>
     <Book Series="Micronauts" Number="39" Volume="1979" Year="1982">
-      <Id>14090a49-6f92-420b-85d2-07a1e332dd26</Id>
+      <Database Name="cv" Series="3008" Issue="22019" />
     </Book>
     <Book Series="Micronauts" Number="40" Volume="1979" Year="1982">
-      <Id>410a9ed3-8e91-4d74-a7a8-676cd89ea6d5</Id>
+      <Database Name="cv" Series="3008" Issue="22091" />
     </Book>
     <Book Series="Micronauts" Number="41" Volume="1979" Year="1982">
-      <Id>284b28a5-a0f1-4225-bb1d-011fb4496838</Id>
+      <Database Name="cv" Series="3008" Issue="22171" />
     </Book>
     <Book Series="Fantastic Four" Number="246" Volume="1961" Year="1982">
-      <Id>b8ca080a-0682-4c37-8997-5966813c32d0</Id>
+      <Database Name="cv" Series="2045" Issue="22442" />
     </Book>
     <Book Series="Marvel Super Hero Contest of Champions" Number="1" Volume="1982" Year="1982">
-      <Id>337d7b43-3a31-4e15-91d7-23ba35969822</Id>
+      <Database Name="cv" Series="3147" Issue="22234" />
     </Book>
     <Book Series="Marvel Super Hero Contest of Champions" Number="2" Volume="1982" Year="1982">
-      <Id>9e2cb9d9-7b40-4f64-a95d-9c01198f5109</Id>
+      <Database Name="cv" Series="3147" Issue="22304" />
     </Book>
     <Book Series="Marvel Super Hero Contest of Champions" Number="3" Volume="1982" Year="1982">
-      <Id>15cfa04f-c9c7-4e75-a331-6c6715c6e24c</Id>
+      <Database Name="cv" Series="3147" Issue="22378" />
     </Book>
     <Book Series="Micronauts" Number="42" Volume="1979" Year="1982">
-      <Id>3dbb5c8f-7399-4fce-8836-77409c9d79ff</Id>
+      <Database Name="cv" Series="3008" Issue="22239" />
     </Book>
     <Book Series="Micronauts" Number="43" Volume="1979" Year="1982">
-      <Id>ae08c8e4-c787-4ce5-98de-2520dbc1b4ad</Id>
+      <Database Name="cv" Series="3008" Issue="22310" />
     </Book>
     <Book Series="Micronauts" Number="44" Volume="1979" Year="1982">
-      <Id>f0c5cedc-14c4-473e-a5cc-0279e5ed1466</Id>
+      <Database Name="cv" Series="3008" Issue="22384" />
     </Book>
     <Book Series="Micronauts" Number="45" Volume="1979" Year="1982">
-      <Id>d989f1eb-8cd8-4f85-a7b4-2e8e2cdcacfd</Id>
+      <Database Name="cv" Series="3008" Issue="22454" />
     </Book>
     <Book Series="Micronauts" Number="46" Volume="1979" Year="1982">
-      <Id>c7574744-08cf-4a8c-84ef-ad388eb429c5</Id>
+      <Database Name="cv" Series="3008" Issue="22528" />
     </Book>
     <Book Series="Micronauts" Number="47" Volume="1979" Year="1982">
-      <Id>6ad3fef5-7c34-418b-b18f-165379e167f4</Id>
+      <Database Name="cv" Series="3008" Issue="22602" />
     </Book>
     <Book Series="Micronauts" Number="48" Volume="1979" Year="1982">
-      <Id>64a0b285-1d79-4926-a5db-0f00e7ea7422</Id>
+      <Database Name="cv" Series="3008" Issue="22678" />
     </Book>
     <Book Series="Micronauts" Number="49" Volume="1979" Year="1983">
-      <Id>90777be9-e01c-436d-9ef4-f63a8ecc86cf</Id>
+      <Database Name="cv" Series="3008" Issue="22800" />
     </Book>
     <Book Series="Micronauts" Number="50" Volume="1979" Year="1983">
-      <Id>dace9d38-04dd-4f8c-b332-8f8dd21464df</Id>
+      <Database Name="cv" Series="3008" Issue="22871" />
     </Book>
     <Book Series="Micronauts" Number="51" Volume="1979" Year="1983">
-      <Id>b7464e98-3e2f-4e2b-a603-99a1be61e1aa</Id>
+      <Database Name="cv" Series="3008" Issue="22959" />
     </Book>
     <Book Series="Micronauts" Number="52" Volume="1979" Year="1983">
-      <Id>bf4339a9-1fa7-4b70-9618-436aa3ac178d</Id>
+      <Database Name="cv" Series="3008" Issue="23129" />
     </Book>
     <Book Series="Micronauts" Number="53" Volume="1979" Year="1983">
-      <Id>34c80b10-7d26-4970-9cd9-cc96d6b96555</Id>
+      <Database Name="cv" Series="3008" Issue="23298" />
     </Book>
     <Book Series="Micronauts" Number="54" Volume="1979" Year="1983">
-      <Id>afd21ecd-6cfa-456c-a5d2-f2ba2d806d93</Id>
+      <Database Name="cv" Series="3008" Issue="23317" />
     </Book>
     <Book Series="Micronauts" Number="55" Volume="1979" Year="1983">
-      <Id>c8780d12-7810-470d-9a07-75e5522b73ad</Id>
+      <Database Name="cv" Series="3008" Issue="23636" />
     </Book>
     <Book Series="Micronauts" Number="56" Volume="1979" Year="1984">
-      <Id>be365a45-2d13-45af-b313-49cfb6d934df</Id>
+      <Database Name="cv" Series="3008" Issue="23883" />
     </Book>
     <Book Series="Micronauts" Number="57" Volume="1979" Year="1984">
-      <Id>f04f8f43-49a1-403c-81a8-a52ad761b121</Id>
+      <Database Name="cv" Series="3008" Issue="24104" />
     </Book>
     <Book Series="The X-Men and The Micronauts" Number="1" Volume="1984" Year="1984">
-      <Id>00b1a847-8603-4cb0-a76d-b9c7e3fd378b</Id>
-    </Book>
-    <Book Series="The X-Men and The Micronauts" Number="1" Volume="1984" Year="1984">
-      <Id>6e9e29bf-68d1-45a7-863b-87462dc03077</Id>
+      <Database Name="cv" Series="3373" Issue="23895" />
     </Book>
     <Book Series="The X-Men and The Micronauts" Number="2" Volume="1984" Year="1984">
-      <Id>2583884e-d1a3-4572-a4a6-a367f7a4d2d9</Id>
-    </Book>
-    <Book Series="The X-Men and The Micronauts" Number="2" Volume="1984" Year="1984">
-      <Id>1182e7f9-f693-4289-8709-6a1b0d0c9c12</Id>
+      <Database Name="cv" Series="3373" Issue="23996" />
     </Book>
     <Book Series="The X-Men and The Micronauts" Number="3" Volume="1984" Year="1984">
-      <Id>dc2af0dc-6c71-47bd-88f7-19a8418004a7</Id>
-    </Book>
-    <Book Series="The X-Men and The Micronauts" Number="3" Volume="1984" Year="1984">
-      <Id>8f8b50f2-5e22-45f0-a96b-16aaa1918762</Id>
+      <Database Name="cv" Series="3373" Issue="24113" />
     </Book>
     <Book Series="The X-Men and The Micronauts" Number="4" Volume="1984" Year="1984">
-      <Id>6afb61e7-3b22-4f0d-8ea4-41fe61e174b8</Id>
-    </Book>
-    <Book Series="The X-Men and The Micronauts" Number="4" Volume="1984" Year="1984">
-      <Id>88c9b1eb-6539-4cd7-a98a-22c33fa6c9f4</Id>
+      <Database Name="cv" Series="3373" Issue="24218" />
     </Book>
     <Book Series="The New Mutants" Number="14" Volume="1983" Year="1984">
-      <Id>d46c7cbe-e2ea-43e0-ad61-2bec4f2a59b6</Id>
+      <Database Name="cv" Series="3234" Issue="24229" />
     </Book>
     <Book Series="The Uncanny X-Men" Number="180" Volume="1981" Year="1984">
-      <Id>e6e91394-147c-4485-adbc-ee2b3b6ab999</Id>
+      <Database Name="cv" Series="3092" Issue="24216" />
     </Book>
     <Book Series="Micronauts" Number="58" Volume="1979" Year="1984">
-      <Id>208d70dd-793e-4445-b5b8-eeb91575c948</Id>
+      <Database Name="cv" Series="3008" Issue="24314" />
     </Book>
     <Book Series="Micronauts" Number="59" Volume="1979" Year="1984">
-      <Id>f52e0b32-8338-4ce1-af13-446d771aa7c6</Id>
+      <Database Name="cv" Series="3008" Issue="24609" />
     </Book>
     <Book Series="Micronauts: The New Voyages" Number="1" Volume="1984" Year="1984">
-      <Id>bf02ae09-e037-45b6-98bc-cafa4ddf0548</Id>
-    </Book>
-    <Book Series="Micronauts: The New Voyages" Number="1" Volume="1984" Year="1984">
-      <Id>b3b91c10-45bd-4ec5-98f9-bbc0e4602f64</Id>
+      <Database Name="cv" Series="3353" Issue="24798" />
     </Book>
     <Book Series="Micronauts: The New Voyages" Number="2" Volume="1984" Year="1984">
-      <Id>3899aced-07da-456f-b5cf-4f6e22c2d642</Id>
-    </Book>
-    <Book Series="Micronauts: The New Voyages" Number="2" Volume="1984" Year="1984">
-      <Id>8c35e771-8e31-4ac3-96b6-a9f7379b2494</Id>
+      <Database Name="cv" Series="3353" Issue="24898" />
     </Book>
     <Book Series="Micronauts: The New Voyages" Number="3" Volume="1984" Year="1984">
-      <Id>a1d5dad7-383e-4cb1-996b-f356b0a99521</Id>
-    </Book>
-    <Book Series="Micronauts: The New Voyages" Number="3" Volume="1984" Year="1984">
-      <Id>98f4ccd1-9fc8-436e-93ee-457bd0db23a6</Id>
+      <Database Name="cv" Series="3353" Issue="25003" />
     </Book>
     <Book Series="Micronauts: The New Voyages" Number="4" Volume="1984" Year="1985">
-      <Id>ffbfa167-0bec-43b3-b3d6-036e40f1ef73</Id>
-    </Book>
-    <Book Series="Micronauts: The New Voyages" Number="4" Volume="1984" Year="1985">
-      <Id>5caeec20-fd4e-4da8-9dc6-7369d885e6b9</Id>
+      <Database Name="cv" Series="3353" Issue="25033" />
     </Book>
     <Book Series="Micronauts: The New Voyages" Number="5" Volume="1984" Year="1985">
-      <Id>6df5c98a-05d6-4287-857a-7c436118dba4</Id>
-    </Book>
-    <Book Series="Micronauts: The New Voyages" Number="5" Volume="1984" Year="1985">
-      <Id>526217e1-0d90-48b1-bca9-6863eacc2b16</Id>
+      <Database Name="cv" Series="3353" Issue="217565" />
     </Book>
     <Book Series="Micronauts: The New Voyages" Number="6" Volume="1984" Year="1985">
-      <Id>18b28117-fafe-48af-8074-0dcf84ddbcf6</Id>
-    </Book>
-    <Book Series="Micronauts: The New Voyages" Number="6" Volume="1984" Year="1985">
-      <Id>ebf1cf90-2e7c-404b-8568-5d814a682015</Id>
+      <Database Name="cv" Series="3353" Issue="217566" />
     </Book>
     <Book Series="Micronauts: The New Voyages" Number="7" Volume="1984" Year="1985">
-      <Id>b7ff5195-8e18-4885-a21b-848ba9e916d3</Id>
-    </Book>
-    <Book Series="Micronauts: The New Voyages" Number="7" Volume="1984" Year="1985">
-      <Id>64d92c7e-a295-485d-b980-222d6613fa47</Id>
+      <Database Name="cv" Series="3353" Issue="187105" />
     </Book>
     <Book Series="Micronauts: The New Voyages" Number="8" Volume="1984" Year="1985">
-      <Id>13ae7d3f-76e5-4836-a5a3-33c359efb646</Id>
-    </Book>
-    <Book Series="Micronauts: The New Voyages" Number="8" Volume="1984" Year="1985">
-      <Id>a4573e47-4eec-4d91-9fb8-fef0297ad556</Id>
+      <Database Name="cv" Series="3353" Issue="217567" />
     </Book>
     <Book Series="Micronauts: The New Voyages" Number="9" Volume="1984" Year="1985">
-      <Id>fe6afbe1-34bc-45cb-80d0-89f2807082f1</Id>
-    </Book>
-    <Book Series="Micronauts: The New Voyages" Number="9" Volume="1984" Year="1985">
-      <Id>090dcf88-d67d-4059-b730-3f0ca1d51d3e</Id>
+      <Database Name="cv" Series="3353" Issue="217568" />
     </Book>
     <Book Series="Micronauts: The New Voyages" Number="10" Volume="1984" Year="1985">
-      <Id>a626fc14-6e60-4e14-a080-11a564c4d7c2</Id>
-    </Book>
-    <Book Series="Micronauts: The New Voyages" Number="10" Volume="1984" Year="1985">
-      <Id>3bfe078c-13c6-4531-bb45-b50e28522de7</Id>
+      <Database Name="cv" Series="3353" Issue="217569" />
     </Book>
     <Book Series="Micronauts: The New Voyages" Number="11" Volume="1984" Year="1985">
-      <Id>2f49f7d2-f3dd-4b0e-b3a3-39399450e035</Id>
-    </Book>
-    <Book Series="Micronauts: The New Voyages" Number="11" Volume="1984" Year="1985">
-      <Id>1fba30cf-81dc-452a-a78d-3d8dfbd86287</Id>
+      <Database Name="cv" Series="3353" Issue="217570" />
     </Book>
     <Book Series="Micronauts: The New Voyages" Number="12" Volume="1984" Year="1985">
-      <Id>b873949c-f9c1-45e6-a0cc-b701c2210550</Id>
-    </Book>
-    <Book Series="Micronauts: The New Voyages" Number="12" Volume="1984" Year="1985">
-      <Id>ea857fa3-6e6a-463f-857e-7f5305a66a13</Id>
+      <Database Name="cv" Series="3353" Issue="217571" />
     </Book>
     <Book Series="Micronauts: The New Voyages" Number="13" Volume="1984" Year="1985">
-      <Id>314506d4-0fbc-4931-94ad-a2f263bb25f7</Id>
-    </Book>
-    <Book Series="Micronauts: The New Voyages" Number="13" Volume="1984" Year="1985">
-      <Id>1b6046df-6400-40d3-baca-4930e190ec4f</Id>
+      <Database Name="cv" Series="3353" Issue="217572" />
     </Book>
     <Book Series="Micronauts: The New Voyages" Number="14" Volume="1984" Year="1985">
-      <Id>954ac04d-dc6c-4779-840c-cd8fa0448eb4</Id>
-    </Book>
-    <Book Series="Micronauts: The New Voyages" Number="14" Volume="1984" Year="1985">
-      <Id>c257d0f0-dc6f-4ddd-81ef-ef77bca91798</Id>
+      <Database Name="cv" Series="3353" Issue="206153" />
     </Book>
     <Book Series="Micronauts: The New Voyages" Number="15" Volume="1984" Year="1985">
-      <Id>33f067c6-cfcb-4af5-aa57-f3f4cecce448</Id>
-    </Book>
-    <Book Series="Micronauts: The New Voyages" Number="15" Volume="1984" Year="1985">
-      <Id>78c1d5b8-60a4-44d4-a4ca-cec6f7856494</Id>
+      <Database Name="cv" Series="3353" Issue="217573" />
     </Book>
     <Book Series="Micronauts: The New Voyages" Number="16" Volume="1984" Year="1986">
-      <Id>25a7854b-e416-4e9b-a443-fded9492c91f</Id>
-    </Book>
-    <Book Series="Micronauts: The New Voyages" Number="16" Volume="1984" Year="1986">
-      <Id>b37fa2cd-e614-4beb-8f6c-33ad6424a2e0</Id>
+      <Database Name="cv" Series="3353" Issue="136160" />
     </Book>
     <Book Series="Micronauts: The New Voyages" Number="17" Volume="1984" Year="1986">
-      <Id>f4d537f7-cb2f-494f-b495-43338f1b2b1c</Id>
-    </Book>
-    <Book Series="Micronauts: The New Voyages" Number="17" Volume="1984" Year="1986">
-      <Id>6fbfefe1-733a-442f-a012-258427354494</Id>
+      <Database Name="cv" Series="3353" Issue="217574" />
     </Book>
     <Book Series="Micronauts: The New Voyages" Number="18" Volume="1984" Year="1986">
-      <Id>8e5c5359-400d-4106-b93f-984de9006c7f</Id>
-    </Book>
-    <Book Series="Micronauts: The New Voyages" Number="18" Volume="1984" Year="1986">
-      <Id>48352a01-81df-4c25-b93f-812ec0b38e42</Id>
+      <Database Name="cv" Series="3353" Issue="217575" />
     </Book>
     <Book Series="Micronauts: The New Voyages" Number="19" Volume="1984" Year="1986">
-      <Id>f0303af5-ff3b-4c21-892a-08e2adb81a5d</Id>
-    </Book>
-    <Book Series="Micronauts: The New Voyages" Number="19" Volume="1984" Year="1986">
-      <Id>44308c52-78c0-4537-847f-431c0d235ed4</Id>
+      <Database Name="cv" Series="3353" Issue="217576" />
     </Book>
     <Book Series="Micronauts: The New Voyages" Number="20" Volume="1984" Year="1986">
-      <Id>e2edcbd0-26f0-4538-9560-79c6ed99ea55</Id>
-    </Book>
-    <Book Series="Micronauts: The New Voyages" Number="20" Volume="1984" Year="1986">
-      <Id>8669a495-035b-4b82-9398-6039fff4baac</Id>
+      <Database Name="cv" Series="3353" Issue="217577" />
     </Book>
     <Book Series="Spider-Man" Number="78" Volume="1990" Year="1997">
-      <Id>17d9f617-6bf9-4810-b85e-e6c62b91181e</Id>
+      <Database Name="cv" Series="4421" Issue="64656" />
     </Book>
     <Book Series="X-Force" Number="59" Volume="1991" Year="1996">
-      <Id>613f2e80-32d3-4c01-abd5-07402c28353a</Id>
+      <Database Name="cv" Series="4604" Issue="64533" />
     </Book>
     <Book Series="Excalibur" Number="107" Volume="1988" Year="1997">
-      <Id>3f8573c8-4449-48ac-b630-ff248a387b30</Id>
+      <Database Name="cv" Series="4052" Issue="43481" />
     </Book>
     <Book Series="X-Men" Number="74" Volume="1991" Year="1998">
-      <Id>7cdb52ed-8f5d-42e3-a177-f1b41dc47b92</Id>
+      <Database Name="cv" Series="4605" Issue="65774" />
     </Book>
     <Book Series="X-Men" Number="75" Volume="1991" Year="1998">
-      <Id>13b2a928-e006-40b5-bb9a-68a99adbdc2c</Id>
+      <Database Name="cv" Series="4605" Issue="65775" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Micronauts/The Micronauts.cbl
+++ b/Marvel/Characters/unsorted/Micronauts/The Micronauts.cbl
@@ -35,7 +35,7 @@
     <Book Series="Micronauts" Number="11" Volume="1979" Year="1979">
       <Id>c2c734cd-11d9-4640-9403-fe41470b6465</Id>
     </Book>
-    <Book Series="Micronauts Annual" Number="1" Volume="1979" Year="1979" Format="Annual">
+    <Book Series="Micronauts Annual" Number="1" Volume="1979" Year="1979">
       <Id>698cd8bb-ebdd-4b1b-ad76-c35e245a9aea</Id>
     </Book>
     <Book Series="Micronauts" Number="12" Volume="1979" Year="1979">
@@ -74,7 +74,7 @@
     <Book Series="Micronauts" Number="23" Volume="1979" Year="1980">
       <Id>4bec974b-b6de-45c0-baa1-17f3bbc7619b</Id>
     </Book>
-    <Book Series="Micronauts Annual" Number="2" Volume="1979" Year="1980" Format="Annual">
+    <Book Series="Micronauts Annual" Number="2" Volume="1979" Year="1980">
       <Id>8c8831db-ccf6-41ea-838a-cc743c242536</Id>
     </Book>
     <Book Series="Micronauts" Number="25" Volume="1979" Year="1981">

--- a/Marvel/Characters/unsorted/She-Hullk/She-Hulk.cbl
+++ b/Marvel/Characters/unsorted/She-Hullk/She-Hulk.cbl
@@ -2,622 +2,622 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>She-Hulk</Name>
   <Books>
-    <Book Series="Marvel Masterworks: The Savage She-Hulk" Number="1" Volume="2017" Year="2017" Format="TPB">
+    <Book Series="Marvel Masterworks: The Savage She-Hulk" Number="1" Volume="2017" Year="2017">
       <Id>bab6f2ea-d604-4058-845c-0b86e9ce3af4</Id>
     </Book>
-    <Book Series="The Savage She-Hulk" Number="15" Volume="1980" Year="1981" Format="Main Series">
+    <Book Series="The Savage She-Hulk" Number="15" Volume="1980" Year="1981">
       <Id>05124708-f4ab-414f-9fda-3af21c773eb6</Id>
     </Book>
-    <Book Series="The Savage She-Hulk" Number="16" Volume="1980" Year="1981" Format="Main Series">
+    <Book Series="The Savage She-Hulk" Number="16" Volume="1980" Year="1981">
       <Id>f63db51b-4c38-43c7-ac09-8db063b3e444</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="107" Volume="1972" Year="1981" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="107" Volume="1972" Year="1981">
       <Id>46c9a275-735d-43ee-a498-d93b8d1b116b</Id>
     </Book>
-    <Book Series="The Savage She-Hulk" Number="17" Volume="1980" Year="1981" Format="Main Series">
+    <Book Series="The Savage She-Hulk" Number="17" Volume="1980" Year="1981">
       <Id>3b87aa56-344b-489d-a622-818a4044181c</Id>
     </Book>
-    <Book Series="The Savage She-Hulk" Number="18" Volume="1980" Year="1981" Format="Main Series">
+    <Book Series="The Savage She-Hulk" Number="18" Volume="1980" Year="1981">
       <Id>6529cd56-f77d-47cd-8778-63ec6d9830ae</Id>
     </Book>
-    <Book Series="The Savage She-Hulk" Number="19" Volume="1980" Year="1981" Format="Main Series">
+    <Book Series="The Savage She-Hulk" Number="19" Volume="1980" Year="1981">
       <Id>ce7efd7e-ca5e-4586-a9d7-62aea5f515df</Id>
     </Book>
-    <Book Series="The Savage She-Hulk" Number="20" Volume="1980" Year="1981" Format="Main Series">
+    <Book Series="The Savage She-Hulk" Number="20" Volume="1980" Year="1981">
       <Id>bf3e2663-f70c-49fb-9a8d-dc0fe8c926fc</Id>
     </Book>
-    <Book Series="The Savage She-Hulk" Number="21" Volume="1980" Year="1981" Format="Main Series">
+    <Book Series="The Savage She-Hulk" Number="21" Volume="1980" Year="1981">
       <Id>b9ea1444-544d-439f-8fdd-d685adc23320</Id>
     </Book>
-    <Book Series="The Savage She-Hulk" Number="22" Volume="1980" Year="1981" Format="Main Series">
+    <Book Series="The Savage She-Hulk" Number="22" Volume="1980" Year="1981">
       <Id>2168464d-f883-4580-93e9-e900adc97583</Id>
     </Book>
-    <Book Series="The Savage She-Hulk" Number="23" Volume="1980" Year="1981" Format="Main Series">
+    <Book Series="The Savage She-Hulk" Number="23" Volume="1980" Year="1981">
       <Id>f7b3116d-14be-4fba-82ba-30d6b6cd20ba</Id>
     </Book>
-    <Book Series="The Savage She-Hulk" Number="24" Volume="1980" Year="1982" Format="Main Series">
+    <Book Series="The Savage She-Hulk" Number="24" Volume="1980" Year="1982">
       <Id>e967471a-2ac4-4da1-b115-fb2d9a670ad5</Id>
     </Book>
-    <Book Series="The Savage She-Hulk" Number="25" Volume="1980" Year="1982" Format="Main Series">
+    <Book Series="The Savage She-Hulk" Number="25" Volume="1980" Year="1982">
       <Id>1ae035df-e131-45c5-97a5-b4c9598074d4</Id>
     </Book>
-    <Book Series="Dazzler" Number="14" Volume="1981" Year="1982" Format="Main Series">
+    <Book Series="Dazzler" Number="14" Volume="1981" Year="1982">
       <Id>b44312ad-29c5-4643-a3e6-49e243ab0940</Id>
     </Book>
-    <Book Series="Marvel Two-in-One" Number="88" Volume="1974" Year="1982" Format="Main Series">
+    <Book Series="Marvel Two-in-One" Number="88" Volume="1974" Year="1982">
       <Id>0ea1a15d-42cc-4a93-a27c-597edfd25b4d</Id>
     </Book>
-    <Book Series="Marvel Super Hero Contest of Champions" Number="1" Volume="1982" Year="1982" Format="Crossover">
+    <Book Series="Marvel Super Hero Contest of Champions" Number="1" Volume="1982" Year="1982">
       <Id>21316dcb-b049-47bd-9372-75429ecdad85</Id>
     </Book>
-    <Book Series="Marvel Super Hero Contest of Champions" Number="2" Volume="1982" Year="1982" Format="Crossover">
+    <Book Series="Marvel Super Hero Contest of Champions" Number="2" Volume="1982" Year="1982">
       <Id>e10fc5d4-dcb6-4071-85a2-19aab7266e35</Id>
     </Book>
-    <Book Series="Marvel Super Hero Contest of Champions" Number="3" Volume="1982" Year="1982" Format="Crossover">
+    <Book Series="Marvel Super Hero Contest of Champions" Number="3" Volume="1982" Year="1982">
       <Id>d51c20ee-2f44-49a5-97ae-60b8f9012db7</Id>
     </Book>
-    <Book Series="The Avengers" Number="221" Volume="1963" Year="1982" Format="Main Series">
+    <Book Series="The Avengers" Number="221" Volume="1963" Year="1982">
       <Id>cd2a81ad-cb08-4251-80af-0fcffbc7c19b</Id>
     </Book>
-    <Book Series="The Avengers" Number="222" Volume="1963" Year="1982" Format="Main Series">
+    <Book Series="The Avengers" Number="222" Volume="1963" Year="1982">
       <Id>5d31043d-daaa-4249-bb7c-5fff955c9339</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="282" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="282" Volume="1968" Year="1983">
       <Id>2c2d83fc-efc8-41bf-96e1-b91a194b1a46</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="283" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="283" Volume="1968" Year="1983">
       <Id>c26454fc-043d-4430-a76b-45f0e13277cc</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="284" Volume="1968" Year="1983" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="284" Volume="1968" Year="1983">
       <Id>54943606-0d74-468a-b280-8dcd1ed44ae7</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="265" Volume="1961" Year="1984" Format="Main Series">
+    <Book Series="Fantastic Four" Number="265" Volume="1961" Year="1984">
       <Id>c7f9899f-716c-42eb-a8c1-a493f4177ee4</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="275" Volume="1961" Year="1985" Format="Main Series">
+    <Book Series="Fantastic Four" Number="275" Volume="1961" Year="1985">
       <Id>b1515857-0d7a-4fe0-a355-fbe718175ffa</Id>
     </Book>
-    <Book Series="Marvel Graphic Novel" Number="18" Volume="1982" Year="1985" Format="Graphic Novel">
+    <Book Series="Marvel Graphic Novel" Number="18" Volume="1982" Year="1985">
       <Id>7dec831f-7257-4e2f-af10-fec4ec2d9b84</Id>
     </Book>
-    <Book Series="The Thing" Number="36" Volume="1983" Year="1986" Format="Main Series">
+    <Book Series="The Thing" Number="36" Volume="1983" Year="1986">
       <Id>ca94dee9-7afd-4e0b-a94a-72cfd66bccdd</Id>
     </Book>
-    <Book Series="She-Hulk: Ceremony" Number="1" Volume="1989" Year="1989" Format="Limited Series">
+    <Book Series="She-Hulk: Ceremony" Number="1" Volume="1989" Year="1989">
       <Id>218ee0d4-496d-4381-a420-8c7471c275b8</Id>
     </Book>
-    <Book Series="She-Hulk: Ceremony" Number="2" Volume="1989" Year="1989" Format="Limited Series">
+    <Book Series="She-Hulk: Ceremony" Number="2" Volume="1989" Year="1989">
       <Id>4fbe0e95-4b4a-416a-b575-09980c19dad2</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="1" Volume="1989" Year="1989" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="1" Volume="1989" Year="1989">
       <Id>94bbdc52-7c82-44d9-b105-7dda2b8d34bf</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="2" Volume="1989" Year="1989" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="2" Volume="1989" Year="1989">
       <Id>5171ffc4-1427-48d3-8075-7f9563202651</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="3" Volume="1989" Year="1989" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="3" Volume="1989" Year="1989">
       <Id>6eefeb0f-e7df-4d9b-b2b7-aacdd2120583</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="4" Volume="1989" Year="1989" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="4" Volume="1989" Year="1989">
       <Id>aa9b445b-e02a-4677-b420-5a47f8c42467</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="5" Volume="1989" Year="1989" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="5" Volume="1989" Year="1989">
       <Id>730a4efb-cc00-45c3-819b-e315b07ef465</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="6" Volume="1989" Year="1989" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="6" Volume="1989" Year="1989">
       <Id>d07ee29f-019f-4de6-b518-1ffc4c57919d</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="7" Volume="1989" Year="1989" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="7" Volume="1989" Year="1989">
       <Id>86bdc43a-b86c-439b-8266-20f07321a501</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="8" Volume="1989" Year="1989" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="8" Volume="1989" Year="1989">
       <Id>5eaf2e39-3fc2-48e9-ad46-5dfbcaf23785</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="9" Volume="1989" Year="1989" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="9" Volume="1989" Year="1989">
       <Id>f7398b3c-8e7b-4801-9600-4f2a00c2e63d</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="10" Volume="1989" Year="1989" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="10" Volume="1989" Year="1989">
       <Id>0edca990-f6fd-45d4-a441-076ce4c77099</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="11" Volume="1989" Year="1990" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="11" Volume="1989" Year="1990">
       <Id>98ccce70-731b-46dd-a646-9b7fe71be2fc</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="12" Volume="1989" Year="1990" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="12" Volume="1989" Year="1990">
       <Id>cb76f574-c5b8-4471-937a-4be60498b1cc</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="13" Volume="1989" Year="1990" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="13" Volume="1989" Year="1990">
       <Id>a5d0da48-c26f-428c-b13e-b4d3c3ca8b49</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="14" Volume="1989" Year="1990" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="14" Volume="1989" Year="1990">
       <Id>dc3d28ec-581e-456b-a2aa-47a839385008</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="15" Volume="1989" Year="1990" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="15" Volume="1989" Year="1990">
       <Id>06a167f0-bdf4-4244-ade7-65b3cb0dbc00</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="16" Volume="1989" Year="1990" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="16" Volume="1989" Year="1990">
       <Id>4d1d7958-263c-4047-8731-66ba1a1eb7da</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="17" Volume="1989" Year="1990" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="17" Volume="1989" Year="1990">
       <Id>5ede205b-48de-4457-993c-c0dbfc0c6d30</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="18" Volume="1989" Year="1990" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="18" Volume="1989" Year="1990">
       <Id>f2e6010e-424a-419d-a13d-8726fb8a3958</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="19" Volume="1989" Year="1990" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="19" Volume="1989" Year="1990">
       <Id>ab3f2159-5525-431b-93ef-e30558c1a27e</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="20" Volume="1989" Year="1990" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="20" Volume="1989" Year="1990">
       <Id>44906b81-fb7d-4237-bab7-875df383f460</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="21" Volume="1989" Year="1990" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="21" Volume="1989" Year="1990">
       <Id>e8968326-38b1-4a3e-8e17-cf524c9f467b</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="22" Volume="1989" Year="1990" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="22" Volume="1989" Year="1990">
       <Id>a9319d58-76a5-4fc6-8891-5a1498c93505</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="23" Volume="1989" Year="1991" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="23" Volume="1989" Year="1991">
       <Id>5098013e-fc4c-47ac-850b-80a31df09c0f</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="24" Volume="1989" Year="1991" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="24" Volume="1989" Year="1991">
       <Id>690ec6a3-62c6-4296-bf9c-b49b901ccb9c</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="25" Volume="1989" Year="1991" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="25" Volume="1989" Year="1991">
       <Id>f1377f06-5ed3-4349-91a2-1c1e00a51313</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="26" Volume="1989" Year="1991" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="26" Volume="1989" Year="1991">
       <Id>ecf727f2-39c3-4f34-9695-87398ade1d27</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="27" Volume="1989" Year="1991" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="27" Volume="1989" Year="1991">
       <Id>c8d8791d-0fcd-4caa-be4c-7d3b0f8edd84</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="28" Volume="1989" Year="1991" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="28" Volume="1989" Year="1991">
       <Id>723b1785-a057-4b7c-8220-ff0811ad7e8f</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="29" Volume="1989" Year="1991" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="29" Volume="1989" Year="1991">
       <Id>42f38f10-480f-4403-9cc3-c3e60f7f6a11</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="30" Volume="1989" Year="1991" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="30" Volume="1989" Year="1991">
       <Id>d95addf2-ad46-4268-9ae2-67442f735a58</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="31" Volume="1989" Year="1991" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="31" Volume="1989" Year="1991">
       <Id>8635fad0-a9af-458e-a47a-850fe2a4cbd1</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="32" Volume="1989" Year="1991" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="32" Volume="1989" Year="1991">
       <Id>0f0a6c65-46b2-4087-af95-9801671c6731</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="33" Volume="1989" Year="1991" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="33" Volume="1989" Year="1991">
       <Id>06b82b78-b3dc-4459-9794-9911f2cdf33a</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="34" Volume="1989" Year="1991" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="34" Volume="1989" Year="1991">
       <Id>1e423e0d-6ba0-4dbc-bc6a-5f460103feee</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="35" Volume="1989" Year="1992" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="35" Volume="1989" Year="1992">
       <Id>aa35dec9-ee18-444a-8c46-84c99e9d4c02</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="36" Volume="1989" Year="1992" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="36" Volume="1989" Year="1992">
       <Id>cafce097-5c83-4ed2-ba08-74a0cbd5c360</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="37" Volume="1989" Year="1992" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="37" Volume="1989" Year="1992">
       <Id>043e2438-a240-4cf1-b2ea-c6a59e78262c</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="38" Volume="1989" Year="1992" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="38" Volume="1989" Year="1992">
       <Id>84de3c8d-41da-418a-a0ee-caab505a62aa</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="39" Volume="1989" Year="1992" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="39" Volume="1989" Year="1992">
       <Id>743b2117-dd18-457a-9753-2f86d5dd1773</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="40" Volume="1989" Year="1992" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="40" Volume="1989" Year="1992">
       <Id>7ca99a33-0341-49d0-b487-b0a13de3b42b</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="41" Volume="1989" Year="1992" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="41" Volume="1989" Year="1992">
       <Id>b8dcca84-35cd-4292-a15b-f32ca4b5ad61</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="42" Volume="1989" Year="1992" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="42" Volume="1989" Year="1992">
       <Id>a9c1af1c-ef32-4546-8616-5f47b4853668</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="43" Volume="1989" Year="1992" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="43" Volume="1989" Year="1992">
       <Id>a8867068-ba95-4442-b55f-b0700ee2aa52</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="44" Volume="1989" Year="1992" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="44" Volume="1989" Year="1992">
       <Id>e297bd9d-7e6a-4c00-95cc-815af9252955</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="45" Volume="1989" Year="1992" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="45" Volume="1989" Year="1992">
       <Id>d1e96705-117b-4804-aa66-c0e07f466aba</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="46" Volume="1989" Year="1992" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="46" Volume="1989" Year="1992">
       <Id>3109a2fd-3d7d-44e9-bcaf-97607d9a9f48</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="47" Volume="1989" Year="1993" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="47" Volume="1989" Year="1993">
       <Id>5e87a0d4-f592-4a4a-b138-b0bb16d2fa22</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="48" Volume="1989" Year="1993" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="48" Volume="1989" Year="1993">
       <Id>021945e7-6321-4a42-95fd-7a18cef5fbde</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="49" Volume="1989" Year="1993" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="49" Volume="1989" Year="1993">
       <Id>21c59c88-7ba0-4a24-accb-858b3634d586</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="50" Volume="1989" Year="1993" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="50" Volume="1989" Year="1993">
       <Id>9edf2944-f7c9-47f8-96fc-2d76fffb39d2</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="51" Volume="1989" Year="1993" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="51" Volume="1989" Year="1993">
       <Id>e90a65ec-a13e-4057-904d-a61d7c90dbab</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="52" Volume="1989" Year="1993" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="52" Volume="1989" Year="1993">
       <Id>98f56dc1-d16d-4a99-aaa3-42b3b30c864a</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="53" Volume="1989" Year="1993" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="53" Volume="1989" Year="1993">
       <Id>dfa56245-bda1-43dc-8cc2-ccfcde783783</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="54" Volume="1989" Year="1993" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="54" Volume="1989" Year="1993">
       <Id>092e5725-389c-49da-808e-d73f16393a60</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="55" Volume="1989" Year="1993" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="55" Volume="1989" Year="1993">
       <Id>e86e210e-5407-4f97-abe4-72f3f7364e7c</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="56" Volume="1989" Year="1993" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="56" Volume="1989" Year="1993">
       <Id>eee4f908-96b1-4d0f-8c19-e8b16253f6c3</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="57" Volume="1989" Year="1993" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="57" Volume="1989" Year="1993">
       <Id>bf423288-efad-45e9-a9a0-f198e97e448a</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="58" Volume="1989" Year="1993" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="58" Volume="1989" Year="1993">
       <Id>5d07904c-d633-4677-8b94-9754ed29690b</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="59" Volume="1989" Year="1994" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="59" Volume="1989" Year="1994">
       <Id>3e5409ed-3a28-4546-b7a1-b33f5d040117</Id>
     </Book>
-    <Book Series="The Sensational She-Hulk" Number="60" Volume="1989" Year="1994" Format="Main Series">
+    <Book Series="The Sensational She-Hulk" Number="60" Volume="1989" Year="1994">
       <Id>0455fc92-1b0b-4d8f-ac11-1f9b300d5405</Id>
     </Book>
-    <Book Series="Thing &amp; She-Hulk: The Long Night" Number="1" Volume="2002" Year="2002" Format="One-Shot">
+    <Book Series="Thing &amp; She-Hulk: The Long Night" Number="1" Volume="2002" Year="2002">
       <Id>df923a19-c1ea-43f0-baa0-64ff057db727</Id>
     </Book>
-    <Book Series="Avengers" Number="72" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Avengers" Number="72" Volume="1998" Year="2003">
       <Id>ee899576-ebac-4f97-a534-dd9c017bb95c</Id>
     </Book>
-    <Book Series="Avengers" Number="73" Volume="1998" Year="2003" Format="Main Series">
+    <Book Series="Avengers" Number="73" Volume="1998" Year="2003">
       <Id>33d6d883-3112-4702-b1e9-28ec2dd590ee</Id>
     </Book>
-    <Book Series="Avengers" Number="74" Volume="1998" Year="2004" Format="Main Series">
+    <Book Series="Avengers" Number="74" Volume="1998" Year="2004">
       <Id>8fe320e1-a978-495a-beae-7443db446a3e</Id>
     </Book>
-    <Book Series="Avengers" Number="75" Volume="1998" Year="2004" Format="Main Series">
+    <Book Series="Avengers" Number="75" Volume="1998" Year="2004">
       <Id>e6a9e8ba-bd8b-4b9a-911a-0b9c47d93ed0</Id>
     </Book>
-    <Book Series="She-Hulk" Number="1" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="She-Hulk" Number="1" Volume="2004" Year="2004">
       <Id>a7fc940f-fc31-4f53-9086-d2201de737ae</Id>
     </Book>
-    <Book Series="She-Hulk" Number="2" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="She-Hulk" Number="2" Volume="2004" Year="2004">
       <Id>d885431b-a0de-439a-994c-ac7b9e9c4e87</Id>
     </Book>
-    <Book Series="She-Hulk" Number="3" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="She-Hulk" Number="3" Volume="2004" Year="2004">
       <Id>af381844-cde8-424a-8ee9-dc6d4910c46f</Id>
     </Book>
-    <Book Series="She-Hulk" Number="4" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="She-Hulk" Number="4" Volume="2004" Year="2004">
       <Id>e9ef645e-1ccc-48ec-9f7a-2b140cd40d93</Id>
     </Book>
-    <Book Series="She-Hulk" Number="5" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="She-Hulk" Number="5" Volume="2004" Year="2004">
       <Id>9c6e310d-6629-421f-8f93-242222cbda78</Id>
     </Book>
-    <Book Series="She-Hulk" Number="6" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="She-Hulk" Number="6" Volume="2004" Year="2004">
       <Id>772d2a9c-9050-4599-a97f-1608a71ceee0</Id>
     </Book>
-    <Book Series="She-Hulk" Number="7" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="She-Hulk" Number="7" Volume="2004" Year="2004">
       <Id>96c6dcf8-7764-4cc4-aab7-a83b78c8e2da</Id>
     </Book>
-    <Book Series="She-Hulk" Number="8" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="She-Hulk" Number="8" Volume="2004" Year="2004">
       <Id>b68aeba9-b7ea-4fa9-ae74-8e8203113edc</Id>
     </Book>
-    <Book Series="She-Hulk" Number="9" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="She-Hulk" Number="9" Volume="2004" Year="2005">
       <Id>505fd72d-6ca9-4c2b-99e2-88a8fec5111b</Id>
     </Book>
-    <Book Series="She-Hulk" Number="10" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="She-Hulk" Number="10" Volume="2004" Year="2005">
       <Id>1b686d0d-339b-4dff-b7f7-6770c42809a7</Id>
     </Book>
-    <Book Series="She-Hulk" Number="11" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="She-Hulk" Number="11" Volume="2004" Year="2005">
       <Id>0fe5a7c8-2a6e-4ec4-a0a6-419f0a839464</Id>
     </Book>
-    <Book Series="She-Hulk" Number="12" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="She-Hulk" Number="12" Volume="2004" Year="2005">
       <Id>ac22d0d9-806f-4f59-b158-6ee89d6f62a7</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="11" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="11" Volume="2005" Year="2005">
       <Id>643c5589-97bc-4ebe-8d7b-15114088b1cc</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="12" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="12" Volume="2005" Year="2005">
       <Id>ba109392-bd6a-46ff-bf9e-cef1b7d17578</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="13" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="13" Volume="2005" Year="2005">
       <Id>ea316fbc-852a-4728-83fe-2dd7b502c772</Id>
     </Book>
-    <Book Series="She-Hulk" Number="1" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="She-Hulk" Number="1" Volume="2005" Year="2005">
       <Id>a64c72b8-ad12-414b-9bdc-4f4601c432f8</Id>
     </Book>
-    <Book Series="She-Hulk" Number="2" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="She-Hulk" Number="2" Volume="2005" Year="2006">
       <Id>67bdd35d-a0ea-4365-8fec-9997a674b640</Id>
     </Book>
-    <Book Series="She-Hulk" Number="3" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="She-Hulk" Number="3" Volume="2005" Year="2006">
       <Id>a630774a-f99c-473c-bd11-962ba67d967c</Id>
     </Book>
-    <Book Series="She-Hulk" Number="4" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="She-Hulk" Number="4" Volume="2005" Year="2006">
       <Id>e4d5dd25-d926-4256-90d9-91a38d0d2701</Id>
     </Book>
-    <Book Series="She-Hulk" Number="5" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="She-Hulk" Number="5" Volume="2005" Year="2006">
       <Id>1eb216b0-a285-49c9-8d57-1d0fb2d39ff9</Id>
     </Book>
-    <Book Series="She-Hulk" Number="6" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="She-Hulk" Number="6" Volume="2005" Year="2006">
       <Id>65b475e0-1d51-4050-8f95-43bd9cd1f0d0</Id>
     </Book>
-    <Book Series="She-Hulk" Number="7" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="She-Hulk" Number="7" Volume="2005" Year="2006">
       <Id>71420aeb-9639-41ba-9dea-f7a4ba0386d7</Id>
     </Book>
-    <Book Series="She-Hulk" Number="8" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="She-Hulk" Number="8" Volume="2005" Year="2006">
       <Id>ffd1ef82-3daf-40fb-bbe4-164ca795adf2</Id>
     </Book>
-    <Book Series="She-Hulk" Number="9" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="She-Hulk" Number="9" Volume="2005" Year="2006">
       <Id>1119648d-e79f-4dea-a49f-7821fd1852f6</Id>
     </Book>
-    <Book Series="She-Hulk" Number="10" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="She-Hulk" Number="10" Volume="2005" Year="2006">
       <Id>d4f83c4f-6c8f-49cd-8394-4bef99c1be05</Id>
     </Book>
-    <Book Series="She-Hulk" Number="11" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="She-Hulk" Number="11" Volume="2005" Year="2006">
       <Id>0865253a-204e-4de1-b17e-cd0201788df7</Id>
     </Book>
-    <Book Series="She-Hulk" Number="12" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="She-Hulk" Number="12" Volume="2005" Year="2006">
       <Id>293f52f9-8251-4ab2-b9e7-6ed8e321a06d</Id>
     </Book>
-    <Book Series="She-Hulk" Number="13" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="She-Hulk" Number="13" Volume="2005" Year="2006">
       <Id>e7c418d9-b78e-4a01-84e9-5e2654f8ccfe</Id>
     </Book>
-    <Book Series="She-Hulk" Number="14" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="She-Hulk" Number="14" Volume="2005" Year="2007">
       <Id>2c64e627-0c0a-4ead-b6e5-24510e0430a2</Id>
     </Book>
-    <Book Series="She-Hulk" Number="15" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="She-Hulk" Number="15" Volume="2005" Year="2007">
       <Id>21ec9241-d3da-46ca-9f17-f261f00df4a4</Id>
     </Book>
-    <Book Series="She-Hulk" Number="16" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="She-Hulk" Number="16" Volume="2005" Year="2007">
       <Id>2803888c-70b3-47d1-8501-2270e072de2a</Id>
     </Book>
-    <Book Series="She-Hulk" Number="17" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="She-Hulk" Number="17" Volume="2005" Year="2007">
       <Id>2580d415-ad22-47b1-82e8-a03b7b2982e2</Id>
     </Book>
-    <Book Series="She-Hulk" Number="18" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="She-Hulk" Number="18" Volume="2005" Year="2007">
       <Id>647dfa7b-be2d-4979-9b35-d03f756ebcf7</Id>
     </Book>
-    <Book Series="She-Hulk" Number="19" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="She-Hulk" Number="19" Volume="2005" Year="2007">
       <Id>89068712-0d00-4f2e-807a-8ec43eb27f64</Id>
     </Book>
-    <Book Series="She-Hulk" Number="20" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="She-Hulk" Number="20" Volume="2005" Year="2007">
       <Id>58d5dcd7-3128-48bc-ab8d-52b4eee4daf6</Id>
     </Book>
-    <Book Series="She-Hulk" Number="21" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="She-Hulk" Number="21" Volume="2005" Year="2007">
       <Id>2176aea0-28a1-4083-8ca2-16eeb0d38e54</Id>
     </Book>
-    <Book Series="She-Hulk" Number="22" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="She-Hulk" Number="22" Volume="2005" Year="2007">
       <Id>2b0aeaf7-31dc-4d4b-960a-b22d5ab64f0f</Id>
     </Book>
-    <Book Series="She-Hulk" Number="23" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="She-Hulk" Number="23" Volume="2005" Year="2008">
       <Id>24d6818d-ef2e-4513-baa1-c9fa4f8560a3</Id>
     </Book>
-    <Book Series="She-Hulk" Number="24" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="She-Hulk" Number="24" Volume="2005" Year="2008">
       <Id>2176c106-e4ee-41a9-8505-81b27ea525c3</Id>
     </Book>
-    <Book Series="She-Hulk" Number="25" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="She-Hulk" Number="25" Volume="2005" Year="2008">
       <Id>127c1199-a020-4a66-b1d7-b83e31da133d</Id>
     </Book>
-    <Book Series="She-Hulk" Number="26" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="She-Hulk" Number="26" Volume="2005" Year="2008">
       <Id>6db60764-5654-4947-8e14-6980e30dcc09</Id>
     </Book>
-    <Book Series="She-Hulk" Number="27" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="She-Hulk" Number="27" Volume="2005" Year="2008">
       <Id>7f15ed3d-843a-4828-b505-4b0a4d927d32</Id>
     </Book>
-    <Book Series="She-Hulk" Number="28" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="She-Hulk" Number="28" Volume="2005" Year="2008">
       <Id>cdda94ff-19cf-4cc4-9842-2b82b77238f3</Id>
     </Book>
-    <Book Series="She-Hulk" Number="29" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="She-Hulk" Number="29" Volume="2005" Year="2008">
       <Id>ffd1fd56-a450-4b53-9ce4-52f5edffe868</Id>
     </Book>
-    <Book Series="She-Hulk" Number="30" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="She-Hulk" Number="30" Volume="2005" Year="2008">
       <Id>0ea06f06-1afd-41d9-967d-03fccd701896</Id>
     </Book>
-    <Book Series="She-Hulk: Cosmic Collision" Number="1" Volume="2009" Year="2009" Format="One-Shot">
+    <Book Series="She-Hulk: Cosmic Collision" Number="1" Volume="2009" Year="2009">
       <Id>f65c0e1c-fd59-4269-98db-b57929923a4a</Id>
     </Book>
-    <Book Series="She-Hulk" Number="31" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="She-Hulk" Number="31" Volume="2005" Year="2008">
       <Id>54fbe521-6221-4bcd-9444-38e32d486c7d</Id>
     </Book>
-    <Book Series="X-Factor" Number="34" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="X-Factor" Number="34" Volume="2006" Year="2008">
       <Id>52e5dea3-f4f6-48b3-a067-5b63d9665157</Id>
     </Book>
-    <Book Series="She-Hulk" Number="32" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="She-Hulk" Number="32" Volume="2005" Year="2008">
       <Id>313c7d77-2222-41f7-b897-d018380620db</Id>
     </Book>
-    <Book Series="She-Hulk" Number="33" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="She-Hulk" Number="33" Volume="2005" Year="2008">
       <Id>081480f4-c72b-4ecf-9f76-b001fe84f53b</Id>
     </Book>
-    <Book Series="She-Hulk" Number="34" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="She-Hulk" Number="34" Volume="2005" Year="2008">
       <Id>7cb3797f-cff2-435e-b6b2-b13247f88498</Id>
     </Book>
-    <Book Series="She-Hulk" Number="35" Volume="2005" Year="2009" Format="Main Series">
+    <Book Series="She-Hulk" Number="35" Volume="2005" Year="2009">
       <Id>eaad1cea-b68b-4165-abc7-80e034de25bc</Id>
     </Book>
-    <Book Series="She-Hulk" Number="36" Volume="2005" Year="2009" Format="Main Series">
+    <Book Series="She-Hulk" Number="36" Volume="2005" Year="2009">
       <Id>89ea888b-c712-4a5c-87e4-64260b43e129</Id>
     </Book>
-    <Book Series="She-Hulk" Number="37" Volume="2005" Year="2009" Format="Main Series">
+    <Book Series="She-Hulk" Number="37" Volume="2005" Year="2009">
       <Id>87135258-bb04-4c41-aa5b-6a334edeeb34</Id>
     </Book>
-    <Book Series="She-Hulk" Number="38" Volume="2005" Year="2009" Format="Main Series">
+    <Book Series="She-Hulk" Number="38" Volume="2005" Year="2009">
       <Id>26235e2c-75c1-4e31-aade-2e953a80e82a</Id>
     </Book>
-    <Book Series="Hulk Family: Green Genes" Number="1" Volume="2009" Year="2009" Format="One-Shot">
+    <Book Series="Hulk Family: Green Genes" Number="1" Volume="2009" Year="2009">
       <Id>c737b6ed-3d36-4445-9054-d90c270d36e1</Id>
     </Book>
-    <Book Series="All-New Savage She-Hulk" Number="1" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="All-New Savage She-Hulk" Number="1" Volume="2009" Year="2009">
       <Id>e323bae7-839f-4015-a885-1850cefe8643</Id>
     </Book>
-    <Book Series="All-New Savage She-Hulk" Number="2" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="All-New Savage She-Hulk" Number="2" Volume="2009" Year="2009">
       <Id>40ecbeb0-de27-4de9-ad3c-b331be334dac</Id>
     </Book>
-    <Book Series="All-New Savage She-Hulk" Number="3" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="All-New Savage She-Hulk" Number="3" Volume="2009" Year="2009">
       <Id>dbaaaf70-b55f-4f28-8a06-90bcb06052e7</Id>
     </Book>
-    <Book Series="All-New Savage She-Hulk" Number="4" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="All-New Savage She-Hulk" Number="4" Volume="2009" Year="2009">
       <Id>b7fd5315-5710-4def-9bf9-a20dbb5a0e62</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="600" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="600" Volume="2009" Year="2009">
       <Id>9d3400fe-1e8b-414f-95ef-2c6f638f39c6</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="601" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="601" Volume="2009" Year="2009">
       <Id>302eaa74-7787-468e-8e10-50e4e5285b70</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="602" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="602" Volume="2009" Year="2009">
       <Id>af075fab-3722-4a59-b466-aded57a1509c</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="603" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="603" Volume="2009" Year="2009">
       <Id>e4022aef-0618-4a44-804c-21075cd2d895</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="604" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="604" Volume="2009" Year="2010">
       <Id>c83d6851-546b-492e-b6c5-0d420a033958</Id>
     </Book>
-    <Book Series="Incredible Hulk" Number="605" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Incredible Hulk" Number="605" Volume="2009" Year="2010">
       <Id>3894de43-62f4-4d09-8b78-44923087dc3c</Id>
     </Book>
-    <Book Series="Fall of the Hulks: The Savage She-Hulks" Number="1" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Fall of the Hulks: The Savage She-Hulks" Number="1" Volume="2010" Year="2010">
       <Id>55b51039-bda9-4feb-8cb1-c38b9ddf7df5</Id>
     </Book>
-    <Book Series="Fall of the Hulks: The Savage She-Hulks" Number="2" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Fall of the Hulks: The Savage She-Hulks" Number="2" Volume="2010" Year="2010">
       <Id>38656409-830f-4b8d-933d-b6f23d8a6527</Id>
     </Book>
-    <Book Series="Fall of the Hulks: The Savage She-Hulks" Number="3" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Fall of the Hulks: The Savage She-Hulks" Number="3" Volume="2010" Year="2010">
       <Id>0e5cd3b4-c208-4bb3-9587-fe85d63148f6</Id>
     </Book>
-    <Book Series="She-Hulk Sensational" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="She-Hulk Sensational" Number="1" Volume="2010" Year="2010">
       <Id>2c6139a6-34dd-47b6-9f1c-af5b8a3bd474</Id>
     </Book>
-    <Book Series="She-Hulks" Number="1" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="She-Hulks" Number="1" Volume="2011" Year="2011">
       <Id>73fc8850-95d4-479f-aa3d-335f515fc09d</Id>
     </Book>
-    <Book Series="She-Hulks" Number="2" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="She-Hulks" Number="2" Volume="2011" Year="2011">
       <Id>79d0ea43-cb10-45e5-abd5-ff51574bd4ff</Id>
     </Book>
-    <Book Series="She-Hulks" Number="3" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="She-Hulks" Number="3" Volume="2011" Year="2011">
       <Id>c09d947b-a968-4004-9c67-eb94273fa9cb</Id>
     </Book>
-    <Book Series="She-Hulks" Number="4" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="She-Hulks" Number="4" Volume="2011" Year="2011">
       <Id>1ad05b37-a6aa-408d-80ee-14491cdd326a</Id>
     </Book>
-    <Book Series="Red She-Hulk" Number="58" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Red She-Hulk" Number="58" Volume="2012" Year="2012">
       <Id>e56aeb9c-4249-41bf-9746-865e489dad18</Id>
     </Book>
-    <Book Series="Red She-Hulk" Number="59" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Red She-Hulk" Number="59" Volume="2012" Year="2013">
       <Id>892254c6-88aa-4e06-9217-0f8755227187</Id>
     </Book>
-    <Book Series="Red She-Hulk" Number="60" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Red She-Hulk" Number="60" Volume="2012" Year="2013">
       <Id>73eee3e1-1c24-4747-bd83-f150ec9e5943</Id>
     </Book>
-    <Book Series="Red She-Hulk" Number="61" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Red She-Hulk" Number="61" Volume="2012" Year="2013">
       <Id>8c5286ee-de3c-4ad4-b3ee-a9231eaed5c8</Id>
     </Book>
-    <Book Series="Red She-Hulk" Number="62" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Red She-Hulk" Number="62" Volume="2012" Year="2013">
       <Id>780ecbcf-81eb-4240-84d8-3d4e544bb486</Id>
     </Book>
-    <Book Series="Red She-Hulk" Number="63" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Red She-Hulk" Number="63" Volume="2012" Year="2013">
       <Id>e213028a-c9a7-4f65-92c9-16a2af3d9dce</Id>
     </Book>
-    <Book Series="Red She-Hulk" Number="64" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Red She-Hulk" Number="64" Volume="2012" Year="2013">
       <Id>15490f0e-805b-419c-acde-ffb729e04028</Id>
     </Book>
-    <Book Series="Red She-Hulk" Number="65" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Red She-Hulk" Number="65" Volume="2012" Year="2013">
       <Id>8187cf6d-dc86-47aa-a384-597a9e2852db</Id>
     </Book>
-    <Book Series="Red She-Hulk" Number="66" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Red She-Hulk" Number="66" Volume="2012" Year="2013">
       <Id>1c0fabe4-30e8-4980-b7ae-459d5e48ac0e</Id>
     </Book>
-    <Book Series="Red She-Hulk" Number="67" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Red She-Hulk" Number="67" Volume="2012" Year="2013">
       <Id>54ac5670-65b8-4011-87f4-ac8c023d7665</Id>
     </Book>
-    <Book Series="She-Hulk" Number="1" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="She-Hulk" Number="1" Volume="2014" Year="2014">
       <Id>9e5e48e1-6a9f-46a5-998a-21a2deb58cd0</Id>
     </Book>
-    <Book Series="She-Hulk" Number="2" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="She-Hulk" Number="2" Volume="2014" Year="2014">
       <Id>34e93888-0644-4827-90b5-f8dd4ee3d6bf</Id>
     </Book>
-    <Book Series="She-Hulk" Number="3" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="She-Hulk" Number="3" Volume="2014" Year="2014">
       <Id>d47510bd-bf9f-4977-9c82-50045ceec5f9</Id>
     </Book>
-    <Book Series="She-Hulk" Number="4" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="She-Hulk" Number="4" Volume="2014" Year="2014">
       <Id>79ad80c2-d382-4ef2-b16b-d12ffbc6ca46</Id>
     </Book>
-    <Book Series="She-Hulk" Number="5" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="She-Hulk" Number="5" Volume="2014" Year="2014">
       <Id>9b02e7f3-ca5a-4349-922e-1b2f031cd814</Id>
     </Book>
-    <Book Series="She-Hulk" Number="6" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="She-Hulk" Number="6" Volume="2014" Year="2014">
       <Id>b7a93708-a9f0-49b0-b886-ac85e1a38554</Id>
     </Book>
-    <Book Series="She-Hulk" Number="7" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="She-Hulk" Number="7" Volume="2014" Year="2014">
       <Id>13a9c9aa-479f-4e1f-9853-2ad9a17986af</Id>
     </Book>
-    <Book Series="She-Hulk" Number="8" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="She-Hulk" Number="8" Volume="2014" Year="2014">
       <Id>ac75a126-372a-4077-9fde-33570abade54</Id>
     </Book>
-    <Book Series="She-Hulk" Number="9" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="She-Hulk" Number="9" Volume="2014" Year="2014">
       <Id>28956fce-c6c0-48cd-aa7e-b5cd8d76e211</Id>
     </Book>
-    <Book Series="She-Hulk" Number="10" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="She-Hulk" Number="10" Volume="2014" Year="2015">
       <Id>e7f4d54b-3e57-4e2b-89cf-76c80832ceff</Id>
     </Book>
-    <Book Series="She-Hulk" Number="11" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="She-Hulk" Number="11" Volume="2014" Year="2015">
       <Id>4f837d73-4225-4bcc-b2ff-d91097832621</Id>
     </Book>
-    <Book Series="She-Hulk" Number="12" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="She-Hulk" Number="12" Volume="2014" Year="2015">
       <Id>818b6f09-b5d7-4bc4-8a18-f14029678353</Id>
     </Book>
-    <Book Series="Hulk" Number="1" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Hulk" Number="1" Volume="2016" Year="2017">
       <Id>5d67027f-af50-47e2-8e03-f1d4c724d32c</Id>
     </Book>
-    <Book Series="Hulk" Number="2" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Hulk" Number="2" Volume="2016" Year="2017">
       <Id>08f6af19-01ba-405d-b9b5-40101157b05e</Id>
     </Book>
-    <Book Series="Hulk" Number="3" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Hulk" Number="3" Volume="2016" Year="2017">
       <Id>04a67e69-4911-452f-a071-90611099b1fe</Id>
     </Book>
-    <Book Series="Hulk" Number="4" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Hulk" Number="4" Volume="2016" Year="2017">
       <Id>4e5eb614-414d-4bd2-ab4e-dd470da1df5f</Id>
     </Book>
-    <Book Series="Hulk" Number="5" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Hulk" Number="5" Volume="2016" Year="2017">
       <Id>97837cfb-2823-4287-b7b5-5db80d9cf105</Id>
     </Book>
-    <Book Series="Hulk" Number="6" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Hulk" Number="6" Volume="2016" Year="2017">
       <Id>fe29a2ad-93b7-409f-bbba-3b08aacdc398</Id>
     </Book>
-    <Book Series="Hulk" Number="7" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Hulk" Number="7" Volume="2016" Year="2017">
       <Id>f0c6eea3-f430-4862-822b-43167e90434e</Id>
     </Book>
-    <Book Series="Hulk" Number="8" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Hulk" Number="8" Volume="2016" Year="2017">
       <Id>86a0d3b7-c0a8-4db7-a534-ee3ea7cce948</Id>
     </Book>
-    <Book Series="Hulk" Number="9" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Hulk" Number="9" Volume="2016" Year="2017">
       <Id>bceea13a-4960-45b4-9248-091d837e734e</Id>
     </Book>
-    <Book Series="Hulk" Number="10" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Hulk" Number="10" Volume="2016" Year="2017">
       <Id>8f5be685-d2b6-4983-b06d-e14d25a928d9</Id>
     </Book>
-    <Book Series="Hulk" Number="11" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Hulk" Number="11" Volume="2016" Year="2017">
       <Id>e6948c24-ccf8-42d2-901a-5265296c7dda</Id>
     </Book>
-    <Book Series="She-Hulk" Number="159" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="She-Hulk" Number="159" Volume="2017" Year="2018">
       <Id>614bb0ac-285f-4574-a8d1-b93ddb839d7a</Id>
     </Book>
-    <Book Series="She-Hulk" Number="160" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="She-Hulk" Number="160" Volume="2017" Year="2018">
       <Id>53bd717d-8efd-43ba-b228-15fa0d2ec8b4</Id>
     </Book>
-    <Book Series="She-Hulk" Number="161" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="She-Hulk" Number="161" Volume="2017" Year="2018">
       <Id>0587e8df-a8c7-45b2-a407-d52618527f08</Id>
     </Book>
-    <Book Series="She-Hulk" Number="162" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="She-Hulk" Number="162" Volume="2017" Year="2018">
       <Id>28174acb-382e-4e4b-b6e5-ee59d927b2b2</Id>
     </Book>
-    <Book Series="She-Hulk" Number="163" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="She-Hulk" Number="163" Volume="2017" Year="2018">
       <Id>b051d4e7-89ca-4b86-883b-556bf7eee0e6</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/She-Hullk/She-Hulk.cbl
+++ b/Marvel/Characters/unsorted/She-Hullk/She-Hulk.cbl
@@ -1,624 +1,625 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>She-Hulk</Name>
+  <NumIssues>206</NumIssues>
   <Books>
     <Book Series="Marvel Masterworks: The Savage She-Hulk" Number="1" Volume="2017" Year="2017">
-      <Id>bab6f2ea-d604-4058-845c-0b86e9ce3af4</Id>
+      <Database Name="cv" Series="103250" Issue="612044" />
     </Book>
     <Book Series="The Savage She-Hulk" Number="15" Volume="1980" Year="1981">
-      <Id>05124708-f4ab-414f-9fda-3af21c773eb6</Id>
+      <Database Name="cv" Series="3053" Issue="21189" />
     </Book>
     <Book Series="The Savage She-Hulk" Number="16" Volume="1980" Year="1981">
-      <Id>f63db51b-4c38-43c7-ac09-8db063b3e444</Id>
+      <Database Name="cv" Series="3053" Issue="21253" />
     </Book>
     <Book Series="Marvel Team-Up" Number="107" Volume="1972" Year="1981">
-      <Id>46c9a275-735d-43ee-a498-d93b8d1b116b</Id>
+      <Database Name="cv" Series="2576" Issue="21380" />
     </Book>
     <Book Series="The Savage She-Hulk" Number="17" Volume="1980" Year="1981">
-      <Id>3b87aa56-344b-489d-a622-818a4044181c</Id>
+      <Database Name="cv" Series="3053" Issue="21313" />
     </Book>
     <Book Series="The Savage She-Hulk" Number="18" Volume="1980" Year="1981">
-      <Id>6529cd56-f77d-47cd-8778-63ec6d9830ae</Id>
+      <Database Name="cv" Series="3053" Issue="21387" />
     </Book>
     <Book Series="The Savage She-Hulk" Number="19" Volume="1980" Year="1981">
-      <Id>ce7efd7e-ca5e-4586-a9d7-62aea5f515df</Id>
+      <Database Name="cv" Series="3053" Issue="21453" />
     </Book>
     <Book Series="The Savage She-Hulk" Number="20" Volume="1980" Year="1981">
-      <Id>bf3e2663-f70c-49fb-9a8d-dc0fe8c926fc</Id>
+      <Database Name="cv" Series="3053" Issue="21525" />
     </Book>
     <Book Series="The Savage She-Hulk" Number="21" Volume="1980" Year="1981">
-      <Id>b9ea1444-544d-439f-8fdd-d685adc23320</Id>
+      <Database Name="cv" Series="3053" Issue="21607" />
     </Book>
     <Book Series="The Savage She-Hulk" Number="22" Volume="1980" Year="1981">
-      <Id>2168464d-f883-4580-93e9-e900adc97583</Id>
+      <Database Name="cv" Series="3053" Issue="21674" />
     </Book>
     <Book Series="The Savage She-Hulk" Number="23" Volume="1980" Year="1981">
-      <Id>f7b3116d-14be-4fba-82ba-30d6b6cd20ba</Id>
+      <Database Name="cv" Series="3053" Issue="21744" />
     </Book>
     <Book Series="The Savage She-Hulk" Number="24" Volume="1980" Year="1982">
-      <Id>e967471a-2ac4-4da1-b115-fb2d9a670ad5</Id>
+      <Database Name="cv" Series="3053" Issue="21870" />
     </Book>
     <Book Series="The Savage She-Hulk" Number="25" Volume="1980" Year="1982">
-      <Id>1ae035df-e131-45c5-97a5-b4c9598074d4</Id>
+      <Database Name="cv" Series="3053" Issue="21943" />
     </Book>
     <Book Series="Dazzler" Number="14" Volume="1981" Year="1982">
-      <Id>b44312ad-29c5-4643-a3e6-49e243ab0940</Id>
+      <Database Name="cv" Series="3083" Issue="22078" />
     </Book>
     <Book Series="Marvel Two-in-One" Number="88" Volume="1974" Year="1982">
-      <Id>0ea1a15d-42cc-4a93-a27c-597edfd25b4d</Id>
+      <Database Name="cv" Series="2696" Issue="22237" />
     </Book>
     <Book Series="Marvel Super Hero Contest of Champions" Number="1" Volume="1982" Year="1982">
-      <Id>21316dcb-b049-47bd-9372-75429ecdad85</Id>
+      <Database Name="cv" Series="3147" Issue="22234" />
     </Book>
     <Book Series="Marvel Super Hero Contest of Champions" Number="2" Volume="1982" Year="1982">
-      <Id>e10fc5d4-dcb6-4071-85a2-19aab7266e35</Id>
+      <Database Name="cv" Series="3147" Issue="22304" />
     </Book>
     <Book Series="Marvel Super Hero Contest of Champions" Number="3" Volume="1982" Year="1982">
-      <Id>d51c20ee-2f44-49a5-97ae-60b8f9012db7</Id>
+      <Database Name="cv" Series="3147" Issue="22378" />
     </Book>
     <Book Series="The Avengers" Number="221" Volume="1963" Year="1982">
-      <Id>cd2a81ad-cb08-4251-80af-0fcffbc7c19b</Id>
+      <Database Name="cv" Series="2128" Issue="22293" />
     </Book>
     <Book Series="The Avengers" Number="222" Volume="1963" Year="1982">
-      <Id>5d31043d-daaa-4249-bb7c-5fff955c9339</Id>
+      <Database Name="cv" Series="2128" Issue="22365" />
     </Book>
     <Book Series="The Incredible Hulk" Number="282" Volume="1968" Year="1983">
-      <Id>2c2d83fc-efc8-41bf-96e1-b91a194b1a46</Id>
+      <Database Name="cv" Series="2406" Issue="23034" />
     </Book>
     <Book Series="The Incredible Hulk" Number="283" Volume="1968" Year="1983">
-      <Id>c26454fc-043d-4430-a76b-45f0e13277cc</Id>
+      <Database Name="cv" Series="2406" Issue="23120" />
     </Book>
     <Book Series="The Incredible Hulk" Number="284" Volume="1968" Year="1983">
-      <Id>54943606-0d74-468a-b280-8dcd1ed44ae7</Id>
+      <Database Name="cv" Series="2406" Issue="23205" />
     </Book>
     <Book Series="Fantastic Four" Number="265" Volume="1961" Year="1984">
-      <Id>c7f9899f-716c-42eb-a8c1-a493f4177ee4</Id>
+      <Database Name="cv" Series="2045" Issue="24202" />
     </Book>
     <Book Series="Fantastic Four" Number="275" Volume="1961" Year="1985">
-      <Id>b1515857-0d7a-4fe0-a355-fbe718175ffa</Id>
+      <Database Name="cv" Series="2045" Issue="25260" />
     </Book>
     <Book Series="Marvel Graphic Novel" Number="18" Volume="1982" Year="1985">
-      <Id>7dec831f-7257-4e2f-af10-fec4ec2d9b84</Id>
+      <Database Name="cv" Series="3144" Issue="123224" />
     </Book>
     <Book Series="The Thing" Number="36" Volume="1983" Year="1986">
-      <Id>ca94dee9-7afd-4e0b-a94a-72cfd66bccdd</Id>
+      <Database Name="cv" Series="3245" Issue="26900" />
     </Book>
-    <Book Series="She-Hulk: Ceremony" Number="1" Volume="1989" Year="1989">
-      <Id>218ee0d4-496d-4381-a420-8c7471c275b8</Id>
+    <Book Series="The Sensational She-Hulk in Ceremony" Number="1" Volume="1989" Year="1989">
+      <Database Name="cv" Series="22095" Issue="132923" />
     </Book>
-    <Book Series="She-Hulk: Ceremony" Number="2" Volume="1989" Year="1989">
-      <Id>4fbe0e95-4b4a-416a-b575-09980c19dad2</Id>
+    <Book Series="The Sensational She-Hulk in Ceremony" Number="2" Volume="1989" Year="1989">
+      <Database Name="cv" Series="22095" Issue="132924" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="1" Volume="1989" Year="1989">
-      <Id>94bbdc52-7c82-44d9-b105-7dda2b8d34bf</Id>
+      <Database Name="cv" Series="4243" Issue="31221" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="2" Volume="1989" Year="1989">
-      <Id>5171ffc4-1427-48d3-8075-7f9563202651</Id>
+      <Database Name="cv" Series="4243" Issue="31332" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="3" Volume="1989" Year="1989">
-      <Id>6eefeb0f-e7df-4d9b-b2b7-aacdd2120583</Id>
+      <Database Name="cv" Series="4243" Issue="31444" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="4" Volume="1989" Year="1989">
-      <Id>aa9b445b-e02a-4677-b420-5a47f8c42467</Id>
+      <Database Name="cv" Series="4243" Issue="31549" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="5" Volume="1989" Year="1989">
-      <Id>730a4efb-cc00-45c3-819b-e315b07ef465</Id>
+      <Database Name="cv" Series="4243" Issue="31665" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="6" Volume="1989" Year="1989">
-      <Id>d07ee29f-019f-4de6-b518-1ffc4c57919d</Id>
+      <Database Name="cv" Series="4243" Issue="31776" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="7" Volume="1989" Year="1989">
-      <Id>86bdc43a-b86c-439b-8266-20f07321a501</Id>
+      <Database Name="cv" Series="4243" Issue="31880" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="8" Volume="1989" Year="1989">
-      <Id>5eaf2e39-3fc2-48e9-ad46-5dfbcaf23785</Id>
+      <Database Name="cv" Series="4243" Issue="31930" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="9" Volume="1989" Year="1989">
-      <Id>f7398b3c-8e7b-4801-9600-4f2a00c2e63d</Id>
+      <Database Name="cv" Series="4243" Issue="32011" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="10" Volume="1989" Year="1989">
-      <Id>0edca990-f6fd-45d4-a441-076ce4c77099</Id>
+      <Database Name="cv" Series="4243" Issue="32331" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="11" Volume="1989" Year="1990">
-      <Id>98ccce70-731b-46dd-a646-9b7fe71be2fc</Id>
+      <Database Name="cv" Series="4243" Issue="32366" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="12" Volume="1989" Year="1990">
-      <Id>cb76f574-c5b8-4471-937a-4be60498b1cc</Id>
+      <Database Name="cv" Series="4243" Issue="32431" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="13" Volume="1989" Year="1990">
-      <Id>a5d0da48-c26f-428c-b13e-b4d3c3ca8b49</Id>
+      <Database Name="cv" Series="4243" Issue="32530" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="14" Volume="1989" Year="1990">
-      <Id>dc3d28ec-581e-456b-a2aa-47a839385008</Id>
+      <Database Name="cv" Series="4243" Issue="32643" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="15" Volume="1989" Year="1990">
-      <Id>06a167f0-bdf4-4244-ade7-65b3cb0dbc00</Id>
+      <Database Name="cv" Series="4243" Issue="32737" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="16" Volume="1989" Year="1990">
-      <Id>4d1d7958-263c-4047-8731-66ba1a1eb7da</Id>
+      <Database Name="cv" Series="4243" Issue="32857" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="17" Volume="1989" Year="1990">
-      <Id>5ede205b-48de-4457-993c-c0dbfc0c6d30</Id>
+      <Database Name="cv" Series="4243" Issue="32978" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="18" Volume="1989" Year="1990">
-      <Id>f2e6010e-424a-419d-a13d-8726fb8a3958</Id>
+      <Database Name="cv" Series="4243" Issue="33094" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="19" Volume="1989" Year="1990">
-      <Id>ab3f2159-5525-431b-93ef-e30558c1a27e</Id>
+      <Database Name="cv" Series="4243" Issue="33209" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="20" Volume="1989" Year="1990">
-      <Id>44906b81-fb7d-4237-bab7-875df383f460</Id>
+      <Database Name="cv" Series="4243" Issue="33331" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="21" Volume="1989" Year="1990">
-      <Id>e8968326-38b1-4a3e-8e17-cf524c9f467b</Id>
+      <Database Name="cv" Series="4243" Issue="33439" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="22" Volume="1989" Year="1990">
-      <Id>a9319d58-76a5-4fc6-8891-5a1498c93505</Id>
+      <Database Name="cv" Series="4243" Issue="33547" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="23" Volume="1989" Year="1991">
-      <Id>5098013e-fc4c-47ac-850b-80a31df09c0f</Id>
+      <Database Name="cv" Series="4243" Issue="33789" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="24" Volume="1989" Year="1991">
-      <Id>690ec6a3-62c6-4296-bf9c-b49b901ccb9c</Id>
+      <Database Name="cv" Series="4243" Issue="33889" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="25" Volume="1989" Year="1991">
-      <Id>f1377f06-5ed3-4349-91a2-1c1e00a51313</Id>
+      <Database Name="cv" Series="4243" Issue="130926" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="26" Volume="1989" Year="1991">
-      <Id>ecf727f2-39c3-4f34-9695-87398ade1d27</Id>
+      <Database Name="cv" Series="4243" Issue="130927" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="27" Volume="1989" Year="1991">
-      <Id>c8d8791d-0fcd-4caa-be4c-7d3b0f8edd84</Id>
+      <Database Name="cv" Series="4243" Issue="130928" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="28" Volume="1989" Year="1991">
-      <Id>723b1785-a057-4b7c-8220-ff0811ad7e8f</Id>
+      <Database Name="cv" Series="4243" Issue="73798" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="29" Volume="1989" Year="1991">
-      <Id>42f38f10-480f-4403-9cc3-c3e60f7f6a11</Id>
+      <Database Name="cv" Series="4243" Issue="73799" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="30" Volume="1989" Year="1991">
-      <Id>d95addf2-ad46-4268-9ae2-67442f735a58</Id>
+      <Database Name="cv" Series="4243" Issue="73800" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="31" Volume="1989" Year="1991">
-      <Id>8635fad0-a9af-458e-a47a-850fe2a4cbd1</Id>
+      <Database Name="cv" Series="4243" Issue="73801" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="32" Volume="1989" Year="1991">
-      <Id>0f0a6c65-46b2-4087-af95-9801671c6731</Id>
+      <Database Name="cv" Series="4243" Issue="34775" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="33" Volume="1989" Year="1991">
-      <Id>06b82b78-b3dc-4459-9794-9911f2cdf33a</Id>
+      <Database Name="cv" Series="4243" Issue="34891" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="34" Volume="1989" Year="1991">
-      <Id>1e423e0d-6ba0-4dbc-bc6a-5f460103feee</Id>
+      <Database Name="cv" Series="4243" Issue="73802" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="35" Volume="1989" Year="1992">
-      <Id>aa35dec9-ee18-444a-8c46-84c99e9d4c02</Id>
+      <Database Name="cv" Series="4243" Issue="73803" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="36" Volume="1989" Year="1992">
-      <Id>cafce097-5c83-4ed2-ba08-74a0cbd5c360</Id>
+      <Database Name="cv" Series="4243" Issue="73804" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="37" Volume="1989" Year="1992">
-      <Id>043e2438-a240-4cf1-b2ea-c6a59e78262c</Id>
+      <Database Name="cv" Series="4243" Issue="73805" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="38" Volume="1989" Year="1992">
-      <Id>84de3c8d-41da-418a-a0ee-caab505a62aa</Id>
+      <Database Name="cv" Series="4243" Issue="73806" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="39" Volume="1989" Year="1992">
-      <Id>743b2117-dd18-457a-9753-2f86d5dd1773</Id>
+      <Database Name="cv" Series="4243" Issue="73807" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="40" Volume="1989" Year="1992">
-      <Id>7ca99a33-0341-49d0-b487-b0a13de3b42b</Id>
+      <Database Name="cv" Series="4243" Issue="130929" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="41" Volume="1989" Year="1992">
-      <Id>b8dcca84-35cd-4292-a15b-f32ca4b5ad61</Id>
+      <Database Name="cv" Series="4243" Issue="130930" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="42" Volume="1989" Year="1992">
-      <Id>a9c1af1c-ef32-4546-8616-5f47b4853668</Id>
+      <Database Name="cv" Series="4243" Issue="130931" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="43" Volume="1989" Year="1992">
-      <Id>a8867068-ba95-4442-b55f-b0700ee2aa52</Id>
+      <Database Name="cv" Series="4243" Issue="130932" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="44" Volume="1989" Year="1992">
-      <Id>e297bd9d-7e6a-4c00-95cc-815af9252955</Id>
+      <Database Name="cv" Series="4243" Issue="130933" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="45" Volume="1989" Year="1992">
-      <Id>d1e96705-117b-4804-aa66-c0e07f466aba</Id>
+      <Database Name="cv" Series="4243" Issue="130934" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="46" Volume="1989" Year="1992">
-      <Id>3109a2fd-3d7d-44e9-bcaf-97607d9a9f48</Id>
+      <Database Name="cv" Series="4243" Issue="130935" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="47" Volume="1989" Year="1993">
-      <Id>5e87a0d4-f592-4a4a-b138-b0bb16d2fa22</Id>
+      <Database Name="cv" Series="4243" Issue="130936" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="48" Volume="1989" Year="1993">
-      <Id>021945e7-6321-4a42-95fd-7a18cef5fbde</Id>
+      <Database Name="cv" Series="4243" Issue="112038" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="49" Volume="1989" Year="1993">
-      <Id>21c59c88-7ba0-4a24-accb-858b3634d586</Id>
+      <Database Name="cv" Series="4243" Issue="130937" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="50" Volume="1989" Year="1993">
-      <Id>9edf2944-f7c9-47f8-96fc-2d76fffb39d2</Id>
+      <Database Name="cv" Series="4243" Issue="73818" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="51" Volume="1989" Year="1993">
-      <Id>e90a65ec-a13e-4057-904d-a61d7c90dbab</Id>
+      <Database Name="cv" Series="4243" Issue="73819" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="52" Volume="1989" Year="1993">
-      <Id>98f56dc1-d16d-4a99-aaa3-42b3b30c864a</Id>
+      <Database Name="cv" Series="4243" Issue="73820" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="53" Volume="1989" Year="1993">
-      <Id>dfa56245-bda1-43dc-8cc2-ccfcde783783</Id>
+      <Database Name="cv" Series="4243" Issue="73821" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="54" Volume="1989" Year="1993">
-      <Id>092e5725-389c-49da-808e-d73f16393a60</Id>
+      <Database Name="cv" Series="4243" Issue="73822" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="55" Volume="1989" Year="1993">
-      <Id>e86e210e-5407-4f97-abe4-72f3f7364e7c</Id>
+      <Database Name="cv" Series="4243" Issue="73823" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="56" Volume="1989" Year="1993">
-      <Id>eee4f908-96b1-4d0f-8c19-e8b16253f6c3</Id>
+      <Database Name="cv" Series="4243" Issue="73824" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="57" Volume="1989" Year="1993">
-      <Id>bf423288-efad-45e9-a9a0-f198e97e448a</Id>
+      <Database Name="cv" Series="4243" Issue="73825" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="58" Volume="1989" Year="1993">
-      <Id>5d07904c-d633-4677-8b94-9754ed29690b</Id>
+      <Database Name="cv" Series="4243" Issue="73826" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="59" Volume="1989" Year="1994">
-      <Id>3e5409ed-3a28-4546-b7a1-b33f5d040117</Id>
+      <Database Name="cv" Series="4243" Issue="73827" />
     </Book>
     <Book Series="The Sensational She-Hulk" Number="60" Volume="1989" Year="1994">
-      <Id>0455fc92-1b0b-4d8f-ac11-1f9b300d5405</Id>
+      <Database Name="cv" Series="4243" Issue="130940" />
     </Book>
-    <Book Series="Thing &amp; She-Hulk: The Long Night" Number="1" Volume="2002" Year="2002">
-      <Id>df923a19-c1ea-43f0-baa0-64ff057db727</Id>
+    <Book Series="Thing &#38; She-Hulk: The Long Night" Number="1" Volume="2002" Year="2002">
+      <Database Name="cv" Series="28195" Issue="173346" />
     </Book>
     <Book Series="Avengers" Number="72" Volume="1998" Year="2003">
-      <Id>ee899576-ebac-4f97-a534-dd9c017bb95c</Id>
+      <Database Name="cv" Series="7084" Issue="114422" />
     </Book>
     <Book Series="Avengers" Number="73" Volume="1998" Year="2003">
-      <Id>33d6d883-3112-4702-b1e9-28ec2dd590ee</Id>
+      <Database Name="cv" Series="7084" Issue="114477" />
     </Book>
     <Book Series="Avengers" Number="74" Volume="1998" Year="2004">
-      <Id>8fe320e1-a978-495a-beae-7443db446a3e</Id>
+      <Database Name="cv" Series="7084" Issue="114478" />
     </Book>
     <Book Series="Avengers" Number="75" Volume="1998" Year="2004">
-      <Id>e6a9e8ba-bd8b-4b9a-911a-0b9c47d93ed0</Id>
+      <Database Name="cv" Series="7084" Issue="114479" />
     </Book>
     <Book Series="She-Hulk" Number="1" Volume="2004" Year="2004">
-      <Id>a7fc940f-fc31-4f53-9086-d2201de737ae</Id>
+      <Database Name="cv" Series="11058" Issue="96783" />
     </Book>
     <Book Series="She-Hulk" Number="2" Volume="2004" Year="2004">
-      <Id>d885431b-a0de-439a-994c-ac7b9e9c4e87</Id>
+      <Database Name="cv" Series="11058" Issue="96784" />
     </Book>
     <Book Series="She-Hulk" Number="3" Volume="2004" Year="2004">
-      <Id>af381844-cde8-424a-8ee9-dc6d4910c46f</Id>
+      <Database Name="cv" Series="11058" Issue="96785" />
     </Book>
     <Book Series="She-Hulk" Number="4" Volume="2004" Year="2004">
-      <Id>e9ef645e-1ccc-48ec-9f7a-2b140cd40d93</Id>
+      <Database Name="cv" Series="11058" Issue="96786" />
     </Book>
     <Book Series="She-Hulk" Number="5" Volume="2004" Year="2004">
-      <Id>9c6e310d-6629-421f-8f93-242222cbda78</Id>
+      <Database Name="cv" Series="11058" Issue="96787" />
     </Book>
     <Book Series="She-Hulk" Number="6" Volume="2004" Year="2004">
-      <Id>772d2a9c-9050-4599-a97f-1608a71ceee0</Id>
+      <Database Name="cv" Series="11058" Issue="96788" />
     </Book>
     <Book Series="She-Hulk" Number="7" Volume="2004" Year="2004">
-      <Id>96c6dcf8-7764-4cc4-aab7-a83b78c8e2da</Id>
+      <Database Name="cv" Series="11058" Issue="96789" />
     </Book>
     <Book Series="She-Hulk" Number="8" Volume="2004" Year="2004">
-      <Id>b68aeba9-b7ea-4fa9-ae74-8e8203113edc</Id>
+      <Database Name="cv" Series="11058" Issue="96790" />
     </Book>
     <Book Series="She-Hulk" Number="9" Volume="2004" Year="2005">
-      <Id>505fd72d-6ca9-4c2b-99e2-88a8fec5111b</Id>
+      <Database Name="cv" Series="11058" Issue="96791" />
     </Book>
     <Book Series="She-Hulk" Number="10" Volume="2004" Year="2005">
-      <Id>1b686d0d-339b-4dff-b7f7-6770c42809a7</Id>
+      <Database Name="cv" Series="11058" Issue="96792" />
     </Book>
     <Book Series="She-Hulk" Number="11" Volume="2004" Year="2005">
-      <Id>0fe5a7c8-2a6e-4ec4-a0a6-419f0a839464</Id>
+      <Database Name="cv" Series="11058" Issue="99191" />
     </Book>
     <Book Series="She-Hulk" Number="12" Volume="2004" Year="2005">
-      <Id>ac22d0d9-806f-4f59-b158-6ee89d6f62a7</Id>
+      <Database Name="cv" Series="11058" Issue="99192" />
     </Book>
-    <Book Series="Marvel Team-Up" Number="11" Volume="2005" Year="2005">
-      <Id>643c5589-97bc-4ebe-8d7b-15114088b1cc</Id>
+    <Book Series="Marvel Team-Up" Number="11" Volume="2004" Year="2005">
+      <Database Name="cv" Series="18024" Issue="120886" />
     </Book>
-    <Book Series="Marvel Team-Up" Number="12" Volume="2005" Year="2005">
-      <Id>ba109392-bd6a-46ff-bf9e-cef1b7d17578</Id>
+    <Book Series="Marvel Team-Up" Number="12" Volume="2004" Year="2005">
+      <Database Name="cv" Series="18024" Issue="120887" />
     </Book>
-    <Book Series="Marvel Team-Up" Number="13" Volume="2005" Year="2005">
-      <Id>ea316fbc-852a-4728-83fe-2dd7b502c772</Id>
+    <Book Series="Marvel Team-Up" Number="13" Volume="2004" Year="2005">
+      <Database Name="cv" Series="18024" Issue="120888" />
     </Book>
     <Book Series="She-Hulk" Number="1" Volume="2005" Year="2005">
-      <Id>a64c72b8-ad12-414b-9bdc-4f4601c432f8</Id>
+      <Database Name="cv" Series="18293" Issue="107056" />
     </Book>
     <Book Series="She-Hulk" Number="2" Volume="2005" Year="2006">
-      <Id>67bdd35d-a0ea-4365-8fec-9997a674b640</Id>
+      <Database Name="cv" Series="18293" Issue="107079" />
     </Book>
     <Book Series="She-Hulk" Number="3" Volume="2005" Year="2006">
-      <Id>a630774a-f99c-473c-bd11-962ba67d967c</Id>
+      <Database Name="cv" Series="18293" Issue="107080" />
     </Book>
     <Book Series="She-Hulk" Number="4" Volume="2005" Year="2006">
-      <Id>e4d5dd25-d926-4256-90d9-91a38d0d2701</Id>
+      <Database Name="cv" Series="18293" Issue="107081" />
     </Book>
     <Book Series="She-Hulk" Number="5" Volume="2005" Year="2006">
-      <Id>1eb216b0-a285-49c9-8d57-1d0fb2d39ff9</Id>
+      <Database Name="cv" Series="18293" Issue="107082" />
     </Book>
     <Book Series="She-Hulk" Number="6" Volume="2005" Year="2006">
-      <Id>65b475e0-1d51-4050-8f95-43bd9cd1f0d0</Id>
+      <Database Name="cv" Series="18293" Issue="107085" />
     </Book>
     <Book Series="She-Hulk" Number="7" Volume="2005" Year="2006">
-      <Id>71420aeb-9639-41ba-9dea-f7a4ba0386d7</Id>
+      <Database Name="cv" Series="18293" Issue="107243" />
     </Book>
     <Book Series="She-Hulk" Number="8" Volume="2005" Year="2006">
-      <Id>ffd1ef82-3daf-40fb-bbe4-164ca795adf2</Id>
+      <Database Name="cv" Series="18293" Issue="107245" />
     </Book>
     <Book Series="She-Hulk" Number="9" Volume="2005" Year="2006">
-      <Id>1119648d-e79f-4dea-a49f-7821fd1852f6</Id>
+      <Database Name="cv" Series="18293" Issue="107246" />
     </Book>
     <Book Series="She-Hulk" Number="10" Volume="2005" Year="2006">
-      <Id>d4f83c4f-6c8f-49cd-8394-4bef99c1be05</Id>
+      <Database Name="cv" Series="18293" Issue="107247" />
     </Book>
     <Book Series="She-Hulk" Number="11" Volume="2005" Year="2006">
-      <Id>0865253a-204e-4de1-b17e-cd0201788df7</Id>
+      <Database Name="cv" Series="18293" Issue="107248" />
     </Book>
     <Book Series="She-Hulk" Number="12" Volume="2005" Year="2006">
-      <Id>293f52f9-8251-4ab2-b9e7-6ed8e321a06d</Id>
+      <Database Name="cv" Series="18293" Issue="107249" />
     </Book>
     <Book Series="She-Hulk" Number="13" Volume="2005" Year="2006">
-      <Id>e7c418d9-b78e-4a01-84e9-5e2654f8ccfe</Id>
+      <Database Name="cv" Series="18293" Issue="107250" />
     </Book>
     <Book Series="She-Hulk" Number="14" Volume="2005" Year="2007">
-      <Id>2c64e627-0c0a-4ead-b6e5-24510e0430a2</Id>
+      <Database Name="cv" Series="18293" Issue="107251" />
     </Book>
     <Book Series="She-Hulk" Number="15" Volume="2005" Year="2007">
-      <Id>21ec9241-d3da-46ca-9f17-f261f00df4a4</Id>
+      <Database Name="cv" Series="18293" Issue="111509" />
     </Book>
     <Book Series="She-Hulk" Number="16" Volume="2005" Year="2007">
-      <Id>2803888c-70b3-47d1-8501-2270e072de2a</Id>
+      <Database Name="cv" Series="18293" Issue="111510" />
     </Book>
     <Book Series="She-Hulk" Number="17" Volume="2005" Year="2007">
-      <Id>2580d415-ad22-47b1-82e8-a03b7b2982e2</Id>
+      <Database Name="cv" Series="18293" Issue="108358" />
     </Book>
     <Book Series="She-Hulk" Number="18" Volume="2005" Year="2007">
-      <Id>647dfa7b-be2d-4979-9b35-d03f756ebcf7</Id>
+      <Database Name="cv" Series="18293" Issue="109841" />
     </Book>
     <Book Series="She-Hulk" Number="19" Volume="2005" Year="2007">
-      <Id>89068712-0d00-4f2e-807a-8ec43eb27f64</Id>
+      <Database Name="cv" Series="18293" Issue="111121" />
     </Book>
     <Book Series="She-Hulk" Number="20" Volume="2005" Year="2007">
-      <Id>58d5dcd7-3128-48bc-ab8d-52b4eee4daf6</Id>
+      <Database Name="cv" Series="18293" Issue="113320" />
     </Book>
     <Book Series="She-Hulk" Number="21" Volume="2005" Year="2007">
-      <Id>2176aea0-28a1-4083-8ca2-16eeb0d38e54</Id>
+      <Database Name="cv" Series="18293" Issue="114283" />
     </Book>
     <Book Series="She-Hulk" Number="22" Volume="2005" Year="2007">
-      <Id>2b0aeaf7-31dc-4d4b-960a-b22d5ab64f0f</Id>
+      <Database Name="cv" Series="18293" Issue="115849" />
     </Book>
     <Book Series="She-Hulk" Number="23" Volume="2005" Year="2008">
-      <Id>24d6818d-ef2e-4513-baa1-c9fa4f8560a3</Id>
+      <Database Name="cv" Series="18293" Issue="118173" />
     </Book>
     <Book Series="She-Hulk" Number="24" Volume="2005" Year="2008">
-      <Id>2176c106-e4ee-41a9-8505-81b27ea525c3</Id>
+      <Database Name="cv" Series="18293" Issue="120315" />
     </Book>
     <Book Series="She-Hulk" Number="25" Volume="2005" Year="2008">
-      <Id>127c1199-a020-4a66-b1d7-b83e31da133d</Id>
+      <Database Name="cv" Series="18293" Issue="121965" />
     </Book>
     <Book Series="She-Hulk" Number="26" Volume="2005" Year="2008">
-      <Id>6db60764-5654-4947-8e14-6980e30dcc09</Id>
+      <Database Name="cv" Series="18293" Issue="124131" />
     </Book>
     <Book Series="She-Hulk" Number="27" Volume="2005" Year="2008">
-      <Id>7f15ed3d-843a-4828-b505-4b0a4d927d32</Id>
+      <Database Name="cv" Series="18293" Issue="126008" />
     </Book>
     <Book Series="She-Hulk" Number="28" Volume="2005" Year="2008">
-      <Id>cdda94ff-19cf-4cc4-9842-2b82b77238f3</Id>
+      <Database Name="cv" Series="18293" Issue="128261" />
     </Book>
     <Book Series="She-Hulk" Number="29" Volume="2005" Year="2008">
-      <Id>ffd1fd56-a450-4b53-9ce4-52f5edffe868</Id>
+      <Database Name="cv" Series="18293" Issue="131019" />
     </Book>
     <Book Series="She-Hulk" Number="30" Volume="2005" Year="2008">
-      <Id>0ea06f06-1afd-41d9-967d-03fccd701896</Id>
+      <Database Name="cv" Series="18293" Issue="131878" />
     </Book>
     <Book Series="She-Hulk: Cosmic Collision" Number="1" Volume="2009" Year="2009">
-      <Id>f65c0e1c-fd59-4269-98db-b57929923a4a</Id>
+      <Database Name="cv" Series="24249" Issue="144353" />
     </Book>
     <Book Series="She-Hulk" Number="31" Volume="2005" Year="2008">
-      <Id>54fbe521-6221-4bcd-9444-38e32d486c7d</Id>
+      <Database Name="cv" Series="18293" Issue="134099" />
     </Book>
     <Book Series="X-Factor" Number="34" Volume="2006" Year="2008">
-      <Id>52e5dea3-f4f6-48b3-a067-5b63d9665157</Id>
+      <Database Name="cv" Series="18109" Issue="135993" />
     </Book>
     <Book Series="She-Hulk" Number="32" Volume="2005" Year="2008">
-      <Id>313c7d77-2222-41f7-b897-d018380620db</Id>
+      <Database Name="cv" Series="18293" Issue="136562" />
     </Book>
     <Book Series="She-Hulk" Number="33" Volume="2005" Year="2008">
-      <Id>081480f4-c72b-4ecf-9f76-b001fe84f53b</Id>
+      <Database Name="cv" Series="18293" Issue="139371" />
     </Book>
     <Book Series="She-Hulk" Number="34" Volume="2005" Year="2008">
-      <Id>7cb3797f-cff2-435e-b6b2-b13247f88498</Id>
+      <Database Name="cv" Series="18293" Issue="140898" />
     </Book>
     <Book Series="She-Hulk" Number="35" Volume="2005" Year="2009">
-      <Id>eaad1cea-b68b-4165-abc7-80e034de25bc</Id>
+      <Database Name="cv" Series="18293" Issue="143314" />
     </Book>
     <Book Series="She-Hulk" Number="36" Volume="2005" Year="2009">
-      <Id>89ea888b-c712-4a5c-87e4-64260b43e129</Id>
+      <Database Name="cv" Series="18293" Issue="148685" />
     </Book>
     <Book Series="She-Hulk" Number="37" Volume="2005" Year="2009">
-      <Id>87135258-bb04-4c41-aa5b-6a334edeeb34</Id>
+      <Database Name="cv" Series="18293" Issue="150689" />
     </Book>
     <Book Series="She-Hulk" Number="38" Volume="2005" Year="2009">
-      <Id>26235e2c-75c1-4e31-aade-2e953a80e82a</Id>
+      <Database Name="cv" Series="18293" Issue="152817" />
     </Book>
     <Book Series="Hulk Family: Green Genes" Number="1" Volume="2009" Year="2009">
-      <Id>c737b6ed-3d36-4445-9054-d90c270d36e1</Id>
+      <Database Name="cv" Series="24450" Issue="144995" />
     </Book>
     <Book Series="All-New Savage She-Hulk" Number="1" Volume="2009" Year="2009">
-      <Id>e323bae7-839f-4015-a885-1850cefe8643</Id>
+      <Database Name="cv" Series="26151" Issue="155152" />
     </Book>
     <Book Series="All-New Savage She-Hulk" Number="2" Volume="2009" Year="2009">
-      <Id>40ecbeb0-de27-4de9-ad3c-b331be334dac</Id>
+      <Database Name="cv" Series="26151" Issue="157367" />
     </Book>
     <Book Series="All-New Savage She-Hulk" Number="3" Volume="2009" Year="2009">
-      <Id>dbaaaf70-b55f-4f28-8a06-90bcb06052e7</Id>
+      <Database Name="cv" Series="26151" Issue="160413" />
     </Book>
     <Book Series="All-New Savage She-Hulk" Number="4" Volume="2009" Year="2009">
-      <Id>b7fd5315-5710-4def-9bf9-a20dbb5a0e62</Id>
+      <Database Name="cv" Series="26151" Issue="164815" />
     </Book>
     <Book Series="Incredible Hulk" Number="600" Volume="2009" Year="2009">
-      <Id>9d3400fe-1e8b-414f-95ef-2c6f638f39c6</Id>
+      <Database Name="cv" Series="24715" Issue="165068" />
     </Book>
     <Book Series="Incredible Hulk" Number="601" Volume="2009" Year="2009">
-      <Id>302eaa74-7787-468e-8e10-50e4e5285b70</Id>
+      <Database Name="cv" Series="24715" Issue="168304" />
     </Book>
     <Book Series="Incredible Hulk" Number="602" Volume="2009" Year="2009">
-      <Id>af075fab-3722-4a59-b466-aded57a1509c</Id>
+      <Database Name="cv" Series="24715" Issue="172437" />
     </Book>
     <Book Series="Incredible Hulk" Number="603" Volume="2009" Year="2009">
-      <Id>e4022aef-0618-4a44-804c-21075cd2d895</Id>
+      <Database Name="cv" Series="24715" Issue="176845" />
     </Book>
     <Book Series="Incredible Hulk" Number="604" Volume="2009" Year="2010">
-      <Id>c83d6851-546b-492e-b6c5-0d420a033958</Id>
+      <Database Name="cv" Series="24715" Issue="183869" />
     </Book>
     <Book Series="Incredible Hulk" Number="605" Volume="2009" Year="2010">
-      <Id>3894de43-62f4-4d09-8b78-44923087dc3c</Id>
+      <Database Name="cv" Series="24715" Issue="186768" />
     </Book>
     <Book Series="Fall of the Hulks: The Savage She-Hulks" Number="1" Volume="2010" Year="2010">
-      <Id>55b51039-bda9-4feb-8cb1-c38b9ddf7df5</Id>
+      <Database Name="cv" Series="31734" Issue="198873" />
     </Book>
     <Book Series="Fall of the Hulks: The Savage She-Hulks" Number="2" Volume="2010" Year="2010">
-      <Id>38656409-830f-4b8d-933d-b6f23d8a6527</Id>
+      <Database Name="cv" Series="31734" Issue="208680" />
     </Book>
     <Book Series="Fall of the Hulks: The Savage She-Hulks" Number="3" Volume="2010" Year="2010">
-      <Id>0e5cd3b4-c208-4bb3-9587-fe85d63148f6</Id>
+      <Database Name="cv" Series="31734" Issue="216204" />
     </Book>
     <Book Series="She-Hulk Sensational" Number="1" Volume="2010" Year="2010">
-      <Id>2c6139a6-34dd-47b6-9f1c-af5b8a3bd474</Id>
+      <Database Name="cv" Series="32290" Issue="202663" />
     </Book>
     <Book Series="She-Hulks" Number="1" Volume="2011" Year="2011">
-      <Id>73fc8850-95d4-479f-aa3d-335f515fc09d</Id>
+      <Database Name="cv" Series="36561" Issue="242167" />
     </Book>
     <Book Series="She-Hulks" Number="2" Volume="2011" Year="2011">
-      <Id>79d0ea43-cb10-45e5-abd5-ff51574bd4ff</Id>
+      <Database Name="cv" Series="36561" Issue="247312" />
     </Book>
     <Book Series="She-Hulks" Number="3" Volume="2011" Year="2011">
-      <Id>c09d947b-a968-4004-9c67-eb94273fa9cb</Id>
+      <Database Name="cv" Series="36561" Issue="254574" />
     </Book>
     <Book Series="She-Hulks" Number="4" Volume="2011" Year="2011">
-      <Id>1ad05b37-a6aa-408d-80ee-14491cdd326a</Id>
+      <Database Name="cv" Series="36561" Issue="260032" />
     </Book>
     <Book Series="Red She-Hulk" Number="58" Volume="2012" Year="2012">
-      <Id>e56aeb9c-4249-41bf-9746-865e489dad18</Id>
+      <Database Name="cv" Series="52884" Issue="360902" />
     </Book>
     <Book Series="Red She-Hulk" Number="59" Volume="2012" Year="2013">
-      <Id>892254c6-88aa-4e06-9217-0f8755227187</Id>
+      <Database Name="cv" Series="52884" Issue="367784" />
     </Book>
     <Book Series="Red She-Hulk" Number="60" Volume="2012" Year="2013">
-      <Id>73eee3e1-1c24-4747-bd83-f150ec9e5943</Id>
+      <Database Name="cv" Series="52884" Issue="371259" />
     </Book>
     <Book Series="Red She-Hulk" Number="61" Volume="2012" Year="2013">
-      <Id>8c5286ee-de3c-4ad4-b3ee-a9231eaed5c8</Id>
+      <Database Name="cv" Series="52884" Issue="376660" />
     </Book>
     <Book Series="Red She-Hulk" Number="62" Volume="2012" Year="2013">
-      <Id>780ecbcf-81eb-4240-84d8-3d4e544bb486</Id>
+      <Database Name="cv" Series="52884" Issue="384961" />
     </Book>
     <Book Series="Red She-Hulk" Number="63" Volume="2012" Year="2013">
-      <Id>e213028a-c9a7-4f65-92c9-16a2af3d9dce</Id>
+      <Database Name="cv" Series="52884" Issue="390451" />
     </Book>
     <Book Series="Red She-Hulk" Number="64" Volume="2012" Year="2013">
-      <Id>15490f0e-805b-419c-acde-ffb729e04028</Id>
+      <Database Name="cv" Series="52884" Issue="395703" />
     </Book>
     <Book Series="Red She-Hulk" Number="65" Volume="2012" Year="2013">
-      <Id>8187cf6d-dc86-47aa-a384-597a9e2852db</Id>
+      <Database Name="cv" Series="52884" Issue="400151" />
     </Book>
     <Book Series="Red She-Hulk" Number="66" Volume="2012" Year="2013">
-      <Id>1c0fabe4-30e8-4980-b7ae-459d5e48ac0e</Id>
+      <Database Name="cv" Series="52884" Issue="408998" />
     </Book>
     <Book Series="Red She-Hulk" Number="67" Volume="2012" Year="2013">
-      <Id>54ac5670-65b8-4011-87f4-ac8c023d7665</Id>
+      <Database Name="cv" Series="52884" Issue="415240" />
     </Book>
     <Book Series="She-Hulk" Number="1" Volume="2014" Year="2014">
-      <Id>9e5e48e1-6a9f-46a5-998a-21a2deb58cd0</Id>
+      <Database Name="cv" Series="71612" Issue="445183" />
     </Book>
     <Book Series="She-Hulk" Number="2" Volume="2014" Year="2014">
-      <Id>34e93888-0644-4827-90b5-f8dd4ee3d6bf</Id>
+      <Database Name="cv" Series="71612" Issue="446997" />
     </Book>
     <Book Series="She-Hulk" Number="3" Volume="2014" Year="2014">
-      <Id>d47510bd-bf9f-4977-9c82-50045ceec5f9</Id>
+      <Database Name="cv" Series="71612" Issue="449600" />
     </Book>
     <Book Series="She-Hulk" Number="4" Volume="2014" Year="2014">
-      <Id>79ad80c2-d382-4ef2-b16b-d12ffbc6ca46</Id>
+      <Database Name="cv" Series="71612" Issue="452320" />
     </Book>
     <Book Series="She-Hulk" Number="5" Volume="2014" Year="2014">
-      <Id>9b02e7f3-ca5a-4349-922e-1b2f031cd814</Id>
+      <Database Name="cv" Series="71612" Issue="456031" />
     </Book>
     <Book Series="She-Hulk" Number="6" Volume="2014" Year="2014">
-      <Id>b7a93708-a9f0-49b0-b886-ac85e1a38554</Id>
+      <Database Name="cv" Series="71612" Issue="459681" />
     </Book>
     <Book Series="She-Hulk" Number="7" Volume="2014" Year="2014">
-      <Id>13a9c9aa-479f-4e1f-9853-2ad9a17986af</Id>
+      <Database Name="cv" Series="71612" Issue="461738" />
     </Book>
     <Book Series="She-Hulk" Number="8" Volume="2014" Year="2014">
-      <Id>ac75a126-372a-4077-9fde-33570abade54</Id>
+      <Database Name="cv" Series="71612" Issue="463995" />
     </Book>
     <Book Series="She-Hulk" Number="9" Volume="2014" Year="2014">
-      <Id>28956fce-c6c0-48cd-aa7e-b5cd8d76e211</Id>
+      <Database Name="cv" Series="71612" Issue="468465" />
     </Book>
     <Book Series="She-Hulk" Number="10" Volume="2014" Year="2015">
-      <Id>e7f4d54b-3e57-4e2b-89cf-76c80832ceff</Id>
+      <Database Name="cv" Series="71612" Issue="469840" />
     </Book>
     <Book Series="She-Hulk" Number="11" Volume="2014" Year="2015">
-      <Id>4f837d73-4225-4bcc-b2ff-d91097832621</Id>
+      <Database Name="cv" Series="71612" Issue="474635" />
     </Book>
     <Book Series="She-Hulk" Number="12" Volume="2014" Year="2015">
-      <Id>818b6f09-b5d7-4bc4-8a18-f14029678353</Id>
+      <Database Name="cv" Series="71612" Issue="479981" />
     </Book>
     <Book Series="Hulk" Number="1" Volume="2016" Year="2017">
-      <Id>5d67027f-af50-47e2-8e03-f1d4c724d32c</Id>
+      <Database Name="cv" Series="97422" Issue="571670" />
     </Book>
     <Book Series="Hulk" Number="2" Volume="2016" Year="2017">
-      <Id>08f6af19-01ba-405d-b9b5-40101157b05e</Id>
+      <Database Name="cv" Series="97422" Issue="578462" />
     </Book>
     <Book Series="Hulk" Number="3" Volume="2016" Year="2017">
-      <Id>04a67e69-4911-452f-a071-90611099b1fe</Id>
+      <Database Name="cv" Series="97422" Issue="582532" />
     </Book>
     <Book Series="Hulk" Number="4" Volume="2016" Year="2017">
-      <Id>4e5eb614-414d-4bd2-ab4e-dd470da1df5f</Id>
+      <Database Name="cv" Series="97422" Issue="588566" />
     </Book>
     <Book Series="Hulk" Number="5" Volume="2016" Year="2017">
-      <Id>97837cfb-2823-4287-b7b5-5db80d9cf105</Id>
+      <Database Name="cv" Series="97422" Issue="593261" />
     </Book>
     <Book Series="Hulk" Number="6" Volume="2016" Year="2017">
-      <Id>fe29a2ad-93b7-409f-bbba-3b08aacdc398</Id>
+      <Database Name="cv" Series="97422" Issue="598377" />
     </Book>
     <Book Series="Hulk" Number="7" Volume="2016" Year="2017">
-      <Id>f0c6eea3-f430-4862-822b-43167e90434e</Id>
+      <Database Name="cv" Series="97422" Issue="601794" />
     </Book>
     <Book Series="Hulk" Number="8" Volume="2016" Year="2017">
-      <Id>86a0d3b7-c0a8-4db7-a534-ee3ea7cce948</Id>
+      <Database Name="cv" Series="97422" Issue="608246" />
     </Book>
     <Book Series="Hulk" Number="9" Volume="2016" Year="2017">
-      <Id>bceea13a-4960-45b4-9248-091d837e734e</Id>
+      <Database Name="cv" Series="97422" Issue="613791" />
     </Book>
     <Book Series="Hulk" Number="10" Volume="2016" Year="2017">
-      <Id>8f5be685-d2b6-4983-b06d-e14d25a928d9</Id>
+      <Database Name="cv" Series="97422" Issue="621666" />
     </Book>
     <Book Series="Hulk" Number="11" Volume="2016" Year="2017">
-      <Id>e6948c24-ccf8-42d2-901a-5265296c7dda</Id>
+      <Database Name="cv" Series="97422" Issue="628581" />
     </Book>
     <Book Series="She-Hulk" Number="159" Volume="2017" Year="2018">
-      <Id>614bb0ac-285f-4574-a8d1-b93ddb839d7a</Id>
+      <Database Name="cv" Series="105965" Issue="636382" />
     </Book>
     <Book Series="She-Hulk" Number="160" Volume="2017" Year="2018">
-      <Id>53bd717d-8efd-43ba-b228-15fa0d2ec8b4</Id>
+      <Database Name="cv" Series="105965" Issue="646199" />
     </Book>
     <Book Series="She-Hulk" Number="161" Volume="2017" Year="2018">
-      <Id>0587e8df-a8c7-45b2-a407-d52618527f08</Id>
+      <Database Name="cv" Series="105965" Issue="652639" />
     </Book>
     <Book Series="She-Hulk" Number="162" Volume="2017" Year="2018">
-      <Id>28174acb-382e-4e4b-b6e5-ee59d927b2b2</Id>
+      <Database Name="cv" Series="105965" Issue="658730" />
     </Book>
     <Book Series="She-Hulk" Number="163" Volume="2017" Year="2018">
-      <Id>b051d4e7-89ca-4b86-883b-556bf7eee0e6</Id>
+      <Database Name="cv" Series="105965" Issue="662095" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Silver Surfer/Silver Surfer.cbl
+++ b/Marvel/Characters/unsorted/Silver Surfer/Silver Surfer.cbl
@@ -1,177 +1,178 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Silver Surfer</Name>
+  <NumIssues>57</NumIssues>
   <Books>
     <Book Series="Fantastic Four" Number="48" Volume="1961" Year="1966">
-      <Id>a4425bcc-ea56-4c9e-ab4d-e3d2a869fa7d</Id>
+      <Database Name="cv" Series="2045" Issue="8428" />
     </Book>
     <Book Series="Fantastic Four" Number="49" Volume="1961" Year="1966">
-      <Id>b09db0ef-1568-4903-9db3-863089e4cc44</Id>
+      <Database Name="cv" Series="2045" Issue="8490" />
     </Book>
     <Book Series="Fantastic Four" Number="50" Volume="1961" Year="1966">
-      <Id>6cb1761f-c4d3-48af-a0a6-267ebf3d50b2</Id>
+      <Database Name="cv" Series="2045" Issue="8546" />
     </Book>
     <Book Series="Fantastic Four" Number="55" Volume="1961" Year="1966">
-      <Id>28c354a7-0021-404a-93c9-8ef72dd3553f</Id>
+      <Database Name="cv" Series="2045" Issue="8876" />
     </Book>
     <Book Series="Fantastic Four" Number="56" Volume="1961" Year="1966">
-      <Id>f0a9fc22-f3eb-43a2-a757-d007346f94d9</Id>
+      <Database Name="cv" Series="2045" Issue="8943" />
     </Book>
     <Book Series="Fantastic Four" Number="57" Volume="1961" Year="1966">
-      <Id>a5a3b38b-bd88-4c33-8188-7da3b6c985a5</Id>
+      <Database Name="cv" Series="2045" Issue="9017" />
     </Book>
     <Book Series="Fantastic Four" Number="58" Volume="1961" Year="1967">
-      <Id>ed7c19bb-a2bc-4d4d-b29a-a45b9d27f272</Id>
+      <Database Name="cv" Series="2045" Issue="9090" />
     </Book>
     <Book Series="Fantastic Four" Number="59" Volume="1961" Year="1967">
-      <Id>fb98f334-2269-4d9e-a5d6-32ef5aadd29f</Id>
+      <Database Name="cv" Series="2045" Issue="9153" />
     </Book>
     <Book Series="Fantastic Four" Number="60" Volume="1961" Year="1967">
-      <Id>5c99d4ec-cb3f-474a-814a-ca4892aa35e8</Id>
+      <Database Name="cv" Series="2045" Issue="9226" />
     </Book>
     <Book Series="Fantastic Four" Number="61" Volume="1961" Year="1967">
-      <Id>8126a2b4-5101-4725-a301-f4bedbc05f9b</Id>
+      <Database Name="cv" Series="2045" Issue="9293" />
     </Book>
     <Book Series="Tales to Astonish" Number="92" Volume="1959" Year="1967">
-      <Id>09747135-f117-4de6-875c-88d8c5783f5b</Id>
+      <Database Name="cv" Series="2008" Issue="9432" />
     </Book>
     <Book Series="Tales to Astonish" Number="93" Volume="1959" Year="1967">
-      <Id>cc213d99-2bfd-4431-ba0e-7c9e56f5b21b</Id>
+      <Database Name="cv" Series="2008" Issue="9491" />
     </Book>
     <Book Series="The Incredible Hulk" Number="102" Volume="1968" Year="1968">
-      <Id>d65df262-f7ad-43a5-afe0-87ecf8752fd4</Id>
+      <Database Name="cv" Series="2406" Issue="111601" />
     </Book>
     <Book Series="The Silver Surfer" Number="1" Volume="1968" Year="1968">
-      <Id>49760f9b-ae7b-40e0-93c6-48901fe3c47d</Id>
+      <Database Name="cv" Series="2411" Issue="109883" />
     </Book>
     <Book Series="The Silver Surfer" Number="2" Volume="1968" Year="1968">
-      <Id>2d22c5f9-fc7d-4244-a448-7ad0e4645823</Id>
+      <Database Name="cv" Series="2411" Issue="109884" />
     </Book>
     <Book Series="The Silver Surfer" Number="3" Volume="1968" Year="1968">
-      <Id>9583a467-1ba7-4d5a-8800-ce62bb6d17c2</Id>
+      <Database Name="cv" Series="2411" Issue="144300" />
     </Book>
     <Book Series="The Silver Surfer" Number="4" Volume="1968" Year="1969">
-      <Id>79a27778-8794-49ac-a1f5-4f542979f47f</Id>
+      <Database Name="cv" Series="2411" Issue="10053" />
     </Book>
     <Book Series="The Silver Surfer" Number="5" Volume="1968" Year="1969">
-      <Id>98ed2777-e8f8-47c5-8b18-06e4d0c7254a</Id>
+      <Database Name="cv" Series="2411" Issue="10160" />
     </Book>
     <Book Series="The Silver Surfer" Number="6" Volume="1968" Year="1969">
-      <Id>fc83ca52-717e-4c44-83f7-ff4c59c1455e</Id>
+      <Database Name="cv" Series="2411" Issue="10267" />
     </Book>
     <Book Series="The Silver Surfer" Number="7" Volume="1968" Year="1969">
-      <Id>fab9cd19-284c-49b0-8940-f69897cf3b18</Id>
+      <Database Name="cv" Series="2411" Issue="10363" />
     </Book>
     <Book Series="The Silver Surfer" Number="8" Volume="1968" Year="1969">
-      <Id>7a1e1e95-fb23-4de7-ae6c-ef7734922881</Id>
+      <Database Name="cv" Series="2411" Issue="10413" />
     </Book>
     <Book Series="The Silver Surfer" Number="9" Volume="1968" Year="1969">
-      <Id>10dd4550-b4fb-4d9e-95bf-103bf1727db6</Id>
+      <Database Name="cv" Series="2411" Issue="10472" />
     </Book>
     <Book Series="The Silver Surfer" Number="10" Volume="1968" Year="1969">
-      <Id>58db246e-bff5-4f7d-ae99-863a81ecc80e</Id>
+      <Database Name="cv" Series="2411" Issue="10522" />
     </Book>
     <Book Series="The Silver Surfer" Number="11" Volume="1968" Year="1969">
-      <Id>8c3fb7fe-e194-4f9d-8b44-390dc53cfe8e</Id>
+      <Database Name="cv" Series="2411" Issue="10577" />
     </Book>
     <Book Series="The Silver Surfer" Number="12" Volume="1968" Year="1970">
-      <Id>7e60d61b-7cb1-42ab-8a57-87eff9da71a2</Id>
+      <Database Name="cv" Series="2411" Issue="10630" />
     </Book>
     <Book Series="The Silver Surfer" Number="13" Volume="1968" Year="1970">
-      <Id>9ae95dbe-ab14-4a25-9221-38cee0f0355a</Id>
+      <Database Name="cv" Series="2411" Issue="10673" />
     </Book>
     <Book Series="The Silver Surfer" Number="14" Volume="1968" Year="1970">
-      <Id>d9c84066-0bef-44ea-b1a7-21b5fe86f13d</Id>
+      <Database Name="cv" Series="2411" Issue="10719" />
     </Book>
     <Book Series="The Silver Surfer" Number="15" Volume="1968" Year="1970">
-      <Id>e29598d2-0f58-463b-ad8f-ed45e03e00f8</Id>
+      <Database Name="cv" Series="2411" Issue="10764" />
     </Book>
     <Book Series="The Silver Surfer" Number="16" Volume="1968" Year="1970">
-      <Id>6a2c761c-56c0-449e-b936-ebcc2a34e8b7</Id>
+      <Database Name="cv" Series="2411" Issue="10813" />
     </Book>
     <Book Series="The Silver Surfer" Number="17" Volume="1968" Year="1970">
-      <Id>abec20aa-4ac0-4981-9e76-a58995cd16e7</Id>
+      <Database Name="cv" Series="2411" Issue="10864" />
     </Book>
     <Book Series="The Silver Surfer" Number="18" Volume="1968" Year="1970">
-      <Id>0dbfd05d-b1ae-4c8b-8e9b-b3098fb65f55</Id>
+      <Database Name="cv" Series="2411" Issue="11011" />
     </Book>
     <Book Series="Fantastic Four" Number="72" Volume="1961" Year="1968">
-      <Id>a7994c8b-e67c-4d9b-b6bf-06803bef3bf8</Id>
+      <Database Name="cv" Series="2045" Issue="111735" />
     </Book>
     <Book Series="Fantastic Four" Number="73" Volume="1961" Year="1968">
-      <Id>c7e81d19-e381-48b8-8b47-f23f3f8b631b</Id>
+      <Database Name="cv" Series="2045" Issue="136901" />
     </Book>
     <Book Series="Fantastic Four" Number="74" Volume="1961" Year="1968">
-      <Id>bfc33528-6d37-4a3f-9298-3e74d3dc8e9f</Id>
+      <Database Name="cv" Series="2045" Issue="136902" />
     </Book>
     <Book Series="Fantastic Four" Number="75" Volume="1961" Year="1968">
-      <Id>581fcca0-5a09-466d-92ab-c4b4aaddb437</Id>
+      <Database Name="cv" Series="2045" Issue="136903" />
     </Book>
     <Book Series="Fantastic Four" Number="76" Volume="1961" Year="1968">
-      <Id>cddc04ec-9984-4d3b-9793-52921bf72824</Id>
+      <Database Name="cv" Series="2045" Issue="136904" />
     </Book>
     <Book Series="Fantastic Four" Number="77" Volume="1961" Year="1968">
-      <Id>7980debd-52b9-4a5b-ba96-c2872a1af2db</Id>
+      <Database Name="cv" Series="2045" Issue="136907" />
     </Book>
     <Book Series="Fantastic Four" Number="116" Volume="1961" Year="1971">
-      <Id>4ccfcadc-5c87-44f1-844d-52e55bd434df</Id>
+      <Database Name="cv" Series="2045" Issue="11782" />
     </Book>
     <Book Series="Thor" Number="192" Volume="1966" Year="1971">
-      <Id>f42ba2c9-fb7c-46c4-8498-7f86a2a577bb</Id>
+      <Database Name="cv" Series="2294" Issue="11674" />
     </Book>
     <Book Series="Thor" Number="193" Volume="1966" Year="1971">
-      <Id>8209e881-1787-4241-9565-208c808954d7</Id>
+      <Database Name="cv" Series="2294" Issue="11796" />
     </Book>
     <Book Series="Fantastic Four" Number="121" Volume="1961" Year="1972">
-      <Id>181aff51-ba95-4809-aa5c-2ed9e45359b5</Id>
+      <Database Name="cv" Series="2045" Issue="12122" />
     </Book>
     <Book Series="Fantastic Four" Number="122" Volume="1961" Year="1972">
-      <Id>a86bd52f-2e81-4df2-b234-2c5a30ac10e7</Id>
+      <Database Name="cv" Series="2045" Issue="12188" />
     </Book>
     <Book Series="Fantastic Four" Number="123" Volume="1961" Year="1972">
-      <Id>0a1cc838-a8bb-4208-8052-908965c90867</Id>
+      <Database Name="cv" Series="2045" Issue="12264" />
     </Book>
     <Book Series="Fantastic Four" Number="128" Volume="1961" Year="1972">
-      <Id>0d75110a-2f21-4508-af50-e0525d2add86</Id>
+      <Database Name="cv" Series="2045" Issue="12649" />
     </Book>
     <Book Series="The Avengers" Number="116" Volume="1963" Year="1973">
-      <Id>5ba73bde-b8de-45f6-a6ff-7666470116e5</Id>
+      <Database Name="cv" Series="2128" Issue="13684" />
     </Book>
     <Book Series="The Avengers" Number="117" Volume="1963" Year="1973">
-      <Id>bdeccf9b-ee3a-4133-98be-9c1f872cd30e</Id>
+      <Database Name="cv" Series="2128" Issue="13835" />
     </Book>
     <Book Series="The Avengers" Number="118" Volume="1963" Year="1973">
-      <Id>6c9697ce-f213-43a5-9536-26b9f22015c0</Id>
+      <Database Name="cv" Series="2128" Issue="13915" />
     </Book>
     <Book Series="The Avengers" Number="135" Volume="1963" Year="1975">
-      <Id>02994246-5c0e-4fb3-a504-f8c54a3b5579</Id>
+      <Database Name="cv" Series="2128" Issue="15216" />
     </Book>
     <Book Series="Fantastic Four" Number="155" Volume="1961" Year="1975">
-      <Id>8b9f9d32-01e0-4345-b43f-876f63f65270</Id>
+      <Database Name="cv" Series="2045" Issue="15054" />
     </Book>
     <Book Series="Fantastic Four" Number="156" Volume="1961" Year="1975">
-      <Id>819b7d51-b165-4494-b89a-3172ddeee8a2</Id>
+      <Database Name="cv" Series="2045" Issue="15146" />
     </Book>
     <Book Series="Fantastic Four" Number="157" Volume="1961" Year="1975">
-      <Id>89e4c4b7-ef36-4fb5-9c3d-bbf969022b5e</Id>
+      <Database Name="cv" Series="2045" Issue="123630" />
     </Book>
     <Book Series="Fantastic Four" Number="242" Volume="1961" Year="1982">
-      <Id>d6511a59-e43e-49e1-a395-458c411c2972</Id>
+      <Database Name="cv" Series="2045" Issue="22159" />
     </Book>
     <Book Series="Fantastic Four" Number="243" Volume="1961" Year="1982">
-      <Id>53206f30-d2b3-43cd-ac8a-8da75c0d4441</Id>
+      <Database Name="cv" Series="2045" Issue="22230" />
     </Book>
     <Book Series="Fantastic Four" Number="244" Volume="1961" Year="1982">
-      <Id>549825b8-cda6-4816-b468-a374d8718ecc</Id>
+      <Database Name="cv" Series="2045" Issue="22299" />
     </Book>
     <Book Series="Fantastic Four" Number="259" Volume="1961" Year="1983">
-      <Id>bbbb09eb-03ac-4a70-85c9-4b31f80eb0a8</Id>
+      <Database Name="cv" Series="2045" Issue="23540" />
     </Book>
     <Book Series="Fantastic Four" Number="260" Volume="1961" Year="1983">
-      <Id>38f15848-0b67-40b4-b756-b6bea299023f</Id>
+      <Database Name="cv" Series="2045" Issue="23625" />
     </Book>
     <Book Series="Fantastic Four" Number="261" Volume="1961" Year="1983">
-      <Id>f2ec0fe2-5289-4a43-b6e4-d0da54f49e5f</Id>
+      <Database Name="cv" Series="2045" Issue="23724" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Silver Surfer/Silver Surfer.cbl
+++ b/Marvel/Characters/unsorted/Silver Surfer/Silver Surfer.cbl
@@ -2,175 +2,175 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Silver Surfer</Name>
   <Books>
-    <Book Series="Fantastic Four" Number="48" Volume="1961" Year="1966" Format="Main Series">
+    <Book Series="Fantastic Four" Number="48" Volume="1961" Year="1966">
       <Id>a4425bcc-ea56-4c9e-ab4d-e3d2a869fa7d</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="49" Volume="1961" Year="1966" Format="Main Series">
+    <Book Series="Fantastic Four" Number="49" Volume="1961" Year="1966">
       <Id>b09db0ef-1568-4903-9db3-863089e4cc44</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="50" Volume="1961" Year="1966" Format="Main Series">
+    <Book Series="Fantastic Four" Number="50" Volume="1961" Year="1966">
       <Id>6cb1761f-c4d3-48af-a0a6-267ebf3d50b2</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="55" Volume="1961" Year="1966" Format="Main Series">
+    <Book Series="Fantastic Four" Number="55" Volume="1961" Year="1966">
       <Id>28c354a7-0021-404a-93c9-8ef72dd3553f</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="56" Volume="1961" Year="1966" Format="Main Series">
+    <Book Series="Fantastic Four" Number="56" Volume="1961" Year="1966">
       <Id>f0a9fc22-f3eb-43a2-a757-d007346f94d9</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="57" Volume="1961" Year="1966" Format="Main Series">
+    <Book Series="Fantastic Four" Number="57" Volume="1961" Year="1966">
       <Id>a5a3b38b-bd88-4c33-8188-7da3b6c985a5</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="58" Volume="1961" Year="1967" Format="Main Series">
+    <Book Series="Fantastic Four" Number="58" Volume="1961" Year="1967">
       <Id>ed7c19bb-a2bc-4d4d-b29a-a45b9d27f272</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="59" Volume="1961" Year="1967" Format="Main Series">
+    <Book Series="Fantastic Four" Number="59" Volume="1961" Year="1967">
       <Id>fb98f334-2269-4d9e-a5d6-32ef5aadd29f</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="60" Volume="1961" Year="1967" Format="Main Series">
+    <Book Series="Fantastic Four" Number="60" Volume="1961" Year="1967">
       <Id>5c99d4ec-cb3f-474a-814a-ca4892aa35e8</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="61" Volume="1961" Year="1967" Format="Main Series">
+    <Book Series="Fantastic Four" Number="61" Volume="1961" Year="1967">
       <Id>8126a2b4-5101-4725-a301-f4bedbc05f9b</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="92" Volume="1959" Year="1967" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="92" Volume="1959" Year="1967">
       <Id>09747135-f117-4de6-875c-88d8c5783f5b</Id>
     </Book>
-    <Book Series="Tales to Astonish" Number="93" Volume="1959" Year="1967" Format="Main Series">
+    <Book Series="Tales to Astonish" Number="93" Volume="1959" Year="1967">
       <Id>cc213d99-2bfd-4431-ba0e-7c9e56f5b21b</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="102" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="102" Volume="1968" Year="1968">
       <Id>d65df262-f7ad-43a5-afe0-87ecf8752fd4</Id>
     </Book>
-    <Book Series="The Silver Surfer" Number="1" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="The Silver Surfer" Number="1" Volume="1968" Year="1968">
       <Id>49760f9b-ae7b-40e0-93c6-48901fe3c47d</Id>
     </Book>
-    <Book Series="The Silver Surfer" Number="2" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="The Silver Surfer" Number="2" Volume="1968" Year="1968">
       <Id>2d22c5f9-fc7d-4244-a448-7ad0e4645823</Id>
     </Book>
-    <Book Series="The Silver Surfer" Number="3" Volume="1968" Year="1968" Format="Main Series">
+    <Book Series="The Silver Surfer" Number="3" Volume="1968" Year="1968">
       <Id>9583a467-1ba7-4d5a-8800-ce62bb6d17c2</Id>
     </Book>
-    <Book Series="The Silver Surfer" Number="4" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="The Silver Surfer" Number="4" Volume="1968" Year="1969">
       <Id>79a27778-8794-49ac-a1f5-4f542979f47f</Id>
     </Book>
-    <Book Series="The Silver Surfer" Number="5" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="The Silver Surfer" Number="5" Volume="1968" Year="1969">
       <Id>98ed2777-e8f8-47c5-8b18-06e4d0c7254a</Id>
     </Book>
-    <Book Series="The Silver Surfer" Number="6" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="The Silver Surfer" Number="6" Volume="1968" Year="1969">
       <Id>fc83ca52-717e-4c44-83f7-ff4c59c1455e</Id>
     </Book>
-    <Book Series="The Silver Surfer" Number="7" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="The Silver Surfer" Number="7" Volume="1968" Year="1969">
       <Id>fab9cd19-284c-49b0-8940-f69897cf3b18</Id>
     </Book>
-    <Book Series="The Silver Surfer" Number="8" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="The Silver Surfer" Number="8" Volume="1968" Year="1969">
       <Id>7a1e1e95-fb23-4de7-ae6c-ef7734922881</Id>
     </Book>
-    <Book Series="The Silver Surfer" Number="9" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="The Silver Surfer" Number="9" Volume="1968" Year="1969">
       <Id>10dd4550-b4fb-4d9e-95bf-103bf1727db6</Id>
     </Book>
-    <Book Series="The Silver Surfer" Number="10" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="The Silver Surfer" Number="10" Volume="1968" Year="1969">
       <Id>58db246e-bff5-4f7d-ae99-863a81ecc80e</Id>
     </Book>
-    <Book Series="The Silver Surfer" Number="11" Volume="1968" Year="1969" Format="Main Series">
+    <Book Series="The Silver Surfer" Number="11" Volume="1968" Year="1969">
       <Id>8c3fb7fe-e194-4f9d-8b44-390dc53cfe8e</Id>
     </Book>
-    <Book Series="The Silver Surfer" Number="12" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="The Silver Surfer" Number="12" Volume="1968" Year="1970">
       <Id>7e60d61b-7cb1-42ab-8a57-87eff9da71a2</Id>
     </Book>
-    <Book Series="The Silver Surfer" Number="13" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="The Silver Surfer" Number="13" Volume="1968" Year="1970">
       <Id>9ae95dbe-ab14-4a25-9221-38cee0f0355a</Id>
     </Book>
-    <Book Series="The Silver Surfer" Number="14" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="The Silver Surfer" Number="14" Volume="1968" Year="1970">
       <Id>d9c84066-0bef-44ea-b1a7-21b5fe86f13d</Id>
     </Book>
-    <Book Series="The Silver Surfer" Number="15" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="The Silver Surfer" Number="15" Volume="1968" Year="1970">
       <Id>e29598d2-0f58-463b-ad8f-ed45e03e00f8</Id>
     </Book>
-    <Book Series="The Silver Surfer" Number="16" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="The Silver Surfer" Number="16" Volume="1968" Year="1970">
       <Id>6a2c761c-56c0-449e-b936-ebcc2a34e8b7</Id>
     </Book>
-    <Book Series="The Silver Surfer" Number="17" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="The Silver Surfer" Number="17" Volume="1968" Year="1970">
       <Id>abec20aa-4ac0-4981-9e76-a58995cd16e7</Id>
     </Book>
-    <Book Series="The Silver Surfer" Number="18" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="The Silver Surfer" Number="18" Volume="1968" Year="1970">
       <Id>0dbfd05d-b1ae-4c8b-8e9b-b3098fb65f55</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="72" Volume="1961" Year="1968" Format="Main Series">
+    <Book Series="Fantastic Four" Number="72" Volume="1961" Year="1968">
       <Id>a7994c8b-e67c-4d9b-b6bf-06803bef3bf8</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="73" Volume="1961" Year="1968" Format="Main Series">
+    <Book Series="Fantastic Four" Number="73" Volume="1961" Year="1968">
       <Id>c7e81d19-e381-48b8-8b47-f23f3f8b631b</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="74" Volume="1961" Year="1968" Format="Main Series">
+    <Book Series="Fantastic Four" Number="74" Volume="1961" Year="1968">
       <Id>bfc33528-6d37-4a3f-9298-3e74d3dc8e9f</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="75" Volume="1961" Year="1968" Format="Main Series">
+    <Book Series="Fantastic Four" Number="75" Volume="1961" Year="1968">
       <Id>581fcca0-5a09-466d-92ab-c4b4aaddb437</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="76" Volume="1961" Year="1968" Format="Main Series">
+    <Book Series="Fantastic Four" Number="76" Volume="1961" Year="1968">
       <Id>cddc04ec-9984-4d3b-9793-52921bf72824</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="77" Volume="1961" Year="1968" Format="Main Series">
+    <Book Series="Fantastic Four" Number="77" Volume="1961" Year="1968">
       <Id>7980debd-52b9-4a5b-ba96-c2872a1af2db</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="116" Volume="1961" Year="1971" Format="Main Series">
+    <Book Series="Fantastic Four" Number="116" Volume="1961" Year="1971">
       <Id>4ccfcadc-5c87-44f1-844d-52e55bd434df</Id>
     </Book>
-    <Book Series="Thor" Number="192" Volume="1966" Year="1971" Format="Main Series">
+    <Book Series="Thor" Number="192" Volume="1966" Year="1971">
       <Id>f42ba2c9-fb7c-46c4-8498-7f86a2a577bb</Id>
     </Book>
-    <Book Series="Thor" Number="193" Volume="1966" Year="1971" Format="Main Series">
+    <Book Series="Thor" Number="193" Volume="1966" Year="1971">
       <Id>8209e881-1787-4241-9565-208c808954d7</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="121" Volume="1961" Year="1972" Format="Main Series">
+    <Book Series="Fantastic Four" Number="121" Volume="1961" Year="1972">
       <Id>181aff51-ba95-4809-aa5c-2ed9e45359b5</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="122" Volume="1961" Year="1972" Format="Main Series">
+    <Book Series="Fantastic Four" Number="122" Volume="1961" Year="1972">
       <Id>a86bd52f-2e81-4df2-b234-2c5a30ac10e7</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="123" Volume="1961" Year="1972" Format="Main Series">
+    <Book Series="Fantastic Four" Number="123" Volume="1961" Year="1972">
       <Id>0a1cc838-a8bb-4208-8052-908965c90867</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="128" Volume="1961" Year="1972" Format="Main Series">
+    <Book Series="Fantastic Four" Number="128" Volume="1961" Year="1972">
       <Id>0d75110a-2f21-4508-af50-e0525d2add86</Id>
     </Book>
-    <Book Series="The Avengers" Number="116" Volume="1963" Year="1973" Format="Main Series">
+    <Book Series="The Avengers" Number="116" Volume="1963" Year="1973">
       <Id>5ba73bde-b8de-45f6-a6ff-7666470116e5</Id>
     </Book>
-    <Book Series="The Avengers" Number="117" Volume="1963" Year="1973" Format="Main Series">
+    <Book Series="The Avengers" Number="117" Volume="1963" Year="1973">
       <Id>bdeccf9b-ee3a-4133-98be-9c1f872cd30e</Id>
     </Book>
-    <Book Series="The Avengers" Number="118" Volume="1963" Year="1973" Format="Main Series">
+    <Book Series="The Avengers" Number="118" Volume="1963" Year="1973">
       <Id>6c9697ce-f213-43a5-9536-26b9f22015c0</Id>
     </Book>
-    <Book Series="The Avengers" Number="135" Volume="1963" Year="1975" Format="Main Series">
+    <Book Series="The Avengers" Number="135" Volume="1963" Year="1975">
       <Id>02994246-5c0e-4fb3-a504-f8c54a3b5579</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="155" Volume="1961" Year="1975" Format="Main Series">
+    <Book Series="Fantastic Four" Number="155" Volume="1961" Year="1975">
       <Id>8b9f9d32-01e0-4345-b43f-876f63f65270</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="156" Volume="1961" Year="1975" Format="Main Series">
+    <Book Series="Fantastic Four" Number="156" Volume="1961" Year="1975">
       <Id>819b7d51-b165-4494-b89a-3172ddeee8a2</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="157" Volume="1961" Year="1975" Format="Main Series">
+    <Book Series="Fantastic Four" Number="157" Volume="1961" Year="1975">
       <Id>89e4c4b7-ef36-4fb5-9c3d-bbf969022b5e</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="242" Volume="1961" Year="1982" Format="Main Series">
+    <Book Series="Fantastic Four" Number="242" Volume="1961" Year="1982">
       <Id>d6511a59-e43e-49e1-a395-458c411c2972</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="243" Volume="1961" Year="1982" Format="Main Series">
+    <Book Series="Fantastic Four" Number="243" Volume="1961" Year="1982">
       <Id>53206f30-d2b3-43cd-ac8a-8da75c0d4441</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="244" Volume="1961" Year="1982" Format="Main Series">
+    <Book Series="Fantastic Four" Number="244" Volume="1961" Year="1982">
       <Id>549825b8-cda6-4816-b468-a374d8718ecc</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="259" Volume="1961" Year="1983" Format="Main Series">
+    <Book Series="Fantastic Four" Number="259" Volume="1961" Year="1983">
       <Id>bbbb09eb-03ac-4a70-85c9-4b31f80eb0a8</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="260" Volume="1961" Year="1983" Format="Main Series">
+    <Book Series="Fantastic Four" Number="260" Volume="1961" Year="1983">
       <Id>38f15848-0b67-40b4-b756-b6bea299023f</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="261" Volume="1961" Year="1983" Format="Main Series">
+    <Book Series="Fantastic Four" Number="261" Volume="1961" Year="1983">
       <Id>f2ec0fe2-5289-4a43-b6e4-d0da54f49e5f</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Spider-Man/Spider-Man 001 (Silver Age).cbl
+++ b/Marvel/Characters/unsorted/Spider-Man/Spider-Man 001 (Silver Age).cbl
@@ -2,379 +2,379 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Spider-Man 1 (Silver Age)</Name>
   <Books>
-    <Book Series="Amazing Fantasy" Number="15" Volume="1962" Year="1962" Format="Main Series">
+    <Book Series="Amazing Fantasy" Number="15" Volume="1962" Year="1962">
       <Id>59ab9b4d-a5cf-4dc8-a930-4772af80f5a6</Id>
     </Book>
-    <Book Series="Amazing Fantasy" Number="16" Volume="1962" Year="1995" Format="Main Series">
+    <Book Series="Amazing Fantasy" Number="16" Volume="1962" Year="1995">
       <Id>ecd5d16f-057b-4b59-afc0-24a2756c427f</Id>
     </Book>
-    <Book Series="Amazing Fantasy" Number="17" Volume="1962" Year="1996" Format="Main Series">
+    <Book Series="Amazing Fantasy" Number="17" Volume="1962" Year="1996">
       <Id>99cf546f-b7e8-4386-b898-7940f34ace57</Id>
     </Book>
-    <Book Series="Amazing Fantasy" Number="18" Volume="1962" Year="1996" Format="Main Series">
+    <Book Series="Amazing Fantasy" Number="18" Volume="1962" Year="1996">
       <Id>e04f72e3-5a18-4576-9140-23ebb741e625</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="1" Volume="1963" Year="1963" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="1" Volume="1963" Year="1963">
       <Id>ba02b0e3-baab-4f8f-9c9a-9dd383193f8b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="2" Volume="1963" Year="1963" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="2" Volume="1963" Year="1963">
       <Id>2bd785e3-dc4d-48e8-8880-1dd5f84a1fc2</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="3" Volume="1963" Year="1963" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="3" Volume="1963" Year="1963">
       <Id>422a1179-8095-4b55-b422-abc85f4d5a91</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="4" Volume="1963" Year="1963" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="4" Volume="1963" Year="1963">
       <Id>f3ea436b-9d79-48e7-9b31-8ba4a0d2e892</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="5" Volume="1963" Year="1963" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="5" Volume="1963" Year="1963">
       <Id>2363e7c8-e180-4999-9486-437ec1ad6327</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="6" Volume="1963" Year="1963" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="6" Volume="1963" Year="1963">
       <Id>abd54c00-5277-4e76-850d-a1856924e982</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man" Number="1" Volume="1995" Year="1995" Format="Main Series">
+    <Book Series="Untold Tales of Spider-Man" Number="1" Volume="1995" Year="1995">
       <Id>776b0043-760c-4e76-92af-7163356a1cb2</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man" Number="2" Volume="1995" Year="1995" Format="Main Series">
+    <Book Series="Untold Tales of Spider-Man" Number="2" Volume="1995" Year="1995">
       <Id>ea9e444a-a80f-414e-aa4b-fc526031e580</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="7" Volume="1963" Year="1963" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="7" Volume="1963" Year="1963">
       <Id>87e79599-ec22-45d3-b213-51522bb6d494</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man" Number="3" Volume="1995" Year="1995" Format="Main Series">
+    <Book Series="Untold Tales of Spider-Man" Number="3" Volume="1995" Year="1995">
       <Id>3cb81229-f8e9-449e-b5d1-c02bcd59299b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="8" Volume="1963" Year="1964" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="8" Volume="1963" Year="1964">
       <Id>cc2472d4-4d99-4369-9cb0-dd37ec656bd1</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man" Number="4" Volume="1995" Year="1995" Format="Main Series">
+    <Book Series="Untold Tales of Spider-Man" Number="4" Volume="1995" Year="1995">
       <Id>c3ce7846-9701-408e-96e7-7ab5d012ad05</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="9" Volume="1963" Year="1964" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="9" Volume="1963" Year="1964">
       <Id>3a79a53e-05fa-4235-a4c7-66eb521aadba</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man" Number="5" Volume="1995" Year="1996" Format="Main Series">
+    <Book Series="Untold Tales of Spider-Man" Number="5" Volume="1995" Year="1996">
       <Id>b7a1c927-db92-4686-a674-33f4b1bdab77</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man" Number="6" Volume="1995" Year="1996" Format="Main Series">
+    <Book Series="Untold Tales of Spider-Man" Number="6" Volume="1995" Year="1996">
       <Id>f2c377c0-d979-4b0b-a7a1-becf7e411a53</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man" Number="7" Volume="1995" Year="1996" Format="Main Series">
+    <Book Series="Untold Tales of Spider-Man" Number="7" Volume="1995" Year="1996">
       <Id>f1a072ae-65d5-4f18-9f53-6385a0436adc</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="10" Volume="1963" Year="1964" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="10" Volume="1963" Year="1964">
       <Id>ba66df5a-ff6d-4bf5-8b37-8c59b76bd0b0</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man" Number="8" Volume="1995" Year="1996" Format="Main Series">
+    <Book Series="Untold Tales of Spider-Man" Number="8" Volume="1995" Year="1996">
       <Id>5cbc8929-6211-4423-ba5b-b21259ac5669</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man" Number="9" Volume="1995" Year="1996" Format="Main Series">
+    <Book Series="Untold Tales of Spider-Man" Number="9" Volume="1995" Year="1996">
       <Id>d53906cc-d73c-4476-afd4-e92814acaee7</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="11" Volume="1963" Year="1964" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="11" Volume="1963" Year="1964">
       <Id>f68963bf-70d3-480a-8c19-2e7cd1496367</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man" Number="10" Volume="1995" Year="1996" Format="Main Series">
+    <Book Series="Untold Tales of Spider-Man" Number="10" Volume="1995" Year="1996">
       <Id>c2a76173-0977-4966-8b30-701288144f2c</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="12" Volume="1963" Year="1964" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="12" Volume="1963" Year="1964">
       <Id>3a391139-e934-4395-a0d4-f08234320cfb</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man" Number="11" Volume="1995" Year="1996" Format="Main Series">
+    <Book Series="Untold Tales of Spider-Man" Number="11" Volume="1995" Year="1996">
       <Id>12e90cf2-819e-46dc-be41-58e46f7b4af0</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man" Number="12" Volume="1995" Year="1996" Format="Main Series">
+    <Book Series="Untold Tales of Spider-Man" Number="12" Volume="1995" Year="1996">
       <Id>2008938d-09d4-4952-ad68-feb31aca29dc</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man" Number="13" Volume="1995" Year="1996" Format="Main Series">
+    <Book Series="Untold Tales of Spider-Man" Number="13" Volume="1995" Year="1996">
       <Id>344509e0-c9a5-4f7b-8202-334376e0ec20</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="13" Volume="1963" Year="1964" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="13" Volume="1963" Year="1964">
       <Id>f8f111a4-3011-4dc2-a0d5-8b8db10913cc</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man" Number="14" Volume="1995" Year="1996" Format="Main Series">
+    <Book Series="Untold Tales of Spider-Man" Number="14" Volume="1995" Year="1996">
       <Id>e29ab415-8978-45b3-9835-7dba3cdec8f8</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="14" Volume="1963" Year="1964" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="14" Volume="1963" Year="1964">
       <Id>a1d3bd42-14dd-4721-b9b2-547f5f3d031e</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man" Number="15" Volume="1995" Year="1996" Format="Main Series">
+    <Book Series="Untold Tales of Spider-Man" Number="15" Volume="1995" Year="1996">
       <Id>0587fc67-3f36-44b1-9960-58b26ea38d3f</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man" Number="16" Volume="1995" Year="1996" Format="Main Series">
+    <Book Series="Untold Tales of Spider-Man" Number="16" Volume="1995" Year="1996">
       <Id>2a47f799-6420-47b5-9299-45d20156a78d</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="15" Volume="1963" Year="1964" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="15" Volume="1963" Year="1964">
       <Id>138e6d7e-c400-4055-bd10-fa5e9dc2dfd4</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man" Number="17" Volume="1995" Year="1997" Format="Main Series">
+    <Book Series="Untold Tales of Spider-Man" Number="17" Volume="1995" Year="1997">
       <Id>0a960366-d1ef-44f9-89e1-a29bfc475b0e</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man: Strange Encounters" Number="1" Volume="1998" Year="1998" Format="One-Shot">
+    <Book Series="Untold Tales of Spider-Man: Strange Encounters" Number="1" Volume="1998" Year="1998">
       <Id>404a5f46-06a4-427f-a730-9fc7dc52b834</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="16" Volume="1963" Year="1964" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="16" Volume="1963" Year="1964">
       <Id>500da22b-db48-424a-8472-e96fe24ca1e9</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man" Number="18" Volume="1995" Year="1997" Format="Main Series">
+    <Book Series="Untold Tales of Spider-Man" Number="18" Volume="1995" Year="1997">
       <Id>13568f85-eea8-462b-8307-2b70542c6549</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="1" Volume="1964" Year="1964" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="1" Volume="1964" Year="1964">
       <Id>fc2e1973-7681-4c90-aa0b-54c008e234d7</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man" Number="19" Volume="1995" Year="1997" Format="Main Series">
+    <Book Series="Untold Tales of Spider-Man" Number="19" Volume="1995" Year="1997">
       <Id>b787449b-22c3-472d-a852-0b20ef1bffdf</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="17" Volume="1963" Year="1964" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="17" Volume="1963" Year="1964">
       <Id>8d1ae8ef-6bb7-4b52-85f1-13a6186da58d</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man" Number="20" Volume="1995" Year="1997" Format="Main Series">
+    <Book Series="Untold Tales of Spider-Man" Number="20" Volume="1995" Year="1997">
       <Id>7b4596c7-dbdb-4d7a-a20c-daf101e59e1c</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man" Number="21" Volume="1995" Year="1997" Format="Main Series">
+    <Book Series="Untold Tales of Spider-Man" Number="21" Volume="1995" Year="1997">
       <Id>23fcd13b-4ac0-4e99-8f01-1496a5750402</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="18" Volume="1963" Year="1964" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="18" Volume="1963" Year="1964">
       <Id>f6cac47e-4be6-4eab-8e62-6ce1b5875c33</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man" Number="22" Volume="1995" Year="1997" Format="Main Series">
+    <Book Series="Untold Tales of Spider-Man" Number="22" Volume="1995" Year="1997">
       <Id>02794ca1-edd3-41a8-985d-be7d8e1c9ac4</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="19" Volume="1963" Year="1964" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="19" Volume="1963" Year="1964">
       <Id>9d1ef409-adc4-405f-bcf8-47d9419fc58b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="20" Volume="1963" Year="1965" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="20" Volume="1963" Year="1965">
       <Id>35e0fb1d-13d6-4ca1-8804-b40787d3a068</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man" Number="23" Volume="1995" Year="1997" Format="Main Series">
+    <Book Series="Untold Tales of Spider-Man" Number="23" Volume="1995" Year="1997">
       <Id>14c1d570-1d1d-4fc2-aa7f-9f01aa8c7768</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man Annual '97" Number="1" Volume="1997" Year="1997" Format="Annual">
+    <Book Series="Untold Tales of Spider-Man Annual '97" Number="1" Volume="1997" Year="1997">
       <Id>de012d66-045a-489b-a9b7-f79f2168bbfe</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="21" Volume="1963" Year="1965" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="21" Volume="1963" Year="1965">
       <Id>1c2a9bb8-3a39-48c8-90b7-f1b69c827dab</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man Annual '96" Number="1" Volume="1996" Year="1996" Format="Annual">
+    <Book Series="Untold Tales of Spider-Man Annual '96" Number="1" Volume="1996" Year="1996">
       <Id>f3daf9a1-4d98-44c4-9ed4-bc0395cee75a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="22" Volume="1963" Year="1965" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="22" Volume="1963" Year="1965">
       <Id>258d6bea-e8e6-4d0d-b3e5-ab27671a0e96</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man" Number="24" Volume="1995" Year="1997" Format="Main Series">
+    <Book Series="Untold Tales of Spider-Man" Number="24" Volume="1995" Year="1997">
       <Id>06db3af4-543d-4b2f-abe3-42964e0f8260</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="23" Volume="1963" Year="1965" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="23" Volume="1963" Year="1965">
       <Id>c2625cce-759b-40a3-89d3-75146839f36f</Id>
     </Book>
-    <Book Series="Untold Tales of Spider-Man" Number="25" Volume="1995" Year="1997" Format="Main Series">
+    <Book Series="Untold Tales of Spider-Man" Number="25" Volume="1995" Year="1997">
       <Id>8cfe41fa-0b75-41fe-9a7a-37566e3c5d1b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="24" Volume="1963" Year="1965" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="24" Volume="1963" Year="1965">
       <Id>b41297ad-c36c-4f67-bc35-6e017ef1340e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="25" Volume="1963" Year="1965" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="25" Volume="1963" Year="1965">
       <Id>e0affd61-c87d-4270-8c20-1b9b42c0e339</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="26" Volume="1963" Year="1965" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="26" Volume="1963" Year="1965">
       <Id>a03e9396-e5cb-4f5f-9945-610be3909d51</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="27" Volume="1963" Year="1965" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="27" Volume="1963" Year="1965">
       <Id>8b5b2e0f-f950-451a-9256-c072a32f1cbb</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="28" Volume="1963" Year="1965" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="28" Volume="1963" Year="1965">
       <Id>85f42b0a-27b2-4ec8-a210-b6b4bb712c98</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="2" Volume="1964" Year="1965" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="2" Volume="1964" Year="1965">
       <Id>a002b2cf-be89-4934-9e23-cc2869f459e1</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="29" Volume="1963" Year="1965" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="29" Volume="1963" Year="1965">
       <Id>1bff73c1-82f1-4183-a39a-2cdc424745b3</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="30" Volume="1963" Year="1965" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="30" Volume="1963" Year="1965">
       <Id>281b74fd-9a89-44a4-b890-054f2402ca14</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="31" Volume="1963" Year="1965" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="31" Volume="1963" Year="1965">
       <Id>4e557fb6-6bb2-433b-945e-c5cd1fba4781</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="32" Volume="1963" Year="1966" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="32" Volume="1963" Year="1966">
       <Id>73f627d1-f652-4877-a390-abe626bd6aa6</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="33" Volume="1963" Year="1966" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="33" Volume="1963" Year="1966">
       <Id>96c7b4e7-e132-4486-b77b-94237a1e0594</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="34" Volume="1963" Year="1966" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="34" Volume="1963" Year="1966">
       <Id>0d8853ed-c68e-4c9b-b781-5ce59096a99d</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="35" Volume="1963" Year="1966" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="35" Volume="1963" Year="1966">
       <Id>bc8ee0ee-2680-4e8f-8fef-16d4b11daa67</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="36" Volume="1963" Year="1966" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="36" Volume="1963" Year="1966">
       <Id>cb6c9e9f-db47-411d-9668-2667143eb95b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="37" Volume="1963" Year="1966" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="37" Volume="1963" Year="1966">
       <Id>64aedfcd-5f6f-4cd4-a51a-11e03374ae4b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="38" Volume="1963" Year="1966" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="38" Volume="1963" Year="1966">
       <Id>8f3849ab-fde7-4fc1-9ffd-09d7e95b8cb0</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="39" Volume="1963" Year="1966" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="39" Volume="1963" Year="1966">
       <Id>224a5eca-4504-466d-b977-8f65de4c94b9</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="40" Volume="1963" Year="1966" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="40" Volume="1963" Year="1966">
       <Id>00fd0696-8581-4bcc-b373-cf143d8fd9f7</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="41" Volume="1963" Year="1966" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="41" Volume="1963" Year="1966">
       <Id>b809ac7d-d9d6-4209-854e-81899d08eda9</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="42" Volume="1963" Year="1966" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="42" Volume="1963" Year="1966">
       <Id>5d3137af-6397-42dc-aa70-f8c53a67e301</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="43" Volume="1963" Year="1966" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="43" Volume="1963" Year="1966">
       <Id>6ba0d125-6bcd-4248-a6fa-d84ae01bf148</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="3" Volume="1964" Year="1966" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="3" Volume="1964" Year="1966">
       <Id>a438f172-6f25-41e1-a578-e339113a02a4</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="44" Volume="1963" Year="1967" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="44" Volume="1963" Year="1967">
       <Id>54acbe8a-e70b-41eb-8855-237668565c56</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="45" Volume="1963" Year="1967" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="45" Volume="1963" Year="1967">
       <Id>d354e0a2-8347-4123-9524-354162d7a0aa</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="46" Volume="1963" Year="1967" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="46" Volume="1963" Year="1967">
       <Id>90434e03-4c21-4dfc-bc61-2bfdb2d69c69</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="47" Volume="1963" Year="1967" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="47" Volume="1963" Year="1967">
       <Id>877fe118-8bd0-4ef6-abae-7ec813a994d8</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="48" Volume="1963" Year="1967" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="48" Volume="1963" Year="1967">
       <Id>a622153a-b454-4925-b26d-309d4d1a28e0</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="49" Volume="1963" Year="1967" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="49" Volume="1963" Year="1967">
       <Id>74788242-dc85-4b3a-95a4-0631dc80afc6</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="50" Volume="1963" Year="1967" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="50" Volume="1963" Year="1967">
       <Id>ca290203-fa04-4c98-8758-2449d6ba819d</Id>
     </Book>
-    <Book Series="The X-Men" Number="35" Volume="1963" Year="1967" Format="Main Series">
+    <Book Series="The X-Men" Number="35" Volume="1963" Year="1967">
       <Id>5e8b9532-6538-4811-b88c-3cbd464f00cc</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="51" Volume="1963" Year="1967" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="51" Volume="1963" Year="1967">
       <Id>28c9a697-4d36-472c-ab4b-e712f569fa94</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="52" Volume="1963" Year="1967" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="52" Volume="1963" Year="1967">
       <Id>5af87a4a-3491-4453-a436-1764534b48ae</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="4" Volume="1964" Year="1967" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="4" Volume="1964" Year="1967">
       <Id>a48f8a84-300c-4e94-98a2-86346a5ec1a0</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="53" Volume="1963" Year="1967" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="53" Volume="1963" Year="1967">
       <Id>62f0ec33-99b8-4583-b186-8f92ac2b3374</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="54" Volume="1963" Year="1967" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="54" Volume="1963" Year="1967">
       <Id>9eea3fbf-03f5-448c-b562-cd843032ea70</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="55" Volume="1963" Year="1967" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="55" Volume="1963" Year="1967">
       <Id>87ed48a8-4f98-4ca4-98a6-d1433f1211e0</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="56" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="56" Volume="1963" Year="1968">
       <Id>d85413d6-1336-47a9-b2c3-cdaf36377461</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="57" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="57" Volume="1963" Year="1968">
       <Id>49777139-62aa-4559-a847-7c4bcf13bc9b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="58" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="58" Volume="1963" Year="1968">
       <Id>44cb02f5-b2a4-49fb-903e-fb8d23624d37</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="59" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="59" Volume="1963" Year="1968">
       <Id>ab3ae33b-08d7-4bf5-91e2-7dbccfa13b0a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="60" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="60" Volume="1963" Year="1968">
       <Id>8c51c861-8e32-4aed-8a50-47177aff7693</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="61" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="61" Volume="1963" Year="1968">
       <Id>33d6aac7-00a0-4b5d-9f45-4cce110f39be</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="62" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="62" Volume="1963" Year="1968">
       <Id>b23ca440-8420-4cfe-9bb0-5b3982f06942</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="5" Volume="1964" Year="1968" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="5" Volume="1964" Year="1968">
       <Id>95aabf16-9d7c-44a6-b9e5-8a80b0465ab6</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="63" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="63" Volume="1963" Year="1968">
       <Id>a909f520-71a5-42cd-b882-2277248b4161</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="64" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="64" Volume="1963" Year="1968">
       <Id>c09fb67a-6575-4e53-a53a-80080ccc974b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="65" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="65" Volume="1963" Year="1968">
       <Id>89fa5d29-d204-4d7e-bdbe-fb617b580ec4</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="66" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="66" Volume="1963" Year="1968">
       <Id>3974432a-276b-497b-a595-a8bca6f834f5</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="67" Volume="1963" Year="1968" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="67" Volume="1963" Year="1968">
       <Id>b0a88279-ea46-4b9c-99c8-d0c88c116340</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="68" Volume="1963" Year="1969" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="68" Volume="1963" Year="1969">
       <Id>24d17e20-1c39-4a8d-b9fb-1098fe0abb7b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="69" Volume="1963" Year="1969" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="69" Volume="1963" Year="1969">
       <Id>3dbe4770-3df1-4c5b-afb0-831a28613c58</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="70" Volume="1963" Year="1969" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="70" Volume="1963" Year="1969">
       <Id>b88c235b-c9eb-4404-ba2f-64058870b348</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="71" Volume="1963" Year="1969" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="71" Volume="1963" Year="1969">
       <Id>b64ca721-59a0-48dd-8217-59cb131deff9</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="72" Volume="1963" Year="1969" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="72" Volume="1963" Year="1969">
       <Id>5591201d-ae46-41e5-9477-788c3adca262</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="73" Volume="1963" Year="1969" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="73" Volume="1963" Year="1969">
       <Id>e43b6b30-9f98-4125-b13d-27c210f96ecf</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="74" Volume="1963" Year="1969" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="74" Volume="1963" Year="1969">
       <Id>9e12ed23-dcc3-4e27-a403-1b4759281fdd</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="75" Volume="1963" Year="1969" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="75" Volume="1963" Year="1969">
       <Id>d90c2238-fcb6-4fd5-bbb8-6afb8eeb7940</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="76" Volume="1963" Year="1969" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="76" Volume="1963" Year="1969">
       <Id>807705b6-9430-4659-af88-186576f31f47</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="77" Volume="1963" Year="1969" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="77" Volume="1963" Year="1969">
       <Id>2a5cd551-3915-449d-a8da-c1aeb05924e1</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="78" Volume="1963" Year="1969" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="78" Volume="1963" Year="1969">
       <Id>d4cc1ac4-75f5-4906-a122-9e21dbeb2bc4</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="79" Volume="1963" Year="1969" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="79" Volume="1963" Year="1969">
       <Id>33095fc7-d5f8-4e20-a2c5-351aaa3dd58c</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="80" Volume="1963" Year="1970" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="80" Volume="1963" Year="1970">
       <Id>42250e88-77f6-4639-a6fb-3b7538511f11</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="81" Volume="1963" Year="1970" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="81" Volume="1963" Year="1970">
       <Id>4b2d97df-cad3-456f-b651-2a3eae60278c</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="82" Volume="1963" Year="1970" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="82" Volume="1963" Year="1970">
       <Id>f7c6916d-7adc-45b0-b9d8-22724b637676</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="83" Volume="1963" Year="1970" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="83" Volume="1963" Year="1970">
       <Id>c1feb585-c6a2-4d42-a616-4d2f7d8974fa</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="84" Volume="1963" Year="1970" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="84" Volume="1963" Year="1970">
       <Id>940b540a-c94a-452e-a4de-a35414e2c581</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="85" Volume="1963" Year="1970" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="85" Volume="1963" Year="1970">
       <Id>48792bb8-d4fd-4ee5-b2b9-00b2441ae9c8</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="86" Volume="1963" Year="1970" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="86" Volume="1963" Year="1970">
       <Id>ed802c84-e723-4a2d-9e54-a95d117f518f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="87" Volume="1963" Year="1970" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="87" Volume="1963" Year="1970">
       <Id>9f00d650-3e74-40c1-ad22-061635e35eab</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Spider-Man/Spider-Man 001 (Silver Age).cbl
+++ b/Marvel/Characters/unsorted/Spider-Man/Spider-Man 001 (Silver Age).cbl
@@ -1,381 +1,382 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Spider-Man 1 (Silver Age)</Name>
+  <Name>Spider-Man 001 (Silver Age)</Name>
+  <NumIssues>125</NumIssues>
   <Books>
     <Book Series="Amazing Fantasy" Number="15" Volume="1962" Year="1962">
-      <Id>59ab9b4d-a5cf-4dc8-a930-4772af80f5a6</Id>
+      <Database Name="cv" Series="5533" Issue="105342" />
     </Book>
     <Book Series="Amazing Fantasy" Number="16" Volume="1962" Year="1995">
-      <Id>ecd5d16f-057b-4b59-afc0-24a2756c427f</Id>
+      <Database Name="cv" Series="5533" Issue="41765" />
     </Book>
     <Book Series="Amazing Fantasy" Number="17" Volume="1962" Year="1996">
-      <Id>99cf546f-b7e8-4386-b898-7940f34ace57</Id>
+      <Database Name="cv" Series="5533" Issue="41984" />
     </Book>
     <Book Series="Amazing Fantasy" Number="18" Volume="1962" Year="1996">
-      <Id>e04f72e3-5a18-4576-9140-23ebb741e625</Id>
+      <Database Name="cv" Series="5533" Issue="42201" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="1" Volume="1963" Year="1963">
-      <Id>ba02b0e3-baab-4f8f-9c9a-9dd383193f8b</Id>
+      <Database Name="cv" Series="2127" Issue="6422" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="2" Volume="1963" Year="1963">
-      <Id>2bd785e3-dc4d-48e8-8880-1dd5f84a1fc2</Id>
+      <Database Name="cv" Series="2127" Issue="6503" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="3" Volume="1963" Year="1963">
-      <Id>422a1179-8095-4b55-b422-abc85f4d5a91</Id>
+      <Database Name="cv" Series="2127" Issue="6595" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="4" Volume="1963" Year="1963">
-      <Id>f3ea436b-9d79-48e7-9b31-8ba4a0d2e892</Id>
+      <Database Name="cv" Series="2127" Issue="6685" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="5" Volume="1963" Year="1963">
-      <Id>2363e7c8-e180-4999-9486-437ec1ad6327</Id>
+      <Database Name="cv" Series="2127" Issue="6734" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="6" Volume="1963" Year="1963">
-      <Id>abd54c00-5277-4e76-850d-a1856924e982</Id>
+      <Database Name="cv" Series="2127" Issue="6778" />
     </Book>
     <Book Series="Untold Tales of Spider-Man" Number="1" Volume="1995" Year="1995">
-      <Id>776b0043-760c-4e76-92af-7163356a1cb2</Id>
+      <Database Name="cv" Series="5562" Issue="41388" />
     </Book>
     <Book Series="Untold Tales of Spider-Man" Number="2" Volume="1995" Year="1995">
-      <Id>ea9e444a-a80f-414e-aa4b-fc526031e580</Id>
+      <Database Name="cv" Series="5562" Issue="41517" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="7" Volume="1963" Year="1963">
-      <Id>87e79599-ec22-45d3-b213-51522bb6d494</Id>
+      <Database Name="cv" Series="2127" Issue="105844" />
     </Book>
     <Book Series="Untold Tales of Spider-Man" Number="3" Volume="1995" Year="1995">
-      <Id>3cb81229-f8e9-449e-b5d1-c02bcd59299b</Id>
+      <Database Name="cv" Series="5562" Issue="41645" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="8" Volume="1963" Year="1964">
-      <Id>cc2472d4-4d99-4369-9cb0-dd37ec656bd1</Id>
+      <Database Name="cv" Series="2127" Issue="6937" />
     </Book>
     <Book Series="Untold Tales of Spider-Man" Number="4" Volume="1995" Year="1995">
-      <Id>c3ce7846-9701-408e-96e7-7ab5d012ad05</Id>
+      <Database Name="cv" Series="5562" Issue="41774" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="9" Volume="1963" Year="1964">
-      <Id>3a79a53e-05fa-4235-a4c7-66eb521aadba</Id>
+      <Database Name="cv" Series="2127" Issue="6985" />
     </Book>
     <Book Series="Untold Tales of Spider-Man" Number="5" Volume="1995" Year="1996">
-      <Id>b7a1c927-db92-4686-a674-33f4b1bdab77</Id>
+      <Database Name="cv" Series="5562" Issue="41991" />
     </Book>
     <Book Series="Untold Tales of Spider-Man" Number="6" Volume="1995" Year="1996">
-      <Id>f2c377c0-d979-4b0b-a7a1-becf7e411a53</Id>
+      <Database Name="cv" Series="5562" Issue="42099" />
     </Book>
     <Book Series="Untold Tales of Spider-Man" Number="7" Volume="1995" Year="1996">
-      <Id>f1a072ae-65d5-4f18-9f53-6385a0436adc</Id>
+      <Database Name="cv" Series="5562" Issue="42210" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="10" Volume="1963" Year="1964">
-      <Id>ba66df5a-ff6d-4bf5-8b37-8c59b76bd0b0</Id>
+      <Database Name="cv" Series="2127" Issue="7024" />
     </Book>
     <Book Series="Untold Tales of Spider-Man" Number="8" Volume="1995" Year="1996">
-      <Id>5cbc8929-6211-4423-ba5b-b21259ac5669</Id>
+      <Database Name="cv" Series="5562" Issue="42305" />
     </Book>
     <Book Series="Untold Tales of Spider-Man" Number="9" Volume="1995" Year="1996">
-      <Id>d53906cc-d73c-4476-afd4-e92814acaee7</Id>
+      <Database Name="cv" Series="5562" Issue="42401" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="11" Volume="1963" Year="1964">
-      <Id>f68963bf-70d3-480a-8c19-2e7cd1496367</Id>
+      <Database Name="cv" Series="2127" Issue="7066" />
     </Book>
     <Book Series="Untold Tales of Spider-Man" Number="10" Volume="1995" Year="1996">
-      <Id>c2a76173-0977-4966-8b30-701288144f2c</Id>
+      <Database Name="cv" Series="5562" Issue="42497" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="12" Volume="1963" Year="1964">
-      <Id>3a391139-e934-4395-a0d4-f08234320cfb</Id>
+      <Database Name="cv" Series="2127" Issue="7105" />
     </Book>
     <Book Series="Untold Tales of Spider-Man" Number="11" Volume="1995" Year="1996">
-      <Id>12e90cf2-819e-46dc-be41-58e46f7b4af0</Id>
+      <Database Name="cv" Series="5562" Issue="42605" />
     </Book>
     <Book Series="Untold Tales of Spider-Man" Number="12" Volume="1995" Year="1996">
-      <Id>2008938d-09d4-4952-ad68-feb31aca29dc</Id>
+      <Database Name="cv" Series="5562" Issue="42703" />
     </Book>
     <Book Series="Untold Tales of Spider-Man" Number="13" Volume="1995" Year="1996">
-      <Id>344509e0-c9a5-4f7b-8202-334376e0ec20</Id>
+      <Database Name="cv" Series="5562" Issue="42799" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="13" Volume="1963" Year="1964">
-      <Id>f8f111a4-3011-4dc2-a0d5-8b8db10913cc</Id>
+      <Database Name="cv" Series="2127" Issue="7156" />
     </Book>
     <Book Series="Untold Tales of Spider-Man" Number="14" Volume="1995" Year="1996">
-      <Id>e29ab415-8978-45b3-9835-7dba3cdec8f8</Id>
+      <Database Name="cv" Series="5562" Issue="42886" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="14" Volume="1963" Year="1964">
-      <Id>a1d3bd42-14dd-4721-b9b2-547f5f3d031e</Id>
+      <Database Name="cv" Series="2127" Issue="7198" />
     </Book>
     <Book Series="Untold Tales of Spider-Man" Number="15" Volume="1995" Year="1996">
-      <Id>0587fc67-3f36-44b1-9960-58b26ea38d3f</Id>
+      <Database Name="cv" Series="5562" Issue="42992" />
     </Book>
     <Book Series="Untold Tales of Spider-Man" Number="16" Volume="1995" Year="1996">
-      <Id>2a47f799-6420-47b5-9299-45d20156a78d</Id>
+      <Database Name="cv" Series="5562" Issue="43089" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="15" Volume="1963" Year="1964">
-      <Id>138e6d7e-c400-4055-bd10-fa5e9dc2dfd4</Id>
+      <Database Name="cv" Series="2127" Issue="7253" />
     </Book>
     <Book Series="Untold Tales of Spider-Man" Number="17" Volume="1995" Year="1997">
-      <Id>0a960366-d1ef-44f9-89e1-a29bfc475b0e</Id>
+      <Database Name="cv" Series="5562" Issue="43283" />
     </Book>
     <Book Series="Untold Tales of Spider-Man: Strange Encounters" Number="1" Volume="1998" Year="1998">
-      <Id>404a5f46-06a4-427f-a730-9fc7dc52b834</Id>
+      <Database Name="cv" Series="31409" Issue="195706" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="16" Volume="1963" Year="1964">
-      <Id>500da22b-db48-424a-8472-e96fe24ca1e9</Id>
+      <Database Name="cv" Series="2127" Issue="7301" />
     </Book>
     <Book Series="Untold Tales of Spider-Man" Number="18" Volume="1995" Year="1997">
-      <Id>13568f85-eea8-462b-8307-2b70542c6549</Id>
+      <Database Name="cv" Series="5562" Issue="43395" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="1" Volume="1964" Year="1964">
-      <Id>fc2e1973-7681-4c90-aa0b-54c008e234d7</Id>
+      <Database Name="cv" Series="2189" Issue="6837" />
     </Book>
     <Book Series="Untold Tales of Spider-Man" Number="19" Volume="1995" Year="1997">
-      <Id>b787449b-22c3-472d-a852-0b20ef1bffdf</Id>
+      <Database Name="cv" Series="5562" Issue="43493" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="17" Volume="1963" Year="1964">
-      <Id>8d1ae8ef-6bb7-4b52-85f1-13a6186da58d</Id>
+      <Database Name="cv" Series="2127" Issue="7370" />
     </Book>
     <Book Series="Untold Tales of Spider-Man" Number="20" Volume="1995" Year="1997">
-      <Id>7b4596c7-dbdb-4d7a-a20c-daf101e59e1c</Id>
+      <Database Name="cv" Series="5562" Issue="43592" />
     </Book>
     <Book Series="Untold Tales of Spider-Man" Number="21" Volume="1995" Year="1997">
-      <Id>23fcd13b-4ac0-4e99-8f01-1496a5750402</Id>
+      <Database Name="cv" Series="5562" Issue="43694" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="18" Volume="1963" Year="1964">
-      <Id>f6cac47e-4be6-4eab-8e62-6ce1b5875c33</Id>
+      <Database Name="cv" Series="2127" Issue="7422" />
     </Book>
     <Book Series="Untold Tales of Spider-Man" Number="22" Volume="1995" Year="1997">
-      <Id>02794ca1-edd3-41a8-985d-be7d8e1c9ac4</Id>
+      <Database Name="cv" Series="5562" Issue="43782" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="19" Volume="1963" Year="1964">
-      <Id>9d1ef409-adc4-405f-bcf8-47d9419fc58b</Id>
+      <Database Name="cv" Series="2127" Issue="7481" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="20" Volume="1963" Year="1965">
-      <Id>35e0fb1d-13d6-4ca1-8804-b40787d3a068</Id>
+      <Database Name="cv" Series="2127" Issue="7550" />
     </Book>
     <Book Series="Untold Tales of Spider-Man" Number="23" Volume="1995" Year="1997">
-      <Id>14c1d570-1d1d-4fc2-aa7f-9f01aa8c7768</Id>
+      <Database Name="cv" Series="5562" Issue="43982" />
     </Book>
-    <Book Series="Untold Tales of Spider-Man Annual '97" Number="1" Volume="1997" Year="1997">
-      <Id>de012d66-045a-489b-a9b7-f79f2168bbfe</Id>
+    <Book Series="Untold Tales of Spider-Man '97" Number="1" Volume="1997" Year="1997">
+      <Database Name="cv" Series="44361" Issue="305566" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="21" Volume="1963" Year="1965">
-      <Id>1c2a9bb8-3a39-48c8-90b7-f1b69c827dab</Id>
+      <Database Name="cv" Series="2127" Issue="7607" />
     </Book>
-    <Book Series="Untold Tales of Spider-Man Annual '96" Number="1" Volume="1996" Year="1996">
-      <Id>f3daf9a1-4d98-44c4-9ed4-bc0395cee75a</Id>
+    <Book Series="Untold Tales of Spider-Man '96" Number="1" Volume="1996" Year="1996">
+      <Database Name="cv" Series="44353" Issue="305538" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="22" Volume="1963" Year="1965">
-      <Id>258d6bea-e8e6-4d0d-b3e5-ab27671a0e96</Id>
+      <Database Name="cv" Series="2127" Issue="7665" />
     </Book>
     <Book Series="Untold Tales of Spider-Man" Number="24" Volume="1995" Year="1997">
-      <Id>06db3af4-543d-4b2f-abe3-42964e0f8260</Id>
+      <Database Name="cv" Series="5562" Issue="44095" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="23" Volume="1963" Year="1965">
-      <Id>c2625cce-759b-40a3-89d3-75146839f36f</Id>
+      <Database Name="cv" Series="2127" Issue="7723" />
     </Book>
     <Book Series="Untold Tales of Spider-Man" Number="25" Volume="1995" Year="1997">
-      <Id>8cfe41fa-0b75-41fe-9a7a-37566e3c5d1b</Id>
+      <Database Name="cv" Series="5562" Issue="44200" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="24" Volume="1963" Year="1965">
-      <Id>b41297ad-c36c-4f67-bc35-6e017ef1340e</Id>
+      <Database Name="cv" Series="2127" Issue="7773" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="25" Volume="1963" Year="1965">
-      <Id>e0affd61-c87d-4270-8c20-1b9b42c0e339</Id>
+      <Database Name="cv" Series="2127" Issue="7834" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="26" Volume="1963" Year="1965">
-      <Id>a03e9396-e5cb-4f5f-9945-610be3909d51</Id>
+      <Database Name="cv" Series="2127" Issue="107547" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="27" Volume="1963" Year="1965">
-      <Id>8b5b2e0f-f950-451a-9256-c072a32f1cbb</Id>
+      <Database Name="cv" Series="2127" Issue="7958" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="28" Volume="1963" Year="1965">
-      <Id>85f42b0a-27b2-4ec8-a210-b6b4bb712c98</Id>
+      <Database Name="cv" Series="2127" Issue="8028" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="2" Volume="1964" Year="1965">
-      <Id>a002b2cf-be89-4934-9e23-cc2869f459e1</Id>
+      <Database Name="cv" Series="2189" Issue="7502" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="29" Volume="1963" Year="1965">
-      <Id>1bff73c1-82f1-4183-a39a-2cdc424745b3</Id>
+      <Database Name="cv" Series="2127" Issue="8100" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="30" Volume="1963" Year="1965">
-      <Id>281b74fd-9a89-44a4-b890-054f2402ca14</Id>
+      <Database Name="cv" Series="2127" Issue="8161" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="31" Volume="1963" Year="1965">
-      <Id>4e557fb6-6bb2-433b-945e-c5cd1fba4781</Id>
+      <Database Name="cv" Series="2127" Issue="8228" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="32" Volume="1963" Year="1966">
-      <Id>73f627d1-f652-4877-a390-abe626bd6aa6</Id>
+      <Database Name="cv" Series="2127" Issue="8305" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="33" Volume="1963" Year="1966">
-      <Id>96c7b4e7-e132-4486-b77b-94237a1e0594</Id>
+      <Database Name="cv" Series="2127" Issue="8364" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="34" Volume="1963" Year="1966">
-      <Id>0d8853ed-c68e-4c9b-b781-5ce59096a99d</Id>
+      <Database Name="cv" Series="2127" Issue="8425" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="35" Volume="1963" Year="1966">
-      <Id>bc8ee0ee-2680-4e8f-8fef-16d4b11daa67</Id>
+      <Database Name="cv" Series="2127" Issue="8487" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="36" Volume="1963" Year="1966">
-      <Id>cb6c9e9f-db47-411d-9668-2667143eb95b</Id>
+      <Database Name="cv" Series="2127" Issue="8543" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="37" Volume="1963" Year="1966">
-      <Id>64aedfcd-5f6f-4cd4-a51a-11e03374ae4b</Id>
+      <Database Name="cv" Series="2127" Issue="8610" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="38" Volume="1963" Year="1966">
-      <Id>8f3849ab-fde7-4fc1-9ffd-09d7e95b8cb0</Id>
+      <Database Name="cv" Series="2127" Issue="8663" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="39" Volume="1963" Year="1966">
-      <Id>224a5eca-4504-466d-b977-8f65de4c94b9</Id>
+      <Database Name="cv" Series="2127" Issue="8729" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="40" Volume="1963" Year="1966">
-      <Id>00fd0696-8581-4bcc-b373-cf143d8fd9f7</Id>
+      <Database Name="cv" Series="2127" Issue="8807" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="41" Volume="1963" Year="1966">
-      <Id>b809ac7d-d9d6-4209-854e-81899d08eda9</Id>
+      <Database Name="cv" Series="2127" Issue="8873" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="42" Volume="1963" Year="1966">
-      <Id>5d3137af-6397-42dc-aa70-f8c53a67e301</Id>
+      <Database Name="cv" Series="2127" Issue="8940" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="43" Volume="1963" Year="1966">
-      <Id>6ba0d125-6bcd-4248-a6fa-d84ae01bf148</Id>
+      <Database Name="cv" Series="2127" Issue="9014" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="3" Volume="1964" Year="1966">
-      <Id>a438f172-6f25-41e1-a578-e339113a02a4</Id>
+      <Database Name="cv" Series="2189" Issue="8905" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="44" Volume="1963" Year="1967">
-      <Id>54acbe8a-e70b-41eb-8855-237668565c56</Id>
+      <Database Name="cv" Series="2127" Issue="9087" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="45" Volume="1963" Year="1967">
-      <Id>d354e0a2-8347-4123-9524-354162d7a0aa</Id>
+      <Database Name="cv" Series="2127" Issue="9150" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="46" Volume="1963" Year="1967">
-      <Id>90434e03-4c21-4dfc-bc61-2bfdb2d69c69</Id>
+      <Database Name="cv" Series="2127" Issue="9223" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="47" Volume="1963" Year="1967">
-      <Id>877fe118-8bd0-4ef6-abae-7ec813a994d8</Id>
+      <Database Name="cv" Series="2127" Issue="9290" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="48" Volume="1963" Year="1967">
-      <Id>a622153a-b454-4925-b26d-309d4d1a28e0</Id>
+      <Database Name="cv" Series="2127" Issue="9353" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="49" Volume="1963" Year="1967">
-      <Id>74788242-dc85-4b3a-95a4-0631dc80afc6</Id>
+      <Database Name="cv" Series="2127" Issue="9423" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="50" Volume="1963" Year="1967">
-      <Id>ca290203-fa04-4c98-8758-2449d6ba819d</Id>
+      <Database Name="cv" Series="2127" Issue="9483" />
     </Book>
     <Book Series="The X-Men" Number="35" Volume="1963" Year="1967">
-      <Id>5e8b9532-6538-4811-b88c-3cbd464f00cc</Id>
+      <Database Name="cv" Series="2133" Issue="9565" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="51" Volume="1963" Year="1967">
-      <Id>28c9a697-4d36-472c-ab4b-e712f569fa94</Id>
+      <Database Name="cv" Series="2127" Issue="9552" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="52" Volume="1963" Year="1967">
-      <Id>5af87a4a-3491-4453-a436-1764534b48ae</Id>
+      <Database Name="cv" Series="2127" Issue="9610" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="4" Volume="1964" Year="1967">
-      <Id>a48f8a84-300c-4e94-98a2-86346a5ec1a0</Id>
+      <Database Name="cv" Series="2189" Issue="9714" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="53" Volume="1963" Year="1967">
-      <Id>62f0ec33-99b8-4583-b186-8f92ac2b3374</Id>
+      <Database Name="cv" Series="2127" Issue="9682" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="54" Volume="1963" Year="1967">
-      <Id>9eea3fbf-03f5-448c-b562-cd843032ea70</Id>
+      <Database Name="cv" Series="2127" Issue="9751" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="55" Volume="1963" Year="1967">
-      <Id>87ed48a8-4f98-4ca4-98a6-d1433f1211e0</Id>
+      <Database Name="cv" Series="2127" Issue="9813" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="56" Volume="1963" Year="1968">
-      <Id>d85413d6-1336-47a9-b2c3-cdaf36377461</Id>
+      <Database Name="cv" Series="2127" Issue="9876" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="57" Volume="1963" Year="1968">
-      <Id>49777139-62aa-4559-a847-7c4bcf13bc9b</Id>
+      <Database Name="cv" Series="2127" Issue="9934" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="58" Volume="1963" Year="1968">
-      <Id>44cb02f5-b2a4-49fb-903e-fb8d23624d37</Id>
+      <Database Name="cv" Series="2127" Issue="109460" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="59" Volume="1963" Year="1968">
-      <Id>ab3ae33b-08d7-4bf5-91e2-7dbccfa13b0a</Id>
+      <Database Name="cv" Series="2127" Issue="109464" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="60" Volume="1963" Year="1968">
-      <Id>8c51c861-8e32-4aed-8a50-47177aff7693</Id>
+      <Database Name="cv" Series="2127" Issue="109466" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="61" Volume="1963" Year="1968">
-      <Id>33d6aac7-00a0-4b5d-9f45-4cce110f39be</Id>
+      <Database Name="cv" Series="2127" Issue="109467" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="62" Volume="1963" Year="1968">
-      <Id>b23ca440-8420-4cfe-9bb0-5b3982f06942</Id>
+      <Database Name="cv" Series="2127" Issue="109499" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="5" Volume="1964" Year="1968">
-      <Id>95aabf16-9d7c-44a6-b9e5-8a80b0465ab6</Id>
+      <Database Name="cv" Series="2189" Issue="111514" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="63" Volume="1963" Year="1968">
-      <Id>a909f520-71a5-42cd-b882-2277248b4161</Id>
+      <Database Name="cv" Series="2127" Issue="109500" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="64" Volume="1963" Year="1968">
-      <Id>c09fb67a-6575-4e53-a53a-80080ccc974b</Id>
+      <Database Name="cv" Series="2127" Issue="109501" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="65" Volume="1963" Year="1968">
-      <Id>89fa5d29-d204-4d7e-bdbe-fb617b580ec4</Id>
+      <Database Name="cv" Series="2127" Issue="109502" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="66" Volume="1963" Year="1968">
-      <Id>3974432a-276b-497b-a595-a8bca6f834f5</Id>
+      <Database Name="cv" Series="2127" Issue="109503" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="67" Volume="1963" Year="1968">
-      <Id>b0a88279-ea46-4b9c-99c8-d0c88c116340</Id>
+      <Database Name="cv" Series="2127" Issue="109504" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="68" Volume="1963" Year="1969">
-      <Id>24d17e20-1c39-4a8d-b9fb-1098fe0abb7b</Id>
+      <Database Name="cv" Series="2127" Issue="9986" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="69" Volume="1963" Year="1969">
-      <Id>3dbe4770-3df1-4c5b-afb0-831a28613c58</Id>
+      <Database Name="cv" Series="2127" Issue="10038" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="70" Volume="1963" Year="1969">
-      <Id>b88c235b-c9eb-4404-ba2f-64058870b348</Id>
+      <Database Name="cv" Series="2127" Issue="10091" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="71" Volume="1963" Year="1969">
-      <Id>b64ca721-59a0-48dd-8217-59cb131deff9</Id>
+      <Database Name="cv" Series="2127" Issue="10146" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="72" Volume="1963" Year="1969">
-      <Id>5591201d-ae46-41e5-9477-788c3adca262</Id>
+      <Database Name="cv" Series="2127" Issue="10198" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="73" Volume="1963" Year="1969">
-      <Id>e43b6b30-9f98-4125-b13d-27c210f96ecf</Id>
+      <Database Name="cv" Series="2127" Issue="10257" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="74" Volume="1963" Year="1969">
-      <Id>9e12ed23-dcc3-4e27-a403-1b4759281fdd</Id>
+      <Database Name="cv" Series="2127" Issue="10302" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="75" Volume="1963" Year="1969">
-      <Id>d90c2238-fcb6-4fd5-bbb8-6afb8eeb7940</Id>
+      <Database Name="cv" Series="2127" Issue="10352" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="76" Volume="1963" Year="1969">
-      <Id>807705b6-9430-4659-af88-186576f31f47</Id>
+      <Database Name="cv" Series="2127" Issue="10399" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="77" Volume="1963" Year="1969">
-      <Id>2a5cd551-3915-449d-a8da-c1aeb05924e1</Id>
+      <Database Name="cv" Series="2127" Issue="10461" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="78" Volume="1963" Year="1969">
-      <Id>d4cc1ac4-75f5-4906-a122-9e21dbeb2bc4</Id>
+      <Database Name="cv" Series="2127" Issue="10506" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="79" Volume="1963" Year="1969">
-      <Id>33095fc7-d5f8-4e20-a2c5-351aaa3dd58c</Id>
+      <Database Name="cv" Series="2127" Issue="10566" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="80" Volume="1963" Year="1970">
-      <Id>42250e88-77f6-4639-a6fb-3b7538511f11</Id>
+      <Database Name="cv" Series="2127" Issue="10616" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="81" Volume="1963" Year="1970">
-      <Id>4b2d97df-cad3-456f-b651-2a3eae60278c</Id>
+      <Database Name="cv" Series="2127" Issue="10662" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="82" Volume="1963" Year="1970">
-      <Id>f7c6916d-7adc-45b0-b9d8-22724b637676</Id>
+      <Database Name="cv" Series="2127" Issue="10707" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="83" Volume="1963" Year="1970">
-      <Id>c1feb585-c6a2-4d42-a616-4d2f7d8974fa</Id>
+      <Database Name="cv" Series="2127" Issue="10753" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="84" Volume="1963" Year="1970">
-      <Id>940b540a-c94a-452e-a4de-a35414e2c581</Id>
+      <Database Name="cv" Series="2127" Issue="10799" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="85" Volume="1963" Year="1970">
-      <Id>48792bb8-d4fd-4ee5-b2b9-00b2441ae9c8</Id>
+      <Database Name="cv" Series="2127" Issue="10852" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="86" Volume="1963" Year="1970">
-      <Id>ed802c84-e723-4a2d-9e54-a95d117f518f</Id>
+      <Database Name="cv" Series="2127" Issue="10895" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="87" Volume="1963" Year="1970">
-      <Id>9f00d650-3e74-40c1-ad22-061635e35eab</Id>
+      <Database Name="cv" Series="2127" Issue="10947" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Spider-Man/Spider-Man 002 (The 70s).cbl
+++ b/Marvel/Characters/unsorted/Spider-Man/Spider-Man 002 (The 70s).cbl
@@ -2,772 +2,772 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Spider-Man 2 (The 70s)</Name>
   <Books>
-    <Book Series="The Amazing Spider-Man" Number="88" Volume="1963" Year="1970" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="88" Volume="1963" Year="1970">
       <Id>beddbdd6-3918-44a0-8dac-6fe256c06e89</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="89" Volume="1963" Year="1970" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="89" Volume="1963" Year="1970">
       <Id>d069decf-63b1-4db4-b7e9-7825194f4619</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="90" Volume="1963" Year="1970" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="90" Volume="1963" Year="1970">
       <Id>734cd5a7-20a0-47e1-a3a9-490d4fbc5238</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="91" Volume="1963" Year="1970" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="91" Volume="1963" Year="1970">
       <Id>412f8abf-62b9-4acb-bb36-7735c5eef831</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="92" Volume="1963" Year="1971" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="92" Volume="1963" Year="1971">
       <Id>d47fd0f1-a213-49e8-ab9c-0913224ce8dd</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="93" Volume="1963" Year="1971" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="93" Volume="1963" Year="1971">
       <Id>68e4096d-7a82-4e3b-8040-4c770b46ec2a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="94" Volume="1963" Year="1971" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="94" Volume="1963" Year="1971">
       <Id>e3592671-443e-4748-8d36-6517c88dce67</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="95" Volume="1963" Year="1971" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="95" Volume="1963" Year="1971">
       <Id>b763810a-9cec-47c7-9668-55c9812d88aa</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="96" Volume="1963" Year="1971" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="96" Volume="1963" Year="1971">
       <Id>28e9702b-f00b-4855-a859-f1e87090d956</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="97" Volume="1963" Year="1971" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="97" Volume="1963" Year="1971">
       <Id>37805ab2-27f7-44eb-8d0b-2e5a318d548a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="98" Volume="1963" Year="1971" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="98" Volume="1963" Year="1971">
       <Id>4a60fe1e-4511-4a6a-a78a-64f3b463d8a8</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="99" Volume="1963" Year="1971" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="99" Volume="1963" Year="1971">
       <Id>6dc08714-ba63-4078-8360-a04a5f080037</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="1" Volume="1972" Year="1972" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="1" Volume="1972" Year="1972">
       <Id>279df447-72fb-4844-ad0b-d29f2f5fc61d</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="2" Volume="1972" Year="1972" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="2" Volume="1972" Year="1972">
       <Id>5ba6ea7b-07aa-496c-81fc-2808ca23f5c9</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="100" Volume="1963" Year="1971" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="100" Volume="1963" Year="1971">
       <Id>25689355-23b8-4fa7-a563-949622f22c7f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="101" Volume="1963" Year="1971" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="101" Volume="1963" Year="1971">
       <Id>98173ed0-af0d-4d28-8f03-a3cc5fb12826</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="102" Volume="1963" Year="1971" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="102" Volume="1963" Year="1971">
       <Id>61241658-f751-4dae-b7fd-c995216fb040</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="3" Volume="1972" Year="1972" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="3" Volume="1972" Year="1972">
       <Id>219d0fc2-dca1-4b34-8d3c-4ad28b85e5fd</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="103" Volume="1963" Year="1971" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="103" Volume="1963" Year="1971">
       <Id>a39042bb-7874-4f21-b89c-bf463855d27d</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="104" Volume="1963" Year="1972" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="104" Volume="1963" Year="1972">
       <Id>fc005e44-6376-423c-a938-04e5decc209d</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="105" Volume="1963" Year="1972" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="105" Volume="1963" Year="1972">
       <Id>ac24b55e-c824-4374-92bc-828ad42dcfda</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="4" Volume="1972" Year="1972" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="4" Volume="1972" Year="1972">
       <Id>e89a39f2-eb95-4852-9465-e4518a55f1b9</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="106" Volume="1963" Year="1972" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="106" Volume="1963" Year="1972">
       <Id>61ecdc8f-eb97-49e4-82a4-1961825c4ed2</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="107" Volume="1963" Year="1972" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="107" Volume="1963" Year="1972">
       <Id>e3f158ed-a849-4267-8f8c-d93ef24ba5ec</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="5" Volume="1972" Year="1972" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="5" Volume="1972" Year="1972">
       <Id>c04513f9-0e39-4432-8ba5-f423e005e40e</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="6" Volume="1972" Year="1973" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="6" Volume="1972" Year="1973">
       <Id>c45377bf-d5db-47f5-9935-7eb6b0b3d459</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="7" Volume="1972" Year="1973" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="7" Volume="1972" Year="1973">
       <Id>8f94670e-40f3-4d13-a0dd-6a6e394e0bd2</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="108" Volume="1963" Year="1972" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="108" Volume="1963" Year="1972">
       <Id>50d2fe3d-fc09-47ba-b8d5-601952094b27</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="109" Volume="1963" Year="1972" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="109" Volume="1963" Year="1972">
       <Id>b6df13bc-1320-4efe-a1e5-f5622013b278</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="110" Volume="1963" Year="1972" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="110" Volume="1963" Year="1972">
       <Id>79eda093-c696-4e6b-9450-ff3e15e5b6a3</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="111" Volume="1963" Year="1972" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="111" Volume="1963" Year="1972">
       <Id>6a444214-a1f7-4a61-8461-811cafe04b07</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="112" Volume="1963" Year="1972" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="112" Volume="1963" Year="1972">
       <Id>e32bd47b-073f-4d1d-97f1-06341564f08a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="113" Volume="1963" Year="1972" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="113" Volume="1963" Year="1972">
       <Id>6420287b-8d4b-4b3d-a028-d9b0154e82c8</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="114" Volume="1963" Year="1972" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="114" Volume="1963" Year="1972">
       <Id>0d66701a-6185-423f-91f3-20e32106fd2f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="115" Volume="1963" Year="1972" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="115" Volume="1963" Year="1972">
       <Id>9d12e44a-84b4-4e5f-9e9f-2eb6d3295ba8</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="116" Volume="1963" Year="1973" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="116" Volume="1963" Year="1973">
       <Id>dd5a1584-dbf6-4f41-9ba6-7fdd0dbf8b9a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="117" Volume="1963" Year="1973" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="117" Volume="1963" Year="1973">
       <Id>d6438a2b-0991-43e0-9f2b-b8cb7d77aed5</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="118" Volume="1963" Year="1973" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="118" Volume="1963" Year="1973">
       <Id>9ea92b92-4925-4bc3-bb56-30b526d12b91</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="8" Volume="1972" Year="1973" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="8" Volume="1972" Year="1973">
       <Id>10553bad-4198-4cfa-b6c9-adb3ae566e18</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="9" Volume="1972" Year="1973" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="9" Volume="1972" Year="1973">
       <Id>488adc57-266b-4cda-b61f-195588322a62</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="10" Volume="1972" Year="1973" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="10" Volume="1972" Year="1973">
       <Id>73dda0e1-917c-4e75-9e89-c0374f29f9a3</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="11" Volume="1972" Year="1973" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="11" Volume="1972" Year="1973">
       <Id>73844aeb-2abc-4f8d-88b7-97bf209f56fe</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="119" Volume="1963" Year="1973" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="119" Volume="1963" Year="1973">
       <Id>a7915d7b-53f9-44b3-ad5b-68c019fe7720</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="120" Volume="1963" Year="1973" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="120" Volume="1963" Year="1973">
       <Id>fa8e8c9f-204b-4e99-b8dd-7a9b062f8cbc</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="121" Volume="1963" Year="1973" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="121" Volume="1963" Year="1973">
       <Id>7305cf58-fe85-43cb-a900-317ad91f7ff2</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="122" Volume="1963" Year="1973" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="122" Volume="1963" Year="1973">
       <Id>0c5c5768-750e-4b34-b742-5b9420a9a075</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="123" Volume="1963" Year="1973" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="123" Volume="1963" Year="1973">
       <Id>236bc95e-8031-49b6-976d-fc68c6e75562</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="12" Volume="1972" Year="1973" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="12" Volume="1972" Year="1973">
       <Id>75180be1-d981-4c27-9ae4-411566709690</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="13" Volume="1972" Year="1973" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="13" Volume="1972" Year="1973">
       <Id>a0bdbfed-6aed-4f61-98a9-1da49af7f41c</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="124" Volume="1963" Year="1973" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="124" Volume="1963" Year="1973">
       <Id>edae19d1-1f35-450c-8c4f-eef1bd015b76</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="125" Volume="1963" Year="1973" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="125" Volume="1963" Year="1973">
       <Id>f6e60ad8-983a-40b2-9cb0-5d743c26fe70</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="14" Volume="1972" Year="1973" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="14" Volume="1972" Year="1973">
       <Id>e7c0f7a6-1beb-4146-974e-690c00c200fe</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="126" Volume="1963" Year="1973" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="126" Volume="1963" Year="1973">
       <Id>57f591cd-1ab4-4989-85fe-71c62280d748</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="15" Volume="1972" Year="1973" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="15" Volume="1972" Year="1973">
       <Id>97392d8f-1f0f-4635-9928-8141921beb35</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="127" Volume="1963" Year="1973" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="127" Volume="1963" Year="1973">
       <Id>32032613-7697-453b-8a25-18ed57e1205d</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="128" Volume="1963" Year="1974" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="128" Volume="1963" Year="1974">
       <Id>8801388a-b47f-411e-a2dc-33fe02501c46</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="16" Volume="1972" Year="1973" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="16" Volume="1972" Year="1973">
       <Id>61fc3960-f82f-4b29-9ae1-b123ee13be41</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="17" Volume="1972" Year="1974" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="17" Volume="1972" Year="1974">
       <Id>1d20df12-2e90-4627-ab7f-daa6f1203168</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="129" Volume="1963" Year="1974" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="129" Volume="1963" Year="1974">
       <Id>f6c5c806-0a50-4e24-8681-6cb47af4ab49</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="130" Volume="1963" Year="1974" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="130" Volume="1963" Year="1974">
       <Id>bb5f9c67-df98-480c-8a0f-ed33da04c09f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="131" Volume="1963" Year="1974" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="131" Volume="1963" Year="1974">
       <Id>7ef28532-1ff0-40e3-b30f-c6f00972a31e</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="19" Volume="1972" Year="1974" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="19" Volume="1972" Year="1974">
       <Id>010ea037-187e-4996-90c1-f764fb3decf3</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="20" Volume="1972" Year="1974" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="20" Volume="1972" Year="1974">
       <Id>0a4b7735-19c7-4855-bb99-7fbca1dce284</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="21" Volume="1972" Year="1974" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="21" Volume="1972" Year="1974">
       <Id>40d0301c-87d4-44b8-928a-87dfa3ed6f7b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="132" Volume="1963" Year="1974" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="132" Volume="1963" Year="1974">
       <Id>0cd2c3af-54c9-4278-bf98-fb2074fe2020</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="133" Volume="1963" Year="1974" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="133" Volume="1963" Year="1974">
       <Id>a1005c9d-8b3a-48d8-b482-335eb8b9feeb</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="22" Volume="1972" Year="1974" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="22" Volume="1972" Year="1974">
       <Id>d78c7ac0-79c3-4a28-aab5-ba565b5538ab</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="23" Volume="1972" Year="1974" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="23" Volume="1972" Year="1974">
       <Id>4c5c3d40-3e89-4ecb-99e6-2f016af39de8</Id>
     </Book>
-    <Book Series="Giant-Size Spider-Man" Number="1" Volume="1974" Year="1974" Format="Giant Size">
+    <Book Series="Giant-Size Spider-Man" Number="1" Volume="1974" Year="1974">
       <Id>fd6eee62-b945-4925-9d33-c996280d9f40</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="134" Volume="1963" Year="1974" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="134" Volume="1963" Year="1974">
       <Id>adf7f231-f718-4c85-aa13-5d2ce0909565</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="135" Volume="1963" Year="1974" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="135" Volume="1963" Year="1974">
       <Id>59cdcf68-3ef2-4bef-94dd-d2c1713efb46</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="24" Volume="1972" Year="1974" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="24" Volume="1972" Year="1974">
       <Id>f033dd25-f675-49fd-a15f-cb81c135638c</Id>
     </Book>
-    <Book Series="Giant-Size Spider-Man" Number="2" Volume="1974" Year="1974" Format="Giant Size">
+    <Book Series="Giant-Size Spider-Man" Number="2" Volume="1974" Year="1974">
       <Id>342b2987-59fd-4616-a0ee-4460b50ea7bf</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="25" Volume="1972" Year="1974" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="25" Volume="1972" Year="1974">
       <Id>ce92afb6-8465-41d7-95a0-5349bebfb531</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="27" Volume="1972" Year="1974" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="27" Volume="1972" Year="1974">
       <Id>45145d7d-c730-482c-bddc-0a3614550518</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="136" Volume="1963" Year="1974" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="136" Volume="1963" Year="1974">
       <Id>3d794b8e-805d-45e9-b9ca-436987a7e541</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="137" Volume="1963" Year="1974" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="137" Volume="1963" Year="1974">
       <Id>8c6f7eb4-a9d7-4854-933e-c93ff0db678a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="138" Volume="1963" Year="1974" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="138" Volume="1963" Year="1974">
       <Id>2ecfe1a5-a9d2-4925-b761-1f6770e11074</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="28" Volume="1972" Year="1974" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="28" Volume="1972" Year="1974">
       <Id>78931425-5c81-4d56-bc2f-8fa0af9d1590</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="139" Volume="1963" Year="1974" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="139" Volume="1963" Year="1974">
       <Id>715dec38-77cf-42c3-8b09-824bf18c5dc4</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="140" Volume="1963" Year="1975" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="140" Volume="1963" Year="1975">
       <Id>b01d2571-7532-4d42-a8fb-918fd7c8dab2</Id>
     </Book>
-    <Book Series="Giant-Size Spider-Man" Number="3" Volume="1974" Year="1975" Format="Giant Size">
+    <Book Series="Giant-Size Spider-Man" Number="3" Volume="1974" Year="1975">
       <Id>799863e0-db4a-46fb-b68e-0f2abb59cff0</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="30" Volume="1972" Year="1975" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="30" Volume="1972" Year="1975">
       <Id>5fec99c6-c961-47f8-b05f-2fd69689f112</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="141" Volume="1963" Year="1975" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="141" Volume="1963" Year="1975">
       <Id>3789c403-06af-4e7f-9fb3-72e238fec754</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="142" Volume="1963" Year="1975" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="142" Volume="1963" Year="1975">
       <Id>7ce00053-9ee0-4329-831e-c2cb9ef2458d</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="31" Volume="1972" Year="1975" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="31" Volume="1972" Year="1975">
       <Id>8b1c81f2-8301-4be9-bdbc-6e9480066527</Id>
     </Book>
-    <Book Series="Giant-Size Spider-Man" Number="4" Volume="1974" Year="1975" Format="Giant Size">
+    <Book Series="Giant-Size Spider-Man" Number="4" Volume="1974" Year="1975">
       <Id>1cfb324b-179a-40db-8c8e-3fc2b1bcb5c7</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="143" Volume="1963" Year="1975" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="143" Volume="1963" Year="1975">
       <Id>5b42d07b-a117-44d2-879a-177eb1de7ca3</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="144" Volume="1963" Year="1975" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="144" Volume="1963" Year="1975">
       <Id>9bdddad0-716b-4d40-9fb4-f2442b73439a</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="33" Volume="1972" Year="1975" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="33" Volume="1972" Year="1975">
       <Id>01b4768e-5ae5-4352-810f-5a39b50e2f90</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="145" Volume="1963" Year="1975" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="145" Volume="1963" Year="1975">
       <Id>af876451-ca07-4b09-b65e-d702fca068cf</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="146" Volume="1963" Year="1975" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="146" Volume="1963" Year="1975">
       <Id>52e97f38-477c-44b2-b849-1abf26917f46</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="34" Volume="1972" Year="1975" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="34" Volume="1972" Year="1975">
       <Id>24e9fb7d-2d3e-4570-adae-bf61ab277dab</Id>
     </Book>
-    <Book Series="Giant-Size Spider-Man" Number="5" Volume="1974" Year="1975" Format="Giant Size">
+    <Book Series="Giant-Size Spider-Man" Number="5" Volume="1974" Year="1975">
       <Id>4a5e21e0-1dfa-47df-98c5-0794ad4fb766</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="147" Volume="1963" Year="1975" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="147" Volume="1963" Year="1975">
       <Id>f7ab06c9-c13e-4bbf-b293-293876d0278d</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="148" Volume="1963" Year="1975" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="148" Volume="1963" Year="1975">
       <Id>ec47e5d9-bb31-4a81-825d-b6dcf8d1612f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="149" Volume="1963" Year="1975" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="149" Volume="1963" Year="1975">
       <Id>08cae150-f950-45ba-ad6a-f513709650e2</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="150" Volume="1963" Year="1975" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="150" Volume="1963" Year="1975">
       <Id>add55f9b-d1be-42f7-b601-dc4150f341e4</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="36" Volume="1972" Year="1975" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="36" Volume="1972" Year="1975">
       <Id>1d2f6e13-7c3d-4452-8bf6-5bc11d3e1fe1</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="37" Volume="1972" Year="1975" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="37" Volume="1972" Year="1975">
       <Id>d479dd5c-190e-4b47-bc33-5ccc010e5ae1</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="38" Volume="1972" Year="1975" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="38" Volume="1972" Year="1975">
       <Id>4979b850-f3da-4c03-b818-f1b3969c506b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="151" Volume="1963" Year="1975" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="151" Volume="1963" Year="1975">
       <Id>8437df5c-7393-49d3-acd1-6f0cdd652208</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="152" Volume="1963" Year="1976" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="152" Volume="1963" Year="1976">
       <Id>0498d0ab-4e0c-443e-8be8-18b17fd8f3a0</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="39" Volume="1972" Year="1975" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="39" Volume="1972" Year="1975">
       <Id>aff8e915-e9cc-4109-af98-e6883deef4d6</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="40" Volume="1972" Year="1975" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="40" Volume="1972" Year="1975">
       <Id>8d9d98ba-d26a-4ebd-b4f1-a13101165408</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="153" Volume="1963" Year="1976" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="153" Volume="1963" Year="1976">
       <Id>a5628097-6a8a-4aa4-b5b9-0a3ac39fc1bf</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="154" Volume="1963" Year="1976" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="154" Volume="1963" Year="1976">
       <Id>5cea3a84-f334-422b-9d08-afd63a5dc058</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="155" Volume="1963" Year="1976" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="155" Volume="1963" Year="1976">
       <Id>d5a7ad06-1924-4ab9-bd56-990595334cbd</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="156" Volume="1963" Year="1976" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="156" Volume="1963" Year="1976">
       <Id>cfdd3d5e-d92c-45c7-89f1-9d4ad2532e5e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="157" Volume="1963" Year="1976" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="157" Volume="1963" Year="1976">
       <Id>1666ac64-2510-4009-ae23-fc258da8e909</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="158" Volume="1963" Year="1976" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="158" Volume="1963" Year="1976">
       <Id>52da7d8c-9e6c-4c11-bfec-850c7a7640f7</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="159" Volume="1963" Year="1976" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="159" Volume="1963" Year="1976">
       <Id>a7da22fd-d6cd-48fb-a159-0c7b5e7fc45e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="10" Volume="1964" Year="1976" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="10" Volume="1964" Year="1976">
       <Id>c233bfca-caf5-4d35-aff1-352255794515</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="160" Volume="1963" Year="1976" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="160" Volume="1963" Year="1976">
       <Id>97c3a59e-551b-4151-9653-2c57497daac5</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="161" Volume="1963" Year="1976" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="161" Volume="1963" Year="1976">
       <Id>c3143aba-249e-45a4-b923-5d7cd01fd3db</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="162" Volume="1963" Year="1976" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="162" Volume="1963" Year="1976">
       <Id>9eaee2e6-6788-4889-b3b5-4d2e17f59fa3</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="41" Volume="1972" Year="1976" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="41" Volume="1972" Year="1976">
       <Id>99d98622-0bd3-4d3f-ab5d-ac5b08a6c38c</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="42" Volume="1972" Year="1976" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="42" Volume="1972" Year="1976">
       <Id>d5fc0d19-4429-4dc8-ab52-48c0063d4bc8</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="43" Volume="1972" Year="1976" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="43" Volume="1972" Year="1976">
       <Id>c4d40aa8-8071-46f8-ba5e-0f8f9832839f</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="44" Volume="1972" Year="1976" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="44" Volume="1972" Year="1976">
       <Id>af2274c3-b9f4-4ea1-8cb2-ee88d0ae63d4</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="45" Volume="1972" Year="1976" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="45" Volume="1972" Year="1976">
       <Id>5d7d8699-6f87-4772-b54a-0ef9d6564cd8</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="46" Volume="1972" Year="1976" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="46" Volume="1972" Year="1976">
       <Id>2c76cb9f-595d-4146-816d-a42df75f8b80</Id>
     </Book>
-    <Book Series="Marvel Two-in-One" Number="17" Volume="1974" Year="1976" Format="Main Series">
+    <Book Series="Marvel Two-in-One" Number="17" Volume="1974" Year="1976">
       <Id>2ff81e52-baf3-4b84-a0dd-3bef707f8f85</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="47" Volume="1972" Year="1976" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="47" Volume="1972" Year="1976">
       <Id>c0326a1c-ee19-4885-94a8-03cb4b721a9b</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="48" Volume="1972" Year="1976" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="48" Volume="1972" Year="1976">
       <Id>d43e6f81-0130-474f-a32b-8d8b00701e98</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="49" Volume="1972" Year="1976" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="49" Volume="1972" Year="1976">
       <Id>9b52eeae-c591-4872-bac1-93763dbbde70</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="50" Volume="1972" Year="1976" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="50" Volume="1972" Year="1976">
       <Id>7f3b5984-31e5-4eba-9d1c-25db872af394</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="51" Volume="1972" Year="1976" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="51" Volume="1972" Year="1976">
       <Id>f933ea33-3274-40a5-b376-9069ef9e7fcd</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="1" Volume="1976" Year="1976" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="1" Volume="1976" Year="1976">
       <Id>e1693616-894f-44e2-a45f-e54499b1175c</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="52" Volume="1972" Year="1976" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="52" Volume="1972" Year="1976">
       <Id>3dd0fa06-c6d2-4ddd-9aa9-2ee2893cbd74</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="163" Volume="1963" Year="1976" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="163" Volume="1963" Year="1976">
       <Id>1312eec8-9f82-4038-a97e-bde789747259</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="164" Volume="1963" Year="1977" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="164" Volume="1963" Year="1977">
       <Id>df7c49d0-facc-4e19-9bc1-7b7f33a84961</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="2" Volume="1976" Year="1977" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="2" Volume="1976" Year="1977">
       <Id>79cead0c-e171-471a-8203-5fd18c77bf60</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="3" Volume="1976" Year="1977" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="3" Volume="1976" Year="1977">
       <Id>86dea6be-173f-41ce-b920-e80a15a4ecd6</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="165" Volume="1963" Year="1977" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="165" Volume="1963" Year="1977">
       <Id>f05a5887-870e-4cb5-9cb8-fa492dfb506c</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="166" Volume="1963" Year="1977" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="166" Volume="1963" Year="1977">
       <Id>c0ac655a-7cc2-4e96-ae7a-e6dfad1dcbdb</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="4" Volume="1976" Year="1977" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="4" Volume="1976" Year="1977">
       <Id>c81037be-b80d-48d1-bce6-632706a19666</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="5" Volume="1976" Year="1977" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="5" Volume="1976" Year="1977">
       <Id>84c9cbfe-2349-49cf-af55-062e6d3747fe</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="167" Volume="1963" Year="1977" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="167" Volume="1963" Year="1977">
       <Id>dd8ad9b3-408b-4a4c-9faf-a3e6e3186659</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="168" Volume="1963" Year="1977" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="168" Volume="1963" Year="1977">
       <Id>aca1e0c8-c67d-4319-89db-eef09be987b0</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="169" Volume="1963" Year="1977" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="169" Volume="1963" Year="1977">
       <Id>ced558c9-6a41-4451-a5e7-711affc33d7d</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="170" Volume="1963" Year="1977" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="170" Volume="1963" Year="1977">
       <Id>a8119ccc-824e-4052-a0df-621803ca08c2</Id>
     </Book>
-    <Book Series="Marvel Team-Up Annual" Number="1" Volume="1976" Year="1976" Format="Annual">
+    <Book Series="Marvel Team-Up Annual" Number="1" Volume="1976" Year="1976">
       <Id>14fd04f7-dd94-49fc-9f95-77b499cce667</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="53" Volume="1972" Year="1977" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="53" Volume="1972" Year="1977">
       <Id>d08363ed-9564-4f30-9b76-36e7924d1484</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="54" Volume="1972" Year="1977" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="54" Volume="1972" Year="1977">
       <Id>7fa6ed4c-5762-4dc0-a2ae-19dbe3e0b9e3</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="55" Volume="1972" Year="1977" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="55" Volume="1972" Year="1977">
       <Id>edb0d8e9-3647-4642-8a17-5e758278dacc</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="56" Volume="1972" Year="1977" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="56" Volume="1972" Year="1977">
       <Id>02a8392e-35cb-42e9-a030-7e67038108b4</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="6" Volume="1976" Year="1977" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="6" Volume="1976" Year="1977">
       <Id>180af9b4-814c-4778-86e1-601abe14febb</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="7" Volume="1976" Year="1977" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="7" Volume="1976" Year="1977">
       <Id>86e36534-4cb2-425e-bf57-c0e54051a24f</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="8" Volume="1976" Year="1977" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="8" Volume="1976" Year="1977">
       <Id>66d042ac-c8c8-401c-9f55-17557e63150f</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="57" Volume="1972" Year="1977" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="57" Volume="1972" Year="1977">
       <Id>af0412b1-11ad-4e8b-8d21-d8afff05f9e5</Id>
     </Book>
-    <Book Series="Nova" Number="12" Volume="1976" Year="1977" Format="Main Series">
+    <Book Series="Nova" Number="12" Volume="1976" Year="1977">
       <Id>01d31d6e-88d1-4b95-83d0-49fea6967147</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="171" Volume="1963" Year="1977" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="171" Volume="1963" Year="1977">
       <Id>30aa5b72-56b7-4e02-99df-2b15b7efb52b</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="58" Volume="1972" Year="1977" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="58" Volume="1972" Year="1977">
       <Id>4620c456-9101-4f0b-bb31-487dc5cde7a5</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="181" Volume="1963" Year="1978" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="181" Volume="1963" Year="1978">
       <Id>d5fb2ae8-9caa-40e4-a790-f041f5805224</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="59" Volume="1972" Year="1977" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="59" Volume="1972" Year="1977">
       <Id>1d7d2101-10da-48b6-b5c8-db6ae34bfdb3</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="60" Volume="1972" Year="1977" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="60" Volume="1972" Year="1977">
       <Id>9ab3ed93-753e-4212-929b-46e23de17bcd</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="61" Volume="1972" Year="1977" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="61" Volume="1972" Year="1977">
       <Id>4fb505ec-4d28-4e31-b10c-663b53c784e1</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="62" Volume="1972" Year="1977" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="62" Volume="1972" Year="1977">
       <Id>bf924923-901b-4796-a9fe-f3de78b6cee2</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="9" Volume="1976" Year="1977" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="9" Volume="1976" Year="1977">
       <Id>e822825b-642d-4383-a896-3afb89a8e8db</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="10" Volume="1976" Year="1977" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="10" Volume="1976" Year="1977">
       <Id>95e599e6-a89b-40a6-806f-63d3e212dd4a</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="63" Volume="1972" Year="1977" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="63" Volume="1972" Year="1977">
       <Id>6322444b-2e05-4473-8de1-0aed183f28d5</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="64" Volume="1972" Year="1977" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="64" Volume="1972" Year="1977">
       <Id>f4405a9c-f3a9-4f14-8004-ea10d3825840</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="11" Volume="1976" Year="1977" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="11" Volume="1976" Year="1977">
       <Id>3dc09bbc-fdfe-49ff-9352-14acea000e4d</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="65" Volume="1972" Year="1978" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="65" Volume="1972" Year="1978">
       <Id>8fa6b125-fbbb-4653-b683-055f2877e526</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="66" Volume="1972" Year="1978" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="66" Volume="1972" Year="1978">
       <Id>721942d9-8613-4eb4-8bde-833e1af55346</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="67" Volume="1972" Year="1978" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="67" Volume="1972" Year="1978">
       <Id>4df1cc43-77f9-4450-a8d7-283a83b8411e</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="68" Volume="1972" Year="1978" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="68" Volume="1972" Year="1978">
       <Id>85b8b253-8b8d-4d5a-807d-1f9d9f7492d1</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="69" Volume="1972" Year="1978" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="69" Volume="1972" Year="1978">
       <Id>91c263c2-233d-4fa6-827d-0b98859c6fd8</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="70" Volume="1972" Year="1978" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="70" Volume="1972" Year="1978">
       <Id>94a0ed95-4435-4b32-a873-6eeb645b0c3a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="11" Volume="1964" Year="1977" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="11" Volume="1964" Year="1977">
       <Id>3d48d499-c6c8-41c2-bd5b-1638509a3d41</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="172" Volume="1963" Year="1977" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="172" Volume="1963" Year="1977">
       <Id>3e2765d6-cb99-4930-91bf-e916da572e37</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="173" Volume="1963" Year="1977" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="173" Volume="1963" Year="1977">
       <Id>2a5b8b23-7025-4cfa-9e6a-eb2b37e7f903</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="174" Volume="1963" Year="1977" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="174" Volume="1963" Year="1977">
       <Id>258552f4-eccd-4b5b-a35b-2c297276f0ca</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="175" Volume="1963" Year="1977" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="175" Volume="1963" Year="1977">
       <Id>02b19a18-72d8-4976-a6b7-5eb93e0df600</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="176" Volume="1963" Year="1978" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="176" Volume="1963" Year="1978">
       <Id>89fd42f2-1513-489a-9b0b-7487b0798b37</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="177" Volume="1963" Year="1978" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="177" Volume="1963" Year="1978">
       <Id>e5631644-f056-4856-8ca7-b8beae3c2f11</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="178" Volume="1963" Year="1978" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="178" Volume="1963" Year="1978">
       <Id>0b16976f-0370-49df-8b6c-4b956b2ac9b6</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="179" Volume="1963" Year="1978" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="179" Volume="1963" Year="1978">
       <Id>5ff4a280-9842-4602-a33a-e995ce28c6e7</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="180" Volume="1963" Year="1978" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="180" Volume="1963" Year="1978">
       <Id>9dda87c8-37f5-4f82-a141-9a5251b8dd7a</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="12" Volume="1976" Year="1977" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="12" Volume="1976" Year="1977">
       <Id>de213278-fcd4-4dac-98f8-47b0d427fc03</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="13" Volume="1976" Year="1977" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="13" Volume="1976" Year="1977">
       <Id>f924ba62-b4ae-48c7-bcca-90342ffa778b</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="14" Volume="1976" Year="1978" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="14" Volume="1976" Year="1978">
       <Id>b8db1c7c-2711-4b00-b414-1640d4f2d31f</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="15" Volume="1976" Year="1978" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="15" Volume="1976" Year="1978">
       <Id>2b0102cc-2ad9-4766-8958-f7f0d6238e20</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="71" Volume="1972" Year="1978" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="71" Volume="1972" Year="1978">
       <Id>e0fc88ba-3a1f-4884-a762-e49c8af8fc3d</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="16" Volume="1976" Year="1978" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="16" Volume="1976" Year="1978">
       <Id>dbcffdc4-b181-4c7f-83de-385ecfd2543e</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="17" Volume="1976" Year="1978" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="17" Volume="1976" Year="1978">
       <Id>e45df949-2418-48d1-8f12-0333588c3af4</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="18" Volume="1976" Year="1978" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="18" Volume="1976" Year="1978">
       <Id>8524c4af-f38c-48c8-85ee-74e301adbb42</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="19" Volume="1976" Year="1978" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="19" Volume="1976" Year="1978">
       <Id>3b5c62d5-c526-40a3-9d64-da29d666600b</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="20" Volume="1976" Year="1978" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="20" Volume="1976" Year="1978">
       <Id>71db6726-2cd8-4cf2-a262-68a2009feddc</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="182" Volume="1963" Year="1978" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="182" Volume="1963" Year="1978">
       <Id>7624cb82-9f5c-48de-8a88-a56dca8d419e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="183" Volume="1963" Year="1978" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="183" Volume="1963" Year="1978">
       <Id>fbfeec5c-e1b5-431b-82d4-4e26ae16541d</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="184" Volume="1963" Year="1978" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="184" Volume="1963" Year="1978">
       <Id>e21f2ce5-8fe5-44cf-bd72-5b87012c24cd</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="185" Volume="1963" Year="1978" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="185" Volume="1963" Year="1978">
       <Id>7b747f86-820b-4cc9-9609-65c8547b9ed5</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="21" Volume="1976" Year="1978" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="21" Volume="1976" Year="1978">
       <Id>4a38ca38-1b8f-41f7-87c8-e5b52015b1ee</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="72" Volume="1972" Year="1978" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="72" Volume="1972" Year="1978">
       <Id>122b8f98-99ad-4ac1-ab71-581d581597b4</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="22" Volume="1976" Year="1978" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="22" Volume="1976" Year="1978">
       <Id>49ed0d39-7933-4ee0-b454-f797e9e29746</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="23" Volume="1976" Year="1978" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="23" Volume="1976" Year="1978">
       <Id>02768584-6302-4f2c-80af-31eba4830f01</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="186" Volume="1963" Year="1978" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="186" Volume="1963" Year="1978">
       <Id>0551384d-0294-424b-9d3a-50a2c6cb3d77</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="73" Volume="1972" Year="1978" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="73" Volume="1972" Year="1978">
       <Id>116b3e09-aae0-42d7-89cc-1d4fd2477695</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="24" Volume="1976" Year="1978" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="24" Volume="1976" Year="1978">
       <Id>7ee03bc9-0d81-4e49-ba3e-8e41ba529dea</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="74" Volume="1972" Year="1978" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="74" Volume="1972" Year="1978">
       <Id>a0e7c76a-371a-447f-8cde-e03eaf7886c7</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="75" Volume="1972" Year="1978" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="75" Volume="1972" Year="1978">
       <Id>abb1d032-6ee9-4e04-8f28-76f234d8e051</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="76" Volume="1972" Year="1978" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="76" Volume="1972" Year="1978">
       <Id>71b8fde4-25c2-48b7-8be0-173130a26fa0</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="77" Volume="1972" Year="1979" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="77" Volume="1972" Year="1979">
       <Id>26a2d197-62f9-45e0-96e1-3bd61fe537dd</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="78" Volume="1972" Year="1979" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="78" Volume="1972" Year="1979">
       <Id>62c30dc2-9cb0-48b6-a82e-a20c14322012</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="80" Volume="1972" Year="1979" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="80" Volume="1972" Year="1979">
       <Id>07ccd08d-9dae-4afc-866d-834ee1d1acf1</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="81" Volume="1972" Year="1979" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="81" Volume="1972" Year="1979">
       <Id>30596cb8-8937-437e-9de2-195a2e210da6</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="90" Volume="1972" Year="1980" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="90" Volume="1972" Year="1980">
       <Id>6bae6b67-4ab6-43e5-9154-42d0343b0b22</Id>
     </Book>
-    <Book Series="Marvel Team-Up Annual" Number="2" Volume="1976" Year="1979" Format="Annual">
+    <Book Series="Marvel Team-Up Annual" Number="2" Volume="1976" Year="1979">
       <Id>eb18a92d-4253-4f31-8118-76c5acd3ec7e</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="86" Volume="1972" Year="1979" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="86" Volume="1972" Year="1979">
       <Id>bc125985-d28d-4b58-b387-ec3a4403dff8</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="87" Volume="1972" Year="1979" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="87" Volume="1972" Year="1979">
       <Id>f1d135f7-87e0-4d79-b2f5-77dc6b51e3b3</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="88" Volume="1972" Year="1979" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="88" Volume="1972" Year="1979">
       <Id>4787999d-b40f-4332-8e06-d9a791f00f43</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="89" Volume="1972" Year="1980" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="89" Volume="1972" Year="1980">
       <Id>fa2a0c83-60c9-4531-948a-ce4084e0ac95</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="91" Volume="1972" Year="1980" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="91" Volume="1972" Year="1980">
       <Id>4c765ea0-eb6c-4bdf-a2e5-391bbfdc1077</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="25" Volume="1976" Year="1978" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="25" Volume="1976" Year="1978">
       <Id>8b32e239-e37c-4771-ab9e-7f30fb2e7583</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="26" Volume="1976" Year="1979" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="26" Volume="1976" Year="1979">
       <Id>8e30f1a5-b3ec-4e98-887f-7ec7ce3f7bf9</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="27" Volume="1976" Year="1979" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="27" Volume="1976" Year="1979">
       <Id>9c1dd9c3-3a91-442d-9298-7375b659d1c6</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="28" Volume="1976" Year="1979" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="28" Volume="1976" Year="1979">
       <Id>6383f634-fb2d-4a6f-856a-916076ceea05</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="29" Volume="1976" Year="1979" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="29" Volume="1976" Year="1979">
       <Id>ef112262-cda0-438c-8ad3-a35a53d7f8a3</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="30" Volume="1976" Year="1979" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="30" Volume="1976" Year="1979">
       <Id>44599c46-212a-46a8-aae1-a04d0010a8b7</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="31" Volume="1976" Year="1979" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="31" Volume="1976" Year="1979">
       <Id>9340522d-317b-4d52-b058-4e3375f37bbe</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="32" Volume="1976" Year="1979" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="32" Volume="1976" Year="1979">
       <Id>b2a2dfb0-6a37-4d16-8a4e-60218c621dc1</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="33" Volume="1976" Year="1979" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="33" Volume="1976" Year="1979">
       <Id>fb3ab9a9-7045-4dee-88b2-d1f21296dd40</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="34" Volume="1976" Year="1979" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="34" Volume="1976" Year="1979">
       <Id>20464122-df84-4db1-8a0b-b9f185f3d079</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="187" Volume="1963" Year="1978" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="187" Volume="1963" Year="1978">
       <Id>53162e2b-3867-4b96-b0a9-2b6e01f200a2</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="188" Volume="1963" Year="1979" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="188" Volume="1963" Year="1979">
       <Id>75b2ac33-4321-4b8f-af74-2561c712f547</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="189" Volume="1963" Year="1979" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="189" Volume="1963" Year="1979">
       <Id>2e774239-488c-4d77-912d-01c48b279960</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="190" Volume="1963" Year="1979" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="190" Volume="1963" Year="1979">
       <Id>76dc07be-1bdc-4ea4-9af1-2cd9b1632e85</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="191" Volume="1963" Year="1979" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="191" Volume="1963" Year="1979">
       <Id>46c251f4-7a83-4a7b-af89-584ac0596bac</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="192" Volume="1963" Year="1979" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="192" Volume="1963" Year="1979">
       <Id>897c54e8-e0f4-44f8-b381-d90c3ec49305</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="193" Volume="1963" Year="1979" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="193" Volume="1963" Year="1979">
       <Id>3f851dd3-bacf-4dee-938b-2933ce0bd9e1</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="194" Volume="1963" Year="1979" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="194" Volume="1963" Year="1979">
       <Id>e4b14a8a-813f-47ae-86f2-238700b259d3</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="195" Volume="1963" Year="1979" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="195" Volume="1963" Year="1979">
       <Id>c3d4f1aa-05b2-4e7c-adca-d5b8d130eb8f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="196" Volume="1963" Year="1979" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="196" Volume="1963" Year="1979">
       <Id>60008df6-c90c-40a8-96ec-13af010eab77</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="197" Volume="1963" Year="1979" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="197" Volume="1963" Year="1979">
       <Id>06d72404-b7a9-48fe-93d4-4d0bb5a2ec8e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="198" Volume="1963" Year="1979" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="198" Volume="1963" Year="1979">
       <Id>b4c868d1-539e-4d49-ab80-7d4589e433bf</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="199" Volume="1963" Year="1979" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="199" Volume="1963" Year="1979">
       <Id>27a6948f-81e7-4aaf-9389-02ef67cd289e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="200" Volume="1963" Year="1980" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="200" Volume="1963" Year="1980">
       <Id>137d7de8-e489-49f5-b715-bf1a0335e6af</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="35" Volume="1976" Year="1979" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="35" Volume="1976" Year="1979">
       <Id>f4527522-cf63-43d4-b973-a5dbe41c9126</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="36" Volume="1976" Year="1979" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="36" Volume="1976" Year="1979">
       <Id>5a3bc912-57d5-44a1-a45f-ded35f656a8c</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="37" Volume="1976" Year="1979" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="37" Volume="1976" Year="1979">
       <Id>eb51fda1-ea34-4e2a-b7eb-c6bf54579598</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="92" Volume="1972" Year="1980" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="92" Volume="1972" Year="1980">
       <Id>5afa1dc1-1070-47c4-9d20-a1fb3294b376</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="93" Volume="1972" Year="1980" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="93" Volume="1972" Year="1980">
       <Id>367daac3-9486-4dc6-8f7b-a067c4dc9b16</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="94" Volume="1972" Year="1980" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="94" Volume="1972" Year="1980">
       <Id>3d95c710-d9da-43d3-982e-d8cd2a8db39e</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="95" Volume="1972" Year="1980" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="95" Volume="1972" Year="1980">
       <Id>11617c3b-d445-4874-b6f8-e652651ced6e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="13" Volume="1964" Year="1979" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="13" Volume="1964" Year="1979">
       <Id>06c834f2-448f-4e24-9d6d-83659c09e7f1</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man Annual" Number="1" Volume="1979" Year="1979" Format="Annual">
+    <Book Series="The Spectacular Spider-Man Annual" Number="1" Volume="1979" Year="1979">
       <Id>bbc7af9d-3e23-4b77-8be7-5b30c334b513</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="38" Volume="1976" Year="1980" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="38" Volume="1976" Year="1980">
       <Id>4b50c3bc-1c0e-4ac3-a0ab-400e92b0f3ed</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="39" Volume="1976" Year="1980" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="39" Volume="1976" Year="1980">
       <Id>76cc8ccf-2e62-4c12-96ea-e776716d00e3</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="40" Volume="1976" Year="1980" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="40" Volume="1976" Year="1980">
       <Id>fe2dadfa-2247-4d5e-8142-7b30ce6c9932</Id>
     </Book>
-    <Book Series="Peter Parker" Number="1" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Peter Parker" Number="1" Volume="2010" Year="2010">
       <Id>d90931bb-87fa-40fc-a11e-3e000b8c9502</Id>
     </Book>
-    <Book Series="Peter Parker" Number="2" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Peter Parker" Number="2" Volume="2010" Year="2010">
       <Id>3d65e23d-cdef-43be-a180-11b5990058f9</Id>
     </Book>
-    <Book Series="Peter Parker" Number="3" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Peter Parker" Number="3" Volume="2010" Year="2010">
       <Id>274b6567-ad48-4f03-a63b-10f3762e8295</Id>
     </Book>
-    <Book Series="Peter Parker" Number="4" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Peter Parker" Number="4" Volume="2010" Year="2010">
       <Id>19829a05-901e-46ab-b4c9-cd606640c93a</Id>
     </Book>
-    <Book Series="Peter Parker" Number="5" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Peter Parker" Number="5" Volume="2010" Year="2010">
       <Id>04fb87fe-9fc1-483c-802e-4b4ab12de97f</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Spider-Man/Spider-Man 002 (The 70s).cbl
+++ b/Marvel/Characters/unsorted/Spider-Man/Spider-Man 002 (The 70s).cbl
@@ -1,774 +1,775 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Spider-Man 2 (The 70s)</Name>
+  <Name>Spider-Man 002 (The 70s)</Name>
+  <NumIssues>256</NumIssues>
   <Books>
     <Book Series="The Amazing Spider-Man" Number="88" Volume="1963" Year="1970">
-      <Id>beddbdd6-3918-44a0-8dac-6fe256c06e89</Id>
+      <Database Name="cv" Series="2127" Issue="11001" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="89" Volume="1963" Year="1970">
-      <Id>d069decf-63b1-4db4-b7e9-7825194f4619</Id>
+      <Database Name="cv" Series="2127" Issue="11047" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="90" Volume="1963" Year="1970">
-      <Id>734cd5a7-20a0-47e1-a3a9-490d4fbc5238</Id>
+      <Database Name="cv" Series="2127" Issue="11095" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="91" Volume="1963" Year="1970">
-      <Id>412f8abf-62b9-4acb-bb36-7735c5eef831</Id>
+      <Database Name="cv" Series="2127" Issue="11150" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="92" Volume="1963" Year="1971">
-      <Id>d47fd0f1-a213-49e8-ab9c-0913224ce8dd</Id>
+      <Database Name="cv" Series="2127" Issue="11214" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="93" Volume="1963" Year="1971">
-      <Id>68e4096d-7a82-4e3b-8040-4c770b46ec2a</Id>
+      <Database Name="cv" Series="2127" Issue="11271" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="94" Volume="1963" Year="1971">
-      <Id>e3592671-443e-4748-8d36-6517c88dce67</Id>
+      <Database Name="cv" Series="2127" Issue="11320" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="95" Volume="1963" Year="1971">
-      <Id>b763810a-9cec-47c7-9668-55c9812d88aa</Id>
+      <Database Name="cv" Series="2127" Issue="11374" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="96" Volume="1963" Year="1971">
-      <Id>28e9702b-f00b-4855-a859-f1e87090d956</Id>
+      <Database Name="cv" Series="2127" Issue="11424" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="97" Volume="1963" Year="1971">
-      <Id>37805ab2-27f7-44eb-8d0b-2e5a318d548a</Id>
+      <Database Name="cv" Series="2127" Issue="11483" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="98" Volume="1963" Year="1971">
-      <Id>4a60fe1e-4511-4a6a-a78a-64f3b463d8a8</Id>
+      <Database Name="cv" Series="2127" Issue="11538" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="99" Volume="1963" Year="1971">
-      <Id>6dc08714-ba63-4078-8360-a04a5f080037</Id>
+      <Database Name="cv" Series="2127" Issue="11597" />
     </Book>
     <Book Series="Marvel Team-Up" Number="1" Volume="1972" Year="1972">
-      <Id>279df447-72fb-4844-ad0b-d29f2f5fc61d</Id>
+      <Database Name="cv" Series="2576" Issue="12058" />
     </Book>
     <Book Series="Marvel Team-Up" Number="2" Volume="1972" Year="1972">
-      <Id>5ba6ea7b-07aa-496c-81fc-2808ca23f5c9</Id>
+      <Database Name="cv" Series="2576" Issue="12196" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="100" Volume="1963" Year="1971">
-      <Id>25689355-23b8-4fa7-a563-949622f22c7f</Id>
+      <Database Name="cv" Series="2127" Issue="11657" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="101" Volume="1963" Year="1971">
-      <Id>98173ed0-af0d-4d28-8f03-a3cc5fb12826</Id>
+      <Database Name="cv" Series="2127" Issue="11717" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="102" Volume="1963" Year="1971">
-      <Id>61241658-f751-4dae-b7fd-c995216fb040</Id>
+      <Database Name="cv" Series="2127" Issue="11776" />
     </Book>
     <Book Series="Marvel Team-Up" Number="3" Volume="1972" Year="1972">
-      <Id>219d0fc2-dca1-4b34-8d3c-4ad28b85e5fd</Id>
+      <Database Name="cv" Series="2576" Issue="12345" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="103" Volume="1963" Year="1971">
-      <Id>a39042bb-7874-4f21-b89c-bf463855d27d</Id>
+      <Database Name="cv" Series="2127" Issue="11838" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="104" Volume="1963" Year="1972">
-      <Id>fc005e44-6376-423c-a938-04e5decc209d</Id>
+      <Database Name="cv" Series="2127" Issue="11916" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="105" Volume="1963" Year="1972">
-      <Id>ac24b55e-c824-4374-92bc-828ad42dcfda</Id>
+      <Database Name="cv" Series="2127" Issue="11987" />
     </Book>
     <Book Series="Marvel Team-Up" Number="4" Volume="1972" Year="1972">
-      <Id>e89a39f2-eb95-4852-9465-e4518a55f1b9</Id>
+      <Database Name="cv" Series="2576" Issue="12489" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="106" Volume="1963" Year="1972">
-      <Id>61ecdc8f-eb97-49e4-82a4-1961825c4ed2</Id>
+      <Database Name="cv" Series="2127" Issue="12047" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="107" Volume="1963" Year="1972">
-      <Id>e3f158ed-a849-4267-8f8c-d93ef24ba5ec</Id>
+      <Database Name="cv" Series="2127" Issue="12117" />
     </Book>
     <Book Series="Marvel Team-Up" Number="5" Volume="1972" Year="1972">
-      <Id>c04513f9-0e39-4432-8ba5-f423e005e40e</Id>
+      <Database Name="cv" Series="2576" Issue="12658" />
     </Book>
     <Book Series="Marvel Team-Up" Number="6" Volume="1972" Year="1973">
-      <Id>c45377bf-d5db-47f5-9935-7eb6b0b3d459</Id>
+      <Database Name="cv" Series="2576" Issue="12840" />
     </Book>
     <Book Series="Marvel Team-Up" Number="7" Volume="1972" Year="1973">
-      <Id>8f94670e-40f3-4d13-a0dd-6a6e394e0bd2</Id>
+      <Database Name="cv" Series="2576" Issue="13017" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="108" Volume="1963" Year="1972">
-      <Id>50d2fe3d-fc09-47ba-b8d5-601952094b27</Id>
+      <Database Name="cv" Series="2127" Issue="12182" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="109" Volume="1963" Year="1972">
-      <Id>b6df13bc-1320-4efe-a1e5-f5622013b278</Id>
+      <Database Name="cv" Series="2127" Issue="12258" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="110" Volume="1963" Year="1972">
-      <Id>79eda093-c696-4e6b-9450-ff3e15e5b6a3</Id>
+      <Database Name="cv" Series="2127" Issue="12332" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="111" Volume="1963" Year="1972">
-      <Id>6a444214-a1f7-4a61-8461-811cafe04b07</Id>
+      <Database Name="cv" Series="2127" Issue="12409" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="112" Volume="1963" Year="1972">
-      <Id>e32bd47b-073f-4d1d-97f1-06341564f08a</Id>
+      <Database Name="cv" Series="2127" Issue="12473" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="113" Volume="1963" Year="1972">
-      <Id>6420287b-8d4b-4b3d-a028-d9b0154e82c8</Id>
+      <Database Name="cv" Series="2127" Issue="12563" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="114" Volume="1963" Year="1972">
-      <Id>0d66701a-6185-423f-91f3-20e32106fd2f</Id>
+      <Database Name="cv" Series="2127" Issue="12640" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="115" Volume="1963" Year="1972">
-      <Id>9d12e44a-84b4-4e5f-9e9f-2eb6d3295ba8</Id>
+      <Database Name="cv" Series="2127" Issue="12728" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="116" Volume="1963" Year="1973">
-      <Id>dd5a1584-dbf6-4f41-9ba6-7fdd0dbf8b9a</Id>
+      <Database Name="cv" Series="2127" Issue="12822" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="117" Volume="1963" Year="1973">
-      <Id>d6438a2b-0991-43e0-9f2b-b8cb7d77aed5</Id>
+      <Database Name="cv" Series="2127" Issue="12914" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="118" Volume="1963" Year="1973">
-      <Id>9ea92b92-4925-4bc3-bb56-30b526d12b91</Id>
+      <Database Name="cv" Series="2127" Issue="12999" />
     </Book>
     <Book Series="Marvel Team-Up" Number="8" Volume="1972" Year="1973">
-      <Id>10553bad-4198-4cfa-b6c9-adb3ae566e18</Id>
+      <Database Name="cv" Series="2576" Issue="13118" />
     </Book>
     <Book Series="Marvel Team-Up" Number="9" Volume="1972" Year="1973">
-      <Id>488adc57-266b-4cda-b61f-195588322a62</Id>
+      <Database Name="cv" Series="2576" Issue="13186" />
     </Book>
     <Book Series="Marvel Team-Up" Number="10" Volume="1972" Year="1973">
-      <Id>73dda0e1-917c-4e75-9e89-c0374f29f9a3</Id>
+      <Database Name="cv" Series="2576" Issue="13285" />
     </Book>
     <Book Series="Marvel Team-Up" Number="11" Volume="1972" Year="1973">
-      <Id>73844aeb-2abc-4f8d-88b7-97bf209f56fe</Id>
+      <Database Name="cv" Series="2576" Issue="13395" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="119" Volume="1963" Year="1973">
-      <Id>a7915d7b-53f9-44b3-ad5b-68c019fe7720</Id>
+      <Database Name="cv" Series="2127" Issue="13096" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="120" Volume="1963" Year="1973">
-      <Id>fa8e8c9f-204b-4e99-b8dd-7a9b062f8cbc</Id>
+      <Database Name="cv" Series="2127" Issue="13169" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="121" Volume="1963" Year="1973">
-      <Id>7305cf58-fe85-43cb-a900-317ad91f7ff2</Id>
+      <Database Name="cv" Series="2127" Issue="13263" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="122" Volume="1963" Year="1973">
-      <Id>0c5c5768-750e-4b34-b742-5b9420a9a075</Id>
+      <Database Name="cv" Series="2127" Issue="13377" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="123" Volume="1963" Year="1973">
-      <Id>236bc95e-8031-49b6-976d-fc68c6e75562</Id>
+      <Database Name="cv" Series="2127" Issue="13467" />
     </Book>
     <Book Series="Marvel Team-Up" Number="12" Volume="1972" Year="1973">
-      <Id>75180be1-d981-4c27-9ae4-411566709690</Id>
+      <Database Name="cv" Series="2576" Issue="13487" />
     </Book>
     <Book Series="Marvel Team-Up" Number="13" Volume="1972" Year="1973">
-      <Id>a0bdbfed-6aed-4f61-98a9-1da49af7f41c</Id>
+      <Database Name="cv" Series="2576" Issue="13589" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="124" Volume="1963" Year="1973">
-      <Id>edae19d1-1f35-450c-8c4f-eef1bd015b76</Id>
+      <Database Name="cv" Series="2127" Issue="13564" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="125" Volume="1963" Year="1973">
-      <Id>f6e60ad8-983a-40b2-9cb0-5d743c26fe70</Id>
+      <Database Name="cv" Series="2127" Issue="13682" />
     </Book>
     <Book Series="Marvel Team-Up" Number="14" Volume="1972" Year="1973">
-      <Id>e7c0f7a6-1beb-4146-974e-690c00c200fe</Id>
+      <Database Name="cv" Series="2576" Issue="13706" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="126" Volume="1963" Year="1973">
-      <Id>57f591cd-1ab4-4989-85fe-71c62280d748</Id>
+      <Database Name="cv" Series="2127" Issue="13783" />
     </Book>
     <Book Series="Marvel Team-Up" Number="15" Volume="1972" Year="1973">
-      <Id>97392d8f-1f0f-4635-9928-8141921beb35</Id>
+      <Database Name="cv" Series="2576" Issue="13805" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="127" Volume="1963" Year="1973">
-      <Id>32032613-7697-453b-8a25-18ed57e1205d</Id>
+      <Database Name="cv" Series="2127" Issue="13875" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="128" Volume="1963" Year="1974">
-      <Id>8801388a-b47f-411e-a2dc-33fe02501c46</Id>
+      <Database Name="cv" Series="2127" Issue="13978" />
     </Book>
     <Book Series="Marvel Team-Up" Number="16" Volume="1972" Year="1973">
-      <Id>61fc3960-f82f-4b29-9ae1-b123ee13be41</Id>
+      <Database Name="cv" Series="2576" Issue="13891" />
     </Book>
     <Book Series="Marvel Team-Up" Number="17" Volume="1972" Year="1974">
-      <Id>1d20df12-2e90-4627-ab7f-daa6f1203168</Id>
+      <Database Name="cv" Series="2576" Issue="13999" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="129" Volume="1963" Year="1974">
-      <Id>f6c5c806-0a50-4e24-8681-6cb47af4ab49</Id>
+      <Database Name="cv" Series="2127" Issue="105443" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="130" Volume="1963" Year="1974">
-      <Id>bb5f9c67-df98-480c-8a0f-ed33da04c09f</Id>
+      <Database Name="cv" Series="2127" Issue="14117" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="131" Volume="1963" Year="1974">
-      <Id>7ef28532-1ff0-40e3-b30f-c6f00972a31e</Id>
+      <Database Name="cv" Series="2127" Issue="14188" />
     </Book>
     <Book Series="Marvel Team-Up" Number="19" Volume="1972" Year="1974">
-      <Id>010ea037-187e-4996-90c1-f764fb3decf3</Id>
+      <Database Name="cv" Series="2576" Issue="14135" />
     </Book>
     <Book Series="Marvel Team-Up" Number="20" Volume="1972" Year="1974">
-      <Id>0a4b7735-19c7-4855-bb99-7fbca1dce284</Id>
+      <Database Name="cv" Series="2576" Issue="14203" />
     </Book>
     <Book Series="Marvel Team-Up" Number="21" Volume="1972" Year="1974">
-      <Id>40d0301c-87d4-44b8-928a-87dfa3ed6f7b</Id>
+      <Database Name="cv" Series="2576" Issue="14275" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="132" Volume="1963" Year="1974">
-      <Id>0cd2c3af-54c9-4278-bf98-fb2074fe2020</Id>
+      <Database Name="cv" Series="2127" Issue="14255" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="133" Volume="1963" Year="1974">
-      <Id>a1005c9d-8b3a-48d8-b482-335eb8b9feeb</Id>
+      <Database Name="cv" Series="2127" Issue="14328" />
     </Book>
     <Book Series="Marvel Team-Up" Number="22" Volume="1972" Year="1974">
-      <Id>d78c7ac0-79c3-4a28-aab5-ba565b5538ab</Id>
+      <Database Name="cv" Series="2576" Issue="14347" />
     </Book>
     <Book Series="Marvel Team-Up" Number="23" Volume="1972" Year="1974">
-      <Id>4c5c3d40-3e89-4ecb-99e6-2f016af39de8</Id>
+      <Database Name="cv" Series="2576" Issue="14432" />
     </Book>
     <Book Series="Giant-Size Spider-Man" Number="1" Volume="1974" Year="1974">
-      <Id>fd6eee62-b945-4925-9d33-c996280d9f40</Id>
+      <Database Name="cv" Series="2686" Issue="14421" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="134" Volume="1963" Year="1974">
-      <Id>adf7f231-f718-4c85-aa13-5d2ce0909565</Id>
+      <Database Name="cv" Series="2127" Issue="14408" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="135" Volume="1963" Year="1974">
-      <Id>59cdcf68-3ef2-4bef-94dd-d2c1713efb46</Id>
+      <Database Name="cv" Series="2127" Issue="14480" />
     </Book>
     <Book Series="Marvel Team-Up" Number="24" Volume="1972" Year="1974">
-      <Id>f033dd25-f675-49fd-a15f-cb81c135638c</Id>
+      <Database Name="cv" Series="2576" Issue="14500" />
     </Book>
     <Book Series="Giant-Size Spider-Man" Number="2" Volume="1974" Year="1974">
-      <Id>342b2987-59fd-4616-a0ee-4460b50ea7bf</Id>
+      <Database Name="cv" Series="2686" Issue="14665" />
     </Book>
     <Book Series="Marvel Team-Up" Number="25" Volume="1972" Year="1974">
-      <Id>ce92afb6-8465-41d7-95a0-5349bebfb531</Id>
+      <Database Name="cv" Series="2576" Issue="14595" />
     </Book>
     <Book Series="Marvel Team-Up" Number="27" Volume="1972" Year="1974">
-      <Id>45145d7d-c730-482c-bddc-0a3614550518</Id>
+      <Database Name="cv" Series="2576" Issue="14770" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="136" Volume="1963" Year="1974">
-      <Id>3d794b8e-805d-45e9-b9ca-436987a7e541</Id>
+      <Database Name="cv" Series="2127" Issue="14569" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="137" Volume="1963" Year="1974">
-      <Id>8c6f7eb4-a9d7-4854-933e-c93ff0db678a</Id>
+      <Database Name="cv" Series="2127" Issue="14652" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="138" Volume="1963" Year="1974">
-      <Id>2ecfe1a5-a9d2-4925-b761-1f6770e11074</Id>
+      <Database Name="cv" Series="2127" Issue="14745" />
     </Book>
     <Book Series="Marvel Team-Up" Number="28" Volume="1972" Year="1974">
-      <Id>78931425-5c81-4d56-bc2f-8fa0af9d1590</Id>
+      <Database Name="cv" Series="2576" Issue="14848" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="139" Volume="1963" Year="1974">
-      <Id>715dec38-77cf-42c3-8b09-824bf18c5dc4</Id>
+      <Database Name="cv" Series="2127" Issue="14827" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="140" Volume="1963" Year="1975">
-      <Id>b01d2571-7532-4d42-a8fb-918fd7c8dab2</Id>
+      <Database Name="cv" Series="2127" Issue="14952" />
     </Book>
     <Book Series="Giant-Size Spider-Man" Number="3" Volume="1974" Year="1975">
-      <Id>799863e0-db4a-46fb-b68e-0f2abb59cff0</Id>
+      <Database Name="cv" Series="2686" Issue="14966" />
     </Book>
     <Book Series="Marvel Team-Up" Number="30" Volume="1972" Year="1975">
-      <Id>5fec99c6-c961-47f8-b05f-2fd69689f112</Id>
+      <Database Name="cv" Series="2576" Issue="15067" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="141" Volume="1963" Year="1975">
-      <Id>3789c403-06af-4e7f-9fb3-72e238fec754</Id>
+      <Database Name="cv" Series="2127" Issue="15046" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="142" Volume="1963" Year="1975">
-      <Id>7ce00053-9ee0-4329-831e-c2cb9ef2458d</Id>
+      <Database Name="cv" Series="2127" Issue="15137" />
     </Book>
     <Book Series="Marvel Team-Up" Number="31" Volume="1972" Year="1975">
-      <Id>8b1c81f2-8301-4be9-bdbc-6e9480066527</Id>
+      <Database Name="cv" Series="2576" Issue="113536" />
     </Book>
     <Book Series="Giant-Size Spider-Man" Number="4" Volume="1974" Year="1975">
-      <Id>1cfb324b-179a-40db-8c8e-3fc2b1bcb5c7</Id>
+      <Database Name="cv" Series="2686" Issue="121299" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="143" Volume="1963" Year="1975">
-      <Id>5b42d07b-a117-44d2-879a-177eb1de7ca3</Id>
+      <Database Name="cv" Series="2127" Issue="111360" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="144" Volume="1963" Year="1975">
-      <Id>9bdddad0-716b-4d40-9fb4-f2442b73439a</Id>
+      <Database Name="cv" Series="2127" Issue="15170" />
     </Book>
     <Book Series="Marvel Team-Up" Number="33" Volume="1972" Year="1975">
-      <Id>01b4768e-5ae5-4352-810f-5a39b50e2f90</Id>
+      <Database Name="cv" Series="2576" Issue="15191" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="145" Volume="1963" Year="1975">
-      <Id>af876451-ca07-4b09-b65e-d702fca068cf</Id>
+      <Database Name="cv" Series="2127" Issue="15259" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="146" Volume="1963" Year="1975">
-      <Id>52e97f38-477c-44b2-b849-1abf26917f46</Id>
+      <Database Name="cv" Series="2127" Issue="15364" />
     </Book>
     <Book Series="Marvel Team-Up" Number="34" Volume="1972" Year="1975">
-      <Id>24e9fb7d-2d3e-4570-adae-bf61ab277dab</Id>
+      <Database Name="cv" Series="2576" Issue="15283" />
     </Book>
     <Book Series="Giant-Size Spider-Man" Number="5" Volume="1974" Year="1975">
-      <Id>4a5e21e0-1dfa-47df-98c5-0794ad4fb766</Id>
+      <Database Name="cv" Series="2686" Issue="15378" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="147" Volume="1963" Year="1975">
-      <Id>f7ab06c9-c13e-4bbf-b293-293876d0278d</Id>
+      <Database Name="cv" Series="2127" Issue="15469" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="148" Volume="1963" Year="1975">
-      <Id>ec47e5d9-bb31-4a81-825d-b6dcf8d1612f</Id>
+      <Database Name="cv" Series="2127" Issue="15572" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="149" Volume="1963" Year="1975">
-      <Id>08cae150-f950-45ba-ad6a-f513709650e2</Id>
+      <Database Name="cv" Series="2127" Issue="15668" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="150" Volume="1963" Year="1975">
-      <Id>add55f9b-d1be-42f7-b601-dc4150f341e4</Id>
+      <Database Name="cv" Series="2127" Issue="15772" />
     </Book>
     <Book Series="Marvel Team-Up" Number="36" Volume="1972" Year="1975">
-      <Id>1d2f6e13-7c3d-4452-8bf6-5bc11d3e1fe1</Id>
+      <Database Name="cv" Series="2576" Issue="15491" />
     </Book>
     <Book Series="Marvel Team-Up" Number="37" Volume="1972" Year="1975">
-      <Id>d479dd5c-190e-4b47-bc33-5ccc010e5ae1</Id>
+      <Database Name="cv" Series="2576" Issue="15593" />
     </Book>
     <Book Series="Marvel Team-Up" Number="38" Volume="1972" Year="1975">
-      <Id>4979b850-f3da-4c03-b818-f1b3969c506b</Id>
+      <Database Name="cv" Series="2576" Issue="15694" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="151" Volume="1963" Year="1975">
-      <Id>8437df5c-7393-49d3-acd1-6f0cdd652208</Id>
+      <Database Name="cv" Series="2127" Issue="15855" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="152" Volume="1963" Year="1976">
-      <Id>0498d0ab-4e0c-443e-8be8-18b17fd8f3a0</Id>
+      <Database Name="cv" Series="2127" Issue="15991" />
     </Book>
     <Book Series="Marvel Team-Up" Number="39" Volume="1972" Year="1975">
-      <Id>aff8e915-e9cc-4109-af98-e6883deef4d6</Id>
+      <Database Name="cv" Series="2576" Issue="15791" />
     </Book>
     <Book Series="Marvel Team-Up" Number="40" Volume="1972" Year="1975">
-      <Id>8d9d98ba-d26a-4ebd-b4f1-a13101165408</Id>
+      <Database Name="cv" Series="2576" Issue="15874" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="153" Volume="1963" Year="1976">
-      <Id>a5628097-6a8a-4aa4-b5b9-0a3ac39fc1bf</Id>
+      <Database Name="cv" Series="2127" Issue="16069" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="154" Volume="1963" Year="1976">
-      <Id>5cea3a84-f334-422b-9d08-afd63a5dc058</Id>
+      <Database Name="cv" Series="2127" Issue="16156" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="155" Volume="1963" Year="1976">
-      <Id>d5a7ad06-1924-4ab9-bd56-990595334cbd</Id>
+      <Database Name="cv" Series="2127" Issue="16243" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="156" Volume="1963" Year="1976">
-      <Id>cfdd3d5e-d92c-45c7-89f1-9d4ad2532e5e</Id>
+      <Database Name="cv" Series="2127" Issue="16330" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="157" Volume="1963" Year="1976">
-      <Id>1666ac64-2510-4009-ae23-fc258da8e909</Id>
+      <Database Name="cv" Series="2127" Issue="16405" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="158" Volume="1963" Year="1976">
-      <Id>52da7d8c-9e6c-4c11-bfec-850c7a7640f7</Id>
+      <Database Name="cv" Series="2127" Issue="16494" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="159" Volume="1963" Year="1976">
-      <Id>a7da22fd-d6cd-48fb-a159-0c7b5e7fc45e</Id>
+      <Database Name="cv" Series="2127" Issue="16583" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="10" Volume="1964" Year="1976">
-      <Id>c233bfca-caf5-4d35-aff1-352255794515</Id>
+      <Database Name="cv" Series="2189" Issue="15930" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="160" Volume="1963" Year="1976">
-      <Id>97c3a59e-551b-4151-9653-2c57497daac5</Id>
+      <Database Name="cv" Series="2127" Issue="16672" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="161" Volume="1963" Year="1976">
-      <Id>c3143aba-249e-45a4-b923-5d7cd01fd3db</Id>
+      <Database Name="cv" Series="2127" Issue="16760" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="162" Volume="1963" Year="1976">
-      <Id>9eaee2e6-6788-4889-b3b5-4d2e17f59fa3</Id>
+      <Database Name="cv" Series="2127" Issue="16860" />
     </Book>
     <Book Series="Marvel Team-Up" Number="41" Volume="1972" Year="1976">
-      <Id>99d98622-0bd3-4d3f-ab5d-ac5b08a6c38c</Id>
+      <Database Name="cv" Series="2576" Issue="16011" />
     </Book>
     <Book Series="Marvel Team-Up" Number="42" Volume="1972" Year="1976">
-      <Id>d5fc0d19-4429-4dc8-ab52-48c0063d4bc8</Id>
+      <Database Name="cv" Series="2576" Issue="16090" />
     </Book>
     <Book Series="Marvel Team-Up" Number="43" Volume="1972" Year="1976">
-      <Id>c4d40aa8-8071-46f8-ba5e-0f8f9832839f</Id>
+      <Database Name="cv" Series="2576" Issue="16173" />
     </Book>
     <Book Series="Marvel Team-Up" Number="44" Volume="1972" Year="1976">
-      <Id>af2274c3-b9f4-4ea1-8cb2-ee88d0ae63d4</Id>
+      <Database Name="cv" Series="2576" Issue="16267" />
     </Book>
     <Book Series="Marvel Team-Up" Number="45" Volume="1972" Year="1976">
-      <Id>5d7d8699-6f87-4772-b54a-0ef9d6564cd8</Id>
+      <Database Name="cv" Series="2576" Issue="16347" />
     </Book>
     <Book Series="Marvel Team-Up" Number="46" Volume="1972" Year="1976">
-      <Id>2c76cb9f-595d-4146-816d-a42df75f8b80</Id>
+      <Database Name="cv" Series="2576" Issue="16427" />
     </Book>
     <Book Series="Marvel Two-in-One" Number="17" Volume="1974" Year="1976">
-      <Id>2ff81e52-baf3-4b84-a0dd-3bef707f8f85</Id>
+      <Database Name="cv" Series="2696" Issue="16515" />
     </Book>
     <Book Series="Marvel Team-Up" Number="47" Volume="1972" Year="1976">
-      <Id>c0326a1c-ee19-4885-94a8-03cb4b721a9b</Id>
+      <Database Name="cv" Series="2576" Issue="16514" />
     </Book>
     <Book Series="Marvel Team-Up" Number="48" Volume="1972" Year="1976">
-      <Id>d43e6f81-0130-474f-a32b-8d8b00701e98</Id>
+      <Database Name="cv" Series="2576" Issue="16607" />
     </Book>
     <Book Series="Marvel Team-Up" Number="49" Volume="1972" Year="1976">
-      <Id>9b52eeae-c591-4872-bac1-93763dbbde70</Id>
+      <Database Name="cv" Series="2576" Issue="16690" />
     </Book>
     <Book Series="Marvel Team-Up" Number="50" Volume="1972" Year="1976">
-      <Id>7f3b5984-31e5-4eba-9d1c-25db872af394</Id>
+      <Database Name="cv" Series="2576" Issue="16788" />
     </Book>
     <Book Series="Marvel Team-Up" Number="51" Volume="1972" Year="1976">
-      <Id>f933ea33-3274-40a5-b376-9069ef9e7fcd</Id>
+      <Database Name="cv" Series="2576" Issue="16880" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="1" Volume="1976" Year="1976">
-      <Id>e1693616-894f-44e2-a45f-e54499b1175c</Id>
+      <Database Name="cv" Series="2870" Issue="16976" />
     </Book>
     <Book Series="Marvel Team-Up" Number="52" Volume="1972" Year="1976">
-      <Id>3dd0fa06-c6d2-4ddd-9aa9-2ee2893cbd74</Id>
+      <Database Name="cv" Series="2576" Issue="16968" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="163" Volume="1963" Year="1976">
-      <Id>1312eec8-9f82-4038-a97e-bde789747259</Id>
+      <Database Name="cv" Series="2127" Issue="16943" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="164" Volume="1963" Year="1977">
-      <Id>df7c49d0-facc-4e19-9bc1-7b7f33a84961</Id>
+      <Database Name="cv" Series="2127" Issue="17089" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="2" Volume="1976" Year="1977">
-      <Id>79cead0c-e171-471a-8203-5fd18c77bf60</Id>
+      <Database Name="cv" Series="2870" Issue="17119" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="3" Volume="1976" Year="1977">
-      <Id>86dea6be-173f-41ce-b920-e80a15a4ecd6</Id>
+      <Database Name="cv" Series="2870" Issue="17204" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="165" Volume="1963" Year="1977">
-      <Id>f05a5887-870e-4cb5-9cb8-fa492dfb506c</Id>
+      <Database Name="cv" Series="2127" Issue="17171" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="166" Volume="1963" Year="1977">
-      <Id>c0ac655a-7cc2-4e96-ae7a-e6dfad1dcbdb</Id>
+      <Database Name="cv" Series="2127" Issue="17258" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="4" Volume="1976" Year="1977">
-      <Id>c81037be-b80d-48d1-bce6-632706a19666</Id>
+      <Database Name="cv" Series="2870" Issue="17283" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="5" Volume="1976" Year="1977">
-      <Id>84c9cbfe-2349-49cf-af55-062e6d3747fe</Id>
+      <Database Name="cv" Series="2870" Issue="17366" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="167" Volume="1963" Year="1977">
-      <Id>dd8ad9b3-408b-4a4c-9faf-a3e6e3186659</Id>
+      <Database Name="cv" Series="2127" Issue="17335" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="168" Volume="1963" Year="1977">
-      <Id>aca1e0c8-c67d-4319-89db-eef09be987b0</Id>
+      <Database Name="cv" Series="2127" Issue="17421" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="169" Volume="1963" Year="1977">
-      <Id>ced558c9-6a41-4451-a5e7-711affc33d7d</Id>
+      <Database Name="cv" Series="2127" Issue="17491" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="170" Volume="1963" Year="1977">
-      <Id>a8119ccc-824e-4052-a0df-621803ca08c2</Id>
+      <Database Name="cv" Series="2127" Issue="17588" />
     </Book>
     <Book Series="Marvel Team-Up Annual" Number="1" Volume="1976" Year="1976">
-      <Id>14fd04f7-dd94-49fc-9f95-77b499cce667</Id>
+      <Database Name="cv" Series="2863" Issue="15915" />
     </Book>
     <Book Series="Marvel Team-Up" Number="53" Volume="1972" Year="1977">
-      <Id>d08363ed-9564-4f30-9b76-36e7924d1484</Id>
+      <Database Name="cv" Series="2576" Issue="17108" />
     </Book>
     <Book Series="Marvel Team-Up" Number="54" Volume="1972" Year="1977">
-      <Id>7fa6ed4c-5762-4dc0-a2ae-19dbe3e0b9e3</Id>
+      <Database Name="cv" Series="2576" Issue="17195" />
     </Book>
     <Book Series="Marvel Team-Up" Number="55" Volume="1972" Year="1977">
-      <Id>edb0d8e9-3647-4642-8a17-5e758278dacc</Id>
+      <Database Name="cv" Series="2576" Issue="17274" />
     </Book>
     <Book Series="Marvel Team-Up" Number="56" Volume="1972" Year="1977">
-      <Id>02a8392e-35cb-42e9-a030-7e67038108b4</Id>
+      <Database Name="cv" Series="2576" Issue="17357" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="6" Volume="1976" Year="1977">
-      <Id>180af9b4-814c-4778-86e1-601abe14febb</Id>
+      <Database Name="cv" Series="2870" Issue="17445" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="7" Volume="1976" Year="1977">
-      <Id>86e36534-4cb2-425e-bf57-c0e54051a24f</Id>
+      <Database Name="cv" Series="2870" Issue="17520" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="8" Volume="1976" Year="1977">
-      <Id>66d042ac-c8c8-401c-9f55-17557e63150f</Id>
+      <Database Name="cv" Series="2870" Issue="17615" />
     </Book>
     <Book Series="Marvel Team-Up" Number="57" Volume="1972" Year="1977">
-      <Id>af0412b1-11ad-4e8b-8d21-d8afff05f9e5</Id>
+      <Database Name="cv" Series="2576" Issue="17436" />
     </Book>
     <Book Series="Nova" Number="12" Volume="1976" Year="1977">
-      <Id>01d31d6e-88d1-4b95-83d0-49fea6967147</Id>
+      <Database Name="cv" Series="2867" Issue="17696" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="171" Volume="1963" Year="1977">
-      <Id>30aa5b72-56b7-4e02-99df-2b15b7efb52b</Id>
+      <Database Name="cv" Series="2127" Issue="17672" />
     </Book>
     <Book Series="Marvel Team-Up" Number="58" Volume="1972" Year="1977">
-      <Id>4620c456-9101-4f0b-bb31-487dc5cde7a5</Id>
+      <Database Name="cv" Series="2576" Issue="17512" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="181" Volume="1963" Year="1978">
-      <Id>d5fb2ae8-9caa-40e4-a790-f041f5805224</Id>
+      <Database Name="cv" Series="2127" Issue="18568" />
     </Book>
     <Book Series="Marvel Team-Up" Number="59" Volume="1972" Year="1977">
-      <Id>1d7d2101-10da-48b6-b5c8-db6ae34bfdb3</Id>
+      <Database Name="cv" Series="2576" Issue="17605" />
     </Book>
     <Book Series="Marvel Team-Up" Number="60" Volume="1972" Year="1977">
-      <Id>9ab3ed93-753e-4212-929b-46e23de17bcd</Id>
+      <Database Name="cv" Series="2576" Issue="17693" />
     </Book>
     <Book Series="Marvel Team-Up" Number="61" Volume="1972" Year="1977">
-      <Id>4fb505ec-4d28-4e31-b10c-663b53c784e1</Id>
+      <Database Name="cv" Series="2576" Issue="17787" />
     </Book>
     <Book Series="Marvel Team-Up" Number="62" Volume="1972" Year="1977">
-      <Id>bf924923-901b-4796-a9fe-f3de78b6cee2</Id>
+      <Database Name="cv" Series="2576" Issue="17880" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="9" Volume="1976" Year="1977">
-      <Id>e822825b-642d-4383-a896-3afb89a8e8db</Id>
+      <Database Name="cv" Series="2870" Issue="17700" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="10" Volume="1976" Year="1977">
-      <Id>95e599e6-a89b-40a6-806f-63d3e212dd4a</Id>
+      <Database Name="cv" Series="2870" Issue="17795" />
     </Book>
     <Book Series="Marvel Team-Up" Number="63" Volume="1972" Year="1977">
-      <Id>6322444b-2e05-4473-8de1-0aed183f28d5</Id>
+      <Database Name="cv" Series="2576" Issue="17970" />
     </Book>
     <Book Series="Marvel Team-Up" Number="64" Volume="1972" Year="1977">
-      <Id>f4405a9c-f3a9-4f14-8004-ea10d3825840</Id>
+      <Database Name="cv" Series="2576" Issue="18051" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="11" Volume="1976" Year="1977">
-      <Id>3dc09bbc-fdfe-49ff-9352-14acea000e4d</Id>
+      <Database Name="cv" Series="2870" Issue="17889" />
     </Book>
     <Book Series="Marvel Team-Up" Number="65" Volume="1972" Year="1978">
-      <Id>8fa6b125-fbbb-4653-b683-055f2877e526</Id>
+      <Database Name="cv" Series="2576" Issue="18173" />
     </Book>
     <Book Series="Marvel Team-Up" Number="66" Volume="1972" Year="1978">
-      <Id>721942d9-8613-4eb4-8bde-833e1af55346</Id>
+      <Database Name="cv" Series="2576" Issue="18256" />
     </Book>
     <Book Series="Marvel Team-Up" Number="67" Volume="1972" Year="1978">
-      <Id>4df1cc43-77f9-4450-a8d7-283a83b8411e</Id>
+      <Database Name="cv" Series="2576" Issue="18333" />
     </Book>
     <Book Series="Marvel Team-Up" Number="68" Volume="1972" Year="1978">
-      <Id>85b8b253-8b8d-4d5a-807d-1f9d9f7492d1</Id>
+      <Database Name="cv" Series="2576" Issue="18422" />
     </Book>
     <Book Series="Marvel Team-Up" Number="69" Volume="1972" Year="1978">
-      <Id>91c263c2-233d-4fa6-827d-0b98859c6fd8</Id>
+      <Database Name="cv" Series="2576" Issue="18503" />
     </Book>
     <Book Series="Marvel Team-Up" Number="70" Volume="1972" Year="1978">
-      <Id>94a0ed95-4435-4b32-a873-6eeb645b0c3a</Id>
+      <Database Name="cv" Series="2576" Issue="18586" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="11" Volume="1964" Year="1977">
-      <Id>3d48d499-c6c8-41c2-bd5b-1638509a3d41</Id>
+      <Database Name="cv" Series="2189" Issue="17035" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="172" Volume="1963" Year="1977">
-      <Id>3e2765d6-cb99-4930-91bf-e916da572e37</Id>
+      <Database Name="cv" Series="2127" Issue="17767" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="173" Volume="1963" Year="1977">
-      <Id>2a5b8b23-7025-4cfa-9e6a-eb2b37e7f903</Id>
+      <Database Name="cv" Series="2127" Issue="17862" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="174" Volume="1963" Year="1977">
-      <Id>258552f4-eccd-4b5b-a35b-2c297276f0ca</Id>
+      <Database Name="cv" Series="2127" Issue="17952" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="175" Volume="1963" Year="1977">
-      <Id>02b19a18-72d8-4976-a6b7-5eb93e0df600</Id>
+      <Database Name="cv" Series="2127" Issue="18033" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="176" Volume="1963" Year="1978">
-      <Id>89fd42f2-1513-489a-9b0b-7487b0798b37</Id>
+      <Database Name="cv" Series="2127" Issue="18155" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="177" Volume="1963" Year="1978">
-      <Id>e5631644-f056-4856-8ca7-b8beae3c2f11</Id>
+      <Database Name="cv" Series="2127" Issue="18238" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="178" Volume="1963" Year="1978">
-      <Id>0b16976f-0370-49df-8b6c-4b956b2ac9b6</Id>
+      <Database Name="cv" Series="2127" Issue="18318" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="179" Volume="1963" Year="1978">
-      <Id>5ff4a280-9842-4602-a33a-e995ce28c6e7</Id>
+      <Database Name="cv" Series="2127" Issue="18402" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="180" Volume="1963" Year="1978">
-      <Id>9dda87c8-37f5-4f82-a141-9a5251b8dd7a</Id>
+      <Database Name="cv" Series="2127" Issue="18487" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="12" Volume="1976" Year="1977">
-      <Id>de213278-fcd4-4dac-98f8-47b0d427fc03</Id>
+      <Database Name="cv" Series="2870" Issue="17979" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="13" Volume="1976" Year="1977">
-      <Id>f924ba62-b4ae-48c7-bcca-90342ffa778b</Id>
+      <Database Name="cv" Series="2870" Issue="18059" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="14" Volume="1976" Year="1978">
-      <Id>b8db1c7c-2711-4b00-b414-1640d4f2d31f</Id>
+      <Database Name="cv" Series="2870" Issue="18181" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="15" Volume="1976" Year="1978">
-      <Id>2b0102cc-2ad9-4766-8958-f7f0d6238e20</Id>
+      <Database Name="cv" Series="2870" Issue="18262" />
     </Book>
     <Book Series="Marvel Team-Up" Number="71" Volume="1972" Year="1978">
-      <Id>e0fc88ba-3a1f-4884-a762-e49c8af8fc3d</Id>
+      <Database Name="cv" Series="2576" Issue="18665" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="16" Volume="1976" Year="1978">
-      <Id>dbcffdc4-b181-4c7f-83de-385ecfd2543e</Id>
+      <Database Name="cv" Series="2870" Issue="18341" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="17" Volume="1976" Year="1978">
-      <Id>e45df949-2418-48d1-8f12-0333588c3af4</Id>
+      <Database Name="cv" Series="2870" Issue="18429" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="18" Volume="1976" Year="1978">
-      <Id>8524c4af-f38c-48c8-85ee-74e301adbb42</Id>
+      <Database Name="cv" Series="2870" Issue="18511" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="19" Volume="1976" Year="1978">
-      <Id>3b5c62d5-c526-40a3-9d64-da29d666600b</Id>
+      <Database Name="cv" Series="2870" Issue="18593" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="20" Volume="1976" Year="1978">
-      <Id>71db6726-2cd8-4cf2-a262-68a2009feddc</Id>
+      <Database Name="cv" Series="2870" Issue="109294" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="182" Volume="1963" Year="1978">
-      <Id>7624cb82-9f5c-48de-8a88-a56dca8d419e</Id>
+      <Database Name="cv" Series="2127" Issue="18648" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="183" Volume="1963" Year="1978">
-      <Id>fbfeec5c-e1b5-431b-82d4-4e26ae16541d</Id>
+      <Database Name="cv" Series="2127" Issue="18726" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="184" Volume="1963" Year="1978">
-      <Id>e21f2ce5-8fe5-44cf-bd72-5b87012c24cd</Id>
+      <Database Name="cv" Series="2127" Issue="18808" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="185" Volume="1963" Year="1978">
-      <Id>7b747f86-820b-4cc9-9609-65c8547b9ed5</Id>
+      <Database Name="cv" Series="2127" Issue="18884" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="21" Volume="1976" Year="1978">
-      <Id>4a38ca38-1b8f-41f7-87c8-e5b52015b1ee</Id>
+      <Database Name="cv" Series="2870" Issue="18751" />
     </Book>
     <Book Series="Marvel Team-Up" Number="72" Volume="1972" Year="1978">
-      <Id>122b8f98-99ad-4ac1-ab71-581d581597b4</Id>
+      <Database Name="cv" Series="2576" Issue="18745" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="22" Volume="1976" Year="1978">
-      <Id>49ed0d39-7933-4ee0-b454-f797e9e29746</Id>
+      <Database Name="cv" Series="2870" Issue="18831" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="23" Volume="1976" Year="1978">
-      <Id>02768584-6302-4f2c-80af-31eba4830f01</Id>
+      <Database Name="cv" Series="2870" Issue="18910" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="186" Volume="1963" Year="1978">
-      <Id>0551384d-0294-424b-9d3a-50a2c6cb3d77</Id>
+      <Database Name="cv" Series="2127" Issue="18954" />
     </Book>
     <Book Series="Marvel Team-Up" Number="73" Volume="1972" Year="1978">
-      <Id>116b3e09-aae0-42d7-89cc-1d4fd2477695</Id>
+      <Database Name="cv" Series="2576" Issue="18824" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="24" Volume="1976" Year="1978">
-      <Id>7ee03bc9-0d81-4e49-ba3e-8e41ba529dea</Id>
+      <Database Name="cv" Series="2870" Issue="18978" />
     </Book>
     <Book Series="Marvel Team-Up" Number="74" Volume="1972" Year="1978">
-      <Id>a0e7c76a-371a-447f-8cde-e03eaf7886c7</Id>
+      <Database Name="cv" Series="2576" Issue="18904" />
     </Book>
     <Book Series="Marvel Team-Up" Number="75" Volume="1972" Year="1978">
-      <Id>abb1d032-6ee9-4e04-8f28-76f234d8e051</Id>
+      <Database Name="cv" Series="2576" Issue="18971" />
     </Book>
     <Book Series="Marvel Team-Up" Number="76" Volume="1972" Year="1978">
-      <Id>71b8fde4-25c2-48b7-8be0-173130a26fa0</Id>
+      <Database Name="cv" Series="2576" Issue="19048" />
     </Book>
     <Book Series="Marvel Team-Up" Number="77" Volume="1972" Year="1979">
-      <Id>26a2d197-62f9-45e0-96e1-3bd61fe537dd</Id>
+      <Database Name="cv" Series="2576" Issue="19200" />
     </Book>
     <Book Series="Marvel Team-Up" Number="78" Volume="1972" Year="1979">
-      <Id>62c30dc2-9cb0-48b6-a82e-a20c14322012</Id>
+      <Database Name="cv" Series="2576" Issue="19302" />
     </Book>
     <Book Series="Marvel Team-Up" Number="80" Volume="1972" Year="1979">
-      <Id>07ccd08d-9dae-4afc-866d-834ee1d1acf1</Id>
+      <Database Name="cv" Series="2576" Issue="19440" />
     </Book>
     <Book Series="Marvel Team-Up" Number="81" Volume="1972" Year="1979">
-      <Id>30596cb8-8937-437e-9de2-195a2e210da6</Id>
+      <Database Name="cv" Series="2576" Issue="19513" />
     </Book>
     <Book Series="Marvel Team-Up" Number="90" Volume="1972" Year="1980">
-      <Id>6bae6b67-4ab6-43e5-9154-42d0343b0b22</Id>
+      <Database Name="cv" Series="2576" Issue="20171" />
     </Book>
     <Book Series="Marvel Team-Up Annual" Number="2" Volume="1976" Year="1979">
-      <Id>eb18a92d-4253-4f31-8118-76c5acd3ec7e</Id>
+      <Database Name="cv" Series="2863" Issue="19085" />
     </Book>
     <Book Series="Marvel Team-Up" Number="86" Volume="1972" Year="1979">
-      <Id>bc125985-d28d-4b58-b387-ec3a4403dff8</Id>
+      <Database Name="cv" Series="2576" Issue="19851" />
     </Book>
     <Book Series="Marvel Team-Up" Number="87" Volume="1972" Year="1979">
-      <Id>f1d135f7-87e0-4d79-b2f5-77dc6b51e3b3</Id>
+      <Database Name="cv" Series="2576" Issue="19925" />
     </Book>
     <Book Series="Marvel Team-Up" Number="88" Volume="1972" Year="1979">
-      <Id>4787999d-b40f-4332-8e06-d9a791f00f43</Id>
+      <Database Name="cv" Series="2576" Issue="19991" />
     </Book>
     <Book Series="Marvel Team-Up" Number="89" Volume="1972" Year="1980">
-      <Id>fa2a0c83-60c9-4531-948a-ce4084e0ac95</Id>
+      <Database Name="cv" Series="2576" Issue="20104" />
     </Book>
     <Book Series="Marvel Team-Up" Number="91" Volume="1972" Year="1980">
-      <Id>4c765ea0-eb6c-4bdf-a2e5-391bbfdc1077</Id>
+      <Database Name="cv" Series="2576" Issue="20247" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="25" Volume="1976" Year="1978">
-      <Id>8b32e239-e37c-4771-ab9e-7f30fb2e7583</Id>
+      <Database Name="cv" Series="2870" Issue="19054" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="26" Volume="1976" Year="1979">
-      <Id>8e30f1a5-b3ec-4e98-887f-7ec7ce3f7bf9</Id>
+      <Database Name="cv" Series="2870" Issue="19205" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="27" Volume="1976" Year="1979">
-      <Id>9c1dd9c3-3a91-442d-9298-7375b659d1c6</Id>
+      <Database Name="cv" Series="2870" Issue="19310" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="28" Volume="1976" Year="1979">
-      <Id>6383f634-fb2d-4a6f-856a-916076ceea05</Id>
+      <Database Name="cv" Series="2870" Issue="19381" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="29" Volume="1976" Year="1979">
-      <Id>ef112262-cda0-438c-8ad3-a35a53d7f8a3</Id>
+      <Database Name="cv" Series="2870" Issue="19448" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="30" Volume="1976" Year="1979">
-      <Id>44599c46-212a-46a8-aae1-a04d0010a8b7</Id>
+      <Database Name="cv" Series="2870" Issue="19519" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="31" Volume="1976" Year="1979">
-      <Id>9340522d-317b-4d52-b058-4e3375f37bbe</Id>
+      <Database Name="cv" Series="2870" Issue="19587" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="32" Volume="1976" Year="1979">
-      <Id>b2a2dfb0-6a37-4d16-8a4e-60218c621dc1</Id>
+      <Database Name="cv" Series="2870" Issue="19653" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="33" Volume="1976" Year="1979">
-      <Id>fb3ab9a9-7045-4dee-88b2-d1f21296dd40</Id>
+      <Database Name="cv" Series="2870" Issue="19719" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="34" Volume="1976" Year="1979">
-      <Id>20464122-df84-4db1-8a0b-b9f185f3d079</Id>
+      <Database Name="cv" Series="2870" Issue="19789" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="187" Volume="1963" Year="1978">
-      <Id>53162e2b-3867-4b96-b0a9-2b6e01f200a2</Id>
+      <Database Name="cv" Series="2127" Issue="19028" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="188" Volume="1963" Year="1979">
-      <Id>75b2ac33-4321-4b8f-af74-2561c712f547</Id>
+      <Database Name="cv" Series="2127" Issue="19182" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="189" Volume="1963" Year="1979">
-      <Id>2e774239-488c-4d77-912d-01c48b279960</Id>
+      <Database Name="cv" Series="2127" Issue="19284" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="190" Volume="1963" Year="1979">
-      <Id>76dc07be-1bdc-4ea4-9af1-2cd9b1632e85</Id>
+      <Database Name="cv" Series="2127" Issue="19358" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="191" Volume="1963" Year="1979">
-      <Id>46c251f4-7a83-4a7b-af89-584ac0596bac</Id>
+      <Database Name="cv" Series="2127" Issue="19422" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="192" Volume="1963" Year="1979">
-      <Id>897c54e8-e0f4-44f8-b381-d90c3ec49305</Id>
+      <Database Name="cv" Series="2127" Issue="19497" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="193" Volume="1963" Year="1979">
-      <Id>3f851dd3-bacf-4dee-938b-2933ce0bd9e1</Id>
+      <Database Name="cv" Series="2127" Issue="19568" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="194" Volume="1963" Year="1979">
-      <Id>e4b14a8a-813f-47ae-86f2-238700b259d3</Id>
+      <Database Name="cv" Series="2127" Issue="19634" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="195" Volume="1963" Year="1979">
-      <Id>c3d4f1aa-05b2-4e7c-adca-d5b8d130eb8f</Id>
+      <Database Name="cv" Series="2127" Issue="19698" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="196" Volume="1963" Year="1979">
-      <Id>60008df6-c90c-40a8-96ec-13af010eab77</Id>
+      <Database Name="cv" Series="2127" Issue="19773" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="197" Volume="1963" Year="1979">
-      <Id>06d72404-b7a9-48fe-93d4-4d0bb5a2ec8e</Id>
+      <Database Name="cv" Series="2127" Issue="19836" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="198" Volume="1963" Year="1979">
-      <Id>b4c868d1-539e-4d49-ab80-7d4589e433bf</Id>
+      <Database Name="cv" Series="2127" Issue="19913" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="199" Volume="1963" Year="1979">
-      <Id>27a6948f-81e7-4aaf-9389-02ef67cd289e</Id>
+      <Database Name="cv" Series="2127" Issue="19976" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="200" Volume="1963" Year="1980">
-      <Id>137d7de8-e489-49f5-b715-bf1a0335e6af</Id>
+      <Database Name="cv" Series="2127" Issue="20091" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="35" Volume="1976" Year="1979">
-      <Id>f4527522-cf63-43d4-b973-a5dbe41c9126</Id>
+      <Database Name="cv" Series="2870" Issue="19858" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="36" Volume="1976" Year="1979">
-      <Id>5a3bc912-57d5-44a1-a45f-ded35f656a8c</Id>
+      <Database Name="cv" Series="2870" Issue="19930" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="37" Volume="1976" Year="1979">
-      <Id>eb51fda1-ea34-4e2a-b7eb-c6bf54579598</Id>
+      <Database Name="cv" Series="2870" Issue="20000" />
     </Book>
     <Book Series="Marvel Team-Up" Number="92" Volume="1972" Year="1980">
-      <Id>5afa1dc1-1070-47c4-9d20-a1fb3294b376</Id>
+      <Database Name="cv" Series="2576" Issue="20317" />
     </Book>
     <Book Series="Marvel Team-Up" Number="93" Volume="1972" Year="1980">
-      <Id>367daac3-9486-4dc6-8f7b-a067c4dc9b16</Id>
+      <Database Name="cv" Series="2576" Issue="20391" />
     </Book>
     <Book Series="Marvel Team-Up" Number="94" Volume="1972" Year="1980">
-      <Id>3d95c710-d9da-43d3-982e-d8cd2a8db39e</Id>
+      <Database Name="cv" Series="2576" Issue="20460" />
     </Book>
     <Book Series="Marvel Team-Up" Number="95" Volume="1972" Year="1980">
-      <Id>11617c3b-d445-4874-b6f8-e652651ced6e</Id>
+      <Database Name="cv" Series="2576" Issue="20534" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="13" Volume="1964" Year="1979">
-      <Id>06c834f2-448f-4e24-9d6d-83659c09e7f1</Id>
+      <Database Name="cv" Series="2189" Issue="19111" />
     </Book>
     <Book Series="The Spectacular Spider-Man Annual" Number="1" Volume="1979" Year="1979">
-      <Id>bbc7af9d-3e23-4b77-8be7-5b30c334b513</Id>
+      <Database Name="cv" Series="3012" Issue="19082" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="38" Volume="1976" Year="1980">
-      <Id>4b50c3bc-1c0e-4ac3-a0ab-400e92b0f3ed</Id>
+      <Database Name="cv" Series="2870" Issue="20110" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="39" Volume="1976" Year="1980">
-      <Id>76cc8ccf-2e62-4c12-96ea-e776716d00e3</Id>
+      <Database Name="cv" Series="2870" Issue="20180" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="40" Volume="1976" Year="1980">
-      <Id>fe2dadfa-2247-4d5e-8142-7b30ce6c9932</Id>
+      <Database Name="cv" Series="2870" Issue="20254" />
     </Book>
     <Book Series="Peter Parker" Number="1" Volume="2010" Year="2010">
-      <Id>d90931bb-87fa-40fc-a11e-3e000b8c9502</Id>
+      <Database Name="cv" Series="32170" Issue="201849" />
     </Book>
     <Book Series="Peter Parker" Number="2" Volume="2010" Year="2010">
-      <Id>3d65e23d-cdef-43be-a180-11b5990058f9</Id>
+      <Database Name="cv" Series="32170" Issue="211117" />
     </Book>
     <Book Series="Peter Parker" Number="3" Volume="2010" Year="2010">
-      <Id>274b6567-ad48-4f03-a63b-10f3762e8295</Id>
+      <Database Name="cv" Series="32170" Issue="216451" />
     </Book>
     <Book Series="Peter Parker" Number="4" Volume="2010" Year="2010">
-      <Id>19829a05-901e-46ab-b4c9-cd606640c93a</Id>
+      <Database Name="cv" Series="32170" Issue="220723" />
     </Book>
     <Book Series="Peter Parker" Number="5" Volume="2010" Year="2010">
-      <Id>04fb87fe-9fc1-483c-802e-4b4ab12de97f</Id>
+      <Database Name="cv" Series="32170" Issue="227335" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Spider-Man/Spider-Man 003 (The 80s).cbl
+++ b/Marvel/Characters/unsorted/Spider-Man/Spider-Man 003 (The 80s).cbl
@@ -2,943 +2,943 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Spider-Man 3 (The 80s)</Name>
   <Books>
-    <Book Series="The Amazing Spider-Man" Number="201" Volume="1963" Year="1980" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="201" Volume="1963" Year="1980">
       <Id>6991ff85-2f76-4343-ad2a-4d9372877ea1</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="202" Volume="1963" Year="1980" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="202" Volume="1963" Year="1980">
       <Id>91a6a870-32a9-4d18-baab-52b7584f44de</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="41" Volume="1976" Year="1980" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="41" Volume="1976" Year="1980">
       <Id>ef3e4756-11d6-4928-9f8b-67f4d9a294c8</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="203" Volume="1963" Year="1980" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="203" Volume="1963" Year="1980">
       <Id>8b422c83-491d-449c-9b81-358c39f55154</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="42" Volume="1976" Year="1980" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="42" Volume="1976" Year="1980">
       <Id>14a8848a-ea48-4f71-b900-5fd62e47c51a</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="218" Volume="1961" Year="1980" Format="Main Series">
+    <Book Series="Fantastic Four" Number="218" Volume="1961" Year="1980">
       <Id>58968996-8098-4484-9275-6d2e65ad6f3a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="204" Volume="1963" Year="1980" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="204" Volume="1963" Year="1980">
       <Id>8a60b828-23ee-43ff-8e1a-05a94d4f18c9</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="205" Volume="1963" Year="1980" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="205" Volume="1963" Year="1980">
       <Id>135c60bc-9aae-4131-a7ca-d7bdb1f33518</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="43" Volume="1976" Year="1980" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="43" Volume="1976" Year="1980">
       <Id>034ca65e-f766-48d6-9967-73ec91ebfe5d</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="79" Volume="1972" Year="1979" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="79" Volume="1972" Year="1979">
       <Id>833dd51b-1c86-4270-ba3e-4e2b4743fabb</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="206" Volume="1963" Year="1980" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="206" Volume="1963" Year="1980">
       <Id>1db86ced-8ba3-424b-9f93-2ca65f3c497a</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="82" Volume="1972" Year="1979" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="82" Volume="1972" Year="1979">
       <Id>34e1e7fa-2c3d-44cd-81b9-f4b0c3fe8301</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="83" Volume="1972" Year="1979" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="83" Volume="1972" Year="1979">
       <Id>b020c26b-407f-47d6-a8e3-63241c689fcf</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="84" Volume="1972" Year="1979" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="84" Volume="1972" Year="1979">
       <Id>9523b0ce-111b-49ae-a4da-53104da7fda7</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="85" Volume="1972" Year="1979" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="85" Volume="1972" Year="1979">
       <Id>1bcdf288-b9cc-47d1-87e9-6620d269392e</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="44" Volume="1976" Year="1980" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="44" Volume="1976" Year="1980">
       <Id>733a8fdb-2207-421d-abb6-63017078453b</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="45" Volume="1976" Year="1980" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="45" Volume="1976" Year="1980">
       <Id>0f7c428a-4320-4de4-846c-de30f799c1fb</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="207" Volume="1963" Year="1980" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="207" Volume="1963" Year="1980">
       <Id>2019dce0-6f56-480f-bd0d-dc297c3451ca</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="46" Volume="1976" Year="1980" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="46" Volume="1976" Year="1980">
       <Id>667d2d44-55b1-4c2b-a441-93e1376e0383</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="208" Volume="1963" Year="1980" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="208" Volume="1963" Year="1980">
       <Id>51cf1a03-4956-491d-a93c-3b8a006b3ca0</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="96" Volume="1972" Year="1980" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="96" Volume="1972" Year="1980">
       <Id>c950e843-c530-48ce-a4ee-4671165d001c</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="47" Volume="1976" Year="1980" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="47" Volume="1976" Year="1980">
       <Id>a2443e5d-3576-432d-9953-7c2a668cd5f3</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="48" Volume="1976" Year="1980" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="48" Volume="1976" Year="1980">
       <Id>98781066-2a07-4576-91e0-12e605a8e701</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="98" Volume="1972" Year="1980" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="98" Volume="1972" Year="1980">
       <Id>72badeff-d2ae-4d64-93a6-aa14d54a6df9</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="209" Volume="1963" Year="1980" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="209" Volume="1963" Year="1980">
       <Id>9c87df3d-190c-44d8-9a1f-85ebf5e8f721</Id>
     </Book>
-    <Book Series="Marvel Team-Up Annual" Number="3" Volume="1976" Year="1980" Format="Annual">
+    <Book Series="Marvel Team-Up Annual" Number="3" Volume="1976" Year="1980">
       <Id>a5e5216d-a9fc-4afb-9635-d827b45934f2</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="99" Volume="1972" Year="1980" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="99" Volume="1972" Year="1980">
       <Id>ea1c1b59-7ed4-4f9a-8eaf-86eb191f7dea</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="14" Volume="1964" Year="1980" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="14" Volume="1964" Year="1980">
       <Id>16a846bc-cd64-4df1-a2df-8739f06da95b</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="100" Volume="1972" Year="1980" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="100" Volume="1972" Year="1980">
       <Id>9e06028c-a47c-4e47-be8b-f7b97458d063</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="101" Volume="1972" Year="1981" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="101" Volume="1972" Year="1981">
       <Id>a84de755-0baf-4d69-b1e6-e4a78da5e08e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="210" Volume="1963" Year="1980" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="210" Volume="1963" Year="1980">
       <Id>0d38fdcd-3ea8-4ff6-8986-245f053348c4</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="49" Volume="1976" Year="1980" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="49" Volume="1976" Year="1980">
       <Id>589ab9ae-49a8-4fbf-8336-5ad53e30faab</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="50" Volume="1976" Year="1981" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="50" Volume="1976" Year="1981">
       <Id>94cb0678-f6be-4797-866c-7f12afbd8854</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="51" Volume="1976" Year="1981" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="51" Volume="1976" Year="1981">
       <Id>77ec4942-eedb-4819-ab51-4707fa515430</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="211" Volume="1963" Year="1980" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="211" Volume="1963" Year="1980">
       <Id>d0c60bd6-7388-4339-8502-f2f815ac9a32</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="212" Volume="1963" Year="1981" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="212" Volume="1963" Year="1981">
       <Id>a2b3cca9-b86e-4e09-925d-ab5558ef8f5f</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man Annual" Number="2" Volume="1979" Year="1980" Format="Annual">
+    <Book Series="The Spectacular Spider-Man Annual" Number="2" Volume="1979" Year="1980">
       <Id>0a9f02ec-27e1-46f0-8a36-b0f078ae0cb7</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="52" Volume="1976" Year="1981" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="52" Volume="1976" Year="1981">
       <Id>1092c016-83d0-4284-8bec-35c1f023f773</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="102" Volume="1972" Year="1981" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="102" Volume="1972" Year="1981">
       <Id>5a8f5fb7-1ef1-47bc-8d2b-a210a45097dc</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="53" Volume="1976" Year="1981" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="53" Volume="1976" Year="1981">
       <Id>fdae770a-f65e-4503-8dd2-199fa8a78f4a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="213" Volume="1963" Year="1981" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="213" Volume="1963" Year="1981">
       <Id>d56ea304-4233-4185-9881-a46d753a656b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="214" Volume="1963" Year="1981" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="214" Volume="1963" Year="1981">
       <Id>0ea46c34-9ae2-49ea-90ae-4b2463592c61</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="215" Volume="1963" Year="1981" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="215" Volume="1963" Year="1981">
       <Id>5b65aaaf-4fdb-4289-9949-70581f86ddee</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="216" Volume="1963" Year="1981" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="216" Volume="1963" Year="1981">
       <Id>2a1a70a6-aec9-4b97-bcf6-9ea9759214f3</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="217" Volume="1963" Year="1981" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="217" Volume="1963" Year="1981">
       <Id>a5657b5c-ae01-4c57-924c-113c69deeb6c</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="103" Volume="1972" Year="1981" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="103" Volume="1972" Year="1981">
       <Id>255d067f-dac4-495f-b07f-430764a54bf7</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="54" Volume="1976" Year="1981" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="54" Volume="1976" Year="1981">
       <Id>6cb609de-b96c-4943-bdc7-ffac37fa641a</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="55" Volume="1976" Year="1981" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="55" Volume="1976" Year="1981">
       <Id>8e68d422-c044-4a4f-a504-2aac1d6c720b</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="106" Volume="1972" Year="1981" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="106" Volume="1972" Year="1981">
       <Id>85650311-3c59-4de5-82be-06e8d0192625</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="56" Volume="1976" Year="1981" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="56" Volume="1976" Year="1981">
       <Id>2f8634b2-39aa-4f5f-ae93-9327a82a50ab</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="107" Volume="1972" Year="1981" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="107" Volume="1972" Year="1981">
       <Id>46c9a275-735d-43ee-a498-d93b8d1b116b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="218" Volume="1963" Year="1981" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="218" Volume="1963" Year="1981">
       <Id>2d0e7880-c953-42ce-a0be-76e8dc231163</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="57" Volume="1976" Year="1981" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="57" Volume="1976" Year="1981">
       <Id>b618ac18-b666-43f8-8a76-f3222d7ef268</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="219" Volume="1963" Year="1981" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="219" Volume="1963" Year="1981">
       <Id>a01f8249-e6e7-4816-b389-2ce78b8df2aa</Id>
     </Book>
-    <Book Series="Marvel Team-Up Annual" Number="4" Volume="1976" Year="1981" Format="Annual">
+    <Book Series="Marvel Team-Up Annual" Number="4" Volume="1976" Year="1981">
       <Id>4fc8be7e-5799-4337-9af8-614809746edc</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="71" Volume="1976" Year="1982" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="71" Volume="1976" Year="1982">
       <Id>942ced05-b7fb-49d8-aa09-234419811b39</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="58" Volume="1976" Year="1981" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="58" Volume="1976" Year="1981">
       <Id>0965a974-1610-45cc-bf2d-da5c0dfbf9d0</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="108" Volume="1972" Year="1981" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="108" Volume="1972" Year="1981">
       <Id>a3fef71c-f59f-4001-840f-ce01b142f689</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="109" Volume="1972" Year="1981" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="109" Volume="1972" Year="1981">
       <Id>22fce1ab-5d18-4804-80d7-efcb9678972e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="220" Volume="1963" Year="1981" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="220" Volume="1963" Year="1981">
       <Id>d76b859f-8ce1-429a-aed8-b15a44edbbb1</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="221" Volume="1963" Year="1981" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="221" Volume="1963" Year="1981">
       <Id>dba5b7ea-c4d0-4fca-a9ff-13a43328b88a</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="110" Volume="1972" Year="1981" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="110" Volume="1972" Year="1981">
       <Id>9d354afd-4343-43b4-96c9-1bfd9d1d6fff</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="59" Volume="1976" Year="1981" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="59" Volume="1976" Year="1981">
       <Id>0490d5ed-bb1c-4568-827c-ee0119b1db31</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="60" Volume="1976" Year="1981" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="60" Volume="1976" Year="1981">
       <Id>3dc6f1ad-fedb-4b7d-bb7f-ca46aeec82dc</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="222" Volume="1963" Year="1981" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="222" Volume="1963" Year="1981">
       <Id>a371ac95-29d2-4b25-a146-b74edc62bfd0</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="111" Volume="1972" Year="1981" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="111" Volume="1972" Year="1981">
       <Id>52592f2a-e207-458f-8cfe-972fd5dfe9ef</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="112" Volume="1972" Year="1981" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="112" Volume="1972" Year="1981">
       <Id>1914a121-6c5c-460b-b2fa-53848a35b896</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="223" Volume="1963" Year="1981" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="223" Volume="1963" Year="1981">
       <Id>e7a6cd82-4893-4f59-a27f-d1aeff5bb8f7</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="15" Volume="1964" Year="1981" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="15" Volume="1964" Year="1981">
       <Id>ed784dd2-ef1c-4b9f-a1b5-a8c26b9b4f0f</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="113" Volume="1972" Year="1982" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="113" Volume="1972" Year="1982">
       <Id>6a4f8fc9-ca61-42bc-9fa5-af410d0abba9</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man Annual" Number="3" Volume="1979" Year="1981" Format="Annual">
+    <Book Series="The Spectacular Spider-Man Annual" Number="3" Volume="1979" Year="1981">
       <Id>8b981efa-c503-40c7-9280-7057d96dddd4</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="61" Volume="1976" Year="1981" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="61" Volume="1976" Year="1981">
       <Id>eccc7123-44b8-4317-a5db-a9c6929a317f</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="62" Volume="1976" Year="1982" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="62" Volume="1976" Year="1982">
       <Id>df5728da-5e25-4db7-b14b-9eb8754dd0e9</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="224" Volume="1963" Year="1982" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="224" Volume="1963" Year="1982">
       <Id>5b684c7b-1b27-4520-a5cf-58afa0b79538</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="225" Volume="1963" Year="1982" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="225" Volume="1963" Year="1982">
       <Id>2d59e91d-c1a2-4ec5-999f-979ddb78d1fa</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="63" Volume="1976" Year="1982" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="63" Volume="1976" Year="1982">
       <Id>d149843a-8977-4b7f-af9b-727e5c0c8e19</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="114" Volume="1972" Year="1982" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="114" Volume="1972" Year="1982">
       <Id>54791edb-9d04-45b7-9f4b-b78090a9b51c</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="64" Volume="1976" Year="1982" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="64" Volume="1976" Year="1982">
       <Id>aec545ea-66d3-42c7-add7-ca1aec686fea</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="226" Volume="1963" Year="1982" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="226" Volume="1963" Year="1982">
       <Id>b948b8ad-b7b1-4ebb-9f34-2c42df1f450b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="227" Volume="1963" Year="1982" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="227" Volume="1963" Year="1982">
       <Id>24f74f53-23e8-47e4-a72b-d7edd559a548</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="115" Volume="1972" Year="1982" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="115" Volume="1972" Year="1982">
       <Id>34c41299-e168-4bce-8b42-62f89ab89b0e</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="116" Volume="1972" Year="1982" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="116" Volume="1972" Year="1982">
       <Id>b48bbdbc-622b-46b3-985e-c0cb756b22e5</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="65" Volume="1976" Year="1982" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="65" Volume="1976" Year="1982">
       <Id>3e67427a-cab0-438b-b1e0-6d3c672233b6</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="66" Volume="1976" Year="1982" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="66" Volume="1976" Year="1982">
       <Id>b72ad7e3-bc50-4947-b8e6-5dc62b3c8a5e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="228" Volume="1963" Year="1982" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="228" Volume="1963" Year="1982">
       <Id>048513b3-f653-4cb8-a94b-96a1b7fd7494</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="67" Volume="1976" Year="1982" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="67" Volume="1976" Year="1982">
       <Id>89857791-0e9a-4282-8a06-baa1b43606bd</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="229" Volume="1963" Year="1982" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="229" Volume="1963" Year="1982">
       <Id>608ecbce-a0d1-4203-a31d-8360ee7c3f26</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="230" Volume="1963" Year="1982" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="230" Volume="1963" Year="1982">
       <Id>4547b26c-9ec0-4389-861b-9dd5671e3475</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="68" Volume="1976" Year="1982" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="68" Volume="1976" Year="1982">
       <Id>caadc967-619a-46da-a319-d848f6c947a5</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="117" Volume="1972" Year="1982" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="117" Volume="1972" Year="1982">
       <Id>8d512f10-54f6-4c5d-9782-5e63532176fd</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="118" Volume="1972" Year="1982" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="118" Volume="1972" Year="1982">
       <Id>fe1ea911-1a31-454e-9785-68c952e1614d</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="119" Volume="1972" Year="1982" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="119" Volume="1972" Year="1982">
       <Id>36abe115-2e69-4ec9-a4a8-fa06f6875cf1</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="69" Volume="1976" Year="1982" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="69" Volume="1976" Year="1982">
       <Id>abbb3f1d-e53b-4031-9472-e0ff45360c69</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="70" Volume="1976" Year="1982" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="70" Volume="1976" Year="1982">
       <Id>61c28a05-19fa-47d1-a506-4f9d4944fae8</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="120" Volume="1972" Year="1982" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="120" Volume="1972" Year="1982">
       <Id>05f16ab3-9331-4685-9e8a-7a0d5a2dd9e4</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="231" Volume="1963" Year="1982" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="231" Volume="1963" Year="1982">
       <Id>74fc9791-25cb-45db-b9d0-dd3b99c0b2f8</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="232" Volume="1963" Year="1982" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="232" Volume="1963" Year="1982">
       <Id>bbb63dcd-a799-4ad2-8d11-a0683dcac4c4</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="16" Volume="1964" Year="1982" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="16" Volume="1964" Year="1982">
       <Id>8ab10111-13cb-4f45-8859-71f73a0923d9</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="233" Volume="1963" Year="1982" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="233" Volume="1963" Year="1982">
       <Id>f8bc3741-49d9-45fc-aae2-07c7d8a79a48</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="234" Volume="1963" Year="1982" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="234" Volume="1963" Year="1982">
       <Id>b99f073a-b561-4c34-8948-556c12a9ab54</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="235" Volume="1963" Year="1982" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="235" Volume="1963" Year="1982">
       <Id>2f68993e-78e2-4b63-bda5-cb3eea24a853</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="236" Volume="1963" Year="1983" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="236" Volume="1963" Year="1983">
       <Id>6934e9fa-7f73-4ff3-8428-51a22d7ecacb</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="121" Volume="1972" Year="1982" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="121" Volume="1972" Year="1982">
       <Id>d732ec11-1493-4b5d-8f87-b6563ff297e7</Id>
     </Book>
-    <Book Series="Marvel Team-Up Annual" Number="6" Volume="1976" Year="1983" Format="Annual">
+    <Book Series="Marvel Team-Up Annual" Number="6" Volume="1976" Year="1983">
       <Id>c8d9d312-1a7a-45dc-9e11-e0f604250597</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="122" Volume="1972" Year="1982" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="122" Volume="1972" Year="1982">
       <Id>e19740be-744c-4598-b5f8-55f288d981bd</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="123" Volume="1972" Year="1982" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="123" Volume="1972" Year="1982">
       <Id>beb4caf7-50f3-4a4f-893d-10990c4093a8</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="72" Volume="1976" Year="1982" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="72" Volume="1976" Year="1982">
       <Id>b6c571f1-23f3-4f9b-9eab-a98c013f8ac2</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="124" Volume="1972" Year="1982" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="124" Volume="1972" Year="1982">
       <Id>c0081ee2-7115-4e90-911f-d4118b7db317</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="73" Volume="1976" Year="1982" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="73" Volume="1976" Year="1982">
       <Id>f57d72e2-9f05-40c3-b036-be40597c2057</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="125" Volume="1972" Year="1983" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="125" Volume="1972" Year="1983">
       <Id>350cdea4-e842-4d10-990e-daa1b4968d77</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="237" Volume="1963" Year="1983" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="237" Volume="1963" Year="1983">
       <Id>09e538fc-c288-43a0-8ffc-439ea442367e</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="74" Volume="1976" Year="1983" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="74" Volume="1976" Year="1983">
       <Id>4270abf0-3f12-4441-b5f2-7a9a9d76683d</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="75" Volume="1976" Year="1983" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="75" Volume="1976" Year="1983">
       <Id>d64d18b1-01bc-4b86-8ace-8c6dc2017644</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="76" Volume="1976" Year="1983" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="76" Volume="1976" Year="1983">
       <Id>1c3fcb7a-393d-430e-9a2a-8743d62dd464</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="77" Volume="1976" Year="1983" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="77" Volume="1976" Year="1983">
       <Id>495b300f-6b27-4ee5-b8da-77da48f7b539</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="238" Volume="1963" Year="1983" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="238" Volume="1963" Year="1983">
       <Id>78fec5ae-cb1b-414e-a6ec-c18d4e945f08</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="239" Volume="1963" Year="1983" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="239" Volume="1963" Year="1983">
       <Id>14873884-a065-426a-8b0d-d4d9447cdc1e</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="78" Volume="1976" Year="1983" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="78" Volume="1976" Year="1983">
       <Id>b2b163e5-671e-468f-acc7-37f3216fbc05</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="79" Volume="1976" Year="1983" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="79" Volume="1976" Year="1983">
       <Id>812688a5-1f01-4f7c-b9e6-b14c7aa18e4e</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="127" Volume="1972" Year="1983" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="127" Volume="1972" Year="1983">
       <Id>11abe5fc-4a39-479d-9b92-29895578237b</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="128" Volume="1972" Year="1983" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="128" Volume="1972" Year="1983">
       <Id>6a320371-96e4-4d18-b352-d68037016d23</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="240" Volume="1963" Year="1983" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="240" Volume="1963" Year="1983">
       <Id>97f4909e-995b-4228-8b60-2843e1d7f6fc</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="241" Volume="1963" Year="1983" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="241" Volume="1963" Year="1983">
       <Id>f4a8fac0-9957-4c5e-8662-d4ab5eed5785</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="129" Volume="1972" Year="1983" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="129" Volume="1972" Year="1983">
       <Id>35423193-7c13-404f-8c03-ecac735e379e</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="130" Volume="1972" Year="1983" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="130" Volume="1972" Year="1983">
       <Id>48b547e2-7fe7-4f43-949e-d936272c8228</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="80" Volume="1976" Year="1983" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="80" Volume="1976" Year="1983">
       <Id>5a4a9246-c958-4c0a-85e1-b32e26b01095</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="131" Volume="1972" Year="1983" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="131" Volume="1972" Year="1983">
       <Id>4ab6e3b7-a839-4c03-99c9-7ba302bd08a4</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="242" Volume="1963" Year="1983" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="242" Volume="1963" Year="1983">
       <Id>0893e19d-d7d6-42fb-8fad-d246de088643</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="243" Volume="1963" Year="1983" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="243" Volume="1963" Year="1983">
       <Id>357ccdaa-b250-413d-97b5-3df00e0b9442</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="132" Volume="1972" Year="1983" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="132" Volume="1972" Year="1983">
       <Id>54483449-679b-4966-8058-0ef1a9ee93f3</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="133" Volume="1972" Year="1983" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="133" Volume="1972" Year="1983">
       <Id>9621718e-7e42-4662-8b1a-d393ad298b6e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="244" Volume="1963" Year="1983" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="244" Volume="1963" Year="1983">
       <Id>51052ded-2e47-438c-8262-2d2109c2618d</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="81" Volume="1976" Year="1983" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="81" Volume="1976" Year="1983">
       <Id>75620cc3-803c-45d0-8127-e44fed6fafb4</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="82" Volume="1976" Year="1983" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="82" Volume="1976" Year="1983">
       <Id>4d748e64-e16a-4833-8380-c95de3643f7d</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="134" Volume="1972" Year="1983" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="134" Volume="1972" Year="1983">
       <Id>2a277948-e426-4ca9-a891-09a81e66412b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="245" Volume="1963" Year="1983" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="245" Volume="1963" Year="1983">
       <Id>b9cdb73b-3b31-4249-aec3-55babcadf901</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="83" Volume="1976" Year="1983" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="83" Volume="1976" Year="1983">
       <Id>cb8d142b-99f9-425b-8ea7-4e949a3b65e9</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="246" Volume="1963" Year="1983" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="246" Volume="1963" Year="1983">
       <Id>a15f7fdb-0373-4911-a5ef-84d68929d919</Id>
     </Book>
-    <Book Series="The Avengers" Number="236" Volume="1963" Year="1983" Format="Main Series">
+    <Book Series="The Avengers" Number="236" Volume="1963" Year="1983">
       <Id>2d54a7bd-faef-434b-9888-0958a7aedb67</Id>
     </Book>
-    <Book Series="The Avengers" Number="237" Volume="1963" Year="1983" Format="Main Series">
+    <Book Series="The Avengers" Number="237" Volume="1963" Year="1983">
       <Id>0aec27d4-1b8e-447e-af9d-c0d8cb698c7e</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="135" Volume="1972" Year="1983" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="135" Volume="1972" Year="1983">
       <Id>4ed39763-7a8c-4586-8867-5090dda6fa92</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="84" Volume="1976" Year="1983" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="84" Volume="1976" Year="1983">
       <Id>7495dc0c-a17c-4d64-8945-2754c9bb643f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="247" Volume="1963" Year="1983" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="247" Volume="1963" Year="1983">
       <Id>958a5863-80d2-4950-b7a4-139882cfe912</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="248" Volume="1963" Year="1984" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="248" Volume="1963" Year="1984">
       <Id>5142d3ce-ff0c-48c5-868a-205ca1af1195</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="85" Volume="1976" Year="1983" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="85" Volume="1976" Year="1983">
       <Id>0dd2597b-6265-48b3-9b5e-24111c4e40d9</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="17" Volume="1964" Year="1983" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="17" Volume="1964" Year="1983">
       <Id>a551edbe-5f21-4d47-aee1-bcda1613bcc6</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="136" Volume="1972" Year="1983" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="136" Volume="1972" Year="1983">
       <Id>2c353f56-ecaa-4f60-acd3-b297bab6dd8d</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="137" Volume="1972" Year="1984" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="137" Volume="1972" Year="1984">
       <Id>2f23db0e-0198-4647-acef-a822d17845ff</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="86" Volume="1976" Year="1984" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="86" Volume="1976" Year="1984">
       <Id>41a44ac8-f972-423b-b9bc-4862cd1a7700</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="249" Volume="1963" Year="1984" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="249" Volume="1963" Year="1984">
       <Id>6e8367ab-f870-498d-888b-cb038e327c2b</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="138" Volume="1972" Year="1984" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="138" Volume="1972" Year="1984">
       <Id>3eb81dd6-4de7-4410-b3ac-2b9e440fea30</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="87" Volume="1976" Year="1984" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="87" Volume="1976" Year="1984">
       <Id>ff827394-7211-4031-9267-262a8f1b1bd4</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="250" Volume="1963" Year="1984" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="250" Volume="1963" Year="1984">
       <Id>d9ca1c0d-8738-499a-9f1c-5687f0a5037d</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="139" Volume="1972" Year="1984" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="139" Volume="1972" Year="1984">
       <Id>b3b85591-57e6-425d-bb7b-45e6b36adfb7</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="140" Volume="1972" Year="1984" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="140" Volume="1972" Year="1984">
       <Id>9db89044-a303-4dbe-89eb-b84dda7cccfb</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="251" Volume="1963" Year="1984" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="251" Volume="1963" Year="1984">
       <Id>939247ce-1345-4312-8a3e-3e7d99fb8c07</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="26" Volume="1985" Year="1987" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="26" Volume="1985" Year="1987">
       <Id>66c0cf08-1d36-4831-ba4d-016871bbb90d</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="88" Volume="1976" Year="1984" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="88" Volume="1976" Year="1984">
       <Id>bc5475aa-535e-42b4-abce-c066aa41a339</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="89" Volume="1976" Year="1984" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="89" Volume="1976" Year="1984">
       <Id>42074ff8-a5ea-48e2-9f67-2b712a569eb7</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="1" Volume="1984" Year="1984" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="1" Volume="1984" Year="1984">
       <Id>8cca6608-ad5c-4934-835c-22b03be105b7</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="2" Volume="1984" Year="1984" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="2" Volume="1984" Year="1984">
       <Id>26b8b46b-2789-4c5c-8783-81336cc9cddb</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="3" Volume="1984" Year="1984" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="3" Volume="1984" Year="1984">
       <Id>c7e233c8-fb62-44e1-874d-40da0a2bdd1e</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="4" Volume="1984" Year="1984" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="4" Volume="1984" Year="1984">
       <Id>88b8416d-9788-40d2-9885-53e208c46cbd</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="5" Volume="1984" Year="1984" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="5" Volume="1984" Year="1984">
       <Id>996c2542-1459-4d0e-8588-71fedeb17283</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="6" Volume="1984" Year="1984" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="6" Volume="1984" Year="1984">
       <Id>dff7685a-da38-4375-af65-12e8f68be23e</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="7" Volume="1984" Year="1984" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="7" Volume="1984" Year="1984">
       <Id>0a7b085a-3499-40cb-b0cd-fe7729986bcc</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="8" Volume="1984" Year="1984" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="8" Volume="1984" Year="1984">
       <Id>725f3771-5867-4f54-8fc6-8e14a70128bf</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="9" Volume="1984" Year="1985" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="9" Volume="1984" Year="1985">
       <Id>758f01d8-5db5-4d9e-85cc-6ab5e2fc9cf1</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="10" Volume="1984" Year="1985" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="10" Volume="1984" Year="1985">
       <Id>7f658ccd-cd23-48dc-8200-98dbf5878d23</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="11" Volume="1984" Year="1985" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="11" Volume="1984" Year="1985">
       <Id>65d2beab-745a-40da-aa31-e0f2a9f21965</Id>
     </Book>
-    <Book Series="Marvel Super Heroes Secret Wars" Number="12" Volume="1984" Year="1985" Format="Crossover">
+    <Book Series="Marvel Super Heroes Secret Wars" Number="12" Volume="1984" Year="1985">
       <Id>b3a0a236-200e-4b07-b75a-c5d00841e516</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="252" Volume="1963" Year="1984" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="252" Volume="1963" Year="1984">
       <Id>1fcb29a2-919d-4912-80c3-0b3e3d140149</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="90" Volume="1976" Year="1984" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="90" Volume="1976" Year="1984">
       <Id>1b20f3e9-5ccb-4873-ab55-29117b77135a</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="141" Volume="1972" Year="1984" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="141" Volume="1972" Year="1984">
       <Id>b0b15eb4-131a-4947-a03f-4f7ae1cfd5a3</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="253" Volume="1963" Year="1984" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="253" Volume="1963" Year="1984">
       <Id>acc7607a-1e38-4a93-a2f2-d5f9f30d1bc6</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="91" Volume="1976" Year="1984" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="91" Volume="1976" Year="1984">
       <Id>48a381bd-5e54-4ae6-90d0-aeab63856206</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="254" Volume="1963" Year="1984" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="254" Volume="1963" Year="1984">
       <Id>e058ad3c-9595-476c-81f2-7f8f741a46ae</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="92" Volume="1976" Year="1984" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="92" Volume="1976" Year="1984">
       <Id>a2c90c2a-e855-42bf-9a56-72f6fbae0a12</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="142" Volume="1972" Year="1984" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="142" Volume="1972" Year="1984">
       <Id>6b5b31ad-b685-487e-a562-20b4a5e31624</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="143" Volume="1972" Year="1984" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="143" Volume="1972" Year="1984">
       <Id>56d13bdf-c718-4f5b-9b10-df3728a43712</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="255" Volume="1963" Year="1984" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="255" Volume="1963" Year="1984">
       <Id>97c48585-c5e1-4bfe-96da-f855472cc306</Id>
     </Book>
-    <Book Series="Marvel Team-Up Annual" Number="7" Volume="1976" Year="1984" Format="Annual">
+    <Book Series="Marvel Team-Up Annual" Number="7" Volume="1976" Year="1984">
       <Id>47743708-e8e5-4884-9c64-2e7167dc0673</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="93" Volume="1976" Year="1984" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="93" Volume="1976" Year="1984">
       <Id>36494da8-d5e2-4d61-9135-fd3be556663f</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="144" Volume="1972" Year="1984" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="144" Volume="1972" Year="1984">
       <Id>089a56e7-cb6a-4f94-83bb-0c6514a90bcf</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="94" Volume="1976" Year="1984" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="94" Volume="1976" Year="1984">
       <Id>6bbe99ce-d3bb-41f2-8810-4c6564f0e96e</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="95" Volume="1976" Year="1984" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="95" Volume="1976" Year="1984">
       <Id>ec4b5e6f-3869-4633-bd7c-9b8a82506e57</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man Annual" Number="4" Volume="1979" Year="1984" Format="Annual">
+    <Book Series="The Spectacular Spider-Man Annual" Number="4" Volume="1979" Year="1984">
       <Id>56188e24-50f2-4980-8224-6134e66cf0ec</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="145" Volume="1972" Year="1984" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="145" Volume="1972" Year="1984">
       <Id>ceaed3a0-44cd-4325-88e2-4bb84226184f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="256" Volume="1963" Year="1984" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="256" Volume="1963" Year="1984">
       <Id>b1b9dca6-7230-4a96-8ad2-c688f61728a3</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="257" Volume="1963" Year="1984" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="257" Volume="1963" Year="1984">
       <Id>53011458-6d99-44fa-8f14-db8968629355</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="146" Volume="1972" Year="1984" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="146" Volume="1972" Year="1984">
       <Id>e977a0d9-33e3-4bfc-8e28-e511d7311b89</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="258" Volume="1963" Year="1984" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="258" Volume="1963" Year="1984">
       <Id>dcfc4856-c97c-4376-bf82-45cc50640472</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="259" Volume="1963" Year="1984" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="259" Volume="1963" Year="1984">
       <Id>5a1750f0-5dfd-4bc1-9708-c164714888f2</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="96" Volume="1976" Year="1984" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="96" Volume="1976" Year="1984">
       <Id>a227e967-3eb0-4c9c-924f-b40d057217cb</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="97" Volume="1976" Year="1984" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="97" Volume="1976" Year="1984">
       <Id>c3e393d0-25f7-47f0-968a-f56136771571</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="147" Volume="1972" Year="1984" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="147" Volume="1972" Year="1984">
       <Id>f814442a-9a5b-466d-b8ee-e66318811b8f</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="148" Volume="1972" Year="1984" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="148" Volume="1972" Year="1984">
       <Id>15b8f164-7940-4921-9656-4a13830a5e98</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="18" Volume="1964" Year="1984" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="18" Volume="1964" Year="1984">
       <Id>d75811bc-fcf2-4737-aea1-c9d23ff4c2a6</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="260" Volume="1963" Year="1985" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="260" Volume="1963" Year="1985">
       <Id>d41bdcf7-47cd-487b-8816-e81625dae380</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="261" Volume="1963" Year="1985" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="261" Volume="1963" Year="1985">
       <Id>06f2537b-4381-4003-96b0-3ead700d7352</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="98" Volume="1976" Year="1985" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="98" Volume="1976" Year="1985">
       <Id>5ea95856-9dc0-4536-8fbd-fe4f402cd5f6</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="149" Volume="1972" Year="1985" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="149" Volume="1972" Year="1985">
       <Id>a04bca6c-a140-4cc3-8d1b-e229bbb46a90</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="262" Volume="1963" Year="1985" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="262" Volume="1963" Year="1985">
       <Id>ff79de41-8ec6-4906-acfb-a92d52459292</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="99" Volume="1976" Year="1985" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="99" Volume="1976" Year="1985">
       <Id>250d08a4-14ac-4491-b420-91be5b626c18</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="150" Volume="1972" Year="1985" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="150" Volume="1972" Year="1985">
       <Id>f5d5ced7-c2ab-41ea-8544-e3cc6f996ab9</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="263" Volume="1963" Year="1985" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="263" Volume="1963" Year="1985">
       <Id>06f04e74-f0ee-48db-ae47-0efbc6ad4bce</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="100" Volume="1976" Year="1985" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="100" Volume="1976" Year="1985">
       <Id>d64ad43b-a301-4c87-be8c-b1a86d638906</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="1" Volume="1985" Year="1985" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="1" Volume="1985" Year="1985">
       <Id>5e3f0ec9-6ba8-44d2-ac9b-a9afe73168e2</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="101" Volume="1976" Year="1985" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="101" Volume="1976" Year="1985">
       <Id>e2b677de-3e7e-470f-ac69-38f24e5f0c8f</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="2" Volume="1985" Year="1985" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="2" Volume="1985" Year="1985">
       <Id>e1b38adc-4e97-45cd-b759-6201b2b3473a</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="102" Volume="1976" Year="1985" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="102" Volume="1976" Year="1985">
       <Id>20b79ab1-cf0d-4ef0-bdb1-d5f8de1bb807</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="264" Volume="1963" Year="1985" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="264" Volume="1963" Year="1985">
       <Id>eb235026-a97b-44c7-857d-e44dd3c41fee</Id>
     </Book>
-    <Book Series="Amazing Spider-Man: Hooky" Number="1" Volume="2012" Year="2012" Format="One-Shot">
+    <Book Series="Amazing Spider-Man: Hooky" Number="1" Volume="2012" Year="2012">
       <Id>c6512fa1-1558-419c-a771-68e40c19b814</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="3" Volume="1985" Year="1985" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="3" Volume="1985" Year="1985">
       <Id>a0454b88-ceb4-4b93-83ba-4cdeec6944e2</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="265" Volume="1963" Year="1985" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="265" Volume="1963" Year="1985">
       <Id>ca3b6339-1934-42e5-9bf6-85500b707209</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="103" Volume="1976" Year="1985" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="103" Volume="1976" Year="1985">
       <Id>6f7a17f7-4c5d-4708-9ee6-27a062c0ef66</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="4" Volume="1985" Year="1985" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="4" Volume="1985" Year="1985">
       <Id>dd29c5bf-b7fe-4fd1-b6fe-8d083b92bfce</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="266" Volume="1963" Year="1985" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="266" Volume="1963" Year="1985">
       <Id>cc9f569b-5651-4de6-854e-10d1c75ff7dd</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="104" Volume="1976" Year="1985" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="104" Volume="1976" Year="1985">
       <Id>ab799991-27c0-401f-a2f1-d7968a93d253</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="267" Volume="1963" Year="1985" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="267" Volume="1963" Year="1985">
       <Id>4e9e23f3-ae87-4ffb-aba7-e64359af3c72</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="5" Volume="1985" Year="1985" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="5" Volume="1985" Year="1985">
       <Id>a2275b78-0269-4619-b06f-901510cb8163</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="105" Volume="1976" Year="1985" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="105" Volume="1976" Year="1985">
       <Id>dec167ea-4206-49c8-8ce5-34df6435aafe</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="106" Volume="1976" Year="1985" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="106" Volume="1976" Year="1985">
       <Id>303283be-240d-407d-9d33-9395c100d49e</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="6" Volume="1985" Year="1985" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="6" Volume="1985" Year="1985">
       <Id>088869d7-da84-4d28-bdb3-c854cdc0da28</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="268" Volume="1963" Year="1985" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="268" Volume="1963" Year="1985">
       <Id>d5ca3e81-9b50-4e98-a33a-3db0559587a6</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="7" Volume="1985" Year="1985" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="7" Volume="1985" Year="1985">
       <Id>77aeae01-86fc-47ad-a16c-ed0b9d1138f2</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="269" Volume="1963" Year="1985" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="269" Volume="1963" Year="1985">
       <Id>b977d526-f320-4547-bf3a-f9e7b892b65f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="270" Volume="1963" Year="1985" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="270" Volume="1963" Year="1985">
       <Id>31e33480-2285-4292-b6e1-86829a27299f</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man Annual" Number="5" Volume="1979" Year="1985" Format="Annual">
+    <Book Series="The Spectacular Spider-Man Annual" Number="5" Volume="1979" Year="1985">
       <Id>d1bb791d-5199-428c-9ac3-6f8c9738b612</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="19" Volume="1964" Year="1985" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="19" Volume="1964" Year="1985">
       <Id>acebbce4-81c9-43ad-ad5c-253a633a2d30</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="8" Volume="1985" Year="1985" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="8" Volume="1985" Year="1985">
       <Id>5480060d-530a-4e19-b4e4-d5781f5ecb99</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="9" Volume="1985" Year="1985" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="9" Volume="1985" Year="1985">
       <Id>05b5c09a-3b77-4b58-8606-a4adee577fcb</Id>
     </Book>
-    <Book Series="Web of Spider-Man Annual" Number="1" Volume="1985" Year="1985" Format="Annual">
+    <Book Series="Web of Spider-Man Annual" Number="1" Volume="1985" Year="1985">
       <Id>9c24b9e4-f3c0-4dc3-a3bf-911803ef906b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="271" Volume="1963" Year="1985" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="271" Volume="1963" Year="1985">
       <Id>4edb7fa3-1324-48b9-82d5-6c0ed46f52fe</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="272" Volume="1963" Year="1986" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="272" Volume="1963" Year="1986">
       <Id>a295ef3c-45d7-4147-822b-d52d79e5b151</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="10" Volume="1985" Year="1986" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="10" Volume="1985" Year="1986">
       <Id>3a6f745e-0719-41a1-8843-69ce7533a970</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="11" Volume="1985" Year="1986" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="11" Volume="1985" Year="1986">
       <Id>afa7e0bb-a885-4496-8f74-711bb458aa6c</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="12" Volume="1985" Year="1986" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="12" Volume="1985" Year="1986">
       <Id>0136db9e-f329-4557-a112-60bf23c1f209</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="107" Volume="1976" Year="1985" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="107" Volume="1976" Year="1985">
       <Id>d475b8d8-a6d5-4609-9f2e-0e85319e5e8e</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="108" Volume="1976" Year="1985" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="108" Volume="1976" Year="1985">
       <Id>98591799-7aa2-46fd-9437-08e7b210f39c</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="109" Volume="1976" Year="1985" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="109" Volume="1976" Year="1985">
       <Id>892c0b35-457f-4bca-b5f0-c63fdcfda040</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="110" Volume="1976" Year="1986" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="110" Volume="1976" Year="1986">
       <Id>44ded460-3a5f-45a4-82a1-cd3822453ca7</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="13" Volume="1985" Year="1986" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="13" Volume="1985" Year="1986">
       <Id>7eb81826-dd6c-48eb-b466-d23117584167</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="273" Volume="1963" Year="1986" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="273" Volume="1963" Year="1986">
       <Id>6b59de62-f894-46f6-98e2-4c12ef3e9cbc</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="111" Volume="1976" Year="1986" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="111" Volume="1976" Year="1986">
       <Id>330f8184-0d41-4639-9aee-a7de9c5dd017</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="274" Volume="1963" Year="1986" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="274" Volume="1963" Year="1986">
       <Id>3c7e635c-112c-4be8-8926-13e2a5f70bbe</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="112" Volume="1976" Year="1986" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="112" Volume="1976" Year="1986">
       <Id>2705cb5f-5952-4fa5-8f97-038ecdb654ab</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="275" Volume="1963" Year="1986" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="275" Volume="1963" Year="1986">
       <Id>f5bda4fa-01e5-4887-8ed1-35ffaff9f122</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="276" Volume="1963" Year="1986" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="276" Volume="1963" Year="1986">
       <Id>c8fd83bd-6618-450c-8861-ae60f7e743c9</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="113" Volume="1976" Year="1986" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="113" Volume="1976" Year="1986">
       <Id>d3eeca2a-31d1-4211-8afc-7d90fbaa9853</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="277" Volume="1963" Year="1986" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="277" Volume="1963" Year="1986">
       <Id>11b4388d-5d08-4c1e-96c2-1003674b323c</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="14" Volume="1985" Year="1986" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="14" Volume="1985" Year="1986">
       <Id>c2012db3-9702-4647-864e-6039b167c7c8</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="15" Volume="1985" Year="1986" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="15" Volume="1985" Year="1986">
       <Id>b23138eb-2848-43b2-bfd6-7c7ef4efad2c</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="114" Volume="1976" Year="1986" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="114" Volume="1976" Year="1986">
       <Id>fac2f7a1-fa4b-42ea-8bc9-08daf8570d95</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="278" Volume="1963" Year="1986" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="278" Volume="1963" Year="1986">
       <Id>8fe3e19c-0413-45c1-b46d-5a14c78e5f73</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="115" Volume="1976" Year="1986" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="115" Volume="1976" Year="1986">
       <Id>a40d53e7-ad92-4d92-bace-0e0730555e19</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="116" Volume="1976" Year="1986" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="116" Volume="1976" Year="1986">
       <Id>886b9f1e-6af7-417f-b9cb-c49b4f8ea96c</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="16" Volume="1985" Year="1986" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="16" Volume="1985" Year="1986">
       <Id>e1a09f77-d497-4e30-9530-dd9e5cc36170</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="17" Volume="1985" Year="1986" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="17" Volume="1985" Year="1986">
       <Id>053ab11b-18bf-4a42-aea5-120aff0bc2fd</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="117" Volume="1976" Year="1986" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="117" Volume="1976" Year="1986">
       <Id>642c06c4-3da5-4419-afa8-06c187d2e728</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="279" Volume="1963" Year="1986" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="279" Volume="1963" Year="1986">
       <Id>dff4e150-56de-4db9-9a68-d599dcd8ea31</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="18" Volume="1985" Year="1986" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="18" Volume="1985" Year="1986">
       <Id>0e560183-8440-4acb-b09f-d856c3bdd8db</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="19" Volume="1985" Year="1986" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="19" Volume="1985" Year="1986">
       <Id>1f566ec9-c3ec-4f7a-8122-1c5b98e2b87e</Id>
     </Book>
-    <Book Series="Web of Spider-Man Annual" Number="2" Volume="1985" Year="1986" Format="Annual">
+    <Book Series="Web of Spider-Man Annual" Number="2" Volume="1985" Year="1986">
       <Id>7ef60f8c-862e-4bcd-ad96-b5a4f65e4e48</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="118" Volume="1976" Year="1986" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="118" Volume="1976" Year="1986">
       <Id>cd5b48b6-1b14-402f-8020-bdcdeb21be8c</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="20" Volume="1985" Year="1986" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="20" Volume="1985" Year="1986">
       <Id>b4c6fb9a-f814-41c5-848d-365a4550b5b8</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="21" Volume="1985" Year="1986" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="21" Volume="1985" Year="1986">
       <Id>f9740a76-0d91-4d77-8804-c0c69b5c9e03</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="22" Volume="1985" Year="1987" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="22" Volume="1985" Year="1987">
       <Id>3a18bd5f-a412-45dc-a961-254f32ae13bd</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="280" Volume="1963" Year="1986" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="280" Volume="1963" Year="1986">
       <Id>cf70e917-9456-4b78-b4d4-338424b98ae2</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="281" Volume="1963" Year="1986" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="281" Volume="1963" Year="1986">
       <Id>cc202db3-43f0-4949-a80d-0f1c216a2da3</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="282" Volume="1963" Year="1986" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="282" Volume="1963" Year="1986">
       <Id>acaf5301-ad9c-40cd-b844-20d3ba42ba37</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="119" Volume="1976" Year="1986" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="119" Volume="1976" Year="1986">
       <Id>669f1ca2-08d0-48c0-8739-1f75406c89b1</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man Annual" Number="6" Volume="1979" Year="1986" Format="Annual">
+    <Book Series="The Spectacular Spider-Man Annual" Number="6" Volume="1979" Year="1986">
       <Id>a04739a2-b166-4d43-98cd-2ff73d91a742</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="20" Volume="1964" Year="1986" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="20" Volume="1964" Year="1986">
       <Id>31fe0413-f9a0-40b4-850d-f952f2cecc5c</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="120" Volume="1976" Year="1986" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="120" Volume="1976" Year="1986">
       <Id>96b0bac3-43aa-4ad4-b86c-d77e8de82201</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="283" Volume="1963" Year="1986" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="283" Volume="1963" Year="1986">
       <Id>a0a21568-f792-46b2-ab66-29c3f4008607</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="121" Volume="1976" Year="1986" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="121" Volume="1976" Year="1986">
       <Id>47061c9e-bc7c-48e8-9e55-256781c552d2</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="122" Volume="1976" Year="1987" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="122" Volume="1976" Year="1987">
       <Id>c134a156-580a-4c78-860e-ea5b6cf6a010</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="23" Volume="1985" Year="1987" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="23" Volume="1985" Year="1987">
       <Id>f07e6f1b-a706-490c-b97c-30754e3e2cd9</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="24" Volume="1985" Year="1987" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="24" Volume="1985" Year="1987">
       <Id>e27aad53-1a39-4b04-bd84-68094a918469</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="284" Volume="1963" Year="1987" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="284" Volume="1963" Year="1987">
       <Id>16103f98-5320-4745-9c03-ba79a60ab5c8</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="285" Volume="1963" Year="1987" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="285" Volume="1963" Year="1987">
       <Id>aaea720b-627f-4329-84a9-d4e09d0b10e9</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="286" Volume="1963" Year="1987" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="286" Volume="1963" Year="1987">
       <Id>81e4a74e-e661-4042-81f2-3f31cc10e9dc</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="123" Volume="1976" Year="1987" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="123" Volume="1976" Year="1987">
       <Id>16c19bc5-128e-4e88-a7fe-3c514e64ea75</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="25" Volume="1985" Year="1987" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="25" Volume="1985" Year="1987">
       <Id>f542b8a0-a368-455a-9f98-687d8ced0756</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="27" Volume="1985" Year="1987" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="27" Volume="1985" Year="1987">
       <Id>64006435-1c5f-42a2-8244-7bb647ee3b70</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="287" Volume="1963" Year="1987" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="287" Volume="1963" Year="1987">
       <Id>815e4524-32da-4639-8e54-8d356caceefe</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="288" Volume="1963" Year="1987" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="288" Volume="1963" Year="1987">
       <Id>0b0b8484-0ec4-4bde-a643-dab7e7da1090</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="125" Volume="1976" Year="1987" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="125" Volume="1976" Year="1987">
       <Id>9bd587f8-dd6a-4d80-b078-3e33439d59aa</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="126" Volume="1976" Year="1987" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="126" Volume="1976" Year="1987">
       <Id>a2fabb08-6f1c-431d-a422-8784f12a8b70</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="28" Volume="1985" Year="1987" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="28" Volume="1985" Year="1987">
       <Id>aaba8ff8-b8cf-4a24-af7c-84ad6faac327</Id>
     </Book>
-    <Book Series="Spider-Man vs. Wolverine" Number="1" Volume="1987" Year="1987" Format="One-Shot">
+    <Book Series="Spider-Man vs. Wolverine" Number="1" Volume="1987" Year="1987">
       <Id>a32df54a-f54f-4138-bc68-843655b85f42</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="289" Volume="1963" Year="1987" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="289" Volume="1963" Year="1987">
       <Id>82422e12-ae19-44da-8f66-eeb82f142d85</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="29" Volume="1985" Year="1987" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="29" Volume="1985" Year="1987">
       <Id>6f1fa6ea-9346-47a2-9267-34aec54ade7a</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="30" Volume="1985" Year="1987" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="30" Volume="1985" Year="1987">
       <Id>4ec78a1d-c36f-49a5-b1aa-79bdc0355141</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="127" Volume="1976" Year="1987" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="127" Volume="1976" Year="1987">
       <Id>576648a9-fac8-4989-a36a-dd87778d13de</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="128" Volume="1976" Year="1987" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="128" Volume="1976" Year="1987">
       <Id>bbb948f4-7d0d-4d51-a7a0-3e3de5da09e9</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="129" Volume="1976" Year="1987" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="129" Volume="1976" Year="1987">
       <Id>a39015a2-a7f5-4f37-ba5b-ec5faecdbc05</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="290" Volume="1963" Year="1987" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="290" Volume="1963" Year="1987">
       <Id>3bff865f-896a-4c61-8ee6-c9f46382b472</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="291" Volume="1963" Year="1987" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="291" Volume="1963" Year="1987">
       <Id>24133cc6-846d-42cd-811b-712f195b85a9</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="292" Volume="1963" Year="1987" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="292" Volume="1963" Year="1987">
       <Id>ef0014de-0d4e-4d98-b353-5fc1ec8ff250</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="21" Volume="1964" Year="1987" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="21" Volume="1964" Year="1987">
       <Id>2605a598-f703-465c-a5d6-15e52d989b08</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man Annual" Number="7" Volume="1979" Year="1987" Format="Annual">
+    <Book Series="The Spectacular Spider-Man Annual" Number="7" Volume="1979" Year="1987">
       <Id>e2680a5f-1dcf-44bc-89f6-1407dbc8cf6e</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="31" Volume="1985" Year="1987" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="31" Volume="1985" Year="1987">
       <Id>86a272fd-acac-43bb-b814-6312e69a9501</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="293" Volume="1963" Year="1987" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="293" Volume="1963" Year="1987">
       <Id>47d5c352-b5cc-414f-a47d-50d80e5e5240</Id>
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="131" Volume="1976" Year="1987">
       <Id>1265d711-1b80-4cb3-aa95-25d2627d3621</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="32" Volume="1985" Year="1987" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="32" Volume="1985" Year="1987">
       <Id>7366129f-db64-4148-8eec-0718d5437125</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="294" Volume="1963" Year="1987" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="294" Volume="1963" Year="1987">
       <Id>b893aa2e-08b0-4d22-bc98-510d6294c369</Id>
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="132" Volume="1976" Year="1987">
       <Id>a6a4a04a-ee67-46f4-802f-b9495b8e42b8</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="33" Volume="1985" Year="1987" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="33" Volume="1985" Year="1987">
       <Id>18b52439-4598-4271-bbc4-d379e6b19304</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="295" Volume="1963" Year="1987" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="295" Volume="1963" Year="1987">
       <Id>80fcc115-68cd-410b-adaa-a829e4904517</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="133" Volume="1976" Year="1987" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="133" Volume="1976" Year="1987">
       <Id>a4551096-2010-4b46-a35c-ede7efc7cfe7</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="34" Volume="1985" Year="1988" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="34" Volume="1985" Year="1988">
       <Id>30a51f0c-001c-48af-8762-d48f4f40ea5c</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Spider-Man/Spider-Man 003 (The 80s).cbl
+++ b/Marvel/Characters/unsorted/Spider-Man/Spider-Man 003 (The 80s).cbl
@@ -1,945 +1,946 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Spider-Man 3 (The 80s)</Name>
+  <Name>Spider-Man 003 (The 80s)</Name>
+  <NumIssues>313</NumIssues>
   <Books>
     <Book Series="The Amazing Spider-Man" Number="201" Volume="1963" Year="1980">
-      <Id>6991ff85-2f76-4343-ad2a-4d9372877ea1</Id>
+      <Database Name="cv" Series="2127" Issue="20158" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="202" Volume="1963" Year="1980">
-      <Id>91a6a870-32a9-4d18-baab-52b7584f44de</Id>
+      <Database Name="cv" Series="2127" Issue="20233" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="41" Volume="1976" Year="1980">
-      <Id>ef3e4756-11d6-4928-9f8b-67f4d9a294c8</Id>
+      <Database Name="cv" Series="2870" Issue="20326" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="203" Volume="1963" Year="1980">
-      <Id>8b422c83-491d-449c-9b81-358c39f55154</Id>
+      <Database Name="cv" Series="2127" Issue="20302" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="42" Volume="1976" Year="1980">
-      <Id>14a8848a-ea48-4f71-b900-5fd62e47c51a</Id>
+      <Database Name="cv" Series="2870" Issue="20398" />
     </Book>
     <Book Series="Fantastic Four" Number="218" Volume="1961" Year="1980">
-      <Id>58968996-8098-4484-9275-6d2e65ad6f3a</Id>
+      <Database Name="cv" Series="2045" Issue="20385" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="204" Volume="1963" Year="1980">
-      <Id>8a60b828-23ee-43ff-8e1a-05a94d4f18c9</Id>
+      <Database Name="cv" Series="2127" Issue="20379" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="205" Volume="1963" Year="1980">
-      <Id>135c60bc-9aae-4131-a7ca-d7bdb1f33518</Id>
+      <Database Name="cv" Series="2127" Issue="20445" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="43" Volume="1976" Year="1980">
-      <Id>034ca65e-f766-48d6-9967-73ec91ebfe5d</Id>
+      <Database Name="cv" Series="2870" Issue="20469" />
     </Book>
     <Book Series="Marvel Team-Up" Number="79" Volume="1972" Year="1979">
-      <Id>833dd51b-1c86-4270-ba3e-4e2b4743fabb</Id>
+      <Database Name="cv" Series="2576" Issue="19374" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="206" Volume="1963" Year="1980">
-      <Id>1db86ced-8ba3-424b-9f93-2ca65f3c497a</Id>
+      <Database Name="cv" Series="2127" Issue="20520" />
     </Book>
     <Book Series="Marvel Team-Up" Number="82" Volume="1972" Year="1979">
-      <Id>34e1e7fa-2c3d-44cd-81b9-f4b0c3fe8301</Id>
+      <Database Name="cv" Series="2576" Issue="19580" />
     </Book>
     <Book Series="Marvel Team-Up" Number="83" Volume="1972" Year="1979">
-      <Id>b020c26b-407f-47d6-a8e3-63241c689fcf</Id>
+      <Database Name="cv" Series="2576" Issue="19648" />
     </Book>
     <Book Series="Marvel Team-Up" Number="84" Volume="1972" Year="1979">
-      <Id>9523b0ce-111b-49ae-a4da-53104da7fda7</Id>
+      <Database Name="cv" Series="2576" Issue="19712" />
     </Book>
     <Book Series="Marvel Team-Up" Number="85" Volume="1972" Year="1979">
-      <Id>1bcdf288-b9cc-47d1-87e9-6620d269392e</Id>
+      <Database Name="cv" Series="2576" Issue="19784" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="44" Volume="1976" Year="1980">
-      <Id>733a8fdb-2207-421d-abb6-63017078453b</Id>
+      <Database Name="cv" Series="2870" Issue="20541" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="45" Volume="1976" Year="1980">
-      <Id>0f7c428a-4320-4de4-846c-de30f799c1fb</Id>
+      <Database Name="cv" Series="2870" Issue="20606" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="207" Volume="1963" Year="1980">
-      <Id>2019dce0-6f56-480f-bd0d-dc297c3451ca</Id>
+      <Database Name="cv" Series="2127" Issue="20583" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="46" Volume="1976" Year="1980">
-      <Id>667d2d44-55b1-4c2b-a441-93e1376e0383</Id>
+      <Database Name="cv" Series="2870" Issue="20676" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="208" Volume="1963" Year="1980">
-      <Id>51cf1a03-4956-491d-a93c-3b8a006b3ca0</Id>
+      <Database Name="cv" Series="2127" Issue="20654" />
     </Book>
     <Book Series="Marvel Team-Up" Number="96" Volume="1972" Year="1980">
-      <Id>c950e843-c530-48ce-a4ee-4671165d001c</Id>
+      <Database Name="cv" Series="2576" Issue="20596" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="47" Volume="1976" Year="1980">
-      <Id>a2443e5d-3576-432d-9953-7c2a668cd5f3</Id>
+      <Database Name="cv" Series="2870" Issue="20745" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="48" Volume="1976" Year="1980">
-      <Id>98781066-2a07-4576-91e0-12e605a8e701</Id>
+      <Database Name="cv" Series="2870" Issue="20807" />
     </Book>
     <Book Series="Marvel Team-Up" Number="98" Volume="1972" Year="1980">
-      <Id>72badeff-d2ae-4d64-93a6-aa14d54a6df9</Id>
+      <Database Name="cv" Series="2576" Issue="20736" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="209" Volume="1963" Year="1980">
-      <Id>9c87df3d-190c-44d8-9a1f-85ebf5e8f721</Id>
+      <Database Name="cv" Series="2127" Issue="20722" />
     </Book>
     <Book Series="Marvel Team-Up Annual" Number="3" Volume="1976" Year="1980">
-      <Id>a5e5216d-a9fc-4afb-9635-d827b45934f2</Id>
+      <Database Name="cv" Series="2863" Issue="20036" />
     </Book>
     <Book Series="Marvel Team-Up" Number="99" Volume="1972" Year="1980">
-      <Id>ea1c1b59-7ed4-4f9a-8eaf-86eb191f7dea</Id>
+      <Database Name="cv" Series="2576" Issue="20799" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="14" Volume="1964" Year="1980">
-      <Id>16a846bc-cd64-4df1-a2df-8739f06da95b</Id>
+      <Database Name="cv" Series="2189" Issue="20047" />
     </Book>
     <Book Series="Marvel Team-Up" Number="100" Volume="1972" Year="1980">
-      <Id>9e06028c-a47c-4e47-be8b-f7b97458d063</Id>
+      <Database Name="cv" Series="2576" Issue="20866" />
     </Book>
     <Book Series="Marvel Team-Up" Number="101" Volume="1972" Year="1981">
-      <Id>a84de755-0baf-4d69-b1e6-e4a78da5e08e</Id>
+      <Database Name="cv" Series="2576" Issue="20975" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="210" Volume="1963" Year="1980">
-      <Id>0d38fdcd-3ea8-4ff6-8986-245f053348c4</Id>
+      <Database Name="cv" Series="2127" Issue="20787" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="49" Volume="1976" Year="1980">
-      <Id>589ab9ae-49a8-4fbf-8336-5ad53e30faab</Id>
+      <Database Name="cv" Series="2870" Issue="20877" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="50" Volume="1976" Year="1981">
-      <Id>94cb0678-f6be-4797-866c-7f12afbd8854</Id>
+      <Database Name="cv" Series="2870" Issue="20983" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="51" Volume="1976" Year="1981">
-      <Id>77ec4942-eedb-4819-ab51-4707fa515430</Id>
+      <Database Name="cv" Series="2870" Issue="21052" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="211" Volume="1963" Year="1980">
-      <Id>d0c60bd6-7388-4339-8502-f2f815ac9a32</Id>
+      <Database Name="cv" Series="2127" Issue="20851" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="212" Volume="1963" Year="1981">
-      <Id>a2b3cca9-b86e-4e09-925d-ab5558ef8f5f</Id>
+      <Database Name="cv" Series="2127" Issue="20961" />
     </Book>
     <Book Series="The Spectacular Spider-Man Annual" Number="2" Volume="1979" Year="1980">
-      <Id>0a9f02ec-27e1-46f0-8a36-b0f078ae0cb7</Id>
+      <Database Name="cv" Series="3012" Issue="20034" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="52" Volume="1976" Year="1981">
-      <Id>1092c016-83d0-4284-8bec-35c1f023f773</Id>
+      <Database Name="cv" Series="2870" Issue="21122" />
     </Book>
     <Book Series="Marvel Team-Up" Number="102" Volume="1972" Year="1981">
-      <Id>5a8f5fb7-1ef1-47bc-8d2b-a210a45097dc</Id>
+      <Database Name="cv" Series="2576" Issue="21042" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="53" Volume="1976" Year="1981">
-      <Id>fdae770a-f65e-4503-8dd2-199fa8a78f4a</Id>
+      <Database Name="cv" Series="2870" Issue="21192" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="213" Volume="1963" Year="1981">
-      <Id>d56ea304-4233-4185-9881-a46d753a656b</Id>
+      <Database Name="cv" Series="2127" Issue="21028" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="214" Volume="1963" Year="1981">
-      <Id>0ea46c34-9ae2-49ea-90ae-4b2463592c61</Id>
+      <Database Name="cv" Series="2127" Issue="21100" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="215" Volume="1963" Year="1981">
-      <Id>5b65aaaf-4fdb-4289-9949-70581f86ddee</Id>
+      <Database Name="cv" Series="2127" Issue="21167" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="216" Volume="1963" Year="1981">
-      <Id>2a1a70a6-aec9-4b97-bcf6-9ea9759214f3</Id>
+      <Database Name="cv" Series="2127" Issue="21232" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="217" Volume="1963" Year="1981">
-      <Id>a5657b5c-ae01-4c57-924c-113c69deeb6c</Id>
+      <Database Name="cv" Series="2127" Issue="21291" />
     </Book>
     <Book Series="Marvel Team-Up" Number="103" Volume="1972" Year="1981">
-      <Id>255d067f-dac4-495f-b07f-430764a54bf7</Id>
+      <Database Name="cv" Series="2576" Issue="21115" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="54" Volume="1976" Year="1981">
-      <Id>6cb609de-b96c-4943-bdc7-ffac37fa641a</Id>
+      <Database Name="cv" Series="2870" Issue="21255" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="55" Volume="1976" Year="1981">
-      <Id>8e68d422-c044-4a4f-a504-2aac1d6c720b</Id>
+      <Database Name="cv" Series="2870" Issue="109296" />
     </Book>
     <Book Series="Marvel Team-Up" Number="106" Volume="1972" Year="1981">
-      <Id>85650311-3c59-4de5-82be-06e8d0192625</Id>
+      <Database Name="cv" Series="2576" Issue="21306" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="56" Volume="1976" Year="1981">
-      <Id>2f8634b2-39aa-4f5f-ae93-9327a82a50ab</Id>
+      <Database Name="cv" Series="2870" Issue="21389" />
     </Book>
     <Book Series="Marvel Team-Up" Number="107" Volume="1972" Year="1981">
-      <Id>46c9a275-735d-43ee-a498-d93b8d1b116b</Id>
+      <Database Name="cv" Series="2576" Issue="21380" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="218" Volume="1963" Year="1981">
-      <Id>2d0e7880-c953-42ce-a0be-76e8dc231163</Id>
+      <Database Name="cv" Series="2127" Issue="21366" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="57" Volume="1976" Year="1981">
-      <Id>b618ac18-b666-43f8-8a76-f3222d7ef268</Id>
+      <Database Name="cv" Series="2870" Issue="21456" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="219" Volume="1963" Year="1981">
-      <Id>a01f8249-e6e7-4816-b389-2ce78b8df2aa</Id>
+      <Database Name="cv" Series="2127" Issue="21432" />
     </Book>
     <Book Series="Marvel Team-Up Annual" Number="4" Volume="1976" Year="1981">
-      <Id>4fc8be7e-5799-4337-9af8-614809746edc</Id>
+      <Database Name="cv" Series="2863" Issue="20904" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="71" Volume="1976" Year="1982">
-      <Id>942ced05-b7fb-49d8-aa09-234419811b39</Id>
+      <Database Name="cv" Series="2870" Issue="22533" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="58" Volume="1976" Year="1981">
-      <Id>0965a974-1610-45cc-bf2d-da5c0dfbf9d0</Id>
+      <Database Name="cv" Series="2870" Issue="21528" />
     </Book>
     <Book Series="Marvel Team-Up" Number="108" Volume="1972" Year="1981">
-      <Id>a3fef71c-f59f-4001-840f-ce01b142f689</Id>
+      <Database Name="cv" Series="2576" Issue="21446" />
     </Book>
     <Book Series="Marvel Team-Up" Number="109" Volume="1972" Year="1981">
-      <Id>22fce1ab-5d18-4804-80d7-efcb9678972e</Id>
+      <Database Name="cv" Series="2576" Issue="21518" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="220" Volume="1963" Year="1981">
-      <Id>d76b859f-8ce1-429a-aed8-b15a44edbbb1</Id>
+      <Database Name="cv" Series="2127" Issue="21504" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="221" Volume="1963" Year="1981">
-      <Id>dba5b7ea-c4d0-4fca-a9ff-13a43328b88a</Id>
+      <Database Name="cv" Series="2127" Issue="21583" />
     </Book>
     <Book Series="Marvel Team-Up" Number="110" Volume="1972" Year="1981">
-      <Id>9d354afd-4343-43b4-96c9-1bfd9d1d6fff</Id>
+      <Database Name="cv" Series="2576" Issue="21600" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="59" Volume="1976" Year="1981">
-      <Id>0490d5ed-bb1c-4568-827c-ee0119b1db31</Id>
+      <Database Name="cv" Series="2870" Issue="21609" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="60" Volume="1976" Year="1981">
-      <Id>3dc6f1ad-fedb-4b7d-bb7f-ca46aeec82dc</Id>
+      <Database Name="cv" Series="2870" Issue="21676" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="222" Volume="1963" Year="1981">
-      <Id>a371ac95-29d2-4b25-a146-b74edc62bfd0</Id>
+      <Database Name="cv" Series="2127" Issue="21653" />
     </Book>
     <Book Series="Marvel Team-Up" Number="111" Volume="1972" Year="1981">
-      <Id>52592f2a-e207-458f-8cfe-972fd5dfe9ef</Id>
+      <Database Name="cv" Series="2576" Issue="21667" />
     </Book>
     <Book Series="Marvel Team-Up" Number="112" Volume="1972" Year="1981">
-      <Id>1914a121-6c5c-460b-b2fa-53848a35b896</Id>
+      <Database Name="cv" Series="2576" Issue="21737" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="223" Volume="1963" Year="1981">
-      <Id>e7a6cd82-4893-4f59-a27f-d1aeff5bb8f7</Id>
+      <Database Name="cv" Series="2127" Issue="21719" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="15" Volume="1964" Year="1981">
-      <Id>ed784dd2-ef1c-4b9f-a1b5-a8c26b9b4f0f</Id>
+      <Database Name="cv" Series="2189" Issue="20919" />
     </Book>
     <Book Series="Marvel Team-Up" Number="113" Volume="1972" Year="1982">
-      <Id>6a4f8fc9-ca61-42bc-9fa5-af410d0abba9</Id>
+      <Database Name="cv" Series="2576" Issue="21863" />
     </Book>
     <Book Series="The Spectacular Spider-Man Annual" Number="3" Volume="1979" Year="1981">
-      <Id>8b981efa-c503-40c7-9280-7057d96dddd4</Id>
+      <Database Name="cv" Series="3012" Issue="20901" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="61" Volume="1976" Year="1981">
-      <Id>eccc7123-44b8-4317-a5db-a9c6929a317f</Id>
+      <Database Name="cv" Series="2870" Issue="21747" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="62" Volume="1976" Year="1982">
-      <Id>df5728da-5e25-4db7-b14b-9eb8754dd0e9</Id>
+      <Database Name="cv" Series="2870" Issue="21872" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="224" Volume="1963" Year="1982">
-      <Id>5b684c7b-1b27-4520-a5cf-58afa0b79538</Id>
+      <Database Name="cv" Series="2127" Issue="21849" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="225" Volume="1963" Year="1982">
-      <Id>2d59e91d-c1a2-4ec5-999f-979ddb78d1fa</Id>
+      <Database Name="cv" Series="2127" Issue="21919" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="63" Volume="1976" Year="1982">
-      <Id>d149843a-8977-4b7f-af9b-727e5c0c8e19</Id>
+      <Database Name="cv" Series="2870" Issue="21945" />
     </Book>
     <Book Series="Marvel Team-Up" Number="114" Volume="1972" Year="1982">
-      <Id>54791edb-9d04-45b7-9f4b-b78090a9b51c</Id>
+      <Database Name="cv" Series="2576" Issue="21936" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="64" Volume="1976" Year="1982">
-      <Id>aec545ea-66d3-42c7-add7-ca1aec686fea</Id>
+      <Database Name="cv" Series="2870" Issue="22024" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="226" Volume="1963" Year="1982">
-      <Id>b948b8ad-b7b1-4ebb-9f34-2c42df1f450b</Id>
+      <Database Name="cv" Series="2127" Issue="22000" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="227" Volume="1963" Year="1982">
-      <Id>24f74f53-23e8-47e4-a72b-d7edd559a548</Id>
+      <Database Name="cv" Series="2127" Issue="22072" />
     </Book>
     <Book Series="Marvel Team-Up" Number="115" Volume="1972" Year="1982">
-      <Id>34c41299-e168-4bce-8b42-62f89ab89b0e</Id>
+      <Database Name="cv" Series="2576" Issue="22016" />
     </Book>
     <Book Series="Marvel Team-Up" Number="116" Volume="1972" Year="1982">
-      <Id>b48bbdbc-622b-46b3-985e-c0cb756b22e5</Id>
+      <Database Name="cv" Series="2576" Issue="22088" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="65" Volume="1976" Year="1982">
-      <Id>3e67427a-cab0-438b-b1e0-6d3c672233b6</Id>
+      <Database Name="cv" Series="2870" Issue="22096" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="66" Volume="1976" Year="1982">
-      <Id>b72ad7e3-bc50-4947-b8e6-5dc62b3c8a5e</Id>
+      <Database Name="cv" Series="2870" Issue="22176" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="228" Volume="1963" Year="1982">
-      <Id>048513b3-f653-4cb8-a94b-96a1b7fd7494</Id>
+      <Database Name="cv" Series="2127" Issue="22152" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="67" Volume="1976" Year="1982">
-      <Id>89857791-0e9a-4282-8a06-baa1b43606bd</Id>
+      <Database Name="cv" Series="2870" Issue="22244" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="229" Volume="1963" Year="1982">
-      <Id>608ecbce-a0d1-4203-a31d-8360ee7c3f26</Id>
+      <Database Name="cv" Series="2127" Issue="22221" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="230" Volume="1963" Year="1982">
-      <Id>4547b26c-9ec0-4389-861b-9dd5671e3475</Id>
+      <Database Name="cv" Series="2127" Issue="22292" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="68" Volume="1976" Year="1982">
-      <Id>caadc967-619a-46da-a319-d848f6c947a5</Id>
+      <Database Name="cv" Series="2870" Issue="22315" />
     </Book>
     <Book Series="Marvel Team-Up" Number="117" Volume="1972" Year="1982">
-      <Id>8d512f10-54f6-4c5d-9782-5e63532176fd</Id>
+      <Database Name="cv" Series="2576" Issue="22168" />
     </Book>
     <Book Series="Marvel Team-Up" Number="118" Volume="1972" Year="1982">
-      <Id>fe1ea911-1a31-454e-9785-68c952e1614d</Id>
+      <Database Name="cv" Series="2576" Issue="22236" />
     </Book>
     <Book Series="Marvel Team-Up" Number="119" Volume="1972" Year="1982">
-      <Id>36abe115-2e69-4ec9-a4a8-fa06f6875cf1</Id>
+      <Database Name="cv" Series="2576" Issue="22307" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="69" Volume="1976" Year="1982">
-      <Id>abbb3f1d-e53b-4031-9472-e0ff45360c69</Id>
+      <Database Name="cv" Series="2870" Issue="22389" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="70" Volume="1976" Year="1982">
-      <Id>61c28a05-19fa-47d1-a506-4f9d4944fae8</Id>
+      <Database Name="cv" Series="2870" Issue="22459" />
     </Book>
     <Book Series="Marvel Team-Up" Number="120" Volume="1972" Year="1982">
-      <Id>05f16ab3-9331-4685-9e8a-7a0d5a2dd9e4</Id>
+      <Database Name="cv" Series="2576" Issue="22381" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="231" Volume="1963" Year="1982">
-      <Id>74fc9791-25cb-45db-b9d0-dd3b99c0b2f8</Id>
+      <Database Name="cv" Series="2127" Issue="22364" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="232" Volume="1963" Year="1982">
-      <Id>bbb63dcd-a799-4ad2-8d11-a0683dcac4c4</Id>
+      <Database Name="cv" Series="2127" Issue="22435" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="16" Volume="1964" Year="1982">
-      <Id>8ab10111-13cb-4f45-8859-71f73a0923d9</Id>
+      <Database Name="cv" Series="2189" Issue="21812" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="233" Volume="1963" Year="1982">
-      <Id>f8bc3741-49d9-45fc-aae2-07c7d8a79a48</Id>
+      <Database Name="cv" Series="2127" Issue="22506" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="234" Volume="1963" Year="1982">
-      <Id>b99f073a-b561-4c34-8948-556c12a9ab54</Id>
+      <Database Name="cv" Series="2127" Issue="22581" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="235" Volume="1963" Year="1982">
-      <Id>2f68993e-78e2-4b63-bda5-cb3eea24a853</Id>
+      <Database Name="cv" Series="2127" Issue="22659" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="236" Volume="1963" Year="1983">
-      <Id>6934e9fa-7f73-4ff3-8428-51a22d7ecacb</Id>
+      <Database Name="cv" Series="2127" Issue="22781" />
     </Book>
     <Book Series="Marvel Team-Up" Number="121" Volume="1972" Year="1982">
-      <Id>d732ec11-1493-4b5d-8f87-b6563ff297e7</Id>
+      <Database Name="cv" Series="2576" Issue="22451" />
     </Book>
     <Book Series="Marvel Team-Up Annual" Number="6" Volume="1976" Year="1983">
-      <Id>c8d9d312-1a7a-45dc-9e11-e0f604250597</Id>
+      <Database Name="cv" Series="2863" Issue="22723" />
     </Book>
     <Book Series="Marvel Team-Up" Number="122" Volume="1972" Year="1982">
-      <Id>e19740be-744c-4598-b5f8-55f288d981bd</Id>
+      <Database Name="cv" Series="2576" Issue="22525" />
     </Book>
     <Book Series="Marvel Team-Up" Number="123" Volume="1972" Year="1982">
-      <Id>beb4caf7-50f3-4a4f-893d-10990c4093a8</Id>
+      <Database Name="cv" Series="2576" Issue="22599" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="72" Volume="1976" Year="1982">
-      <Id>b6c571f1-23f3-4f9b-9eab-a98c013f8ac2</Id>
+      <Database Name="cv" Series="2870" Issue="22608" />
     </Book>
     <Book Series="Marvel Team-Up" Number="124" Volume="1972" Year="1982">
-      <Id>c0081ee2-7115-4e90-911f-d4118b7db317</Id>
+      <Database Name="cv" Series="2576" Issue="22676" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="73" Volume="1976" Year="1982">
-      <Id>f57d72e2-9f05-40c3-b036-be40597c2057</Id>
+      <Database Name="cv" Series="2870" Issue="22683" />
     </Book>
     <Book Series="Marvel Team-Up" Number="125" Volume="1972" Year="1983">
-      <Id>350cdea4-e842-4d10-990e-daa1b4968d77</Id>
+      <Database Name="cv" Series="2576" Issue="22797" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="237" Volume="1963" Year="1983">
-      <Id>09e538fc-c288-43a0-8ffc-439ea442367e</Id>
+      <Database Name="cv" Series="2127" Issue="22852" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="74" Volume="1976" Year="1983">
-      <Id>4270abf0-3f12-4441-b5f2-7a9a9d76683d</Id>
+      <Database Name="cv" Series="2870" Issue="22805" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="75" Volume="1976" Year="1983">
-      <Id>d64d18b1-01bc-4b86-8ace-8c6dc2017644</Id>
+      <Database Name="cv" Series="2870" Issue="22878" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="76" Volume="1976" Year="1983">
-      <Id>1c3fcb7a-393d-430e-9a2a-8743d62dd464</Id>
+      <Database Name="cv" Series="2870" Issue="22966" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="77" Volume="1976" Year="1983">
-      <Id>495b300f-6b27-4ee5-b8da-77da48f7b539</Id>
+      <Database Name="cv" Series="2870" Issue="23047" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="238" Volume="1963" Year="1983">
-      <Id>78fec5ae-cb1b-414e-a6ec-c18d4e945f08</Id>
+      <Database Name="cv" Series="2127" Issue="22939" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="239" Volume="1963" Year="1983">
-      <Id>14873884-a065-426a-8b0d-d4d9447cdc1e</Id>
+      <Database Name="cv" Series="2127" Issue="23021" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="78" Volume="1976" Year="1983">
-      <Id>b2b163e5-671e-468f-acc7-37f3216fbc05</Id>
+      <Database Name="cv" Series="2870" Issue="23135" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="79" Volume="1976" Year="1983">
-      <Id>812688a5-1f01-4f7c-b9e6-b14c7aa18e4e</Id>
+      <Database Name="cv" Series="2870" Issue="23215" />
     </Book>
     <Book Series="Marvel Team-Up" Number="127" Volume="1972" Year="1983">
-      <Id>11abe5fc-4a39-479d-9b92-29895578237b</Id>
+      <Database Name="cv" Series="2576" Issue="22956" />
     </Book>
     <Book Series="Marvel Team-Up" Number="128" Volume="1972" Year="1983">
-      <Id>6a320371-96e4-4d18-b352-d68037016d23</Id>
+      <Database Name="cv" Series="2576" Issue="23038" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="240" Volume="1963" Year="1983">
-      <Id>97f4909e-995b-4228-8b60-2843e1d7f6fc</Id>
+      <Database Name="cv" Series="2127" Issue="23109" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="241" Volume="1963" Year="1983">
-      <Id>f4a8fac0-9957-4c5e-8662-d4ab5eed5785</Id>
+      <Database Name="cv" Series="2127" Issue="23192" />
     </Book>
     <Book Series="Marvel Team-Up" Number="129" Volume="1972" Year="1983">
-      <Id>35423193-7c13-404f-8c03-ecac735e379e</Id>
+      <Database Name="cv" Series="2576" Issue="23126" />
     </Book>
     <Book Series="Marvel Team-Up" Number="130" Volume="1972" Year="1983">
-      <Id>48b547e2-7fe7-4f43-949e-d936272c8228</Id>
+      <Database Name="cv" Series="2576" Issue="23209" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="80" Volume="1976" Year="1983">
-      <Id>5a4a9246-c958-4c0a-85e1-b32e26b01095</Id>
+      <Database Name="cv" Series="2870" Issue="23303" />
     </Book>
     <Book Series="Marvel Team-Up" Number="131" Volume="1972" Year="1983">
-      <Id>4ab6e3b7-a839-4c03-99c9-7ba302bd08a4</Id>
+      <Database Name="cv" Series="2576" Issue="23297" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="242" Volume="1963" Year="1983">
-      <Id>0893e19d-d7d6-42fb-8fad-d246de088643</Id>
+      <Database Name="cv" Series="2127" Issue="23280" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="243" Volume="1963" Year="1983">
-      <Id>357ccdaa-b250-413d-97b5-3df00e0b9442</Id>
+      <Database Name="cv" Series="2127" Issue="23362" />
     </Book>
     <Book Series="Marvel Team-Up" Number="132" Volume="1972" Year="1983">
-      <Id>54483449-679b-4966-8058-0ef1a9ee93f3</Id>
+      <Database Name="cv" Series="2576" Issue="23379" />
     </Book>
     <Book Series="Marvel Team-Up" Number="133" Volume="1972" Year="1983">
-      <Id>9621718e-7e42-4662-8b1a-d393ad298b6e</Id>
+      <Database Name="cv" Series="2576" Issue="23459" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="244" Volume="1963" Year="1983">
-      <Id>51052ded-2e47-438c-8262-2d2109c2618d</Id>
+      <Database Name="cv" Series="2127" Issue="23441" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="81" Volume="1976" Year="1983">
-      <Id>75620cc3-803c-45d0-8127-e44fed6fafb4</Id>
+      <Database Name="cv" Series="2870" Issue="23383" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="82" Volume="1976" Year="1983">
-      <Id>4d748e64-e16a-4833-8380-c95de3643f7d</Id>
+      <Database Name="cv" Series="2870" Issue="23465" />
     </Book>
     <Book Series="Marvel Team-Up" Number="134" Volume="1972" Year="1983">
-      <Id>2a277948-e426-4ca9-a891-09a81e66412b</Id>
+      <Database Name="cv" Series="2576" Issue="23548" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="245" Volume="1963" Year="1983">
-      <Id>b9cdb73b-3b31-4249-aec3-55babcadf901</Id>
+      <Database Name="cv" Series="2127" Issue="23531" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="83" Volume="1976" Year="1983">
-      <Id>cb8d142b-99f9-425b-8ea7-4e949a3b65e9</Id>
+      <Database Name="cv" Series="2870" Issue="23552" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="246" Volume="1963" Year="1983">
-      <Id>a15f7fdb-0373-4911-a5ef-84d68929d919</Id>
+      <Database Name="cv" Series="2127" Issue="23614" />
     </Book>
     <Book Series="The Avengers" Number="236" Volume="1963" Year="1983">
-      <Id>2d54a7bd-faef-434b-9888-0958a7aedb67</Id>
+      <Database Name="cv" Series="2128" Issue="23532" />
     </Book>
     <Book Series="The Avengers" Number="237" Volume="1963" Year="1983">
-      <Id>0aec27d4-1b8e-447e-af9d-c0d8cb698c7e</Id>
+      <Database Name="cv" Series="2128" Issue="23615" />
     </Book>
     <Book Series="Marvel Team-Up" Number="135" Volume="1972" Year="1983">
-      <Id>4ed39763-7a8c-4586-8867-5090dda6fa92</Id>
+      <Database Name="cv" Series="2576" Issue="23635" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="84" Volume="1976" Year="1983">
-      <Id>7495dc0c-a17c-4d64-8945-2754c9bb643f</Id>
+      <Database Name="cv" Series="2870" Issue="23644" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="247" Volume="1963" Year="1983">
-      <Id>958a5863-80d2-4950-b7a4-139882cfe912</Id>
+      <Database Name="cv" Series="2127" Issue="23715" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="248" Volume="1963" Year="1984">
-      <Id>5142d3ce-ff0c-48c5-868a-205ca1af1195</Id>
+      <Database Name="cv" Series="2127" Issue="23862" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="85" Volume="1976" Year="1983">
-      <Id>0dd2597b-6265-48b3-9b5e-24111c4e40d9</Id>
+      <Database Name="cv" Series="2870" Issue="23739" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="17" Volume="1964" Year="1983">
-      <Id>a551edbe-5f21-4d47-aee1-bcda1613bcc6</Id>
+      <Database Name="cv" Series="2189" Issue="22738" />
     </Book>
     <Book Series="Marvel Team-Up" Number="136" Volume="1972" Year="1983">
-      <Id>2c353f56-ecaa-4f60-acd3-b297bab6dd8d</Id>
+      <Database Name="cv" Series="2576" Issue="23733" />
     </Book>
     <Book Series="Marvel Team-Up" Number="137" Volume="1972" Year="1984">
-      <Id>2f23db0e-0198-4647-acef-a822d17845ff</Id>
+      <Database Name="cv" Series="2576" Issue="23882" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="86" Volume="1976" Year="1984">
-      <Id>41a44ac8-f972-423b-b9bc-4862cd1a7700</Id>
+      <Database Name="cv" Series="2870" Issue="23890" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="249" Volume="1963" Year="1984">
-      <Id>6e8367ab-f870-498d-888b-cb038e327c2b</Id>
+      <Database Name="cv" Series="2127" Issue="23969" />
     </Book>
     <Book Series="Marvel Team-Up" Number="138" Volume="1972" Year="1984">
-      <Id>3eb81dd6-4de7-4410-b3ac-2b9e440fea30</Id>
+      <Database Name="cv" Series="2576" Issue="23986" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="87" Volume="1976" Year="1984">
-      <Id>ff827394-7211-4031-9267-262a8f1b1bd4</Id>
+      <Database Name="cv" Series="2870" Issue="23989" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="250" Volume="1963" Year="1984">
-      <Id>d9ca1c0d-8738-499a-9f1c-5687f0a5037d</Id>
+      <Database Name="cv" Series="2127" Issue="24086" />
     </Book>
     <Book Series="Marvel Team-Up" Number="139" Volume="1972" Year="1984">
-      <Id>b3b85591-57e6-425d-bb7b-45e6b36adfb7</Id>
+      <Database Name="cv" Series="2576" Issue="24103" />
     </Book>
     <Book Series="Marvel Team-Up" Number="140" Volume="1972" Year="1984">
-      <Id>9db89044-a303-4dbe-89eb-b84dda7cccfb</Id>
+      <Database Name="cv" Series="2576" Issue="24209" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="251" Volume="1963" Year="1984">
-      <Id>939247ce-1345-4312-8a3e-3e7d99fb8c07</Id>
+      <Database Name="cv" Series="2127" Issue="24191" />
     </Book>
     <Book Series="Web of Spider-Man" Number="26" Volume="1985" Year="1987">
-      <Id>66c0cf08-1d36-4831-ba4d-016871bbb90d</Id>
+      <Database Name="cv" Series="3519" Issue="28125" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="88" Volume="1976" Year="1984">
-      <Id>bc5475aa-535e-42b4-abce-c066aa41a339</Id>
+      <Database Name="cv" Series="2870" Issue="24108" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="89" Volume="1976" Year="1984">
-      <Id>42074ff8-a5ea-48e2-9f67-2b712a569eb7</Id>
+      <Database Name="cv" Series="2870" Issue="24212" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="1" Volume="1984" Year="1984">
-      <Id>8cca6608-ad5c-4934-835c-22b03be105b7</Id>
+      <Database Name="cv" Series="3352" Issue="57504" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="2" Volume="1984" Year="1984">
-      <Id>26b8b46b-2789-4c5c-8783-81336cc9cddb</Id>
+      <Database Name="cv" Series="3352" Issue="57505" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="3" Volume="1984" Year="1984">
-      <Id>c7e233c8-fb62-44e1-874d-40da0a2bdd1e</Id>
+      <Database Name="cv" Series="3352" Issue="57506" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="4" Volume="1984" Year="1984">
-      <Id>88b8416d-9788-40d2-9885-53e208c46cbd</Id>
+      <Database Name="cv" Series="3352" Issue="57507" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="5" Volume="1984" Year="1984">
-      <Id>996c2542-1459-4d0e-8588-71fedeb17283</Id>
+      <Database Name="cv" Series="3352" Issue="57508" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="6" Volume="1984" Year="1984">
-      <Id>dff7685a-da38-4375-af65-12e8f68be23e</Id>
+      <Database Name="cv" Series="3352" Issue="57509" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="7" Volume="1984" Year="1984">
-      <Id>0a7b085a-3499-40cb-b0cd-fe7729986bcc</Id>
+      <Database Name="cv" Series="3352" Issue="57510" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="8" Volume="1984" Year="1984">
-      <Id>725f3771-5867-4f54-8fc6-8e14a70128bf</Id>
+      <Database Name="cv" Series="3352" Issue="57511" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="9" Volume="1984" Year="1985">
-      <Id>758f01d8-5db5-4d9e-85cc-6ab5e2fc9cf1</Id>
+      <Database Name="cv" Series="3352" Issue="57512" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="10" Volume="1984" Year="1985">
-      <Id>7f658ccd-cd23-48dc-8200-98dbf5878d23</Id>
+      <Database Name="cv" Series="3352" Issue="57513" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="11" Volume="1984" Year="1985">
-      <Id>65d2beab-745a-40da-aa31-e0f2a9f21965</Id>
+      <Database Name="cv" Series="3352" Issue="57514" />
     </Book>
     <Book Series="Marvel Super Heroes Secret Wars" Number="12" Volume="1984" Year="1985">
-      <Id>b3a0a236-200e-4b07-b75a-c5d00841e516</Id>
+      <Database Name="cv" Series="3352" Issue="57515" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="252" Volume="1963" Year="1984">
-      <Id>1fcb29a2-919d-4912-80c3-0b3e3d140149</Id>
+      <Database Name="cv" Series="2127" Issue="24297" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="90" Volume="1976" Year="1984">
-      <Id>1b20f3e9-5ccb-4873-ab55-29117b77135a</Id>
+      <Database Name="cv" Series="2870" Issue="24318" />
     </Book>
     <Book Series="Marvel Team-Up" Number="141" Volume="1972" Year="1984">
-      <Id>b0b15eb4-131a-4947-a03f-4f7ae1cfd5a3</Id>
+      <Database Name="cv" Series="2576" Issue="24313" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="253" Volume="1963" Year="1984">
-      <Id>acc7607a-1e38-4a93-a2f2-d5f9f30d1bc6</Id>
+      <Database Name="cv" Series="2127" Issue="24396" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="91" Volume="1976" Year="1984">
-      <Id>48a381bd-5e54-4ae6-90d0-aeab63856206</Id>
+      <Database Name="cv" Series="2870" Issue="24415" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="254" Volume="1963" Year="1984">
-      <Id>e058ad3c-9595-476c-81f2-7f8f741a46ae</Id>
+      <Database Name="cv" Series="2127" Issue="24496" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="92" Volume="1976" Year="1984">
-      <Id>a2c90c2a-e855-42bf-9a56-72f6fbae0a12</Id>
+      <Database Name="cv" Series="2870" Issue="24513" />
     </Book>
     <Book Series="Marvel Team-Up" Number="142" Volume="1972" Year="1984">
-      <Id>6b5b31ad-b685-487e-a562-20b4a5e31624</Id>
+      <Database Name="cv" Series="2576" Issue="24412" />
     </Book>
     <Book Series="Marvel Team-Up" Number="143" Volume="1972" Year="1984">
-      <Id>56d13bdf-c718-4f5b-9b10-df3728a43712</Id>
+      <Database Name="cv" Series="2576" Issue="24508" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="255" Volume="1963" Year="1984">
-      <Id>97c48585-c5e1-4bfe-96da-f855472cc306</Id>
+      <Database Name="cv" Series="2127" Issue="24593" />
     </Book>
     <Book Series="Marvel Team-Up Annual" Number="7" Volume="1976" Year="1984">
-      <Id>47743708-e8e5-4884-9c64-2e7167dc0673</Id>
+      <Database Name="cv" Series="2863" Issue="23785" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="93" Volume="1976" Year="1984">
-      <Id>36494da8-d5e2-4d61-9135-fd3be556663f</Id>
+      <Database Name="cv" Series="2870" Issue="24615" />
     </Book>
     <Book Series="Marvel Team-Up" Number="144" Volume="1972" Year="1984">
-      <Id>089a56e7-cb6a-4f94-83bb-0c6514a90bcf</Id>
+      <Database Name="cv" Series="2576" Issue="24608" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="94" Volume="1976" Year="1984">
-      <Id>6bbe99ce-d3bb-41f2-8810-4c6564f0e96e</Id>
+      <Database Name="cv" Series="2870" Issue="24704" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="95" Volume="1976" Year="1984">
-      <Id>ec4b5e6f-3869-4633-bd7c-9b8a82506e57</Id>
+      <Database Name="cv" Series="2870" Issue="24803" />
     </Book>
     <Book Series="The Spectacular Spider-Man Annual" Number="4" Volume="1979" Year="1984">
-      <Id>56188e24-50f2-4980-8224-6134e66cf0ec</Id>
+      <Database Name="cv" Series="3012" Issue="24921" />
     </Book>
     <Book Series="Marvel Team-Up" Number="145" Volume="1972" Year="1984">
-      <Id>ceaed3a0-44cd-4325-88e2-4bb84226184f</Id>
+      <Database Name="cv" Series="2576" Issue="24698" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="256" Volume="1963" Year="1984">
-      <Id>b1b9dca6-7230-4a96-8ad2-c688f61728a3</Id>
+      <Database Name="cv" Series="2127" Issue="24687" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="257" Volume="1963" Year="1984">
-      <Id>53011458-6d99-44fa-8f14-db8968629355</Id>
+      <Database Name="cv" Series="2127" Issue="24777" />
     </Book>
     <Book Series="Marvel Team-Up" Number="146" Volume="1972" Year="1984">
-      <Id>e977a0d9-33e3-4bfc-8e28-e511d7311b89</Id>
+      <Database Name="cv" Series="2576" Issue="24797" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="258" Volume="1963" Year="1984">
-      <Id>dcfc4856-c97c-4376-bf82-45cc50640472</Id>
+      <Database Name="cv" Series="2127" Issue="24880" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="259" Volume="1963" Year="1984">
-      <Id>5a1750f0-5dfd-4bc1-9708-c164714888f2</Id>
+      <Database Name="cv" Series="2127" Issue="24981" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="96" Volume="1976" Year="1984">
-      <Id>a227e967-3eb0-4c9c-924f-b40d057217cb</Id>
+      <Database Name="cv" Series="2870" Issue="24899" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="97" Volume="1976" Year="1984">
-      <Id>c3e393d0-25f7-47f0-968a-f56136771571</Id>
+      <Database Name="cv" Series="2870" Issue="25004" />
     </Book>
     <Book Series="Marvel Team-Up" Number="147" Volume="1972" Year="1984">
-      <Id>f814442a-9a5b-466d-b8ee-e66318811b8f</Id>
+      <Database Name="cv" Series="2576" Issue="24897" />
     </Book>
     <Book Series="Marvel Team-Up" Number="148" Volume="1972" Year="1984">
-      <Id>15b8f164-7940-4921-9656-4a13830a5e98</Id>
+      <Database Name="cv" Series="2576" Issue="25002" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="18" Volume="1964" Year="1984">
-      <Id>d75811bc-fcf2-4737-aea1-c9d23ff4c2a6</Id>
+      <Database Name="cv" Series="2189" Issue="64426" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="260" Volume="1963" Year="1985">
-      <Id>d41bdcf7-47cd-487b-8816-e81625dae380</Id>
+      <Database Name="cv" Series="2127" Issue="25154" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="261" Volume="1963" Year="1985">
-      <Id>06f2537b-4381-4003-96b0-3ead700d7352</Id>
+      <Database Name="cv" Series="2127" Issue="25250" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="98" Volume="1976" Year="1985">
-      <Id>5ea95856-9dc0-4536-8fbd-fe4f402cd5f6</Id>
+      <Database Name="cv" Series="2870" Issue="25171" />
     </Book>
     <Book Series="Marvel Team-Up" Number="149" Volume="1972" Year="1985">
-      <Id>a04bca6c-a140-4cc3-8d1b-e229bbb46a90</Id>
+      <Database Name="cv" Series="2576" Issue="25170" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="262" Volume="1963" Year="1985">
-      <Id>ff79de41-8ec6-4906-acfb-a92d52459292</Id>
+      <Database Name="cv" Series="2127" Issue="112034" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="99" Volume="1976" Year="1985">
-      <Id>250d08a4-14ac-4491-b420-91be5b626c18</Id>
+      <Database Name="cv" Series="2870" Issue="25269" />
     </Book>
     <Book Series="Marvel Team-Up" Number="150" Volume="1972" Year="1985">
-      <Id>f5d5ced7-c2ab-41ea-8544-e3cc6f996ab9</Id>
+      <Database Name="cv" Series="2576" Issue="25268" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="263" Volume="1963" Year="1985">
-      <Id>06f04e74-f0ee-48db-ae47-0efbc6ad4bce</Id>
+      <Database Name="cv" Series="2127" Issue="25379" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="100" Volume="1976" Year="1985">
-      <Id>d64ad43b-a301-4c87-be8c-b1a86d638906</Id>
+      <Database Name="cv" Series="2870" Issue="25294" />
     </Book>
     <Book Series="Web of Spider-Man" Number="1" Volume="1985" Year="1985">
-      <Id>5e3f0ec9-6ba8-44d2-ac9b-a9afe73168e2</Id>
+      <Database Name="cv" Series="3519" Issue="25407" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="101" Volume="1976" Year="1985">
-      <Id>e2b677de-3e7e-470f-ac69-38f24e5f0c8f</Id>
+      <Database Name="cv" Series="2870" Issue="25396" />
     </Book>
     <Book Series="Web of Spider-Man" Number="2" Volume="1985" Year="1985">
-      <Id>e1b38adc-4e97-45cd-b759-6201b2b3473a</Id>
+      <Database Name="cv" Series="3519" Issue="25501" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="102" Volume="1976" Year="1985">
-      <Id>20b79ab1-cf0d-4ef0-bdb1-d5f8de1bb807</Id>
+      <Database Name="cv" Series="2870" Issue="25492" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="264" Volume="1963" Year="1985">
-      <Id>eb235026-a97b-44c7-857d-e44dd3c41fee</Id>
+      <Database Name="cv" Series="2127" Issue="25479" />
     </Book>
     <Book Series="Amazing Spider-Man: Hooky" Number="1" Volume="2012" Year="2012">
-      <Id>c6512fa1-1558-419c-a771-68e40c19b814</Id>
+      <Database Name="cv" Series="47832" Issue="329636" />
     </Book>
     <Book Series="Web of Spider-Man" Number="3" Volume="1985" Year="1985">
-      <Id>a0454b88-ceb4-4b93-83ba-4cdeec6944e2</Id>
+      <Database Name="cv" Series="3519" Issue="25603" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="265" Volume="1963" Year="1985">
-      <Id>ca3b6339-1934-42e5-9bf6-85500b707209</Id>
+      <Database Name="cv" Series="2127" Issue="25574" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="103" Volume="1976" Year="1985">
-      <Id>6f7a17f7-4c5d-4708-9ee6-27a062c0ef66</Id>
+      <Database Name="cv" Series="2870" Issue="25597" />
     </Book>
     <Book Series="Web of Spider-Man" Number="4" Volume="1985" Year="1985">
-      <Id>dd29c5bf-b7fe-4fd1-b6fe-8d083b92bfce</Id>
+      <Database Name="cv" Series="3519" Issue="25702" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="266" Volume="1963" Year="1985">
-      <Id>cc9f569b-5651-4de6-854e-10d1c75ff7dd</Id>
+      <Database Name="cv" Series="2127" Issue="25673" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="104" Volume="1976" Year="1985">
-      <Id>ab799991-27c0-401f-a2f1-d7968a93d253</Id>
+      <Database Name="cv" Series="2870" Issue="25692" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="267" Volume="1963" Year="1985">
-      <Id>4e9e23f3-ae87-4ffb-aba7-e64359af3c72</Id>
+      <Database Name="cv" Series="2127" Issue="25775" />
     </Book>
     <Book Series="Web of Spider-Man" Number="5" Volume="1985" Year="1985">
-      <Id>a2275b78-0269-4619-b06f-901510cb8163</Id>
+      <Database Name="cv" Series="3519" Issue="25802" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="105" Volume="1976" Year="1985">
-      <Id>dec167ea-4206-49c8-8ce5-34df6435aafe</Id>
+      <Database Name="cv" Series="2870" Issue="25796" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="106" Volume="1976" Year="1985">
-      <Id>303283be-240d-407d-9d33-9395c100d49e</Id>
+      <Database Name="cv" Series="2870" Issue="25890" />
     </Book>
     <Book Series="Web of Spider-Man" Number="6" Volume="1985" Year="1985">
-      <Id>088869d7-da84-4d28-bdb3-c854cdc0da28</Id>
+      <Database Name="cv" Series="3519" Issue="25897" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="268" Volume="1963" Year="1985">
-      <Id>d5ca3e81-9b50-4e98-a33a-3db0559587a6</Id>
+      <Database Name="cv" Series="2127" Issue="25866" />
     </Book>
     <Book Series="Web of Spider-Man" Number="7" Volume="1985" Year="1985">
-      <Id>77aeae01-86fc-47ad-a16c-ed0b9d1138f2</Id>
+      <Database Name="cv" Series="3519" Issue="26001" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="269" Volume="1963" Year="1985">
-      <Id>b977d526-f320-4547-bf3a-f9e7b892b65f</Id>
+      <Database Name="cv" Series="2127" Issue="25971" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="270" Volume="1963" Year="1985">
-      <Id>31e33480-2285-4292-b6e1-86829a27299f</Id>
+      <Database Name="cv" Series="2127" Issue="26071" />
     </Book>
     <Book Series="The Spectacular Spider-Man Annual" Number="5" Volume="1979" Year="1985">
-      <Id>d1bb791d-5199-428c-9ac3-6f8c9738b612</Id>
+      <Database Name="cv" Series="3012" Issue="25091" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="19" Volume="1964" Year="1985">
-      <Id>acebbce4-81c9-43ad-ad5c-253a633a2d30</Id>
+      <Database Name="cv" Series="2189" Issue="64427" />
     </Book>
     <Book Series="Web of Spider-Man" Number="8" Volume="1985" Year="1985">
-      <Id>5480060d-530a-4e19-b4e4-d5781f5ecb99</Id>
+      <Database Name="cv" Series="3519" Issue="26107" />
     </Book>
     <Book Series="Web of Spider-Man" Number="9" Volume="1985" Year="1985">
-      <Id>05b5c09a-3b77-4b58-8606-a4adee577fcb</Id>
+      <Database Name="cv" Series="3519" Issue="26212" />
     </Book>
     <Book Series="Web of Spider-Man Annual" Number="1" Volume="1985" Year="1985">
-      <Id>9c24b9e4-f3c0-4dc3-a3bf-911803ef906b</Id>
+      <Database Name="cv" Series="3520" Issue="77992" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="271" Volume="1963" Year="1985">
-      <Id>4edb7fa3-1324-48b9-82d5-6c0ed46f52fe</Id>
+      <Database Name="cv" Series="2127" Issue="26183" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="272" Volume="1963" Year="1986">
-      <Id>a295ef3c-45d7-4147-822b-d52d79e5b151</Id>
+      <Database Name="cv" Series="2127" Issue="26387" />
     </Book>
     <Book Series="Web of Spider-Man" Number="10" Volume="1985" Year="1986">
-      <Id>3a6f745e-0719-41a1-8843-69ce7533a970</Id>
+      <Database Name="cv" Series="3519" Issue="26415" />
     </Book>
     <Book Series="Web of Spider-Man" Number="11" Volume="1985" Year="1986">
-      <Id>afa7e0bb-a885-4496-8f74-711bb458aa6c</Id>
+      <Database Name="cv" Series="3519" Issue="26521" />
     </Book>
     <Book Series="Web of Spider-Man" Number="12" Volume="1985" Year="1986">
-      <Id>0136db9e-f329-4557-a112-60bf23c1f209</Id>
+      <Database Name="cv" Series="3519" Issue="26615" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="107" Volume="1976" Year="1985">
-      <Id>d475b8d8-a6d5-4609-9f2e-0e85319e5e8e</Id>
+      <Database Name="cv" Series="2870" Issue="25993" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="108" Volume="1976" Year="1985">
-      <Id>98591799-7aa2-46fd-9437-08e7b210f39c</Id>
+      <Database Name="cv" Series="2870" Issue="26099" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="109" Volume="1976" Year="1985">
-      <Id>892c0b35-457f-4bca-b5f0-c63fdcfda040</Id>
+      <Database Name="cv" Series="2870" Issue="26205" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="110" Volume="1976" Year="1986">
-      <Id>44ded460-3a5f-45a4-82a1-cd3822453ca7</Id>
+      <Database Name="cv" Series="2870" Issue="26409" />
     </Book>
     <Book Series="Web of Spider-Man" Number="13" Volume="1985" Year="1986">
-      <Id>7eb81826-dd6c-48eb-b466-d23117584167</Id>
+      <Database Name="cv" Series="3519" Issue="26712" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="273" Volume="1963" Year="1986">
-      <Id>6b59de62-f894-46f6-98e2-4c12ef3e9cbc</Id>
+      <Database Name="cv" Series="2127" Issue="26495" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="111" Volume="1976" Year="1986">
-      <Id>330f8184-0d41-4639-9aee-a7de9c5dd017</Id>
+      <Database Name="cv" Series="2870" Issue="26514" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="274" Volume="1963" Year="1986">
-      <Id>3c7e635c-112c-4be8-8926-13e2a5f70bbe</Id>
+      <Database Name="cv" Series="2127" Issue="26592" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="112" Volume="1976" Year="1986">
-      <Id>2705cb5f-5952-4fa5-8f97-038ecdb654ab</Id>
+      <Database Name="cv" Series="2870" Issue="26608" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="275" Volume="1963" Year="1986">
-      <Id>f5bda4fa-01e5-4887-8ed1-35ffaff9f122</Id>
+      <Database Name="cv" Series="2127" Issue="26692" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="276" Volume="1963" Year="1986">
-      <Id>c8fd83bd-6618-450c-8861-ae60f7e743c9</Id>
+      <Database Name="cv" Series="2127" Issue="26783" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="113" Volume="1976" Year="1986">
-      <Id>d3eeca2a-31d1-4211-8afc-7d90fbaa9853</Id>
+      <Database Name="cv" Series="2870" Issue="26707" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="277" Volume="1963" Year="1986">
-      <Id>11b4388d-5d08-4c1e-96c2-1003674b323c</Id>
+      <Database Name="cv" Series="2127" Issue="26884" />
     </Book>
     <Book Series="Web of Spider-Man" Number="14" Volume="1985" Year="1986">
-      <Id>c2012db3-9702-4647-864e-6039b167c7c8</Id>
+      <Database Name="cv" Series="3519" Issue="26806" />
     </Book>
     <Book Series="Web of Spider-Man" Number="15" Volume="1985" Year="1986">
-      <Id>b23138eb-2848-43b2-bfd6-7c7ef4efad2c</Id>
+      <Database Name="cv" Series="3519" Issue="26904" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="114" Volume="1976" Year="1986">
-      <Id>fac2f7a1-fa4b-42ea-8bc9-08daf8570d95</Id>
+      <Database Name="cv" Series="2870" Issue="26796" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="278" Volume="1963" Year="1986">
-      <Id>8fe3e19c-0413-45c1-b46d-5a14c78e5f73</Id>
+      <Database Name="cv" Series="2127" Issue="26982" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="115" Volume="1976" Year="1986">
-      <Id>a40d53e7-ad92-4d92-bace-0e0730555e19</Id>
+      <Database Name="cv" Series="2870" Issue="26898" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="116" Volume="1976" Year="1986">
-      <Id>886b9f1e-6af7-417f-b9cb-c49b4f8ea96c</Id>
+      <Database Name="cv" Series="2870" Issue="26994" />
     </Book>
     <Book Series="Web of Spider-Man" Number="16" Volume="1985" Year="1986">
-      <Id>e1a09f77-d497-4e30-9530-dd9e5cc36170</Id>
+      <Database Name="cv" Series="3519" Issue="26999" />
     </Book>
     <Book Series="Web of Spider-Man" Number="17" Volume="1985" Year="1986">
-      <Id>053ab11b-18bf-4a42-aea5-120aff0bc2fd</Id>
+      <Database Name="cv" Series="3519" Issue="27095" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="117" Volume="1976" Year="1986">
-      <Id>642c06c4-3da5-4419-afa8-06c187d2e728</Id>
+      <Database Name="cv" Series="2870" Issue="27090" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="279" Volume="1963" Year="1986">
-      <Id>dff4e150-56de-4db9-9a68-d599dcd8ea31</Id>
+      <Database Name="cv" Series="2127" Issue="27076" />
     </Book>
     <Book Series="Web of Spider-Man" Number="18" Volume="1985" Year="1986">
-      <Id>0e560183-8440-4acb-b09f-d856c3bdd8db</Id>
+      <Database Name="cv" Series="3519" Issue="27191" />
     </Book>
     <Book Series="Web of Spider-Man" Number="19" Volume="1985" Year="1986">
-      <Id>1f566ec9-c3ec-4f7a-8122-1c5b98e2b87e</Id>
+      <Database Name="cv" Series="3519" Issue="27288" />
     </Book>
     <Book Series="Web of Spider-Man Annual" Number="2" Volume="1985" Year="1986">
-      <Id>7ef60f8c-862e-4bcd-ad96-b5a4f65e4e48</Id>
+      <Database Name="cv" Series="3520" Issue="77993" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="118" Volume="1976" Year="1986">
-      <Id>cd5b48b6-1b14-402f-8020-bdcdeb21be8c</Id>
+      <Database Name="cv" Series="2870" Issue="27187" />
     </Book>
     <Book Series="Web of Spider-Man" Number="20" Volume="1985" Year="1986">
-      <Id>b4c6fb9a-f814-41c5-848d-365a4550b5b8</Id>
+      <Database Name="cv" Series="3519" Issue="27397" />
     </Book>
     <Book Series="Web of Spider-Man" Number="21" Volume="1985" Year="1986">
-      <Id>f9740a76-0d91-4d77-8804-c0c69b5c9e03</Id>
+      <Database Name="cv" Series="3519" Issue="27502" />
     </Book>
     <Book Series="Web of Spider-Man" Number="22" Volume="1985" Year="1987">
-      <Id>3a18bd5f-a412-45dc-a961-254f32ae13bd</Id>
+      <Database Name="cv" Series="3519" Issue="27692" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="280" Volume="1963" Year="1986">
-      <Id>cf70e917-9456-4b78-b4d4-338424b98ae2</Id>
+      <Database Name="cv" Series="2127" Issue="27174" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="281" Volume="1963" Year="1986">
-      <Id>cc202db3-43f0-4949-a80d-0f1c216a2da3</Id>
+      <Database Name="cv" Series="2127" Issue="27270" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="282" Volume="1963" Year="1986">
-      <Id>acaf5301-ad9c-40cd-b844-20d3ba42ba37</Id>
+      <Database Name="cv" Series="2127" Issue="27375" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="119" Volume="1976" Year="1986">
-      <Id>669f1ca2-08d0-48c0-8739-1f75406c89b1</Id>
+      <Database Name="cv" Series="2870" Issue="109297" />
     </Book>
     <Book Series="The Spectacular Spider-Man Annual" Number="6" Volume="1979" Year="1986">
-      <Id>a04739a2-b166-4d43-98cd-2ff73d91a742</Id>
+      <Database Name="cv" Series="3012" Issue="26301" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="20" Volume="1964" Year="1986">
-      <Id>31fe0413-f9a0-40b4-850d-f952f2cecc5c</Id>
+      <Database Name="cv" Series="2189" Issue="112515" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="120" Volume="1976" Year="1986">
-      <Id>96b0bac3-43aa-4ad4-b86c-d77e8de82201</Id>
+      <Database Name="cv" Series="2870" Issue="27392" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="283" Volume="1963" Year="1986">
-      <Id>a0a21568-f792-46b2-ab66-29c3f4008607</Id>
+      <Database Name="cv" Series="2127" Issue="27481" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="121" Volume="1976" Year="1986">
-      <Id>47061c9e-bc7c-48e8-9e55-256781c552d2</Id>
+      <Database Name="cv" Series="2870" Issue="27497" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="122" Volume="1976" Year="1987">
-      <Id>c134a156-580a-4c78-860e-ea5b6cf6a010</Id>
+      <Database Name="cv" Series="2870" Issue="27686" />
     </Book>
     <Book Series="Web of Spider-Man" Number="23" Volume="1985" Year="1987">
-      <Id>f07e6f1b-a706-490c-b97c-30754e3e2cd9</Id>
+      <Database Name="cv" Series="3519" Issue="27804" />
     </Book>
     <Book Series="Web of Spider-Man" Number="24" Volume="1985" Year="1987">
-      <Id>e27aad53-1a39-4b04-bd84-68094a918469</Id>
+      <Database Name="cv" Series="3519" Issue="27913" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="284" Volume="1963" Year="1987">
-      <Id>16103f98-5320-4745-9c03-ba79a60ab5c8</Id>
+      <Database Name="cv" Series="2127" Issue="27671" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="285" Volume="1963" Year="1987">
-      <Id>aaea720b-627f-4329-84a9-d4e09d0b10e9</Id>
+      <Database Name="cv" Series="2127" Issue="27783" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="286" Volume="1963" Year="1987">
-      <Id>81e4a74e-e661-4042-81f2-3f31cc10e9dc</Id>
+      <Database Name="cv" Series="2127" Issue="27893" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="123" Volume="1976" Year="1987">
-      <Id>16c19bc5-128e-4e88-a7fe-3c514e64ea75</Id>
+      <Database Name="cv" Series="2870" Issue="27800" />
     </Book>
     <Book Series="Web of Spider-Man" Number="25" Volume="1985" Year="1987">
-      <Id>f542b8a0-a368-455a-9f98-687d8ced0756</Id>
+      <Database Name="cv" Series="3519" Issue="28024" />
     </Book>
     <Book Series="Web of Spider-Man" Number="27" Volume="1985" Year="1987">
-      <Id>64006435-1c5f-42a2-8244-7bb647ee3b70</Id>
+      <Database Name="cv" Series="3519" Issue="28235" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="287" Volume="1963" Year="1987">
-      <Id>815e4524-32da-4639-8e54-8d356caceefe</Id>
+      <Database Name="cv" Series="2127" Issue="28007" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="288" Volume="1963" Year="1987">
-      <Id>0b0b8484-0ec4-4bde-a643-dab7e7da1090</Id>
+      <Database Name="cv" Series="2127" Issue="28108" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="125" Volume="1976" Year="1987">
-      <Id>9bd587f8-dd6a-4d80-b078-3e33439d59aa</Id>
+      <Database Name="cv" Series="2870" Issue="28017" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="126" Volume="1976" Year="1987">
-      <Id>a2fabb08-6f1c-431d-a422-8784f12a8b70</Id>
+      <Database Name="cv" Series="2870" Issue="28118" />
     </Book>
     <Book Series="Web of Spider-Man" Number="28" Volume="1985" Year="1987">
-      <Id>aaba8ff8-b8cf-4a24-af7c-84ad6faac327</Id>
+      <Database Name="cv" Series="3519" Issue="28352" />
     </Book>
     <Book Series="Spider-Man vs. Wolverine" Number="1" Volume="1987" Year="1987">
-      <Id>a32df54a-f54f-4138-bc68-843655b85f42</Id>
+      <Database Name="cv" Series="19148" Issue="114552" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="289" Volume="1963" Year="1987">
-      <Id>82422e12-ae19-44da-8f66-eeb82f142d85</Id>
+      <Database Name="cv" Series="2127" Issue="28218" />
     </Book>
     <Book Series="Web of Spider-Man" Number="29" Volume="1985" Year="1987">
-      <Id>6f1fa6ea-9346-47a2-9267-34aec54ade7a</Id>
+      <Database Name="cv" Series="3519" Issue="28471" />
     </Book>
     <Book Series="Web of Spider-Man" Number="30" Volume="1985" Year="1987">
-      <Id>4ec78a1d-c36f-49a5-b1aa-79bdc0355141</Id>
+      <Database Name="cv" Series="3519" Issue="28579" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="127" Volume="1976" Year="1987">
-      <Id>576648a9-fac8-4989-a36a-dd87778d13de</Id>
+      <Database Name="cv" Series="2870" Issue="28228" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="128" Volume="1976" Year="1987">
-      <Id>bbb948f4-7d0d-4d51-a7a0-3e3de5da09e9</Id>
+      <Database Name="cv" Series="2870" Issue="28342" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="129" Volume="1976" Year="1987">
-      <Id>a39015a2-a7f5-4f37-ba5b-ec5faecdbc05</Id>
+      <Database Name="cv" Series="2870" Issue="28462" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="290" Volume="1963" Year="1987">
-      <Id>3bff865f-896a-4c61-8ee6-c9f46382b472</Id>
+      <Database Name="cv" Series="2127" Issue="28332" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="291" Volume="1963" Year="1987">
-      <Id>24133cc6-846d-42cd-811b-712f195b85a9</Id>
+      <Database Name="cv" Series="2127" Issue="28453" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="292" Volume="1963" Year="1987">
-      <Id>ef0014de-0d4e-4d98-b353-5fc1ec8ff250</Id>
+      <Database Name="cv" Series="2127" Issue="28560" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="21" Volume="1964" Year="1987">
-      <Id>2605a598-f703-465c-a5d6-15e52d989b08</Id>
+      <Database Name="cv" Series="2189" Issue="27607" />
     </Book>
     <Book Series="The Spectacular Spider-Man Annual" Number="7" Volume="1979" Year="1987">
-      <Id>e2680a5f-1dcf-44bc-89f6-1407dbc8cf6e</Id>
+      <Database Name="cv" Series="3012" Issue="27587" />
     </Book>
     <Book Series="Web of Spider-Man" Number="31" Volume="1985" Year="1987">
-      <Id>86a272fd-acac-43bb-b814-6312e69a9501</Id>
+      <Database Name="cv" Series="3519" Issue="28701" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="293" Volume="1963" Year="1987">
-      <Id>47d5c352-b5cc-414f-a47d-50d80e5e5240</Id>
+      <Database Name="cv" Series="2127" Issue="28682" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="131" Volume="1976" Year="1987">
-      <Id>1265d711-1b80-4cb3-aa95-25d2627d3621</Id>
+      <Database Name="cv" Series="2870" Issue="28691" />
     </Book>
     <Book Series="Web of Spider-Man" Number="32" Volume="1985" Year="1987">
-      <Id>7366129f-db64-4148-8eec-0718d5437125</Id>
+      <Database Name="cv" Series="3519" Issue="28819" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="294" Volume="1963" Year="1987">
-      <Id>b893aa2e-08b0-4d22-bc98-510d6294c369</Id>
+      <Database Name="cv" Series="2127" Issue="28795" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="132" Volume="1976" Year="1987">
-      <Id>a6a4a04a-ee67-46f4-802f-b9495b8e42b8</Id>
+      <Database Name="cv" Series="2870" Issue="28805" />
     </Book>
     <Book Series="Web of Spider-Man" Number="33" Volume="1985" Year="1987">
-      <Id>18b52439-4598-4271-bbc4-d379e6b19304</Id>
+      <Database Name="cv" Series="3519" Issue="28936" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="295" Volume="1963" Year="1987">
-      <Id>80fcc115-68cd-410b-adaa-a829e4904517</Id>
+      <Database Name="cv" Series="2127" Issue="28919" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="133" Volume="1976" Year="1987">
-      <Id>a4551096-2010-4b46-a35c-ede7efc7cfe7</Id>
+      <Database Name="cv" Series="2870" Issue="28931" />
     </Book>
     <Book Series="Web of Spider-Man" Number="34" Volume="1985" Year="1988">
-      <Id>30a51f0c-001c-48af-8762-d48f4f40ea5c</Id>
+      <Database Name="cv" Series="3519" Issue="29159" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Spider-Man/Spider-Man 004 (Venomous).cbl
+++ b/Marvel/Characters/unsorted/Spider-Man/Spider-Man 004 (Venomous).cbl
@@ -1,942 +1,943 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Spider-Man 4 (Venomous)</Name>
+  <Name>Spider-Man 004 (Venomous)</Name>
+  <NumIssues>312</NumIssues>
   <Books>
     <Book Series="The Amazing Spider-Man" Number="296" Volume="1963" Year="1988">
-      <Id>5d756d30-b868-4856-ab5c-c12310f46258</Id>
+      <Database Name="cv" Series="2127" Issue="29137" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="297" Volume="1963" Year="1988">
-      <Id>00c56823-14db-4b69-ad04-dcec06b15715</Id>
+      <Database Name="cv" Series="2127" Issue="29256" />
     </Book>
     <Book Series="Web of Spider-Man" Number="35" Volume="1985" Year="1988">
-      <Id>56ced775-43a9-4d40-8576-6071a217801d</Id>
+      <Database Name="cv" Series="3519" Issue="29274" />
     </Book>
     <Book Series="Web of Spider-Man" Number="36" Volume="1985" Year="1988">
-      <Id>9d1056dd-7566-4941-93ae-996ca463677e</Id>
+      <Database Name="cv" Series="3519" Issue="29385" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="134" Volume="1976" Year="1988">
-      <Id>ea792877-c2d8-4173-b41e-665b946a2c35</Id>
+      <Database Name="cv" Series="2870" Issue="29152" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="135" Volume="1976" Year="1988">
-      <Id>7196434f-b290-4ca3-9031-53f88970e55b</Id>
+      <Database Name="cv" Series="2870" Issue="29269" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="136" Volume="1976" Year="1988">
-      <Id>77226462-4212-4c36-bf5d-e6dc533af953</Id>
+      <Database Name="cv" Series="2870" Issue="29378" />
     </Book>
     <Book Series="Web of Spider-Man" Number="37" Volume="1985" Year="1988">
-      <Id>b4737e53-7609-4bd6-b1da-926b1a5a5e94</Id>
+      <Database Name="cv" Series="3519" Issue="29495" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="137" Volume="1976" Year="1988">
-      <Id>436be8a9-7209-4692-932f-ef59078a6f4a</Id>
+      <Database Name="cv" Series="2870" Issue="29490" />
     </Book>
     <Book Series="Web of Spider-Man" Number="38" Volume="1985" Year="1988">
-      <Id>1a927612-6693-4315-8fbc-a911b02ced9e</Id>
+      <Database Name="cv" Series="3519" Issue="29605" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="298" Volume="1963" Year="1988">
-      <Id>ada96e4c-09a3-4c76-9bb7-4b15c47f0ab6</Id>
+      <Database Name="cv" Series="2127" Issue="29365" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="299" Volume="1963" Year="1988">
-      <Id>ada1c729-aca3-4d6c-89ea-e6051b02238b</Id>
+      <Database Name="cv" Series="2127" Issue="29476" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="300" Volume="1963" Year="1988">
-      <Id>30f309b8-52d4-4be8-8ed4-7a178d3fa919</Id>
+      <Database Name="cv" Series="2127" Issue="29584" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="138" Volume="1976" Year="1988">
-      <Id>87087452-344d-4e29-84c2-bb81061283cc</Id>
+      <Database Name="cv" Series="2870" Issue="29598" />
     </Book>
     <Book Series="Web of Spider-Man" Number="39" Volume="1985" Year="1988">
-      <Id>ca626b3d-af24-474f-ba22-8d6140a5cee9</Id>
+      <Database Name="cv" Series="3519" Issue="29720" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="301" Volume="1963" Year="1988">
-      <Id>8066b610-c2c6-4677-8858-79c5b861f2ff</Id>
+      <Database Name="cv" Series="2127" Issue="29701" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="302" Volume="1963" Year="1988">
-      <Id>6f9c3987-87f7-4014-832e-5e0d14ca3326</Id>
+      <Database Name="cv" Series="2127" Issue="29819" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="303" Volume="1963" Year="1988">
-      <Id>284e2923-f796-42eb-b69f-d4e447755d31</Id>
+      <Database Name="cv" Series="2127" Issue="29936" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="139" Volume="1976" Year="1988">
-      <Id>205a54d4-cbbc-4775-82a9-5aa8d866d238</Id>
+      <Database Name="cv" Series="2870" Issue="29715" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="140" Volume="1976" Year="1988">
-      <Id>d5b71a01-e799-41e1-981e-a432c1a8ef40</Id>
+      <Database Name="cv" Series="2870" Issue="29833" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="141" Volume="1976" Year="1988">
-      <Id>8a7d0c12-7a64-4333-b393-4e66c86ee2d0</Id>
+      <Database Name="cv" Series="2870" Issue="109298" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="142" Volume="1976" Year="1988">
-      <Id>1c81103d-3a47-4d72-9812-19b0130f0efd</Id>
+      <Database Name="cv" Series="2870" Issue="30064" />
     </Book>
     <Book Series="Web of Spider-Man" Number="40" Volume="1985" Year="1988">
-      <Id>d8be9b30-effd-4fe3-98b2-16c337915454</Id>
+      <Database Name="cv" Series="3519" Issue="29840" />
     </Book>
     <Book Series="Web of Spider-Man" Number="41" Volume="1985" Year="1988">
-      <Id>a61eb71f-0fb2-4e12-ba78-f299e860e5a7</Id>
+      <Database Name="cv" Series="3519" Issue="29955" />
     </Book>
     <Book Series="Web of Spider-Man" Number="42" Volume="1985" Year="1988">
-      <Id>0afd6bf1-afb1-4dcb-a2d3-05a1a0ecfc99</Id>
+      <Database Name="cv" Series="3519" Issue="30072" />
     </Book>
     <Book Series="Web of Spider-Man" Number="43" Volume="1985" Year="1988">
-      <Id>51e06bea-df0e-4055-809c-cc028a710b60</Id>
+      <Database Name="cv" Series="3519" Issue="30195" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="22" Volume="1964" Year="1988">
-      <Id>4a64cc0a-b6ce-468a-a2fb-2679c8a1f89f</Id>
+      <Database Name="cv" Series="2189" Issue="64428" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="304" Volume="1963" Year="1988">
-      <Id>a3c1939a-200a-4875-8092-45e75555db20</Id>
+      <Database Name="cv" Series="2127" Issue="30048" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="305" Volume="1963" Year="1988">
-      <Id>dbe19330-467f-4f6f-bee2-4add1811379c</Id>
+      <Database Name="cv" Series="2127" Issue="30101" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="306" Volume="1963" Year="1988">
-      <Id>67f081ab-1215-42fa-8069-b61513fd88e8</Id>
+      <Database Name="cv" Series="2127" Issue="30173" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="307" Volume="1963" Year="1988">
-      <Id>dab30fba-ee6a-4b4b-9470-eb65ba4bcc73</Id>
+      <Database Name="cv" Series="2127" Issue="30230" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="308" Volume="1963" Year="1988">
-      <Id>a9bc88a9-8fea-453b-8806-528d86115bc9</Id>
+      <Database Name="cv" Series="2127" Issue="30301" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="309" Volume="1963" Year="1988">
-      <Id>4b6d2c45-4fec-46a6-9145-2b060d55551a</Id>
+      <Database Name="cv" Series="2127" Issue="30358" />
     </Book>
     <Book Series="Web of Spider-Man Annual" Number="4" Volume="1985" Year="1988">
-      <Id>e668be42-6a3f-446f-8cb3-f215b203d50c</Id>
+      <Database Name="cv" Series="3520" Issue="77994" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="143" Volume="1976" Year="1988">
-      <Id>e50fec55-0a3f-4b02-b0eb-b7c88e65a49d</Id>
+      <Database Name="cv" Series="2870" Issue="30189" />
     </Book>
     <Book Series="Web of Spider-Man" Number="44" Volume="1985" Year="1988">
-      <Id>32340d79-4ef4-464a-89f4-76ae96f0e6cf</Id>
+      <Database Name="cv" Series="3519" Issue="30327" />
     </Book>
     <Book Series="The Incredible Hulk" Number="349" Volume="1968" Year="1988">
-      <Id>064119b8-a2bf-4afa-a3a2-e2daeabf6f59</Id>
+      <Database Name="cv" Series="2406" Issue="30310" />
     </Book>
     <Book Series="Web of Spider-Man" Number="45" Volume="1985" Year="1988">
-      <Id>be1abc72-a069-4e3d-9bc3-c042f8317cec</Id>
+      <Database Name="cv" Series="3519" Issue="30449" />
     </Book>
     <Book Series="The Spectacular Spider-Man Annual" Number="8" Volume="1979" Year="1988">
-      <Id>bae610b1-a775-4546-ae78-59b4984df9dc</Id>
+      <Database Name="cv" Series="3012" Issue="29040" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="144" Volume="1976" Year="1988">
-      <Id>f4cd4278-fe3b-47a4-8950-1a59370bda7f</Id>
+      <Database Name="cv" Series="2870" Issue="30321" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="145" Volume="1976" Year="1988">
-      <Id>64c560cc-cc64-4896-8726-57bad3653771</Id>
+      <Database Name="cv" Series="2870" Issue="30444" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="310" Volume="1963" Year="1988">
-      <Id>4f841a22-059d-4baf-8881-a26fd0f099f7</Id>
+      <Database Name="cv" Series="2127" Issue="30423" />
     </Book>
     <Book Series="Web of Spider-Man" Number="46" Volume="1985" Year="1989">
-      <Id>ac294a5a-c141-4a41-a897-58aa990c5ecf</Id>
+      <Database Name="cv" Series="3519" Issue="30798" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="311" Volume="1963" Year="1989">
-      <Id>d384f6c2-452c-4a85-8935-7d8779d6119c</Id>
+      <Database Name="cv" Series="2127" Issue="30773" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="146" Volume="1976" Year="1989">
-      <Id>b531002f-a72e-4238-b0c5-c7b5cfa8509d</Id>
+      <Database Name="cv" Series="2870" Issue="30792" />
     </Book>
     <Book Series="Web of Spider-Man" Number="47" Volume="1985" Year="1989">
-      <Id>85272668-d114-494d-aacc-96dff0c1bcad</Id>
+      <Database Name="cv" Series="3519" Issue="30906" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="312" Volume="1963" Year="1989">
-      <Id>e2cd30dd-5d43-42da-b0a6-db4382547eb5</Id>
+      <Database Name="cv" Series="2127" Issue="30883" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="147" Volume="1976" Year="1989">
-      <Id>6d4973f3-b683-4d08-a64c-5532e5794d32</Id>
+      <Database Name="cv" Series="2870" Issue="30901" />
     </Book>
     <Book Series="Web of Spider-Man" Number="48" Volume="1985" Year="1989">
-      <Id>4c14a05c-bcbc-47d5-a91b-08eceb549be8</Id>
+      <Database Name="cv" Series="3519" Issue="31007" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="313" Volume="1963" Year="1989">
-      <Id>61ae07d2-2139-4ede-b9cc-eb76165af013</Id>
+      <Database Name="cv" Series="2127" Issue="113269" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="148" Volume="1976" Year="1989">
-      <Id>b1215b15-809c-4170-9db3-9d1d9c144043</Id>
+      <Database Name="cv" Series="2870" Issue="31001" />
     </Book>
     <Book Series="Web of Spider-Man" Number="49" Volume="1985" Year="1989">
-      <Id>07d5039b-13b8-447d-8dad-35acdef25f0e</Id>
+      <Database Name="cv" Series="3519" Issue="31118" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="314" Volume="1963" Year="1989">
-      <Id>35d75b2c-8d6e-47ba-b9fb-426d14c0fdf7</Id>
+      <Database Name="cv" Series="2127" Issue="31094" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="149" Volume="1976" Year="1989">
-      <Id>f0aa624a-1a88-41de-9daf-078f7ab5b97a</Id>
+      <Database Name="cv" Series="2870" Issue="31113" />
     </Book>
     <Book Series="Web of Spider-Man" Number="50" Volume="1985" Year="1989">
-      <Id>268f009f-94d1-4a3b-a784-a330ea4fa18f</Id>
+      <Database Name="cv" Series="3519" Issue="31231" />
     </Book>
     <Book Series="Spider-Man: Spirits of the Earth" Number="1" Volume="1990" Year="1990">
-      <Id>45c2657d-5a64-490c-886d-dcafa41ef435</Id>
+      <Database Name="cv" Series="37819" Issue="251050" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="315" Volume="1963" Year="1989">
-      <Id>d0e3836e-4af2-4a46-aa28-880d75b440ba</Id>
+      <Database Name="cv" Series="2127" Issue="31207" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="150" Volume="1976" Year="1989">
-      <Id>c3d8b8e7-a931-4378-9211-cbaaf531b1dc</Id>
+      <Database Name="cv" Series="2870" Issue="31225" />
     </Book>
     <Book Series="Web of Spider-Man" Number="51" Volume="1985" Year="1989">
-      <Id>ea06724b-cad5-445e-b061-d8d5e3fc22b7</Id>
+      <Database Name="cv" Series="3519" Issue="31342" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="316" Volume="1963" Year="1989">
-      <Id>8edefe11-a8b4-46f0-8030-c4a408ba7c50</Id>
+      <Database Name="cv" Series="2127" Issue="31316" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="317" Volume="1963" Year="1989">
-      <Id>ef076a57-1a30-45e5-bbcf-6b4f91a6dad8</Id>
+      <Database Name="cv" Series="2127" Issue="31429" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="151" Volume="1976" Year="1989">
-      <Id>df16afe5-9933-40fe-8fe0-80a10ae1520b</Id>
+      <Database Name="cv" Series="2870" Issue="31336" />
     </Book>
     <Book Series="Web of Spider-Man" Number="52" Volume="1985" Year="1989">
-      <Id>42d6611b-c7cf-4269-af3c-37e089c7dfb8</Id>
+      <Database Name="cv" Series="3519" Issue="31452" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="318" Volume="1963" Year="1989">
-      <Id>92ced8a9-ae60-4b6f-a022-7b61bef24723</Id>
+      <Database Name="cv" Series="2127" Issue="31533" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="319" Volume="1963" Year="1989">
-      <Id>3ac48c7e-acac-4734-b46c-25d90504b6cc</Id>
+      <Database Name="cv" Series="2127" Issue="31646" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="152" Volume="1976" Year="1989">
-      <Id>a41d94aa-d029-45e7-a090-e1a647393789</Id>
+      <Database Name="cv" Series="2870" Issue="31448" />
     </Book>
     <Book Series="Web of Spider-Man" Number="53" Volume="1985" Year="1989">
-      <Id>307886df-bc95-4422-bf06-9b216cf64d70</Id>
+      <Database Name="cv" Series="3519" Issue="31555" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="153" Volume="1976" Year="1989">
-      <Id>cfffe42b-eafd-4079-b5d7-b2ab902edc69</Id>
+      <Database Name="cv" Series="2870" Issue="31552" />
     </Book>
     <Book Series="Web of Spider-Man" Number="54" Volume="1985" Year="1989">
-      <Id>92845c6f-08df-46bf-b4e7-d9355799411e</Id>
+      <Database Name="cv" Series="3519" Issue="31672" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="23" Volume="1964" Year="1989">
-      <Id>c63ae719-12e4-4eb0-bc5b-772a2f864add</Id>
+      <Database Name="cv" Series="2189" Issue="30692" />
     </Book>
     <Book Series="The Spectacular Spider-Man Annual" Number="9" Volume="1979" Year="1989">
-      <Id>965dc48c-d57e-46e0-b3f0-dc99c881ac39</Id>
+      <Database Name="cv" Series="3012" Issue="30632" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="320" Volume="1963" Year="1989">
-      <Id>5d933da5-9d97-486c-a66c-7a5eb6f4c1f3</Id>
+      <Database Name="cv" Series="2127" Issue="31698" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="154" Volume="1976" Year="1989">
-      <Id>8720b7b5-a717-4bb5-b707-f8f381c888db</Id>
+      <Database Name="cv" Series="2870" Issue="31668" />
     </Book>
     <Book Series="Web of Spider-Man" Number="55" Volume="1985" Year="1989">
-      <Id>466a93cd-833b-48ce-8d9f-a75d3b864c4c</Id>
+      <Database Name="cv" Series="3519" Issue="31782" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="321" Volume="1963" Year="1989">
-      <Id>b67acc5a-4671-4401-b411-2c7636948c5a</Id>
+      <Database Name="cv" Series="2127" Issue="31756" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="322" Volume="1963" Year="1989">
-      <Id>539f0645-5aee-44e0-b710-d8eedb254872</Id>
+      <Database Name="cv" Series="2127" Issue="31804" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="323" Volume="1963" Year="1989">
-      <Id>d09f11b4-67c0-492d-afcb-fc6ddc9cdfe9</Id>
+      <Database Name="cv" Series="2127" Issue="31860" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="324" Volume="1963" Year="1989">
-      <Id>47e2e6b0-051b-41cd-9475-8c681a796c2a</Id>
+      <Database Name="cv" Series="2127" Issue="31916" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="325" Volume="1963" Year="1989">
-      <Id>8bb76b6d-f714-4de8-a518-1298162f4c39</Id>
+      <Database Name="cv" Series="2127" Issue="31941" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="155" Volume="1976" Year="1989">
-      <Id>87dabd0f-8908-40d3-a098-a786c0949a93</Id>
+      <Database Name="cv" Series="2870" Issue="31779" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="156" Volume="1976" Year="1989">
-      <Id>511e0014-a9da-47e6-b41e-434d262591ab</Id>
+      <Database Name="cv" Series="2870" Issue="31883" />
     </Book>
     <Book Series="Web of Spider-Man Annual" Number="5" Volume="1985" Year="1989">
-      <Id>5af0bf28-70d5-47e1-9239-74db6a8efaa0</Id>
+      <Database Name="cv" Series="3520" Issue="30615" />
     </Book>
     <Book Series="Web of Spider-Man" Number="56" Volume="1985" Year="1989">
-      <Id>95c4b2d0-b55b-4466-965d-b078eeb002a8</Id>
+      <Database Name="cv" Series="3519" Issue="31886" />
     </Book>
     <Book Series="Web of Spider-Man" Number="57" Volume="1985" Year="1989">
-      <Id>7422b724-b7a2-4e37-8167-62614a152dc5</Id>
+      <Database Name="cv" Series="3519" Issue="31936" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="157" Volume="1976" Year="1989">
-      <Id>0205d888-7977-4a75-801b-6e589afaa7e6</Id>
+      <Database Name="cv" Series="2870" Issue="31933" />
     </Book>
     <Book Series="Web of Spider-Man" Number="58" Volume="1985" Year="1989">
-      <Id>951f88ad-80cc-4ccc-9255-d524cf08091e</Id>
+      <Database Name="cv" Series="3519" Issue="32019" />
     </Book>
     <Book Series="Amazing Spider-Man: Parallel Lives" Number="1" Volume="2012" Year="2012">
-      <Id>ae725b69-b4f4-4cc2-ae31-17930565ffeb</Id>
+      <Database Name="cv" Series="49618" Issue="339939" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="326" Volume="1963" Year="1989">
-      <Id>b06c9ae8-5766-41ef-b30c-cac21072c184</Id>
+      <Database Name="cv" Series="2127" Issue="31991" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="158" Volume="1976" Year="1989">
-      <Id>001f9f61-5449-4503-93d1-75f96a6e7c15</Id>
+      <Database Name="cv" Series="2870" Issue="32014" />
     </Book>
     <Book Series="Web of Spider-Man" Number="59" Volume="1985" Year="1989">
-      <Id>928c47c9-76f1-4118-b8e4-0e36fe574ad7</Id>
+      <Database Name="cv" Series="3519" Issue="32075" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="327" Volume="1963" Year="1989">
-      <Id>894f8080-0e9a-40a1-a8d7-d1d1277c2a2c</Id>
+      <Database Name="cv" Series="2127" Issue="32053" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="159" Volume="1976" Year="1989">
-      <Id>f1e63045-ccde-4daa-b1fd-d18186bc5cda</Id>
+      <Database Name="cv" Series="2870" Issue="32071" />
     </Book>
     <Book Series="Web of Spider-Man" Number="60" Volume="1985" Year="1990">
-      <Id>b8ff33c3-8133-4994-ac2c-b6a95d93d5da</Id>
+      <Database Name="cv" Series="3519" Issue="32338" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="328" Volume="1963" Year="1990">
-      <Id>2030fc16-b582-46d8-b53a-b13a36dcdc00</Id>
+      <Database Name="cv" Series="2127" Issue="113265" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="160" Volume="1976" Year="1990">
-      <Id>b1469029-4a48-4b26-8ecd-c9639e98e21f</Id>
+      <Database Name="cv" Series="2870" Issue="32334" />
     </Book>
     <Book Series="Web of Spider-Man" Number="61" Volume="1985" Year="1990">
-      <Id>6cc0be2a-dfc8-4bc4-bdab-8bb6494c4a7e</Id>
+      <Database Name="cv" Series="3519" Issue="32437" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="329" Volume="1963" Year="1990">
-      <Id>d96463d7-9ef3-4181-add2-c6671e4b84a9</Id>
+      <Database Name="cv" Series="2127" Issue="32412" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="161" Volume="1976" Year="1990">
-      <Id>d6e6a296-17a4-4fa4-a9c2-9eeb2432ee9f</Id>
+      <Database Name="cv" Series="2870" Issue="65555" />
     </Book>
     <Book Series="Web of Spider-Man" Number="62" Volume="1985" Year="1990">
-      <Id>778ef7b4-435d-4afd-8692-04791f946901</Id>
+      <Database Name="cv" Series="3519" Issue="32537" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="330" Volume="1963" Year="1990">
-      <Id>8e09c3df-9d8b-43c9-bb2a-07dd02d4bf6e</Id>
+      <Database Name="cv" Series="2127" Issue="32513" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="331" Volume="1963" Year="1990">
-      <Id>a010f2a1-07f3-4afd-9c05-ce6dcc154f47</Id>
+      <Database Name="cv" Series="2127" Issue="32622" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="332" Volume="1963" Year="1990">
-      <Id>257aa295-e31d-4950-b824-052beb0d21d1</Id>
+      <Database Name="cv" Series="2127" Issue="113926" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="333" Volume="1963" Year="1990">
-      <Id>0d8c469c-36aa-4da3-a888-48472c56b7b7</Id>
+      <Database Name="cv" Series="2127" Issue="32830" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="24" Volume="1964" Year="1990">
-      <Id>84328ff2-aa42-4d69-8de6-73650d6fd4f9</Id>
+      <Database Name="cv" Series="2189" Issue="112516" />
     </Book>
     <Book Series="The Spectacular Spider-Man Annual" Number="10" Volume="1979" Year="1990">
-      <Id>104da0c0-a9fa-49fd-ac5b-18b1ef8f9878</Id>
+      <Database Name="cv" Series="3012" Issue="32216" />
     </Book>
     <Book Series="Web of Spider-Man Annual" Number="6" Volume="1985" Year="1990">
-      <Id>f9230bd1-1ae2-48b0-8adc-ee8a8e71b7aa</Id>
+      <Database Name="cv" Series="3520" Issue="77995" />
     </Book>
     <Book Series="Web of Spider-Man" Number="63" Volume="1985" Year="1990">
-      <Id>ae385bd2-5efd-4bc2-aa3a-28e4be198b04</Id>
+      <Database Name="cv" Series="3519" Issue="32648" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="162" Volume="1976" Year="1990">
-      <Id>707049f3-ae97-4f60-ba70-ba1436d136d6</Id>
+      <Database Name="cv" Series="2870" Issue="65556" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="163" Volume="1976" Year="1990">
-      <Id>757cff27-34ed-4761-b6d8-2ddcee03c8b3</Id>
+      <Database Name="cv" Series="2870" Issue="65557" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="164" Volume="1976" Year="1990">
-      <Id>fdbef2f7-74eb-4d64-8f6d-deeea3bd479d</Id>
+      <Database Name="cv" Series="2870" Issue="65558" />
     </Book>
     <Book Series="The Avengers" Number="314" Volume="1963" Year="1990">
-      <Id>2bc38271-0696-4bf9-91eb-c113c83198c6</Id>
+      <Database Name="cv" Series="2128" Issue="32414" />
     </Book>
     <Book Series="The Avengers" Number="315" Volume="1963" Year="1990">
-      <Id>c311c602-1890-40bb-b0e2-83160944ad23</Id>
+      <Database Name="cv" Series="2128" Issue="32515" />
     </Book>
     <Book Series="The Avengers" Number="316" Volume="1963" Year="1990">
-      <Id>b92b3f18-a197-40b4-a0b9-b64daa20cba8</Id>
+      <Database Name="cv" Series="2128" Issue="32624" />
     </Book>
     <Book Series="The Avengers" Number="317" Volume="1963" Year="1990">
-      <Id>ba677782-daf4-49cb-bda1-02d13c358383</Id>
+      <Database Name="cv" Series="2128" Issue="32722" />
     </Book>
     <Book Series="The Avengers" Number="318" Volume="1963" Year="1990">
-      <Id>e6535320-7ad6-4f81-8493-4b4007fb6125</Id>
+      <Database Name="cv" Series="2128" Issue="32832" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="334" Volume="1963" Year="1990">
-      <Id>07bbb5de-aa27-4521-ba84-33eb8bea97a4</Id>
+      <Database Name="cv" Series="2127" Issue="32956" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="335" Volume="1963" Year="1990">
-      <Id>06bcab42-79bd-413b-8cd1-50c5bb786ef1</Id>
+      <Database Name="cv" Series="2127" Issue="33012" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="336" Volume="1963" Year="1990">
-      <Id>761e760e-09c7-4c13-81ad-d095a46d2aa3</Id>
+      <Database Name="cv" Series="2127" Issue="33070" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="337" Volume="1963" Year="1990">
-      <Id>6e0add08-a280-430f-a6ee-b45bb05ccc52</Id>
+      <Database Name="cv" Series="2127" Issue="33131" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="338" Volume="1963" Year="1990">
-      <Id>660ef118-39bd-45db-a2cb-97af20299e31</Id>
+      <Database Name="cv" Series="2127" Issue="33186" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="339" Volume="1963" Year="1990">
-      <Id>69a5c7e2-2eee-48b1-a3a3-cfab1649c5e4</Id>
+      <Database Name="cv" Series="2127" Issue="33251" />
     </Book>
     <Book Series="Spider-Man" Number="1" Volume="1990" Year="1990">
-      <Id>1c0d95b2-dd92-404b-853b-125bae48d584</Id>
+      <Database Name="cv" Series="4421" Issue="64603" />
     </Book>
     <Book Series="Spider-Man" Number="2" Volume="1990" Year="1990">
-      <Id>011a2ad0-3c8c-4010-ad21-ca2b8ffc5fd3</Id>
+      <Database Name="cv" Series="4421" Issue="64604" />
     </Book>
     <Book Series="Spider-Man" Number="3" Volume="1990" Year="1990">
-      <Id>4696557d-6769-4808-ad92-56fa41795d6b</Id>
+      <Database Name="cv" Series="4421" Issue="64605" />
     </Book>
     <Book Series="Spider-Man" Number="4" Volume="1990" Year="1990">
-      <Id>eecf1403-1539-40c3-a46a-ec13255711bd</Id>
+      <Database Name="cv" Series="4421" Issue="64606" />
     </Book>
     <Book Series="Spider-Man" Number="5" Volume="1990" Year="1990">
-      <Id>5dd11e4f-a26f-43f0-a1b9-defb6c4b5063</Id>
+      <Database Name="cv" Series="4421" Issue="64607" />
     </Book>
     <Book Series="Web of Spider-Man" Number="64" Volume="1985" Year="1990">
-      <Id>62e065c3-484b-4a44-b0b2-60e6ea78133c</Id>
+      <Database Name="cv" Series="3519" Issue="32742" />
     </Book>
     <Book Series="Web of Spider-Man" Number="65" Volume="1985" Year="1990">
-      <Id>346e2c9a-9c4e-42bd-ac5e-dd2f9277eea0</Id>
+      <Database Name="cv" Series="3519" Issue="32862" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="165" Volume="1976" Year="1990">
-      <Id>a708eee9-0f0a-4033-98e6-4a5d41d5129d</Id>
+      <Database Name="cv" Series="2870" Issue="65559" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="166" Volume="1976" Year="1990">
-      <Id>c49ff2fc-282b-4582-b5e9-74be285a7f10</Id>
+      <Database Name="cv" Series="2870" Issue="65560" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="167" Volume="1976" Year="1990">
-      <Id>667ea7db-1554-48c7-91b1-5d744b1882ed</Id>
+      <Database Name="cv" Series="2870" Issue="65561" />
     </Book>
     <Book Series="Web of Spider-Man" Number="66" Volume="1985" Year="1990">
-      <Id>d671df0e-390e-45e2-801d-43a277368f4a</Id>
+      <Database Name="cv" Series="3519" Issue="32983" />
     </Book>
     <Book Series="Web of Spider-Man" Number="67" Volume="1985" Year="1990">
-      <Id>a14b04cc-d9e1-442f-a9bc-3503d44dfa3a</Id>
+      <Database Name="cv" Series="3519" Issue="33100" />
     </Book>
     <Book Series="Web of Spider-Man" Number="68" Volume="1985" Year="1990">
-      <Id>29c62ba3-65d1-4719-a988-04af6d70f707</Id>
+      <Database Name="cv" Series="3519" Issue="33213" />
     </Book>
     <Book Series="Web of Spider-Man" Number="69" Volume="1985" Year="1990">
-      <Id>6b0dff06-f375-494d-8fa6-d1e304629eb0</Id>
+      <Database Name="cv" Series="3519" Issue="33335" />
     </Book>
     <Book Series="Web of Spider-Man" Number="70" Volume="1985" Year="1990">
-      <Id>7704adf1-d0fa-4cfe-8890-26d2e1c09f36</Id>
+      <Database Name="cv" Series="3519" Issue="33444" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="168" Volume="1976" Year="1990">
-      <Id>15eccf5a-89d1-473c-8549-4d0dd2e09578</Id>
+      <Database Name="cv" Series="2870" Issue="65562" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="169" Volume="1976" Year="1990">
-      <Id>85cb823f-46d4-44b5-bec9-e90c5df9738c</Id>
+      <Database Name="cv" Series="2870" Issue="65563" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="170" Volume="1976" Year="1990">
-      <Id>6707fd94-a26d-4074-9f26-4c94162401fe</Id>
+      <Database Name="cv" Series="2870" Issue="65564" />
     </Book>
     <Book Series="Deadly Foes of Spider-Man" Number="1" Volume="1991" Year="1991">
-      <Id>0db8dfab-ba88-4936-acbb-051358b11a6b</Id>
+      <Database Name="cv" Series="4588" Issue="34233" />
     </Book>
     <Book Series="Deadly Foes of Spider-Man" Number="2" Volume="1991" Year="1991">
-      <Id>daf01a8d-3e31-4ade-aec8-b461c67e333e</Id>
+      <Database Name="cv" Series="4588" Issue="34330" />
     </Book>
     <Book Series="Deadly Foes of Spider-Man" Number="3" Volume="1991" Year="1991">
-      <Id>6517fa7a-f303-4d3e-9ae1-e49c05f606f9</Id>
+      <Database Name="cv" Series="4588" Issue="34455" />
     </Book>
     <Book Series="Deadly Foes of Spider-Man" Number="4" Volume="1991" Year="1991">
-      <Id>476ce8cf-0974-4d89-befb-b844360793d2</Id>
+      <Database Name="cv" Series="4588" Issue="34564" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="340" Volume="1963" Year="1990">
-      <Id>d35b1165-c1f0-4458-a881-4e445deedebd</Id>
+      <Database Name="cv" Series="2127" Issue="33306" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="341" Volume="1963" Year="1990">
-      <Id>872e0bac-33e5-4157-9c64-8be96ff9e9a1</Id>
+      <Database Name="cv" Series="2127" Issue="33417" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="342" Volume="1963" Year="1990">
-      <Id>b3a6eff3-ef34-4a3b-a4f9-2fcab8a6f119</Id>
+      <Database Name="cv" Series="2127" Issue="33524" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="343" Volume="1963" Year="1991">
-      <Id>ded506e4-d85d-4230-ad15-f73250f31a6f</Id>
+      <Database Name="cv" Series="2127" Issue="33768" />
     </Book>
     <Book Series="Fantastic Four" Number="347" Volume="1961" Year="1990">
-      <Id>f81cac5e-8ad0-442e-a6a1-039f88a3d43d</Id>
+      <Database Name="cv" Series="2045" Issue="33871" />
     </Book>
     <Book Series="Fantastic Four" Number="348" Volume="1961" Year="1991">
-      <Id>8cf9919f-4249-4d15-9b06-3877f75d47f1</Id>
+      <Database Name="cv" Series="2045" Issue="33989" />
     </Book>
     <Book Series="Fantastic Four" Number="349" Volume="1961" Year="1991">
-      <Id>c7ddb595-8c6f-45ec-873f-667d4df2765e</Id>
+      <Database Name="cv" Series="2045" Issue="34092" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="171" Volume="1976" Year="1990">
-      <Id>13c44c63-fa92-43bf-82cb-fc802faf4a45</Id>
+      <Database Name="cv" Series="2870" Issue="65565" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="172" Volume="1976" Year="1991">
-      <Id>96f12364-746e-4ac9-aa95-9771bfd7101a</Id>
+      <Database Name="cv" Series="2870" Issue="65566" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="344" Volume="1963" Year="1991">
-      <Id>5135c885-c615-4d09-9316-8fc978910394</Id>
+      <Database Name="cv" Series="2127" Issue="33866" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="345" Volume="1963" Year="1991">
-      <Id>008787b0-7a50-49bb-8668-174829380f2f</Id>
+      <Database Name="cv" Series="2127" Issue="33983" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="346" Volume="1963" Year="1991">
-      <Id>7199cb23-8a26-47a1-b8a1-da8aff7b6648</Id>
+      <Database Name="cv" Series="2127" Issue="34086" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="347" Volume="1963" Year="1991">
-      <Id>5c728109-6377-4fc5-b805-2e6f4969576d</Id>
+      <Database Name="cv" Series="2127" Issue="34192" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="173" Volume="1976" Year="1991">
-      <Id>986405c0-5bee-4741-ab98-b4d20187e772</Id>
+      <Database Name="cv" Series="2870" Issue="65567" />
     </Book>
     <Book Series="Spider-Man" Number="6" Volume="1990" Year="1991">
-      <Id>a31da179-85a8-4283-a1ff-a8c751adffa4</Id>
+      <Database Name="cv" Series="4421" Issue="64608" />
     </Book>
     <Book Series="Spider-Man" Number="7" Volume="1990" Year="1991">
-      <Id>6d451c38-1325-4fe0-8c40-546fac538f2c</Id>
+      <Database Name="cv" Series="4421" Issue="64609" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="174" Volume="1976" Year="1991">
-      <Id>f14831f9-cf95-42ab-b9e5-26d5570621cf</Id>
+      <Database Name="cv" Series="2870" Issue="65568" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="175" Volume="1976" Year="1991">
-      <Id>fe983729-4e11-4ead-adb3-c5c09cd21455</Id>
+      <Database Name="cv" Series="2870" Issue="65569" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="348" Volume="1963" Year="1991">
-      <Id>4c2b27f0-97db-4c4f-9a3f-b246ce32cea3</Id>
+      <Database Name="cv" Series="2127" Issue="34290" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="176" Volume="1976" Year="1991">
-      <Id>2fe7a27f-29e5-404f-906c-6d6ec854f04f</Id>
+      <Database Name="cv" Series="2870" Issue="65570" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="177" Volume="1976" Year="1991">
-      <Id>07f1c4ae-c238-4196-b141-0e07565adef2</Id>
+      <Database Name="cv" Series="2870" Issue="65571" />
     </Book>
     <Book Series="Web of Spider-Man" Number="73" Volume="1985" Year="1991">
-      <Id>70c5007b-5276-4779-98a6-511ee0867781</Id>
+      <Database Name="cv" Series="3519" Issue="33894" />
     </Book>
     <Book Series="Web of Spider-Man" Number="74" Volume="1985" Year="1991">
-      <Id>fbf062a5-d5f1-40ea-b4d6-548ecc96bf21</Id>
+      <Database Name="cv" Series="3519" Issue="34008" />
     </Book>
     <Book Series="Web of Spider-Man" Number="75" Volume="1985" Year="1991">
-      <Id>566960a7-b7f1-4ee8-84f7-3f07bfe74f65</Id>
+      <Database Name="cv" Series="3519" Issue="34112" />
     </Book>
     <Book Series="Web of Spider-Man" Number="76" Volume="1985" Year="1991">
-      <Id>f2a7e190-8536-4f06-ad4e-47d0eb736bb1</Id>
+      <Database Name="cv" Series="3519" Issue="34215" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="25" Volume="1964" Year="1991">
-      <Id>6f8f3056-cf2f-4c4d-a6df-e929c5713ba3</Id>
+      <Database Name="cv" Series="2189" Issue="64429" />
     </Book>
     <Book Series="The Spectacular Spider-Man Annual" Number="11" Volume="1979" Year="1991">
-      <Id>10d6f487-3c22-4064-98ce-d8799b308ce0</Id>
+      <Database Name="cv" Series="3012" Issue="33688" />
     </Book>
     <Book Series="Web of Spider-Man Annual" Number="7" Volume="1985" Year="1991">
-      <Id>ea55304c-55de-4711-892f-5b182d2bef5b</Id>
+      <Database Name="cv" Series="3520" Issue="77996" />
     </Book>
     <Book Series="Spider-Man" Number="17" Volume="1990" Year="1991">
-      <Id>fdd0c633-4233-4318-9ce7-b47669591d6c</Id>
+      <Database Name="cv" Series="4421" Issue="64619" />
     </Book>
     <Book Series="Spider-Man" Number="8" Volume="1990" Year="1991">
-      <Id>13032b09-de84-4e6e-9ded-dd8d84fe38b9</Id>
+      <Database Name="cv" Series="4421" Issue="64610" />
     </Book>
     <Book Series="Spider-Man" Number="9" Volume="1990" Year="1991">
-      <Id>db69f1a3-1f73-40fc-813a-e4d88894c3aa</Id>
+      <Database Name="cv" Series="4421" Issue="64611" />
     </Book>
     <Book Series="Spider-Man" Number="10" Volume="1990" Year="1991">
-      <Id>1e71fd0e-7671-462a-8504-9b08514184ca</Id>
+      <Database Name="cv" Series="4421" Issue="64612" />
     </Book>
     <Book Series="Spider-Man" Number="11" Volume="1990" Year="1991">
-      <Id>b0572143-eb11-4e26-9334-10fa17f27068</Id>
+      <Database Name="cv" Series="4421" Issue="64613" />
     </Book>
     <Book Series="Spider-Man" Number="12" Volume="1990" Year="1991">
-      <Id>17a8434a-6b33-4c1f-a0b4-42a1842acb0e</Id>
+      <Database Name="cv" Series="4421" Issue="64614" />
     </Book>
     <Book Series="Web of Spider-Man" Number="77" Volume="1985" Year="1991">
-      <Id>86f440b7-01ff-4567-842d-86b89028fd21</Id>
+      <Database Name="cv" Series="3519" Issue="34314" />
     </Book>
     <Book Series="Web of Spider-Man" Number="78" Volume="1985" Year="1991">
-      <Id>27792dde-8c15-4d9f-b497-022d39cbdcf0</Id>
+      <Database Name="cv" Series="3519" Issue="34431" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="349" Volume="1963" Year="1991">
-      <Id>b79671b8-1582-4d96-937e-b5d380545536</Id>
+      <Database Name="cv" Series="2127" Issue="34405" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="350" Volume="1963" Year="1991">
-      <Id>5148a4d4-b769-463c-9906-bb0fc51aab37</Id>
+      <Database Name="cv" Series="2127" Issue="34520" />
     </Book>
     <Book Series="Web of Spider-Man" Number="79" Volume="1985" Year="1991">
-      <Id>cd5807a1-060d-429e-80d6-b85f04eb5dbd</Id>
+      <Database Name="cv" Series="3519" Issue="34546" />
     </Book>
     <Book Series="Web of Spider-Man" Number="80" Volume="1985" Year="1991">
-      <Id>67685c0c-b7e0-49f0-99b7-ff09a0ad4a6b</Id>
+      <Database Name="cv" Series="3519" Issue="34662" />
     </Book>
     <Book Series="Spider-Man" Number="13" Volume="1990" Year="1991">
-      <Id>6915637b-55a3-471e-9a42-1b5d98d8ff99</Id>
+      <Database Name="cv" Series="4421" Issue="64615" />
     </Book>
     <Book Series="Spider-Man" Number="14" Volume="1990" Year="1991">
-      <Id>6655a83a-ed09-4362-9ca8-83f4a6636896</Id>
+      <Database Name="cv" Series="4421" Issue="64616" />
     </Book>
     <Book Series="Spider-Man" Number="15" Volume="1990" Year="1991">
-      <Id>c5b0aaad-31e7-40c4-a95d-f765a980d96b</Id>
+      <Database Name="cv" Series="4421" Issue="64617" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="351" Volume="1963" Year="1991">
-      <Id>58a2d2d5-f40f-4f71-936f-da9c652cecc7</Id>
+      <Database Name="cv" Series="2127" Issue="34638" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="352" Volume="1963" Year="1991">
-      <Id>9b37e589-654b-4ee8-aa5a-cdcb8773c523</Id>
+      <Database Name="cv" Series="2127" Issue="34755" />
     </Book>
     <Book Series="X-Force" Number="3" Volume="1991" Year="1991">
-      <Id>06699a51-bc5b-4d61-bc3b-202ccbfd510b</Id>
+      <Database Name="cv" Series="4604" Issue="34783" />
     </Book>
     <Book Series="Spider-Man" Number="16" Volume="1990" Year="1991">
-      <Id>86dbb27b-74fc-4055-9d3f-94e23e550341</Id>
+      <Database Name="cv" Series="4421" Issue="64618" />
     </Book>
     <Book Series="X-Force" Number="4" Volume="1991" Year="1991">
-      <Id>1c7835de-abba-4399-b394-a4af9301e66c</Id>
+      <Database Name="cv" Series="4604" Issue="34899" />
     </Book>
     <Book Series="Web of Spider-Man" Number="81" Volume="1985" Year="1991">
-      <Id>34e42dad-a250-400d-9a6f-87b8661cb902</Id>
+      <Database Name="cv" Series="3519" Issue="34780" />
     </Book>
     <Book Series="Web of Spider-Man" Number="82" Volume="1985" Year="1991">
-      <Id>70211038-224c-4bf7-8f0e-fdb450637d3d</Id>
+      <Database Name="cv" Series="3519" Issue="34896" />
     </Book>
     <Book Series="Web of Spider-Man" Number="83" Volume="1985" Year="1991">
-      <Id>13ebdf6f-ba98-4b4e-8f61-71f3ade5e3ed</Id>
+      <Database Name="cv" Series="3519" Issue="35015" />
     </Book>
     <Book Series="Spider-Man" Number="18" Volume="1990" Year="1992">
-      <Id>110562f4-5117-4472-9401-5bd737f0c5e4</Id>
+      <Database Name="cv" Series="4421" Issue="64620" />
     </Book>
     <Book Series="Spider-Man" Number="19" Volume="1990" Year="1992">
-      <Id>1cbbf730-87ad-44bd-a20a-995288540842</Id>
+      <Database Name="cv" Series="4421" Issue="64621" />
     </Book>
     <Book Series="Spider-Man" Number="20" Volume="1990" Year="1992">
-      <Id>158ac9ef-05d1-4c72-a91b-34b5a5bfff3a</Id>
+      <Database Name="cv" Series="4421" Issue="64622" />
     </Book>
     <Book Series="Spider-Man" Number="21" Volume="1990" Year="1992">
-      <Id>1ba06b99-ec02-4d5e-b3bf-730b1a151493</Id>
+      <Database Name="cv" Series="4421" Issue="64623" />
     </Book>
     <Book Series="Spider-Man" Number="22" Volume="1990" Year="1992">
-      <Id>381cd4dd-439b-4ea9-b3ce-3d2f804ff3c2</Id>
+      <Database Name="cv" Series="4421" Issue="64624" />
     </Book>
     <Book Series="Spider-Man" Number="23" Volume="1990" Year="1992">
-      <Id>0d5c4cfd-74e6-46ac-89f4-70490f6337ab</Id>
+      <Database Name="cv" Series="4421" Issue="64625" />
     </Book>
     <Book Series="Web of Spider-Man" Number="84" Volume="1985" Year="1992">
-      <Id>cb2806e4-a31b-4fd1-8b2f-370c1feed8db</Id>
+      <Database Name="cv" Series="3519" Issue="35272" />
     </Book>
     <Book Series="Web of Spider-Man" Number="85" Volume="1985" Year="1992">
-      <Id>ed3406c1-eec6-4c99-8c7b-b1f5d333864b</Id>
+      <Database Name="cv" Series="3519" Issue="35375" />
     </Book>
     <Book Series="Web of Spider-Man" Number="86" Volume="1985" Year="1992">
-      <Id>e1b97817-873f-437c-94c9-11adc7eea705</Id>
+      <Database Name="cv" Series="3519" Issue="35481" />
     </Book>
     <Book Series="Web of Spider-Man" Number="87" Volume="1985" Year="1992">
-      <Id>d1ac8d93-774c-44fc-bb7a-11a5e9c69dde</Id>
+      <Database Name="cv" Series="3519" Issue="35584" />
     </Book>
     <Book Series="Web of Spider-Man" Number="88" Volume="1985" Year="1992">
-      <Id>7b65604b-89e5-4b0e-bed6-488e249fb7b3</Id>
+      <Database Name="cv" Series="3519" Issue="35687" />
     </Book>
     <Book Series="Web of Spider-Man" Number="89" Volume="1985" Year="1992">
-      <Id>4574671e-9df0-4ff6-a8e8-25141eac9c5b</Id>
+      <Database Name="cv" Series="3519" Issue="35792" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="353" Volume="1963" Year="1991">
-      <Id>2f4aac57-37da-4dad-bf15-3ff088b8d176</Id>
+      <Database Name="cv" Series="2127" Issue="34871" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="354" Volume="1963" Year="1991">
-      <Id>4f7b582a-6cb8-4eb8-9a45-6f24e24a0fdf</Id>
+      <Database Name="cv" Series="2127" Issue="34930" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="355" Volume="1963" Year="1991">
-      <Id>076379d3-58ca-4ab8-82db-0497681bf212</Id>
+      <Database Name="cv" Series="2127" Issue="34993" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="356" Volume="1963" Year="1991">
-      <Id>8bb6815f-2417-4048-8b5d-3d1b4c8bba24</Id>
+      <Database Name="cv" Series="2127" Issue="35047" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="357" Volume="1963" Year="1992">
-      <Id>03586f87-b7f4-455a-8699-d526790367a5</Id>
+      <Database Name="cv" Series="2127" Issue="113266" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="358" Volume="1963" Year="1992">
-      <Id>6a7bccce-30e3-4679-baf9-f2bd081dc7e7</Id>
+      <Database Name="cv" Series="2127" Issue="113267" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="178" Volume="1976" Year="1991">
-      <Id>0687d84c-bbdd-4691-b11b-0f6d484d2a27</Id>
+      <Database Name="cv" Series="2870" Issue="65572" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="179" Volume="1976" Year="1991">
-      <Id>56b8b114-b3e6-4bf1-ae14-ac9300f7d873</Id>
+      <Database Name="cv" Series="2870" Issue="65573" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="180" Volume="1976" Year="1991">
-      <Id>5a5c01ff-4e3b-4185-a4af-9942c43b7762</Id>
+      <Database Name="cv" Series="2870" Issue="65574" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="181" Volume="1976" Year="1991">
-      <Id>9037aca2-8fc1-469b-84d8-3ea221f96f1b</Id>
+      <Database Name="cv" Series="2870" Issue="65575" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="182" Volume="1976" Year="1991">
-      <Id>c62201d1-6e22-4473-a7ba-608db347b124</Id>
+      <Database Name="cv" Series="2870" Issue="65576" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="183" Volume="1976" Year="1991">
-      <Id>8cd3e5f2-6892-4268-97f2-dfb12c71eea3</Id>
+      <Database Name="cv" Series="2870" Issue="65577" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="184" Volume="1976" Year="1992">
-      <Id>2ea8f351-74b4-4ad9-b387-006f54886595</Id>
+      <Database Name="cv" Series="2870" Issue="65578" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="185" Volume="1976" Year="1992">
-      <Id>5029c912-aa9b-4449-a6f9-3d4b97bd987b</Id>
+      <Database Name="cv" Series="2870" Issue="65579" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="359" Volume="1963" Year="1992">
-      <Id>5bbf1903-9157-4ceb-ae7b-b5f153ceadba</Id>
+      <Database Name="cv" Series="2127" Issue="64492" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="360" Volume="1963" Year="1992">
-      <Id>42c0618d-7fb4-4ddd-94ee-3c06eff0ffdb</Id>
+      <Database Name="cv" Series="2127" Issue="64493" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="186" Volume="1976" Year="1992">
-      <Id>b140f5b1-f959-4d80-b132-b68aecd2f64e</Id>
+      <Database Name="cv" Series="2870" Issue="65580" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="187" Volume="1976" Year="1992">
-      <Id>ad0690a8-3b60-4fe4-873e-83b3bf05a63f</Id>
+      <Database Name="cv" Series="2870" Issue="65581" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="188" Volume="1976" Year="1992">
-      <Id>aa5ab9dd-f103-46d4-a9ef-6666f40ff239</Id>
+      <Database Name="cv" Series="2870" Issue="65582" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="189" Volume="1976" Year="1992">
-      <Id>a97bf039-d444-4034-9ef8-d468e928fba9</Id>
+      <Database Name="cv" Series="2870" Issue="65583" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="190" Volume="1976" Year="1992">
-      <Id>2e674d62-7c40-4562-8761-884b078b47af</Id>
+      <Database Name="cv" Series="2870" Issue="65584" />
     </Book>
     <Book Series="Spider-Man: Fear Itself" Number="1" Volume="1992" Year="1992">
-      <Id>a7c313e3-bccb-4ee8-a797-134d661400e1</Id>
+      <Database Name="cv" Series="33873" Issue="220213" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="361" Volume="1963" Year="1992">
-      <Id>2818d86f-8b2c-45f7-aae9-60eba47b6b7b</Id>
+      <Database Name="cv" Series="2127" Issue="64494" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="362" Volume="1963" Year="1992">
-      <Id>afade355-ebe0-4417-a8e2-acd7b084a2e4</Id>
+      <Database Name="cv" Series="2127" Issue="64495" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="363" Volume="1963" Year="1992">
-      <Id>caecee3b-b2f6-47a6-b2dd-ff3c00249d1d</Id>
+      <Database Name="cv" Series="2127" Issue="64496" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="26" Volume="1964" Year="1992">
-      <Id>0a159601-bbeb-4ca4-9f37-82d2e71b02bc</Id>
+      <Database Name="cv" Series="2189" Issue="64430" />
     </Book>
     <Book Series="The Spectacular Spider-Man Annual" Number="12" Volume="1979" Year="1992">
-      <Id>c4410df4-27ac-489f-a894-ea36b1531bfe</Id>
+      <Database Name="cv" Series="3012" Issue="35171" />
     </Book>
     <Book Series="Web of Spider-Man Annual" Number="8" Volume="1985" Year="1992">
-      <Id>884df1fe-102f-4999-819f-3b6cf2b98f82</Id>
+      <Database Name="cv" Series="3520" Issue="77997" />
     </Book>
     <Book Series="Web of Spider-Man" Number="90" Volume="1985" Year="1992">
-      <Id>266286b2-4bab-4163-8456-04868238f57b</Id>
+      <Database Name="cv" Series="3519" Issue="35916" />
     </Book>
     <Book Series="The Infinity War" Number="1" Volume="1992" Year="1992">
-      <Id>59924df1-1d16-4945-b7b3-11026aa32400</Id>
+      <Database Name="cv" Series="4795" Issue="35783" />
     </Book>
     <Book Series="Spider-Man" Number="24" Volume="1990" Year="1992">
-      <Id>f327bf9e-c28a-4243-9df4-2fcb1124249f</Id>
+      <Database Name="cv" Series="4421" Issue="64626" />
     </Book>
     <Book Series="The Infinity War" Number="2" Volume="1992" Year="1992">
-      <Id>8cf0524d-bbdd-4b13-aeba-4a04f4fff951</Id>
+      <Database Name="cv" Series="4795" Issue="35907" />
     </Book>
     <Book Series="The Infinity War" Number="3" Volume="1992" Year="1992">
-      <Id>5383ed89-27b6-4caf-a0f2-3a1663f80876</Id>
+      <Database Name="cv" Series="4795" Issue="36025" />
     </Book>
     <Book Series="Spider-Man" Number="25" Volume="1990" Year="1992">
-      <Id>e4197d58-a262-4049-8a74-770a5d82a33a</Id>
+      <Database Name="cv" Series="4421" Issue="64627" />
     </Book>
     <Book Series="Spider-Man" Number="26" Volume="1990" Year="1992">
-      <Id>50ee60b5-303d-4e8f-94d6-8b4321115f7a</Id>
+      <Database Name="cv" Series="4421" Issue="64628" />
     </Book>
     <Book Series="The Amazing Spider-Man: Soul of the Hunter" Number="1" Volume="1992" Year="1992">
-      <Id>810d8117-fa7b-4374-af83-630f4d98ae98</Id>
+      <Database Name="cv" Series="29270" Issue="180862" />
     </Book>
     <Book Series="Web of Spider-Man" Number="91" Volume="1985" Year="1992">
-      <Id>93f2e6c9-8909-43ff-b3ac-8b6306a5ffee</Id>
+      <Database Name="cv" Series="3519" Issue="36033" />
     </Book>
     <Book Series="Web of Spider-Man" Number="92" Volume="1985" Year="1992">
-      <Id>fa087c0a-2749-48aa-b7a7-7d1cd32020f0</Id>
+      <Database Name="cv" Series="3519" Issue="36161" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="364" Volume="1963" Year="1992">
-      <Id>15e0e110-e893-4896-8555-06c24610d49f</Id>
+      <Database Name="cv" Series="2127" Issue="64497" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="365" Volume="1963" Year="1992">
-      <Id>1cbea70f-01a0-40a0-abc6-5d9f5ea8f477</Id>
+      <Database Name="cv" Series="2127" Issue="64498" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="366" Volume="1963" Year="1992">
-      <Id>96ae646c-51ee-47a7-8f5a-e05d746c8783</Id>
+      <Database Name="cv" Series="2127" Issue="36144" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="367" Volume="1963" Year="1992">
-      <Id>9485a70d-a3b3-451f-b40d-c90ebe8dcdb3</Id>
+      <Database Name="cv" Series="2127" Issue="64591" />
     </Book>
     <Book Series="Spider-Man/Dr. Strange: &quot;The Way to Dusty Death&quot;" Number="1" Volume="1992" Year="1992">
-      <Id>ec528b58-24c8-4ce8-be50-c93feabbcbec</Id>
+      <Database Name="cv" Series="31408" Issue="195705" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="191" Volume="1976" Year="1992">
-      <Id>12a3e2e8-247e-4893-8b12-a5bf35457d9d</Id>
+      <Database Name="cv" Series="2870" Issue="65585" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="192" Volume="1976" Year="1992">
-      <Id>c7249ee0-4fd4-4ae6-8d5f-d1e86bf3ad0f</Id>
+      <Database Name="cv" Series="2870" Issue="65586" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="193" Volume="1976" Year="1992">
-      <Id>ff32dfdc-8599-4986-81f8-84673c8972d8</Id>
+      <Database Name="cv" Series="2870" Issue="65587" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="194" Volume="1976" Year="1992">
-      <Id>1dbbf0d2-7034-4776-84b3-34c045c0ef46</Id>
+      <Database Name="cv" Series="2870" Issue="65588" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="195" Volume="1976" Year="1992">
-      <Id>6595677d-797c-4a27-ae46-549e6ebb6eb4</Id>
+      <Database Name="cv" Series="2870" Issue="65589" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="196" Volume="1976" Year="1993">
-      <Id>d6b2a748-5ca5-4298-a148-1c5691eccd72</Id>
+      <Database Name="cv" Series="2870" Issue="65590" />
     </Book>
     <Book Series="Web of Spider-Man" Number="93" Volume="1985" Year="1992">
-      <Id>0facaa38-ce6a-4b37-aaa0-452038a0facf</Id>
+      <Database Name="cv" Series="3519" Issue="36287" />
     </Book>
     <Book Series="Web of Spider-Man" Number="94" Volume="1985" Year="1992">
-      <Id>4e6c5d2b-65f0-408b-87a8-38587863c37c</Id>
+      <Database Name="cv" Series="3519" Issue="36411" />
     </Book>
     <Book Series="Web of Spider-Man" Number="95" Volume="1985" Year="1992">
-      <Id>ed2e5dee-a5dc-4f24-8bf8-4d4204f3569b</Id>
+      <Database Name="cv" Series="3519" Issue="36524" />
     </Book>
     <Book Series="Web of Spider-Man" Number="96" Volume="1985" Year="1993">
-      <Id>1ecd30a8-ee0d-4838-9f68-460f373136f1</Id>
+      <Database Name="cv" Series="3519" Issue="36768" />
     </Book>
     <Book Series="Ghost Rider/Blaze: Spirits of Vengeance" Number="6" Volume="1992" Year="1993">
-      <Id>656ba115-ffb7-4e43-bc1d-9d03be5d8d4a</Id>
+      <Database Name="cv" Series="4790" Issue="66525" />
     </Book>
     <Book Series="Spider-Man" Number="27" Volume="1990" Year="1992">
-      <Id>a565bc40-b210-41d4-aab3-eb439f5a1b80</Id>
+      <Database Name="cv" Series="4421" Issue="36284" />
     </Book>
     <Book Series="Spider-Man" Number="28" Volume="1990" Year="1992">
-      <Id>b584a99f-777b-4197-8fff-2805ae660c85</Id>
+      <Database Name="cv" Series="4421" Issue="36409" />
     </Book>
     <Book Series="Spider-Man" Number="29" Volume="1990" Year="1992">
-      <Id>1c74ccf6-4856-4b54-a0d3-84667f771173</Id>
+      <Database Name="cv" Series="4421" Issue="36522" />
     </Book>
     <Book Series="Spider-Man" Number="30" Volume="1990" Year="1993">
-      <Id>331ed03b-321a-4b87-8c4e-8634ca2865aa</Id>
+      <Database Name="cv" Series="4421" Issue="36766" />
     </Book>
     <Book Series="Spider-Man" Number="31" Volume="1990" Year="1993">
-      <Id>1ecd4403-bb5a-4297-a242-ea7a3600f0f2</Id>
+      <Database Name="cv" Series="4421" Issue="36869" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="368" Volume="1963" Year="1992">
-      <Id>df869827-3dae-4467-b6f9-22244ac6c417</Id>
+      <Database Name="cv" Series="2127" Issue="64592" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="369" Volume="1963" Year="1992">
-      <Id>31d60e6b-a255-4634-9857-d902d70fe37d</Id>
+      <Database Name="cv" Series="2127" Issue="64593" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="370" Volume="1963" Year="1992">
-      <Id>8cd4f5cf-f609-4f56-82bc-88150c8449c9</Id>
+      <Database Name="cv" Series="2127" Issue="64594" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="371" Volume="1963" Year="1992">
-      <Id>1ab7cdf2-5111-4b80-a4e4-117b860e4f0f</Id>
+      <Database Name="cv" Series="2127" Issue="64595" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="372" Volume="1963" Year="1993">
-      <Id>aa438c58-1714-42cd-ae73-f141066777e0</Id>
+      <Database Name="cv" Series="2127" Issue="64596" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="373" Volume="1963" Year="1993">
-      <Id>7be81e4c-eccf-4997-8039-f2abeb0a1b76</Id>
+      <Database Name="cv" Series="2127" Issue="64597" />
     </Book>
     <Book Series="Spider-Man Special Edition" Number="1" Volume="1992" Year="1992">
-      <Id>76a4b638-65da-4bb6-a6c6-9aea9742dcb6</Id>
+      <Database Name="cv" Series="21781" Issue="131350" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="374" Volume="1963" Year="1993">
-      <Id>40ad9c56-7443-4bf4-a9e3-5c666cd4493e</Id>
+      <Database Name="cv" Series="2127" Issue="64598" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="375" Volume="1963" Year="1993">
-      <Id>e7a0b56b-2cfe-453e-b2df-d7f33b62c467</Id>
+      <Database Name="cv" Series="2127" Issue="64599" />
     </Book>
     <Book Series="Spider-Man, Punisher, Sabretooth: Designer Genes" Number="1" Volume="1993" Year="1993">
-      <Id>a78ae9fd-b580-4819-8f78-4eb3e9cec103</Id>
+      <Database Name="cv" Series="18432" Issue="108126" />
     </Book>
     <Book Series="Venom: Lethal Protector" Number="1" Volume="1993" Year="1993">
-      <Id>869e76b4-8a1a-4249-80fd-1d1e352926fe</Id>
+      <Database Name="cv" Series="5059" Issue="57641" />
     </Book>
     <Book Series="Venom: Lethal Protector" Number="2" Volume="1993" Year="1993">
-      <Id>0c2bd2ba-3d11-49b0-8834-68b10e7ad616</Id>
+      <Database Name="cv" Series="5059" Issue="57642" />
     </Book>
     <Book Series="Venom: Lethal Protector" Number="3" Volume="1993" Year="1993">
-      <Id>cf51d6a0-b095-4ec7-a145-6a55fbd1006c</Id>
+      <Database Name="cv" Series="5059" Issue="57643" />
     </Book>
     <Book Series="Venom: Lethal Protector" Number="4" Volume="1993" Year="1993">
-      <Id>7cd5dbdb-8ec0-4ab0-9bf0-55615b3662f2</Id>
+      <Database Name="cv" Series="5059" Issue="57644" />
     </Book>
     <Book Series="Venom: Lethal Protector" Number="5" Volume="1993" Year="1993">
-      <Id>5ff74b87-dae7-403a-904b-60751bfd111b</Id>
+      <Database Name="cv" Series="5059" Issue="57645" />
     </Book>
     <Book Series="Venom: Lethal Protector" Number="6" Volume="1993" Year="1993">
-      <Id>7bb2893a-ea1c-4167-893a-e71b2f92fa3c</Id>
+      <Database Name="cv" Series="5059" Issue="57646" />
     </Book>
     <Book Series="Web of Spider-Man" Number="97" Volume="1985" Year="1993">
-      <Id>c0e43723-f4ba-4f9b-afcf-f2bc82a62c7b</Id>
+      <Database Name="cv" Series="3519" Issue="36871" />
     </Book>
     <Book Series="Web of Spider-Man" Number="98" Volume="1985" Year="1993">
-      <Id>58f338b3-936c-4b40-b177-02841915868d</Id>
+      <Database Name="cv" Series="3519" Issue="36984" />
     </Book>
     <Book Series="Web of Spider-Man" Number="99" Volume="1985" Year="1993">
-      <Id>43063936-e6ad-4112-9747-29aa04872ed9</Id>
+      <Database Name="cv" Series="3519" Issue="37103" />
     </Book>
     <Book Series="Web of Spider-Man" Number="100" Volume="1985" Year="1993">
-      <Id>f43fcf8a-8469-4f38-9959-54e959f0d57f</Id>
+      <Database Name="cv" Series="3519" Issue="37241" />
     </Book>
     <Book Series="Spider-Man" Number="32" Volume="1990" Year="1993">
-      <Id>257445f1-eb1a-4e19-ab3e-a31720bc4be1</Id>
+      <Database Name="cv" Series="4421" Issue="106440" />
     </Book>
     <Book Series="Spider-Man" Number="33" Volume="1990" Year="1993">
-      <Id>f85895e5-e473-44b1-91d6-83d378c7ac58</Id>
+      <Database Name="cv" Series="4421" Issue="37099" />
     </Book>
     <Book Series="Spider-Man" Number="34" Volume="1990" Year="1993">
-      <Id>007c61a9-ea7e-4249-a58e-3da122fe8a71</Id>
+      <Database Name="cv" Series="4421" Issue="37237" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="376" Volume="1963" Year="1993">
-      <Id>dac3c090-9672-4521-8260-e1220e3d0623</Id>
+      <Database Name="cv" Series="2127" Issue="37134" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="377" Volume="1963" Year="1993">
-      <Id>f105ba9f-50f2-4da1-9284-46eb2fee5d16</Id>
+      <Database Name="cv" Series="2127" Issue="37272" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="27" Volume="1964" Year="1993">
-      <Id>f9bbca21-9618-491f-9f05-7d203e7055d5</Id>
+      <Database Name="cv" Series="2189" Issue="64431" />
     </Book>
     <Book Series="Fantastic Four" Number="374" Volume="1961" Year="1993">
-      <Id>1d3e5377-27fc-4654-8037-e9e931841e60</Id>
+      <Database Name="cv" Series="2045" Issue="77551" />
     </Book>
     <Book Series="Fantastic Four" Number="375" Volume="1961" Year="1993">
-      <Id>e4b59047-93c2-4930-9f66-fa563c5133e3</Id>
+      <Database Name="cv" Series="2045" Issue="77552" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="197" Volume="1976" Year="1993">
-      <Id>f58345f2-ae1e-4996-9cdd-0f6ea81fbd3b</Id>
+      <Database Name="cv" Series="2870" Issue="65591" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="198" Volume="1976" Year="1993">
-      <Id>2ea0e18a-8ff7-4f35-b422-0ca9abe34266</Id>
+      <Database Name="cv" Series="2870" Issue="65592" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="199" Volume="1976" Year="1993">
-      <Id>75c202ea-6c90-4501-9452-7f9e84668539</Id>
+      <Database Name="cv" Series="2870" Issue="65593" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="200" Volume="1976" Year="1993">
-      <Id>5421a0d7-c86f-40c0-b442-19ff09c51b85</Id>
+      <Database Name="cv" Series="2870" Issue="65594" />
     </Book>
     <Book Series="Web of Spider-Man Annual" Number="9" Volume="1985" Year="1993">
-      <Id>d92387d5-b468-423b-87e5-6f6ac650cf8b</Id>
+      <Database Name="cv" Series="3520" Issue="77998" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="1" Volume="1993" Year="1993">
-      <Id>1f8f393a-4801-4b90-92e2-df05cd7a2679</Id>
+      <Database Name="cv" Series="5048" Issue="57288" />
     </Book>
     <Book Series="Web of Spider-Man" Number="101" Volume="1985" Year="1993">
-      <Id>089a8091-293e-4282-9270-7097c00b9650</Id>
+      <Database Name="cv" Series="3519" Issue="37378" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="378" Volume="1963" Year="1993">
-      <Id>ec777331-1fb6-41fa-9972-65faf3d62f0b</Id>
+      <Database Name="cv" Series="2127" Issue="37416" />
     </Book>
     <Book Series="Spider-Man" Number="35" Volume="1990" Year="1993">
-      <Id>cf67ec48-995b-4244-b7fb-ce77c5c3d179</Id>
+      <Database Name="cv" Series="4421" Issue="37374" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="201" Volume="1976" Year="1993">
-      <Id>c0471964-0bb3-4562-a481-c82470ad4853</Id>
+      <Database Name="cv" Series="2870" Issue="65595" />
     </Book>
     <Book Series="Web of Spider-Man" Number="102" Volume="1985" Year="1993">
-      <Id>26e71d3a-a141-4385-b39f-61097cfc642a</Id>
+      <Database Name="cv" Series="3519" Issue="37530" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="379" Volume="1963" Year="1993">
-      <Id>65452b42-7b15-4f7b-a16c-feed7ccee2a0</Id>
+      <Database Name="cv" Series="2127" Issue="37565" />
     </Book>
     <Book Series="Spider-Man" Number="36" Volume="1990" Year="1993">
-      <Id>57cea88d-2d28-4bcc-909c-ad4dcbe8c290</Id>
+      <Database Name="cv" Series="4421" Issue="37526" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="202" Volume="1976" Year="1993">
-      <Id>48c5dc87-7a5b-480e-94a5-46ff2e83772b</Id>
+      <Database Name="cv" Series="2870" Issue="65596" />
     </Book>
     <Book Series="Web of Spider-Man" Number="103" Volume="1985" Year="1993">
-      <Id>5461c499-539b-43f4-99c9-db00139de999</Id>
+      <Database Name="cv" Series="3519" Issue="37672" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="380" Volume="1963" Year="1993">
-      <Id>e884b63a-faeb-475e-9292-10f11658001f</Id>
+      <Database Name="cv" Series="2127" Issue="37703" />
     </Book>
     <Book Series="Spider-Man" Number="37" Volume="1990" Year="1993">
-      <Id>f57621fa-b1c4-433e-9200-e5cca26c92cd</Id>
+      <Database Name="cv" Series="4421" Issue="37668" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="203" Volume="1976" Year="1993">
-      <Id>847ef62f-ab10-457d-ba86-280275f4c338</Id>
+      <Database Name="cv" Series="2870" Issue="65597" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="2" Volume="1993" Year="1993">
-      <Id>51ff4f04-c12c-40fe-b814-27875042c85f</Id>
+      <Database Name="cv" Series="5048" Issue="57289" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Spider-Man/Spider-Man 004 (Venomous).cbl
+++ b/Marvel/Characters/unsorted/Spider-Man/Spider-Man 004 (Venomous).cbl
@@ -2,937 +2,937 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Spider-Man 4 (Venomous)</Name>
   <Books>
-    <Book Series="The Amazing Spider-Man" Number="296" Volume="1963" Year="1988" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="296" Volume="1963" Year="1988">
       <Id>5d756d30-b868-4856-ab5c-c12310f46258</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="297" Volume="1963" Year="1988" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="297" Volume="1963" Year="1988">
       <Id>00c56823-14db-4b69-ad04-dcec06b15715</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="35" Volume="1985" Year="1988" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="35" Volume="1985" Year="1988">
       <Id>56ced775-43a9-4d40-8576-6071a217801d</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="36" Volume="1985" Year="1988" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="36" Volume="1985" Year="1988">
       <Id>9d1056dd-7566-4941-93ae-996ca463677e</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="134" Volume="1976" Year="1988" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="134" Volume="1976" Year="1988">
       <Id>ea792877-c2d8-4173-b41e-665b946a2c35</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="135" Volume="1976" Year="1988" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="135" Volume="1976" Year="1988">
       <Id>7196434f-b290-4ca3-9031-53f88970e55b</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="136" Volume="1976" Year="1988" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="136" Volume="1976" Year="1988">
       <Id>77226462-4212-4c36-bf5d-e6dc533af953</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="37" Volume="1985" Year="1988" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="37" Volume="1985" Year="1988">
       <Id>b4737e53-7609-4bd6-b1da-926b1a5a5e94</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="137" Volume="1976" Year="1988" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="137" Volume="1976" Year="1988">
       <Id>436be8a9-7209-4692-932f-ef59078a6f4a</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="38" Volume="1985" Year="1988" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="38" Volume="1985" Year="1988">
       <Id>1a927612-6693-4315-8fbc-a911b02ced9e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="298" Volume="1963" Year="1988" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="298" Volume="1963" Year="1988">
       <Id>ada96e4c-09a3-4c76-9bb7-4b15c47f0ab6</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="299" Volume="1963" Year="1988" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="299" Volume="1963" Year="1988">
       <Id>ada1c729-aca3-4d6c-89ea-e6051b02238b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="300" Volume="1963" Year="1988" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="300" Volume="1963" Year="1988">
       <Id>30f309b8-52d4-4be8-8ed4-7a178d3fa919</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="138" Volume="1976" Year="1988" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="138" Volume="1976" Year="1988">
       <Id>87087452-344d-4e29-84c2-bb81061283cc</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="39" Volume="1985" Year="1988" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="39" Volume="1985" Year="1988">
       <Id>ca626b3d-af24-474f-ba22-8d6140a5cee9</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="301" Volume="1963" Year="1988" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="301" Volume="1963" Year="1988">
       <Id>8066b610-c2c6-4677-8858-79c5b861f2ff</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="302" Volume="1963" Year="1988" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="302" Volume="1963" Year="1988">
       <Id>6f9c3987-87f7-4014-832e-5e0d14ca3326</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="303" Volume="1963" Year="1988" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="303" Volume="1963" Year="1988">
       <Id>284e2923-f796-42eb-b69f-d4e447755d31</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="139" Volume="1976" Year="1988" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="139" Volume="1976" Year="1988">
       <Id>205a54d4-cbbc-4775-82a9-5aa8d866d238</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="140" Volume="1976" Year="1988" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="140" Volume="1976" Year="1988">
       <Id>d5b71a01-e799-41e1-981e-a432c1a8ef40</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="141" Volume="1976" Year="1988" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="141" Volume="1976" Year="1988">
       <Id>8a7d0c12-7a64-4333-b393-4e66c86ee2d0</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="142" Volume="1976" Year="1988" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="142" Volume="1976" Year="1988">
       <Id>1c81103d-3a47-4d72-9812-19b0130f0efd</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="40" Volume="1985" Year="1988" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="40" Volume="1985" Year="1988">
       <Id>d8be9b30-effd-4fe3-98b2-16c337915454</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="41" Volume="1985" Year="1988" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="41" Volume="1985" Year="1988">
       <Id>a61eb71f-0fb2-4e12-ba78-f299e860e5a7</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="42" Volume="1985" Year="1988" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="42" Volume="1985" Year="1988">
       <Id>0afd6bf1-afb1-4dcb-a2d3-05a1a0ecfc99</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="43" Volume="1985" Year="1988" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="43" Volume="1985" Year="1988">
       <Id>51e06bea-df0e-4055-809c-cc028a710b60</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="22" Volume="1964" Year="1988" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="22" Volume="1964" Year="1988">
       <Id>4a64cc0a-b6ce-468a-a2fb-2679c8a1f89f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="304" Volume="1963" Year="1988" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="304" Volume="1963" Year="1988">
       <Id>a3c1939a-200a-4875-8092-45e75555db20</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="305" Volume="1963" Year="1988" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="305" Volume="1963" Year="1988">
       <Id>dbe19330-467f-4f6f-bee2-4add1811379c</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="306" Volume="1963" Year="1988" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="306" Volume="1963" Year="1988">
       <Id>67f081ab-1215-42fa-8069-b61513fd88e8</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="307" Volume="1963" Year="1988" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="307" Volume="1963" Year="1988">
       <Id>dab30fba-ee6a-4b4b-9470-eb65ba4bcc73</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="308" Volume="1963" Year="1988" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="308" Volume="1963" Year="1988">
       <Id>a9bc88a9-8fea-453b-8806-528d86115bc9</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="309" Volume="1963" Year="1988" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="309" Volume="1963" Year="1988">
       <Id>4b6d2c45-4fec-46a6-9145-2b060d55551a</Id>
     </Book>
-    <Book Series="Web of Spider-Man Annual" Number="4" Volume="1985" Year="1988" Format="Annual">
+    <Book Series="Web of Spider-Man Annual" Number="4" Volume="1985" Year="1988">
       <Id>e668be42-6a3f-446f-8cb3-f215b203d50c</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="143" Volume="1976" Year="1988" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="143" Volume="1976" Year="1988">
       <Id>e50fec55-0a3f-4b02-b0eb-b7c88e65a49d</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="44" Volume="1985" Year="1988" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="44" Volume="1985" Year="1988">
       <Id>32340d79-4ef4-464a-89f4-76ae96f0e6cf</Id>
     </Book>
-    <Book Series="The Incredible Hulk" Number="349" Volume="1968" Year="1988" Format="Main Series">
+    <Book Series="The Incredible Hulk" Number="349" Volume="1968" Year="1988">
       <Id>064119b8-a2bf-4afa-a3a2-e2daeabf6f59</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="45" Volume="1985" Year="1988" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="45" Volume="1985" Year="1988">
       <Id>be1abc72-a069-4e3d-9bc3-c042f8317cec</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man Annual" Number="8" Volume="1979" Year="1988" Format="Annual">
+    <Book Series="The Spectacular Spider-Man Annual" Number="8" Volume="1979" Year="1988">
       <Id>bae610b1-a775-4546-ae78-59b4984df9dc</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="144" Volume="1976" Year="1988" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="144" Volume="1976" Year="1988">
       <Id>f4cd4278-fe3b-47a4-8950-1a59370bda7f</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="145" Volume="1976" Year="1988" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="145" Volume="1976" Year="1988">
       <Id>64c560cc-cc64-4896-8726-57bad3653771</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="310" Volume="1963" Year="1988" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="310" Volume="1963" Year="1988">
       <Id>4f841a22-059d-4baf-8881-a26fd0f099f7</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="46" Volume="1985" Year="1989" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="46" Volume="1985" Year="1989">
       <Id>ac294a5a-c141-4a41-a897-58aa990c5ecf</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="311" Volume="1963" Year="1989" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="311" Volume="1963" Year="1989">
       <Id>d384f6c2-452c-4a85-8935-7d8779d6119c</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="146" Volume="1976" Year="1989" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="146" Volume="1976" Year="1989">
       <Id>b531002f-a72e-4238-b0c5-c7b5cfa8509d</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="47" Volume="1985" Year="1989" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="47" Volume="1985" Year="1989">
       <Id>85272668-d114-494d-aacc-96dff0c1bcad</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="312" Volume="1963" Year="1989" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="312" Volume="1963" Year="1989">
       <Id>e2cd30dd-5d43-42da-b0a6-db4382547eb5</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="147" Volume="1976" Year="1989" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="147" Volume="1976" Year="1989">
       <Id>6d4973f3-b683-4d08-a64c-5532e5794d32</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="48" Volume="1985" Year="1989" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="48" Volume="1985" Year="1989">
       <Id>4c14a05c-bcbc-47d5-a91b-08eceb549be8</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="313" Volume="1963" Year="1989" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="313" Volume="1963" Year="1989">
       <Id>61ae07d2-2139-4ede-b9cc-eb76165af013</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="148" Volume="1976" Year="1989" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="148" Volume="1976" Year="1989">
       <Id>b1215b15-809c-4170-9db3-9d1d9c144043</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="49" Volume="1985" Year="1989" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="49" Volume="1985" Year="1989">
       <Id>07d5039b-13b8-447d-8dad-35acdef25f0e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="314" Volume="1963" Year="1989" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="314" Volume="1963" Year="1989">
       <Id>35d75b2c-8d6e-47ba-b9fb-426d14c0fdf7</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="149" Volume="1976" Year="1989" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="149" Volume="1976" Year="1989">
       <Id>f0aa624a-1a88-41de-9daf-078f7ab5b97a</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="50" Volume="1985" Year="1989" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="50" Volume="1985" Year="1989">
       <Id>268f009f-94d1-4a3b-a784-a330ea4fa18f</Id>
     </Book>
-    <Book Series="Spider-Man: Spirits of the Earth" Number="1" Volume="1990" Year="1990" Format="One-Shot">
+    <Book Series="Spider-Man: Spirits of the Earth" Number="1" Volume="1990" Year="1990">
       <Id>45c2657d-5a64-490c-886d-dcafa41ef435</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="315" Volume="1963" Year="1989" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="315" Volume="1963" Year="1989">
       <Id>d0e3836e-4af2-4a46-aa28-880d75b440ba</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="150" Volume="1976" Year="1989" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="150" Volume="1976" Year="1989">
       <Id>c3d8b8e7-a931-4378-9211-cbaaf531b1dc</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="51" Volume="1985" Year="1989" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="51" Volume="1985" Year="1989">
       <Id>ea06724b-cad5-445e-b061-d8d5e3fc22b7</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="316" Volume="1963" Year="1989" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="316" Volume="1963" Year="1989">
       <Id>8edefe11-a8b4-46f0-8030-c4a408ba7c50</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="317" Volume="1963" Year="1989" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="317" Volume="1963" Year="1989">
       <Id>ef076a57-1a30-45e5-bbcf-6b4f91a6dad8</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="151" Volume="1976" Year="1989" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="151" Volume="1976" Year="1989">
       <Id>df16afe5-9933-40fe-8fe0-80a10ae1520b</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="52" Volume="1985" Year="1989" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="52" Volume="1985" Year="1989">
       <Id>42d6611b-c7cf-4269-af3c-37e089c7dfb8</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="318" Volume="1963" Year="1989" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="318" Volume="1963" Year="1989">
       <Id>92ced8a9-ae60-4b6f-a022-7b61bef24723</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="319" Volume="1963" Year="1989" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="319" Volume="1963" Year="1989">
       <Id>3ac48c7e-acac-4734-b46c-25d90504b6cc</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="152" Volume="1976" Year="1989" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="152" Volume="1976" Year="1989">
       <Id>a41d94aa-d029-45e7-a090-e1a647393789</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="53" Volume="1985" Year="1989" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="53" Volume="1985" Year="1989">
       <Id>307886df-bc95-4422-bf06-9b216cf64d70</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="153" Volume="1976" Year="1989" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="153" Volume="1976" Year="1989">
       <Id>cfffe42b-eafd-4079-b5d7-b2ab902edc69</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="54" Volume="1985" Year="1989" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="54" Volume="1985" Year="1989">
       <Id>92845c6f-08df-46bf-b4e7-d9355799411e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="23" Volume="1964" Year="1989" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="23" Volume="1964" Year="1989">
       <Id>c63ae719-12e4-4eb0-bc5b-772a2f864add</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man Annual" Number="9" Volume="1979" Year="1989" Format="Annual">
+    <Book Series="The Spectacular Spider-Man Annual" Number="9" Volume="1979" Year="1989">
       <Id>965dc48c-d57e-46e0-b3f0-dc99c881ac39</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="320" Volume="1963" Year="1989" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="320" Volume="1963" Year="1989">
       <Id>5d933da5-9d97-486c-a66c-7a5eb6f4c1f3</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="154" Volume="1976" Year="1989" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="154" Volume="1976" Year="1989">
       <Id>8720b7b5-a717-4bb5-b707-f8f381c888db</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="55" Volume="1985" Year="1989" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="55" Volume="1985" Year="1989">
       <Id>466a93cd-833b-48ce-8d9f-a75d3b864c4c</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="321" Volume="1963" Year="1989" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="321" Volume="1963" Year="1989">
       <Id>b67acc5a-4671-4401-b411-2c7636948c5a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="322" Volume="1963" Year="1989" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="322" Volume="1963" Year="1989">
       <Id>539f0645-5aee-44e0-b710-d8eedb254872</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="323" Volume="1963" Year="1989" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="323" Volume="1963" Year="1989">
       <Id>d09f11b4-67c0-492d-afcb-fc6ddc9cdfe9</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="324" Volume="1963" Year="1989" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="324" Volume="1963" Year="1989">
       <Id>47e2e6b0-051b-41cd-9475-8c681a796c2a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="325" Volume="1963" Year="1989" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="325" Volume="1963" Year="1989">
       <Id>8bb76b6d-f714-4de8-a518-1298162f4c39</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="155" Volume="1976" Year="1989" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="155" Volume="1976" Year="1989">
       <Id>87dabd0f-8908-40d3-a098-a786c0949a93</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="156" Volume="1976" Year="1989" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="156" Volume="1976" Year="1989">
       <Id>511e0014-a9da-47e6-b41e-434d262591ab</Id>
     </Book>
-    <Book Series="Web of Spider-Man Annual" Number="5" Volume="1985" Year="1989" Format="Annual">
+    <Book Series="Web of Spider-Man Annual" Number="5" Volume="1985" Year="1989">
       <Id>5af0bf28-70d5-47e1-9239-74db6a8efaa0</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="56" Volume="1985" Year="1989" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="56" Volume="1985" Year="1989">
       <Id>95c4b2d0-b55b-4466-965d-b078eeb002a8</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="57" Volume="1985" Year="1989" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="57" Volume="1985" Year="1989">
       <Id>7422b724-b7a2-4e37-8167-62614a152dc5</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="157" Volume="1976" Year="1989" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="157" Volume="1976" Year="1989">
       <Id>0205d888-7977-4a75-801b-6e589afaa7e6</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="58" Volume="1985" Year="1989" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="58" Volume="1985" Year="1989">
       <Id>951f88ad-80cc-4ccc-9255-d524cf08091e</Id>
     </Book>
-    <Book Series="Amazing Spider-Man: Parallel Lives" Number="1" Volume="2012" Year="2012" Format="One-Shot">
+    <Book Series="Amazing Spider-Man: Parallel Lives" Number="1" Volume="2012" Year="2012">
       <Id>ae725b69-b4f4-4cc2-ae31-17930565ffeb</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="326" Volume="1963" Year="1989" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="326" Volume="1963" Year="1989">
       <Id>b06c9ae8-5766-41ef-b30c-cac21072c184</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="158" Volume="1976" Year="1989" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="158" Volume="1976" Year="1989">
       <Id>001f9f61-5449-4503-93d1-75f96a6e7c15</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="59" Volume="1985" Year="1989" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="59" Volume="1985" Year="1989">
       <Id>928c47c9-76f1-4118-b8e4-0e36fe574ad7</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="327" Volume="1963" Year="1989" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="327" Volume="1963" Year="1989">
       <Id>894f8080-0e9a-40a1-a8d7-d1d1277c2a2c</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="159" Volume="1976" Year="1989" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="159" Volume="1976" Year="1989">
       <Id>f1e63045-ccde-4daa-b1fd-d18186bc5cda</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="60" Volume="1985" Year="1990" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="60" Volume="1985" Year="1990">
       <Id>b8ff33c3-8133-4994-ac2c-b6a95d93d5da</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="328" Volume="1963" Year="1990" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="328" Volume="1963" Year="1990">
       <Id>2030fc16-b582-46d8-b53a-b13a36dcdc00</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="160" Volume="1976" Year="1990" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="160" Volume="1976" Year="1990">
       <Id>b1469029-4a48-4b26-8ecd-c9639e98e21f</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="61" Volume="1985" Year="1990" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="61" Volume="1985" Year="1990">
       <Id>6cc0be2a-dfc8-4bc4-bdab-8bb6494c4a7e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="329" Volume="1963" Year="1990" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="329" Volume="1963" Year="1990">
       <Id>d96463d7-9ef3-4181-add2-c6671e4b84a9</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="161" Volume="1976" Year="1990" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="161" Volume="1976" Year="1990">
       <Id>d6e6a296-17a4-4fa4-a9c2-9eeb2432ee9f</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="62" Volume="1985" Year="1990" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="62" Volume="1985" Year="1990">
       <Id>778ef7b4-435d-4afd-8692-04791f946901</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="330" Volume="1963" Year="1990" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="330" Volume="1963" Year="1990">
       <Id>8e09c3df-9d8b-43c9-bb2a-07dd02d4bf6e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="331" Volume="1963" Year="1990" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="331" Volume="1963" Year="1990">
       <Id>a010f2a1-07f3-4afd-9c05-ce6dcc154f47</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="332" Volume="1963" Year="1990" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="332" Volume="1963" Year="1990">
       <Id>257aa295-e31d-4950-b824-052beb0d21d1</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="333" Volume="1963" Year="1990" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="333" Volume="1963" Year="1990">
       <Id>0d8c469c-36aa-4da3-a888-48472c56b7b7</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="24" Volume="1964" Year="1990" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="24" Volume="1964" Year="1990">
       <Id>84328ff2-aa42-4d69-8de6-73650d6fd4f9</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man Annual" Number="10" Volume="1979" Year="1990" Format="Annual">
+    <Book Series="The Spectacular Spider-Man Annual" Number="10" Volume="1979" Year="1990">
       <Id>104da0c0-a9fa-49fd-ac5b-18b1ef8f9878</Id>
     </Book>
-    <Book Series="Web of Spider-Man Annual" Number="6" Volume="1985" Year="1990" Format="Annual">
+    <Book Series="Web of Spider-Man Annual" Number="6" Volume="1985" Year="1990">
       <Id>f9230bd1-1ae2-48b0-8adc-ee8a8e71b7aa</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="63" Volume="1985" Year="1990" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="63" Volume="1985" Year="1990">
       <Id>ae385bd2-5efd-4bc2-aa3a-28e4be198b04</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="162" Volume="1976" Year="1990" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="162" Volume="1976" Year="1990">
       <Id>707049f3-ae97-4f60-ba70-ba1436d136d6</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="163" Volume="1976" Year="1990" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="163" Volume="1976" Year="1990">
       <Id>757cff27-34ed-4761-b6d8-2ddcee03c8b3</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="164" Volume="1976" Year="1990" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="164" Volume="1976" Year="1990">
       <Id>fdbef2f7-74eb-4d64-8f6d-deeea3bd479d</Id>
     </Book>
-    <Book Series="The Avengers" Number="314" Volume="1963" Year="1990" Format="Main Series">
+    <Book Series="The Avengers" Number="314" Volume="1963" Year="1990">
       <Id>2bc38271-0696-4bf9-91eb-c113c83198c6</Id>
     </Book>
-    <Book Series="The Avengers" Number="315" Volume="1963" Year="1990" Format="Main Series">
+    <Book Series="The Avengers" Number="315" Volume="1963" Year="1990">
       <Id>c311c602-1890-40bb-b0e2-83160944ad23</Id>
     </Book>
-    <Book Series="The Avengers" Number="316" Volume="1963" Year="1990" Format="Main Series">
+    <Book Series="The Avengers" Number="316" Volume="1963" Year="1990">
       <Id>b92b3f18-a197-40b4-a0b9-b64daa20cba8</Id>
     </Book>
-    <Book Series="The Avengers" Number="317" Volume="1963" Year="1990" Format="Main Series">
+    <Book Series="The Avengers" Number="317" Volume="1963" Year="1990">
       <Id>ba677782-daf4-49cb-bda1-02d13c358383</Id>
     </Book>
-    <Book Series="The Avengers" Number="318" Volume="1963" Year="1990" Format="Main Series">
+    <Book Series="The Avengers" Number="318" Volume="1963" Year="1990">
       <Id>e6535320-7ad6-4f81-8493-4b4007fb6125</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="334" Volume="1963" Year="1990" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="334" Volume="1963" Year="1990">
       <Id>07bbb5de-aa27-4521-ba84-33eb8bea97a4</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="335" Volume="1963" Year="1990" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="335" Volume="1963" Year="1990">
       <Id>06bcab42-79bd-413b-8cd1-50c5bb786ef1</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="336" Volume="1963" Year="1990" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="336" Volume="1963" Year="1990">
       <Id>761e760e-09c7-4c13-81ad-d095a46d2aa3</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="337" Volume="1963" Year="1990" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="337" Volume="1963" Year="1990">
       <Id>6e0add08-a280-430f-a6ee-b45bb05ccc52</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="338" Volume="1963" Year="1990" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="338" Volume="1963" Year="1990">
       <Id>660ef118-39bd-45db-a2cb-97af20299e31</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="339" Volume="1963" Year="1990" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="339" Volume="1963" Year="1990">
       <Id>69a5c7e2-2eee-48b1-a3a3-cfab1649c5e4</Id>
     </Book>
-    <Book Series="Spider-Man" Number="1" Volume="1990" Year="1990" Format="Main Series">
+    <Book Series="Spider-Man" Number="1" Volume="1990" Year="1990">
       <Id>1c0d95b2-dd92-404b-853b-125bae48d584</Id>
     </Book>
-    <Book Series="Spider-Man" Number="2" Volume="1990" Year="1990" Format="Main Series">
+    <Book Series="Spider-Man" Number="2" Volume="1990" Year="1990">
       <Id>011a2ad0-3c8c-4010-ad21-ca2b8ffc5fd3</Id>
     </Book>
-    <Book Series="Spider-Man" Number="3" Volume="1990" Year="1990" Format="Main Series">
+    <Book Series="Spider-Man" Number="3" Volume="1990" Year="1990">
       <Id>4696557d-6769-4808-ad92-56fa41795d6b</Id>
     </Book>
-    <Book Series="Spider-Man" Number="4" Volume="1990" Year="1990" Format="Main Series">
+    <Book Series="Spider-Man" Number="4" Volume="1990" Year="1990">
       <Id>eecf1403-1539-40c3-a46a-ec13255711bd</Id>
     </Book>
-    <Book Series="Spider-Man" Number="5" Volume="1990" Year="1990" Format="Main Series">
+    <Book Series="Spider-Man" Number="5" Volume="1990" Year="1990">
       <Id>5dd11e4f-a26f-43f0-a1b9-defb6c4b5063</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="64" Volume="1985" Year="1990" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="64" Volume="1985" Year="1990">
       <Id>62e065c3-484b-4a44-b0b2-60e6ea78133c</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="65" Volume="1985" Year="1990" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="65" Volume="1985" Year="1990">
       <Id>346e2c9a-9c4e-42bd-ac5e-dd2f9277eea0</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="165" Volume="1976" Year="1990" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="165" Volume="1976" Year="1990">
       <Id>a708eee9-0f0a-4033-98e6-4a5d41d5129d</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="166" Volume="1976" Year="1990" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="166" Volume="1976" Year="1990">
       <Id>c49ff2fc-282b-4582-b5e9-74be285a7f10</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="167" Volume="1976" Year="1990" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="167" Volume="1976" Year="1990">
       <Id>667ea7db-1554-48c7-91b1-5d744b1882ed</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="66" Volume="1985" Year="1990" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="66" Volume="1985" Year="1990">
       <Id>d671df0e-390e-45e2-801d-43a277368f4a</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="67" Volume="1985" Year="1990" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="67" Volume="1985" Year="1990">
       <Id>a14b04cc-d9e1-442f-a9bc-3503d44dfa3a</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="68" Volume="1985" Year="1990" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="68" Volume="1985" Year="1990">
       <Id>29c62ba3-65d1-4719-a988-04af6d70f707</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="69" Volume="1985" Year="1990" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="69" Volume="1985" Year="1990">
       <Id>6b0dff06-f375-494d-8fa6-d1e304629eb0</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="70" Volume="1985" Year="1990" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="70" Volume="1985" Year="1990">
       <Id>7704adf1-d0fa-4cfe-8890-26d2e1c09f36</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="168" Volume="1976" Year="1990" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="168" Volume="1976" Year="1990">
       <Id>15eccf5a-89d1-473c-8549-4d0dd2e09578</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="169" Volume="1976" Year="1990" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="169" Volume="1976" Year="1990">
       <Id>85cb823f-46d4-44b5-bec9-e90c5df9738c</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="170" Volume="1976" Year="1990" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="170" Volume="1976" Year="1990">
       <Id>6707fd94-a26d-4074-9f26-4c94162401fe</Id>
     </Book>
-    <Book Series="Deadly Foes of Spider-Man" Number="1" Volume="1991" Year="1991" Format="Limited Series">
+    <Book Series="Deadly Foes of Spider-Man" Number="1" Volume="1991" Year="1991">
       <Id>0db8dfab-ba88-4936-acbb-051358b11a6b</Id>
     </Book>
-    <Book Series="Deadly Foes of Spider-Man" Number="2" Volume="1991" Year="1991" Format="Limited Series">
+    <Book Series="Deadly Foes of Spider-Man" Number="2" Volume="1991" Year="1991">
       <Id>daf01a8d-3e31-4ade-aec8-b461c67e333e</Id>
     </Book>
-    <Book Series="Deadly Foes of Spider-Man" Number="3" Volume="1991" Year="1991" Format="Limited Series">
+    <Book Series="Deadly Foes of Spider-Man" Number="3" Volume="1991" Year="1991">
       <Id>6517fa7a-f303-4d3e-9ae1-e49c05f606f9</Id>
     </Book>
-    <Book Series="Deadly Foes of Spider-Man" Number="4" Volume="1991" Year="1991" Format="Limited Series">
+    <Book Series="Deadly Foes of Spider-Man" Number="4" Volume="1991" Year="1991">
       <Id>476ce8cf-0974-4d89-befb-b844360793d2</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="340" Volume="1963" Year="1990" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="340" Volume="1963" Year="1990">
       <Id>d35b1165-c1f0-4458-a881-4e445deedebd</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="341" Volume="1963" Year="1990" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="341" Volume="1963" Year="1990">
       <Id>872e0bac-33e5-4157-9c64-8be96ff9e9a1</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="342" Volume="1963" Year="1990" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="342" Volume="1963" Year="1990">
       <Id>b3a6eff3-ef34-4a3b-a4f9-2fcab8a6f119</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="343" Volume="1963" Year="1991" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="343" Volume="1963" Year="1991">
       <Id>ded506e4-d85d-4230-ad15-f73250f31a6f</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="347" Volume="1961" Year="1990" Format="Main Series">
+    <Book Series="Fantastic Four" Number="347" Volume="1961" Year="1990">
       <Id>f81cac5e-8ad0-442e-a6a1-039f88a3d43d</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="348" Volume="1961" Year="1991" Format="Main Series">
+    <Book Series="Fantastic Four" Number="348" Volume="1961" Year="1991">
       <Id>8cf9919f-4249-4d15-9b06-3877f75d47f1</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="349" Volume="1961" Year="1991" Format="Main Series">
+    <Book Series="Fantastic Four" Number="349" Volume="1961" Year="1991">
       <Id>c7ddb595-8c6f-45ec-873f-667d4df2765e</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="171" Volume="1976" Year="1990" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="171" Volume="1976" Year="1990">
       <Id>13c44c63-fa92-43bf-82cb-fc802faf4a45</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="172" Volume="1976" Year="1991" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="172" Volume="1976" Year="1991">
       <Id>96f12364-746e-4ac9-aa95-9771bfd7101a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="344" Volume="1963" Year="1991" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="344" Volume="1963" Year="1991">
       <Id>5135c885-c615-4d09-9316-8fc978910394</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="345" Volume="1963" Year="1991" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="345" Volume="1963" Year="1991">
       <Id>008787b0-7a50-49bb-8668-174829380f2f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="346" Volume="1963" Year="1991" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="346" Volume="1963" Year="1991">
       <Id>7199cb23-8a26-47a1-b8a1-da8aff7b6648</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="347" Volume="1963" Year="1991" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="347" Volume="1963" Year="1991">
       <Id>5c728109-6377-4fc5-b805-2e6f4969576d</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="173" Volume="1976" Year="1991" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="173" Volume="1976" Year="1991">
       <Id>986405c0-5bee-4741-ab98-b4d20187e772</Id>
     </Book>
-    <Book Series="Spider-Man" Number="6" Volume="1990" Year="1991" Format="Main Series">
+    <Book Series="Spider-Man" Number="6" Volume="1990" Year="1991">
       <Id>a31da179-85a8-4283-a1ff-a8c751adffa4</Id>
     </Book>
-    <Book Series="Spider-Man" Number="7" Volume="1990" Year="1991" Format="Main Series">
+    <Book Series="Spider-Man" Number="7" Volume="1990" Year="1991">
       <Id>6d451c38-1325-4fe0-8c40-546fac538f2c</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="174" Volume="1976" Year="1991" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="174" Volume="1976" Year="1991">
       <Id>f14831f9-cf95-42ab-b9e5-26d5570621cf</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="175" Volume="1976" Year="1991" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="175" Volume="1976" Year="1991">
       <Id>fe983729-4e11-4ead-adb3-c5c09cd21455</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="348" Volume="1963" Year="1991" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="348" Volume="1963" Year="1991">
       <Id>4c2b27f0-97db-4c4f-9a3f-b246ce32cea3</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="176" Volume="1976" Year="1991" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="176" Volume="1976" Year="1991">
       <Id>2fe7a27f-29e5-404f-906c-6d6ec854f04f</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="177" Volume="1976" Year="1991" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="177" Volume="1976" Year="1991">
       <Id>07f1c4ae-c238-4196-b141-0e07565adef2</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="73" Volume="1985" Year="1991" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="73" Volume="1985" Year="1991">
       <Id>70c5007b-5276-4779-98a6-511ee0867781</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="74" Volume="1985" Year="1991" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="74" Volume="1985" Year="1991">
       <Id>fbf062a5-d5f1-40ea-b4d6-548ecc96bf21</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="75" Volume="1985" Year="1991" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="75" Volume="1985" Year="1991">
       <Id>566960a7-b7f1-4ee8-84f7-3f07bfe74f65</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="76" Volume="1985" Year="1991" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="76" Volume="1985" Year="1991">
       <Id>f2a7e190-8536-4f06-ad4e-47d0eb736bb1</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="25" Volume="1964" Year="1991" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="25" Volume="1964" Year="1991">
       <Id>6f8f3056-cf2f-4c4d-a6df-e929c5713ba3</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man Annual" Number="11" Volume="1979" Year="1991" Format="Annual">
+    <Book Series="The Spectacular Spider-Man Annual" Number="11" Volume="1979" Year="1991">
       <Id>10d6f487-3c22-4064-98ce-d8799b308ce0</Id>
     </Book>
-    <Book Series="Web of Spider-Man Annual" Number="7" Volume="1985" Year="1991" Format="Annual">
+    <Book Series="Web of Spider-Man Annual" Number="7" Volume="1985" Year="1991">
       <Id>ea55304c-55de-4711-892f-5b182d2bef5b</Id>
     </Book>
-    <Book Series="Spider-Man" Number="17" Volume="1990" Year="1991" Format="Main Series">
+    <Book Series="Spider-Man" Number="17" Volume="1990" Year="1991">
       <Id>fdd0c633-4233-4318-9ce7-b47669591d6c</Id>
     </Book>
-    <Book Series="Spider-Man" Number="8" Volume="1990" Year="1991" Format="Main Series">
+    <Book Series="Spider-Man" Number="8" Volume="1990" Year="1991">
       <Id>13032b09-de84-4e6e-9ded-dd8d84fe38b9</Id>
     </Book>
-    <Book Series="Spider-Man" Number="9" Volume="1990" Year="1991" Format="Main Series">
+    <Book Series="Spider-Man" Number="9" Volume="1990" Year="1991">
       <Id>db69f1a3-1f73-40fc-813a-e4d88894c3aa</Id>
     </Book>
-    <Book Series="Spider-Man" Number="10" Volume="1990" Year="1991" Format="Main Series">
+    <Book Series="Spider-Man" Number="10" Volume="1990" Year="1991">
       <Id>1e71fd0e-7671-462a-8504-9b08514184ca</Id>
     </Book>
-    <Book Series="Spider-Man" Number="11" Volume="1990" Year="1991" Format="Main Series">
+    <Book Series="Spider-Man" Number="11" Volume="1990" Year="1991">
       <Id>b0572143-eb11-4e26-9334-10fa17f27068</Id>
     </Book>
-    <Book Series="Spider-Man" Number="12" Volume="1990" Year="1991" Format="Main Series">
+    <Book Series="Spider-Man" Number="12" Volume="1990" Year="1991">
       <Id>17a8434a-6b33-4c1f-a0b4-42a1842acb0e</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="77" Volume="1985" Year="1991" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="77" Volume="1985" Year="1991">
       <Id>86f440b7-01ff-4567-842d-86b89028fd21</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="78" Volume="1985" Year="1991" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="78" Volume="1985" Year="1991">
       <Id>27792dde-8c15-4d9f-b497-022d39cbdcf0</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="349" Volume="1963" Year="1991" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="349" Volume="1963" Year="1991">
       <Id>b79671b8-1582-4d96-937e-b5d380545536</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="350" Volume="1963" Year="1991" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="350" Volume="1963" Year="1991">
       <Id>5148a4d4-b769-463c-9906-bb0fc51aab37</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="79" Volume="1985" Year="1991" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="79" Volume="1985" Year="1991">
       <Id>cd5807a1-060d-429e-80d6-b85f04eb5dbd</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="80" Volume="1985" Year="1991" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="80" Volume="1985" Year="1991">
       <Id>67685c0c-b7e0-49f0-99b7-ff09a0ad4a6b</Id>
     </Book>
-    <Book Series="Spider-Man" Number="13" Volume="1990" Year="1991" Format="Main Series">
+    <Book Series="Spider-Man" Number="13" Volume="1990" Year="1991">
       <Id>6915637b-55a3-471e-9a42-1b5d98d8ff99</Id>
     </Book>
-    <Book Series="Spider-Man" Number="14" Volume="1990" Year="1991" Format="Main Series">
+    <Book Series="Spider-Man" Number="14" Volume="1990" Year="1991">
       <Id>6655a83a-ed09-4362-9ca8-83f4a6636896</Id>
     </Book>
-    <Book Series="Spider-Man" Number="15" Volume="1990" Year="1991" Format="Main Series">
+    <Book Series="Spider-Man" Number="15" Volume="1990" Year="1991">
       <Id>c5b0aaad-31e7-40c4-a95d-f765a980d96b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="351" Volume="1963" Year="1991" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="351" Volume="1963" Year="1991">
       <Id>58a2d2d5-f40f-4f71-936f-da9c652cecc7</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="352" Volume="1963" Year="1991" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="352" Volume="1963" Year="1991">
       <Id>9b37e589-654b-4ee8-aa5a-cdcb8773c523</Id>
     </Book>
-    <Book Series="X-Force" Number="3" Volume="1991" Year="1991" Format="Main Series">
+    <Book Series="X-Force" Number="3" Volume="1991" Year="1991">
       <Id>06699a51-bc5b-4d61-bc3b-202ccbfd510b</Id>
     </Book>
-    <Book Series="Spider-Man" Number="16" Volume="1990" Year="1991" Format="Main Series">
+    <Book Series="Spider-Man" Number="16" Volume="1990" Year="1991">
       <Id>86dbb27b-74fc-4055-9d3f-94e23e550341</Id>
     </Book>
-    <Book Series="X-Force" Number="4" Volume="1991" Year="1991" Format="Main Series">
+    <Book Series="X-Force" Number="4" Volume="1991" Year="1991">
       <Id>1c7835de-abba-4399-b394-a4af9301e66c</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="81" Volume="1985" Year="1991" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="81" Volume="1985" Year="1991">
       <Id>34e42dad-a250-400d-9a6f-87b8661cb902</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="82" Volume="1985" Year="1991" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="82" Volume="1985" Year="1991">
       <Id>70211038-224c-4bf7-8f0e-fdb450637d3d</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="83" Volume="1985" Year="1991" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="83" Volume="1985" Year="1991">
       <Id>13ebdf6f-ba98-4b4e-8f61-71f3ade5e3ed</Id>
     </Book>
-    <Book Series="Spider-Man" Number="18" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Spider-Man" Number="18" Volume="1990" Year="1992">
       <Id>110562f4-5117-4472-9401-5bd737f0c5e4</Id>
     </Book>
-    <Book Series="Spider-Man" Number="19" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Spider-Man" Number="19" Volume="1990" Year="1992">
       <Id>1cbbf730-87ad-44bd-a20a-995288540842</Id>
     </Book>
-    <Book Series="Spider-Man" Number="20" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Spider-Man" Number="20" Volume="1990" Year="1992">
       <Id>158ac9ef-05d1-4c72-a91b-34b5a5bfff3a</Id>
     </Book>
-    <Book Series="Spider-Man" Number="21" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Spider-Man" Number="21" Volume="1990" Year="1992">
       <Id>1ba06b99-ec02-4d5e-b3bf-730b1a151493</Id>
     </Book>
-    <Book Series="Spider-Man" Number="22" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Spider-Man" Number="22" Volume="1990" Year="1992">
       <Id>381cd4dd-439b-4ea9-b3ce-3d2f804ff3c2</Id>
     </Book>
-    <Book Series="Spider-Man" Number="23" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Spider-Man" Number="23" Volume="1990" Year="1992">
       <Id>0d5c4cfd-74e6-46ac-89f4-70490f6337ab</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="84" Volume="1985" Year="1992" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="84" Volume="1985" Year="1992">
       <Id>cb2806e4-a31b-4fd1-8b2f-370c1feed8db</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="85" Volume="1985" Year="1992" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="85" Volume="1985" Year="1992">
       <Id>ed3406c1-eec6-4c99-8c7b-b1f5d333864b</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="86" Volume="1985" Year="1992" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="86" Volume="1985" Year="1992">
       <Id>e1b97817-873f-437c-94c9-11adc7eea705</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="87" Volume="1985" Year="1992" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="87" Volume="1985" Year="1992">
       <Id>d1ac8d93-774c-44fc-bb7a-11a5e9c69dde</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="88" Volume="1985" Year="1992" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="88" Volume="1985" Year="1992">
       <Id>7b65604b-89e5-4b0e-bed6-488e249fb7b3</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="89" Volume="1985" Year="1992" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="89" Volume="1985" Year="1992">
       <Id>4574671e-9df0-4ff6-a8e8-25141eac9c5b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="353" Volume="1963" Year="1991" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="353" Volume="1963" Year="1991">
       <Id>2f4aac57-37da-4dad-bf15-3ff088b8d176</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="354" Volume="1963" Year="1991" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="354" Volume="1963" Year="1991">
       <Id>4f7b582a-6cb8-4eb8-9a45-6f24e24a0fdf</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="355" Volume="1963" Year="1991" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="355" Volume="1963" Year="1991">
       <Id>076379d3-58ca-4ab8-82db-0497681bf212</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="356" Volume="1963" Year="1991" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="356" Volume="1963" Year="1991">
       <Id>8bb6815f-2417-4048-8b5d-3d1b4c8bba24</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="357" Volume="1963" Year="1992" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="357" Volume="1963" Year="1992">
       <Id>03586f87-b7f4-455a-8699-d526790367a5</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="358" Volume="1963" Year="1992" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="358" Volume="1963" Year="1992">
       <Id>6a7bccce-30e3-4679-baf9-f2bd081dc7e7</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="178" Volume="1976" Year="1991" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="178" Volume="1976" Year="1991">
       <Id>0687d84c-bbdd-4691-b11b-0f6d484d2a27</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="179" Volume="1976" Year="1991" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="179" Volume="1976" Year="1991">
       <Id>56b8b114-b3e6-4bf1-ae14-ac9300f7d873</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="180" Volume="1976" Year="1991" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="180" Volume="1976" Year="1991">
       <Id>5a5c01ff-4e3b-4185-a4af-9942c43b7762</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="181" Volume="1976" Year="1991" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="181" Volume="1976" Year="1991">
       <Id>9037aca2-8fc1-469b-84d8-3ea221f96f1b</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="182" Volume="1976" Year="1991" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="182" Volume="1976" Year="1991">
       <Id>c62201d1-6e22-4473-a7ba-608db347b124</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="183" Volume="1976" Year="1991" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="183" Volume="1976" Year="1991">
       <Id>8cd3e5f2-6892-4268-97f2-dfb12c71eea3</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="184" Volume="1976" Year="1992" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="184" Volume="1976" Year="1992">
       <Id>2ea8f351-74b4-4ad9-b387-006f54886595</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="185" Volume="1976" Year="1992" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="185" Volume="1976" Year="1992">
       <Id>5029c912-aa9b-4449-a6f9-3d4b97bd987b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="359" Volume="1963" Year="1992" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="359" Volume="1963" Year="1992">
       <Id>5bbf1903-9157-4ceb-ae7b-b5f153ceadba</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="360" Volume="1963" Year="1992" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="360" Volume="1963" Year="1992">
       <Id>42c0618d-7fb4-4ddd-94ee-3c06eff0ffdb</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="186" Volume="1976" Year="1992" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="186" Volume="1976" Year="1992">
       <Id>b140f5b1-f959-4d80-b132-b68aecd2f64e</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="187" Volume="1976" Year="1992" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="187" Volume="1976" Year="1992">
       <Id>ad0690a8-3b60-4fe4-873e-83b3bf05a63f</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="188" Volume="1976" Year="1992" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="188" Volume="1976" Year="1992">
       <Id>aa5ab9dd-f103-46d4-a9ef-6666f40ff239</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="189" Volume="1976" Year="1992" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="189" Volume="1976" Year="1992">
       <Id>a97bf039-d444-4034-9ef8-d468e928fba9</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="190" Volume="1976" Year="1992" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="190" Volume="1976" Year="1992">
       <Id>2e674d62-7c40-4562-8761-884b078b47af</Id>
     </Book>
-    <Book Series="Spider-Man: Fear Itself" Number="1" Volume="1992" Year="1992" Format="One-Shot">
+    <Book Series="Spider-Man: Fear Itself" Number="1" Volume="1992" Year="1992">
       <Id>a7c313e3-bccb-4ee8-a797-134d661400e1</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="361" Volume="1963" Year="1992" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="361" Volume="1963" Year="1992">
       <Id>2818d86f-8b2c-45f7-aae9-60eba47b6b7b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="362" Volume="1963" Year="1992" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="362" Volume="1963" Year="1992">
       <Id>afade355-ebe0-4417-a8e2-acd7b084a2e4</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="363" Volume="1963" Year="1992" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="363" Volume="1963" Year="1992">
       <Id>caecee3b-b2f6-47a6-b2dd-ff3c00249d1d</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="26" Volume="1964" Year="1992" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="26" Volume="1964" Year="1992">
       <Id>0a159601-bbeb-4ca4-9f37-82d2e71b02bc</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man Annual" Number="12" Volume="1979" Year="1992" Format="Annual">
+    <Book Series="The Spectacular Spider-Man Annual" Number="12" Volume="1979" Year="1992">
       <Id>c4410df4-27ac-489f-a894-ea36b1531bfe</Id>
     </Book>
-    <Book Series="Web of Spider-Man Annual" Number="8" Volume="1985" Year="1992" Format="Annual">
+    <Book Series="Web of Spider-Man Annual" Number="8" Volume="1985" Year="1992">
       <Id>884df1fe-102f-4999-819f-3b6cf2b98f82</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="90" Volume="1985" Year="1992" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="90" Volume="1985" Year="1992">
       <Id>266286b2-4bab-4163-8456-04868238f57b</Id>
     </Book>
-    <Book Series="The Infinity War" Number="1" Volume="1992" Year="1992" Format="Crossover">
+    <Book Series="The Infinity War" Number="1" Volume="1992" Year="1992">
       <Id>59924df1-1d16-4945-b7b3-11026aa32400</Id>
     </Book>
-    <Book Series="Spider-Man" Number="24" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Spider-Man" Number="24" Volume="1990" Year="1992">
       <Id>f327bf9e-c28a-4243-9df4-2fcb1124249f</Id>
     </Book>
-    <Book Series="The Infinity War" Number="2" Volume="1992" Year="1992" Format="Crossover">
+    <Book Series="The Infinity War" Number="2" Volume="1992" Year="1992">
       <Id>8cf0524d-bbdd-4b13-aeba-4a04f4fff951</Id>
     </Book>
-    <Book Series="The Infinity War" Number="3" Volume="1992" Year="1992" Format="Crossover">
+    <Book Series="The Infinity War" Number="3" Volume="1992" Year="1992">
       <Id>5383ed89-27b6-4caf-a0f2-3a1663f80876</Id>
     </Book>
-    <Book Series="Spider-Man" Number="25" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Spider-Man" Number="25" Volume="1990" Year="1992">
       <Id>e4197d58-a262-4049-8a74-770a5d82a33a</Id>
     </Book>
-    <Book Series="Spider-Man" Number="26" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Spider-Man" Number="26" Volume="1990" Year="1992">
       <Id>50ee60b5-303d-4e8f-94d6-8b4321115f7a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man: Soul of the Hunter" Number="1" Volume="1992" Year="1992" Format="One-Shot">
+    <Book Series="The Amazing Spider-Man: Soul of the Hunter" Number="1" Volume="1992" Year="1992">
       <Id>810d8117-fa7b-4374-af83-630f4d98ae98</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="91" Volume="1985" Year="1992" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="91" Volume="1985" Year="1992">
       <Id>93f2e6c9-8909-43ff-b3ac-8b6306a5ffee</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="92" Volume="1985" Year="1992" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="92" Volume="1985" Year="1992">
       <Id>fa087c0a-2749-48aa-b7a7-7d1cd32020f0</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="364" Volume="1963" Year="1992" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="364" Volume="1963" Year="1992">
       <Id>15e0e110-e893-4896-8555-06c24610d49f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="365" Volume="1963" Year="1992" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="365" Volume="1963" Year="1992">
       <Id>1cbea70f-01a0-40a0-abc6-5d9f5ea8f477</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="366" Volume="1963" Year="1992" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="366" Volume="1963" Year="1992">
       <Id>96ae646c-51ee-47a7-8f5a-e05d746c8783</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="367" Volume="1963" Year="1992" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="367" Volume="1963" Year="1992">
       <Id>9485a70d-a3b3-451f-b40d-c90ebe8dcdb3</Id>
     </Book>
-    <Book Series="Spider-Man/Dr. Strange: &quot;The Way to Dusty Death&quot;" Number="1" Volume="1992" Year="1992" Format="One-Shot">
+    <Book Series="Spider-Man/Dr. Strange: &quot;The Way to Dusty Death&quot;" Number="1" Volume="1992" Year="1992">
       <Id>ec528b58-24c8-4ce8-be50-c93feabbcbec</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="191" Volume="1976" Year="1992" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="191" Volume="1976" Year="1992">
       <Id>12a3e2e8-247e-4893-8b12-a5bf35457d9d</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="192" Volume="1976" Year="1992" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="192" Volume="1976" Year="1992">
       <Id>c7249ee0-4fd4-4ae6-8d5f-d1e86bf3ad0f</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="193" Volume="1976" Year="1992" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="193" Volume="1976" Year="1992">
       <Id>ff32dfdc-8599-4986-81f8-84673c8972d8</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="194" Volume="1976" Year="1992" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="194" Volume="1976" Year="1992">
       <Id>1dbbf0d2-7034-4776-84b3-34c045c0ef46</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="195" Volume="1976" Year="1992" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="195" Volume="1976" Year="1992">
       <Id>6595677d-797c-4a27-ae46-549e6ebb6eb4</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="196" Volume="1976" Year="1993" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="196" Volume="1976" Year="1993">
       <Id>d6b2a748-5ca5-4298-a148-1c5691eccd72</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="93" Volume="1985" Year="1992" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="93" Volume="1985" Year="1992">
       <Id>0facaa38-ce6a-4b37-aaa0-452038a0facf</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="94" Volume="1985" Year="1992" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="94" Volume="1985" Year="1992">
       <Id>4e6c5d2b-65f0-408b-87a8-38587863c37c</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="95" Volume="1985" Year="1992" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="95" Volume="1985" Year="1992">
       <Id>ed2e5dee-a5dc-4f24-8bf8-4d4204f3569b</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="96" Volume="1985" Year="1993" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="96" Volume="1985" Year="1993">
       <Id>1ecd30a8-ee0d-4838-9f68-460f373136f1</Id>
     </Book>
-    <Book Series="Ghost Rider/Blaze: Spirits of Vengeance" Number="6" Volume="1992" Year="1993" Format="Series">
+    <Book Series="Ghost Rider/Blaze: Spirits of Vengeance" Number="6" Volume="1992" Year="1993">
       <Id>656ba115-ffb7-4e43-bc1d-9d03be5d8d4a</Id>
     </Book>
-    <Book Series="Spider-Man" Number="27" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Spider-Man" Number="27" Volume="1990" Year="1992">
       <Id>a565bc40-b210-41d4-aab3-eb439f5a1b80</Id>
     </Book>
-    <Book Series="Spider-Man" Number="28" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Spider-Man" Number="28" Volume="1990" Year="1992">
       <Id>b584a99f-777b-4197-8fff-2805ae660c85</Id>
     </Book>
-    <Book Series="Spider-Man" Number="29" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Spider-Man" Number="29" Volume="1990" Year="1992">
       <Id>1c74ccf6-4856-4b54-a0d3-84667f771173</Id>
     </Book>
-    <Book Series="Spider-Man" Number="30" Volume="1990" Year="1993" Format="Main Series">
+    <Book Series="Spider-Man" Number="30" Volume="1990" Year="1993">
       <Id>331ed03b-321a-4b87-8c4e-8634ca2865aa</Id>
     </Book>
-    <Book Series="Spider-Man" Number="31" Volume="1990" Year="1993" Format="Main Series">
+    <Book Series="Spider-Man" Number="31" Volume="1990" Year="1993">
       <Id>1ecd4403-bb5a-4297-a242-ea7a3600f0f2</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="368" Volume="1963" Year="1992" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="368" Volume="1963" Year="1992">
       <Id>df869827-3dae-4467-b6f9-22244ac6c417</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="369" Volume="1963" Year="1992" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="369" Volume="1963" Year="1992">
       <Id>31d60e6b-a255-4634-9857-d902d70fe37d</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="370" Volume="1963" Year="1992" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="370" Volume="1963" Year="1992">
       <Id>8cd4f5cf-f609-4f56-82bc-88150c8449c9</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="371" Volume="1963" Year="1992" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="371" Volume="1963" Year="1992">
       <Id>1ab7cdf2-5111-4b80-a4e4-117b860e4f0f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="372" Volume="1963" Year="1993" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="372" Volume="1963" Year="1993">
       <Id>aa438c58-1714-42cd-ae73-f141066777e0</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="373" Volume="1963" Year="1993" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="373" Volume="1963" Year="1993">
       <Id>7be81e4c-eccf-4997-8039-f2abeb0a1b76</Id>
     </Book>
-    <Book Series="Spider-Man Special Edition" Number="1" Volume="1992" Year="1992" Format="One-Shot">
+    <Book Series="Spider-Man Special Edition" Number="1" Volume="1992" Year="1992">
       <Id>76a4b638-65da-4bb6-a6c6-9aea9742dcb6</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="374" Volume="1963" Year="1993" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="374" Volume="1963" Year="1993">
       <Id>40ad9c56-7443-4bf4-a9e3-5c666cd4493e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="375" Volume="1963" Year="1993" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="375" Volume="1963" Year="1993">
       <Id>e7a0b56b-2cfe-453e-b2df-d7f33b62c467</Id>
     </Book>
-    <Book Series="Spider-Man, Punisher, Sabretooth: Designer Genes" Number="1" Volume="1993" Year="1993" Format="One-Shot">
+    <Book Series="Spider-Man, Punisher, Sabretooth: Designer Genes" Number="1" Volume="1993" Year="1993">
       <Id>a78ae9fd-b580-4819-8f78-4eb3e9cec103</Id>
     </Book>
-    <Book Series="Venom: Lethal Protector" Number="1" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="Venom: Lethal Protector" Number="1" Volume="1993" Year="1993">
       <Id>869e76b4-8a1a-4249-80fd-1d1e352926fe</Id>
     </Book>
-    <Book Series="Venom: Lethal Protector" Number="2" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="Venom: Lethal Protector" Number="2" Volume="1993" Year="1993">
       <Id>0c2bd2ba-3d11-49b0-8834-68b10e7ad616</Id>
     </Book>
-    <Book Series="Venom: Lethal Protector" Number="3" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="Venom: Lethal Protector" Number="3" Volume="1993" Year="1993">
       <Id>cf51d6a0-b095-4ec7-a145-6a55fbd1006c</Id>
     </Book>
-    <Book Series="Venom: Lethal Protector" Number="4" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="Venom: Lethal Protector" Number="4" Volume="1993" Year="1993">
       <Id>7cd5dbdb-8ec0-4ab0-9bf0-55615b3662f2</Id>
     </Book>
-    <Book Series="Venom: Lethal Protector" Number="5" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="Venom: Lethal Protector" Number="5" Volume="1993" Year="1993">
       <Id>5ff74b87-dae7-403a-904b-60751bfd111b</Id>
     </Book>
-    <Book Series="Venom: Lethal Protector" Number="6" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="Venom: Lethal Protector" Number="6" Volume="1993" Year="1993">
       <Id>7bb2893a-ea1c-4167-893a-e71b2f92fa3c</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="97" Volume="1985" Year="1993" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="97" Volume="1985" Year="1993">
       <Id>c0e43723-f4ba-4f9b-afcf-f2bc82a62c7b</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="98" Volume="1985" Year="1993" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="98" Volume="1985" Year="1993">
       <Id>58f338b3-936c-4b40-b177-02841915868d</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="99" Volume="1985" Year="1993" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="99" Volume="1985" Year="1993">
       <Id>43063936-e6ad-4112-9747-29aa04872ed9</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="100" Volume="1985" Year="1993" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="100" Volume="1985" Year="1993">
       <Id>f43fcf8a-8469-4f38-9959-54e959f0d57f</Id>
     </Book>
-    <Book Series="Spider-Man" Number="32" Volume="1990" Year="1993" Format="Main Series">
+    <Book Series="Spider-Man" Number="32" Volume="1990" Year="1993">
       <Id>257445f1-eb1a-4e19-ab3e-a31720bc4be1</Id>
     </Book>
-    <Book Series="Spider-Man" Number="33" Volume="1990" Year="1993" Format="Main Series">
+    <Book Series="Spider-Man" Number="33" Volume="1990" Year="1993">
       <Id>f85895e5-e473-44b1-91d6-83d378c7ac58</Id>
     </Book>
-    <Book Series="Spider-Man" Number="34" Volume="1990" Year="1993" Format="Main Series">
+    <Book Series="Spider-Man" Number="34" Volume="1990" Year="1993">
       <Id>007c61a9-ea7e-4249-a58e-3da122fe8a71</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="376" Volume="1963" Year="1993" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="376" Volume="1963" Year="1993">
       <Id>dac3c090-9672-4521-8260-e1220e3d0623</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="377" Volume="1963" Year="1993" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="377" Volume="1963" Year="1993">
       <Id>f105ba9f-50f2-4da1-9284-46eb2fee5d16</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="27" Volume="1964" Year="1993" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="27" Volume="1964" Year="1993">
       <Id>f9bbca21-9618-491f-9f05-7d203e7055d5</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="374" Volume="1961" Year="1993" Format="Main Series">
+    <Book Series="Fantastic Four" Number="374" Volume="1961" Year="1993">
       <Id>1d3e5377-27fc-4654-8037-e9e931841e60</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="375" Volume="1961" Year="1993" Format="Main Series">
+    <Book Series="Fantastic Four" Number="375" Volume="1961" Year="1993">
       <Id>e4b59047-93c2-4930-9f66-fa563c5133e3</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="197" Volume="1976" Year="1993" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="197" Volume="1976" Year="1993">
       <Id>f58345f2-ae1e-4996-9cdd-0f6ea81fbd3b</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="198" Volume="1976" Year="1993" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="198" Volume="1976" Year="1993">
       <Id>2ea0e18a-8ff7-4f35-b422-0ca9abe34266</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="199" Volume="1976" Year="1993" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="199" Volume="1976" Year="1993">
       <Id>75c202ea-6c90-4501-9452-7f9e84668539</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="200" Volume="1976" Year="1993" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="200" Volume="1976" Year="1993">
       <Id>5421a0d7-c86f-40c0-b442-19ff09c51b85</Id>
     </Book>
-    <Book Series="Web of Spider-Man Annual" Number="9" Volume="1985" Year="1993" Format="Annual">
+    <Book Series="Web of Spider-Man Annual" Number="9" Volume="1985" Year="1993">
       <Id>d92387d5-b468-423b-87e5-6f6ac650cf8b</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="1" Volume="1993" Year="1993" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="1" Volume="1993" Year="1993">
       <Id>1f8f393a-4801-4b90-92e2-df05cd7a2679</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="101" Volume="1985" Year="1993" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="101" Volume="1985" Year="1993">
       <Id>089a8091-293e-4282-9270-7097c00b9650</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="378" Volume="1963" Year="1993" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="378" Volume="1963" Year="1993">
       <Id>ec777331-1fb6-41fa-9972-65faf3d62f0b</Id>
     </Book>
-    <Book Series="Spider-Man" Number="35" Volume="1990" Year="1993" Format="Main Series">
+    <Book Series="Spider-Man" Number="35" Volume="1990" Year="1993">
       <Id>cf67ec48-995b-4244-b7fb-ce77c5c3d179</Id>
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="201" Volume="1976" Year="1993">
       <Id>c0471964-0bb3-4562-a481-c82470ad4853</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="102" Volume="1985" Year="1993" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="102" Volume="1985" Year="1993">
       <Id>26e71d3a-a141-4385-b39f-61097cfc642a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="379" Volume="1963" Year="1993" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="379" Volume="1963" Year="1993">
       <Id>65452b42-7b15-4f7b-a16c-feed7ccee2a0</Id>
     </Book>
-    <Book Series="Spider-Man" Number="36" Volume="1990" Year="1993" Format="Main Series">
+    <Book Series="Spider-Man" Number="36" Volume="1990" Year="1993">
       <Id>57cea88d-2d28-4bcc-909c-ad4dcbe8c290</Id>
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="202" Volume="1976" Year="1993">
       <Id>48c5dc87-7a5b-480e-94a5-46ff2e83772b</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="103" Volume="1985" Year="1993" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="103" Volume="1985" Year="1993">
       <Id>5461c499-539b-43f4-99c9-db00139de999</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="380" Volume="1963" Year="1993" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="380" Volume="1963" Year="1993">
       <Id>e884b63a-faeb-475e-9292-10f11658001f</Id>
     </Book>
-    <Book Series="Spider-Man" Number="37" Volume="1990" Year="1993" Format="Main Series">
+    <Book Series="Spider-Man" Number="37" Volume="1990" Year="1993">
       <Id>f57621fa-b1c4-433e-9200-e5cca26c92cd</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="203" Volume="1976" Year="1993" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="203" Volume="1976" Year="1993">
       <Id>847ef62f-ab10-457d-ba86-280275f4c338</Id>
     </Book>
     <Book Series="Spider-Man Unlimited" Number="2" Volume="1993" Year="1993">

--- a/Marvel/Characters/unsorted/Spider-Man/Spider-Man 005 (Clone Years).cbl
+++ b/Marvel/Characters/unsorted/Spider-Man/Spider-Man 005 (Clone Years).cbl
@@ -2,862 +2,862 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Spider-Man 5 (Clone Years)</Name>
   <Books>
-    <Book Series="The Infinity Crusade" Number="1" Volume="1993" Year="1993" Format="Crossover">
+    <Book Series="The Infinity Crusade" Number="1" Volume="1993" Year="1993">
       <Id>4d712c58-3e96-4c10-ad93-bb1c0d2231e8</Id>
     </Book>
-    <Book Series="The Infinity Crusade" Number="2" Volume="1993" Year="1993" Format="Crossover">
+    <Book Series="The Infinity Crusade" Number="2" Volume="1993" Year="1993">
       <Id>286b67dd-c39d-4d13-b7e2-28f0a4affa36</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="104" Volume="1985" Year="1993" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="104" Volume="1985" Year="1993">
       <Id>1e5c58d7-97c1-4d44-8af6-6c587b95492f</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="105" Volume="1985" Year="1993" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="105" Volume="1985" Year="1993">
       <Id>f74331cb-5194-4419-8a7e-66529033f24f</Id>
     </Book>
-    <Book Series="The Infinity Crusade" Number="3" Volume="1993" Year="1993" Format="Crossover">
+    <Book Series="The Infinity Crusade" Number="3" Volume="1993" Year="1993">
       <Id>28b6a455-2b88-4cf7-a105-ba02cd35b5b8</Id>
     </Book>
-    <Book Series="The Infinity Crusade" Number="4" Volume="1993" Year="1993" Format="Crossover">
+    <Book Series="The Infinity Crusade" Number="4" Volume="1993" Year="1993">
       <Id>8982b62d-8e8a-4551-81d3-e7196463901b</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="106" Volume="1985" Year="1993" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="106" Volume="1985" Year="1993">
       <Id>0a29d66f-be41-4221-8442-7c480ca132e2</Id>
     </Book>
-    <Book Series="The Infinity Crusade" Number="5" Volume="1993" Year="1993" Format="Crossover">
+    <Book Series="The Infinity Crusade" Number="5" Volume="1993" Year="1993">
       <Id>27aff520-8589-4fa5-92e9-4b213a358787</Id>
     </Book>
-    <Book Series="The Infinity Crusade" Number="6" Volume="1993" Year="1993" Format="Crossover">
+    <Book Series="The Infinity Crusade" Number="6" Volume="1993" Year="1993">
       <Id>a68e1f0b-08d6-4fd3-9de7-1512067e4fff</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="381" Volume="1963" Year="1993" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="381" Volume="1963" Year="1993">
       <Id>fa5f0bdc-628c-48a5-aba5-8b4d45abf453</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="382" Volume="1963" Year="1993" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="382" Volume="1963" Year="1993">
       <Id>82d644e2-cc70-4fba-9a1f-53c67c48b9e0</Id>
     </Book>
-    <Book Series="Spider-Man" Number="38" Volume="1990" Year="1993" Format="Main Series">
+    <Book Series="Spider-Man" Number="38" Volume="1990" Year="1993">
       <Id>e3784ec7-6116-4a3d-8f5f-8b80e3b032bb</Id>
     </Book>
-    <Book Series="Spider-Man" Number="39" Volume="1990" Year="1993" Format="Main Series">
+    <Book Series="Spider-Man" Number="39" Volume="1990" Year="1993">
       <Id>b3693d3c-7ce3-4591-b78a-2475b55c76b6</Id>
     </Book>
-    <Book Series="Spider-Man" Number="40" Volume="1990" Year="1993" Format="Main Series">
+    <Book Series="Spider-Man" Number="40" Volume="1990" Year="1993">
       <Id>aba68572-c0e1-489b-950b-fecf7d6cd082</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man Annual" Number="13" Volume="1979" Year="1993" Format="Annual">
+    <Book Series="The Spectacular Spider-Man Annual" Number="13" Volume="1979" Year="1993">
       <Id>43dfd119-5f96-46d8-9b66-5fe115a8e557</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="204" Volume="1976" Year="1993" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="204" Volume="1976" Year="1993">
       <Id>17265394-b0c9-4f0f-b7e6-91d3411935d7</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="205" Volume="1976" Year="1993" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="205" Volume="1976" Year="1993">
       <Id>a09cd694-a6e4-4fc7-80ff-b2b2b7f9db4b</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="206" Volume="1976" Year="1993" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="206" Volume="1976" Year="1993">
       <Id>d632697d-6aba-4181-94e6-05fd38a32307</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="107" Volume="1985" Year="1993" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="107" Volume="1985" Year="1993">
       <Id>28c9c776-568a-4453-95bf-9f4426558a9c</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="108" Volume="1985" Year="1994" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="108" Volume="1985" Year="1994">
       <Id>d256320a-4751-49f0-8905-891afeb43c15</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="383" Volume="1963" Year="1993" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="383" Volume="1963" Year="1993">
       <Id>b490bf01-8c7f-45cb-af7b-e87f8258e57b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="384" Volume="1963" Year="1993" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="384" Volume="1963" Year="1993">
       <Id>3c2501eb-b0b6-40c0-b991-68f040ef16b3</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="385" Volume="1963" Year="1994" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="385" Volume="1963" Year="1994">
       <Id>32a09068-56f4-4fda-8970-5f98e2a3b479</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="109" Volume="1985" Year="1994" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="109" Volume="1985" Year="1994">
       <Id>1c28429a-c839-4297-9f8b-cd65025200b7</Id>
     </Book>
-    <Book Series="Lethal Foes of Spider-Man" Number="1" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="Lethal Foes of Spider-Man" Number="1" Volume="1993" Year="1993">
       <Id>5295427b-5a9f-48ba-b41a-69e7e211be94</Id>
     </Book>
-    <Book Series="Lethal Foes of Spider-Man" Number="2" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="Lethal Foes of Spider-Man" Number="2" Volume="1993" Year="1993">
       <Id>dec01e3c-7988-4646-abf1-bdf4fab814a9</Id>
     </Book>
-    <Book Series="Lethal Foes of Spider-Man" Number="3" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="Lethal Foes of Spider-Man" Number="3" Volume="1993" Year="1993">
       <Id>f7982929-d60e-49d9-a0ab-335c8291d256</Id>
     </Book>
-    <Book Series="Lethal Foes of Spider-Man" Number="4" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="Lethal Foes of Spider-Man" Number="4" Volume="1993" Year="1993">
       <Id>5122c45f-3c25-4615-84c8-f5db9c55cdc0</Id>
     </Book>
     <Book Series="Spider-Man Unlimited" Number="3" Volume="1993" Year="1993">
       <Id>5aea9dae-ceb3-4fe0-8bc2-f8429a6009c4</Id>
     </Book>
-    <Book Series="Spider-Man" Number="41" Volume="1990" Year="1993" Format="Main Series">
+    <Book Series="Spider-Man" Number="41" Volume="1990" Year="1993">
       <Id>a19a1be1-42b6-45fd-9ed9-fe16ea13b1b8</Id>
     </Book>
-    <Book Series="Spider-Man" Number="42" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="Spider-Man" Number="42" Volume="1990" Year="1994">
       <Id>04432a30-fabf-4a9e-a1ad-4a9b6496cf8b</Id>
     </Book>
-    <Book Series="Spider-Man" Number="43" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="Spider-Man" Number="43" Volume="1990" Year="1994">
       <Id>7844eed4-5a2a-4670-af2a-7e27c540d4c6</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="4" Volume="1993" Year="1994" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="4" Volume="1993" Year="1994">
       <Id>6cfc1325-af0e-4e3f-a3ed-43f09b4a044c</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="207" Volume="1976" Year="1993" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="207" Volume="1976" Year="1993">
       <Id>f9bf800d-bb1a-4555-8e3c-cc652524c7fa</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="208" Volume="1976" Year="1994" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="208" Volume="1976" Year="1994">
       <Id>d6b83563-e58f-49bd-b6fc-7ec1adbf2146</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="28" Volume="1964" Year="1994" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="28" Volume="1964" Year="1994">
       <Id>7b7d9b97-a49b-4bf4-a521-a4a25e9e3789</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="209" Volume="1976" Year="1994" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="209" Volume="1976" Year="1994">
       <Id>2c8ef3bd-5177-4b54-8e4a-52de64ca90f4</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="210" Volume="1976" Year="1994" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="210" Volume="1976" Year="1994">
       <Id>5d386b4b-9de2-4e37-aa5d-62ceddad3727</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="386" Volume="1963" Year="1994" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="386" Volume="1963" Year="1994">
       <Id>eacfcad8-0acd-47d8-8df2-e6b5efb361e3</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="110" Volume="1985" Year="1994" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="110" Volume="1985" Year="1994">
       <Id>4b262995-eef6-4179-8bec-872bed1f4e69</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="111" Volume="1985" Year="1994" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="111" Volume="1985" Year="1994">
       <Id>7c257be2-5329-4294-92ae-89f33bb282cf</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="387" Volume="1963" Year="1994" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="387" Volume="1963" Year="1994">
       <Id>afc5e9db-280a-46ce-9894-dd4e53517812</Id>
     </Book>
-    <Book Series="Spider-Man" Number="44" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="Spider-Man" Number="44" Volume="1990" Year="1994">
       <Id>5a2cf6f1-70e5-462f-abba-0619497a8b56</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="388" Volume="1963" Year="1994" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="388" Volume="1963" Year="1994">
       <Id>bc812b21-3f92-411b-b124-53bbf7704616</Id>
     </Book>
-    <Book Series="Spider-Man" Number="45" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="Spider-Man" Number="45" Volume="1990" Year="1994">
       <Id>e71c0700-c761-4c52-a17a-f1c27b971e23</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="211" Volume="1976" Year="1994" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="211" Volume="1976" Year="1994">
       <Id>9e23fe23-6ebd-47e0-81ca-c56dd4c5ecc1</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="112" Volume="1985" Year="1994" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="112" Volume="1985" Year="1994">
       <Id>3d282e6c-b730-4661-adfc-8a5d1be2c267</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="389" Volume="1963" Year="1994" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="389" Volume="1963" Year="1994">
       <Id>f304bdd0-a1ee-47be-b869-76330a011dca</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="212" Volume="1976" Year="1994" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="212" Volume="1976" Year="1994">
       <Id>a4b73f51-4648-4d4c-9be4-8b66a3334e83</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="5" Volume="1993" Year="1994" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="5" Volume="1993" Year="1994">
       <Id>0d25bac8-cacd-4819-ac3b-1214f8d25490</Id>
     </Book>
-    <Book Series="Web of Spider-Man Annual" Number="10" Volume="1985" Year="1994" Format="Annual">
+    <Book Series="Web of Spider-Man Annual" Number="10" Volume="1985" Year="1994">
       <Id>af106b3a-5c03-40c8-85bb-9eeec6b49f75</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="213" Volume="1976" Year="1994" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="213" Volume="1976" Year="1994">
       <Id>897712d4-57d8-42f8-b1eb-4ace1a8005a1</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="214" Volume="1976" Year="1994" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="214" Volume="1976" Year="1994">
       <Id>962b3310-d91a-4234-9b5e-5a0d6f4ccf0d</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man Annual" Number="14" Volume="1979" Year="1994" Format="Annual">
+    <Book Series="The Spectacular Spider-Man Annual" Number="14" Volume="1979" Year="1994">
       <Id>c00a3d5c-7fd9-454a-be2b-1c0f325957f8</Id>
     </Book>
-    <Book Series="Spider-Man" Number="46" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="Spider-Man" Number="46" Volume="1990" Year="1994">
       <Id>02cd9f38-28a3-487d-9aee-472e4472c662</Id>
     </Book>
-    <Book Series="Spider-Man" Number="47" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="Spider-Man" Number="47" Volume="1990" Year="1994">
       <Id>bb40ca22-5b3c-42ee-b11b-d7477ebaf76e</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="113" Volume="1985" Year="1994" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="113" Volume="1985" Year="1994">
       <Id>a3ab1390-0bd5-4a8f-9b9b-f345e519bc8d</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="114" Volume="1985" Year="1994" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="114" Volume="1985" Year="1994">
       <Id>46297e95-88dd-4e6d-870a-1110adb388e2</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="390" Volume="1963" Year="1994" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="390" Volume="1963" Year="1994">
       <Id>0ed28948-18d5-4444-9b81-b71f283455b9</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="391" Volume="1963" Year="1994" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="391" Volume="1963" Year="1994">
       <Id>a3c72b26-d444-4c74-890e-59d92747c08b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="392" Volume="1963" Year="1994" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="392" Volume="1963" Year="1994">
       <Id>e978e801-15fb-42a0-b9f2-6d7566955a8f</Id>
     </Book>
-    <Book Series="Spider-Man" Number="48" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="Spider-Man" Number="48" Volume="1990" Year="1994">
       <Id>85c3e69b-f99d-4b51-abd7-3be62d439833</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="115" Volume="1985" Year="1994" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="115" Volume="1985" Year="1994">
       <Id>5348bef2-f998-4043-9046-13c1cbcf46f5</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="116" Volume="1985" Year="1994" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="116" Volume="1985" Year="1994">
       <Id>9a7b8a7c-88fa-4802-8dd2-b3d786d511aa</Id>
     </Book>
-    <Book Series="Spider-Man" Number="49" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="Spider-Man" Number="49" Volume="1990" Year="1994">
       <Id>3596d994-5186-4426-9fd6-564892968726</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="6" Volume="1993" Year="1994" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="6" Volume="1993" Year="1994">
       <Id>529534f5-53bd-4499-909c-c43bd60eaf8a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="393" Volume="1963" Year="1994" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="393" Volume="1963" Year="1994">
       <Id>c961af29-8b07-4f5e-969f-d3266fdb0b8b</Id>
     </Book>
-    <Book Series="Spider-Man" Number="50" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="Spider-Man" Number="50" Volume="1990" Year="1994">
       <Id>aac476d1-cd2f-41d9-8ecd-2ee0a73d1680</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="215" Volume="1976" Year="1994" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="215" Volume="1976" Year="1994">
       <Id>d066e6fa-3d10-4935-a942-f9864b69a6e3</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="216" Volume="1976" Year="1994" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="216" Volume="1976" Year="1994">
       <Id>e5bc441c-ed70-4428-9a88-d82a1a2939cc</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="117" Volume="1985" Year="1994" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="117" Volume="1985" Year="1994">
       <Id>58667164-81ef-4141-84c0-ed1781dfb10b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="394" Volume="1963" Year="1994" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="394" Volume="1963" Year="1994">
       <Id>58aa60cc-f76f-4528-84e8-6c36aba8d1f5</Id>
     </Book>
-    <Book Series="Spider-Man" Number="51" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="Spider-Man" Number="51" Volume="1990" Year="1994">
       <Id>1f97afa0-76cf-472f-81e9-d82878c50352</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="217" Volume="1976" Year="1994" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="217" Volume="1976" Year="1994">
       <Id>fe87f875-ff44-47ae-9190-902db37a2fdc</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="7" Volume="1993" Year="1994" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="7" Volume="1993" Year="1994">
       <Id>1e9dbe3c-40d6-4f39-b0fd-a13247ce4fc9</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="118" Volume="1985" Year="1994" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="118" Volume="1985" Year="1994">
       <Id>7381bd8d-c485-418e-9e1c-eedc01a134ca</Id>
     </Book>
-    <Book Series="Spider-Man" Number="52" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="Spider-Man" Number="52" Volume="1990" Year="1994">
       <Id>ff43b6ea-5660-473a-9040-8b1b5722d019</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="119" Volume="1985" Year="1994" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="119" Volume="1985" Year="1994">
       <Id>f44565ce-420b-4ba5-83f0-3c9b062dd543</Id>
     </Book>
-    <Book Series="Spider-Man" Number="53" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="Spider-Man" Number="53" Volume="1990" Year="1994">
       <Id>c4901ed8-1190-4ab1-9842-6ee1e9288277</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="395" Volume="1963" Year="1994" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="395" Volume="1963" Year="1994">
       <Id>8169f8b6-510a-4a84-a9f7-1cbef7ec927a</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="218" Volume="1976" Year="1994" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="218" Volume="1976" Year="1994">
       <Id>ae0b32e2-2120-44d7-a879-93a12a585933</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="396" Volume="1963" Year="1994" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="396" Volume="1963" Year="1994">
       <Id>0dfe3b6f-33d7-4197-a792-d87fc2f2798d</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="120" Volume="1985" Year="1995" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="120" Volume="1985" Year="1995">
       <Id>dff1960d-c5dd-4457-aafa-125d70a31f29</Id>
     </Book>
-    <Book Series="Spider-Man" Number="54" Volume="1990" Year="1995" Format="Main Series">
+    <Book Series="Spider-Man" Number="54" Volume="1990" Year="1995">
       <Id>42a2f9b6-fbae-441c-80ce-8af33535c9c2</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="121" Volume="1985" Year="1995" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="121" Volume="1985" Year="1995">
       <Id>11ed4cd5-39e3-4d1a-ab39-b2ce25616d38</Id>
     </Book>
-    <Book Series="Spider-Man" Number="55" Volume="1990" Year="1995" Format="Main Series">
+    <Book Series="Spider-Man" Number="55" Volume="1990" Year="1995">
       <Id>5099655e-8918-4e83-a669-0641c6aeb217</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="397" Volume="1963" Year="1995" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="397" Volume="1963" Year="1995">
       <Id>de47cb51-1191-4f36-b2be-51dfd407783e</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="220" Volume="1976" Year="1995" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="220" Volume="1976" Year="1995">
       <Id>bed4fb08-dd7e-45fc-b7df-8505eec900e8</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="398" Volume="1963" Year="1995" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="398" Volume="1963" Year="1995">
       <Id>80fc9885-2197-4609-b167-c5302229d614</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="221" Volume="1976" Year="1995" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="221" Volume="1976" Year="1995">
       <Id>64e8fca1-0867-4304-ba9d-09218324be17</Id>
     </Book>
-    <Book Series="Spider-Man: Friends and Enemies" Number="1" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Spider-Man: Friends and Enemies" Number="1" Volume="1995" Year="1995">
       <Id>2f76face-34cb-43b4-b60c-23c283c7c526</Id>
     </Book>
-    <Book Series="Spider-Man: Friends and Enemies" Number="2" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Spider-Man: Friends and Enemies" Number="2" Volume="1995" Year="1995">
       <Id>04e0bbc1-871f-4882-8d8d-27d1d110b73e</Id>
     </Book>
-    <Book Series="Spider-Man: Friends and Enemies" Number="3" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Spider-Man: Friends and Enemies" Number="3" Volume="1995" Year="1995">
       <Id>77219aed-a183-4542-89ce-50ebb5378bae</Id>
     </Book>
-    <Book Series="Spider-Man: Friends and Enemies" Number="4" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Spider-Man: Friends and Enemies" Number="4" Volume="1995" Year="1995">
       <Id>1e44da5f-5d3b-4033-9ad2-4f3e688b397e</Id>
     </Book>
-    <Book Series="Spider-Man: Funeral for an Octopus" Number="1" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Spider-Man: Funeral for an Octopus" Number="1" Volume="1995" Year="1995">
       <Id>a3ca95c3-bd23-4b27-861a-7d417992af77</Id>
     </Book>
-    <Book Series="Spider-Man: Funeral for an Octopus" Number="2" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Spider-Man: Funeral for an Octopus" Number="2" Volume="1995" Year="1995">
       <Id>a202b5ac-0f5b-4c0b-8c4e-9ed84597b7d0</Id>
     </Book>
-    <Book Series="Spider-Man: Funeral for an Octopus" Number="3" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Spider-Man: Funeral for an Octopus" Number="3" Volume="1995" Year="1995">
       <Id>56474ebf-b88c-405a-8f21-556aa05be496</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="8" Volume="1993" Year="1995" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="8" Volume="1993" Year="1995">
       <Id>c6e59ba0-f0a2-43db-9e89-d0b6094815cd</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="122" Volume="1985" Year="1995" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="122" Volume="1985" Year="1995">
       <Id>4f9c7ab7-b3fc-49ad-b076-cbb6a8f21c28</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="399" Volume="1963" Year="1995" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="399" Volume="1963" Year="1995">
       <Id>a0916855-b64c-422a-b263-837f16625e99</Id>
     </Book>
-    <Book Series="Spider-Man" Number="56" Volume="1990" Year="1995" Format="Main Series">
+    <Book Series="Spider-Man" Number="56" Volume="1990" Year="1995">
       <Id>58a83af7-0a72-4b95-9575-9ba03c7b71a3</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="222" Volume="1976" Year="1995" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="222" Volume="1976" Year="1995">
       <Id>54b21053-7ea1-4b5a-a96b-9584e5f90dbd</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="123" Volume="1985" Year="1995" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="123" Volume="1985" Year="1995">
       <Id>6d93fce9-219a-4ffc-b8fe-dfa56d71d284</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="400" Volume="1963" Year="1995" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="400" Volume="1963" Year="1995">
       <Id>1fbcc15b-f221-4804-9ea5-e41fb64876e8</Id>
     </Book>
-    <Book Series="Spider-Man" Number="57" Volume="1990" Year="1995" Format="Main Series">
+    <Book Series="Spider-Man" Number="57" Volume="1990" Year="1995">
       <Id>cf19b512-5e09-4f95-9170-15297a999813</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="223" Volume="1976" Year="1995" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="223" Volume="1976" Year="1995">
       <Id>7711e055-31f8-46e7-9e35-c140a6af2d93</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="124" Volume="1985" Year="1995" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="124" Volume="1985" Year="1995">
       <Id>818cad6a-2bf3-4e0b-a401-651f1cc8d790</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="401" Volume="1963" Year="1995" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="401" Volume="1963" Year="1995">
       <Id>5b91f57b-7b17-4bb3-9d64-0c39eeb9aeff</Id>
     </Book>
-    <Book Series="Spider-Man" Number="58" Volume="1990" Year="1995" Format="Main Series">
+    <Book Series="Spider-Man" Number="58" Volume="1990" Year="1995">
       <Id>2c59be5d-53e4-482f-b3c8-a37ea6546565</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="224" Volume="1976" Year="1995" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="224" Volume="1976" Year="1995">
       <Id>4b5db7d3-a2fa-42ed-958c-78297296d079</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="9" Volume="1993" Year="1995" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="9" Volume="1993" Year="1995">
       <Id>07eb2c00-b19e-47b5-a050-47985f1d9445</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="125" Volume="1985" Year="1995" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="125" Volume="1985" Year="1995">
       <Id>6b0e2fff-c5f7-40c9-a7ed-9d3f971c6245</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="402" Volume="1963" Year="1995" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="402" Volume="1963" Year="1995">
       <Id>b89bc805-7bde-4652-9c7f-6744689bfe89</Id>
     </Book>
-    <Book Series="Spider-Man" Number="59" Volume="1990" Year="1995" Format="Main Series">
+    <Book Series="Spider-Man" Number="59" Volume="1990" Year="1995">
       <Id>c3b21615-11ed-4bc1-a286-f9e15a785a4c</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="225" Volume="1976" Year="1995" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="225" Volume="1976" Year="1995">
       <Id>b90e308f-0717-449b-8c31-481d7ccc83c9</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="126" Volume="1985" Year="1995" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="126" Volume="1985" Year="1995">
       <Id>3c35a562-5eca-432b-b06d-e9e744ca7a11</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="403" Volume="1963" Year="1995" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="403" Volume="1963" Year="1995">
       <Id>e08d215e-a1f8-41a4-b208-588ba8a50b0d</Id>
     </Book>
-    <Book Series="Spider-Man" Number="60" Volume="1990" Year="1995" Format="Main Series">
+    <Book Series="Spider-Man" Number="60" Volume="1990" Year="1995">
       <Id>f4adaf7a-590b-48bc-b727-3efc1d1e121a</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="226" Volume="1976" Year="1995" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="226" Volume="1976" Year="1995">
       <Id>56da8d89-77fe-4782-9a54-36386d311283</Id>
     </Book>
-    <Book Series="Spider-Man: The Jackal Files" Number="1" Volume="1995" Year="1995" Format="One-Shot">
+    <Book Series="Spider-Man: The Jackal Files" Number="1" Volume="1995" Year="1995">
       <Id>87d8460b-1304-40d3-befd-d20dc27433f8</Id>
     </Book>
-    <Book Series="Spider-Man: Maximum Clonage" Number="1" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Spider-Man: Maximum Clonage" Number="1" Volume="1995" Year="1995">
       <Id>d68c8097-57a5-4e2e-adf1-484eae9d1b53</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="127" Volume="1985" Year="1995" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="127" Volume="1985" Year="1995">
       <Id>fa154748-f33b-4b32-acdf-902cede990bc</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="404" Volume="1963" Year="1995" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="404" Volume="1963" Year="1995">
       <Id>cac2fa05-e8ef-4261-9a08-cc393a07a49f</Id>
     </Book>
-    <Book Series="Spider-Man" Number="61" Volume="1990" Year="1995" Format="Main Series">
+    <Book Series="Spider-Man" Number="61" Volume="1990" Year="1995">
       <Id>c52d362d-7722-4ec8-88f5-14622fa36d33</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="227" Volume="1976" Year="1995" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="227" Volume="1976" Year="1995">
       <Id>43db0548-e575-4e56-9642-2070db485b4e</Id>
     </Book>
-    <Book Series="Spider-Man: Maximum Clonage" Number="2" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Spider-Man: Maximum Clonage" Number="2" Volume="1995" Year="1995">
       <Id>28776a75-d58e-4e85-b2dc-619b9ba9475a</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="128" Volume="1985" Year="1995" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="128" Volume="1985" Year="1995">
       <Id>cadea783-5771-4fb6-8a30-8e8351b7a9ba</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="405" Volume="1963" Year="1995" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="405" Volume="1963" Year="1995">
       <Id>3212f92a-7931-41c8-b432-0675cd9043c1</Id>
     </Book>
-    <Book Series="Spider-Man" Number="62" Volume="1990" Year="1995" Format="Main Series">
+    <Book Series="Spider-Man" Number="62" Volume="1990" Year="1995">
       <Id>9e07d1eb-12a7-413a-b3ff-8b3d805412f0</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="10" Volume="1993" Year="1995" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="10" Volume="1993" Year="1995">
       <Id>a30906fc-d622-4d1a-b247-3c05eefdd67e</Id>
     </Book>
-    <Book Series="Amazing Spider-Man Super Special" Number="1" Volume="1995" Year="1995" Format="One-Shot">
+    <Book Series="Amazing Spider-Man Super Special" Number="1" Volume="1995" Year="1995">
       <Id>51a8585a-b02f-4493-887c-aec28e25bd6f</Id>
     </Book>
-    <Book Series="Spider-Man Super Special" Number="1" Volume="1995" Year="1995" Format="One-Shot">
+    <Book Series="Spider-Man Super Special" Number="1" Volume="1995" Year="1995">
       <Id>e4e6bba3-7bed-48af-8e94-b02f65ddcb6a</Id>
     </Book>
-    <Book Series="Venom Super Special" Number="1" Volume="1995" Year="1995" Format="One-Shot">
+    <Book Series="Venom Super Special" Number="1" Volume="1995" Year="1995">
       <Id>59b30264-f4d7-476c-8c24-28d90aeb7450</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man Super Special" Number="1" Volume="1995" Year="1995" Format="One-Shot">
+    <Book Series="Spectacular Spider-Man Super Special" Number="1" Volume="1995" Year="1995">
       <Id>97dd2a0f-ae07-4be6-9ae2-6f962c5c5e05</Id>
     </Book>
-    <Book Series="Web of Spider-Man Super Special" Number="1" Volume="1995" Year="1995" Format="One-Shot">
+    <Book Series="Web of Spider-Man Super Special" Number="1" Volume="1995" Year="1995">
       <Id>3b84b127-59cf-4248-a42d-41d1b7589e42</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="228" Volume="1976" Year="1995" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="228" Volume="1976" Year="1995">
       <Id>2bdd9e32-f9bb-4fa9-83e3-a2f092a9c3be</Id>
     </Book>
-    <Book Series="Web of Spider-Man" Number="129" Volume="1985" Year="1995" Format="Main Series">
+    <Book Series="Web of Spider-Man" Number="129" Volume="1985" Year="1995">
       <Id>d536c0c1-1c4e-4f2b-aa1b-e740ef14e414</Id>
     </Book>
-    <Book Series="Spider-Man Team-Up" Number="1" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Spider-Man Team-Up" Number="1" Volume="1995" Year="1995">
       <Id>b1641e3b-39cb-4658-9d85-4de36b9c14ce</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="406" Volume="1963" Year="1995" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="406" Volume="1963" Year="1995">
       <Id>cd409a5d-6504-4858-b07e-8cc98983d167</Id>
     </Book>
-    <Book Series="Spider-Man" Number="63" Volume="1990" Year="1995" Format="Main Series">
+    <Book Series="Spider-Man" Number="63" Volume="1990" Year="1995">
       <Id>3eff1875-05fa-4ee3-97b9-c84dcc25c7eb</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="229" Volume="1976" Year="1995" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="229" Volume="1976" Year="1995">
       <Id>894b45ed-e490-4429-b80b-5acc916ab187</Id>
     </Book>
-    <Book Series="Scarlet Spider Unlimited" Number="1" Volume="1995" Year="1995" Format="One-Shot">
+    <Book Series="Scarlet Spider Unlimited" Number="1" Volume="1995" Year="1995">
       <Id>306f9248-3992-41d4-9ac4-c46865e72d64</Id>
     </Book>
-    <Book Series="Web of Scarlet Spider" Number="1" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Web of Scarlet Spider" Number="1" Volume="1995" Year="1995">
       <Id>ee0df59f-2a08-4e11-9a55-515af4f6c379</Id>
     </Book>
-    <Book Series="The Amazing Scarlet Spider" Number="1" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="The Amazing Scarlet Spider" Number="1" Volume="1995" Year="1995">
       <Id>866a9e16-24e6-434d-972f-5f8e8248b05e</Id>
     </Book>
-    <Book Series="Scarlet Spider" Number="1" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Scarlet Spider" Number="1" Volume="1995" Year="1995">
       <Id>427cf912-c778-4bb3-9f7d-b25cbc34cb9f</Id>
     </Book>
-    <Book Series="Spider-Man: The Parker Years" Number="1" Volume="1995" Year="1995" Format="One-Shot">
+    <Book Series="Spider-Man: The Parker Years" Number="1" Volume="1995" Year="1995">
       <Id>d8ad4c13-a985-4831-a454-733c5411eb7f</Id>
     </Book>
-    <Book Series="Web of Scarlet Spider" Number="2" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Web of Scarlet Spider" Number="2" Volume="1995" Year="1995">
       <Id>00071540-09ee-45aa-9430-6ebe2309bef8</Id>
     </Book>
-    <Book Series="The Amazing Scarlet Spider" Number="2" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="The Amazing Scarlet Spider" Number="2" Volume="1995" Year="1995">
       <Id>bf1f8eee-ea98-40ef-94dd-b316103f57ad</Id>
     </Book>
-    <Book Series="Scarlet Spider" Number="2" Volume="1995" Year="1995" Format="Limited Series">
+    <Book Series="Scarlet Spider" Number="2" Volume="1995" Year="1995">
       <Id>8bc3f422-4d9b-462f-9e2f-c23e8fa58f49</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="0" Volume="1996" Year="1996" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="0" Volume="1996" Year="1996">
       <Id>a54493d2-cd4c-4cdc-905c-7e5ca78d8441</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="407" Volume="1963" Year="1996" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="407" Volume="1963" Year="1996">
       <Id>751ad696-9ec6-44e9-8727-b92e136dbc2d</Id>
     </Book>
-    <Book Series="Spider-Man: The Final Adventure" Number="1" Volume="1996" Year="1995" Format="Limited Series">
+    <Book Series="Spider-Man: The Final Adventure" Number="1" Volume="1996" Year="1995">
       <Id>f2c7b734-e933-430a-9dcb-1638f44f61f7</Id>
     </Book>
-    <Book Series="Spider-Man: The Final Adventure" Number="2" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Spider-Man: The Final Adventure" Number="2" Volume="1996" Year="1996">
       <Id>fa30b58a-fb4b-4ecd-bcea-cf1beffd4327</Id>
     </Book>
-    <Book Series="Spider-Man: The Final Adventure" Number="3" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Spider-Man: The Final Adventure" Number="3" Volume="1996" Year="1996">
       <Id>fb308727-ad75-468d-a709-9ba6505887e6</Id>
     </Book>
-    <Book Series="Spider-Man: The Final Adventure" Number="4" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Spider-Man: The Final Adventure" Number="4" Volume="1996" Year="1996">
       <Id>55e3aa49-445d-4b03-ab2a-68e91bb534e2</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="11" Volume="1993" Year="1996" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="11" Volume="1993" Year="1996">
       <Id>4fc927e6-6754-4b1b-9726-ba3a811ee9d7</Id>
     </Book>
-    <Book Series="Spider-Man" Number="64" Volume="1990" Year="1996" Format="Main Series">
+    <Book Series="Spider-Man" Number="64" Volume="1990" Year="1996">
       <Id>f2ff2546-082a-4fc3-9737-d3487a7260cb</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="230" Volume="1976" Year="1996" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="230" Volume="1976" Year="1996">
       <Id>4d20f459-992b-47d5-b50c-2c260382f6f8</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="1" Volume="1996" Year="1996" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="1" Volume="1996" Year="1996">
       <Id>bcc0f187-8c09-4a9c-b82f-0de340b9a057</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="408" Volume="1963" Year="1996" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="408" Volume="1963" Year="1996">
       <Id>e46fb5cf-a232-44c3-a3fb-e799892ba78f</Id>
     </Book>
-    <Book Series="Spider-Man" Number="65" Volume="1990" Year="1996" Format="Main Series">
+    <Book Series="Spider-Man" Number="65" Volume="1990" Year="1996">
       <Id>f1ca948a-5f72-4228-a612-00cb0ffd7d5a</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="231" Volume="1976" Year="1996" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="231" Volume="1976" Year="1996">
       <Id>b5cd0943-05e6-4a27-bcae-6ac27c5b68bf</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="2" Volume="1996" Year="1996" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="2" Volume="1996" Year="1996">
       <Id>1920f62c-2a1e-47b1-9749-5eb99c026a52</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="409" Volume="1963" Year="1996" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="409" Volume="1963" Year="1996">
       <Id>6f21caea-b723-46d9-826e-31afd8b18b69</Id>
     </Book>
-    <Book Series="Spider-Man" Number="66" Volume="1990" Year="1996" Format="Main Series">
+    <Book Series="Spider-Man" Number="66" Volume="1990" Year="1996">
       <Id>56fd1318-60e9-4784-bd87-8d66b47d2872</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="232" Volume="1976" Year="1996" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="232" Volume="1976" Year="1996">
       <Id>67d438c6-2bfc-4d47-a61e-f61f524d67aa</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="3" Volume="1996" Year="1996" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="3" Volume="1996" Year="1996">
       <Id>bb2deb26-2a30-4404-a734-097ea9b3132f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="410" Volume="1963" Year="1996" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="410" Volume="1963" Year="1996">
       <Id>74536b64-62c3-458b-ac96-49aafefc9a4f</Id>
     </Book>
-    <Book Series="Spider-Man" Number="67" Volume="1990" Year="1996" Format="Main Series">
+    <Book Series="Spider-Man" Number="67" Volume="1990" Year="1996">
       <Id>ed1f23e8-d692-4e7f-bfd1-7443918d8e72</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="233" Volume="1976" Year="1996" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="233" Volume="1976" Year="1996">
       <Id>5cdebe12-8ad2-43d3-b4a8-793235e67208</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="4" Volume="1996" Year="1996" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="4" Volume="1996" Year="1996">
       <Id>04674dc7-04fc-499d-a804-10020b9085e9</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="411" Volume="1963" Year="1996" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="411" Volume="1963" Year="1996">
       <Id>5a5861ab-4dda-41e1-b3ef-f299d4593755</Id>
     </Book>
-    <Book Series="Spider-Man" Number="68" Volume="1990" Year="1996" Format="Main Series">
+    <Book Series="Spider-Man" Number="68" Volume="1990" Year="1996">
       <Id>5cf6119e-bcfd-44fc-9deb-25251702a4a0</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="234" Volume="1976" Year="1996" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="234" Volume="1976" Year="1996">
       <Id>f95eab6e-f6df-4601-b9b1-51524b59bfb5</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="5" Volume="1996" Year="1996" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="5" Volume="1996" Year="1996">
       <Id>da11577f-d29c-4037-bac4-cb7aec280993</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="412" Volume="1963" Year="1996" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="412" Volume="1963" Year="1996">
       <Id>fb551cf8-cc7e-4dbb-9b39-82c1cd5323d7</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="12" Volume="1993" Year="1996" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="12" Volume="1993" Year="1996">
       <Id>c8534141-f9ab-4a4c-b03a-401c9a01e5d2</Id>
     </Book>
-    <Book Series="Spider-Man" Number="69" Volume="1990" Year="1996" Format="Main Series">
+    <Book Series="Spider-Man" Number="69" Volume="1990" Year="1996">
       <Id>eabb02b5-042e-4130-8e9b-8b46dc9a8472</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="13" Volume="1993" Year="1996" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="13" Volume="1993" Year="1996">
       <Id>b3218b33-080c-4c00-9528-18de72923acb</Id>
     </Book>
-    <Book Series="Spider-Man Team-Up" Number="4" Volume="1995" Year="1996" Format="Limited Series">
+    <Book Series="Spider-Man Team-Up" Number="4" Volume="1995" Year="1996">
       <Id>4976f056-215c-4fad-801d-c8783d0650a4</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="6" Volume="1996" Year="1996" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="6" Volume="1996" Year="1996">
       <Id>292da3ac-fc1d-4314-ba05-4fe69843be8c</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="413" Volume="1963" Year="1996" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="413" Volume="1963" Year="1996">
       <Id>ec4bf48c-cf8b-4319-8c0d-041486696d30</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="235" Volume="1976" Year="1996" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="235" Volume="1976" Year="1996">
       <Id>c8b4b699-61bf-4aed-bdc8-f9e91eb4ca67</Id>
     </Book>
-    <Book Series="Spider-Man" Number="70" Volume="1990" Year="1996" Format="Main Series">
+    <Book Series="Spider-Man" Number="70" Volume="1990" Year="1996">
       <Id>ad0ab92d-3d1d-4090-8c8b-3df5d5d05071</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="236" Volume="1976" Year="1996" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="236" Volume="1976" Year="1996">
       <Id>858c365e-41d7-45a0-95d3-2b3584bdd054</Id>
     </Book>
-    <Book Series="Spider-Man: Redemption" Number="1" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Spider-Man: Redemption" Number="1" Volume="1996" Year="1996">
       <Id>b507f4a2-a6da-4475-8253-268e863f62fa</Id>
     </Book>
-    <Book Series="Spider-Man: Redemption" Number="2" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Spider-Man: Redemption" Number="2" Volume="1996" Year="1996">
       <Id>bb3dd1d9-8f62-4d5f-817e-f1039ea4af43</Id>
     </Book>
-    <Book Series="Spider-Man: Redemption" Number="3" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Spider-Man: Redemption" Number="3" Volume="1996" Year="1996">
       <Id>c3f30fd7-0b23-43c5-9f52-1a84b657432f</Id>
     </Book>
-    <Book Series="Spider-Man: Redemption" Number="4" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Spider-Man: Redemption" Number="4" Volume="1996" Year="1996">
       <Id>67f6d6a0-422e-4c5d-b0ae-21199716f243</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="7" Volume="1996" Year="1996" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="7" Volume="1996" Year="1996">
       <Id>16429bd9-336a-43ef-8f2d-19521248716b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="414" Volume="1963" Year="1996" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="414" Volume="1963" Year="1996">
       <Id>fe17318b-e291-4688-a9c5-41c740b67bd7</Id>
     </Book>
-    <Book Series="Spider-Man" Number="71" Volume="1990" Year="1996" Format="Main Series">
+    <Book Series="Spider-Man" Number="71" Volume="1990" Year="1996">
       <Id>4d426b3a-cc7f-4b2c-9615-00ca2d5058bd</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="237" Volume="1976" Year="1996" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="237" Volume="1976" Year="1996">
       <Id>7f52802f-56e3-4b9c-9860-6f83e968f5a5</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="14" Volume="1993" Year="1996" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="14" Volume="1993" Year="1996">
       <Id>deedb5b8-a68a-49e7-89c3-0e447e9a1ff6</Id>
     </Book>
-    <Book Series="Spider-Man Team-Up" Number="5" Volume="1995" Year="1996" Format="Limited Series">
+    <Book Series="Spider-Man Team-Up" Number="5" Volume="1995" Year="1996">
       <Id>affddce7-51c6-4085-8d3b-436603a4ed4e</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="8" Volume="1996" Year="1996" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="8" Volume="1996" Year="1996">
       <Id>06f47376-a599-47fb-848a-43f6ef0f3f48</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="415" Volume="1963" Year="1996" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="415" Volume="1963" Year="1996">
       <Id>8dcc5eea-b381-4cb2-873d-1be305d19665</Id>
     </Book>
-    <Book Series="Spider-Man" Number="72" Volume="1990" Year="1996" Format="Main Series">
+    <Book Series="Spider-Man" Number="72" Volume="1990" Year="1996">
       <Id>e7560f75-73f8-41d4-9cc1-625e0f37e6b0</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="9" Volume="1996" Year="1996" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="9" Volume="1996" Year="1996">
       <Id>7a0cfe7f-acef-4a96-b9a2-e57b7a76303f</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="10" Volume="1996" Year="1996" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="10" Volume="1996" Year="1996">
       <Id>178a8588-a44c-40a4-afae-0ba2cbf3d473</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="416" Volume="1963" Year="1996" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="416" Volume="1963" Year="1996">
       <Id>cdeb5e88-270b-47c5-bf72-7842ad052d32</Id>
     </Book>
-    <Book Series="Spider-Man" Number="73" Volume="1990" Year="1996" Format="Main Series">
+    <Book Series="Spider-Man" Number="73" Volume="1990" Year="1996">
       <Id>306c13a0-5c7d-4e71-be75-ad3db3c89968</Id>
     </Book>
-    <Book Series="Spider-Man" Number="74" Volume="1990" Year="1996" Format="Main Series">
+    <Book Series="Spider-Man" Number="74" Volume="1990" Year="1996">
       <Id>b7ac0241-f22f-4f27-bdc4-c13c475c909e</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="238" Volume="1976" Year="1996" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="238" Volume="1976" Year="1996">
       <Id>a21b816c-0a16-4d47-9bac-ff5f3806882c</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="239" Volume="1976" Year="1996" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="239" Volume="1976" Year="1996">
       <Id>3c4a5f12-1f2a-44a5-ba89-818df481d2de</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="417" Volume="1963" Year="1996" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="417" Volume="1963" Year="1996">
       <Id>f93d0cda-edc7-4da8-ad8e-0b35b83018d9</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="240" Volume="1976" Year="1996" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="240" Volume="1976" Year="1996">
       <Id>669705db-5230-4d2b-9089-1cb15579c26c</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="11" Volume="1996" Year="1996" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="11" Volume="1996" Year="1996">
       <Id>66576c85-36b9-45e4-809c-82407eefa23f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="418" Volume="1963" Year="1996" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="418" Volume="1963" Year="1996">
       <Id>1469d348-c9ba-4581-9f26-09ceabc272d0</Id>
     </Book>
-    <Book Series="Spider-Man" Number="75" Volume="1990" Year="1996" Format="Main Series">
+    <Book Series="Spider-Man" Number="75" Volume="1990" Year="1996">
       <Id>4af76389-e449-40ef-b28d-a446f66f6ae2</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="241" Volume="1976" Year="1996" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="241" Volume="1976" Year="1996">
       <Id>483a68b9-029d-40a7-b4e0-6ee9cbb85a94</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="12" Volume="1996" Year="1997" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="12" Volume="1996" Year="1997">
       <Id>4eb78a7f-1c08-4a3e-9b0a-0723c89f35a2</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="13" Volume="1996" Year="1997" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="13" Volume="1996" Year="1997">
       <Id>634029d1-29c7-45b0-83b4-508ba0d6c818</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="14" Volume="1996" Year="1997" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="14" Volume="1996" Year="1997">
       <Id>8f6026d6-b97a-41bf-97c1-d49db0b771e3</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="15" Volume="1996" Year="1997" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="15" Volume="1996" Year="1997">
       <Id>84ea7a80-a7ab-4ace-b43f-a297e41d0fdf</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="419" Volume="1963" Year="1997" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="419" Volume="1963" Year="1997">
       <Id>9c9f8f6f-ca4b-4f17-be8d-8ec068c96c77</Id>
     </Book>
-    <Book Series="Spider-Man: Hobgoblin Lives" Number="1" Volume="1997" Year="1997" Format="Limited Series">
+    <Book Series="Spider-Man: Hobgoblin Lives" Number="1" Volume="1997" Year="1997">
       <Id>33599c3c-10a2-4c87-bae6-4f81f34c8015</Id>
     </Book>
-    <Book Series="Spider-Man: Hobgoblin Lives" Number="2" Volume="1997" Year="1997" Format="Limited Series">
+    <Book Series="Spider-Man: Hobgoblin Lives" Number="2" Volume="1997" Year="1997">
       <Id>dbb27c47-d585-4a7a-ba60-5e2ccef69410</Id>
     </Book>
-    <Book Series="Spider-Man: Hobgoblin Lives" Number="3" Volume="1997" Year="1997" Format="Limited Series">
+    <Book Series="Spider-Man: Hobgoblin Lives" Number="3" Volume="1997" Year="1997">
       <Id>9c02a4e6-cc2d-4e3b-805c-05ee3956eed2</Id>
     </Book>
-    <Book Series="Spider-Man" Number="76" Volume="1990" Year="1997" Format="Main Series">
+    <Book Series="Spider-Man" Number="76" Volume="1990" Year="1997">
       <Id>e85558e3-8270-43a2-bc4d-edb21cc36250</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="420" Volume="1963" Year="1997" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="420" Volume="1963" Year="1997">
       <Id>d4167bd7-a8c9-4045-9f65-b4ccd48fac9a</Id>
     </Book>
-    <Book Series="Spider-Man" Number="77" Volume="1990" Year="1997" Format="Main Series">
+    <Book Series="Spider-Man" Number="77" Volume="1990" Year="1997">
       <Id>2aacca21-ceea-44b7-a94d-87ee7352744e</Id>
     </Book>
-    <Book Series="Spider-Man" Number="78" Volume="1990" Year="1997" Format="Main Series">
+    <Book Series="Spider-Man" Number="78" Volume="1990" Year="1997">
       <Id>3fa003b7-8853-4629-8263-722e36f6a216</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="242" Volume="1976" Year="1997" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="242" Volume="1976" Year="1997">
       <Id>f565d62e-2e84-41c5-9f63-28233db635fc</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="243" Volume="1976" Year="1997" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="243" Volume="1976" Year="1997">
       <Id>afed3368-3012-410c-8a27-dd41ce44b99e</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="244" Volume="1976" Year="1997" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="244" Volume="1976" Year="1997">
       <Id>176b5e23-e5ba-497e-a22c-1276422abab4</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="245" Volume="1976" Year="1997" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="245" Volume="1976" Year="1997">
       <Id>10c19c10-5583-4920-98e4-d132a0858c70</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="246" Volume="1976" Year="1997" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="246" Volume="1976" Year="1997">
       <Id>4eec1811-9bdc-4896-9de4-323d400781eb</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="421" Volume="1963" Year="1997" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="421" Volume="1963" Year="1997">
       <Id>2494c175-1d11-44ca-a427-73a91d3d9d46</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="15" Volume="1993" Year="1997" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="15" Volume="1993" Year="1997">
       <Id>776694d3-b690-404d-825b-599a5fb44f57</Id>
     </Book>
-    <Book Series="Spider-Man" Number="79" Volume="1990" Year="1997" Format="Main Series">
+    <Book Series="Spider-Man" Number="79" Volume="1990" Year="1997">
       <Id>d5d485e1-b97c-4c16-8a0c-49dd114ae7c7</Id>
     </Book>
-    <Book Series="Spider-Man" Number="80" Volume="1990" Year="1997" Format="Main Series">
+    <Book Series="Spider-Man" Number="80" Volume="1990" Year="1997">
       <Id>1c0b54f5-dd68-4ed8-bfff-69c2b60e4197</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="16" Volume="1993" Year="1997" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="16" Volume="1993" Year="1997">
       <Id>b6777191-d852-4536-854d-8ba393a44162</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="16" Volume="1996" Year="1997" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="16" Volume="1996" Year="1997">
       <Id>c6a55697-c7e9-4f3d-99b0-11745bb49bd4</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="17" Volume="1996" Year="1997" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="17" Volume="1996" Year="1997">
       <Id>d1bf652c-cda5-40fb-908e-3aa6828f9375</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="18" Volume="1996" Year="1997" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="18" Volume="1996" Year="1997">
       <Id>cec37fa6-236d-4151-a15d-efe5f8b44c2c</Id>
     </Book>
-    <Book Series="Spider-Man: Dead Man's Hand" Number="1" Volume="1997" Year="1997" Format="One-Shot">
+    <Book Series="Spider-Man: Dead Man's Hand" Number="1" Volume="1997" Year="1997">
       <Id>894e2d16-1070-4003-bb49-525a06ea6264</Id>
     </Book>
-    <Book Series="Spider-Man Team-Up" Number="6" Volume="1995" Year="1997" Format="Limited Series">
+    <Book Series="Spider-Man Team-Up" Number="6" Volume="1995" Year="1997">
       <Id>9d859147-5daa-4a07-b806-d3cde687c616</Id>
     </Book>
-    <Book Series="Spider-Man" Number="81" Volume="1990" Year="1997" Format="Main Series">
+    <Book Series="Spider-Man" Number="81" Volume="1990" Year="1997">
       <Id>5a3a0e27-08e2-437d-8dba-648600cc3f19</Id>
     </Book>
-    <Book Series="Spider-Man Team-Up" Number="7" Volume="1995" Year="1997" Format="Limited Series">
+    <Book Series="Spider-Man Team-Up" Number="7" Volume="1995" Year="1997">
       <Id>149ee07f-05ad-43c5-b624-430aedf899f6</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="1" Volume="1997" Year="1997" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="1" Volume="1997" Year="1997">
       <Id>78e0adb6-dbdc-42de-9fce-d393dcdd1ccc</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="2" Volume="1997" Year="1997" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="2" Volume="1997" Year="1997">
       <Id>bc4fc266-b650-4b86-a8dc-f6c5e4a9cd1d</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="3" Volume="1997" Year="1997" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="3" Volume="1997" Year="1997">
       <Id>27b895e9-d323-402e-8959-561b657182bf</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="422" Volume="1963" Year="1997" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="422" Volume="1963" Year="1997">
       <Id>50a8301c-7996-439d-a61a-bb7878db0ec1</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="423" Volume="1963" Year="1997" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="423" Volume="1963" Year="1997">
       <Id>71696672-a451-443e-b930-f399fbfcf4b8</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="424" Volume="1963" Year="1997" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="424" Volume="1963" Year="1997">
       <Id>a41cfbf4-207b-440a-b107-08f9bdee9354</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="247" Volume="1976" Year="1997" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="247" Volume="1976" Year="1997">
       <Id>f8d74c2f-118d-4e95-9109-31eaf2d823bd</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="-1" Volume="1976" Year="1997" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="-1" Volume="1976" Year="1997">
       <Id>e107a742-a18e-4401-b2a2-4f7329640065</Id>
     </Book>
-    <Book Series="Spider-Man" Number="-1" Volume="1990" Year="1997" Format="Main Series">
+    <Book Series="Spider-Man" Number="-1" Volume="1990" Year="1997">
       <Id>295a1946-4a24-4ed8-968a-b6d55527ba4e</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="-1" Volume="1996" Year="1997" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="-1" Volume="1996" Year="1997">
       <Id>5f83a72a-a109-4e17-95e0-3530b3ddcafb</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="-1" Volume="1963" Year="1997" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="-1" Volume="1963" Year="1997">
       <Id>13fa2659-188d-4bcb-8b68-a4b5556dbe64</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="248" Volume="1976" Year="1997" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="248" Volume="1976" Year="1997">
       <Id>c8cb0706-3f4d-4d5a-b068-0db40ab2cac6</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="19" Volume="1996" Year="1997" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="19" Volume="1996" Year="1997">
       <Id>94aca052-80be-4ba6-b492-f2c2fba004bc</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="20" Volume="1996" Year="1997" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="20" Volume="1996" Year="1997">
       <Id>2560a77e-9165-4fc4-9048-83f6c24d5f80</Id>
     </Book>
-    <Book Series="Spider-Man" Number="82" Volume="1990" Year="1997" Format="Main Series">
+    <Book Series="Spider-Man" Number="82" Volume="1990" Year="1997">
       <Id>8a97e2bf-2b8a-42ad-8f45-6a401d3a641a</Id>
     </Book>
-    <Book Series="Spider-Man" Number="83" Volume="1990" Year="1997" Format="Main Series">
+    <Book Series="Spider-Man" Number="83" Volume="1990" Year="1997">
       <Id>b8e65242-63ca-4a82-9a8f-381931b8c16c</Id>
     </Book>
-    <Book Series="Spider-Man" Number="84" Volume="1990" Year="1997" Format="Main Series">
+    <Book Series="Spider-Man" Number="84" Volume="1990" Year="1997">
       <Id>bc646399-54ce-4bba-ad30-d9fd37bf20c1</Id>
     </Book>
-    <Book Series="Amazing Spider-Man Annual '96" Number="1" Volume="1996" Year="1996" Format="Annual">
+    <Book Series="Amazing Spider-Man Annual '96" Number="1" Volume="1996" Year="1996">
       <Id>6e8fd9b6-3c26-43a8-86b2-ec4d1c47cc56</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="17" Volume="1993" Year="1997" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="17" Volume="1993" Year="1997">
       <Id>69d7b75e-a103-452f-b62a-e6c541307bc7</Id>
     </Book>
-    <Book Series="Spider-Man Annual '97" Number="1997" Volume="1997" Year="1997" Format="Annual">
+    <Book Series="Spider-Man Annual '97" Number="1997" Volume="1997" Year="1997">
       <Id>364728c2-7eb9-4cc9-b966-6a1bf7d0218d</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="425" Volume="1963" Year="1997" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="425" Volume="1963" Year="1997">
       <Id>b615bb44-8069-423e-98e5-bacce766660c</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="249" Volume="1976" Year="1997" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="249" Volume="1976" Year="1997">
       <Id>9e664343-f04a-4f15-8058-7b47412a0a1e</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="250" Volume="1976" Year="1997" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="250" Volume="1976" Year="1997">
       <Id>1fb23c3a-9bbe-474f-bd17-0ce047a277df</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="426" Volume="1963" Year="1997" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="426" Volume="1963" Year="1997">
       <Id>428624d5-8739-486e-9ed0-3df6a2b3cb7e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="427" Volume="1963" Year="1997" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="427" Volume="1963" Year="1997">
       <Id>961880bb-7c34-42e3-a0de-a465b62d4de7</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="428" Volume="1963" Year="1997" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="428" Volume="1963" Year="1997">
       <Id>269d5a6e-7770-4b3c-872e-7eeec39c033e</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="18" Volume="1993" Year="1997" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="18" Volume="1993" Year="1997">
       <Id>d3c96be9-1e7b-4703-bb40-e95030bdd3cf</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="21" Volume="1996" Year="1997" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="21" Volume="1996" Year="1997">
       <Id>1c9c07ae-df18-4569-b532-d859ba009d1c</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="22" Volume="1996" Year="1997" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="22" Volume="1996" Year="1997">
       <Id>27775f2e-8928-4df1-a913-ae02682d458c</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="23" Volume="1996" Year="1998" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="23" Volume="1996" Year="1998">
       <Id>2ab2e5a8-f46c-404b-9609-a6f86d0965f3</Id>
     </Book>
-    <Book Series="Spider-Man" Number="85" Volume="1990" Year="1997" Format="Main Series">
+    <Book Series="Spider-Man" Number="85" Volume="1990" Year="1997">
       <Id>ebfdeb9c-1bc4-4108-9eb5-03840f2c7067</Id>
     </Book>
-    <Book Series="Spider-Man" Number="86" Volume="1990" Year="1997" Format="Main Series">
+    <Book Series="Spider-Man" Number="86" Volume="1990" Year="1997">
       <Id>4768d114-3365-43c3-b54d-1d731645785f</Id>
     </Book>
-    <Book Series="Spider-Man" Number="87" Volume="1990" Year="1998" Format="Main Series">
+    <Book Series="Spider-Man" Number="87" Volume="1990" Year="1998">
       <Id>116f4dfa-72fa-4e7d-80f3-3a8c9d29ad81</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="251" Volume="1976" Year="1997" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="251" Volume="1976" Year="1997">
       <Id>26f18be1-4c6b-49d9-a4ea-3a807530ada0</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="252" Volume="1976" Year="1997" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="252" Volume="1976" Year="1997">
       <Id>1710c6fe-0ed9-4263-9953-5a0ba2a5a5c5</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="253" Volume="1976" Year="1998" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="253" Volume="1976" Year="1998">
       <Id>cf919d94-5d1d-470d-a925-061fe3799ac1</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="429" Volume="1963" Year="1997" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="429" Volume="1963" Year="1997">
       <Id>88ee72de-7707-43bf-a860-4a60d5eb6ada</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="4" Volume="1997" Year="1997" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="4" Volume="1997" Year="1997">
       <Id>7cb07307-8125-452b-8861-9d7a95e24e50</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="5" Volume="1997" Year="1998" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="5" Volume="1997" Year="1998">
       <Id>94b1fc1b-85ec-4a55-93a9-812dc18fb2b1</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="430" Volume="1963" Year="1998" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="430" Volume="1963" Year="1998">
       <Id>c393c984-92f1-44b5-8651-ea74e5387f46</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="431" Volume="1963" Year="1998" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="431" Volume="1963" Year="1998">
       <Id>9498aa52-78f7-4db8-9393-9eb46a4e787b</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="6" Volume="1997" Year="1998" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="6" Volume="1997" Year="1998">
       <Id>4c888ccf-f9cf-4962-b4cd-d92554a1221f</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="24" Volume="1996" Year="1998" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="24" Volume="1996" Year="1998">
       <Id>b791f9fe-425d-4360-8b64-c469241c97fc</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="7" Volume="1997" Year="1998" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="7" Volume="1997" Year="1998">
       <Id>4f8c0e34-36c4-42e5-b2f0-66b6fee4e77c</Id>
     </Book>
-    <Book Series="Spider-Man" Number="88" Volume="1990" Year="1998" Format="Main Series">
+    <Book Series="Spider-Man" Number="88" Volume="1990" Year="1998">
       <Id>3c373a91-7891-499e-b2be-9e8a22d7fe91</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="254" Volume="1976" Year="1998" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="254" Volume="1976" Year="1998">
       <Id>b1df40c8-731d-446d-b5ce-bc1363560cc3</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Spider-Man/Spider-Man 005 (Clone Years).cbl
+++ b/Marvel/Characters/unsorted/Spider-Man/Spider-Man 005 (Clone Years).cbl
@@ -1,864 +1,865 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Spider-Man 5 (Clone Years)</Name>
+  <Name>Spider-Man 005 (Clone Years)</Name>
+  <NumIssues>286</NumIssues>
   <Books>
     <Book Series="The Infinity Crusade" Number="1" Volume="1993" Year="1993">
-      <Id>4d712c58-3e96-4c10-ad93-bb1c0d2231e8</Id>
+      <Database Name="cv" Series="5019" Issue="108552" />
     </Book>
     <Book Series="The Infinity Crusade" Number="2" Volume="1993" Year="1993">
-      <Id>286b67dd-c39d-4d13-b7e2-28f0a4affa36</Id>
+      <Database Name="cv" Series="5019" Issue="37517" />
     </Book>
     <Book Series="Web of Spider-Man" Number="104" Volume="1985" Year="1993">
-      <Id>1e5c58d7-97c1-4d44-8af6-6c587b95492f</Id>
+      <Database Name="cv" Series="3519" Issue="37811" />
     </Book>
     <Book Series="Web of Spider-Man" Number="105" Volume="1985" Year="1993">
-      <Id>f74331cb-5194-4419-8a7e-66529033f24f</Id>
+      <Database Name="cv" Series="3519" Issue="37960" />
     </Book>
     <Book Series="The Infinity Crusade" Number="3" Volume="1993" Year="1993">
-      <Id>28b6a455-2b88-4cf7-a105-ba02cd35b5b8</Id>
+      <Database Name="cv" Series="5019" Issue="37658" />
     </Book>
     <Book Series="The Infinity Crusade" Number="4" Volume="1993" Year="1993">
-      <Id>8982b62d-8e8a-4551-81d3-e7196463901b</Id>
+      <Database Name="cv" Series="5019" Issue="37797" />
     </Book>
     <Book Series="Web of Spider-Man" Number="106" Volume="1985" Year="1993">
-      <Id>0a29d66f-be41-4221-8442-7c480ca132e2</Id>
+      <Database Name="cv" Series="3519" Issue="38109" />
     </Book>
     <Book Series="The Infinity Crusade" Number="5" Volume="1993" Year="1993">
-      <Id>27aff520-8589-4fa5-92e9-4b213a358787</Id>
+      <Database Name="cv" Series="5019" Issue="37950" />
     </Book>
     <Book Series="The Infinity Crusade" Number="6" Volume="1993" Year="1993">
-      <Id>a68e1f0b-08d6-4fd3-9de7-1512067e4fff</Id>
+      <Database Name="cv" Series="5019" Issue="38098" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="381" Volume="1963" Year="1993">
-      <Id>fa5f0bdc-628c-48a5-aba5-8b4d45abf453</Id>
+      <Database Name="cv" Series="2127" Issue="37789" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="382" Volume="1963" Year="1993">
-      <Id>82d644e2-cc70-4fba-9a1f-53c67c48b9e0</Id>
+      <Database Name="cv" Series="2127" Issue="37988" />
     </Book>
     <Book Series="Spider-Man" Number="38" Volume="1990" Year="1993">
-      <Id>e3784ec7-6116-4a3d-8f5f-8b80e3b032bb</Id>
+      <Database Name="cv" Series="4421" Issue="37807" />
     </Book>
     <Book Series="Spider-Man" Number="39" Volume="1990" Year="1993">
-      <Id>b3693d3c-7ce3-4591-b78a-2475b55c76b6</Id>
+      <Database Name="cv" Series="4421" Issue="37958" />
     </Book>
     <Book Series="Spider-Man" Number="40" Volume="1990" Year="1993">
-      <Id>aba68572-c0e1-489b-950b-fecf7d6cd082</Id>
+      <Database Name="cv" Series="4421" Issue="38106" />
     </Book>
     <Book Series="The Spectacular Spider-Man Annual" Number="13" Volume="1979" Year="1993">
-      <Id>43dfd119-5f96-46d8-9b66-5fe115a8e557</Id>
+      <Database Name="cv" Series="3012" Issue="36670" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="204" Volume="1976" Year="1993">
-      <Id>17265394-b0c9-4f0f-b7e6-91d3411935d7</Id>
+      <Database Name="cv" Series="2870" Issue="65598" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="205" Volume="1976" Year="1993">
-      <Id>a09cd694-a6e4-4fc7-80ff-b2b2b7f9db4b</Id>
+      <Database Name="cv" Series="2870" Issue="65599" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="206" Volume="1976" Year="1993">
-      <Id>d632697d-6aba-4181-94e6-05fd38a32307</Id>
+      <Database Name="cv" Series="2870" Issue="65600" />
     </Book>
     <Book Series="Web of Spider-Man" Number="107" Volume="1985" Year="1993">
-      <Id>28c9c776-568a-4453-95bf-9f4426558a9c</Id>
+      <Database Name="cv" Series="3519" Issue="38267" />
     </Book>
     <Book Series="Web of Spider-Man" Number="108" Volume="1985" Year="1994">
-      <Id>d256320a-4751-49f0-8905-891afeb43c15</Id>
+      <Database Name="cv" Series="3519" Issue="38516" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="383" Volume="1963" Year="1993">
-      <Id>b490bf01-8c7f-45cb-af7b-e87f8258e57b</Id>
+      <Database Name="cv" Series="2127" Issue="38152" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="384" Volume="1963" Year="1993">
-      <Id>3c2501eb-b0b6-40c0-b991-68f040ef16b3</Id>
+      <Database Name="cv" Series="2127" Issue="38309" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="385" Volume="1963" Year="1994">
-      <Id>32a09068-56f4-4fda-8970-5f98e2a3b479</Id>
+      <Database Name="cv" Series="2127" Issue="38563" />
     </Book>
     <Book Series="Web of Spider-Man" Number="109" Volume="1985" Year="1994">
-      <Id>1c28429a-c839-4297-9f8b-cd65025200b7</Id>
+      <Database Name="cv" Series="3519" Issue="38664" />
     </Book>
     <Book Series="Lethal Foes of Spider-Man" Number="1" Volume="1993" Year="1993">
-      <Id>5295427b-5a9f-48ba-b41a-69e7e211be94</Id>
+      <Database Name="cv" Series="5024" Issue="94943" />
     </Book>
     <Book Series="Lethal Foes of Spider-Man" Number="2" Volume="1993" Year="1993">
-      <Id>dec01e3c-7988-4646-abf1-bdf4fab814a9</Id>
+      <Database Name="cv" Series="5024" Issue="94944" />
     </Book>
     <Book Series="Lethal Foes of Spider-Man" Number="3" Volume="1993" Year="1993">
-      <Id>f7982929-d60e-49d9-a0ab-335c8291d256</Id>
+      <Database Name="cv" Series="5024" Issue="94945" />
     </Book>
     <Book Series="Lethal Foes of Spider-Man" Number="4" Volume="1993" Year="1993">
-      <Id>5122c45f-3c25-4615-84c8-f5db9c55cdc0</Id>
+      <Database Name="cv" Series="5024" Issue="94946" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="3" Volume="1993" Year="1993">
-      <Id>5aea9dae-ceb3-4fe0-8bc2-f8429a6009c4</Id>
+      <Database Name="cv" Series="5048" Issue="57290" />
     </Book>
     <Book Series="Spider-Man" Number="41" Volume="1990" Year="1993">
-      <Id>a19a1be1-42b6-45fd-9ed9-fe16ea13b1b8</Id>
+      <Database Name="cv" Series="4421" Issue="38264" />
     </Book>
     <Book Series="Spider-Man" Number="42" Volume="1990" Year="1994">
-      <Id>04432a30-fabf-4a9e-a1ad-4a9b6496cf8b</Id>
+      <Database Name="cv" Series="4421" Issue="38513" />
     </Book>
     <Book Series="Spider-Man" Number="43" Volume="1990" Year="1994">
-      <Id>7844eed4-5a2a-4670-af2a-7e27c540d4c6</Id>
+      <Database Name="cv" Series="4421" Issue="38661" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="4" Volume="1993" Year="1994">
-      <Id>6cfc1325-af0e-4e3f-a3ed-43f09b4a044c</Id>
+      <Database Name="cv" Series="5048" Issue="57291" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="207" Volume="1976" Year="1993">
-      <Id>f9bf800d-bb1a-4555-8e3c-cc652524c7fa</Id>
+      <Database Name="cv" Series="2870" Issue="65601" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="208" Volume="1976" Year="1994">
-      <Id>d6b83563-e58f-49bd-b6fc-7ec1adbf2146</Id>
+      <Database Name="cv" Series="2870" Issue="65602" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="28" Volume="1964" Year="1994">
-      <Id>7b7d9b97-a49b-4bf4-a521-a4a25e9e3789</Id>
+      <Database Name="cv" Series="2189" Issue="64432" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="209" Volume="1976" Year="1994">
-      <Id>2c8ef3bd-5177-4b54-8e4a-52de64ca90f4</Id>
+      <Database Name="cv" Series="2870" Issue="65603" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="210" Volume="1976" Year="1994">
-      <Id>5d386b4b-9de2-4e37-aa5d-62ceddad3727</Id>
+      <Database Name="cv" Series="2870" Issue="65604" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="386" Volume="1963" Year="1994">
-      <Id>eacfcad8-0acd-47d8-8df2-e6b5efb361e3</Id>
+      <Database Name="cv" Series="2127" Issue="38702" />
     </Book>
     <Book Series="Web of Spider-Man" Number="110" Volume="1985" Year="1994">
-      <Id>4b262995-eef6-4179-8bec-872bed1f4e69</Id>
+      <Database Name="cv" Series="3519" Issue="38809" />
     </Book>
     <Book Series="Web of Spider-Man" Number="111" Volume="1985" Year="1994">
-      <Id>7c257be2-5329-4294-92ae-89f33bb282cf</Id>
+      <Database Name="cv" Series="3519" Issue="38951" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="387" Volume="1963" Year="1994">
-      <Id>afc5e9db-280a-46ce-9894-dd4e53517812</Id>
+      <Database Name="cv" Series="2127" Issue="38852" />
     </Book>
     <Book Series="Spider-Man" Number="44" Volume="1990" Year="1994">
-      <Id>5a2cf6f1-70e5-462f-abba-0619497a8b56</Id>
+      <Database Name="cv" Series="4421" Issue="38806" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="388" Volume="1963" Year="1994">
-      <Id>bc812b21-3f92-411b-b124-53bbf7704616</Id>
+      <Database Name="cv" Series="2127" Issue="38989" />
     </Book>
     <Book Series="Spider-Man" Number="45" Volume="1990" Year="1994">
-      <Id>e71c0700-c761-4c52-a17a-f1c27b971e23</Id>
+      <Database Name="cv" Series="4421" Issue="38948" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="211" Volume="1976" Year="1994">
-      <Id>9e23fe23-6ebd-47e0-81ca-c56dd4c5ecc1</Id>
+      <Database Name="cv" Series="2870" Issue="65605" />
     </Book>
     <Book Series="Web of Spider-Man" Number="112" Volume="1985" Year="1994">
-      <Id>3d282e6c-b730-4661-adfc-8a5d1be2c267</Id>
+      <Database Name="cv" Series="3519" Issue="39091" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="389" Volume="1963" Year="1994">
-      <Id>f304bdd0-a1ee-47be-b869-76330a011dca</Id>
+      <Database Name="cv" Series="2127" Issue="39131" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="212" Volume="1976" Year="1994">
-      <Id>a4b73f51-4648-4d4c-9be4-8b66a3334e83</Id>
+      <Database Name="cv" Series="2870" Issue="65606" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="5" Volume="1993" Year="1994">
-      <Id>0d25bac8-cacd-4819-ac3b-1214f8d25490</Id>
+      <Database Name="cv" Series="5048" Issue="57292" />
     </Book>
     <Book Series="Web of Spider-Man Annual" Number="10" Volume="1985" Year="1994">
-      <Id>af106b3a-5c03-40c8-85bb-9eeec6b49f75</Id>
+      <Database Name="cv" Series="3520" Issue="77999" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="213" Volume="1976" Year="1994">
-      <Id>897712d4-57d8-42f8-b1eb-4ace1a8005a1</Id>
+      <Database Name="cv" Series="2870" Issue="65607" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="214" Volume="1976" Year="1994">
-      <Id>962b3310-d91a-4234-9b5e-5a0d6f4ccf0d</Id>
+      <Database Name="cv" Series="2870" Issue="65608" />
     </Book>
     <Book Series="The Spectacular Spider-Man Annual" Number="14" Volume="1979" Year="1994">
-      <Id>c00a3d5c-7fd9-454a-be2b-1c0f325957f8</Id>
+      <Database Name="cv" Series="3012" Issue="38408" />
     </Book>
     <Book Series="Spider-Man" Number="46" Volume="1990" Year="1994">
-      <Id>02cd9f38-28a3-487d-9aee-472e4472c662</Id>
+      <Database Name="cv" Series="4421" Issue="39088" />
     </Book>
     <Book Series="Spider-Man" Number="47" Volume="1990" Year="1994">
-      <Id>bb40ca22-5b3c-42ee-b11b-d7477ebaf76e</Id>
+      <Database Name="cv" Series="4421" Issue="39230" />
     </Book>
     <Book Series="Web of Spider-Man" Number="113" Volume="1985" Year="1994">
-      <Id>a3ab1390-0bd5-4a8f-9b9b-f345e519bc8d</Id>
+      <Database Name="cv" Series="3519" Issue="39233" />
     </Book>
     <Book Series="Web of Spider-Man" Number="114" Volume="1985" Year="1994">
-      <Id>46297e95-88dd-4e6d-870a-1110adb388e2</Id>
+      <Database Name="cv" Series="3519" Issue="39381" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="390" Volume="1963" Year="1994">
-      <Id>0ed28948-18d5-4444-9b81-b71f283455b9</Id>
+      <Database Name="cv" Series="2127" Issue="39283" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="391" Volume="1963" Year="1994">
-      <Id>a3c72b26-d444-4c74-890e-59d92747c08b</Id>
+      <Database Name="cv" Series="2127" Issue="39424" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="392" Volume="1963" Year="1994">
-      <Id>e978e801-15fb-42a0-b9f2-6d7566955a8f</Id>
+      <Database Name="cv" Series="2127" Issue="39498" />
     </Book>
     <Book Series="Spider-Man" Number="48" Volume="1990" Year="1994">
-      <Id>85c3e69b-f99d-4b51-abd7-3be62d439833</Id>
+      <Database Name="cv" Series="4421" Issue="39378" />
     </Book>
     <Book Series="Web of Spider-Man" Number="115" Volume="1985" Year="1994">
-      <Id>5348bef2-f998-4043-9046-13c1cbcf46f5</Id>
+      <Database Name="cv" Series="3519" Issue="39513" />
     </Book>
     <Book Series="Web of Spider-Man" Number="116" Volume="1985" Year="1994">
-      <Id>9a7b8a7c-88fa-4802-8dd2-b3d786d511aa</Id>
+      <Database Name="cv" Series="3519" Issue="39654" />
     </Book>
     <Book Series="Spider-Man" Number="49" Volume="1990" Year="1994">
-      <Id>3596d994-5186-4426-9fd6-564892968726</Id>
+      <Database Name="cv" Series="4421" Issue="39511" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="6" Volume="1993" Year="1994">
-      <Id>529534f5-53bd-4499-909c-c43bd60eaf8a</Id>
+      <Database Name="cv" Series="5048" Issue="57293" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="393" Volume="1963" Year="1994">
-      <Id>c961af29-8b07-4f5e-969f-d3266fdb0b8b</Id>
+      <Database Name="cv" Series="2127" Issue="39704" />
     </Book>
     <Book Series="Spider-Man" Number="50" Volume="1990" Year="1994">
-      <Id>aac476d1-cd2f-41d9-8ecd-2ee0a73d1680</Id>
+      <Database Name="cv" Series="4421" Issue="64629" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="215" Volume="1976" Year="1994">
-      <Id>d066e6fa-3d10-4935-a942-f9864b69a6e3</Id>
+      <Database Name="cv" Series="2870" Issue="65609" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="216" Volume="1976" Year="1994">
-      <Id>e5bc441c-ed70-4428-9a88-d82a1a2939cc</Id>
+      <Database Name="cv" Series="2870" Issue="65610" />
     </Book>
     <Book Series="Web of Spider-Man" Number="117" Volume="1985" Year="1994">
-      <Id>58667164-81ef-4141-84c0-ed1781dfb10b</Id>
+      <Database Name="cv" Series="3519" Issue="65542" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="394" Volume="1963" Year="1994">
-      <Id>58aa60cc-f76f-4528-84e8-6c36aba8d1f5</Id>
+      <Database Name="cv" Series="2127" Issue="64433" />
     </Book>
     <Book Series="Spider-Man" Number="51" Volume="1990" Year="1994">
-      <Id>1f97afa0-76cf-472f-81e9-d82878c50352</Id>
+      <Database Name="cv" Series="4421" Issue="64630" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="217" Volume="1976" Year="1994">
-      <Id>fe87f875-ff44-47ae-9190-902db37a2fdc</Id>
+      <Database Name="cv" Series="2870" Issue="65611" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="7" Volume="1993" Year="1994">
-      <Id>1e9dbe3c-40d6-4f39-b0fd-a13247ce4fc9</Id>
+      <Database Name="cv" Series="5048" Issue="57294" />
     </Book>
     <Book Series="Web of Spider-Man" Number="118" Volume="1985" Year="1994">
-      <Id>7381bd8d-c485-418e-9e1c-eedc01a134ca</Id>
+      <Database Name="cv" Series="3519" Issue="65543" />
     </Book>
     <Book Series="Spider-Man" Number="52" Volume="1990" Year="1994">
-      <Id>ff43b6ea-5660-473a-9040-8b1b5722d019</Id>
+      <Database Name="cv" Series="4421" Issue="64631" />
     </Book>
     <Book Series="Web of Spider-Man" Number="119" Volume="1985" Year="1994">
-      <Id>f44565ce-420b-4ba5-83f0-3c9b062dd543</Id>
+      <Database Name="cv" Series="3519" Issue="65544" />
     </Book>
     <Book Series="Spider-Man" Number="53" Volume="1990" Year="1994">
-      <Id>c4901ed8-1190-4ab1-9842-6ee1e9288277</Id>
+      <Database Name="cv" Series="4421" Issue="64632" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="395" Volume="1963" Year="1994">
-      <Id>8169f8b6-510a-4a84-a9f7-1cbef7ec927a</Id>
+      <Database Name="cv" Series="2127" Issue="64434" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="218" Volume="1976" Year="1994">
-      <Id>ae0b32e2-2120-44d7-a879-93a12a585933</Id>
+      <Database Name="cv" Series="2870" Issue="65612" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="396" Volume="1963" Year="1994">
-      <Id>0dfe3b6f-33d7-4197-a792-d87fc2f2798d</Id>
+      <Database Name="cv" Series="2127" Issue="64435" />
     </Book>
     <Book Series="Web of Spider-Man" Number="120" Volume="1985" Year="1995">
-      <Id>dff1960d-c5dd-4457-aafa-125d70a31f29</Id>
+      <Database Name="cv" Series="3519" Issue="65545" />
     </Book>
     <Book Series="Spider-Man" Number="54" Volume="1990" Year="1995">
-      <Id>42a2f9b6-fbae-441c-80ce-8af33535c9c2</Id>
+      <Database Name="cv" Series="4421" Issue="64633" />
     </Book>
     <Book Series="Web of Spider-Man" Number="121" Volume="1985" Year="1995">
-      <Id>11ed4cd5-39e3-4d1a-ab39-b2ce25616d38</Id>
+      <Database Name="cv" Series="3519" Issue="65546" />
     </Book>
     <Book Series="Spider-Man" Number="55" Volume="1990" Year="1995">
-      <Id>5099655e-8918-4e83-a669-0641c6aeb217</Id>
+      <Database Name="cv" Series="4421" Issue="64634" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="397" Volume="1963" Year="1995">
-      <Id>de47cb51-1191-4f36-b2be-51dfd407783e</Id>
+      <Database Name="cv" Series="2127" Issue="64436" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="220" Volume="1976" Year="1995">
-      <Id>bed4fb08-dd7e-45fc-b7df-8505eec900e8</Id>
+      <Database Name="cv" Series="2870" Issue="65615" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="398" Volume="1963" Year="1995">
-      <Id>80fc9885-2197-4609-b167-c5302229d614</Id>
+      <Database Name="cv" Series="2127" Issue="64437" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="221" Volume="1976" Year="1995">
-      <Id>64e8fca1-0867-4304-ba9d-09218324be17</Id>
+      <Database Name="cv" Series="2870" Issue="65616" />
     </Book>
     <Book Series="Spider-Man: Friends and Enemies" Number="1" Volume="1995" Year="1995">
-      <Id>2f76face-34cb-43b4-b60c-23c283c7c526</Id>
+      <Database Name="cv" Series="9082" Issue="64972" />
     </Book>
     <Book Series="Spider-Man: Friends and Enemies" Number="2" Volume="1995" Year="1995">
-      <Id>04e0bbc1-871f-4882-8d8d-27d1d110b73e</Id>
+      <Database Name="cv" Series="9082" Issue="64975" />
     </Book>
     <Book Series="Spider-Man: Friends and Enemies" Number="3" Volume="1995" Year="1995">
-      <Id>77219aed-a183-4542-89ce-50ebb5378bae</Id>
+      <Database Name="cv" Series="9082" Issue="64978" />
     </Book>
     <Book Series="Spider-Man: Friends and Enemies" Number="4" Volume="1995" Year="1995">
-      <Id>1e44da5f-5d3b-4033-9ad2-4f3e688b397e</Id>
+      <Database Name="cv" Series="9082" Issue="64981" />
     </Book>
     <Book Series="Spider-Man: Funeral for an Octopus" Number="1" Volume="1995" Year="1995">
-      <Id>a3ca95c3-bd23-4b27-861a-7d417992af77</Id>
+      <Database Name="cv" Series="20983" Issue="125633" />
     </Book>
     <Book Series="Spider-Man: Funeral for an Octopus" Number="2" Volume="1995" Year="1995">
-      <Id>a202b5ac-0f5b-4c0b-8c4e-9ed84597b7d0</Id>
+      <Database Name="cv" Series="20983" Issue="125692" />
     </Book>
     <Book Series="Spider-Man: Funeral for an Octopus" Number="3" Volume="1995" Year="1995">
-      <Id>56474ebf-b88c-405a-8f21-556aa05be496</Id>
+      <Database Name="cv" Series="20983" Issue="125693" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="8" Volume="1993" Year="1995">
-      <Id>c6e59ba0-f0a2-43db-9e89-d0b6094815cd</Id>
+      <Database Name="cv" Series="5048" Issue="57295" />
     </Book>
     <Book Series="Web of Spider-Man" Number="122" Volume="1985" Year="1995">
-      <Id>4f9c7ab7-b3fc-49ad-b076-cbb6a8f21c28</Id>
+      <Database Name="cv" Series="3519" Issue="65547" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="399" Volume="1963" Year="1995">
-      <Id>a0916855-b64c-422a-b263-837f16625e99</Id>
+      <Database Name="cv" Series="2127" Issue="64438" />
     </Book>
     <Book Series="Spider-Man" Number="56" Volume="1990" Year="1995">
-      <Id>58a83af7-0a72-4b95-9575-9ba03c7b71a3</Id>
+      <Database Name="cv" Series="4421" Issue="64635" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="222" Volume="1976" Year="1995">
-      <Id>54b21053-7ea1-4b5a-a96b-9584e5f90dbd</Id>
+      <Database Name="cv" Series="2870" Issue="65617" />
     </Book>
     <Book Series="Web of Spider-Man" Number="123" Volume="1985" Year="1995">
-      <Id>6d93fce9-219a-4ffc-b8fe-dfa56d71d284</Id>
+      <Database Name="cv" Series="3519" Issue="65548" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="400" Volume="1963" Year="1995">
-      <Id>1fbcc15b-f221-4804-9ea5-e41fb64876e8</Id>
+      <Database Name="cv" Series="2127" Issue="64439" />
     </Book>
     <Book Series="Spider-Man" Number="57" Volume="1990" Year="1995">
-      <Id>cf19b512-5e09-4f95-9170-15297a999813</Id>
+      <Database Name="cv" Series="4421" Issue="64636" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="223" Volume="1976" Year="1995">
-      <Id>7711e055-31f8-46e7-9e35-c140a6af2d93</Id>
+      <Database Name="cv" Series="2870" Issue="65618" />
     </Book>
     <Book Series="Web of Spider-Man" Number="124" Volume="1985" Year="1995">
-      <Id>818cad6a-2bf3-4e0b-a401-651f1cc8d790</Id>
+      <Database Name="cv" Series="3519" Issue="65549" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="401" Volume="1963" Year="1995">
-      <Id>5b91f57b-7b17-4bb3-9d64-0c39eeb9aeff</Id>
+      <Database Name="cv" Series="2127" Issue="64440" />
     </Book>
     <Book Series="Spider-Man" Number="58" Volume="1990" Year="1995">
-      <Id>2c59be5d-53e4-482f-b3c8-a37ea6546565</Id>
+      <Database Name="cv" Series="4421" Issue="64637" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="224" Volume="1976" Year="1995">
-      <Id>4b5db7d3-a2fa-42ed-958c-78297296d079</Id>
+      <Database Name="cv" Series="2870" Issue="65619" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="9" Volume="1993" Year="1995">
-      <Id>07eb2c00-b19e-47b5-a050-47985f1d9445</Id>
+      <Database Name="cv" Series="5048" Issue="57296" />
     </Book>
     <Book Series="Web of Spider-Man" Number="125" Volume="1985" Year="1995">
-      <Id>6b0e2fff-c5f7-40c9-a7ed-9d3f971c6245</Id>
+      <Database Name="cv" Series="3519" Issue="65550" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="402" Volume="1963" Year="1995">
-      <Id>b89bc805-7bde-4652-9c7f-6744689bfe89</Id>
+      <Database Name="cv" Series="2127" Issue="111213" />
     </Book>
     <Book Series="Spider-Man" Number="59" Volume="1990" Year="1995">
-      <Id>c3b21615-11ed-4bc1-a286-f9e15a785a4c</Id>
+      <Database Name="cv" Series="4421" Issue="64638" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="225" Volume="1976" Year="1995">
-      <Id>b90e308f-0717-449b-8c31-481d7ccc83c9</Id>
+      <Database Name="cv" Series="2870" Issue="65620" />
     </Book>
     <Book Series="Web of Spider-Man" Number="126" Volume="1985" Year="1995">
-      <Id>3c35a562-5eca-432b-b06d-e9e744ca7a11</Id>
+      <Database Name="cv" Series="3519" Issue="65551" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="403" Volume="1963" Year="1995">
-      <Id>e08d215e-a1f8-41a4-b208-588ba8a50b0d</Id>
+      <Database Name="cv" Series="2127" Issue="64441" />
     </Book>
     <Book Series="Spider-Man" Number="60" Volume="1990" Year="1995">
-      <Id>f4adaf7a-590b-48bc-b727-3efc1d1e121a</Id>
+      <Database Name="cv" Series="4421" Issue="64639" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="226" Volume="1976" Year="1995">
-      <Id>56da8d89-77fe-4782-9a54-36386d311283</Id>
+      <Database Name="cv" Series="2870" Issue="65621" />
     </Book>
     <Book Series="Spider-Man: The Jackal Files" Number="1" Volume="1995" Year="1995">
-      <Id>87d8460b-1304-40d3-befd-d20dc27433f8</Id>
+      <Database Name="cv" Series="31444" Issue="196059" />
     </Book>
-    <Book Series="Spider-Man: Maximum Clonage" Number="1" Volume="1995" Year="1995">
-      <Id>d68c8097-57a5-4e2e-adf1-484eae9d1b53</Id>
+    <Book Series="Spider-Man: Maximum Clonage Alpha" Number="1" Volume="1995" Year="1995">
+      <Database Name="cv" Series="30842" Issue="190583" />
     </Book>
     <Book Series="Web of Spider-Man" Number="127" Volume="1985" Year="1995">
-      <Id>fa154748-f33b-4b32-acdf-902cede990bc</Id>
+      <Database Name="cv" Series="3519" Issue="65552" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="404" Volume="1963" Year="1995">
-      <Id>cac2fa05-e8ef-4261-9a08-cc393a07a49f</Id>
+      <Database Name="cv" Series="2127" Issue="64442" />
     </Book>
     <Book Series="Spider-Man" Number="61" Volume="1990" Year="1995">
-      <Id>c52d362d-7722-4ec8-88f5-14622fa36d33</Id>
+      <Database Name="cv" Series="4421" Issue="64640" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="227" Volume="1976" Year="1995">
-      <Id>43db0548-e575-4e56-9642-2070db485b4e</Id>
+      <Database Name="cv" Series="2870" Issue="109299" />
     </Book>
-    <Book Series="Spider-Man: Maximum Clonage" Number="2" Volume="1995" Year="1995">
-      <Id>28776a75-d58e-4e85-b2dc-619b9ba9475a</Id>
+    <Book Series="Spider-Man: Maximum Clonage Omega" Number="1" Volume="1995" Year="1995">
+      <Database Name="cv" Series="79252" Issue="190632" />
     </Book>
     <Book Series="Web of Spider-Man" Number="128" Volume="1985" Year="1995">
-      <Id>cadea783-5771-4fb6-8a30-8e8351b7a9ba</Id>
+      <Database Name="cv" Series="3519" Issue="65553" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="405" Volume="1963" Year="1995">
-      <Id>3212f92a-7931-41c8-b432-0675cd9043c1</Id>
+      <Database Name="cv" Series="2127" Issue="64443" />
     </Book>
     <Book Series="Spider-Man" Number="62" Volume="1990" Year="1995">
-      <Id>9e07d1eb-12a7-413a-b3ff-8b3d805412f0</Id>
+      <Database Name="cv" Series="4421" Issue="64641" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="10" Volume="1993" Year="1995">
-      <Id>a30906fc-d622-4d1a-b247-3c05eefdd67e</Id>
+      <Database Name="cv" Series="5048" Issue="113553" />
     </Book>
     <Book Series="Amazing Spider-Man Super Special" Number="1" Volume="1995" Year="1995">
-      <Id>51a8585a-b02f-4493-887c-aec28e25bd6f</Id>
+      <Database Name="cv" Series="18772" Issue="110899" />
     </Book>
     <Book Series="Spider-Man Super Special" Number="1" Volume="1995" Year="1995">
-      <Id>e4e6bba3-7bed-48af-8e94-b02f65ddcb6a</Id>
+      <Database Name="cv" Series="23406" Issue="140411" />
     </Book>
     <Book Series="Venom Super Special" Number="1" Volume="1995" Year="1995">
-      <Id>59b30264-f4d7-476c-8c24-28d90aeb7450</Id>
+      <Database Name="cv" Series="22554" Issue="135337" />
     </Book>
     <Book Series="Spectacular Spider-Man Super Special" Number="1" Volume="1995" Year="1995">
-      <Id>97dd2a0f-ae07-4be6-9ae2-6f962c5c5e05</Id>
+      <Database Name="cv" Series="23407" Issue="140414" />
     </Book>
     <Book Series="Web of Spider-Man Super Special" Number="1" Volume="1995" Year="1995">
-      <Id>3b84b127-59cf-4248-a42d-41d1b7589e42</Id>
+      <Database Name="cv" Series="23183" Issue="139552" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="228" Volume="1976" Year="1995">
-      <Id>2bdd9e32-f9bb-4fa9-83e3-a2f092a9c3be</Id>
+      <Database Name="cv" Series="2870" Issue="65623" />
     </Book>
     <Book Series="Web of Spider-Man" Number="129" Volume="1985" Year="1995">
-      <Id>d536c0c1-1c4e-4f2b-aa1b-e740ef14e414</Id>
+      <Database Name="cv" Series="3519" Issue="65554" />
     </Book>
     <Book Series="Spider-Man Team-Up" Number="1" Volume="1995" Year="1995">
-      <Id>b1641e3b-39cb-4658-9d85-4de36b9c14ce</Id>
+      <Database Name="cv" Series="5561" Issue="41773" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="406" Volume="1963" Year="1995">
-      <Id>cd409a5d-6504-4858-b07e-8cc98983d167</Id>
+      <Database Name="cv" Series="2127" Issue="64444" />
     </Book>
     <Book Series="Spider-Man" Number="63" Volume="1990" Year="1995">
-      <Id>3eff1875-05fa-4ee3-97b9-c84dcc25c7eb</Id>
+      <Database Name="cv" Series="4421" Issue="64642" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="229" Volume="1976" Year="1995">
-      <Id>894b45ed-e490-4429-b80b-5acc916ab187</Id>
+      <Database Name="cv" Series="2870" Issue="65624" />
     </Book>
     <Book Series="Scarlet Spider Unlimited" Number="1" Volume="1995" Year="1995">
-      <Id>306f9248-3992-41d4-9ac4-c46865e72d64</Id>
+      <Database Name="cv" Series="23665" Issue="141782" />
     </Book>
     <Book Series="Web of Scarlet Spider" Number="1" Volume="1995" Year="1995">
-      <Id>ee0df59f-2a08-4e11-9a55-515af4f6c379</Id>
+      <Database Name="cv" Series="11136" Issue="97650" />
     </Book>
     <Book Series="The Amazing Scarlet Spider" Number="1" Volume="1995" Year="1995">
-      <Id>866a9e16-24e6-434d-972f-5f8e8248b05e</Id>
+      <Database Name="cv" Series="9539" Issue="78466" />
     </Book>
     <Book Series="Scarlet Spider" Number="1" Volume="1995" Year="1995">
-      <Id>427cf912-c778-4bb3-9f7d-b25cbc34cb9f</Id>
+      <Database Name="cv" Series="22212" Issue="133543" />
     </Book>
     <Book Series="Spider-Man: The Parker Years" Number="1" Volume="1995" Year="1995">
-      <Id>d8ad4c13-a985-4831-a454-733c5411eb7f</Id>
+      <Database Name="cv" Series="20257" Issue="120918" />
     </Book>
     <Book Series="Web of Scarlet Spider" Number="2" Volume="1995" Year="1995">
-      <Id>00071540-09ee-45aa-9430-6ebe2309bef8</Id>
+      <Database Name="cv" Series="11136" Issue="97651" />
     </Book>
     <Book Series="The Amazing Scarlet Spider" Number="2" Volume="1995" Year="1995">
-      <Id>bf1f8eee-ea98-40ef-94dd-b316103f57ad</Id>
+      <Database Name="cv" Series="9539" Issue="78467" />
     </Book>
     <Book Series="Scarlet Spider" Number="2" Volume="1995" Year="1995">
-      <Id>8bc3f422-4d9b-462f-9e2f-c23e8fa58f49</Id>
+      <Database Name="cv" Series="22212" Issue="141786" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="0" Volume="1996" Year="1996">
-      <Id>a54493d2-cd4c-4cdc-905c-7e5ca78d8441</Id>
+      <Database Name="cv" Series="5788" Issue="77941" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="407" Volume="1963" Year="1996">
-      <Id>751ad696-9ec6-44e9-8727-b92e136dbc2d</Id>
+      <Database Name="cv" Series="2127" Issue="64445" />
     </Book>
     <Book Series="Spider-Man: The Final Adventure" Number="1" Volume="1996" Year="1995">
-      <Id>f2c7b734-e933-430a-9dcb-1638f44f61f7</Id>
+      <Database Name="cv" Series="21004" Issue="125747" />
     </Book>
     <Book Series="Spider-Man: The Final Adventure" Number="2" Volume="1996" Year="1996">
-      <Id>fa30b58a-fb4b-4ecd-bcea-cf1beffd4327</Id>
+      <Database Name="cv" Series="21004" Issue="125769" />
     </Book>
     <Book Series="Spider-Man: The Final Adventure" Number="3" Volume="1996" Year="1996">
-      <Id>fb308727-ad75-468d-a709-9ba6505887e6</Id>
+      <Database Name="cv" Series="21004" Issue="125770" />
     </Book>
     <Book Series="Spider-Man: The Final Adventure" Number="4" Volume="1996" Year="1996">
-      <Id>55e3aa49-445d-4b03-ab2a-68e91bb534e2</Id>
+      <Database Name="cv" Series="21004" Issue="125771" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="11" Volume="1993" Year="1996">
-      <Id>4fc927e6-6754-4b1b-9726-ba3a811ee9d7</Id>
+      <Database Name="cv" Series="5048" Issue="57297" />
     </Book>
     <Book Series="Spider-Man" Number="64" Volume="1990" Year="1996">
-      <Id>f2ff2546-082a-4fc3-9737-d3487a7260cb</Id>
+      <Database Name="cv" Series="4421" Issue="64643" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="230" Volume="1976" Year="1996">
-      <Id>4d20f459-992b-47d5-b50c-2c260382f6f8</Id>
+      <Database Name="cv" Series="2870" Issue="65625" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="1" Volume="1996" Year="1996">
-      <Id>bcc0f187-8c09-4a9c-b82f-0de340b9a057</Id>
+      <Database Name="cv" Series="5788" Issue="77942" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="408" Volume="1963" Year="1996">
-      <Id>e46fb5cf-a232-44c3-a3fb-e799892ba78f</Id>
+      <Database Name="cv" Series="2127" Issue="64446" />
     </Book>
     <Book Series="Spider-Man" Number="65" Volume="1990" Year="1996">
-      <Id>f1ca948a-5f72-4228-a612-00cb0ffd7d5a</Id>
+      <Database Name="cv" Series="4421" Issue="64644" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="231" Volume="1976" Year="1996">
-      <Id>b5cd0943-05e6-4a27-bcae-6ac27c5b68bf</Id>
+      <Database Name="cv" Series="2870" Issue="65626" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="2" Volume="1996" Year="1996">
-      <Id>1920f62c-2a1e-47b1-9749-5eb99c026a52</Id>
+      <Database Name="cv" Series="5788" Issue="77943" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="409" Volume="1963" Year="1996">
-      <Id>6f21caea-b723-46d9-826e-31afd8b18b69</Id>
+      <Database Name="cv" Series="2127" Issue="64447" />
     </Book>
     <Book Series="Spider-Man" Number="66" Volume="1990" Year="1996">
-      <Id>56fd1318-60e9-4784-bd87-8d66b47d2872</Id>
+      <Database Name="cv" Series="4421" Issue="64645" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="232" Volume="1976" Year="1996">
-      <Id>67d438c6-2bfc-4d47-a61e-f61f524d67aa</Id>
+      <Database Name="cv" Series="2870" Issue="65627" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="3" Volume="1996" Year="1996">
-      <Id>bb2deb26-2a30-4404-a734-097ea9b3132f</Id>
+      <Database Name="cv" Series="5788" Issue="77944" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="410" Volume="1963" Year="1996">
-      <Id>74536b64-62c3-458b-ac96-49aafefc9a4f</Id>
+      <Database Name="cv" Series="2127" Issue="64448" />
     </Book>
     <Book Series="Spider-Man" Number="67" Volume="1990" Year="1996">
-      <Id>ed1f23e8-d692-4e7f-bfd1-7443918d8e72</Id>
+      <Database Name="cv" Series="4421" Issue="64646" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="233" Volume="1976" Year="1996">
-      <Id>5cdebe12-8ad2-43d3-b4a8-793235e67208</Id>
+      <Database Name="cv" Series="2870" Issue="65628" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="4" Volume="1996" Year="1996">
-      <Id>04674dc7-04fc-499d-a804-10020b9085e9</Id>
+      <Database Name="cv" Series="5788" Issue="77945" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="411" Volume="1963" Year="1996">
-      <Id>5a5861ab-4dda-41e1-b3ef-f299d4593755</Id>
+      <Database Name="cv" Series="2127" Issue="64449" />
     </Book>
     <Book Series="Spider-Man" Number="68" Volume="1990" Year="1996">
-      <Id>5cf6119e-bcfd-44fc-9deb-25251702a4a0</Id>
+      <Database Name="cv" Series="4421" Issue="64647" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="234" Volume="1976" Year="1996">
-      <Id>f95eab6e-f6df-4601-b9b1-51524b59bfb5</Id>
+      <Database Name="cv" Series="2870" Issue="65629" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="5" Volume="1996" Year="1996">
-      <Id>da11577f-d29c-4037-bac4-cb7aec280993</Id>
+      <Database Name="cv" Series="5788" Issue="77946" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="412" Volume="1963" Year="1996">
-      <Id>fb551cf8-cc7e-4dbb-9b39-82c1cd5323d7</Id>
+      <Database Name="cv" Series="2127" Issue="64450" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="12" Volume="1993" Year="1996">
-      <Id>c8534141-f9ab-4a4c-b03a-401c9a01e5d2</Id>
+      <Database Name="cv" Series="5048" Issue="113554" />
     </Book>
     <Book Series="Spider-Man" Number="69" Volume="1990" Year="1996">
-      <Id>eabb02b5-042e-4130-8e9b-8b46dc9a8472</Id>
+      <Database Name="cv" Series="4421" Issue="113519" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="13" Volume="1993" Year="1996">
-      <Id>b3218b33-080c-4c00-9528-18de72923acb</Id>
+      <Database Name="cv" Series="5048" Issue="57298" />
     </Book>
     <Book Series="Spider-Man Team-Up" Number="4" Volume="1995" Year="1996">
-      <Id>4976f056-215c-4fad-801d-c8783d0650a4</Id>
+      <Database Name="cv" Series="5561" Issue="42798" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="6" Volume="1996" Year="1996">
-      <Id>292da3ac-fc1d-4314-ba05-4fe69843be8c</Id>
+      <Database Name="cv" Series="5788" Issue="77947" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="413" Volume="1963" Year="1996">
-      <Id>ec4bf48c-cf8b-4319-8c0d-041486696d30</Id>
+      <Database Name="cv" Series="2127" Issue="64451" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="235" Volume="1976" Year="1996">
-      <Id>c8b4b699-61bf-4aed-bdc8-f9e91eb4ca67</Id>
+      <Database Name="cv" Series="2870" Issue="109397" />
     </Book>
     <Book Series="Spider-Man" Number="70" Volume="1990" Year="1996">
-      <Id>ad0ab92d-3d1d-4090-8c8b-3df5d5d05071</Id>
+      <Database Name="cv" Series="4421" Issue="64648" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="236" Volume="1976" Year="1996">
-      <Id>858c365e-41d7-45a0-95d3-2b3584bdd054</Id>
+      <Database Name="cv" Series="2870" Issue="109398" />
     </Book>
     <Book Series="Spider-Man: Redemption" Number="1" Volume="1996" Year="1996">
-      <Id>b507f4a2-a6da-4475-8253-268e863f62fa</Id>
+      <Database Name="cv" Series="26778" Issue="160702" />
     </Book>
     <Book Series="Spider-Man: Redemption" Number="2" Volume="1996" Year="1996">
-      <Id>bb3dd1d9-8f62-4d5f-817e-f1039ea4af43</Id>
+      <Database Name="cv" Series="26778" Issue="160703" />
     </Book>
     <Book Series="Spider-Man: Redemption" Number="3" Volume="1996" Year="1996">
-      <Id>c3f30fd7-0b23-43c5-9f52-1a84b657432f</Id>
+      <Database Name="cv" Series="26778" Issue="160704" />
     </Book>
     <Book Series="Spider-Man: Redemption" Number="4" Volume="1996" Year="1996">
-      <Id>67f6d6a0-422e-4c5d-b0ae-21199716f243</Id>
+      <Database Name="cv" Series="26778" Issue="160701" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="7" Volume="1996" Year="1996">
-      <Id>16429bd9-336a-43ef-8f2d-19521248716b</Id>
+      <Database Name="cv" Series="5788" Issue="77948" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="414" Volume="1963" Year="1996">
-      <Id>fe17318b-e291-4688-a9c5-41c740b67bd7</Id>
+      <Database Name="cv" Series="2127" Issue="64452" />
     </Book>
     <Book Series="Spider-Man" Number="71" Volume="1990" Year="1996">
-      <Id>4d426b3a-cc7f-4b2c-9615-00ca2d5058bd</Id>
+      <Database Name="cv" Series="4421" Issue="64649" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="237" Volume="1976" Year="1996">
-      <Id>7f52802f-56e3-4b9c-9860-6f83e968f5a5</Id>
+      <Database Name="cv" Series="2870" Issue="109399" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="14" Volume="1993" Year="1996">
-      <Id>deedb5b8-a68a-49e7-89c3-0e447e9a1ff6</Id>
+      <Database Name="cv" Series="5048" Issue="57299" />
     </Book>
     <Book Series="Spider-Man Team-Up" Number="5" Volume="1995" Year="1996">
-      <Id>affddce7-51c6-4085-8d3b-436603a4ed4e</Id>
+      <Database Name="cv" Series="5561" Issue="43083" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="8" Volume="1996" Year="1996">
-      <Id>06f47376-a599-47fb-848a-43f6ef0f3f48</Id>
+      <Database Name="cv" Series="5788" Issue="77949" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="415" Volume="1963" Year="1996">
-      <Id>8dcc5eea-b381-4cb2-873d-1be305d19665</Id>
+      <Database Name="cv" Series="2127" Issue="64453" />
     </Book>
     <Book Series="Spider-Man" Number="72" Volume="1990" Year="1996">
-      <Id>e7560f75-73f8-41d4-9cc1-625e0f37e6b0</Id>
+      <Database Name="cv" Series="4421" Issue="64650" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="9" Volume="1996" Year="1996">
-      <Id>7a0cfe7f-acef-4a96-b9a2-e57b7a76303f</Id>
+      <Database Name="cv" Series="5788" Issue="77950" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="10" Volume="1996" Year="1996">
-      <Id>178a8588-a44c-40a4-afae-0ba2cbf3d473</Id>
+      <Database Name="cv" Series="5788" Issue="77951" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="416" Volume="1963" Year="1996">
-      <Id>cdeb5e88-270b-47c5-bf72-7842ad052d32</Id>
+      <Database Name="cv" Series="2127" Issue="108418" />
     </Book>
     <Book Series="Spider-Man" Number="73" Volume="1990" Year="1996">
-      <Id>306c13a0-5c7d-4e71-be75-ad3db3c89968</Id>
+      <Database Name="cv" Series="4421" Issue="64651" />
     </Book>
     <Book Series="Spider-Man" Number="74" Volume="1990" Year="1996">
-      <Id>b7ac0241-f22f-4f27-bdc4-c13c475c909e</Id>
+      <Database Name="cv" Series="4421" Issue="64652" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="238" Volume="1976" Year="1996">
-      <Id>a21b816c-0a16-4d47-9bac-ff5f3806882c</Id>
+      <Database Name="cv" Series="2870" Issue="65630" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="239" Volume="1976" Year="1996">
-      <Id>3c4a5f12-1f2a-44a5-ba89-818df481d2de</Id>
+      <Database Name="cv" Series="2870" Issue="109400" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="417" Volume="1963" Year="1996">
-      <Id>f93d0cda-edc7-4da8-ad8e-0b35b83018d9</Id>
+      <Database Name="cv" Series="2127" Issue="64454" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="240" Volume="1976" Year="1996">
-      <Id>669705db-5230-4d2b-9089-1cb15579c26c</Id>
+      <Database Name="cv" Series="2870" Issue="42987" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="11" Volume="1996" Year="1996">
-      <Id>66576c85-36b9-45e4-809c-82407eefa23f</Id>
+      <Database Name="cv" Series="5788" Issue="43081" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="418" Volume="1963" Year="1996">
-      <Id>1469d348-c9ba-4581-9f26-09ceabc272d0</Id>
+      <Database Name="cv" Series="2127" Issue="64455" />
     </Book>
     <Book Series="Spider-Man" Number="75" Volume="1990" Year="1996">
-      <Id>4af76389-e449-40ef-b28d-a446f66f6ae2</Id>
+      <Database Name="cv" Series="4421" Issue="64653" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="241" Volume="1976" Year="1996">
-      <Id>483a68b9-029d-40a7-b4e0-6ee9cbb85a94</Id>
+      <Database Name="cv" Series="2870" Issue="43082" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="12" Volume="1996" Year="1997">
-      <Id>4eb78a7f-1c08-4a3e-9b0a-0723c89f35a2</Id>
+      <Database Name="cv" Series="5788" Issue="43276" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="13" Volume="1996" Year="1997">
-      <Id>634029d1-29c7-45b0-83b4-508ba0d6c818</Id>
+      <Database Name="cv" Series="5788" Issue="43387" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="14" Volume="1996" Year="1997">
-      <Id>8f6026d6-b97a-41bf-97c1-d49db0b771e3</Id>
+      <Database Name="cv" Series="5788" Issue="43486" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="15" Volume="1996" Year="1997">
-      <Id>84ea7a80-a7ab-4ace-b43f-a297e41d0fdf</Id>
+      <Database Name="cv" Series="5788" Issue="43582" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="419" Volume="1963" Year="1997">
-      <Id>9c9f8f6f-ca4b-4f17-be8d-8ec068c96c77</Id>
+      <Database Name="cv" Series="2127" Issue="64456" />
     </Book>
     <Book Series="Spider-Man: Hobgoblin Lives" Number="1" Volume="1997" Year="1997">
-      <Id>33599c3c-10a2-4c87-bae6-4f81f34c8015</Id>
+      <Database Name="cv" Series="6014" Issue="43278" />
     </Book>
     <Book Series="Spider-Man: Hobgoblin Lives" Number="2" Volume="1997" Year="1997">
-      <Id>dbb27c47-d585-4a7a-ba60-5e2ccef69410</Id>
+      <Database Name="cv" Series="6014" Issue="43389" />
     </Book>
     <Book Series="Spider-Man: Hobgoblin Lives" Number="3" Volume="1997" Year="1997">
-      <Id>9c02a4e6-cc2d-4e3b-805c-05ee3956eed2</Id>
+      <Database Name="cv" Series="6014" Issue="43584" />
     </Book>
     <Book Series="Spider-Man" Number="76" Volume="1990" Year="1997">
-      <Id>e85558e3-8270-43a2-bc4d-edb21cc36250</Id>
+      <Database Name="cv" Series="4421" Issue="64654" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="420" Volume="1963" Year="1997">
-      <Id>d4167bd7-a8c9-4045-9f65-b4ccd48fac9a</Id>
+      <Database Name="cv" Series="2127" Issue="109110" />
     </Book>
     <Book Series="Spider-Man" Number="77" Volume="1990" Year="1997">
-      <Id>2aacca21-ceea-44b7-a94d-87ee7352744e</Id>
+      <Database Name="cv" Series="4421" Issue="64655" />
     </Book>
     <Book Series="Spider-Man" Number="78" Volume="1990" Year="1997">
-      <Id>3fa003b7-8853-4629-8263-722e36f6a216</Id>
+      <Database Name="cv" Series="4421" Issue="64656" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="242" Volume="1976" Year="1997">
-      <Id>f565d62e-2e84-41c5-9f63-28233db635fc</Id>
+      <Database Name="cv" Series="2870" Issue="43277" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="243" Volume="1976" Year="1997">
-      <Id>afed3368-3012-410c-8a27-dd41ce44b99e</Id>
+      <Database Name="cv" Series="2870" Issue="43388" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="244" Volume="1976" Year="1997">
-      <Id>176b5e23-e5ba-497e-a22c-1276422abab4</Id>
+      <Database Name="cv" Series="2870" Issue="43487" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="245" Volume="1976" Year="1997">
-      <Id>10c19c10-5583-4920-98e4-d132a0858c70</Id>
+      <Database Name="cv" Series="2870" Issue="43583" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="246" Volume="1976" Year="1997">
-      <Id>4eec1811-9bdc-4896-9de4-323d400781eb</Id>
+      <Database Name="cv" Series="2870" Issue="43688" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="421" Volume="1963" Year="1997">
-      <Id>2494c175-1d11-44ca-a427-73a91d3d9d46</Id>
+      <Database Name="cv" Series="2127" Issue="64457" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="15" Volume="1993" Year="1997">
-      <Id>776694d3-b690-404d-825b-599a5fb44f57</Id>
+      <Database Name="cv" Series="5048" Issue="57300" />
     </Book>
     <Book Series="Spider-Man" Number="79" Volume="1990" Year="1997">
-      <Id>d5d485e1-b97c-4c16-8a0c-49dd114ae7c7</Id>
+      <Database Name="cv" Series="4421" Issue="64657" />
     </Book>
     <Book Series="Spider-Man" Number="80" Volume="1990" Year="1997">
-      <Id>1c0b54f5-dd68-4ed8-bfff-69c2b60e4197</Id>
+      <Database Name="cv" Series="4421" Issue="64658" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="16" Volume="1993" Year="1997">
-      <Id>b6777191-d852-4536-854d-8ba393a44162</Id>
+      <Database Name="cv" Series="5048" Issue="57301" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="16" Volume="1996" Year="1997">
-      <Id>c6a55697-c7e9-4f3d-99b0-11745bb49bd4</Id>
+      <Database Name="cv" Series="5788" Issue="43687" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="17" Volume="1996" Year="1997">
-      <Id>d1bf652c-cda5-40fb-908e-3aa6828f9375</Id>
+      <Database Name="cv" Series="5788" Issue="43775" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="18" Volume="1996" Year="1997">
-      <Id>cec37fa6-236d-4151-a15d-efe5f8b44c2c</Id>
+      <Database Name="cv" Series="5788" Issue="43976" />
     </Book>
     <Book Series="Spider-Man: Dead Man's Hand" Number="1" Volume="1997" Year="1997">
-      <Id>894e2d16-1070-4003-bb49-525a06ea6264</Id>
+      <Database Name="cv" Series="32008" Issue="200815" />
     </Book>
     <Book Series="Spider-Man Team-Up" Number="6" Volume="1995" Year="1997">
-      <Id>9d859147-5daa-4a07-b806-d3cde687c616</Id>
+      <Database Name="cv" Series="5561" Issue="43488" />
     </Book>
     <Book Series="Spider-Man" Number="81" Volume="1990" Year="1997">
-      <Id>5a3a0e27-08e2-437d-8dba-648600cc3f19</Id>
+      <Database Name="cv" Series="4421" Issue="64659" />
     </Book>
     <Book Series="Spider-Man Team-Up" Number="7" Volume="1995" Year="1997">
-      <Id>149ee07f-05ad-43c5-b624-430aedf899f6</Id>
+      <Database Name="cv" Series="5561" Issue="43777" />
     </Book>
     <Book Series="Marvel Team-Up" Number="1" Volume="1997" Year="1997">
-      <Id>78e0adb6-dbdc-42de-9fce-d393dcdd1ccc</Id>
+      <Database Name="cv" Series="6011" Issue="44085" />
     </Book>
     <Book Series="Marvel Team-Up" Number="2" Volume="1997" Year="1997">
-      <Id>bc4fc266-b650-4b86-a8dc-f6c5e4a9cd1d</Id>
+      <Database Name="cv" Series="6011" Issue="44190" />
     </Book>
     <Book Series="Marvel Team-Up" Number="3" Volume="1997" Year="1997">
-      <Id>27b895e9-d323-402e-8959-561b657182bf</Id>
+      <Database Name="cv" Series="6011" Issue="44298" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="422" Volume="1963" Year="1997">
-      <Id>50a8301c-7996-439d-a61a-bb7878db0ec1</Id>
+      <Database Name="cv" Series="2127" Issue="64458" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="423" Volume="1963" Year="1997">
-      <Id>71696672-a451-443e-b930-f399fbfcf4b8</Id>
+      <Database Name="cv" Series="2127" Issue="64459" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="424" Volume="1963" Year="1997">
-      <Id>a41cfbf4-207b-440a-b107-08f9bdee9354</Id>
+      <Database Name="cv" Series="2127" Issue="64460" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="247" Volume="1976" Year="1997">
-      <Id>f8d74c2f-118d-4e95-9109-31eaf2d823bd</Id>
+      <Database Name="cv" Series="2870" Issue="43776" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="-1" Volume="1976" Year="1997">
-      <Id>e107a742-a18e-4401-b2a2-4f7329640065</Id>
+      <Database Name="cv" Series="2870" Issue="43880" />
     </Book>
     <Book Series="Spider-Man" Number="-1" Volume="1990" Year="1997">
-      <Id>295a1946-4a24-4ed8-968a-b6d55527ba4e</Id>
+      <Database Name="cv" Series="4421" Issue="68477" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="-1" Volume="1996" Year="1997">
-      <Id>5f83a72a-a109-4e17-95e0-3530b3ddcafb</Id>
+      <Database Name="cv" Series="5788" Issue="43879" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="-1" Volume="1963" Year="1997">
-      <Id>13fa2659-188d-4bcb-8b68-a4b5556dbe64</Id>
+      <Database Name="cv" Series="2127" Issue="101785" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="248" Volume="1976" Year="1997">
-      <Id>c8cb0706-3f4d-4d5a-b068-0db40ab2cac6</Id>
+      <Database Name="cv" Series="2870" Issue="43977" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="19" Volume="1996" Year="1997">
-      <Id>94aca052-80be-4ba6-b492-f2c2fba004bc</Id>
+      <Database Name="cv" Series="5788" Issue="44087" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="20" Volume="1996" Year="1997">
-      <Id>2560a77e-9165-4fc4-9048-83f6c24d5f80</Id>
+      <Database Name="cv" Series="5788" Issue="44192" />
     </Book>
     <Book Series="Spider-Man" Number="82" Volume="1990" Year="1997">
-      <Id>8a97e2bf-2b8a-42ad-8f45-6a401d3a641a</Id>
+      <Database Name="cv" Series="4421" Issue="64660" />
     </Book>
     <Book Series="Spider-Man" Number="83" Volume="1990" Year="1997">
-      <Id>b8e65242-63ca-4a82-9a8f-381931b8c16c</Id>
+      <Database Name="cv" Series="4421" Issue="64661" />
     </Book>
     <Book Series="Spider-Man" Number="84" Volume="1990" Year="1997">
-      <Id>bc646399-54ce-4bba-ad30-d9fd37bf20c1</Id>
+      <Database Name="cv" Series="4421" Issue="64662" />
     </Book>
-    <Book Series="Amazing Spider-Man Annual '96" Number="1" Volume="1996" Year="1996">
-      <Id>6e8fd9b6-3c26-43a8-86b2-ec4d1c47cc56</Id>
+    <Book Series="The Amazing Spider-Man '96" Number="1" Volume="1996" Year="1996">
+      <Database Name="cv" Series="60436" Issue="143308" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="17" Volume="1993" Year="1997">
-      <Id>69d7b75e-a103-452f-b62a-e6c541307bc7</Id>
+      <Database Name="cv" Series="5048" Issue="57302" />
     </Book>
-    <Book Series="Spider-Man Annual '97" Number="1997" Volume="1997" Year="1997">
-      <Id>364728c2-7eb9-4cc9-b966-6a1bf7d0218d</Id>
+    <Book Series="Spider-Man '97" Number="1" Volume="1997" Year="1997">
+      <Database Name="cv" Series="20609" Issue="181104" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="425" Volume="1963" Year="1997">
-      <Id>b615bb44-8069-423e-98e5-bacce766660c</Id>
+      <Database Name="cv" Series="2127" Issue="64461" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="249" Volume="1976" Year="1997">
-      <Id>9e664343-f04a-4f15-8058-7b47412a0a1e</Id>
+      <Database Name="cv" Series="2870" Issue="44088" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="250" Volume="1976" Year="1997">
-      <Id>1fb23c3a-9bbe-474f-bd17-0ce047a277df</Id>
+      <Database Name="cv" Series="2870" Issue="44193" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="426" Volume="1963" Year="1997">
-      <Id>428624d5-8739-486e-9ed0-3df6a2b3cb7e</Id>
+      <Database Name="cv" Series="2127" Issue="64462" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="427" Volume="1963" Year="1997">
-      <Id>961880bb-7c34-42e3-a0de-a465b62d4de7</Id>
+      <Database Name="cv" Series="2127" Issue="64463" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="428" Volume="1963" Year="1997">
-      <Id>269d5a6e-7770-4b3c-872e-7eeec39c033e</Id>
+      <Database Name="cv" Series="2127" Issue="64464" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="18" Volume="1993" Year="1997">
-      <Id>d3c96be9-1e7b-4703-bb40-e95030bdd3cf</Id>
+      <Database Name="cv" Series="5048" Issue="57303" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="21" Volume="1996" Year="1997">
-      <Id>1c9c07ae-df18-4569-b532-d859ba009d1c</Id>
+      <Database Name="cv" Series="5788" Issue="44301" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="22" Volume="1996" Year="1997">
-      <Id>27775f2e-8928-4df1-a913-ae02682d458c</Id>
+      <Database Name="cv" Series="5788" Issue="44398" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="23" Volume="1996" Year="1998">
-      <Id>2ab2e5a8-f46c-404b-9609-a6f86d0965f3</Id>
+      <Database Name="cv" Series="5788" Issue="44568" />
     </Book>
     <Book Series="Spider-Man" Number="85" Volume="1990" Year="1997">
-      <Id>ebfdeb9c-1bc4-4108-9eb5-03840f2c7067</Id>
+      <Database Name="cv" Series="4421" Issue="44303" />
     </Book>
     <Book Series="Spider-Man" Number="86" Volume="1990" Year="1997">
-      <Id>4768d114-3365-43c3-b54d-1d731645785f</Id>
+      <Database Name="cv" Series="4421" Issue="44400" />
     </Book>
     <Book Series="Spider-Man" Number="87" Volume="1990" Year="1998">
-      <Id>116f4dfa-72fa-4e7d-80f3-3a8c9d29ad81</Id>
+      <Database Name="cv" Series="4421" Issue="44570" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="251" Volume="1976" Year="1997">
-      <Id>26f18be1-4c6b-49d9-a4ea-3a807530ada0</Id>
+      <Database Name="cv" Series="2870" Issue="44302" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="252" Volume="1976" Year="1997">
-      <Id>1710c6fe-0ed9-4263-9953-5a0ba2a5a5c5</Id>
+      <Database Name="cv" Series="2870" Issue="44399" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="253" Volume="1976" Year="1998">
-      <Id>cf919d94-5d1d-470d-a925-061fe3799ac1</Id>
+      <Database Name="cv" Series="2870" Issue="44569" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="429" Volume="1963" Year="1997">
-      <Id>88ee72de-7707-43bf-a860-4a60d5eb6ada</Id>
+      <Database Name="cv" Series="2127" Issue="64465" />
     </Book>
     <Book Series="Marvel Team-Up" Number="4" Volume="1997" Year="1997">
-      <Id>7cb07307-8125-452b-8861-9d7a95e24e50</Id>
+      <Database Name="cv" Series="6011" Issue="44395" />
     </Book>
     <Book Series="Marvel Team-Up" Number="5" Volume="1997" Year="1998">
-      <Id>94b1fc1b-85ec-4a55-93a9-812dc18fb2b1</Id>
+      <Database Name="cv" Series="6011" Issue="44565" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="430" Volume="1963" Year="1998">
-      <Id>c393c984-92f1-44b5-8651-ea74e5387f46</Id>
+      <Database Name="cv" Series="2127" Issue="64466" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="431" Volume="1963" Year="1998">
-      <Id>9498aa52-78f7-4db8-9393-9eb46a4e787b</Id>
+      <Database Name="cv" Series="2127" Issue="64467" />
     </Book>
     <Book Series="Marvel Team-Up" Number="6" Volume="1997" Year="1998">
-      <Id>4c888ccf-f9cf-4962-b4cd-d92554a1221f</Id>
+      <Database Name="cv" Series="6011" Issue="44678" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="24" Volume="1996" Year="1998">
-      <Id>b791f9fe-425d-4360-8b64-c469241c97fc</Id>
+      <Database Name="cv" Series="5788" Issue="44680" />
     </Book>
     <Book Series="Marvel Team-Up" Number="7" Volume="1997" Year="1998">
-      <Id>4f8c0e34-36c4-42e5-b2f0-66b6fee4e77c</Id>
+      <Database Name="cv" Series="6011" Issue="44770" />
     </Book>
     <Book Series="Spider-Man" Number="88" Volume="1990" Year="1998">
-      <Id>3c373a91-7891-499e-b2be-9e8a22d7fe91</Id>
+      <Database Name="cv" Series="4421" Issue="44682" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="254" Volume="1976" Year="1998">
-      <Id>b1df40c8-731d-446d-b5ce-bc1363560cc3</Id>
+      <Database Name="cv" Series="2870" Issue="44681" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Spider-Man/Spider-Man 006 (1998-2003).cbl
+++ b/Marvel/Characters/unsorted/Spider-Man/Spider-Man 006 (1998-2003).cbl
@@ -2,697 +2,697 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Spider-Man 6 (1998-2003)</Name>
   <Books>
-    <Book Series="The Sensational Spider-Man" Number="25" Volume="1996" Year="1998" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="25" Volume="1996" Year="1998">
       <Id>14f57b2e-7445-4e64-9fc1-77b46e312004</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="432" Volume="1963" Year="1998" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="432" Volume="1963" Year="1998">
       <Id>1e11f589-50cc-4989-9639-3a06a2b65581</Id>
     </Book>
-    <Book Series="Spider-Man" Number="89" Volume="1990" Year="1998" Format="Main Series">
+    <Book Series="Spider-Man" Number="89" Volume="1990" Year="1998">
       <Id>500c8a53-85e7-40ab-b7e7-ec3c5cd2f1aa</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="255" Volume="1976" Year="1998" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="255" Volume="1976" Year="1998">
       <Id>277d1596-a8b2-4f5c-af53-d9a8627361b2</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="26" Volume="1996" Year="1998" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="26" Volume="1996" Year="1998">
       <Id>ccb4c317-63eb-4cda-81ab-bdd4ba526b72</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="433" Volume="1963" Year="1998" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="433" Volume="1963" Year="1998">
       <Id>5a7db03b-a391-4f26-80ad-ad37234ce197</Id>
     </Book>
-    <Book Series="Spider-Man" Number="90" Volume="1990" Year="1998" Format="Main Series">
+    <Book Series="Spider-Man" Number="90" Volume="1990" Year="1998">
       <Id>3dca906e-5c51-4b7a-abd1-bcd5daf0ce0a</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="256" Volume="1976" Year="1998" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="256" Volume="1976" Year="1998">
       <Id>7d06af9c-228d-49ca-aa50-5b767b807903</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="27" Volume="1996" Year="1998" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="27" Volume="1996" Year="1998">
       <Id>4640a746-5186-47e8-aabc-9cd51919b37b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="434" Volume="1963" Year="1998" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="434" Volume="1963" Year="1998">
       <Id>ea2c2d46-8afa-4634-bb7f-dd67244f64ca</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="28" Volume="1996" Year="1998" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="28" Volume="1996" Year="1998">
       <Id>2958ff2b-b498-4215-a603-f19c1592d63d</Id>
     </Book>
-    <Book Series="Spider-Man" Number="91" Volume="1990" Year="1998" Format="Main Series">
+    <Book Series="Spider-Man" Number="91" Volume="1990" Year="1998">
       <Id>e355f684-d7cd-4954-991b-532627cfc79c</Id>
     </Book>
-    <Book Series="Spider-Man" Number="92" Volume="1990" Year="1998" Format="Main Series">
+    <Book Series="Spider-Man" Number="92" Volume="1990" Year="1998">
       <Id>98603ce3-9806-4a58-8da1-852670708b6a</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="257" Volume="1976" Year="1998" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="257" Volume="1976" Year="1998">
       <Id>a7be97bd-5d76-4b11-92d3-12221a0777dd</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="258" Volume="1976" Year="1998" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="258" Volume="1976" Year="1998">
       <Id>2da9e6b0-d0a4-422e-ac2a-21461d7a1739</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="435" Volume="1963" Year="1998" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="435" Volume="1963" Year="1998">
       <Id>e926a81e-9a5a-42a8-a479-fc4539e49314</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="436" Volume="1963" Year="1998" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="436" Volume="1963" Year="1998">
       <Id>e5e78af0-7e54-4119-84f5-0b6ba5e03048</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="20" Volume="1993" Year="1998" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="20" Volume="1993" Year="1998">
       <Id>96717af6-eace-426d-9a1b-a06832f448cd</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual '97" Number="1" Volume="1997" Year="1997" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual '97" Number="1" Volume="1997" Year="1997">
       <Id>fbb3d4e8-579b-4e47-b499-38b1e0b4c9f3</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="29" Volume="1996" Year="1998" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="29" Volume="1996" Year="1998">
       <Id>f78c45a7-5b57-4f31-b6f2-44b6ea3b837f</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="30" Volume="1996" Year="1998" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="30" Volume="1996" Year="1998">
       <Id>9203db9f-f5e8-42ee-874c-bd5baf8ea1ed</Id>
     </Book>
-    <Book Series="Spider-Man" Number="93" Volume="1990" Year="1998" Format="Main Series">
+    <Book Series="Spider-Man" Number="93" Volume="1990" Year="1998">
       <Id>59b04b7e-f8eb-4e32-bfb4-419dc4f37687</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="259" Volume="1976" Year="1998" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="259" Volume="1976" Year="1998">
       <Id>ae4c1f0f-32ff-4863-958a-c1f071967407</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="260" Volume="1976" Year="1998" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="260" Volume="1976" Year="1998">
       <Id>28ea98cc-317e-4e6f-a4ee-149400dc589b</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="261" Volume="1976" Year="1998" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="261" Volume="1976" Year="1998">
       <Id>97996aa6-2a88-4803-8646-7ac4594b191d</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="437" Volume="1963" Year="1998" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="437" Volume="1963" Year="1998">
       <Id>fd9e7714-ba06-4dc0-997a-21320956c748</Id>
     </Book>
-    <Book Series="Spider-Man" Number="94" Volume="1990" Year="1998" Format="Main Series">
+    <Book Series="Spider-Man" Number="94" Volume="1990" Year="1998">
       <Id>cc21e20e-cfee-4b29-b5b0-c35471bf98e1</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="31" Volume="1996" Year="1998" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="31" Volume="1996" Year="1998">
       <Id>ecc72985-6b4c-4a55-b51e-8c07488ad14b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="438" Volume="1963" Year="1998" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="438" Volume="1963" Year="1998">
       <Id>5df4f7e0-f477-4eb3-ab5b-68f0846618e5</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="439" Volume="1963" Year="1998" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="439" Volume="1963" Year="1998">
       <Id>a3f8dd8c-9d12-4da7-ab9a-40484ac943b5</Id>
     </Book>
-    <Book Series="Spider-Man" Number="95" Volume="1990" Year="1998" Format="Main Series">
+    <Book Series="Spider-Man" Number="95" Volume="1990" Year="1998">
       <Id>9b5eb299-016f-4010-9470-64f1ae11e0a5</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="22" Volume="1993" Year="1998" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="22" Volume="1993" Year="1998">
       <Id>4c889f1b-0f19-4eab-a067-a6730a69b5af</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="32" Volume="1996" Year="1998" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="32" Volume="1996" Year="1998">
       <Id>ad522a5d-5b0a-4570-9621-25627f3674d5</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="440" Volume="1963" Year="1998" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="440" Volume="1963" Year="1998">
       <Id>187c2119-eddb-469c-8f5f-e70624c38939</Id>
     </Book>
-    <Book Series="Spider-Man" Number="96" Volume="1990" Year="1998" Format="Main Series">
+    <Book Series="Spider-Man" Number="96" Volume="1990" Year="1998">
       <Id>2e6504b1-f5ad-4f62-8cdb-b488d90e1c55</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="262" Volume="1976" Year="1998" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="262" Volume="1976" Year="1998">
       <Id>cdcd8d9f-dac7-4a90-babb-26c1c4671efb</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="33" Volume="1996" Year="1998" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="33" Volume="1996" Year="1998">
       <Id>0c8af18a-ad24-4163-ab65-2dae564ebe56</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="441" Volume="1963" Year="1998" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="441" Volume="1963" Year="1998">
       <Id>2f33af4c-e505-4428-82bf-10470bb5c28d</Id>
     </Book>
-    <Book Series="Spider-Man" Number="97" Volume="1990" Year="1998" Format="Main Series">
+    <Book Series="Spider-Man" Number="97" Volume="1990" Year="1998">
       <Id>99f4a495-42d0-41c3-8aa1-08dc3b6b2ed0</Id>
     </Book>
-    <Book Series="The Spectacular Spider-Man" Number="263" Volume="1976" Year="1998" Format="Main Series">
+    <Book Series="The Spectacular Spider-Man" Number="263" Volume="1976" Year="1998">
       <Id>8b1e7044-cb12-47fd-89dd-aaae38496af8</Id>
     </Book>
-    <Book Series="Spider-Man" Number="98" Volume="1990" Year="1998" Format="Main Series">
+    <Book Series="Spider-Man" Number="98" Volume="1990" Year="1998">
       <Id>08ef1d4a-955e-4406-b78f-d893377975bf</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="442" Volume="1963" Year="1999" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="442" Volume="1963" Year="1999">
       <Id>76fb506c-1417-4ea0-8533-844bc1bcb29f</Id>
     </Book>
-    <Book Series="Daredevil" Number="7" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Daredevil" Number="7" Volume="1998" Year="1999">
       <Id>1514e949-77e3-4594-b1df-76cb76c539c3</Id>
     </Book>
-    <Book Series="Daredevil" Number="8" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Daredevil" Number="8" Volume="1998" Year="1999">
       <Id>cb3d0520-44da-45a1-8e87-70b717bcdae6</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="1" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="1" Volume="1999" Year="1999">
       <Id>d23456a6-8e09-426f-9978-a8c41e16666f</Id>
     </Book>
-    <Book Series="Thor" Number="8" Volume="1998" Year="1999" Format="Main Series">
+    <Book Series="Thor" Number="8" Volume="1998" Year="1999">
       <Id>b6b2f12a-025c-4088-950f-641754558309</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="2" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="2" Volume="1999" Year="1999">
       <Id>7b5a465c-0195-4439-b878-4f6cfecf375f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="443" Volume="1963" Year="1999" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="443" Volume="1963" Year="1999">
       <Id>3051d17d-e0ba-41ca-a855-316816d19d09</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="444" Volume="1963" Year="1999" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="444" Volume="1963" Year="1999">
       <Id>c58fac64-2245-4d76-8bef-deba220072a8</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="3" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="3" Volume="1999" Year="1999">
       <Id>58bc4ece-3262-4690-8593-081108f0b349</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="445" Volume="1963" Year="1999" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="445" Volume="1963" Year="1999">
       <Id>82e6b27c-29c1-461e-97a4-166f440fffe9</Id>
     </Book>
-    <Book Series="Daredevil/Spider-Man" Number="1" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Daredevil/Spider-Man" Number="1" Volume="2001" Year="2001">
       <Id>e30dab3a-999d-4076-9727-71aa2fca6a72</Id>
     </Book>
-    <Book Series="Daredevil/Spider-Man" Number="2" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Daredevil/Spider-Man" Number="2" Volume="2001" Year="2001">
       <Id>bc4dbad5-b2d2-467b-965f-f44266895e86</Id>
     </Book>
-    <Book Series="Daredevil/Spider-Man" Number="3" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Daredevil/Spider-Man" Number="3" Volume="2001" Year="2001">
       <Id>29ab8813-70b2-4871-bbbf-57ba8a9d4e0d</Id>
     </Book>
-    <Book Series="Daredevil/Spider-Man" Number="4" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Daredevil/Spider-Man" Number="4" Volume="2001" Year="2001">
       <Id>ec06a0f1-2281-4791-9955-442cb1f8554e</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="4" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="4" Volume="1999" Year="1999">
       <Id>d8679bdc-d647-4497-b7e7-ee09bea79ae4</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man Annual 1999" Number="1" Volume="1999" Year="1999" Format="Annual">
+    <Book Series="Peter Parker: Spider-Man Annual 1999" Number="1" Volume="1999" Year="1999">
       <Id>041c609d-32df-4dce-92cf-8bc5c40574a5</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="446" Volume="1963" Year="1999" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="446" Volume="1963" Year="1999">
       <Id>86cba60d-0e17-41e0-83f8-4d07a5ed8d80</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="5" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="5" Volume="1999" Year="1999">
       <Id>8a4e3cb3-dacc-417b-97ef-eb4aadc7050d</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="447" Volume="1963" Year="1999" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="447" Volume="1963" Year="1999">
       <Id>25d414f1-5ffe-463c-bd60-1b2fa7d0846b</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="6" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="6" Volume="1999" Year="1999">
       <Id>3096b1af-dbad-4130-8c04-9c5a8a7feba0</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="448" Volume="1963" Year="1999" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="448" Volume="1963" Year="1999">
       <Id>69260f09-b09e-4d22-8999-eeb5763a54e2</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="449" Volume="1963" Year="1999" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="449" Volume="1963" Year="1999">
       <Id>0caa2869-c3d5-492d-b756-ae51b82f3dda</Id>
     </Book>
-    <Book Series="Webspinners: Tales of Spider-Man" Number="10" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Webspinners: Tales of Spider-Man" Number="10" Volume="1999" Year="1999">
       <Id>7848f3ec-24b2-4eea-a9e8-06aed57d1f62</Id>
     </Book>
-    <Book Series="Webspinners: Tales of Spider-Man" Number="11" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Webspinners: Tales of Spider-Man" Number="11" Volume="1999" Year="1999">
       <Id>8770bbf7-befa-44fd-9566-803ef85b48ea</Id>
     </Book>
-    <Book Series="Webspinners: Tales of Spider-Man" Number="12" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Webspinners: Tales of Spider-Man" Number="12" Volume="1999" Year="1999">
       <Id>58d10b93-92ab-4195-af15-3cccb3250fa1</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual 1999" Number="1" Volume="1999" Year="1999" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual 1999" Number="1" Volume="1999" Year="1999">
       <Id>d47b8177-a3f8-4822-bcfa-cd12044f359c</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="7" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="7" Volume="1999" Year="1999">
       <Id>4beaf77d-0219-4ce7-aadd-4fcd61d0cb87</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="8" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="8" Volume="1999" Year="1999">
       <Id>ac510ffc-3ab1-4110-82d3-3db01c6b329b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="450" Volume="1963" Year="1999" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="450" Volume="1963" Year="1999">
       <Id>073aeeae-bb1c-4e7e-bacd-ed1466b4b613</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="451" Volume="1963" Year="1999" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="451" Volume="1963" Year="1999">
       <Id>d603a4f5-f76f-4679-b80a-1026016340fb</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="9" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="9" Volume="1999" Year="1999">
       <Id>8d52cef4-c2cb-46c7-9fba-a663fb673b68</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="10" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="10" Volume="1999" Year="1999">
       <Id>d6ee5ba2-71cd-4789-8baa-7076475a1464</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="452" Volume="1963" Year="1999" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="452" Volume="1963" Year="1999">
       <Id>cba4a520-9723-4950-bf7c-96b9d9763f68</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="11" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="11" Volume="1999" Year="1999">
       <Id>5300e0ea-b818-4ee1-80a0-0b0e904d6a77</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="453" Volume="1963" Year="1999" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="453" Volume="1963" Year="1999">
       <Id>02d8f382-17c1-480b-85a1-03b70e82eec3</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="12" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="12" Volume="1999" Year="1999">
       <Id>416f42f6-90e2-4631-8c68-f9bb62db8c16</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="454" Volume="1963" Year="2000" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="454" Volume="1963" Year="2000">
       <Id>452eee45-0fc3-4c64-8c63-c289acd906eb</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="13" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="13" Volume="1999" Year="2000">
       <Id>0b20e55b-804d-44ab-8324-f0cc1035cfb6</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="14" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="14" Volume="1999" Year="2000">
       <Id>7b6277a5-edc5-46df-9cd9-7ea449c2222f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="455" Volume="1963" Year="2000" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="455" Volume="1963" Year="2000">
       <Id>88421ae3-e8a3-4025-b409-6210d1343fb7</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="9" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Spider-Woman" Number="9" Volume="1999" Year="2000">
       <Id>7a0dd85b-5645-480a-9c8d-bd7b0aba478f</Id>
     </Book>
-    <Book Series="Webspinners: Tales of Spider-Man" Number="13" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Webspinners: Tales of Spider-Man" Number="13" Volume="1999" Year="2000">
       <Id>e9cbe8aa-f917-4ac2-9a3d-e81fcec19fef</Id>
     </Book>
-    <Book Series="Webspinners: Tales of Spider-Man" Number="14" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Webspinners: Tales of Spider-Man" Number="14" Volume="1999" Year="2000">
       <Id>f1eb0498-e86f-4b17-930d-0f93a150e5e2</Id>
     </Book>
-    <Book Series="Webspinners: Tales of Spider-Man" Number="15" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Webspinners: Tales of Spider-Man" Number="15" Volume="1999" Year="2000">
       <Id>f4ebb197-394d-4a15-97b5-fbe78874e55c</Id>
     </Book>
-    <Book Series="Webspinners: Tales of Spider-Man" Number="16" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Webspinners: Tales of Spider-Man" Number="16" Volume="1999" Year="2000">
       <Id>7a34ba77-12d1-4c06-b9a3-5aee443be793</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="456" Volume="1963" Year="2000" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="456" Volume="1963" Year="2000">
       <Id>d7f460e8-05fa-459b-94ea-60358a8d4def</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="15" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="15" Volume="1999" Year="2000">
       <Id>02ea028b-5654-4aae-b878-c29f285b976d</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="457" Volume="1963" Year="2000" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="457" Volume="1963" Year="2000">
       <Id>ddce109d-bac7-4c8a-8404-fce8382fbf5b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual 2000" Number="1" Volume="2000" Year="2000" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual 2000" Number="1" Volume="2000" Year="2000">
       <Id>da78daf0-d51d-41b2-9898-3923677900b3</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="16" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="16" Volume="1999" Year="2000">
       <Id>849d4efb-787d-40b5-8390-dfa878bb0bde</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="458" Volume="1963" Year="2000" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="458" Volume="1963" Year="2000">
       <Id>59216087-9310-4607-b467-2c940072026f</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="17" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="17" Volume="1999" Year="2000">
       <Id>dfe8a61c-9d1c-47a2-af5d-288bde101e7c</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="459" Volume="1963" Year="2000" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="459" Volume="1963" Year="2000">
       <Id>b7cc64de-99c3-4cee-bec9-18c80ef95380</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="18" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="18" Volume="1999" Year="2000">
       <Id>0c27925a-08ac-4f7f-b29f-d4cac19d4307</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="460" Volume="1963" Year="2000" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="460" Volume="1963" Year="2000">
       <Id>82e9729f-7a6f-4d6d-ac5a-be04af6eb323</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="19" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="19" Volume="1999" Year="2000">
       <Id>7a90cc3d-4329-48e7-a1c8-87b24d687f5b</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="20" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="20" Volume="1999" Year="2000">
       <Id>39a83670-21d6-4ef2-81cb-985d57a7a7dd</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="21" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="21" Volume="1999" Year="2000">
       <Id>d7a4bca2-6540-43ac-9700-0abd3c1b20ba</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man Annual 2000" Number="1" Volume="2000" Year="2000" Format="Annual">
+    <Book Series="Peter Parker: Spider-Man Annual 2000" Number="1" Volume="2000" Year="2000">
       <Id>a9523b4c-bf42-4853-9040-c66cecfe8167</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="461" Volume="1963" Year="2000" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="461" Volume="1963" Year="2000">
       <Id>c8e11cc2-cbef-4105-a220-a9e8cd7b1fb4</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="462" Volume="1963" Year="2000" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="462" Volume="1963" Year="2000">
       <Id>e0dcea9c-0300-4066-a911-ba7e209c6cbf</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="463" Volume="1963" Year="2000" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="463" Volume="1963" Year="2000">
       <Id>9cf2a854-62fc-44a4-b6b2-31314f04ff45</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="464" Volume="1963" Year="2000" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="464" Volume="1963" Year="2000">
       <Id>7aff3b3a-d9f0-4e12-b19d-835cd9731d8e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="465" Volume="1963" Year="2000" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="465" Volume="1963" Year="2000">
       <Id>229707ae-bfeb-4b49-adf5-6699f162ca7d</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="22" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="22" Volume="1999" Year="2000">
       <Id>27711a39-82b9-4aac-96df-413bb63a369a</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="23" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="23" Volume="1999" Year="2000">
       <Id>1fd8a0a9-52cc-47b0-ba44-d3bb1f24332b</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="24" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="24" Volume="1999" Year="2000">
       <Id>cdb755aa-88a1-46b2-b592-416ad0c090a4</Id>
     </Book>
-    <Book Series="Spider-Man: Revenge of the Green Goblin" Number="1" Volume="2000" Year="2000" Format="Limited Series">
+    <Book Series="Spider-Man: Revenge of the Green Goblin" Number="1" Volume="2000" Year="2000">
       <Id>0b621a19-9666-4897-b99e-0e11d9dda32d</Id>
     </Book>
-    <Book Series="Spider-Man: Revenge of the Green Goblin" Number="2" Volume="2000" Year="2000" Format="Limited Series">
+    <Book Series="Spider-Man: Revenge of the Green Goblin" Number="2" Volume="2000" Year="2000">
       <Id>7b64b33d-5eef-4cd2-a528-c15f7bc02b55</Id>
     </Book>
-    <Book Series="Spider-Man: Revenge of the Green Goblin" Number="3" Volume="2000" Year="2000" Format="Limited Series">
+    <Book Series="Spider-Man: Revenge of the Green Goblin" Number="3" Volume="2000" Year="2000">
       <Id>42a8ec3b-3bae-42c8-81d8-1a7065e11c05</Id>
     </Book>
-    <Book Series="Spider-Man: The Mysterio Manifesto" Number="1" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Spider-Man: The Mysterio Manifesto" Number="1" Volume="2001" Year="2001">
       <Id>c7a57c10-29ec-4937-840a-7b9022edd815</Id>
     </Book>
-    <Book Series="Spider-Man: The Mysterio Manifesto" Number="2" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Spider-Man: The Mysterio Manifesto" Number="2" Volume="2001" Year="2001">
       <Id>0622e1c7-3281-4dfa-ace9-8ab6bb095d42</Id>
     </Book>
-    <Book Series="Spider-Man: The Mysterio Manifesto" Number="3" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Spider-Man: The Mysterio Manifesto" Number="3" Volume="2001" Year="2001">
       <Id>6c61d3a5-627f-47ab-8944-915ea0faf151</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="466" Volume="1963" Year="2001" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="466" Volume="1963" Year="2001">
       <Id>1a146351-44e8-43f9-8835-b97640ac5d21</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="25" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="25" Volume="1999" Year="2001">
       <Id>70c213d6-a090-4d27-9b3c-a137c82977df</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="467" Volume="1963" Year="2001" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="467" Volume="1963" Year="2001">
       <Id>db1b3803-e463-47fd-8194-8ef34e5204f4</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="26" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="26" Volume="1999" Year="2001">
       <Id>d3104362-02b8-4e81-adf7-d2f7ff1041ba</Id>
     </Book>
-    <Book Series="Spidey/Marrow" Number="1" Volume="2001" Year="2001" Format="One-Shot">
+    <Book Series="Spidey/Marrow" Number="1" Volume="2001" Year="2001">
       <Id>dcdcb43a-15bb-43d5-b8b5-ff0406ff1b70</Id>
     </Book>
-    <Book Series="Spider-Man: Lifeline" Number="1" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Spider-Man: Lifeline" Number="1" Volume="2001" Year="2001">
       <Id>b94e479f-6f55-4f13-8d57-8b38b3b0d0ef</Id>
     </Book>
-    <Book Series="Spider-Man: Lifeline" Number="2" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Spider-Man: Lifeline" Number="2" Volume="2001" Year="2001">
       <Id>ed31accb-cce4-4b3f-84a8-b10253e1dd45</Id>
     </Book>
-    <Book Series="Spider-Man: Lifeline" Number="3" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Spider-Man: Lifeline" Number="3" Volume="2001" Year="2001">
       <Id>823366d9-2dc9-45f2-8134-92aa6be29706</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="468" Volume="1963" Year="2001" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="468" Volume="1963" Year="2001">
       <Id>62f34a9c-2b00-4b34-8a40-a80382c50270</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="27" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="27" Volume="1999" Year="2001">
       <Id>74e3e733-12fe-4645-ad08-701568898bbd</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="28" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="28" Volume="1999" Year="2001">
       <Id>5ce453b3-cc9f-4c07-ad82-7f0d827cfff9</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="469" Volume="1963" Year="2001" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="469" Volume="1963" Year="2001">
       <Id>c78c2349-76fd-48e6-8790-4cf4f694ba66</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="470" Volume="1963" Year="2001" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="470" Volume="1963" Year="2001">
       <Id>8e633b7c-d53e-4186-a607-75b255af2dd3</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="29" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="29" Volume="1999" Year="2001">
       <Id>b93aedb8-2c22-4473-a790-8e9e545fd2be</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual 2001" Number="1" Volume="2001" Year="2001" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual 2001" Number="1" Volume="2001" Year="2001">
       <Id>6771575d-8346-47b9-98ee-ed089c4400a0</Id>
     </Book>
-    <Book Series="Spider-Man's Tangled Web" Number="1" Volume="2001" Year="2001" Format="Main Series">
+    <Book Series="Spider-Man's Tangled Web" Number="1" Volume="2001" Year="2001">
       <Id>93d78c9b-9cc1-4216-9674-172563793ab3</Id>
     </Book>
-    <Book Series="Spider-Man's Tangled Web" Number="2" Volume="2001" Year="2001" Format="Main Series">
+    <Book Series="Spider-Man's Tangled Web" Number="2" Volume="2001" Year="2001">
       <Id>0bfac73c-fb5f-4e24-92ea-ad1c6bfaadda</Id>
     </Book>
-    <Book Series="Spider-Man's Tangled Web" Number="3" Volume="2001" Year="2001" Format="Main Series">
+    <Book Series="Spider-Man's Tangled Web" Number="3" Volume="2001" Year="2001">
       <Id>75dbaa7f-84c3-4812-97e7-1bf1f434b435</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="471" Volume="1963" Year="2001" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="471" Volume="1963" Year="2001">
       <Id>0373c4cd-1f8e-4153-b028-477d360b9f94</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="30" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="30" Volume="1999" Year="2001">
       <Id>943d146e-6b6d-4669-8c9c-ed8c6b403c30</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="31" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="31" Volume="1999" Year="2001">
       <Id>db4ca99a-4d7a-4b7b-b70f-035eb072e318</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="32" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="32" Volume="1999" Year="2001">
       <Id>0fd60354-a41d-4f3b-8935-b46f5df754f2</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="33" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="33" Volume="1999" Year="2001">
       <Id>3962c7c4-c6ec-477b-9a41-c015ed9302aa</Id>
     </Book>
-    <Book Series="Spider-Man's Tangled Web" Number="4" Volume="2001" Year="2001" Format="Main Series">
+    <Book Series="Spider-Man's Tangled Web" Number="4" Volume="2001" Year="2001">
       <Id>ba06d1dd-5741-4bfb-8674-3e459541be31</Id>
     </Book>
-    <Book Series="Spider-Man's Tangled Web" Number="5" Volume="2001" Year="2001" Format="Main Series">
+    <Book Series="Spider-Man's Tangled Web" Number="5" Volume="2001" Year="2001">
       <Id>c0949dc5-ba1c-4f83-9957-d3d203aa4ead</Id>
     </Book>
-    <Book Series="Spider-Man's Tangled Web" Number="6" Volume="2001" Year="2001" Format="Main Series">
+    <Book Series="Spider-Man's Tangled Web" Number="6" Volume="2001" Year="2001">
       <Id>3f515b83-6d5e-40d6-9a94-ba6b11520798</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="34" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="34" Volume="1999" Year="2001">
       <Id>f9a1c0a4-54d8-4a48-86d9-191c1c58c6b5</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="472" Volume="1963" Year="2001" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="472" Volume="1963" Year="2001">
       <Id>76f61fe5-6f14-435d-88ef-8485c9a4e6ea</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="473" Volume="1963" Year="2001" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="473" Volume="1963" Year="2001">
       <Id>a953668c-df59-4a24-b5ca-81ed8ab27828</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="474" Volume="1963" Year="2001" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="474" Volume="1963" Year="2001">
       <Id>349996aa-83c2-4fcf-8a2a-3e5e4991da08</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="475" Volume="1963" Year="2001" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="475" Volume="1963" Year="2001">
       <Id>3bafc1a0-4c91-4e1b-bd5a-41c1b446c659</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="477" Volume="1963" Year="2001" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="477" Volume="1963" Year="2001">
       <Id>8fdd2484-4669-46fa-9c7c-e8375ed16891</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="476" Volume="1963" Year="2001" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="476" Volume="1963" Year="2001">
       <Id>b30cc047-07ef-4158-b98d-972ff05dd636</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="478" Volume="1963" Year="2002" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="478" Volume="1963" Year="2002">
       <Id>5ecaf401-07ca-4b29-b601-9d491ff05cd1</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="479" Volume="1963" Year="2002" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="479" Volume="1963" Year="2002">
       <Id>fdad9642-15d4-4171-8ec1-85d948242b03</Id>
     </Book>
-    <Book Series="Spider-Man's Tangled Web" Number="7" Volume="2001" Year="2001" Format="Main Series">
+    <Book Series="Spider-Man's Tangled Web" Number="7" Volume="2001" Year="2001">
       <Id>446a9def-ca8d-4cc3-9069-449e2c953f01</Id>
     </Book>
-    <Book Series="Spider-Man's Tangled Web" Number="8" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="Spider-Man's Tangled Web" Number="8" Volume="2001" Year="2002">
       <Id>e7a33204-7ef3-40a1-afdc-d1c9f1d2ad2b</Id>
     </Book>
-    <Book Series="Spider-Man's Tangled Web" Number="9" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="Spider-Man's Tangled Web" Number="9" Volume="2001" Year="2002">
       <Id>6d9dc673-60ee-4998-9314-ef87d73d1ce9</Id>
     </Book>
-    <Book Series="Spider-Man's Tangled Web" Number="10" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="Spider-Man's Tangled Web" Number="10" Volume="2001" Year="2002">
       <Id>271e18b9-3f7b-4e55-9fcb-b9a3939e8df2</Id>
     </Book>
-    <Book Series="Spider-Man's Tangled Web" Number="11" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="Spider-Man's Tangled Web" Number="11" Volume="2001" Year="2002">
       <Id>7e1077f6-8fc8-425c-acff-ce749af35a31</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="35" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="35" Volume="1999" Year="2001">
       <Id>31d48ccd-632c-4b4c-828f-62937dda3ef5</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="36" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="36" Volume="1999" Year="2001">
       <Id>ed124fe1-6f41-47cf-a205-f2b9d4a01883</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="37" Volume="1999" Year="2002" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="37" Volume="1999" Year="2002">
       <Id>18e272f4-af98-478e-a81b-6bf7d1ec93d2</Id>
     </Book>
-    <Book Series="Infinity Abyss" Number="1" Volume="2002" Year="2002" Format="Crossover">
+    <Book Series="Infinity Abyss" Number="1" Volume="2002" Year="2002">
       <Id>1a13c65c-0d3a-4b3e-9817-4bce5d64cbfd</Id>
     </Book>
-    <Book Series="Infinity Abyss" Number="2" Volume="2002" Year="2002" Format="Crossover">
+    <Book Series="Infinity Abyss" Number="2" Volume="2002" Year="2002">
       <Id>1f44aa37-e546-498f-8cc3-d97022407d56</Id>
     </Book>
-    <Book Series="Infinity Abyss" Number="3" Volume="2002" Year="2002" Format="Crossover">
+    <Book Series="Infinity Abyss" Number="3" Volume="2002" Year="2002">
       <Id>0db89260-7fa0-4db1-960a-96d37ad1a305</Id>
     </Book>
-    <Book Series="Infinity Abyss" Number="4" Volume="2002" Year="2002" Format="Crossover">
+    <Book Series="Infinity Abyss" Number="4" Volume="2002" Year="2002">
       <Id>e70fa627-bf59-4dae-b757-91f911cd5944</Id>
     </Book>
-    <Book Series="Infinity Abyss" Number="5" Volume="2002" Year="2002" Format="Crossover">
+    <Book Series="Infinity Abyss" Number="5" Volume="2002" Year="2002">
       <Id>a5fd2555-cf90-4cca-bfef-88c3153e633c</Id>
     </Book>
-    <Book Series="Infinity Abyss" Number="6" Volume="2002" Year="2002" Format="Crossover">
+    <Book Series="Infinity Abyss" Number="6" Volume="2002" Year="2002">
       <Id>90e78121-583d-42ea-ad03-884dcacfa401</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="38" Volume="1999" Year="2002" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="38" Volume="1999" Year="2002">
       <Id>b9f024f4-490d-45a8-a824-28f9e0acdd52</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="39" Volume="1999" Year="2002" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="39" Volume="1999" Year="2002">
       <Id>204301ee-b2cc-4183-856b-3ce326a79b6f</Id>
     </Book>
-    <Book Series="Spider-Man's Tangled Web" Number="12" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="Spider-Man's Tangled Web" Number="12" Volume="2001" Year="2002">
       <Id>5bb220e2-f717-430c-9550-1a2faf9b5d65</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="40" Volume="1999" Year="2002" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="40" Volume="1999" Year="2002">
       <Id>fdb5bb8f-b561-4b9e-b190-3dd296845e8a</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="41" Volume="1999" Year="2002" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="41" Volume="1999" Year="2002">
       <Id>21351317-5bb6-4876-8339-c9235b96fc45</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="42" Volume="1999" Year="2002" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="42" Volume="1999" Year="2002">
       <Id>a1021527-a3bc-49c1-8fe6-bb9a292136df</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="43" Volume="1999" Year="2002" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="43" Volume="1999" Year="2002">
       <Id>1f67d543-79af-422c-ae18-8b48b7b7db02</Id>
     </Book>
-    <Book Series="Daredevil" Number="34" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Daredevil" Number="34" Volume="1998" Year="2002">
       <Id>60306b77-f47d-4410-b23d-09d6a7d7c772</Id>
     </Book>
-    <Book Series="Daredevil" Number="35" Volume="1998" Year="2002" Format="Main Series">
+    <Book Series="Daredevil" Number="35" Volume="1998" Year="2002">
       <Id>43109af2-3629-49fa-a829-f3c6d041bb2f</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="44" Volume="1999" Year="2002" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="44" Volume="1999" Year="2002">
       <Id>3e5daf48-8c1f-46c7-9f3e-6f85b01ca76c</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="45" Volume="1999" Year="2002" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="45" Volume="1999" Year="2002">
       <Id>9bcee609-6c35-454c-9dfc-6465684e7594</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="46" Volume="1999" Year="2002" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="46" Volume="1999" Year="2002">
       <Id>14eac4d0-afca-4fb7-b2c6-19a48addb39a</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="47" Volume="1999" Year="2002" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="47" Volume="1999" Year="2002">
       <Id>300e5548-53fe-4aae-b84e-25dc6cd6ba65</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="48" Volume="1999" Year="2002" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="48" Volume="1999" Year="2002">
       <Id>2f4ef3e0-4d9f-4af1-96a2-2febbe079be5</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="49" Volume="1999" Year="2002" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="49" Volume="1999" Year="2002">
       <Id>726318c5-77de-437b-bcd3-9f3cb0c191f0</Id>
     </Book>
-    <Book Series="Spider-Man's Tangled Web" Number="18" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="Spider-Man's Tangled Web" Number="18" Volume="2001" Year="2002">
       <Id>cfcee63a-febe-4a43-b74e-4b498769e608</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="480" Volume="1963" Year="2002" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="480" Volume="1963" Year="2002">
       <Id>c8a4fc52-7e66-40d3-afb3-858c08745fce</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="50" Volume="1999" Year="2003" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="50" Volume="1999" Year="2003">
       <Id>d8f3f7ca-42c8-46bb-96d0-a07370210490</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="51" Volume="1999" Year="2003" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="51" Volume="1999" Year="2003">
       <Id>7b1cf42d-6ffa-4b26-b8e2-1167159be994</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="52" Volume="1999" Year="2003" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="52" Volume="1999" Year="2003">
       <Id>cc8492f4-c25b-470a-bd85-a4d56db03333</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="53" Volume="1999" Year="2003" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="53" Volume="1999" Year="2003">
       <Id>e3495168-3d57-4149-ba93-3e3be390260d</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="54" Volume="1999" Year="2003" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="54" Volume="1999" Year="2003">
       <Id>c9392cd3-61a6-44a8-b8ec-62de0fd1f8c5</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="55" Volume="1999" Year="2003" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="55" Volume="1999" Year="2003">
       <Id>1c7df38a-f86f-4479-a34c-eef5d54906aa</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="56" Volume="1999" Year="2003" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="56" Volume="1999" Year="2003">
       <Id>6fa4a550-7dd0-4f54-8da9-52be114991f6</Id>
     </Book>
-    <Book Series="Peter Parker: Spider-Man" Number="57" Volume="1999" Year="2003" Format="Main Series">
+    <Book Series="Peter Parker: Spider-Man" Number="57" Volume="1999" Year="2003">
       <Id>97dcdd8c-7691-47c4-956b-048d5f60852d</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="1" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="1" Volume="2003" Year="2003">
       <Id>4ca923f2-da31-43be-825b-d42c63cab1e3</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="2" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="2" Volume="2003" Year="2003">
       <Id>00306298-4832-44cf-9396-6b3511b92907</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="3" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="3" Volume="2003" Year="2003">
       <Id>cf0c026f-43c6-4783-bab8-4a991a68c557</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="4" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="4" Volume="2003" Year="2003">
       <Id>5c101973-e6cd-44ac-b03c-acded619e8e7</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="5" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="5" Volume="2003" Year="2003">
       <Id>0aeeed8b-efc6-4aa8-9e00-402156eaa369</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="481" Volume="1963" Year="2002" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="481" Volume="1963" Year="2002">
       <Id>5c90e1dd-7aaf-438f-a57c-b1072d76119d</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="482" Volume="1963" Year="2002" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="482" Volume="1963" Year="2002">
       <Id>55762d37-f1e9-4b7c-858d-46ffbfbe5357</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="483" Volume="1963" Year="2002" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="483" Volume="1963" Year="2002">
       <Id>9a8e0d10-5699-4791-88f4-0f8c2671e53c</Id>
     </Book>
-    <Book Series="Spider-Man's Tangled Web" Number="19" Volume="2001" Year="2002" Format="Main Series">
+    <Book Series="Spider-Man's Tangled Web" Number="19" Volume="2001" Year="2002">
       <Id>b277aa18-56aa-43dd-b691-af7c47c0a48f</Id>
     </Book>
-    <Book Series="Spider-Man: Quality of Life" Number="1" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="Spider-Man: Quality of Life" Number="1" Volume="2002" Year="2002">
       <Id>66550b69-3ac6-44d2-9f2f-65a2c9be9ea4</Id>
     </Book>
-    <Book Series="Spider-Man: Quality of Life" Number="2" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="Spider-Man: Quality of Life" Number="2" Volume="2002" Year="2002">
       <Id>1377af38-c014-411e-9000-69481024ea04</Id>
     </Book>
-    <Book Series="Spider-Man: Quality of Life" Number="3" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="Spider-Man: Quality of Life" Number="3" Volume="2002" Year="2002">
       <Id>11f4c55c-693b-4ce3-af66-f3f6fe163add</Id>
     </Book>
-    <Book Series="Spider-Man: Quality of Life" Number="4" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="Spider-Man: Quality of Life" Number="4" Volume="2002" Year="2002">
       <Id>0269840f-6422-4224-b51f-fd8cc6f85016</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="484" Volume="1963" Year="2002" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="484" Volume="1963" Year="2002">
       <Id>dd6c47da-46fc-4f5e-8e80-b5a9fae45d59</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="485" Volume="1963" Year="2002" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="485" Volume="1963" Year="2002">
       <Id>48485779-db11-4afa-bf07-4710bcde4aca</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="486" Volume="1963" Year="2002" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="486" Volume="1963" Year="2002">
       <Id>bf2e2642-762c-4d96-9f99-d9397949c8da</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="487" Volume="1963" Year="2002" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="487" Volume="1963" Year="2002">
       <Id>75671719-dae6-43fc-94a1-30bdd66d3269</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="488" Volume="1963" Year="2003" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="488" Volume="1963" Year="2003">
       <Id>657fbd70-ac4f-4d0d-ad17-d9421042ef02</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="489" Volume="1963" Year="2003" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="489" Volume="1963" Year="2003">
       <Id>190a2e5c-11a5-42b3-8ce2-ab8c8b93144c</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="490" Volume="1963" Year="2003" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="490" Volume="1963" Year="2003">
       <Id>0f3ee25c-71a8-4971-94f1-a09013855ec7</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="491" Volume="1963" Year="2003" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="491" Volume="1963" Year="2003">
       <Id>b036bdca-7b4d-405e-a689-027cfbf6a163</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="492" Volume="1963" Year="2003" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="492" Volume="1963" Year="2003">
       <Id>f2bf6e6d-0ec8-45b4-806d-3cb57bda52fc</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="493" Volume="1963" Year="2003" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="493" Volume="1963" Year="2003">
       <Id>0876b5fc-7349-45fd-951c-a901467eccde</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="494" Volume="1963" Year="2003" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="494" Volume="1963" Year="2003">
       <Id>b00ec3b1-6abe-4f63-b7d4-056b3479c9dd</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="495" Volume="1963" Year="2003" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="495" Volume="1963" Year="2003">
       <Id>09342d4e-0125-48cb-8abe-eeea91fad499</Id>
     </Book>
-    <Book Series="Spider-Man: Blue" Number="1" Volume="2004" Year="2004" Format="One-Shot">
+    <Book Series="Spider-Man: Blue" Number="1" Volume="2004" Year="2004">
       <Id>1cd7dcad-bcf6-4d5e-b7c6-50c4057928ee</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="6" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="6" Volume="2003" Year="2004">
       <Id>d3e825de-a595-409e-b53c-9e17257e937e</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="7" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="7" Volume="2003" Year="2004">
       <Id>248270ed-b6b8-411e-9bed-7963f475b3a3</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="8" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="8" Volume="2003" Year="2004">
       <Id>ca72fdd0-02fc-4a98-8d76-ced3b4e7db12</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="9" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="9" Volume="2003" Year="2004">
       <Id>b84e5f3f-387d-4ac5-a151-55a8842ee923</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="10" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="10" Volume="2003" Year="2004">
       <Id>a7072469-cfff-4be0-86b5-aaf77c101961</Id>
     </Book>
-    <Book Series="Spider-Man's Tangled Web" Number="21" Volume="2001" Year="2003" Format="Main Series">
+    <Book Series="Spider-Man's Tangled Web" Number="21" Volume="2001" Year="2003">
       <Id>99355e82-1214-494e-bab3-e009f1a77d65</Id>
     </Book>
-    <Book Series="Venom vs. Carnage" Number="1" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Venom vs. Carnage" Number="1" Volume="2004" Year="2004">
       <Id>417f657e-e854-4ce8-87f0-7744cd1aa665</Id>
     </Book>
-    <Book Series="Venom vs. Carnage" Number="2" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Venom vs. Carnage" Number="2" Volume="2004" Year="2004">
       <Id>963e70dc-f4ec-4a34-b947-a384cbd8f4ec</Id>
     </Book>
-    <Book Series="Venom vs. Carnage" Number="3" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Venom vs. Carnage" Number="3" Volume="2004" Year="2004">
       <Id>0bcc95db-0d88-4659-9232-e15ead0f4185</Id>
     </Book>
-    <Book Series="Venom vs. Carnage" Number="4" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Venom vs. Carnage" Number="4" Volume="2004" Year="2004">
       <Id>6829f69f-8152-48a1-b6f6-1f6df3a0445e</Id>
     </Book>
-    <Book Series="Marvel Knights: Spider-Man &amp; Wolverine" Number="1" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Marvel Knights: Spider-Man &amp; Wolverine" Number="1" Volume="2003" Year="2003">
       <Id>de8f2c1d-7dbb-4799-af54-dc97bc93ffe2</Id>
     </Book>
-    <Book Series="Marvel Knights: Spider-Man &amp; Wolverine" Number="2" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Marvel Knights: Spider-Man &amp; Wolverine" Number="2" Volume="2003" Year="2003">
       <Id>e0eed7b9-093e-4d06-8b5f-903c4cac0e0c</Id>
     </Book>
-    <Book Series="Marvel Knights: Spider-Man &amp; Wolverine" Number="3" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Marvel Knights: Spider-Man &amp; Wolverine" Number="3" Volume="2003" Year="2003">
       <Id>9b98a30d-632b-4191-ac77-a8e5bd3871c3</Id>
     </Book>
-    <Book Series="Marvel Knights: Spider-Man &amp; Wolverine" Number="4" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Marvel Knights: Spider-Man &amp; Wolverine" Number="4" Volume="2003" Year="2003">
       <Id>c1348b24-3201-482b-99dc-d35a4c219bd5</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="496" Volume="1963" Year="2003" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="496" Volume="1963" Year="2003">
       <Id>e5445ab1-104f-42a9-a3cb-13d3c70ffdc3</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="497" Volume="1963" Year="2003" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="497" Volume="1963" Year="2003">
       <Id>fb8618f2-50cc-4673-8c96-dfaa3b3ff82b</Id>
     </Book>
-    <Book Series="Spider-Man Black &amp; Blue &amp; Read All Over" Number="1" Volume="2006" Year="2006" Format="One-Shot">
+    <Book Series="Spider-Man Black &amp; Blue &amp; Read All Over" Number="1" Volume="2006" Year="2006">
       <Id>ba91ab11-2769-42dd-b945-c5b8ab9df5d4</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Spider-Man/Spider-Man 006 (1998-2003).cbl
+++ b/Marvel/Characters/unsorted/Spider-Man/Spider-Man 006 (1998-2003).cbl
@@ -1,699 +1,700 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Spider-Man 6 (1998-2003)</Name>
+  <Name>Spider-Man 006 (1998-2003)</Name>
+  <NumIssues>231</NumIssues>
   <Books>
     <Book Series="The Sensational Spider-Man" Number="25" Volume="1996" Year="1998">
-      <Id>14f57b2e-7445-4e64-9fc1-77b46e312004</Id>
+      <Database Name="cv" Series="5788" Issue="44772" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="432" Volume="1963" Year="1998">
-      <Id>1e11f589-50cc-4989-9639-3a06a2b65581</Id>
+      <Database Name="cv" Series="2127" Issue="64468" />
     </Book>
     <Book Series="Spider-Man" Number="89" Volume="1990" Year="1998">
-      <Id>500c8a53-85e7-40ab-b7e7-ec3c5cd2f1aa</Id>
+      <Database Name="cv" Series="4421" Issue="44774" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="255" Volume="1976" Year="1998">
-      <Id>277d1596-a8b2-4f5c-af53-d9a8627361b2</Id>
+      <Database Name="cv" Series="2870" Issue="44773" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="26" Volume="1996" Year="1998">
-      <Id>ccb4c317-63eb-4cda-81ab-bdd4ba526b72</Id>
+      <Database Name="cv" Series="5788" Issue="44864" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="433" Volume="1963" Year="1998">
-      <Id>5a7db03b-a391-4f26-80ad-ad37234ce197</Id>
+      <Database Name="cv" Series="2127" Issue="64469" />
     </Book>
     <Book Series="Spider-Man" Number="90" Volume="1990" Year="1998">
-      <Id>3dca906e-5c51-4b7a-abd1-bcd5daf0ce0a</Id>
+      <Database Name="cv" Series="4421" Issue="44866" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="256" Volume="1976" Year="1998">
-      <Id>7d06af9c-228d-49ca-aa50-5b767b807903</Id>
+      <Database Name="cv" Series="2870" Issue="44865" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="27" Volume="1996" Year="1998">
-      <Id>4640a746-5186-47e8-aabc-9cd51919b37b</Id>
+      <Database Name="cv" Series="5788" Issue="44944" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="434" Volume="1963" Year="1998">
-      <Id>ea2c2d46-8afa-4634-bb7f-dd67244f64ca</Id>
+      <Database Name="cv" Series="2127" Issue="64470" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="28" Volume="1996" Year="1998">
-      <Id>2958ff2b-b498-4215-a603-f19c1592d63d</Id>
+      <Database Name="cv" Series="5788" Issue="45032" />
     </Book>
     <Book Series="Spider-Man" Number="91" Volume="1990" Year="1998">
-      <Id>e355f684-d7cd-4954-991b-532627cfc79c</Id>
+      <Database Name="cv" Series="4421" Issue="44946" />
     </Book>
     <Book Series="Spider-Man" Number="92" Volume="1990" Year="1998">
-      <Id>98603ce3-9806-4a58-8da1-852670708b6a</Id>
+      <Database Name="cv" Series="4421" Issue="45034" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="257" Volume="1976" Year="1998">
-      <Id>a7be97bd-5d76-4b11-92d3-12221a0777dd</Id>
+      <Database Name="cv" Series="2870" Issue="44945" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="258" Volume="1976" Year="1998">
-      <Id>2da9e6b0-d0a4-422e-ac2a-21461d7a1739</Id>
+      <Database Name="cv" Series="2870" Issue="45033" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="435" Volume="1963" Year="1998">
-      <Id>e926a81e-9a5a-42a8-a479-fc4539e49314</Id>
+      <Database Name="cv" Series="2127" Issue="64471" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="436" Volume="1963" Year="1998">
-      <Id>e5e78af0-7e54-4119-84f5-0b6ba5e03048</Id>
+      <Database Name="cv" Series="2127" Issue="64472" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="20" Volume="1993" Year="1998">
-      <Id>96717af6-eace-426d-9a1b-a06832f448cd</Id>
+      <Database Name="cv" Series="5048" Issue="57304" />
     </Book>
-    <Book Series="The Amazing Spider-Man Annual '97" Number="1" Volume="1997" Year="1997">
-      <Id>fbb3d4e8-579b-4e47-b499-38b1e0b4c9f3</Id>
+    <Book Series="The Amazing Spider-Man '97" Number="1" Volume="1997" Year="1997">
+      <Database Name="cv" Series="60438" Issue="143309" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="29" Volume="1996" Year="1998">
-      <Id>f78c45a7-5b57-4f31-b6f2-44b6ea3b837f</Id>
+      <Database Name="cv" Series="5788" Issue="45114" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="30" Volume="1996" Year="1998">
-      <Id>9203db9f-f5e8-42ee-874c-bd5baf8ea1ed</Id>
+      <Database Name="cv" Series="5788" Issue="45202" />
     </Book>
     <Book Series="Spider-Man" Number="93" Volume="1990" Year="1998">
-      <Id>59b04b7e-f8eb-4e32-bfb4-419dc4f37687</Id>
+      <Database Name="cv" Series="4421" Issue="45116" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="259" Volume="1976" Year="1998">
-      <Id>ae4c1f0f-32ff-4863-958a-c1f071967407</Id>
+      <Database Name="cv" Series="2870" Issue="45115" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="260" Volume="1976" Year="1998">
-      <Id>28ea98cc-317e-4e6f-a4ee-149400dc589b</Id>
+      <Database Name="cv" Series="2870" Issue="45203" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="261" Volume="1976" Year="1998">
-      <Id>97996aa6-2a88-4803-8646-7ac4594b191d</Id>
+      <Database Name="cv" Series="2870" Issue="45290" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="437" Volume="1963" Year="1998">
-      <Id>fd9e7714-ba06-4dc0-997a-21320956c748</Id>
+      <Database Name="cv" Series="2127" Issue="64473" />
     </Book>
     <Book Series="Spider-Man" Number="94" Volume="1990" Year="1998">
-      <Id>cc21e20e-cfee-4b29-b5b0-c35471bf98e1</Id>
+      <Database Name="cv" Series="4421" Issue="64663" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="31" Volume="1996" Year="1998">
-      <Id>ecc72985-6b4c-4a55-b51e-8c07488ad14b</Id>
+      <Database Name="cv" Series="5788" Issue="45289" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="438" Volume="1963" Year="1998">
-      <Id>5df4f7e0-f477-4eb3-ab5b-68f0846618e5</Id>
+      <Database Name="cv" Series="2127" Issue="64474" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="439" Volume="1963" Year="1998">
-      <Id>a3f8dd8c-9d12-4da7-ab9a-40484ac943b5</Id>
+      <Database Name="cv" Series="2127" Issue="64475" />
     </Book>
     <Book Series="Spider-Man" Number="95" Volume="1990" Year="1998">
-      <Id>9b5eb299-016f-4010-9470-64f1ae11e0a5</Id>
+      <Database Name="cv" Series="4421" Issue="45204" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="22" Volume="1993" Year="1998">
-      <Id>4c889f1b-0f19-4eab-a067-a6730a69b5af</Id>
+      <Database Name="cv" Series="5048" Issue="57306" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="32" Volume="1996" Year="1998">
-      <Id>ad522a5d-5b0a-4570-9621-25627f3674d5</Id>
+      <Database Name="cv" Series="5788" Issue="45363" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="440" Volume="1963" Year="1998">
-      <Id>187c2119-eddb-469c-8f5f-e70624c38939</Id>
+      <Database Name="cv" Series="2127" Issue="64476" />
     </Book>
     <Book Series="Spider-Man" Number="96" Volume="1990" Year="1998">
-      <Id>2e6504b1-f5ad-4f62-8cdb-b488d90e1c55</Id>
+      <Database Name="cv" Series="4421" Issue="45291" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="262" Volume="1976" Year="1998">
-      <Id>cdcd8d9f-dac7-4a90-babb-26c1c4671efb</Id>
+      <Database Name="cv" Series="2870" Issue="45364" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="33" Volume="1996" Year="1998">
-      <Id>0c8af18a-ad24-4163-ab65-2dae564ebe56</Id>
+      <Database Name="cv" Series="5788" Issue="45427" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="441" Volume="1963" Year="1998">
-      <Id>2f33af4c-e505-4428-82bf-10470bb5c28d</Id>
+      <Database Name="cv" Series="2127" Issue="64477" />
     </Book>
     <Book Series="Spider-Man" Number="97" Volume="1990" Year="1998">
-      <Id>99f4a495-42d0-41c3-8aa1-08dc3b6b2ed0</Id>
+      <Database Name="cv" Series="4421" Issue="45441" />
     </Book>
     <Book Series="The Spectacular Spider-Man" Number="263" Volume="1976" Year="1998">
-      <Id>8b1e7044-cb12-47fd-89dd-aaae38496af8</Id>
+      <Database Name="cv" Series="2870" Issue="45428" />
     </Book>
     <Book Series="Spider-Man" Number="98" Volume="1990" Year="1998">
-      <Id>08ef1d4a-955e-4406-b78f-d893377975bf</Id>
+      <Database Name="cv" Series="4421" Issue="45504" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="442" Volume="1963" Year="1999">
-      <Id>76fb506c-1417-4ea0-8533-844bc1bcb29f</Id>
+    <Book Series="The Amazing Spider-Man" Number="1" Volume="1999" Year="1999">
+      <Database Name="cv" Series="78701" Issue="113432" />
     </Book>
     <Book Series="Daredevil" Number="7" Volume="1998" Year="1999">
-      <Id>1514e949-77e3-4594-b1df-76cb76c539c3</Id>
+      <Database Name="cv" Series="6209" Issue="66256" />
     </Book>
     <Book Series="Daredevil" Number="8" Volume="1998" Year="1999">
-      <Id>cb3d0520-44da-45a1-8e87-70b717bcdae6</Id>
+      <Database Name="cv" Series="6209" Issue="66257" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="1" Volume="1999" Year="1999">
-      <Id>d23456a6-8e09-426f-9978-a8c41e16666f</Id>
+      <Database Name="cv" Series="9142" Issue="68478" />
     </Book>
     <Book Series="Thor" Number="8" Volume="1998" Year="1999">
-      <Id>b6b2f12a-025c-4088-950f-641754558309</Id>
+      <Database Name="cv" Series="6226" Issue="45665" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="2" Volume="1999" Year="1999">
-      <Id>7b5a465c-0195-4439-b878-4f6cfecf375f</Id>
+      <Database Name="cv" Series="9142" Issue="68479" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="443" Volume="1963" Year="1999">
-      <Id>3051d17d-e0ba-41ca-a855-316816d19d09</Id>
+    <Book Series="The Amazing Spider-Man" Number="2" Volume="1999" Year="1999">
+      <Database Name="cv" Series="78701" Issue="113433" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="444" Volume="1963" Year="1999">
-      <Id>c58fac64-2245-4d76-8bef-deba220072a8</Id>
+    <Book Series="The Amazing Spider-Man" Number="3" Volume="1999" Year="1999">
+      <Database Name="cv" Series="78701" Issue="113434" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="3" Volume="1999" Year="1999">
-      <Id>58bc4ece-3262-4690-8593-081108f0b349</Id>
+      <Database Name="cv" Series="9142" Issue="68480" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="445" Volume="1963" Year="1999">
-      <Id>82e6b27c-29c1-461e-97a4-166f440fffe9</Id>
+    <Book Series="The Amazing Spider-Man" Number="4" Volume="1999" Year="1999">
+      <Database Name="cv" Series="78701" Issue="113435" />
     </Book>
     <Book Series="Daredevil/Spider-Man" Number="1" Volume="2001" Year="2001">
-      <Id>e30dab3a-999d-4076-9727-71aa2fca6a72</Id>
+      <Database Name="cv" Series="27657" Issue="169132" />
     </Book>
     <Book Series="Daredevil/Spider-Man" Number="2" Volume="2001" Year="2001">
-      <Id>bc4dbad5-b2d2-467b-965f-f44266895e86</Id>
+      <Database Name="cv" Series="27657" Issue="169136" />
     </Book>
     <Book Series="Daredevil/Spider-Man" Number="3" Volume="2001" Year="2001">
-      <Id>29ab8813-70b2-4871-bbbf-57ba8a9d4e0d</Id>
+      <Database Name="cv" Series="27657" Issue="169135" />
     </Book>
     <Book Series="Daredevil/Spider-Man" Number="4" Volume="2001" Year="2001">
-      <Id>ec06a0f1-2281-4791-9955-442cb1f8554e</Id>
+      <Database Name="cv" Series="27657" Issue="169134" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="4" Volume="1999" Year="1999">
-      <Id>d8679bdc-d647-4497-b7e7-ee09bea79ae4</Id>
+      <Database Name="cv" Series="9142" Issue="68481" />
     </Book>
-    <Book Series="Peter Parker: Spider-Man Annual 1999" Number="1" Volume="1999" Year="1999">
-      <Id>041c609d-32df-4dce-92cf-8bc5c40574a5</Id>
+    <Book Series="Peter Parker: Spider-Man 1999" Number="1" Volume="1999" Year="1999">
+      <Database Name="cv" Series="39919" Issue="269238" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="446" Volume="1963" Year="1999">
-      <Id>86cba60d-0e17-41e0-83f8-4d07a5ed8d80</Id>
+    <Book Series="The Amazing Spider-Man" Number="5" Volume="1999" Year="1999">
+      <Database Name="cv" Series="78701" Issue="113436" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="5" Volume="1999" Year="1999">
-      <Id>8a4e3cb3-dacc-417b-97ef-eb4aadc7050d</Id>
+      <Database Name="cv" Series="9142" Issue="68482" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="447" Volume="1963" Year="1999">
-      <Id>25d414f1-5ffe-463c-bd60-1b2fa7d0846b</Id>
+    <Book Series="The Amazing Spider-Man" Number="6" Volume="1999" Year="1999">
+      <Database Name="cv" Series="78701" Issue="113437" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="6" Volume="1999" Year="1999">
-      <Id>3096b1af-dbad-4130-8c04-9c5a8a7feba0</Id>
+      <Database Name="cv" Series="9142" Issue="68483" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="448" Volume="1963" Year="1999">
-      <Id>69260f09-b09e-4d22-8999-eeb5763a54e2</Id>
+    <Book Series="The Amazing Spider-Man" Number="7" Volume="1999" Year="1999">
+      <Database Name="cv" Series="78701" Issue="113438" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="449" Volume="1963" Year="1999">
-      <Id>0caa2869-c3d5-492d-b756-ae51b82f3dda</Id>
+    <Book Series="The Amazing Spider-Man" Number="8" Volume="1999" Year="1999">
+      <Database Name="cv" Series="78701" Issue="113439" />
     </Book>
     <Book Series="Webspinners: Tales of Spider-Man" Number="10" Volume="1999" Year="1999">
-      <Id>7848f3ec-24b2-4eea-a9e8-06aed57d1f62</Id>
+      <Database Name="cv" Series="9375" Issue="75632" />
     </Book>
     <Book Series="Webspinners: Tales of Spider-Man" Number="11" Volume="1999" Year="1999">
-      <Id>8770bbf7-befa-44fd-9566-803ef85b48ea</Id>
+      <Database Name="cv" Series="9375" Issue="117427" />
     </Book>
     <Book Series="Webspinners: Tales of Spider-Man" Number="12" Volume="1999" Year="1999">
-      <Id>58d10b93-92ab-4195-af15-3cccb3250fa1</Id>
+      <Database Name="cv" Series="9375" Issue="117429" />
     </Book>
-    <Book Series="The Amazing Spider-Man Annual 1999" Number="1" Volume="1999" Year="1999">
-      <Id>d47b8177-a3f8-4822-bcfa-cd12044f359c</Id>
+    <Book Series="The Amazing Spider-Man 1999" Number="1" Volume="1999" Year="1999">
+      <Database Name="cv" Series="60440" Issue="143311" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="7" Volume="1999" Year="1999">
-      <Id>4beaf77d-0219-4ce7-aadd-4fcd61d0cb87</Id>
+      <Database Name="cv" Series="9142" Issue="68484" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="8" Volume="1999" Year="1999">
-      <Id>ac510ffc-3ab1-4110-82d3-3db01c6b329b</Id>
+      <Database Name="cv" Series="9142" Issue="68485" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="450" Volume="1963" Year="1999">
-      <Id>073aeeae-bb1c-4e7e-bacd-ed1466b4b613</Id>
+    <Book Series="The Amazing Spider-Man" Number="9" Volume="1999" Year="1999">
+      <Database Name="cv" Series="78701" Issue="113440" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="451" Volume="1963" Year="1999">
-      <Id>d603a4f5-f76f-4679-b80a-1026016340fb</Id>
+    <Book Series="The Amazing Spider-Man" Number="10" Volume="1999" Year="1999">
+      <Database Name="cv" Series="78701" Issue="113441" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="9" Volume="1999" Year="1999">
-      <Id>8d52cef4-c2cb-46c7-9fba-a663fb673b68</Id>
+      <Database Name="cv" Series="9142" Issue="68486" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="10" Volume="1999" Year="1999">
-      <Id>d6ee5ba2-71cd-4789-8baa-7076475a1464</Id>
+      <Database Name="cv" Series="9142" Issue="68487" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="452" Volume="1963" Year="1999">
-      <Id>cba4a520-9723-4950-bf7c-96b9d9763f68</Id>
+    <Book Series="The Amazing Spider-Man" Number="11" Volume="1999" Year="1999">
+      <Database Name="cv" Series="78701" Issue="113442" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="11" Volume="1999" Year="1999">
-      <Id>5300e0ea-b818-4ee1-80a0-0b0e904d6a77</Id>
+      <Database Name="cv" Series="9142" Issue="68488" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="453" Volume="1963" Year="1999">
-      <Id>02d8f382-17c1-480b-85a1-03b70e82eec3</Id>
+    <Book Series="The Amazing Spider-Man" Number="12" Volume="1999" Year="1999">
+      <Database Name="cv" Series="78701" Issue="113443" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="12" Volume="1999" Year="1999">
-      <Id>416f42f6-90e2-4631-8c68-f9bb62db8c16</Id>
+      <Database Name="cv" Series="9142" Issue="68489" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="454" Volume="1963" Year="2000">
-      <Id>452eee45-0fc3-4c64-8c63-c289acd906eb</Id>
+    <Book Series="The Amazing Spider-Man" Number="13" Volume="1999" Year="2000">
+      <Database Name="cv" Series="78701" Issue="113444" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="13" Volume="1999" Year="2000">
-      <Id>0b20e55b-804d-44ab-8324-f0cc1035cfb6</Id>
+      <Database Name="cv" Series="9142" Issue="68490" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="14" Volume="1999" Year="2000">
-      <Id>7b6277a5-edc5-46df-9cd9-7ea449c2222f</Id>
+      <Database Name="cv" Series="9142" Issue="68491" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="455" Volume="1963" Year="2000">
-      <Id>88421ae3-e8a3-4025-b409-6210d1343fb7</Id>
+    <Book Series="The Amazing Spider-Man" Number="14" Volume="1999" Year="2000">
+      <Database Name="cv" Series="78701" Issue="113445" />
     </Book>
     <Book Series="Spider-Woman" Number="9" Volume="1999" Year="2000">
-      <Id>7a0dd85b-5645-480a-9c8d-bd7b0aba478f</Id>
+      <Database Name="cv" Series="9573" Issue="82318" />
     </Book>
     <Book Series="Webspinners: Tales of Spider-Man" Number="13" Volume="1999" Year="2000">
-      <Id>e9cbe8aa-f917-4ac2-9a3d-e81fcec19fef</Id>
+      <Database Name="cv" Series="9375" Issue="117430" />
     </Book>
     <Book Series="Webspinners: Tales of Spider-Man" Number="14" Volume="1999" Year="2000">
-      <Id>f1eb0498-e86f-4b17-930d-0f93a150e5e2</Id>
+      <Database Name="cv" Series="9375" Issue="117431" />
     </Book>
     <Book Series="Webspinners: Tales of Spider-Man" Number="15" Volume="1999" Year="2000">
-      <Id>f4ebb197-394d-4a15-97b5-fbe78874e55c</Id>
+      <Database Name="cv" Series="9375" Issue="117432" />
     </Book>
     <Book Series="Webspinners: Tales of Spider-Man" Number="16" Volume="1999" Year="2000">
-      <Id>7a34ba77-12d1-4c06-b9a3-5aee443be793</Id>
+      <Database Name="cv" Series="9375" Issue="117433" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="456" Volume="1963" Year="2000">
-      <Id>d7f460e8-05fa-459b-94ea-60358a8d4def</Id>
+    <Book Series="The Amazing Spider-Man" Number="15" Volume="1999" Year="2000">
+      <Database Name="cv" Series="78701" Issue="113446" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="15" Volume="1999" Year="2000">
-      <Id>02ea028b-5654-4aae-b878-c29f285b976d</Id>
+      <Database Name="cv" Series="9142" Issue="68492" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="457" Volume="1963" Year="2000">
-      <Id>ddce109d-bac7-4c8a-8404-fce8382fbf5b</Id>
+    <Book Series="The Amazing Spider-Man" Number="16" Volume="1999" Year="2000">
+      <Database Name="cv" Series="78701" Issue="113447" />
     </Book>
-    <Book Series="The Amazing Spider-Man Annual 2000" Number="1" Volume="2000" Year="2000">
-      <Id>da78daf0-d51d-41b2-9898-3923677900b3</Id>
+    <Book Series="The Amazing Spider-Man 2000" Number="1" Volume="2000" Year="2000">
+      <Database Name="cv" Series="60441" Issue="143312" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="16" Volume="1999" Year="2000">
-      <Id>849d4efb-787d-40b5-8390-dfa878bb0bde</Id>
+      <Database Name="cv" Series="9142" Issue="68493" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="458" Volume="1963" Year="2000">
-      <Id>59216087-9310-4607-b467-2c940072026f</Id>
+    <Book Series="The Amazing Spider-Man" Number="17" Volume="1999" Year="2000">
+      <Database Name="cv" Series="78701" Issue="113448" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="17" Volume="1999" Year="2000">
-      <Id>dfe8a61c-9d1c-47a2-af5d-288bde101e7c</Id>
+      <Database Name="cv" Series="9142" Issue="68494" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="459" Volume="1963" Year="2000">
-      <Id>b7cc64de-99c3-4cee-bec9-18c80ef95380</Id>
+    <Book Series="The Amazing Spider-Man" Number="18" Volume="1999" Year="2000">
+      <Database Name="cv" Series="78701" Issue="113449" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="18" Volume="1999" Year="2000">
-      <Id>0c27925a-08ac-4f7f-b29f-d4cac19d4307</Id>
+      <Database Name="cv" Series="9142" Issue="68495" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="460" Volume="1963" Year="2000">
-      <Id>82e9729f-7a6f-4d6d-ac5a-be04af6eb323</Id>
+    <Book Series="The Amazing Spider-Man" Number="19" Volume="1999" Year="2000">
+      <Database Name="cv" Series="78701" Issue="113450" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="19" Volume="1999" Year="2000">
-      <Id>7a90cc3d-4329-48e7-a1c8-87b24d687f5b</Id>
+      <Database Name="cv" Series="9142" Issue="68496" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="20" Volume="1999" Year="2000">
-      <Id>39a83670-21d6-4ef2-81cb-985d57a7a7dd</Id>
+      <Database Name="cv" Series="9142" Issue="68497" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="21" Volume="1999" Year="2000">
-      <Id>d7a4bca2-6540-43ac-9700-0abd3c1b20ba</Id>
+      <Database Name="cv" Series="9142" Issue="68498" />
     </Book>
-    <Book Series="Peter Parker: Spider-Man Annual 2000" Number="1" Volume="2000" Year="2000">
-      <Id>a9523b4c-bf42-4853-9040-c66cecfe8167</Id>
+    <Book Series="Peter Parker: Spider-Man 2000" Number="1" Volume="2000" Year="2000">
+      <Database Name="cv" Series="39920" Issue="269239" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="461" Volume="1963" Year="2000">
-      <Id>c8e11cc2-cbef-4105-a220-a9e8cd7b1fb4</Id>
+    <Book Series="The Amazing Spider-Man" Number="20" Volume="1999" Year="2000">
+      <Database Name="cv" Series="78701" Issue="113451" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="462" Volume="1963" Year="2000">
-      <Id>e0dcea9c-0300-4066-a911-ba7e209c6cbf</Id>
+    <Book Series="The Amazing Spider-Man" Number="21" Volume="1999" Year="2000">
+      <Database Name="cv" Series="78701" Issue="113452" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="463" Volume="1963" Year="2000">
-      <Id>9cf2a854-62fc-44a4-b6b2-31314f04ff45</Id>
+    <Book Series="The Amazing Spider-Man" Number="22" Volume="1999" Year="2000">
+      <Database Name="cv" Series="78701" Issue="113453" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="464" Volume="1963" Year="2000">
-      <Id>7aff3b3a-d9f0-4e12-b19d-835cd9731d8e</Id>
+    <Book Series="The Amazing Spider-Man" Number="23" Volume="1999" Year="2000">
+      <Database Name="cv" Series="78701" Issue="113454" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="465" Volume="1963" Year="2000">
-      <Id>229707ae-bfeb-4b49-adf5-6699f162ca7d</Id>
+    <Book Series="The Amazing Spider-Man" Number="24" Volume="1999" Year="2000">
+      <Database Name="cv" Series="78701" Issue="113455" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="22" Volume="1999" Year="2000">
-      <Id>27711a39-82b9-4aac-96df-413bb63a369a</Id>
+      <Database Name="cv" Series="9142" Issue="68499" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="23" Volume="1999" Year="2000">
-      <Id>1fd8a0a9-52cc-47b0-ba44-d3bb1f24332b</Id>
+      <Database Name="cv" Series="9142" Issue="68500" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="24" Volume="1999" Year="2000">
-      <Id>cdb755aa-88a1-46b2-b592-416ad0c090a4</Id>
+      <Database Name="cv" Series="9142" Issue="68501" />
     </Book>
     <Book Series="Spider-Man: Revenge of the Green Goblin" Number="1" Volume="2000" Year="2000">
-      <Id>0b621a19-9666-4897-b99e-0e11d9dda32d</Id>
+      <Database Name="cv" Series="20677" Issue="124017" />
     </Book>
     <Book Series="Spider-Man: Revenge of the Green Goblin" Number="2" Volume="2000" Year="2000">
-      <Id>7b64b33d-5eef-4cd2-a528-c15f7bc02b55</Id>
+      <Database Name="cv" Series="20677" Issue="124045" />
     </Book>
     <Book Series="Spider-Man: Revenge of the Green Goblin" Number="3" Volume="2000" Year="2000">
-      <Id>42a8ec3b-3bae-42c8-81d8-1a7065e11c05</Id>
+      <Database Name="cv" Series="20677" Issue="124157" />
     </Book>
-    <Book Series="Spider-Man: The Mysterio Manifesto" Number="1" Volume="2001" Year="2001">
-      <Id>c7a57c10-29ec-4937-840a-7b9022edd815</Id>
+    <Book Series="Spider-Man and Mysterio" Number="1" Volume="2001" Year="2001">
+      <Database Name="cv" Series="21938" Issue="132391" />
     </Book>
-    <Book Series="Spider-Man: The Mysterio Manifesto" Number="2" Volume="2001" Year="2001">
-      <Id>0622e1c7-3281-4dfa-ace9-8ab6bb095d42</Id>
+    <Book Series="Spider-Man and Mysterio" Number="2" Volume="2001" Year="2001">
+      <Database Name="cv" Series="21938" Issue="132392" />
     </Book>
-    <Book Series="Spider-Man: The Mysterio Manifesto" Number="3" Volume="2001" Year="2001">
-      <Id>6c61d3a5-627f-47ab-8944-915ea0faf151</Id>
+    <Book Series="Spider-Man and Mysterio" Number="3" Volume="2001" Year="2001">
+      <Database Name="cv" Series="21938" Issue="132393" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="466" Volume="1963" Year="2001">
-      <Id>1a146351-44e8-43f9-8835-b97640ac5d21</Id>
+    <Book Series="The Amazing Spider-Man" Number="25" Volume="1999" Year="2001">
+      <Database Name="cv" Series="78701" Issue="113456" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="25" Volume="1999" Year="2001">
-      <Id>70c213d6-a090-4d27-9b3c-a137c82977df</Id>
+      <Database Name="cv" Series="9142" Issue="68502" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="467" Volume="1963" Year="2001">
-      <Id>db1b3803-e463-47fd-8194-8ef34e5204f4</Id>
+    <Book Series="The Amazing Spider-Man" Number="26" Volume="1999" Year="2001">
+      <Database Name="cv" Series="78701" Issue="113457" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="26" Volume="1999" Year="2001">
-      <Id>d3104362-02b8-4e81-adf7-d2f7ff1041ba</Id>
+      <Database Name="cv" Series="9142" Issue="68503" />
     </Book>
     <Book Series="Spidey/Marrow" Number="1" Volume="2001" Year="2001">
-      <Id>dcdcb43a-15bb-43d5-b8b5-ff0406ff1b70</Id>
+      <Database Name="cv" Series="20622" Issue="123573" />
     </Book>
     <Book Series="Spider-Man: Lifeline" Number="1" Volume="2001" Year="2001">
-      <Id>b94e479f-6f55-4f13-8d57-8b38b3b0d0ef</Id>
+      <Database Name="cv" Series="26788" Issue="160824" />
     </Book>
     <Book Series="Spider-Man: Lifeline" Number="2" Volume="2001" Year="2001">
-      <Id>ed31accb-cce4-4b3f-84a8-b10253e1dd45</Id>
+      <Database Name="cv" Series="26788" Issue="160825" />
     </Book>
     <Book Series="Spider-Man: Lifeline" Number="3" Volume="2001" Year="2001">
-      <Id>823366d9-2dc9-45f2-8134-92aa6be29706</Id>
+      <Database Name="cv" Series="26788" Issue="160826" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="468" Volume="1963" Year="2001">
-      <Id>62f34a9c-2b00-4b34-8a40-a80382c50270</Id>
+    <Book Series="The Amazing Spider-Man" Number="27" Volume="1999" Year="2001">
+      <Database Name="cv" Series="78701" Issue="113458" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="27" Volume="1999" Year="2001">
-      <Id>74e3e733-12fe-4645-ad08-701568898bbd</Id>
+      <Database Name="cv" Series="9142" Issue="68504" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="28" Volume="1999" Year="2001">
-      <Id>5ce453b3-cc9f-4c07-ad82-7f0d827cfff9</Id>
+      <Database Name="cv" Series="9142" Issue="68505" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="469" Volume="1963" Year="2001">
-      <Id>c78c2349-76fd-48e6-8790-4cf4f694ba66</Id>
+    <Book Series="The Amazing Spider-Man" Number="28" Volume="1999" Year="2001">
+      <Database Name="cv" Series="78701" Issue="113459" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="470" Volume="1963" Year="2001">
-      <Id>8e633b7c-d53e-4186-a607-75b255af2dd3</Id>
+    <Book Series="The Amazing Spider-Man" Number="29" Volume="1999" Year="2001">
+      <Database Name="cv" Series="78701" Issue="113460" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="29" Volume="1999" Year="2001">
-      <Id>b93aedb8-2c22-4473-a790-8e9e545fd2be</Id>
+      <Database Name="cv" Series="9142" Issue="68506" />
     </Book>
-    <Book Series="The Amazing Spider-Man Annual 2001" Number="1" Volume="2001" Year="2001">
-      <Id>6771575d-8346-47b9-98ee-ed089c4400a0</Id>
+    <Book Series="The Amazing Spider-Man 2001" Number="1" Volume="2001" Year="2001">
+      <Database Name="cv" Series="60442" Issue="143313" />
     </Book>
     <Book Series="Spider-Man's Tangled Web" Number="1" Volume="2001" Year="2001">
-      <Id>93d78c9b-9cc1-4216-9674-172563793ab3</Id>
+      <Database Name="cv" Series="7255" Issue="51614" />
     </Book>
     <Book Series="Spider-Man's Tangled Web" Number="2" Volume="2001" Year="2001">
-      <Id>0bfac73c-fb5f-4e24-92ea-ad1c6bfaadda</Id>
+      <Database Name="cv" Series="7255" Issue="51615" />
     </Book>
     <Book Series="Spider-Man's Tangled Web" Number="3" Volume="2001" Year="2001">
-      <Id>75dbaa7f-84c3-4812-97e7-1bf1f434b435</Id>
+      <Database Name="cv" Series="7255" Issue="51616" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="471" Volume="1963" Year="2001">
-      <Id>0373c4cd-1f8e-4153-b028-477d360b9f94</Id>
+    <Book Series="The Amazing Spider-Man" Number="30" Volume="1999" Year="2001">
+      <Database Name="cv" Series="78701" Issue="113461" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="30" Volume="1999" Year="2001">
-      <Id>943d146e-6b6d-4669-8c9c-ed8c6b403c30</Id>
+      <Database Name="cv" Series="9142" Issue="68507" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="31" Volume="1999" Year="2001">
-      <Id>db4ca99a-4d7a-4b7b-b70f-035eb072e318</Id>
+      <Database Name="cv" Series="9142" Issue="68508" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="32" Volume="1999" Year="2001">
-      <Id>0fd60354-a41d-4f3b-8935-b46f5df754f2</Id>
+      <Database Name="cv" Series="9142" Issue="68509" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="33" Volume="1999" Year="2001">
-      <Id>3962c7c4-c6ec-477b-9a41-c015ed9302aa</Id>
+      <Database Name="cv" Series="9142" Issue="68510" />
     </Book>
     <Book Series="Spider-Man's Tangled Web" Number="4" Volume="2001" Year="2001">
-      <Id>ba06d1dd-5741-4bfb-8674-3e459541be31</Id>
+      <Database Name="cv" Series="7255" Issue="51617" />
     </Book>
     <Book Series="Spider-Man's Tangled Web" Number="5" Volume="2001" Year="2001">
-      <Id>c0949dc5-ba1c-4f83-9957-d3d203aa4ead</Id>
+      <Database Name="cv" Series="7255" Issue="114254" />
     </Book>
     <Book Series="Spider-Man's Tangled Web" Number="6" Volume="2001" Year="2001">
-      <Id>3f515b83-6d5e-40d6-9a94-ba6b11520798</Id>
+      <Database Name="cv" Series="7255" Issue="114255" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="34" Volume="1999" Year="2001">
-      <Id>f9a1c0a4-54d8-4a48-86d9-191c1c58c6b5</Id>
+      <Database Name="cv" Series="9142" Issue="68511" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="472" Volume="1963" Year="2001">
-      <Id>76f61fe5-6f14-435d-88ef-8485c9a4e6ea</Id>
+    <Book Series="The Amazing Spider-Man" Number="31" Volume="1999" Year="2001">
+      <Database Name="cv" Series="78701" Issue="113462" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="473" Volume="1963" Year="2001">
-      <Id>a953668c-df59-4a24-b5ca-81ed8ab27828</Id>
+    <Book Series="The Amazing Spider-Man" Number="32" Volume="1999" Year="2001">
+      <Database Name="cv" Series="78701" Issue="113463" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="474" Volume="1963" Year="2001">
-      <Id>349996aa-83c2-4fcf-8a2a-3e5e4991da08</Id>
+    <Book Series="The Amazing Spider-Man" Number="33" Volume="1999" Year="2001">
+      <Database Name="cv" Series="78701" Issue="113464" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="475" Volume="1963" Year="2001">
-      <Id>3bafc1a0-4c91-4e1b-bd5a-41c1b446c659</Id>
+    <Book Series="The Amazing Spider-Man" Number="34" Volume="1999" Year="2001">
+      <Database Name="cv" Series="78701" Issue="113465" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="477" Volume="1963" Year="2001">
-      <Id>8fdd2484-4669-46fa-9c7c-e8375ed16891</Id>
+    <Book Series="The Amazing Spider-Man" Number="35" Volume="1999" Year="2001">
+      <Database Name="cv" Series="78701" Issue="113466" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="476" Volume="1963" Year="2001">
-      <Id>b30cc047-07ef-4158-b98d-972ff05dd636</Id>
+    <Book Series="The Amazing Spider-Man" Number="36" Volume="1999" Year="2001">
+      <Database Name="cv" Series="78701" Issue="113467" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="478" Volume="1963" Year="2002">
-      <Id>5ecaf401-07ca-4b29-b601-9d491ff05cd1</Id>
+    <Book Series="The Amazing Spider-Man" Number="37" Volume="1999" Year="2002">
+      <Database Name="cv" Series="78701" Issue="113468" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="479" Volume="1963" Year="2002">
-      <Id>fdad9642-15d4-4171-8ec1-85d948242b03</Id>
+    <Book Series="The Amazing Spider-Man" Number="38" Volume="1999" Year="2002">
+      <Database Name="cv" Series="78701" Issue="113469" />
     </Book>
     <Book Series="Spider-Man's Tangled Web" Number="7" Volume="2001" Year="2001">
-      <Id>446a9def-ca8d-4cc3-9069-449e2c953f01</Id>
+      <Database Name="cv" Series="7255" Issue="114256" />
     </Book>
     <Book Series="Spider-Man's Tangled Web" Number="8" Volume="2001" Year="2002">
-      <Id>e7a33204-7ef3-40a1-afdc-d1c9f1d2ad2b</Id>
+      <Database Name="cv" Series="7255" Issue="114257" />
     </Book>
     <Book Series="Spider-Man's Tangled Web" Number="9" Volume="2001" Year="2002">
-      <Id>6d9dc673-60ee-4998-9314-ef87d73d1ce9</Id>
+      <Database Name="cv" Series="7255" Issue="114258" />
     </Book>
     <Book Series="Spider-Man's Tangled Web" Number="10" Volume="2001" Year="2002">
-      <Id>271e18b9-3f7b-4e55-9fcb-b9a3939e8df2</Id>
+      <Database Name="cv" Series="7255" Issue="114259" />
     </Book>
     <Book Series="Spider-Man's Tangled Web" Number="11" Volume="2001" Year="2002">
-      <Id>7e1077f6-8fc8-425c-acff-ce749af35a31</Id>
+      <Database Name="cv" Series="7255" Issue="114260" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="35" Volume="1999" Year="2001">
-      <Id>31d48ccd-632c-4b4c-828f-62937dda3ef5</Id>
+      <Database Name="cv" Series="9142" Issue="68512" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="36" Volume="1999" Year="2001">
-      <Id>ed124fe1-6f41-47cf-a205-f2b9d4a01883</Id>
+      <Database Name="cv" Series="9142" Issue="68513" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="37" Volume="1999" Year="2002">
-      <Id>18e272f4-af98-478e-a81b-6bf7d1ec93d2</Id>
+      <Database Name="cv" Series="9142" Issue="68514" />
     </Book>
     <Book Series="Infinity Abyss" Number="1" Volume="2002" Year="2002">
-      <Id>1a13c65c-0d3a-4b3e-9817-4bce5d64cbfd</Id>
+      <Database Name="cv" Series="9504" Issue="78316" />
     </Book>
     <Book Series="Infinity Abyss" Number="2" Volume="2002" Year="2002">
-      <Id>1f44aa37-e546-498f-8cc3-d97022407d56</Id>
+      <Database Name="cv" Series="9504" Issue="78317" />
     </Book>
     <Book Series="Infinity Abyss" Number="3" Volume="2002" Year="2002">
-      <Id>0db89260-7fa0-4db1-960a-96d37ad1a305</Id>
+      <Database Name="cv" Series="9504" Issue="78318" />
     </Book>
     <Book Series="Infinity Abyss" Number="4" Volume="2002" Year="2002">
-      <Id>e70fa627-bf59-4dae-b757-91f911cd5944</Id>
+      <Database Name="cv" Series="9504" Issue="78319" />
     </Book>
     <Book Series="Infinity Abyss" Number="5" Volume="2002" Year="2002">
-      <Id>a5fd2555-cf90-4cca-bfef-88c3153e633c</Id>
+      <Database Name="cv" Series="9504" Issue="78320" />
     </Book>
     <Book Series="Infinity Abyss" Number="6" Volume="2002" Year="2002">
-      <Id>90e78121-583d-42ea-ad03-884dcacfa401</Id>
+      <Database Name="cv" Series="9504" Issue="78321" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="38" Volume="1999" Year="2002">
-      <Id>b9f024f4-490d-45a8-a824-28f9e0acdd52</Id>
+      <Database Name="cv" Series="9142" Issue="68515" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="39" Volume="1999" Year="2002">
-      <Id>204301ee-b2cc-4183-856b-3ce326a79b6f</Id>
+      <Database Name="cv" Series="9142" Issue="68516" />
     </Book>
     <Book Series="Spider-Man's Tangled Web" Number="12" Volume="2001" Year="2002">
-      <Id>5bb220e2-f717-430c-9550-1a2faf9b5d65</Id>
+      <Database Name="cv" Series="7255" Issue="114261" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="40" Volume="1999" Year="2002">
-      <Id>fdb5bb8f-b561-4b9e-b190-3dd296845e8a</Id>
+      <Database Name="cv" Series="9142" Issue="68517" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="41" Volume="1999" Year="2002">
-      <Id>21351317-5bb6-4876-8339-c9235b96fc45</Id>
+      <Database Name="cv" Series="9142" Issue="68518" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="42" Volume="1999" Year="2002">
-      <Id>a1021527-a3bc-49c1-8fe6-bb9a292136df</Id>
+      <Database Name="cv" Series="9142" Issue="68519" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="43" Volume="1999" Year="2002">
-      <Id>1f67d543-79af-422c-ae18-8b48b7b7db02</Id>
+      <Database Name="cv" Series="9142" Issue="68520" />
     </Book>
     <Book Series="Daredevil" Number="34" Volume="1998" Year="2002">
-      <Id>60306b77-f47d-4410-b23d-09d6a7d7c772</Id>
+      <Database Name="cv" Series="6209" Issue="80279" />
     </Book>
     <Book Series="Daredevil" Number="35" Volume="1998" Year="2002">
-      <Id>43109af2-3629-49fa-a829-f3c6d041bb2f</Id>
+      <Database Name="cv" Series="6209" Issue="88708" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="44" Volume="1999" Year="2002">
-      <Id>3e5daf48-8c1f-46c7-9f3e-6f85b01ca76c</Id>
+      <Database Name="cv" Series="9142" Issue="80609" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="45" Volume="1999" Year="2002">
-      <Id>9bcee609-6c35-454c-9dfc-6465684e7594</Id>
+      <Database Name="cv" Series="9142" Issue="80610" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="46" Volume="1999" Year="2002">
-      <Id>14eac4d0-afca-4fb7-b2c6-19a48addb39a</Id>
+      <Database Name="cv" Series="9142" Issue="113657" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="47" Volume="1999" Year="2002">
-      <Id>300e5548-53fe-4aae-b84e-25dc6cd6ba65</Id>
+      <Database Name="cv" Series="9142" Issue="113658" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="48" Volume="1999" Year="2002">
-      <Id>2f4ef3e0-4d9f-4af1-96a2-2febbe079be5</Id>
+      <Database Name="cv" Series="9142" Issue="113659" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="49" Volume="1999" Year="2002">
-      <Id>726318c5-77de-437b-bcd3-9f3cb0c191f0</Id>
+      <Database Name="cv" Series="9142" Issue="113660" />
     </Book>
     <Book Series="Spider-Man's Tangled Web" Number="18" Volume="2001" Year="2002">
-      <Id>cfcee63a-febe-4a43-b74e-4b498769e608</Id>
+      <Database Name="cv" Series="7255" Issue="114267" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="480" Volume="1963" Year="2002">
-      <Id>c8a4fc52-7e66-40d3-afb3-858c08745fce</Id>
+    <Book Series="The Amazing Spider-Man" Number="39" Volume="1999" Year="2002">
+      <Database Name="cv" Series="78701" Issue="113470" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="50" Volume="1999" Year="2003">
-      <Id>d8f3f7ca-42c8-46bb-96d0-a07370210490</Id>
+      <Database Name="cv" Series="9142" Issue="113661" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="51" Volume="1999" Year="2003">
-      <Id>7b1cf42d-6ffa-4b26-b8e2-1167159be994</Id>
+      <Database Name="cv" Series="9142" Issue="90345" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="52" Volume="1999" Year="2003">
-      <Id>cc8492f4-c25b-470a-bd85-a4d56db03333</Id>
+      <Database Name="cv" Series="9142" Issue="90346" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="53" Volume="1999" Year="2003">
-      <Id>e3495168-3d57-4149-ba93-3e3be390260d</Id>
+      <Database Name="cv" Series="9142" Issue="90347" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="54" Volume="1999" Year="2003">
-      <Id>c9392cd3-61a6-44a8-b8ec-62de0fd1f8c5</Id>
+      <Database Name="cv" Series="9142" Issue="90348" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="55" Volume="1999" Year="2003">
-      <Id>1c7df38a-f86f-4479-a34c-eef5d54906aa</Id>
+      <Database Name="cv" Series="9142" Issue="90349" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="56" Volume="1999" Year="2003">
-      <Id>6fa4a550-7dd0-4f54-8da9-52be114991f6</Id>
+      <Database Name="cv" Series="9142" Issue="90350" />
     </Book>
     <Book Series="Peter Parker: Spider-Man" Number="57" Volume="1999" Year="2003">
-      <Id>97dcdd8c-7691-47c4-956b-048d5f60852d</Id>
+      <Database Name="cv" Series="9142" Issue="90351" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="1" Volume="2003" Year="2003">
-      <Id>4ca923f2-da31-43be-825b-d42c63cab1e3</Id>
+      <Database Name="cv" Series="11069" Issue="96971" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="2" Volume="2003" Year="2003">
-      <Id>00306298-4832-44cf-9396-6b3511b92907</Id>
+      <Database Name="cv" Series="11069" Issue="96972" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="3" Volume="2003" Year="2003">
-      <Id>cf0c026f-43c6-4783-bab8-4a991a68c557</Id>
+      <Database Name="cv" Series="11069" Issue="96973" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="4" Volume="2003" Year="2003">
-      <Id>5c101973-e6cd-44ac-b03c-acded619e8e7</Id>
+      <Database Name="cv" Series="11069" Issue="96974" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="5" Volume="2003" Year="2003">
-      <Id>0aeeed8b-efc6-4aa8-9e00-402156eaa369</Id>
+      <Database Name="cv" Series="11069" Issue="96975" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="481" Volume="1963" Year="2002">
-      <Id>5c90e1dd-7aaf-438f-a57c-b1072d76119d</Id>
+    <Book Series="The Amazing Spider-Man" Number="40" Volume="1999" Year="2002">
+      <Database Name="cv" Series="78701" Issue="113471" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="482" Volume="1963" Year="2002">
-      <Id>55762d37-f1e9-4b7c-858d-46ffbfbe5357</Id>
+    <Book Series="The Amazing Spider-Man" Number="41" Volume="1999" Year="2002">
+      <Database Name="cv" Series="78701" Issue="113472" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="483" Volume="1963" Year="2002">
-      <Id>9a8e0d10-5699-4791-88f4-0f8c2671e53c</Id>
+    <Book Series="The Amazing Spider-Man" Number="42" Volume="1999" Year="2002">
+      <Database Name="cv" Series="78701" Issue="113473" />
     </Book>
     <Book Series="Spider-Man's Tangled Web" Number="19" Volume="2001" Year="2002">
-      <Id>b277aa18-56aa-43dd-b691-af7c47c0a48f</Id>
+      <Database Name="cv" Series="7255" Issue="114268" />
     </Book>
     <Book Series="Spider-Man: Quality of Life" Number="1" Volume="2002" Year="2002">
-      <Id>66550b69-3ac6-44d2-9f2f-65a2c9be9ea4</Id>
+      <Database Name="cv" Series="9470" Issue="77961" />
     </Book>
     <Book Series="Spider-Man: Quality of Life" Number="2" Volume="2002" Year="2002">
-      <Id>1377af38-c014-411e-9000-69481024ea04</Id>
+      <Database Name="cv" Series="9470" Issue="77962" />
     </Book>
     <Book Series="Spider-Man: Quality of Life" Number="3" Volume="2002" Year="2002">
-      <Id>11f4c55c-693b-4ce3-af66-f3f6fe163add</Id>
+      <Database Name="cv" Series="9470" Issue="77963" />
     </Book>
     <Book Series="Spider-Man: Quality of Life" Number="4" Volume="2002" Year="2002">
-      <Id>0269840f-6422-4224-b51f-fd8cc6f85016</Id>
+      <Database Name="cv" Series="9470" Issue="77964" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="484" Volume="1963" Year="2002">
-      <Id>dd6c47da-46fc-4f5e-8e80-b5a9fae45d59</Id>
+    <Book Series="The Amazing Spider-Man" Number="43" Volume="1999" Year="2002">
+      <Database Name="cv" Series="78701" Issue="113474" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="485" Volume="1963" Year="2002">
-      <Id>48485779-db11-4afa-bf07-4710bcde4aca</Id>
+    <Book Series="The Amazing Spider-Man" Number="44" Volume="1999" Year="2002">
+      <Database Name="cv" Series="78701" Issue="113475" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="486" Volume="1963" Year="2002">
-      <Id>bf2e2642-762c-4d96-9f99-d9397949c8da</Id>
+    <Book Series="The Amazing Spider-Man" Number="45" Volume="1999" Year="2002">
+      <Database Name="cv" Series="78701" Issue="113476" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="487" Volume="1963" Year="2002">
-      <Id>75671719-dae6-43fc-94a1-30bdd66d3269</Id>
+    <Book Series="The Amazing Spider-Man" Number="46" Volume="1999" Year="2002">
+      <Database Name="cv" Series="78701" Issue="113477" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="488" Volume="1963" Year="2003">
-      <Id>657fbd70-ac4f-4d0d-ad17-d9421042ef02</Id>
+    <Book Series="The Amazing Spider-Man" Number="47" Volume="1999" Year="2003">
+      <Database Name="cv" Series="78701" Issue="113478" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="489" Volume="1963" Year="2003">
-      <Id>190a2e5c-11a5-42b3-8ce2-ab8c8b93144c</Id>
+    <Book Series="The Amazing Spider-Man" Number="48" Volume="1999" Year="2003">
+      <Database Name="cv" Series="78701" Issue="113479" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="490" Volume="1963" Year="2003">
-      <Id>0f3ee25c-71a8-4971-94f1-a09013855ec7</Id>
+    <Book Series="The Amazing Spider-Man" Number="49" Volume="1999" Year="2003">
+      <Database Name="cv" Series="78701" Issue="113480" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="491" Volume="1963" Year="2003">
-      <Id>b036bdca-7b4d-405e-a689-027cfbf6a163</Id>
+    <Book Series="The Amazing Spider-Man" Number="50" Volume="1999" Year="2003">
+      <Database Name="cv" Series="78701" Issue="113481" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="492" Volume="1963" Year="2003">
-      <Id>f2bf6e6d-0ec8-45b4-806d-3cb57bda52fc</Id>
+    <Book Series="The Amazing Spider-Man" Number="51" Volume="1999" Year="2003">
+      <Database Name="cv" Series="78701" Issue="113482" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="493" Volume="1963" Year="2003">
-      <Id>0876b5fc-7349-45fd-951c-a901467eccde</Id>
+    <Book Series="The Amazing Spider-Man" Number="52" Volume="1999" Year="2003">
+      <Database Name="cv" Series="78701" Issue="113483" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="494" Volume="1963" Year="2003">
-      <Id>b00ec3b1-6abe-4f63-b7d4-056b3479c9dd</Id>
+    <Book Series="The Amazing Spider-Man" Number="53" Volume="1999" Year="2003">
+      <Database Name="cv" Series="78701" Issue="113484" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="495" Volume="1963" Year="2003">
-      <Id>09342d4e-0125-48cb-8abe-eeea91fad499</Id>
+    <Book Series="The Amazing Spider-Man" Number="54" Volume="1999" Year="2003">
+      <Database Name="cv" Series="78701" Issue="113485" />
     </Book>
     <Book Series="Spider-Man: Blue" Number="1" Volume="2004" Year="2004">
-      <Id>1cd7dcad-bcf6-4d5e-b7c6-50c4057928ee</Id>
+      <Database Name="cv" Series="33400" Issue="216547" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="6" Volume="2003" Year="2004">
-      <Id>d3e825de-a595-409e-b53c-9e17257e937e</Id>
+      <Database Name="cv" Series="11069" Issue="96976" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="7" Volume="2003" Year="2004">
-      <Id>248270ed-b6b8-411e-9bed-7963f475b3a3</Id>
+      <Database Name="cv" Series="11069" Issue="96977" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="8" Volume="2003" Year="2004">
-      <Id>ca72fdd0-02fc-4a98-8d76-ced3b4e7db12</Id>
+      <Database Name="cv" Series="11069" Issue="96978" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="9" Volume="2003" Year="2004">
-      <Id>b84e5f3f-387d-4ac5-a151-55a8842ee923</Id>
+      <Database Name="cv" Series="11069" Issue="96979" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="10" Volume="2003" Year="2004">
-      <Id>a7072469-cfff-4be0-86b5-aaf77c101961</Id>
+      <Database Name="cv" Series="11069" Issue="96980" />
     </Book>
     <Book Series="Spider-Man's Tangled Web" Number="21" Volume="2001" Year="2003">
-      <Id>99355e82-1214-494e-bab3-e009f1a77d65</Id>
+      <Database Name="cv" Series="7255" Issue="114270" />
     </Book>
     <Book Series="Venom vs. Carnage" Number="1" Volume="2004" Year="2004">
-      <Id>417f657e-e854-4ce8-87f0-7744cd1aa665</Id>
+      <Database Name="cv" Series="18079" Issue="105908" />
     </Book>
     <Book Series="Venom vs. Carnage" Number="2" Volume="2004" Year="2004">
-      <Id>963e70dc-f4ec-4a34-b947-a384cbd8f4ec</Id>
+      <Database Name="cv" Series="18079" Issue="105922" />
     </Book>
     <Book Series="Venom vs. Carnage" Number="3" Volume="2004" Year="2004">
-      <Id>0bcc95db-0d88-4659-9232-e15ead0f4185</Id>
+      <Database Name="cv" Series="18079" Issue="118701" />
     </Book>
     <Book Series="Venom vs. Carnage" Number="4" Volume="2004" Year="2004">
-      <Id>6829f69f-8152-48a1-b6f6-1f6df3a0445e</Id>
+      <Database Name="cv" Series="18079" Issue="118702" />
     </Book>
-    <Book Series="Marvel Knights: Spider-Man &amp; Wolverine" Number="1" Volume="2003" Year="2003">
-      <Id>de8f2c1d-7dbb-4799-af54-dc97bc93ffe2</Id>
+    <Book Series="Marvel Knights: Spider-Man &#38; Wolverine" Number="1" Volume="2003" Year="2003">
+      <Database Name="cv" Series="28491" Issue="175541" />
     </Book>
-    <Book Series="Marvel Knights: Spider-Man &amp; Wolverine" Number="2" Volume="2003" Year="2003">
-      <Id>e0eed7b9-093e-4d06-8b5f-903c4cac0e0c</Id>
+    <Book Series="Marvel Knights: Spider-Man &#38; Wolverine" Number="2" Volume="2003" Year="2003">
+      <Database Name="cv" Series="28491" Issue="175543" />
     </Book>
-    <Book Series="Marvel Knights: Spider-Man &amp; Wolverine" Number="3" Volume="2003" Year="2003">
-      <Id>9b98a30d-632b-4191-ac77-a8e5bd3871c3</Id>
+    <Book Series="Marvel Knights: Spider-Man &#38; Wolverine" Number="3" Volume="2003" Year="2003">
+      <Database Name="cv" Series="28491" Issue="175546" />
     </Book>
-    <Book Series="Marvel Knights: Spider-Man &amp; Wolverine" Number="4" Volume="2003" Year="2003">
-      <Id>c1348b24-3201-482b-99dc-d35a4c219bd5</Id>
+    <Book Series="Marvel Knights: Spider-Man &#38; Wolverine" Number="4" Volume="2003" Year="2003">
+      <Database Name="cv" Series="28491" Issue="175548" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="496" Volume="1963" Year="2003">
-      <Id>e5445ab1-104f-42a9-a3cb-13d3c70ffdc3</Id>
+    <Book Series="The Amazing Spider-Man" Number="55" Volume="1999" Year="2003">
+      <Database Name="cv" Series="78701" Issue="113486" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="497" Volume="1963" Year="2003">
-      <Id>fb8618f2-50cc-4673-8c96-dfaa3b3ff82b</Id>
+    <Book Series="The Amazing Spider-Man" Number="56" Volume="1999" Year="2003">
+      <Database Name="cv" Series="78701" Issue="113487" />
     </Book>
-    <Book Series="Spider-Man Black &amp; Blue &amp; Read All Over" Number="1" Volume="2006" Year="2006">
-      <Id>ba91ab11-2769-42dd-b945-c5b8ab9df5d4</Id>
+    <Book Series="Spider-Man Black &#38; Blue &#38; Read All Over" Number="1" Volume="2006" Year="2006">
+      <Database Name="cv" Series="19880" Issue="119069" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Spider-Man/Spider-Man 007 (Straczynski Cont.).cbl
+++ b/Marvel/Characters/unsorted/Spider-Man/Spider-Man 007 (Straczynski Cont.).cbl
@@ -1,804 +1,805 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Spider-Man 7 (Straczynski Cont.)</Name>
+  <Name>Spider-Man 007 (Straczynski Cont.)</Name>
+  <NumIssues>266</NumIssues>
   <Books>
-    <Book Series="The Amazing Spider-Man" Number="498" Volume="1963" Year="2003">
-      <Id>090407e1-f1b4-4135-b837-dc375cdabd97</Id>
+    <Book Series="The Amazing Spider-Man" Number="57" Volume="1999" Year="2003">
+      <Database Name="cv" Series="78701" Issue="113488" />
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="499" Volume="1963" Year="2003">
-      <Id>7790956a-e169-40ea-863e-4bf7056170d0</Id>
+    <Book Series="The Amazing Spider-Man" Number="58" Volume="1999" Year="2003">
+      <Database Name="cv" Series="78701" Issue="113489" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="500" Volume="1963" Year="2003">
-      <Id>6d0ca3b9-b313-4c17-8834-5848afec3e02</Id>
+      <Database Name="cv" Series="2127" Issue="107505" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="501" Volume="1963" Year="2004">
-      <Id>26da5397-d020-4ed5-9495-efcdd387f315</Id>
+      <Database Name="cv" Series="2127" Issue="113490" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="502" Volume="1963" Year="2004">
-      <Id>367fac29-1397-4cb0-a74e-962e8a780ac1</Id>
+      <Database Name="cv" Series="2127" Issue="113241" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="503" Volume="1963" Year="2004">
-      <Id>2c0bae04-16ec-4411-b48b-461faa4b2db7</Id>
+      <Database Name="cv" Series="2127" Issue="113491" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="504" Volume="1963" Year="2004">
-      <Id>b4ab0892-bcec-4817-b43d-58ac8129db15</Id>
+      <Database Name="cv" Series="2127" Issue="113492" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="1" Volume="2004" Year="2004">
-      <Id>ce280de8-a65c-455f-909f-91581336e3c9</Id>
+      <Database Name="cv" Series="11306" Issue="99251" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="2" Volume="2004" Year="2004">
-      <Id>93871308-9aa5-4fe5-a2fe-648174f4daea</Id>
+      <Database Name="cv" Series="11306" Issue="99252" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="505" Volume="1963" Year="2004">
-      <Id>7ca0f34d-b3d6-4fd3-a110-8ad5bada8ce5</Id>
+      <Database Name="cv" Series="2127" Issue="113493" />
     </Book>
     <Book Series="The Pulse" Number="1" Volume="2004" Year="2004">
-      <Id>01a76a27-b59e-43a4-aba5-37ad3dcb256d</Id>
+      <Database Name="cv" Series="11310" Issue="99291" />
     </Book>
     <Book Series="The Pulse" Number="2" Volume="2004" Year="2004">
-      <Id>8e39f625-ab64-4d23-8c94-0737fa44e79e</Id>
+      <Database Name="cv" Series="11310" Issue="99292" />
     </Book>
     <Book Series="The Pulse" Number="3" Volume="2004" Year="2004">
-      <Id>6885b899-8146-45da-b62b-0ee61f9cc629</Id>
+      <Database Name="cv" Series="11310" Issue="99293" />
     </Book>
     <Book Series="The Pulse" Number="4" Volume="2004" Year="2004">
-      <Id>42579f07-fc21-4ef8-8aea-a0cfa6bce941</Id>
+      <Database Name="cv" Series="11310" Issue="99294" />
     </Book>
     <Book Series="The Pulse" Number="5" Volume="2004" Year="2004">
-      <Id>ca5615a1-669d-45b6-a9d6-7106288e7489</Id>
+      <Database Name="cv" Series="11310" Issue="99295" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="11" Volume="2003" Year="2004">
-      <Id>4c0d7f09-cb45-4826-88b9-66ce64f10cb0</Id>
+      <Database Name="cv" Series="11069" Issue="96981" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="12" Volume="2003" Year="2004">
-      <Id>4dac6b8e-b055-404c-967e-c7f2846acc80</Id>
+      <Database Name="cv" Series="11069" Issue="96982" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="13" Volume="2003" Year="2004">
-      <Id>8cea4110-cf2c-4555-80bc-ae28272d2ee4</Id>
+      <Database Name="cv" Series="11069" Issue="96983" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="14" Volume="2003" Year="2004">
-      <Id>6c420a44-0cc8-409c-a511-468a3df4fbf7</Id>
+      <Database Name="cv" Series="11069" Issue="96984" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="506" Volume="1963" Year="2004">
-      <Id>840f527e-5923-490d-8e31-88480e191c5b</Id>
+      <Database Name="cv" Series="2127" Issue="113494" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="507" Volume="1963" Year="2004">
-      <Id>de062d28-069f-4c48-a82f-eefbe1a7a3e4</Id>
+      <Database Name="cv" Series="2127" Issue="113495" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="508" Volume="1963" Year="2004">
-      <Id>43f6bdef-bbf2-49f2-a9c8-c2ab5c141287</Id>
+      <Database Name="cv" Series="2127" Issue="113496" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="509" Volume="1963" Year="2004">
-      <Id>65083661-283b-4e65-b6c1-e86d5a219f2f</Id>
+      <Database Name="cv" Series="2127" Issue="113497" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="510" Volume="1963" Year="2004">
-      <Id>172ad588-7f1a-4da7-a3b5-9c59fb437bf7</Id>
+      <Database Name="cv" Series="2127" Issue="113498" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="511" Volume="1963" Year="2004">
-      <Id>41802fd5-184b-446c-a008-4a081cff5773</Id>
+      <Database Name="cv" Series="2127" Issue="113499" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="512" Volume="1963" Year="2004">
-      <Id>bb6ce53a-c024-4045-8fd7-6579586e5730</Id>
+      <Database Name="cv" Series="2127" Issue="113500" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="513" Volume="1963" Year="2005">
-      <Id>3a659f0f-7330-49c3-8d2f-9292ef99e95d</Id>
+      <Database Name="cv" Series="2127" Issue="113501" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="514" Volume="1963" Year="2005">
-      <Id>d8568c50-3a1d-4359-aea1-a7356ebd82b9</Id>
+      <Database Name="cv" Series="2127" Issue="113502" />
     </Book>
     <Book Series="Spider-Man/Doctor Octopus: Out of Reach" Number="1" Volume="2004" Year="2004">
-      <Id>84d08e6d-3e6f-4ccb-b538-a56b01911162</Id>
+      <Database Name="cv" Series="21696" Issue="152906" />
     </Book>
     <Book Series="Spider-Man/Doctor Octopus: Out of Reach" Number="2" Volume="2004" Year="2004">
-      <Id>c66470f4-c1fb-4ab8-a464-9535964998f0</Id>
+      <Database Name="cv" Series="21696" Issue="152907" />
     </Book>
     <Book Series="Spider-Man/Doctor Octopus: Out of Reach" Number="3" Volume="2004" Year="2004">
-      <Id>23fc1134-4566-4b2c-9752-6f8fb797193a</Id>
+      <Database Name="cv" Series="21696" Issue="141056" />
     </Book>
     <Book Series="Spider-Man/Doctor Octopus: Out of Reach" Number="4" Volume="2004" Year="2004">
-      <Id>9cb55238-bdac-4176-ba38-bcde6bc30d13</Id>
+      <Database Name="cv" Series="21696" Issue="152905" />
     </Book>
     <Book Series="Spider-Man/Doctor Octopus: Out of Reach" Number="5" Volume="2004" Year="2004">
-      <Id>c8f40753-e054-489f-8a37-76159a996c0e</Id>
+      <Database Name="cv" Series="21696" Issue="130884" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="3" Volume="2004" Year="2004">
-      <Id>a24b8cf3-1406-43a4-b79f-2328f555ef22</Id>
+      <Database Name="cv" Series="11306" Issue="99253" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="4" Volume="2004" Year="2004">
-      <Id>f3eff41e-c652-4fe0-bb60-c9e6228c0c09</Id>
+      <Database Name="cv" Series="11306" Issue="99254" />
     </Book>
     <Book Series="Spider-Man/Red Sonja" Number="1" Volume="2007" Year="2007">
-      <Id>b90aa925-6877-4912-b64a-b0c51f6e69d3</Id>
+      <Database Name="cv" Series="18955" Issue="112404" />
     </Book>
     <Book Series="Spider-Man/Red Sonja" Number="2" Volume="2007" Year="2007">
-      <Id>004ed230-bcda-4c65-9ab6-044999bd9d91</Id>
+      <Database Name="cv" Series="18955" Issue="114729" />
     </Book>
     <Book Series="Spider-Man/Red Sonja" Number="3" Volume="2007" Year="2007">
-      <Id>1b21b54f-1cd1-4c64-9ce6-1c17d9bbaa62</Id>
+      <Database Name="cv" Series="18955" Issue="115426" />
     </Book>
     <Book Series="Spider-Man/Red Sonja" Number="4" Volume="2007" Year="2008">
-      <Id>ce057b4a-0cf6-4cf8-ab65-1379c5608e59</Id>
+      <Database Name="cv" Series="18955" Issue="118020" />
     </Book>
     <Book Series="Spider-Man/Red Sonja" Number="5" Volume="2007" Year="2008">
-      <Id>c7892e2a-948c-4c87-85df-f9fb41b6051e</Id>
+      <Database Name="cv" Series="18955" Issue="120158" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="5" Volume="2004" Year="2004">
-      <Id>04019c93-46c0-44f4-be90-46056cb4b39b</Id>
+      <Database Name="cv" Series="11306" Issue="99255" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="6" Volume="2004" Year="2005">
-      <Id>b353cbc0-28d2-4917-b631-bcd213060b35</Id>
+      <Database Name="cv" Series="11306" Issue="99256" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="7" Volume="2004" Year="2005">
-      <Id>71786fcb-cdad-4629-a811-c0579336c0f9</Id>
+      <Database Name="cv" Series="11306" Issue="114311" />
     </Book>
     <Book Series="Marvel Knights Spider-Man" Number="1" Volume="2004" Year="2004">
-      <Id>c254274f-96c3-43b1-8e96-7c0c32a04be6</Id>
+      <Database Name="cv" Series="11066" Issue="96921" />
     </Book>
     <Book Series="Marvel Knights Spider-Man" Number="2" Volume="2004" Year="2004">
-      <Id>14768090-33bb-4a45-8802-e0eae7d8b77e</Id>
+      <Database Name="cv" Series="11066" Issue="96922" />
     </Book>
     <Book Series="Marvel Knights Spider-Man" Number="3" Volume="2004" Year="2004">
-      <Id>4a84676d-6e8c-45b2-979b-c090e9b39497</Id>
+      <Database Name="cv" Series="11066" Issue="96923" />
     </Book>
     <Book Series="Marvel Knights Spider-Man" Number="4" Volume="2004" Year="2004">
-      <Id>2e225267-63bb-4fa3-b708-551959c4c71a</Id>
+      <Database Name="cv" Series="11066" Issue="96924" />
     </Book>
     <Book Series="Marvel Knights Spider-Man" Number="5" Volume="2004" Year="2004">
-      <Id>98b3b16a-26f3-4d1f-95b2-23ecdb07d9fb</Id>
+      <Database Name="cv" Series="11066" Issue="96925" />
     </Book>
     <Book Series="Marvel Knights Spider-Man" Number="6" Volume="2004" Year="2004">
-      <Id>0c7bc4a0-63b5-4624-85c2-e3e067fac68e</Id>
+      <Database Name="cv" Series="11066" Issue="96926" />
     </Book>
     <Book Series="Avengers" Number="500" Volume="1998" Year="2004">
-      <Id>017c6a65-3244-4f15-becb-29d4560f46cc</Id>
+      <Database Name="cv" Series="7084" Issue="90338" />
     </Book>
     <Book Series="Avengers" Number="501" Volume="1998" Year="2004">
-      <Id>593fea94-b9f8-4edd-bf67-ace61ce6a14a</Id>
+      <Database Name="cv" Series="7084" Issue="90339" />
     </Book>
     <Book Series="Avengers" Number="502" Volume="1998" Year="2004">
-      <Id>d790e4c1-669f-4ef4-9653-c28f520b5b8d</Id>
+      <Database Name="cv" Series="7084" Issue="90340" />
     </Book>
     <Book Series="Avengers" Number="503" Volume="1998" Year="2004">
-      <Id>80a2190e-fb39-46b2-af35-6eeb92948155</Id>
+      <Database Name="cv" Series="7084" Issue="101195" />
     </Book>
     <Book Series="Marvel Knights Spider-Man" Number="7" Volume="2004" Year="2004">
-      <Id>bb5ce914-d37a-42d8-b04d-0e01a269758e</Id>
+      <Database Name="cv" Series="11066" Issue="96927" />
     </Book>
     <Book Series="Marvel Knights Spider-Man" Number="8" Volume="2004" Year="2005">
-      <Id>2a9b6200-15da-4c4d-84cc-741bfa89a78f</Id>
+      <Database Name="cv" Series="11066" Issue="97345" />
     </Book>
     <Book Series="Marvel Knights Spider-Man" Number="9" Volume="2004" Year="2005">
-      <Id>eb6ccf42-45d6-4107-aeae-5f714c36984b</Id>
+      <Database Name="cv" Series="11066" Issue="97648" />
     </Book>
     <Book Series="Marvel Knights Spider-Man" Number="10" Volume="2004" Year="2005">
-      <Id>344abf35-15bf-4135-9f0c-29441f425a1e</Id>
+      <Database Name="cv" Series="11066" Issue="97649" />
     </Book>
     <Book Series="Marvel Knights Spider-Man" Number="11" Volume="2004" Year="2005">
-      <Id>7a068d10-d0a2-447c-866e-7a9619ab1c20</Id>
+      <Database Name="cv" Series="11066" Issue="99717" />
     </Book>
     <Book Series="Marvel Knights Spider-Man" Number="12" Volume="2004" Year="2005">
-      <Id>cbfab13d-8322-431f-ab4d-76c82233e739</Id>
+      <Database Name="cv" Series="11066" Issue="99718" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="15" Volume="2003" Year="2004">
-      <Id>a4da6e16-fa39-4bc9-9fdb-5cefb98d97ca</Id>
+      <Database Name="cv" Series="11069" Issue="96985" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="16" Volume="2003" Year="2004">
-      <Id>6b6bb08e-83d4-46f5-8756-6379b66f06ed</Id>
+      <Database Name="cv" Series="11069" Issue="97334" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="17" Volume="2003" Year="2004">
-      <Id>639e805a-2186-4f64-a218-4611d25c9808</Id>
+      <Database Name="cv" Series="11069" Issue="97335" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="18" Volume="2003" Year="2004">
-      <Id>830a20b9-d9bb-43e4-afe8-f8561ff3e596</Id>
+      <Database Name="cv" Series="11069" Issue="97336" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="19" Volume="2003" Year="2004">
-      <Id>29958ff8-50ce-495a-8602-a566ae3b3b83</Id>
+      <Database Name="cv" Series="11069" Issue="97337" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="20" Volume="2003" Year="2004">
-      <Id>699b3592-5fbf-48bc-9a4a-d9b79c7b6563</Id>
+      <Database Name="cv" Series="11069" Issue="97338" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="21" Volume="2003" Year="2005">
-      <Id>efeaa6ab-84cf-47ee-bda4-9b46e5ea1faf</Id>
+      <Database Name="cv" Series="11069" Issue="97339" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="22" Volume="2003" Year="2005">
-      <Id>c625c191-2bfc-4e6c-b198-b90ce8f99d8a</Id>
+      <Database Name="cv" Series="11069" Issue="101138" />
     </Book>
-    <Book Series="Marvel Team-Up" Number="1" Volume="2005" Year="2005">
-      <Id>f6b19189-d93e-427e-80fd-c9024c70d033</Id>
+    <Book Series="Marvel Team-Up" Number="1" Volume="2004" Year="2005">
+      <Database Name="cv" Series="18024" Issue="105549" />
     </Book>
-    <Book Series="Marvel Team-Up" Number="2" Volume="2005" Year="2005">
-      <Id>c79bb015-3539-4446-b970-fcece8d8d5d7</Id>
+    <Book Series="Marvel Team-Up" Number="2" Volume="2004" Year="2005">
+      <Database Name="cv" Series="18024" Issue="105568" />
     </Book>
-    <Book Series="Marvel Team-Up" Number="5" Volume="2005" Year="2005">
-      <Id>1d1c799a-26d6-4884-bc81-9c37b4ce46a9</Id>
+    <Book Series="Marvel Team-Up" Number="5" Volume="2004" Year="2005">
+      <Database Name="cv" Series="18024" Issue="105632" />
     </Book>
-    <Book Series="Marvel Team-Up" Number="6" Volume="2005" Year="2005">
-      <Id>f564475c-35ce-438e-832e-efea5665710e</Id>
+    <Book Series="Marvel Team-Up" Number="6" Volume="2004" Year="2005">
+      <Database Name="cv" Series="18024" Issue="105633" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="8" Volume="2004" Year="2005">
-      <Id>6af6c496-55dc-4340-9b36-35bf27a77061</Id>
+      <Database Name="cv" Series="11306" Issue="114312" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="9" Volume="2004" Year="2005">
-      <Id>318972ae-3c87-4a61-8d50-8584d622a704</Id>
+      <Database Name="cv" Series="11306" Issue="114313" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="10" Volume="2004" Year="2005">
-      <Id>636122e2-7ec7-4012-aaa1-14a7cd1889b3</Id>
+      <Database Name="cv" Series="11306" Issue="114314" />
     </Book>
     <Book Series="Secret War" Number="1" Volume="2004" Year="2004">
-      <Id>656b0c01-2210-46e1-b339-0425383d04f8</Id>
+      <Database Name="cv" Series="18234" Issue="106863" />
     </Book>
     <Book Series="Secret War" Number="2" Volume="2004" Year="2004">
-      <Id>ffb4246d-e097-4e7c-ac18-8fb13bb6f318</Id>
+      <Database Name="cv" Series="18234" Issue="106864" />
     </Book>
     <Book Series="Secret War" Number="3" Volume="2004" Year="2004">
-      <Id>d1f6a606-2cd2-4889-92aa-823f023f98d2</Id>
+      <Database Name="cv" Series="18234" Issue="106865" />
     </Book>
     <Book Series="Secret War" Number="4" Volume="2004" Year="2005">
-      <Id>bb509e6f-eeaa-44c1-b6cc-c2081712832c</Id>
+      <Database Name="cv" Series="18234" Issue="106866" />
     </Book>
     <Book Series="Secret War" Number="5" Volume="2004" Year="2005">
-      <Id>b8d9c94c-348d-411b-8b8e-9d55a0e6bbed</Id>
+      <Database Name="cv" Series="18234" Issue="106867" />
     </Book>
     <Book Series="The Pulse" Number="6" Volume="2004" Year="2005">
-      <Id>13c46993-29d3-43b4-a457-b0194bb7e137</Id>
+      <Database Name="cv" Series="11310" Issue="99296" />
     </Book>
     <Book Series="The Pulse" Number="7" Volume="2004" Year="2005">
-      <Id>f09d848c-5a6f-44a7-b6b6-fcc59fa983fe</Id>
+      <Database Name="cv" Series="11310" Issue="105807" />
     </Book>
     <Book Series="The Pulse" Number="8" Volume="2004" Year="2005">
-      <Id>a2c42029-aa86-4262-a415-f64ec7c65d1a</Id>
+      <Database Name="cv" Series="11310" Issue="105808" />
     </Book>
     <Book Series="The Pulse" Number="9" Volume="2004" Year="2005">
-      <Id>20ba9182-ed39-44b4-a219-792bcd0b09b7</Id>
+      <Database Name="cv" Series="11310" Issue="105809" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="11" Volume="2004" Year="2005">
-      <Id>fc00d477-d58a-453e-b75b-459d5b30d20f</Id>
+      <Database Name="cv" Series="11306" Issue="114315" />
     </Book>
-    <Book Series="New Avengers" Number="1" Volume="2005" Year="2005">
-      <Id>28dcc809-691a-420c-819b-f21038ce0f83</Id>
+    <Book Series="New Avengers" Number="1" Volume="2004" Year="2005">
+      <Database Name="cv" Series="11497" Issue="101407" />
     </Book>
-    <Book Series="New Avengers" Number="2" Volume="2005" Year="2005">
-      <Id>21ec78c6-bd51-428b-93ad-ba2e3f8d8123</Id>
+    <Book Series="New Avengers" Number="2" Volume="2004" Year="2005">
+      <Database Name="cv" Series="11497" Issue="101408" />
     </Book>
-    <Book Series="New Avengers" Number="3" Volume="2005" Year="2005">
-      <Id>b8670db4-d00a-48c7-9c13-5a0932eada3b</Id>
+    <Book Series="New Avengers" Number="3" Volume="2004" Year="2005">
+      <Database Name="cv" Series="11497" Issue="101409" />
     </Book>
-    <Book Series="New Avengers" Number="4" Volume="2005" Year="2005">
-      <Id>ea5dd98b-b933-4463-92a9-95b0fe387797</Id>
+    <Book Series="New Avengers" Number="4" Volume="2004" Year="2005">
+      <Database Name="cv" Series="11497" Issue="108304" />
     </Book>
-    <Book Series="New Avengers" Number="5" Volume="2005" Year="2005">
-      <Id>6852003e-1c79-4850-bc9f-652b2c0d2ef7</Id>
+    <Book Series="New Avengers" Number="5" Volume="2004" Year="2005">
+      <Database Name="cv" Series="11497" Issue="108305" />
     </Book>
-    <Book Series="New Avengers" Number="6" Volume="2005" Year="2005">
-      <Id>7183bbe4-e9d7-4848-bc31-7b86c6cc69d6</Id>
+    <Book Series="New Avengers" Number="6" Volume="2004" Year="2005">
+      <Database Name="cv" Series="11497" Issue="108306" />
     </Book>
     <Book Series="Spider-Man: Breakout" Number="1" Volume="2005" Year="2005">
-      <Id>67729874-2e51-4a48-8de6-05b8eccd2116</Id>
+      <Database Name="cv" Series="19688" Issue="118068" />
     </Book>
     <Book Series="Spider-Man: Breakout" Number="2" Volume="2005" Year="2005">
-      <Id>51e875bc-1a95-44bd-a9f6-03f70b687763</Id>
+      <Database Name="cv" Series="19688" Issue="118222" />
     </Book>
     <Book Series="Spider-Man: Breakout" Number="3" Volume="2005" Year="2005">
-      <Id>12f3d45f-013e-49a0-8ff1-56b1c76c212c</Id>
+      <Database Name="cv" Series="19688" Issue="118223" />
     </Book>
     <Book Series="Spider-Man: Breakout" Number="4" Volume="2005" Year="2005">
-      <Id>b100ffc7-4bbc-469d-9607-b94a60848ef6</Id>
+      <Database Name="cv" Series="19688" Issue="118224" />
     </Book>
     <Book Series="Spider-Man: Breakout" Number="5" Volume="2005" Year="2005">
-      <Id>e62fc777-b093-4b85-b607-586f85679f7c</Id>
+      <Database Name="cv" Series="19688" Issue="118225" />
     </Book>
-    <Book Series="Marvel Team-Up" Number="7" Volume="2005" Year="2005">
-      <Id>11efda7b-b64f-4a21-bb15-6ede94a312a3</Id>
+    <Book Series="Marvel Team-Up" Number="7" Volume="2004" Year="2005">
+      <Database Name="cv" Series="18024" Issue="120881" />
     </Book>
-    <Book Series="Marvel Team-Up" Number="10" Volume="2005" Year="2005">
-      <Id>f66b44d2-b6cd-48fc-87c3-e3a730388b89</Id>
+    <Book Series="Marvel Team-Up" Number="10" Volume="2004" Year="2005">
+      <Database Name="cv" Series="18024" Issue="120885" />
     </Book>
-    <Book Series="Marvel Team-Up" Number="11" Volume="2005" Year="2005">
-      <Id>643c5589-97bc-4ebe-8d7b-15114088b1cc</Id>
+    <Book Series="Marvel Team-Up" Number="11" Volume="2004" Year="2005">
+      <Database Name="cv" Series="18024" Issue="120886" />
     </Book>
-    <Book Series="Marvel Team-Up" Number="12" Volume="2005" Year="2005">
-      <Id>ba109392-bd6a-46ff-bf9e-cef1b7d17578</Id>
+    <Book Series="Marvel Team-Up" Number="12" Volume="2004" Year="2005">
+      <Database Name="cv" Series="18024" Issue="120887" />
     </Book>
-    <Book Series="Marvel Team-Up" Number="13" Volume="2005" Year="2005">
-      <Id>ea316fbc-852a-4728-83fe-2dd7b502c772</Id>
+    <Book Series="Marvel Team-Up" Number="13" Volume="2004" Year="2005">
+      <Database Name="cv" Series="18024" Issue="120888" />
     </Book>
-    <Book Series="New Avengers" Number="7" Volume="2005" Year="2005">
-      <Id>39ae8e6f-50a1-46a3-8e75-bbf036f62d22</Id>
+    <Book Series="New Avengers" Number="7" Volume="2004" Year="2005">
+      <Database Name="cv" Series="11497" Issue="108307" />
     </Book>
-    <Book Series="New Avengers" Number="8" Volume="2005" Year="2005">
-      <Id>0cf5d8a2-4995-4c00-9c33-75029784e830</Id>
+    <Book Series="New Avengers" Number="8" Volume="2004" Year="2005">
+      <Database Name="cv" Series="11497" Issue="108308" />
     </Book>
-    <Book Series="New Avengers" Number="9" Volume="2005" Year="2005">
-      <Id>f7839996-94a8-4ddf-9426-74d8aa065fb1</Id>
+    <Book Series="New Avengers" Number="9" Volume="2004" Year="2005">
+      <Database Name="cv" Series="11497" Issue="108309" />
     </Book>
-    <Book Series="New Avengers" Number="10" Volume="2005" Year="2005">
-      <Id>f91ba1fc-c80c-471c-99d7-0534aa21b86d</Id>
+    <Book Series="New Avengers" Number="10" Volume="2004" Year="2005">
+      <Database Name="cv" Series="11497" Issue="108312" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="12" Volume="2004" Year="2006">
-      <Id>5d741082-716c-443c-b133-e70038689b5b</Id>
+      <Database Name="cv" Series="11306" Issue="114316" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="13" Volume="2004" Year="2006">
-      <Id>650c4fa0-1f49-44bb-9876-b601368d564d</Id>
+      <Database Name="cv" Series="11306" Issue="114318" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="14" Volume="2004" Year="2006">
-      <Id>a3ba40cd-4ef4-4d4a-a96c-7c2ce6e6413f</Id>
+      <Database Name="cv" Series="11306" Issue="114317" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="23" Volume="2003" Year="2005">
-      <Id>5967ade5-858c-4d5c-b5aa-232e600dedd4</Id>
+      <Database Name="cv" Series="11069" Issue="101139" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="24" Volume="2003" Year="2005">
-      <Id>0b9a3320-09a8-44cd-adc4-7815bf04f95e</Id>
+      <Database Name="cv" Series="11069" Issue="101140" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="25" Volume="2003" Year="2005">
-      <Id>56511478-f871-488f-b5af-3f42844a6c9a</Id>
+      <Database Name="cv" Series="11069" Issue="101141" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="26" Volume="2003" Year="2005">
-      <Id>e0d62c34-e006-49aa-a4c1-7e995019ed04</Id>
+      <Database Name="cv" Series="11069" Issue="101142" />
     </Book>
     <Book Series="Spectacular Spider-Man" Number="27" Volume="2003" Year="2005">
-      <Id>ea36c2c1-7ccc-48e0-aaf4-0b49e0fdb5f7</Id>
+      <Database Name="cv" Series="11069" Issue="101143" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="515" Volume="1963" Year="2005">
-      <Id>bbe61c95-55ed-4abe-a79d-5684491b4447</Id>
+      <Database Name="cv" Series="2127" Issue="113503" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="516" Volume="1963" Year="2005">
-      <Id>1430e8dd-6b72-4690-83f1-19c6ba0e2a9f</Id>
+      <Database Name="cv" Series="2127" Issue="113504" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="517" Volume="1963" Year="2005">
-      <Id>7f953a4c-e01b-4d8d-adef-d9a65e27eaff</Id>
+      <Database Name="cv" Series="2127" Issue="113505" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="518" Volume="1963" Year="2005">
-      <Id>8b63df41-71b4-497e-9886-0660798a80c3</Id>
+      <Database Name="cv" Series="2127" Issue="113506" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="519" Volume="1963" Year="2005">
-      <Id>17bc7ba3-62a8-4dc5-be59-fa9e2d29079a</Id>
+      <Database Name="cv" Series="2127" Issue="113507" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="520" Volume="1963" Year="2005">
-      <Id>34a7c9aa-01f1-4521-97f7-6cec15446a29</Id>
+      <Database Name="cv" Series="2127" Issue="113508" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="521" Volume="1963" Year="2005">
-      <Id>084a02aa-721f-4b35-8216-29132cb7a21e</Id>
+      <Database Name="cv" Series="2127" Issue="113509" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="522" Volume="1963" Year="2005">
-      <Id>187276eb-037a-414b-864c-e291ccbcfd03</Id>
+      <Database Name="cv" Series="2127" Issue="113510" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="523" Volume="1963" Year="2005">
-      <Id>24606e48-22b7-47ed-aa66-b86aef0f224a</Id>
+      <Database Name="cv" Series="2127" Issue="113511" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="524" Volume="1963" Year="2005">
-      <Id>75738d07-526f-4422-a64b-68f3e5200b83</Id>
+      <Database Name="cv" Series="2127" Issue="113512" />
     </Book>
     <Book Series="Spider-Man/Human Torch" Number="1" Volume="2005" Year="2005">
-      <Id>c42c8e67-faac-490f-b49f-d0151d19bc04</Id>
+      <Database Name="cv" Series="11800" Issue="103520" />
     </Book>
     <Book Series="Spider-Man/Human Torch" Number="2" Volume="2005" Year="2005">
-      <Id>42a96330-9e04-4cbd-a331-0e4224ed21ea</Id>
+      <Database Name="cv" Series="11800" Issue="103521" />
     </Book>
     <Book Series="Spider-Man/Human Torch" Number="3" Volume="2005" Year="2005">
-      <Id>4bada82d-ab8c-48f4-a9a5-c8bf6abbb339</Id>
+      <Database Name="cv" Series="11800" Issue="103522" />
     </Book>
     <Book Series="Spider-Man/Human Torch" Number="4" Volume="2005" Year="2005">
-      <Id>95683f0b-f449-4e50-90bb-67d1a90f952c</Id>
+      <Database Name="cv" Series="11800" Issue="103523" />
     </Book>
     <Book Series="Spider-Man/Human Torch" Number="5" Volume="2005" Year="2005">
-      <Id>6d0cbe78-cd62-49c1-ba6c-3c951f210332</Id>
+      <Database Name="cv" Series="11800" Issue="103524" />
     </Book>
     <Book Series="Marvel Knights Spider-Man" Number="13" Volume="2004" Year="2005">
-      <Id>eaa5c66a-e65e-46f0-a1fe-bf50ea679659</Id>
+      <Database Name="cv" Series="11066" Issue="104439" />
     </Book>
     <Book Series="Marvel Knights Spider-Man" Number="14" Volume="2004" Year="2005">
-      <Id>35d65ea0-570d-44a8-9d1f-5c1af1315e86</Id>
+      <Database Name="cv" Series="11066" Issue="104440" />
     </Book>
     <Book Series="Marvel Knights Spider-Man" Number="15" Volume="2004" Year="2005">
-      <Id>e3fc501f-e2d2-492e-82ea-6187a452c5e5</Id>
+      <Database Name="cv" Series="11066" Issue="119603" />
     </Book>
     <Book Series="Marvel Knights Spider-Man" Number="16" Volume="2004" Year="2005">
-      <Id>49ef7e7d-440a-42ae-af10-d17054381175</Id>
+      <Database Name="cv" Series="11066" Issue="119604" />
     </Book>
     <Book Series="Marvel Knights Spider-Man" Number="17" Volume="2004" Year="2005">
-      <Id>5aed797a-1afd-4ce5-ac44-78619b030e5a</Id>
+      <Database Name="cv" Series="11066" Issue="119605" />
     </Book>
     <Book Series="Marvel Knights Spider-Man" Number="18" Volume="2004" Year="2005">
-      <Id>93711256-bba0-46f2-9a77-390ca5dc060a</Id>
+      <Database Name="cv" Series="11066" Issue="119606" />
     </Book>
     <Book Series="House of M" Number="1" Volume="2005" Year="2005">
-      <Id>87c12880-5952-4edd-87b2-17ca0f8a8412</Id>
+      <Database Name="cv" Series="12049" Issue="104861" />
     </Book>
     <Book Series="Spider-Man: House of M" Number="1" Volume="2005" Year="2005">
-      <Id>17588345-bf2d-4cba-9a86-54f8a79b2600</Id>
+      <Database Name="cv" Series="19465" Issue="116494" />
     </Book>
     <Book Series="Spider-Man: House of M" Number="2" Volume="2005" Year="2005">
-      <Id>dd36bc56-9f62-4efa-b15c-a0f10d4a0fab</Id>
+      <Database Name="cv" Series="19465" Issue="116546" />
     </Book>
     <Book Series="Spider-Man: House of M" Number="3" Volume="2005" Year="2005">
-      <Id>4a2d547f-5fa4-4dee-8ba3-2a90d0f664bb</Id>
+      <Database Name="cv" Series="19465" Issue="116547" />
     </Book>
     <Book Series="Spider-Man: House of M" Number="4" Volume="2005" Year="2005">
-      <Id>6f7b0fd7-cce3-4255-8077-7107d6ac0fd0</Id>
+      <Database Name="cv" Series="19465" Issue="116549" />
     </Book>
     <Book Series="Spider-Man: House of M" Number="5" Volume="2005" Year="2005">
-      <Id>7386ce5d-b897-4982-ae60-31880a9bac2a</Id>
+      <Database Name="cv" Series="19465" Issue="116548" />
     </Book>
     <Book Series="House of M" Number="2" Volume="2005" Year="2005">
-      <Id>cd404553-6dd2-46e2-a706-b44501cceeb5</Id>
+      <Database Name="cv" Series="12049" Issue="104862" />
     </Book>
     <Book Series="House of M" Number="3" Volume="2005" Year="2005">
-      <Id>52c3157a-6b7b-4a3f-93a3-5c65d8105904</Id>
+      <Database Name="cv" Series="12049" Issue="104863" />
     </Book>
     <Book Series="House of M" Number="4" Volume="2005" Year="2005">
-      <Id>a9152579-cd4a-4fcf-a9fc-a28706d29844</Id>
+      <Database Name="cv" Series="12049" Issue="104864" />
     </Book>
     <Book Series="House of M" Number="5" Volume="2005" Year="2005">
-      <Id>83190f73-884a-416f-968b-d52aaebeacf9</Id>
+      <Database Name="cv" Series="12049" Issue="104865" />
     </Book>
     <Book Series="House of M" Number="6" Volume="2005" Year="2005">
-      <Id>4e3ef330-2fe0-4dbb-9f12-13b2c25ec7ae</Id>
+      <Database Name="cv" Series="12049" Issue="104866" />
     </Book>
     <Book Series="House of M" Number="7" Volume="2005" Year="2005">
-      <Id>f0bdd681-2378-4e2d-a243-4b14799eb6ca</Id>
+      <Database Name="cv" Series="12049" Issue="104867" />
     </Book>
     <Book Series="House of M" Number="8" Volume="2005" Year="2005">
-      <Id>8a2532e6-142d-45e2-ac8a-f8a8548d6e7b</Id>
+      <Database Name="cv" Series="12049" Issue="104868" />
     </Book>
-    <Book Series="New Avengers" Number="11" Volume="2005" Year="2005">
-      <Id>cadbdce4-f720-4a2d-b78d-62ada7310716</Id>
+    <Book Series="New Avengers" Number="11" Volume="2004" Year="2005">
+      <Database Name="cv" Series="11497" Issue="108314" />
     </Book>
-    <Book Series="New Avengers" Number="12" Volume="2005" Year="2005">
-      <Id>c07dbf1d-1965-4605-93ad-15519d12aabb</Id>
+    <Book Series="New Avengers" Number="12" Volume="2004" Year="2005">
+      <Database Name="cv" Series="11497" Issue="108315" />
     </Book>
-    <Book Series="New Avengers" Number="13" Volume="2005" Year="2006">
-      <Id>d862086e-237c-47cc-94fa-af70e264851b</Id>
+    <Book Series="New Avengers" Number="13" Volume="2004" Year="2006">
+      <Database Name="cv" Series="11497" Issue="108316" />
     </Book>
-    <Book Series="New Avengers" Number="14" Volume="2005" Year="2006">
-      <Id>8d03ae36-75ca-4792-bdbe-f731d40c8a33</Id>
+    <Book Series="New Avengers" Number="14" Volume="2004" Year="2006">
+      <Database Name="cv" Series="11497" Issue="108317" />
     </Book>
-    <Book Series="New Avengers" Number="15" Volume="2005" Year="2006">
-      <Id>de1fcb42-950a-4b7a-83df-eea6513410b3</Id>
+    <Book Series="New Avengers" Number="15" Volume="2004" Year="2006">
+      <Database Name="cv" Series="11497" Issue="108318" />
     </Book>
-    <Book Series="Marvel Team-Up" Number="14" Volume="2005" Year="2006">
-      <Id>17ff2a56-4e1c-4437-926c-9142a3c899a3</Id>
+    <Book Series="Marvel Team-Up" Number="14" Volume="2004" Year="2006">
+      <Database Name="cv" Series="18024" Issue="120889" />
     </Book>
     <Book Series="Spider-Man and the Fantastic Four" Number="1" Volume="2007" Year="2007">
-      <Id>ac09a9a5-d8d4-4c1e-a8fb-b9f270d71b03</Id>
+      <Database Name="cv" Series="18482" Issue="108524" />
     </Book>
     <Book Series="Spider-Man and the Fantastic Four" Number="2" Volume="2007" Year="2007">
-      <Id>0c988349-524b-4e34-b340-c4ecabb63da1</Id>
+      <Database Name="cv" Series="18482" Issue="109445" />
     </Book>
     <Book Series="Spider-Man and the Fantastic Four" Number="3" Volume="2007" Year="2007">
-      <Id>e4ee072a-7149-4f18-bb4c-25be4462c130</Id>
+      <Database Name="cv" Series="18482" Issue="110754" />
     </Book>
     <Book Series="Spider-Man and the Fantastic Four" Number="4" Volume="2007" Year="2007">
-      <Id>238713cb-19d6-40cf-8d15-46e3fd315189</Id>
+      <Database Name="cv" Series="18482" Issue="113227" />
     </Book>
     <Book Series="Spider-Man/Black Cat: The Evil that Men Do" Number="1" Volume="2002" Year="2002">
-      <Id>b25e223c-8482-4e90-85f9-f210d0ea7ea1</Id>
+      <Database Name="cv" Series="9469" Issue="77953" />
     </Book>
     <Book Series="Spider-Man/Black Cat: The Evil that Men Do" Number="2" Volume="2002" Year="2002">
-      <Id>2abe24e0-328c-44c6-8567-e68c2e23a329</Id>
+      <Database Name="cv" Series="9469" Issue="77954" />
     </Book>
     <Book Series="Spider-Man/Black Cat: The Evil that Men Do" Number="3" Volume="2002" Year="2002">
-      <Id>09f0f7f2-5ac0-4b61-b792-0e69bbb303db</Id>
+      <Database Name="cv" Series="9469" Issue="77955" />
     </Book>
     <Book Series="Spider-Man/Black Cat: The Evil that Men Do" Number="4" Volume="2002" Year="2006">
-      <Id>7ad3c739-f5b6-4244-82ec-26ba6495d4f2</Id>
+      <Database Name="cv" Series="9469" Issue="77956" />
     </Book>
     <Book Series="Spider-Man/Black Cat: The Evil that Men Do" Number="5" Volume="2002" Year="2006">
-      <Id>90a6986e-c5bc-4bda-a1ca-2b491ccc9b4b</Id>
+      <Database Name="cv" Series="9469" Issue="103301" />
     </Book>
     <Book Series="Spider-Man/Black Cat: The Evil that Men Do" Number="6" Volume="2002" Year="2006">
-      <Id>639ad54d-f957-4722-9708-82ca95f14ef0</Id>
+      <Database Name="cv" Series="9469" Issue="120327" />
     </Book>
     <Book Series="Toxin" Number="1" Volume="2005" Year="2005">
-      <Id>df4d43a2-2bec-4d38-a441-dcdbc64c2ebf</Id>
+      <Database Name="cv" Series="18087" Issue="105930" />
     </Book>
     <Book Series="Toxin" Number="2" Volume="2005" Year="2005">
-      <Id>3a9bff49-64ef-4f07-940b-2bc3518c6730</Id>
+      <Database Name="cv" Series="18087" Issue="119329" />
     </Book>
     <Book Series="Toxin" Number="3" Volume="2005" Year="2005">
-      <Id>2e3caaa5-5a81-490f-81b9-2a3f0a0f19c8</Id>
+      <Database Name="cv" Series="18087" Issue="119330" />
     </Book>
     <Book Series="Toxin" Number="4" Volume="2005" Year="2005">
-      <Id>5f2c7a18-f6d2-4ad1-90bb-c714ace0c8b0</Id>
+      <Database Name="cv" Series="18087" Issue="119332" />
     </Book>
     <Book Series="Toxin" Number="6" Volume="2005" Year="2005">
-      <Id>0498e2ee-9e27-490f-b706-042035cc8824</Id>
+      <Database Name="cv" Series="18087" Issue="119333" />
     </Book>
     <Book Series="Toxin" Number="5" Volume="2005" Year="2005">
-      <Id>03ed3c12-98ee-45d6-b9b7-dbfdda4dd7d3</Id>
+      <Database Name="cv" Series="18087" Issue="119335" />
     </Book>
     <Book Series="The Pulse" Number="11" Volume="2004" Year="2005">
-      <Id>ef90da8d-e0d6-47e1-b25c-b8c4b6092521</Id>
+      <Database Name="cv" Series="11310" Issue="105853" />
     </Book>
     <Book Series="The Pulse" Number="12" Volume="2004" Year="2006">
-      <Id>0787c6c6-d2a6-4467-a130-6f0001d4e764</Id>
+      <Database Name="cv" Series="11310" Issue="105854" />
     </Book>
     <Book Series="The Pulse" Number="13" Volume="2004" Year="2006">
-      <Id>7e59c9ff-bae5-45ec-8aa0-37b1f4508ea5</Id>
+      <Database Name="cv" Series="11310" Issue="105855" />
     </Book>
     <Book Series="The Pulse" Number="14" Volume="2004" Year="2006">
-      <Id>2ca78105-4e01-4e98-b49b-8ac7c1f66458</Id>
+      <Database Name="cv" Series="11310" Issue="105856" />
     </Book>
     <Book Series="Friendly Neighborhood Spider-Man" Number="1" Volume="2005" Year="2005">
-      <Id>fbe09c80-145c-475a-801a-c306470668fd</Id>
+      <Database Name="cv" Series="17998" Issue="105375" />
     </Book>
     <Book Series="Marvel Knights Spider-Man" Number="19" Volume="2004" Year="2005">
-      <Id>963eb547-9fbb-4d5d-8605-14ab080008c6</Id>
+      <Database Name="cv" Series="11066" Issue="135799" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="525" Volume="1963" Year="2005">
-      <Id>f8572cfc-e62c-4c24-9f8d-f12b433cf78c</Id>
+      <Database Name="cv" Series="2127" Issue="113513" />
     </Book>
     <Book Series="Friendly Neighborhood Spider-Man" Number="2" Volume="2005" Year="2006">
-      <Id>beb8ecc1-f2ef-435d-acb6-0932b0c19914</Id>
+      <Database Name="cv" Series="17998" Issue="105376" />
     </Book>
     <Book Series="Marvel Knights Spider-Man" Number="20" Volume="2004" Year="2006">
-      <Id>1b4bd244-5624-459a-9730-d6cfe640d64b</Id>
+      <Database Name="cv" Series="11066" Issue="135800" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="526" Volume="1963" Year="2006">
-      <Id>b3603e5a-71c0-4a0b-be9b-0dfa69630384</Id>
+      <Database Name="cv" Series="2127" Issue="113514" />
     </Book>
     <Book Series="Friendly Neighborhood Spider-Man" Number="3" Volume="2005" Year="2006">
-      <Id>38e815f3-3f15-47c9-b6f4-502cd4a1cd86</Id>
+      <Database Name="cv" Series="17998" Issue="105377" />
     </Book>
     <Book Series="Marvel Knights Spider-Man" Number="21" Volume="2004" Year="2006">
-      <Id>10246e7e-23b1-4ced-a27e-a651a6c14b32</Id>
+      <Database Name="cv" Series="11066" Issue="135804" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="527" Volume="1963" Year="2006">
-      <Id>c86de7a8-bddd-453a-8b87-e043120d41ab</Id>
+      <Database Name="cv" Series="2127" Issue="113515" />
     </Book>
     <Book Series="Friendly Neighborhood Spider-Man" Number="4" Volume="2005" Year="2006">
-      <Id>a31a275a-d36b-4be5-91ed-a0d627ea610c</Id>
+      <Database Name="cv" Series="17998" Issue="105379" />
     </Book>
     <Book Series="Marvel Knights Spider-Man" Number="22" Volume="2004" Year="2006">
-      <Id>9d88936b-01b8-4b7f-8d4a-66aec4a4cbd2</Id>
+      <Database Name="cv" Series="11066" Issue="135805" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="528" Volume="1963" Year="2006">
-      <Id>2d037908-a4dd-4d7e-a985-c9126e51724d</Id>
+      <Database Name="cv" Series="2127" Issue="113516" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="23" Volume="2006" Year="2006">
-      <Id>5a184a4d-2c6d-4b1c-a5cd-f26b7632c7f6</Id>
+      <Database Name="cv" Series="18177" Issue="106729" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="24" Volume="2006" Year="2006">
-      <Id>86a8d41c-3104-4c09-9a03-c3eaa65cde57</Id>
+      <Database Name="cv" Series="18177" Issue="106696" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="25" Volume="2006" Year="2006">
-      <Id>3757f1ee-41f1-4b5b-9cca-747cf2432cb3</Id>
+      <Database Name="cv" Series="18177" Issue="106728" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="529" Volume="1963" Year="2006">
-      <Id>10f91a58-98a9-4861-8ca2-61a56215d166</Id>
+      <Database Name="cv" Series="2127" Issue="106921" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="26" Volume="2006" Year="2006">
-      <Id>c94066c7-efe4-47e9-ba88-9d994d00a666</Id>
+      <Database Name="cv" Series="18177" Issue="108531" />
     </Book>
     <Book Series="Friendly Neighborhood Spider-Man" Number="5" Volume="2005" Year="2006">
-      <Id>c2a32dee-480a-45c3-acb4-be806ca013b6</Id>
+      <Database Name="cv" Series="17998" Issue="105380" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="27" Volume="2006" Year="2006">
-      <Id>e7e869a1-c54b-4163-bfa2-4a5c0fe60fb3</Id>
+      <Database Name="cv" Series="18177" Issue="109582" />
     </Book>
     <Book Series="Friendly Neighborhood Spider-Man" Number="6" Volume="2005" Year="2006">
-      <Id>423354c0-b83b-4411-b70d-ede5c79de0e6</Id>
+      <Database Name="cv" Series="17998" Issue="105388" />
     </Book>
     <Book Series="Friendly Neighborhood Spider-Man" Number="7" Volume="2005" Year="2006">
-      <Id>c0143696-529d-4f76-b4d6-65366d379db7</Id>
+      <Database Name="cv" Series="17998" Issue="105389" />
     </Book>
     <Book Series="Friendly Neighborhood Spider-Man" Number="8" Volume="2005" Year="2006">
-      <Id>99ee9458-3f0c-496d-a20d-9877440002c9</Id>
+      <Database Name="cv" Series="17998" Issue="105381" />
     </Book>
     <Book Series="Friendly Neighborhood Spider-Man" Number="9" Volume="2005" Year="2006">
-      <Id>b2d71c25-94a3-4321-9c9f-c23bf7376538</Id>
+      <Database Name="cv" Series="17998" Issue="105382" />
     </Book>
     <Book Series="Friendly Neighborhood Spider-Man" Number="10" Volume="2005" Year="2006">
-      <Id>e155a99c-3778-4bfa-9473-b20fdee6e5f6</Id>
+      <Database Name="cv" Series="17998" Issue="105383" />
     </Book>
     <Book Series="Spider-Man Unlimited" Number="15" Volume="2004" Year="2006">
-      <Id>85f879cd-2dd1-4658-92b4-d0e9566a6ca4</Id>
+      <Database Name="cv" Series="11306" Issue="114320" />
     </Book>
-    <Book Series="Marvel Team-Up" Number="21" Volume="2005" Year="2006">
-      <Id>dbfc6fa3-374c-49ee-814a-8c947411c979</Id>
+    <Book Series="Marvel Team-Up" Number="21" Volume="2004" Year="2006">
+      <Database Name="cv" Series="18024" Issue="109928" />
     </Book>
-    <Book Series="Marvel Team-Up" Number="23" Volume="2005" Year="2006">
-      <Id>cc38b024-6504-40cb-9dc3-28637bdd31ee</Id>
+    <Book Series="Marvel Team-Up" Number="23" Volume="2004" Year="2006">
+      <Database Name="cv" Series="18024" Issue="120880" />
     </Book>
-    <Book Series="Marvel Team-Up" Number="24" Volume="2005" Year="2006">
-      <Id>fa92241e-609d-4afc-976d-984fcc578b67</Id>
+    <Book Series="Marvel Team-Up" Number="24" Volume="2004" Year="2006">
+      <Database Name="cv" Series="18024" Issue="108310" />
     </Book>
-    <Book Series="Marvel Team-Up" Number="25" Volume="2005" Year="2006">
-      <Id>a4154efc-d041-4acb-b2fe-051f67ed328b</Id>
+    <Book Series="Marvel Team-Up" Number="25" Volume="2004" Year="2006">
+      <Database Name="cv" Series="18024" Issue="120890" />
     </Book>
     <Book Series="The New Avengers: Illuminati" Number="1" Volume="2006" Year="2006">
-      <Id>c570c47d-1e2a-4a69-b920-0724f45b327b</Id>
+      <Database Name="cv" Series="18180" Issue="106482" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="530" Volume="1963" Year="2006">
-      <Id>03870ffb-2756-4850-9253-767f5815d1d2</Id>
+      <Database Name="cv" Series="2127" Issue="113517" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="531" Volume="1963" Year="2006">
-      <Id>66096e78-c880-4645-acce-e441aa60ea9f</Id>
+      <Database Name="cv" Series="2127" Issue="113518" />
     </Book>
     <Book Series="Civil War" Number="1" Volume="2006" Year="2006">
-      <Id>8a3b618d-9877-4c00-8d7f-48d65f4599dd</Id>
+      <Database Name="cv" Series="18023" Issue="105525" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="532" Volume="1963" Year="2006">
-      <Id>fff45c3f-16f7-495c-8291-29a0a47ccbae</Id>
+      <Database Name="cv" Series="2127" Issue="108482" />
     </Book>
     <Book Series="Civil War: Front Line" Number="1" Volume="2006" Year="2006">
-      <Id>cd22c5a3-d863-4530-b142-fbae9c5806c9</Id>
+      <Database Name="cv" Series="18245" Issue="106844" />
     </Book>
     <Book Series="Civil War" Number="2" Volume="2006" Year="2006">
-      <Id>346dc7b4-7523-40ae-8fab-1df067deffd5</Id>
+      <Database Name="cv" Series="18023" Issue="105570" />
     </Book>
     <Book Series="Civil War: Front Line" Number="2" Volume="2006" Year="2006">
-      <Id>ba9f315b-91e3-4cb0-84c4-99b0a5c29be0</Id>
+      <Database Name="cv" Series="18245" Issue="107958" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="533" Volume="1963" Year="2006">
-      <Id>f648f5dc-5c3c-49a7-92f1-0c1cadb99642</Id>
+      <Database Name="cv" Series="2127" Issue="106137" />
     </Book>
-    <Book Series="New Avengers" Number="21" Volume="2005" Year="2006">
-      <Id>328d71db-57d3-4fbf-ad73-1fa7fbfd9283</Id>
+    <Book Series="New Avengers" Number="21" Volume="2004" Year="2006">
+      <Database Name="cv" Series="11497" Issue="107893" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="28" Volume="2006" Year="2006">
-      <Id>dcddadb1-20d5-4258-b147-158a636ff213</Id>
+      <Database Name="cv" Series="18177" Issue="113625" />
     </Book>
     <Book Series="Friendly Neighborhood Spider-Man" Number="11" Volume="2005" Year="2006">
-      <Id>5f94429d-f677-4bfa-89fe-4943bd7dd06f</Id>
+      <Database Name="cv" Series="17998" Issue="105384" />
     </Book>
     <Book Series="Friendly Neighborhood Spider-Man" Number="12" Volume="2005" Year="2006">
-      <Id>f5f835fd-f0d8-4143-bec8-10e4f5706ce7</Id>
+      <Database Name="cv" Series="17998" Issue="105385" />
     </Book>
     <Book Series="Friendly Neighborhood Spider-Man" Number="13" Volume="2005" Year="2006">
-      <Id>b6291025-79b8-4ad2-a1b2-42ce1672bd0c</Id>
+      <Database Name="cv" Series="17998" Issue="105386" />
     </Book>
-    <Book Series="New Avengers" Number="22" Volume="2005" Year="2006">
-      <Id>1148e8d3-c96e-4b35-b3fa-35a948ddb78b</Id>
+    <Book Series="New Avengers" Number="22" Volume="2004" Year="2006">
+      <Database Name="cv" Series="11497" Issue="107895" />
     </Book>
     <Book Series="Daily Bugle Civil War Newspaper Special" Number="1" Volume="2006" Year="2006">
-      <Id>17744c60-ac63-4b68-968a-c2fdb12ae8e9</Id>
+      <Database Name="cv" Series="33595" Issue="218224" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="29" Volume="2006" Year="2006">
-      <Id>0a370035-81c4-4fd2-84ac-10baa4fa3a26</Id>
+      <Database Name="cv" Series="18177" Issue="110139" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="30" Volume="2006" Year="2006">
-      <Id>5e8b8745-94cb-4031-81f7-625822fe226c</Id>
+      <Database Name="cv" Series="18177" Issue="113626" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="31" Volume="2006" Year="2006">
-      <Id>5440f7dc-5d6c-4ddc-93e5-ce6e5527b2af</Id>
+      <Database Name="cv" Series="18177" Issue="113629" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="534" Volume="1963" Year="2006">
-      <Id>da9731ee-c8e1-4588-9963-15f893e74586</Id>
+      <Database Name="cv" Series="2127" Issue="105614" />
     </Book>
     <Book Series="Civil War: Front Line" Number="5" Volume="2006" Year="2006">
-      <Id>aef98b49-0889-4851-8504-3e18c4a9fe9b</Id>
+      <Database Name="cv" Series="18245" Issue="108696" />
     </Book>
-    <Book Series="New Avengers" Number="23" Volume="2005" Year="2006">
-      <Id>7eafbb88-ec73-4b92-9db3-f44900790c97</Id>
+    <Book Series="New Avengers" Number="23" Volume="2004" Year="2006">
+      <Database Name="cv" Series="11497" Issue="108038" />
     </Book>
     <Book Series="Civil War" Number="3" Volume="2006" Year="2006">
-      <Id>7bbd5df4-e746-40d8-9ad1-b135c26c0c20</Id>
+      <Database Name="cv" Series="18023" Issue="105624" />
     </Book>
     <Book Series="Civil War" Number="4" Volume="2006" Year="2006">
-      <Id>4ed27e2e-d39c-4e8e-9dd6-ef44419ec683</Id>
+      <Database Name="cv" Series="18023" Issue="105682" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="535" Volume="1963" Year="2006">
-      <Id>1a779dad-42ee-4c4d-ad03-4cb218b0e8ac</Id>
+      <Database Name="cv" Series="2127" Issue="105556" />
     </Book>
-    <Book Series="New Avengers" Number="24" Volume="2005" Year="2006">
-      <Id>7cd9b1ee-2992-4f7d-8145-c7a502dbeede</Id>
+    <Book Series="New Avengers" Number="24" Volume="2004" Year="2006">
+      <Database Name="cv" Series="11497" Issue="108039" />
     </Book>
     <Book Series="Civil War" Number="5" Volume="2006" Year="2006">
-      <Id>52958b4a-aa5d-4429-b844-9ca8c0ba5b02</Id>
+      <Database Name="cv" Series="18023" Issue="106999" />
     </Book>
-    <Book Series="New Avengers" Number="25" Volume="2005" Year="2006">
-      <Id>82492437-4ce2-4322-a622-d5a9e61f60e3</Id>
+    <Book Series="New Avengers" Number="25" Volume="2004" Year="2006">
+      <Database Name="cv" Series="11497" Issue="108040" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="536" Volume="1963" Year="2006">
-      <Id>927f1dc6-ce2b-492e-8c93-7c247cf5f7f6</Id>
+      <Database Name="cv" Series="2127" Issue="106138" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="32" Volume="2006" Year="2007">
-      <Id>179b7573-0707-4e7b-8cd7-af9af5e55a5c</Id>
+      <Database Name="cv" Series="18177" Issue="110140" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="33" Volume="2006" Year="2007">
-      <Id>a220952f-4231-429b-8acc-d242853f4eb1</Id>
+      <Database Name="cv" Series="18177" Issue="113627" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="34" Volume="2006" Year="2007">
-      <Id>3bd0c32a-f185-4825-abb9-b3930ccb8102</Id>
+      <Database Name="cv" Series="18177" Issue="113628" />
     </Book>
-    <Book Series="Iron Man" Number="14" Volume="2005" Year="2007">
-      <Id>d00ceeeb-fc0a-4f23-94f8-2532e262e853</Id>
+    <Book Series="Iron Man" Number="14" Volume="2004" Year="2007">
+      <Database Name="cv" Series="18220" Issue="111399" />
     </Book>
-    <Book Series="Friendly Neighborhood Spider-Man" Number="14" Volume="2005" Year="2006">
-      <Id>c074c2bc-fd86-46d5-8cd9-81d2bd76b221</Id>
+    <Book Series="Friendly Neighborhood Spider-Man" Number="14" Volume="2005" Year="2007">
+      <Database Name="cv" Series="17998" Issue="105387" />
     </Book>
-    <Book Series="Friendly Neighborhood Spider-Man" Number="15" Volume="2005" Year="2006">
-      <Id>c13b5adf-40fb-4b2c-bda6-e498fa6438ab</Id>
+    <Book Series="Friendly Neighborhood Spider-Man" Number="15" Volume="2005" Year="2007">
+      <Database Name="cv" Series="17998" Issue="106454" />
     </Book>
     <Book Series="Friendly Neighborhood Spider-Man" Number="16" Volume="2005" Year="2007">
-      <Id>90899941-9fbb-4c81-b0a2-51b73d3fd1ef</Id>
+      <Database Name="cv" Series="17998" Issue="106255" />
     </Book>
     <Book Series="Civil War: Front Line" Number="9" Volume="2006" Year="2007">
-      <Id>38793c2d-3b29-4c86-9120-b933f8bb41ac</Id>
+      <Database Name="cv" Series="18245" Issue="108948" />
     </Book>
     <Book Series="Civil War" Number="6" Volume="2006" Year="2006">
-      <Id>72de0c39-09f3-43a0-93dd-5d35d3c409c5</Id>
+      <Database Name="cv" Series="18023" Issue="107000" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="537" Volume="1963" Year="2007">
-      <Id>c96e60b4-e5d8-43e2-8dcb-301cb38d72c4</Id>
+      <Database Name="cv" Series="2127" Issue="106104" />
     </Book>
     <Book Series="Civil War" Number="7" Volume="2006" Year="2007">
-      <Id>88a586c8-129f-4c95-af85-aeff87628b25</Id>
+      <Database Name="cv" Series="18023" Issue="106626" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="538" Volume="1963" Year="2007">
-      <Id>da824c2a-8d66-4b73-82ce-88f80584b337</Id>
+      <Database Name="cv" Series="2127" Issue="106627" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="539" Volume="1963" Year="2007">
-      <Id>9063cb75-e340-44b0-a0d1-f118e5bec8f3</Id>
+      <Database Name="cv" Series="2127" Issue="107203" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="540" Volume="1963" Year="2007">
-      <Id>6101c08b-e826-45da-867b-4e8f9329ff74</Id>
+      <Database Name="cv" Series="2127" Issue="111267" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="541" Volume="1963" Year="2007">
-      <Id>d267075b-0416-4e5f-a5d8-71300511af37</Id>
+      <Database Name="cv" Series="2127" Issue="110596" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="542" Volume="1963" Year="2007">
-      <Id>1da03b6d-1590-44fb-8af2-05d2e02d047d</Id>
+      <Database Name="cv" Series="2127" Issue="111929" />
     </Book>
     <Book Series="Civil War: Front Line" Number="11" Volume="2006" Year="2007">
-      <Id>d0372caf-6dd7-4e0d-96d6-9c32a63870c4</Id>
+      <Database Name="cv" Series="18245" Issue="108968" />
     </Book>
     <Book Series="Friendly Neighborhood Spider-Man" Number="17" Volume="2005" Year="2007">
-      <Id>58e0ec56-6c7e-4752-9d1c-b52f0d18ed1e</Id>
+      <Database Name="cv" Series="17998" Issue="106365" />
     </Book>
     <Book Series="Friendly Neighborhood Spider-Man" Number="18" Volume="2005" Year="2007">
-      <Id>46eba842-8ab2-49cd-acae-72da5440f3b7</Id>
+      <Database Name="cv" Series="17998" Issue="106810" />
     </Book>
     <Book Series="Friendly Neighborhood Spider-Man" Number="19" Volume="2005" Year="2007">
-      <Id>d733979b-9d5f-448d-a1fe-05a1d9e0c7db</Id>
+      <Database Name="cv" Series="17998" Issue="107993" />
     </Book>
     <Book Series="Friendly Neighborhood Spider-Man" Number="20" Volume="2005" Year="2007">
-      <Id>49f38bdc-30be-4980-a8cb-68e0ffdab45d</Id>
+      <Database Name="cv" Series="17998" Issue="108959" />
     </Book>
     <Book Series="Friendly Neighborhood Spider-Man" Number="21" Volume="2005" Year="2007">
-      <Id>14fd9913-6cc4-41b4-a969-751caa21dbbd</Id>
+      <Database Name="cv" Series="17998" Issue="110441" />
     </Book>
     <Book Series="Friendly Neighborhood Spider-Man" Number="22" Volume="2005" Year="2007">
-      <Id>d6cd089e-1b4c-4f73-9a1e-e01a052e9bde</Id>
+      <Database Name="cv" Series="17998" Issue="113624" />
     </Book>
     <Book Series="Friendly Neighborhood Spider-Man" Number="23" Volume="2005" Year="2007">
-      <Id>3b3e1b19-e2d3-4312-bb03-0cfb62bedbee</Id>
+      <Database Name="cv" Series="17998" Issue="113549" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="35" Volume="2006" Year="2007">
-      <Id>0f2c308e-cddd-4e4b-8617-60546baa5f71</Id>
+      <Database Name="cv" Series="18177" Issue="106468" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="36" Volume="2006" Year="2007">
-      <Id>4f1c5b6c-116e-4908-8b32-6d3be591e850</Id>
+      <Database Name="cv" Series="18177" Issue="107593" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="37" Volume="2006" Year="2007">
-      <Id>080d0fe1-eea8-4de7-a012-aeb0f6f99e10</Id>
+      <Database Name="cv" Series="18177" Issue="108583" />
     </Book>
     <Book Series="The Sensational Spider-Man Annual" Number="1" Volume="2007" Year="2007">
-      <Id>6b6477bf-5cb3-4e32-8561-03a9f36fd649</Id>
+      <Database Name="cv" Series="18543" Issue="108966" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="38" Volume="2006" Year="2007">
-      <Id>86ee4358-9917-41bb-90a8-3021a20dcfa8</Id>
+      <Database Name="cv" Series="18177" Issue="110673" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="39" Volume="2006" Year="2007">
-      <Id>6fbd9ab4-c34d-47ee-8c49-259001fee0c0</Id>
+      <Database Name="cv" Series="18177" Issue="111930" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="40" Volume="2006" Year="2007">
-      <Id>f7c234c0-ad78-4e8a-9d6a-82ee6075a015</Id>
+      <Database Name="cv" Series="18177" Issue="113758" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="543" Volume="1963" Year="2007">
-      <Id>741af43f-a525-4c47-9540-7fb56269eeee</Id>
+      <Database Name="cv" Series="2127" Issue="113757" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="544" Volume="1963" Year="2007">
-      <Id>7be85246-361e-4c6a-9125-d0562cf6cfd1</Id>
+      <Database Name="cv" Series="2127" Issue="114199" />
     </Book>
     <Book Series="Friendly Neighborhood Spider-Man" Number="24" Volume="2005" Year="2007">
-      <Id>23939b74-f709-448a-a677-62b54f337363</Id>
+      <Database Name="cv" Series="17998" Issue="115394" />
     </Book>
     <Book Series="The Sensational Spider-Man" Number="41" Volume="2006" Year="2007">
-      <Id>df8a3076-9608-4a70-8b90-8a244ce84a0a</Id>
+      <Database Name="cv" Series="18177" Issue="118735" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="545" Volume="1963" Year="2008">
-      <Id>c9917d64-7411-496f-8eef-10613df03d70</Id>
+      <Database Name="cv" Series="2127" Issue="120557" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Spider-Man/Spider-Man 007 (Straczynski Cont.).cbl
+++ b/Marvel/Characters/unsorted/Spider-Man/Spider-Man 007 (Straczynski Cont.).cbl
@@ -2,802 +2,802 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Spider-Man 7 (Straczynski Cont.)</Name>
   <Books>
-    <Book Series="The Amazing Spider-Man" Number="498" Volume="1963" Year="2003" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="498" Volume="1963" Year="2003">
       <Id>090407e1-f1b4-4135-b837-dc375cdabd97</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="499" Volume="1963" Year="2003" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="499" Volume="1963" Year="2003">
       <Id>7790956a-e169-40ea-863e-4bf7056170d0</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="500" Volume="1963" Year="2003" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="500" Volume="1963" Year="2003">
       <Id>6d0ca3b9-b313-4c17-8834-5848afec3e02</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="501" Volume="1963" Year="2004" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="501" Volume="1963" Year="2004">
       <Id>26da5397-d020-4ed5-9495-efcdd387f315</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="502" Volume="1963" Year="2004" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="502" Volume="1963" Year="2004">
       <Id>367fac29-1397-4cb0-a74e-962e8a780ac1</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="503" Volume="1963" Year="2004" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="503" Volume="1963" Year="2004">
       <Id>2c0bae04-16ec-4411-b48b-461faa4b2db7</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="504" Volume="1963" Year="2004" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="504" Volume="1963" Year="2004">
       <Id>b4ab0892-bcec-4817-b43d-58ac8129db15</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="1" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="1" Volume="2004" Year="2004">
       <Id>ce280de8-a65c-455f-909f-91581336e3c9</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="2" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="2" Volume="2004" Year="2004">
       <Id>93871308-9aa5-4fe5-a2fe-648174f4daea</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="505" Volume="1963" Year="2004" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="505" Volume="1963" Year="2004">
       <Id>7ca0f34d-b3d6-4fd3-a110-8ad5bada8ce5</Id>
     </Book>
-    <Book Series="The Pulse" Number="1" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="The Pulse" Number="1" Volume="2004" Year="2004">
       <Id>01a76a27-b59e-43a4-aba5-37ad3dcb256d</Id>
     </Book>
-    <Book Series="The Pulse" Number="2" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="The Pulse" Number="2" Volume="2004" Year="2004">
       <Id>8e39f625-ab64-4d23-8c94-0737fa44e79e</Id>
     </Book>
-    <Book Series="The Pulse" Number="3" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="The Pulse" Number="3" Volume="2004" Year="2004">
       <Id>6885b899-8146-45da-b62b-0ee61f9cc629</Id>
     </Book>
-    <Book Series="The Pulse" Number="4" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="The Pulse" Number="4" Volume="2004" Year="2004">
       <Id>42579f07-fc21-4ef8-8aea-a0cfa6bce941</Id>
     </Book>
-    <Book Series="The Pulse" Number="5" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="The Pulse" Number="5" Volume="2004" Year="2004">
       <Id>ca5615a1-669d-45b6-a9d6-7106288e7489</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="11" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="11" Volume="2003" Year="2004">
       <Id>4c0d7f09-cb45-4826-88b9-66ce64f10cb0</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="12" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="12" Volume="2003" Year="2004">
       <Id>4dac6b8e-b055-404c-967e-c7f2846acc80</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="13" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="13" Volume="2003" Year="2004">
       <Id>8cea4110-cf2c-4555-80bc-ae28272d2ee4</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="14" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="14" Volume="2003" Year="2004">
       <Id>6c420a44-0cc8-409c-a511-468a3df4fbf7</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="506" Volume="1963" Year="2004" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="506" Volume="1963" Year="2004">
       <Id>840f527e-5923-490d-8e31-88480e191c5b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="507" Volume="1963" Year="2004" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="507" Volume="1963" Year="2004">
       <Id>de062d28-069f-4c48-a82f-eefbe1a7a3e4</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="508" Volume="1963" Year="2004" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="508" Volume="1963" Year="2004">
       <Id>43f6bdef-bbf2-49f2-a9c8-c2ab5c141287</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="509" Volume="1963" Year="2004" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="509" Volume="1963" Year="2004">
       <Id>65083661-283b-4e65-b6c1-e86d5a219f2f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="510" Volume="1963" Year="2004" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="510" Volume="1963" Year="2004">
       <Id>172ad588-7f1a-4da7-a3b5-9c59fb437bf7</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="511" Volume="1963" Year="2004" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="511" Volume="1963" Year="2004">
       <Id>41802fd5-184b-446c-a008-4a081cff5773</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="512" Volume="1963" Year="2004" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="512" Volume="1963" Year="2004">
       <Id>bb6ce53a-c024-4045-8fd7-6579586e5730</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="513" Volume="1963" Year="2005" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="513" Volume="1963" Year="2005">
       <Id>3a659f0f-7330-49c3-8d2f-9292ef99e95d</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="514" Volume="1963" Year="2005" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="514" Volume="1963" Year="2005">
       <Id>d8568c50-3a1d-4359-aea1-a7356ebd82b9</Id>
     </Book>
-    <Book Series="Spider-Man/Doctor Octopus: Out of Reach" Number="1" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Spider-Man/Doctor Octopus: Out of Reach" Number="1" Volume="2004" Year="2004">
       <Id>84d08e6d-3e6f-4ccb-b538-a56b01911162</Id>
     </Book>
-    <Book Series="Spider-Man/Doctor Octopus: Out of Reach" Number="2" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Spider-Man/Doctor Octopus: Out of Reach" Number="2" Volume="2004" Year="2004">
       <Id>c66470f4-c1fb-4ab8-a464-9535964998f0</Id>
     </Book>
-    <Book Series="Spider-Man/Doctor Octopus: Out of Reach" Number="3" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Spider-Man/Doctor Octopus: Out of Reach" Number="3" Volume="2004" Year="2004">
       <Id>23fc1134-4566-4b2c-9752-6f8fb797193a</Id>
     </Book>
-    <Book Series="Spider-Man/Doctor Octopus: Out of Reach" Number="4" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Spider-Man/Doctor Octopus: Out of Reach" Number="4" Volume="2004" Year="2004">
       <Id>9cb55238-bdac-4176-ba38-bcde6bc30d13</Id>
     </Book>
-    <Book Series="Spider-Man/Doctor Octopus: Out of Reach" Number="5" Volume="2004" Year="2004" Format="Limited Series">
+    <Book Series="Spider-Man/Doctor Octopus: Out of Reach" Number="5" Volume="2004" Year="2004">
       <Id>c8f40753-e054-489f-8a37-76159a996c0e</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="3" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="3" Volume="2004" Year="2004">
       <Id>a24b8cf3-1406-43a4-b79f-2328f555ef22</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="4" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="4" Volume="2004" Year="2004">
       <Id>f3eff41e-c652-4fe0-bb60-c9e6228c0c09</Id>
     </Book>
-    <Book Series="Spider-Man/Red Sonja" Number="1" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="Spider-Man/Red Sonja" Number="1" Volume="2007" Year="2007">
       <Id>b90aa925-6877-4912-b64a-b0c51f6e69d3</Id>
     </Book>
-    <Book Series="Spider-Man/Red Sonja" Number="2" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="Spider-Man/Red Sonja" Number="2" Volume="2007" Year="2007">
       <Id>004ed230-bcda-4c65-9ab6-044999bd9d91</Id>
     </Book>
-    <Book Series="Spider-Man/Red Sonja" Number="3" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="Spider-Man/Red Sonja" Number="3" Volume="2007" Year="2007">
       <Id>1b21b54f-1cd1-4c64-9ce6-1c17d9bbaa62</Id>
     </Book>
-    <Book Series="Spider-Man/Red Sonja" Number="4" Volume="2007" Year="2008" Format="Limited Series">
+    <Book Series="Spider-Man/Red Sonja" Number="4" Volume="2007" Year="2008">
       <Id>ce057b4a-0cf6-4cf8-ab65-1379c5608e59</Id>
     </Book>
-    <Book Series="Spider-Man/Red Sonja" Number="5" Volume="2007" Year="2008" Format="Limited Series">
+    <Book Series="Spider-Man/Red Sonja" Number="5" Volume="2007" Year="2008">
       <Id>c7892e2a-948c-4c87-85df-f9fb41b6051e</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="5" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="5" Volume="2004" Year="2004">
       <Id>04019c93-46c0-44f4-be90-46056cb4b39b</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="6" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="6" Volume="2004" Year="2005">
       <Id>b353cbc0-28d2-4917-b631-bcd213060b35</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="7" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="7" Volume="2004" Year="2005">
       <Id>71786fcb-cdad-4629-a811-c0579336c0f9</Id>
     </Book>
-    <Book Series="Marvel Knights Spider-Man" Number="1" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Marvel Knights Spider-Man" Number="1" Volume="2004" Year="2004">
       <Id>c254274f-96c3-43b1-8e96-7c0c32a04be6</Id>
     </Book>
-    <Book Series="Marvel Knights Spider-Man" Number="2" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Marvel Knights Spider-Man" Number="2" Volume="2004" Year="2004">
       <Id>14768090-33bb-4a45-8802-e0eae7d8b77e</Id>
     </Book>
-    <Book Series="Marvel Knights Spider-Man" Number="3" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Marvel Knights Spider-Man" Number="3" Volume="2004" Year="2004">
       <Id>4a84676d-6e8c-45b2-979b-c090e9b39497</Id>
     </Book>
-    <Book Series="Marvel Knights Spider-Man" Number="4" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Marvel Knights Spider-Man" Number="4" Volume="2004" Year="2004">
       <Id>2e225267-63bb-4fa3-b708-551959c4c71a</Id>
     </Book>
-    <Book Series="Marvel Knights Spider-Man" Number="5" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Marvel Knights Spider-Man" Number="5" Volume="2004" Year="2004">
       <Id>98b3b16a-26f3-4d1f-95b2-23ecdb07d9fb</Id>
     </Book>
-    <Book Series="Marvel Knights Spider-Man" Number="6" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Marvel Knights Spider-Man" Number="6" Volume="2004" Year="2004">
       <Id>0c7bc4a0-63b5-4624-85c2-e3e067fac68e</Id>
     </Book>
-    <Book Series="Avengers" Number="500" Volume="1998" Year="2004" Format="Main Series">
+    <Book Series="Avengers" Number="500" Volume="1998" Year="2004">
       <Id>017c6a65-3244-4f15-becb-29d4560f46cc</Id>
     </Book>
-    <Book Series="Avengers" Number="501" Volume="1998" Year="2004" Format="Main Series">
+    <Book Series="Avengers" Number="501" Volume="1998" Year="2004">
       <Id>593fea94-b9f8-4edd-bf67-ace61ce6a14a</Id>
     </Book>
-    <Book Series="Avengers" Number="502" Volume="1998" Year="2004" Format="Main Series">
+    <Book Series="Avengers" Number="502" Volume="1998" Year="2004">
       <Id>d790e4c1-669f-4ef4-9653-c28f520b5b8d</Id>
     </Book>
-    <Book Series="Avengers" Number="503" Volume="1998" Year="2004" Format="Main Series">
+    <Book Series="Avengers" Number="503" Volume="1998" Year="2004">
       <Id>80a2190e-fb39-46b2-af35-6eeb92948155</Id>
     </Book>
-    <Book Series="Marvel Knights Spider-Man" Number="7" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="Marvel Knights Spider-Man" Number="7" Volume="2004" Year="2004">
       <Id>bb5ce914-d37a-42d8-b04d-0e01a269758e</Id>
     </Book>
-    <Book Series="Marvel Knights Spider-Man" Number="8" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Marvel Knights Spider-Man" Number="8" Volume="2004" Year="2005">
       <Id>2a9b6200-15da-4c4d-84cc-741bfa89a78f</Id>
     </Book>
-    <Book Series="Marvel Knights Spider-Man" Number="9" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Marvel Knights Spider-Man" Number="9" Volume="2004" Year="2005">
       <Id>eb6ccf42-45d6-4107-aeae-5f714c36984b</Id>
     </Book>
-    <Book Series="Marvel Knights Spider-Man" Number="10" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Marvel Knights Spider-Man" Number="10" Volume="2004" Year="2005">
       <Id>344abf35-15bf-4135-9f0c-29441f425a1e</Id>
     </Book>
-    <Book Series="Marvel Knights Spider-Man" Number="11" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Marvel Knights Spider-Man" Number="11" Volume="2004" Year="2005">
       <Id>7a068d10-d0a2-447c-866e-7a9619ab1c20</Id>
     </Book>
-    <Book Series="Marvel Knights Spider-Man" Number="12" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Marvel Knights Spider-Man" Number="12" Volume="2004" Year="2005">
       <Id>cbfab13d-8322-431f-ab4d-76c82233e739</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="15" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="15" Volume="2003" Year="2004">
       <Id>a4da6e16-fa39-4bc9-9fdb-5cefb98d97ca</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="16" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="16" Volume="2003" Year="2004">
       <Id>6b6bb08e-83d4-46f5-8756-6379b66f06ed</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="17" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="17" Volume="2003" Year="2004">
       <Id>639e805a-2186-4f64-a218-4611d25c9808</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="18" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="18" Volume="2003" Year="2004">
       <Id>830a20b9-d9bb-43e4-afe8-f8561ff3e596</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="19" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="19" Volume="2003" Year="2004">
       <Id>29958ff8-50ce-495a-8602-a566ae3b3b83</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="20" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="20" Volume="2003" Year="2004">
       <Id>699b3592-5fbf-48bc-9a4a-d9b79c7b6563</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="21" Volume="2003" Year="2005" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="21" Volume="2003" Year="2005">
       <Id>efeaa6ab-84cf-47ee-bda4-9b46e5ea1faf</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="22" Volume="2003" Year="2005" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="22" Volume="2003" Year="2005">
       <Id>c625c191-2bfc-4e6c-b198-b90ce8f99d8a</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="1" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="1" Volume="2005" Year="2005">
       <Id>f6b19189-d93e-427e-80fd-c9024c70d033</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="2" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="2" Volume="2005" Year="2005">
       <Id>c79bb015-3539-4446-b970-fcece8d8d5d7</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="5" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="5" Volume="2005" Year="2005">
       <Id>1d1c799a-26d6-4884-bc81-9c37b4ce46a9</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="6" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="6" Volume="2005" Year="2005">
       <Id>f564475c-35ce-438e-832e-efea5665710e</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="8" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="8" Volume="2004" Year="2005">
       <Id>6af6c496-55dc-4340-9b36-35bf27a77061</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="9" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="9" Volume="2004" Year="2005">
       <Id>318972ae-3c87-4a61-8d50-8584d622a704</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="10" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="10" Volume="2004" Year="2005">
       <Id>636122e2-7ec7-4012-aaa1-14a7cd1889b3</Id>
     </Book>
-    <Book Series="Secret War" Number="1" Volume="2004" Year="2004" Format="Crossover">
+    <Book Series="Secret War" Number="1" Volume="2004" Year="2004">
       <Id>656b0c01-2210-46e1-b339-0425383d04f8</Id>
     </Book>
-    <Book Series="Secret War" Number="2" Volume="2004" Year="2004" Format="Crossover">
+    <Book Series="Secret War" Number="2" Volume="2004" Year="2004">
       <Id>ffb4246d-e097-4e7c-ac18-8fb13bb6f318</Id>
     </Book>
-    <Book Series="Secret War" Number="3" Volume="2004" Year="2004" Format="Crossover">
+    <Book Series="Secret War" Number="3" Volume="2004" Year="2004">
       <Id>d1f6a606-2cd2-4889-92aa-823f023f98d2</Id>
     </Book>
-    <Book Series="Secret War" Number="4" Volume="2004" Year="2005" Format="Crossover">
+    <Book Series="Secret War" Number="4" Volume="2004" Year="2005">
       <Id>bb509e6f-eeaa-44c1-b6cc-c2081712832c</Id>
     </Book>
-    <Book Series="Secret War" Number="5" Volume="2004" Year="2005" Format="Crossover">
+    <Book Series="Secret War" Number="5" Volume="2004" Year="2005">
       <Id>b8d9c94c-348d-411b-8b8e-9d55a0e6bbed</Id>
     </Book>
-    <Book Series="The Pulse" Number="6" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="The Pulse" Number="6" Volume="2004" Year="2005">
       <Id>13c46993-29d3-43b4-a457-b0194bb7e137</Id>
     </Book>
-    <Book Series="The Pulse" Number="7" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="The Pulse" Number="7" Volume="2004" Year="2005">
       <Id>f09d848c-5a6f-44a7-b6b6-fcc59fa983fe</Id>
     </Book>
-    <Book Series="The Pulse" Number="8" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="The Pulse" Number="8" Volume="2004" Year="2005">
       <Id>a2c42029-aa86-4262-a415-f64ec7c65d1a</Id>
     </Book>
-    <Book Series="The Pulse" Number="9" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="The Pulse" Number="9" Volume="2004" Year="2005">
       <Id>20ba9182-ed39-44b4-a219-792bcd0b09b7</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="11" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="11" Volume="2004" Year="2005">
       <Id>fc00d477-d58a-453e-b75b-459d5b30d20f</Id>
     </Book>
-    <Book Series="New Avengers" Number="1" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="New Avengers" Number="1" Volume="2005" Year="2005">
       <Id>28dcc809-691a-420c-819b-f21038ce0f83</Id>
     </Book>
-    <Book Series="New Avengers" Number="2" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="New Avengers" Number="2" Volume="2005" Year="2005">
       <Id>21ec78c6-bd51-428b-93ad-ba2e3f8d8123</Id>
     </Book>
-    <Book Series="New Avengers" Number="3" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="New Avengers" Number="3" Volume="2005" Year="2005">
       <Id>b8670db4-d00a-48c7-9c13-5a0932eada3b</Id>
     </Book>
-    <Book Series="New Avengers" Number="4" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="New Avengers" Number="4" Volume="2005" Year="2005">
       <Id>ea5dd98b-b933-4463-92a9-95b0fe387797</Id>
     </Book>
-    <Book Series="New Avengers" Number="5" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="New Avengers" Number="5" Volume="2005" Year="2005">
       <Id>6852003e-1c79-4850-bc9f-652b2c0d2ef7</Id>
     </Book>
-    <Book Series="New Avengers" Number="6" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="New Avengers" Number="6" Volume="2005" Year="2005">
       <Id>7183bbe4-e9d7-4848-bc31-7b86c6cc69d6</Id>
     </Book>
-    <Book Series="Spider-Man: Breakout" Number="1" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Spider-Man: Breakout" Number="1" Volume="2005" Year="2005">
       <Id>67729874-2e51-4a48-8de6-05b8eccd2116</Id>
     </Book>
-    <Book Series="Spider-Man: Breakout" Number="2" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Spider-Man: Breakout" Number="2" Volume="2005" Year="2005">
       <Id>51e875bc-1a95-44bd-a9f6-03f70b687763</Id>
     </Book>
-    <Book Series="Spider-Man: Breakout" Number="3" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Spider-Man: Breakout" Number="3" Volume="2005" Year="2005">
       <Id>12f3d45f-013e-49a0-8ff1-56b1c76c212c</Id>
     </Book>
-    <Book Series="Spider-Man: Breakout" Number="4" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Spider-Man: Breakout" Number="4" Volume="2005" Year="2005">
       <Id>b100ffc7-4bbc-469d-9607-b94a60848ef6</Id>
     </Book>
-    <Book Series="Spider-Man: Breakout" Number="5" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Spider-Man: Breakout" Number="5" Volume="2005" Year="2005">
       <Id>e62fc777-b093-4b85-b607-586f85679f7c</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="7" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="7" Volume="2005" Year="2005">
       <Id>11efda7b-b64f-4a21-bb15-6ede94a312a3</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="10" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="10" Volume="2005" Year="2005">
       <Id>f66b44d2-b6cd-48fc-87c3-e3a730388b89</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="11" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="11" Volume="2005" Year="2005">
       <Id>643c5589-97bc-4ebe-8d7b-15114088b1cc</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="12" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="12" Volume="2005" Year="2005">
       <Id>ba109392-bd6a-46ff-bf9e-cef1b7d17578</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="13" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="13" Volume="2005" Year="2005">
       <Id>ea316fbc-852a-4728-83fe-2dd7b502c772</Id>
     </Book>
-    <Book Series="New Avengers" Number="7" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="New Avengers" Number="7" Volume="2005" Year="2005">
       <Id>39ae8e6f-50a1-46a3-8e75-bbf036f62d22</Id>
     </Book>
-    <Book Series="New Avengers" Number="8" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="New Avengers" Number="8" Volume="2005" Year="2005">
       <Id>0cf5d8a2-4995-4c00-9c33-75029784e830</Id>
     </Book>
-    <Book Series="New Avengers" Number="9" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="New Avengers" Number="9" Volume="2005" Year="2005">
       <Id>f7839996-94a8-4ddf-9426-74d8aa065fb1</Id>
     </Book>
-    <Book Series="New Avengers" Number="10" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="New Avengers" Number="10" Volume="2005" Year="2005">
       <Id>f91ba1fc-c80c-471c-99d7-0534aa21b86d</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="12" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="12" Volume="2004" Year="2006">
       <Id>5d741082-716c-443c-b133-e70038689b5b</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="13" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="13" Volume="2004" Year="2006">
       <Id>650c4fa0-1f49-44bb-9876-b601368d564d</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="14" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="14" Volume="2004" Year="2006">
       <Id>a3ba40cd-4ef4-4d4a-a96c-7c2ce6e6413f</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="23" Volume="2003" Year="2005" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="23" Volume="2003" Year="2005">
       <Id>5967ade5-858c-4d5c-b5aa-232e600dedd4</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="24" Volume="2003" Year="2005" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="24" Volume="2003" Year="2005">
       <Id>0b9a3320-09a8-44cd-adc4-7815bf04f95e</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="25" Volume="2003" Year="2005" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="25" Volume="2003" Year="2005">
       <Id>56511478-f871-488f-b5af-3f42844a6c9a</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="26" Volume="2003" Year="2005" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="26" Volume="2003" Year="2005">
       <Id>e0d62c34-e006-49aa-a4c1-7e995019ed04</Id>
     </Book>
-    <Book Series="Spectacular Spider-Man" Number="27" Volume="2003" Year="2005" Format="Main Series">
+    <Book Series="Spectacular Spider-Man" Number="27" Volume="2003" Year="2005">
       <Id>ea36c2c1-7ccc-48e0-aaf4-0b49e0fdb5f7</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="515" Volume="1963" Year="2005" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="515" Volume="1963" Year="2005">
       <Id>bbe61c95-55ed-4abe-a79d-5684491b4447</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="516" Volume="1963" Year="2005" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="516" Volume="1963" Year="2005">
       <Id>1430e8dd-6b72-4690-83f1-19c6ba0e2a9f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="517" Volume="1963" Year="2005" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="517" Volume="1963" Year="2005">
       <Id>7f953a4c-e01b-4d8d-adef-d9a65e27eaff</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="518" Volume="1963" Year="2005" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="518" Volume="1963" Year="2005">
       <Id>8b63df41-71b4-497e-9886-0660798a80c3</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="519" Volume="1963" Year="2005" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="519" Volume="1963" Year="2005">
       <Id>17bc7ba3-62a8-4dc5-be59-fa9e2d29079a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="520" Volume="1963" Year="2005" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="520" Volume="1963" Year="2005">
       <Id>34a7c9aa-01f1-4521-97f7-6cec15446a29</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="521" Volume="1963" Year="2005" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="521" Volume="1963" Year="2005">
       <Id>084a02aa-721f-4b35-8216-29132cb7a21e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="522" Volume="1963" Year="2005" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="522" Volume="1963" Year="2005">
       <Id>187276eb-037a-414b-864c-e291ccbcfd03</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="523" Volume="1963" Year="2005" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="523" Volume="1963" Year="2005">
       <Id>24606e48-22b7-47ed-aa66-b86aef0f224a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="524" Volume="1963" Year="2005" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="524" Volume="1963" Year="2005">
       <Id>75738d07-526f-4422-a64b-68f3e5200b83</Id>
     </Book>
-    <Book Series="Spider-Man/Human Torch" Number="1" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Spider-Man/Human Torch" Number="1" Volume="2005" Year="2005">
       <Id>c42c8e67-faac-490f-b49f-d0151d19bc04</Id>
     </Book>
-    <Book Series="Spider-Man/Human Torch" Number="2" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Spider-Man/Human Torch" Number="2" Volume="2005" Year="2005">
       <Id>42a96330-9e04-4cbd-a331-0e4224ed21ea</Id>
     </Book>
-    <Book Series="Spider-Man/Human Torch" Number="3" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Spider-Man/Human Torch" Number="3" Volume="2005" Year="2005">
       <Id>4bada82d-ab8c-48f4-a9a5-c8bf6abbb339</Id>
     </Book>
-    <Book Series="Spider-Man/Human Torch" Number="4" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Spider-Man/Human Torch" Number="4" Volume="2005" Year="2005">
       <Id>95683f0b-f449-4e50-90bb-67d1a90f952c</Id>
     </Book>
-    <Book Series="Spider-Man/Human Torch" Number="5" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Spider-Man/Human Torch" Number="5" Volume="2005" Year="2005">
       <Id>6d0cbe78-cd62-49c1-ba6c-3c951f210332</Id>
     </Book>
-    <Book Series="Marvel Knights Spider-Man" Number="13" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Marvel Knights Spider-Man" Number="13" Volume="2004" Year="2005">
       <Id>eaa5c66a-e65e-46f0-a1fe-bf50ea679659</Id>
     </Book>
-    <Book Series="Marvel Knights Spider-Man" Number="14" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Marvel Knights Spider-Man" Number="14" Volume="2004" Year="2005">
       <Id>35d65ea0-570d-44a8-9d1f-5c1af1315e86</Id>
     </Book>
-    <Book Series="Marvel Knights Spider-Man" Number="15" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Marvel Knights Spider-Man" Number="15" Volume="2004" Year="2005">
       <Id>e3fc501f-e2d2-492e-82ea-6187a452c5e5</Id>
     </Book>
-    <Book Series="Marvel Knights Spider-Man" Number="16" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Marvel Knights Spider-Man" Number="16" Volume="2004" Year="2005">
       <Id>49ef7e7d-440a-42ae-af10-d17054381175</Id>
     </Book>
-    <Book Series="Marvel Knights Spider-Man" Number="17" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Marvel Knights Spider-Man" Number="17" Volume="2004" Year="2005">
       <Id>5aed797a-1afd-4ce5-ac44-78619b030e5a</Id>
     </Book>
-    <Book Series="Marvel Knights Spider-Man" Number="18" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Marvel Knights Spider-Man" Number="18" Volume="2004" Year="2005">
       <Id>93711256-bba0-46f2-9a77-390ca5dc060a</Id>
     </Book>
-    <Book Series="House of M" Number="1" Volume="2005" Year="2005" Format="Crossover">
+    <Book Series="House of M" Number="1" Volume="2005" Year="2005">
       <Id>87c12880-5952-4edd-87b2-17ca0f8a8412</Id>
     </Book>
-    <Book Series="Spider-Man: House of M" Number="1" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Spider-Man: House of M" Number="1" Volume="2005" Year="2005">
       <Id>17588345-bf2d-4cba-9a86-54f8a79b2600</Id>
     </Book>
-    <Book Series="Spider-Man: House of M" Number="2" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Spider-Man: House of M" Number="2" Volume="2005" Year="2005">
       <Id>dd36bc56-9f62-4efa-b15c-a0f10d4a0fab</Id>
     </Book>
-    <Book Series="Spider-Man: House of M" Number="3" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Spider-Man: House of M" Number="3" Volume="2005" Year="2005">
       <Id>4a2d547f-5fa4-4dee-8ba3-2a90d0f664bb</Id>
     </Book>
-    <Book Series="Spider-Man: House of M" Number="4" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Spider-Man: House of M" Number="4" Volume="2005" Year="2005">
       <Id>6f7b0fd7-cce3-4255-8077-7107d6ac0fd0</Id>
     </Book>
-    <Book Series="Spider-Man: House of M" Number="5" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Spider-Man: House of M" Number="5" Volume="2005" Year="2005">
       <Id>7386ce5d-b897-4982-ae60-31880a9bac2a</Id>
     </Book>
-    <Book Series="House of M" Number="2" Volume="2005" Year="2005" Format="Crossover">
+    <Book Series="House of M" Number="2" Volume="2005" Year="2005">
       <Id>cd404553-6dd2-46e2-a706-b44501cceeb5</Id>
     </Book>
-    <Book Series="House of M" Number="3" Volume="2005" Year="2005" Format="Crossover">
+    <Book Series="House of M" Number="3" Volume="2005" Year="2005">
       <Id>52c3157a-6b7b-4a3f-93a3-5c65d8105904</Id>
     </Book>
-    <Book Series="House of M" Number="4" Volume="2005" Year="2005" Format="Crossover">
+    <Book Series="House of M" Number="4" Volume="2005" Year="2005">
       <Id>a9152579-cd4a-4fcf-a9fc-a28706d29844</Id>
     </Book>
-    <Book Series="House of M" Number="5" Volume="2005" Year="2005" Format="Crossover">
+    <Book Series="House of M" Number="5" Volume="2005" Year="2005">
       <Id>83190f73-884a-416f-968b-d52aaebeacf9</Id>
     </Book>
-    <Book Series="House of M" Number="6" Volume="2005" Year="2005" Format="Crossover">
+    <Book Series="House of M" Number="6" Volume="2005" Year="2005">
       <Id>4e3ef330-2fe0-4dbb-9f12-13b2c25ec7ae</Id>
     </Book>
-    <Book Series="House of M" Number="7" Volume="2005" Year="2005" Format="Crossover">
+    <Book Series="House of M" Number="7" Volume="2005" Year="2005">
       <Id>f0bdd681-2378-4e2d-a243-4b14799eb6ca</Id>
     </Book>
-    <Book Series="House of M" Number="8" Volume="2005" Year="2005" Format="Crossover">
+    <Book Series="House of M" Number="8" Volume="2005" Year="2005">
       <Id>8a2532e6-142d-45e2-ac8a-f8a8548d6e7b</Id>
     </Book>
-    <Book Series="New Avengers" Number="11" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="New Avengers" Number="11" Volume="2005" Year="2005">
       <Id>cadbdce4-f720-4a2d-b78d-62ada7310716</Id>
     </Book>
-    <Book Series="New Avengers" Number="12" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="New Avengers" Number="12" Volume="2005" Year="2005">
       <Id>c07dbf1d-1965-4605-93ad-15519d12aabb</Id>
     </Book>
-    <Book Series="New Avengers" Number="13" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="New Avengers" Number="13" Volume="2005" Year="2006">
       <Id>d862086e-237c-47cc-94fa-af70e264851b</Id>
     </Book>
-    <Book Series="New Avengers" Number="14" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="New Avengers" Number="14" Volume="2005" Year="2006">
       <Id>8d03ae36-75ca-4792-bdbe-f731d40c8a33</Id>
     </Book>
-    <Book Series="New Avengers" Number="15" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="New Avengers" Number="15" Volume="2005" Year="2006">
       <Id>de1fcb42-950a-4b7a-83df-eea6513410b3</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="14" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="14" Volume="2005" Year="2006">
       <Id>17ff2a56-4e1c-4437-926c-9142a3c899a3</Id>
     </Book>
-    <Book Series="Spider-Man and the Fantastic Four" Number="1" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="Spider-Man and the Fantastic Four" Number="1" Volume="2007" Year="2007">
       <Id>ac09a9a5-d8d4-4c1e-a8fb-b9f270d71b03</Id>
     </Book>
-    <Book Series="Spider-Man and the Fantastic Four" Number="2" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="Spider-Man and the Fantastic Four" Number="2" Volume="2007" Year="2007">
       <Id>0c988349-524b-4e34-b340-c4ecabb63da1</Id>
     </Book>
-    <Book Series="Spider-Man and the Fantastic Four" Number="3" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="Spider-Man and the Fantastic Four" Number="3" Volume="2007" Year="2007">
       <Id>e4ee072a-7149-4f18-bb4c-25be4462c130</Id>
     </Book>
-    <Book Series="Spider-Man and the Fantastic Four" Number="4" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="Spider-Man and the Fantastic Four" Number="4" Volume="2007" Year="2007">
       <Id>238713cb-19d6-40cf-8d15-46e3fd315189</Id>
     </Book>
-    <Book Series="Spider-Man/Black Cat: The Evil that Men Do" Number="1" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="Spider-Man/Black Cat: The Evil that Men Do" Number="1" Volume="2002" Year="2002">
       <Id>b25e223c-8482-4e90-85f9-f210d0ea7ea1</Id>
     </Book>
-    <Book Series="Spider-Man/Black Cat: The Evil that Men Do" Number="2" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="Spider-Man/Black Cat: The Evil that Men Do" Number="2" Volume="2002" Year="2002">
       <Id>2abe24e0-328c-44c6-8567-e68c2e23a329</Id>
     </Book>
-    <Book Series="Spider-Man/Black Cat: The Evil that Men Do" Number="3" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="Spider-Man/Black Cat: The Evil that Men Do" Number="3" Volume="2002" Year="2002">
       <Id>09f0f7f2-5ac0-4b61-b792-0e69bbb303db</Id>
     </Book>
-    <Book Series="Spider-Man/Black Cat: The Evil that Men Do" Number="4" Volume="2002" Year="2006" Format="Limited Series">
+    <Book Series="Spider-Man/Black Cat: The Evil that Men Do" Number="4" Volume="2002" Year="2006">
       <Id>7ad3c739-f5b6-4244-82ec-26ba6495d4f2</Id>
     </Book>
-    <Book Series="Spider-Man/Black Cat: The Evil that Men Do" Number="5" Volume="2002" Year="2006" Format="Limited Series">
+    <Book Series="Spider-Man/Black Cat: The Evil that Men Do" Number="5" Volume="2002" Year="2006">
       <Id>90a6986e-c5bc-4bda-a1ca-2b491ccc9b4b</Id>
     </Book>
-    <Book Series="Spider-Man/Black Cat: The Evil that Men Do" Number="6" Volume="2002" Year="2006" Format="Limited Series">
+    <Book Series="Spider-Man/Black Cat: The Evil that Men Do" Number="6" Volume="2002" Year="2006">
       <Id>639ad54d-f957-4722-9708-82ca95f14ef0</Id>
     </Book>
-    <Book Series="Toxin" Number="1" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Toxin" Number="1" Volume="2005" Year="2005">
       <Id>df4d43a2-2bec-4d38-a441-dcdbc64c2ebf</Id>
     </Book>
-    <Book Series="Toxin" Number="2" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Toxin" Number="2" Volume="2005" Year="2005">
       <Id>3a9bff49-64ef-4f07-940b-2bc3518c6730</Id>
     </Book>
-    <Book Series="Toxin" Number="3" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Toxin" Number="3" Volume="2005" Year="2005">
       <Id>2e3caaa5-5a81-490f-81b9-2a3f0a0f19c8</Id>
     </Book>
-    <Book Series="Toxin" Number="4" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Toxin" Number="4" Volume="2005" Year="2005">
       <Id>5f2c7a18-f6d2-4ad1-90bb-c714ace0c8b0</Id>
     </Book>
-    <Book Series="Toxin" Number="6" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Toxin" Number="6" Volume="2005" Year="2005">
       <Id>0498e2ee-9e27-490f-b706-042035cc8824</Id>
     </Book>
-    <Book Series="Toxin" Number="5" Volume="2005" Year="2005" Format="Limited Series">
+    <Book Series="Toxin" Number="5" Volume="2005" Year="2005">
       <Id>03ed3c12-98ee-45d6-b9b7-dbfdda4dd7d3</Id>
     </Book>
-    <Book Series="The Pulse" Number="11" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="The Pulse" Number="11" Volume="2004" Year="2005">
       <Id>ef90da8d-e0d6-47e1-b25c-b8c4b6092521</Id>
     </Book>
-    <Book Series="The Pulse" Number="12" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="The Pulse" Number="12" Volume="2004" Year="2006">
       <Id>0787c6c6-d2a6-4467-a130-6f0001d4e764</Id>
     </Book>
-    <Book Series="The Pulse" Number="13" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="The Pulse" Number="13" Volume="2004" Year="2006">
       <Id>7e59c9ff-bae5-45ec-8aa0-37b1f4508ea5</Id>
     </Book>
-    <Book Series="The Pulse" Number="14" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="The Pulse" Number="14" Volume="2004" Year="2006">
       <Id>2ca78105-4e01-4e98-b49b-8ac7c1f66458</Id>
     </Book>
-    <Book Series="Friendly Neighborhood Spider-Man" Number="1" Volume="2005" Year="2005" Format="Main Series">
+    <Book Series="Friendly Neighborhood Spider-Man" Number="1" Volume="2005" Year="2005">
       <Id>fbe09c80-145c-475a-801a-c306470668fd</Id>
     </Book>
-    <Book Series="Marvel Knights Spider-Man" Number="19" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="Marvel Knights Spider-Man" Number="19" Volume="2004" Year="2005">
       <Id>963eb547-9fbb-4d5d-8605-14ab080008c6</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="525" Volume="1963" Year="2005" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="525" Volume="1963" Year="2005">
       <Id>f8572cfc-e62c-4c24-9f8d-f12b433cf78c</Id>
     </Book>
-    <Book Series="Friendly Neighborhood Spider-Man" Number="2" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Friendly Neighborhood Spider-Man" Number="2" Volume="2005" Year="2006">
       <Id>beb8ecc1-f2ef-435d-acb6-0932b0c19914</Id>
     </Book>
-    <Book Series="Marvel Knights Spider-Man" Number="20" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="Marvel Knights Spider-Man" Number="20" Volume="2004" Year="2006">
       <Id>1b4bd244-5624-459a-9730-d6cfe640d64b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="526" Volume="1963" Year="2006" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="526" Volume="1963" Year="2006">
       <Id>b3603e5a-71c0-4a0b-be9b-0dfa69630384</Id>
     </Book>
-    <Book Series="Friendly Neighborhood Spider-Man" Number="3" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Friendly Neighborhood Spider-Man" Number="3" Volume="2005" Year="2006">
       <Id>38e815f3-3f15-47c9-b6f4-502cd4a1cd86</Id>
     </Book>
-    <Book Series="Marvel Knights Spider-Man" Number="21" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="Marvel Knights Spider-Man" Number="21" Volume="2004" Year="2006">
       <Id>10246e7e-23b1-4ced-a27e-a651a6c14b32</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="527" Volume="1963" Year="2006" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="527" Volume="1963" Year="2006">
       <Id>c86de7a8-bddd-453a-8b87-e043120d41ab</Id>
     </Book>
-    <Book Series="Friendly Neighborhood Spider-Man" Number="4" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Friendly Neighborhood Spider-Man" Number="4" Volume="2005" Year="2006">
       <Id>a31a275a-d36b-4be5-91ed-a0d627ea610c</Id>
     </Book>
-    <Book Series="Marvel Knights Spider-Man" Number="22" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="Marvel Knights Spider-Man" Number="22" Volume="2004" Year="2006">
       <Id>9d88936b-01b8-4b7f-8d4a-66aec4a4cbd2</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="528" Volume="1963" Year="2006" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="528" Volume="1963" Year="2006">
       <Id>2d037908-a4dd-4d7e-a985-c9126e51724d</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="23" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="23" Volume="2006" Year="2006">
       <Id>5a184a4d-2c6d-4b1c-a5cd-f26b7632c7f6</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="24" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="24" Volume="2006" Year="2006">
       <Id>86a8d41c-3104-4c09-9a03-c3eaa65cde57</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="25" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="25" Volume="2006" Year="2006">
       <Id>3757f1ee-41f1-4b5b-9cca-747cf2432cb3</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="529" Volume="1963" Year="2006" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="529" Volume="1963" Year="2006">
       <Id>10f91a58-98a9-4861-8ca2-61a56215d166</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="26" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="26" Volume="2006" Year="2006">
       <Id>c94066c7-efe4-47e9-ba88-9d994d00a666</Id>
     </Book>
-    <Book Series="Friendly Neighborhood Spider-Man" Number="5" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Friendly Neighborhood Spider-Man" Number="5" Volume="2005" Year="2006">
       <Id>c2a32dee-480a-45c3-acb4-be806ca013b6</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="27" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="27" Volume="2006" Year="2006">
       <Id>e7e869a1-c54b-4163-bfa2-4a5c0fe60fb3</Id>
     </Book>
-    <Book Series="Friendly Neighborhood Spider-Man" Number="6" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Friendly Neighborhood Spider-Man" Number="6" Volume="2005" Year="2006">
       <Id>423354c0-b83b-4411-b70d-ede5c79de0e6</Id>
     </Book>
-    <Book Series="Friendly Neighborhood Spider-Man" Number="7" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Friendly Neighborhood Spider-Man" Number="7" Volume="2005" Year="2006">
       <Id>c0143696-529d-4f76-b4d6-65366d379db7</Id>
     </Book>
-    <Book Series="Friendly Neighborhood Spider-Man" Number="8" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Friendly Neighborhood Spider-Man" Number="8" Volume="2005" Year="2006">
       <Id>99ee9458-3f0c-496d-a20d-9877440002c9</Id>
     </Book>
-    <Book Series="Friendly Neighborhood Spider-Man" Number="9" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Friendly Neighborhood Spider-Man" Number="9" Volume="2005" Year="2006">
       <Id>b2d71c25-94a3-4321-9c9f-c23bf7376538</Id>
     </Book>
-    <Book Series="Friendly Neighborhood Spider-Man" Number="10" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Friendly Neighborhood Spider-Man" Number="10" Volume="2005" Year="2006">
       <Id>e155a99c-3778-4bfa-9473-b20fdee6e5f6</Id>
     </Book>
-    <Book Series="Spider-Man Unlimited" Number="15" Volume="2004" Year="2006" Format="Main Series">
+    <Book Series="Spider-Man Unlimited" Number="15" Volume="2004" Year="2006">
       <Id>85f879cd-2dd1-4658-92b4-d0e9566a6ca4</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="21" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="21" Volume="2005" Year="2006">
       <Id>dbfc6fa3-374c-49ee-814a-8c947411c979</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="23" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="23" Volume="2005" Year="2006">
       <Id>cc38b024-6504-40cb-9dc3-28637bdd31ee</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="24" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="24" Volume="2005" Year="2006">
       <Id>fa92241e-609d-4afc-976d-984fcc578b67</Id>
     </Book>
-    <Book Series="Marvel Team-Up" Number="25" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Marvel Team-Up" Number="25" Volume="2005" Year="2006">
       <Id>a4154efc-d041-4acb-b2fe-051f67ed328b</Id>
     </Book>
-    <Book Series="The New Avengers: Illuminati" Number="1" Volume="2006" Year="2006" Format="One-Shot">
+    <Book Series="The New Avengers: Illuminati" Number="1" Volume="2006" Year="2006">
       <Id>c570c47d-1e2a-4a69-b920-0724f45b327b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="530" Volume="1963" Year="2006" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="530" Volume="1963" Year="2006">
       <Id>03870ffb-2756-4850-9253-767f5815d1d2</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="531" Volume="1963" Year="2006" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="531" Volume="1963" Year="2006">
       <Id>66096e78-c880-4645-acce-e441aa60ea9f</Id>
     </Book>
-    <Book Series="Civil War" Number="1" Volume="2006" Year="2006" Format="Crossover">
+    <Book Series="Civil War" Number="1" Volume="2006" Year="2006">
       <Id>8a3b618d-9877-4c00-8d7f-48d65f4599dd</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="532" Volume="1963" Year="2006" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="532" Volume="1963" Year="2006">
       <Id>fff45c3f-16f7-495c-8291-29a0a47ccbae</Id>
     </Book>
-    <Book Series="Civil War: Front Line" Number="1" Volume="2006" Year="2006" Format="Crossover">
+    <Book Series="Civil War: Front Line" Number="1" Volume="2006" Year="2006">
       <Id>cd22c5a3-d863-4530-b142-fbae9c5806c9</Id>
     </Book>
-    <Book Series="Civil War" Number="2" Volume="2006" Year="2006" Format="Crossover">
+    <Book Series="Civil War" Number="2" Volume="2006" Year="2006">
       <Id>346dc7b4-7523-40ae-8fab-1df067deffd5</Id>
     </Book>
-    <Book Series="Civil War: Front Line" Number="2" Volume="2006" Year="2006" Format="Crossover">
+    <Book Series="Civil War: Front Line" Number="2" Volume="2006" Year="2006">
       <Id>ba9f315b-91e3-4cb0-84c4-99b0a5c29be0</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="533" Volume="1963" Year="2006" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="533" Volume="1963" Year="2006">
       <Id>f648f5dc-5c3c-49a7-92f1-0c1cadb99642</Id>
     </Book>
-    <Book Series="New Avengers" Number="21" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="New Avengers" Number="21" Volume="2005" Year="2006">
       <Id>328d71db-57d3-4fbf-ad73-1fa7fbfd9283</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="28" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="28" Volume="2006" Year="2006">
       <Id>dcddadb1-20d5-4258-b147-158a636ff213</Id>
     </Book>
-    <Book Series="Friendly Neighborhood Spider-Man" Number="11" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Friendly Neighborhood Spider-Man" Number="11" Volume="2005" Year="2006">
       <Id>5f94429d-f677-4bfa-89fe-4943bd7dd06f</Id>
     </Book>
-    <Book Series="Friendly Neighborhood Spider-Man" Number="12" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Friendly Neighborhood Spider-Man" Number="12" Volume="2005" Year="2006">
       <Id>f5f835fd-f0d8-4143-bec8-10e4f5706ce7</Id>
     </Book>
-    <Book Series="Friendly Neighborhood Spider-Man" Number="13" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Friendly Neighborhood Spider-Man" Number="13" Volume="2005" Year="2006">
       <Id>b6291025-79b8-4ad2-a1b2-42ce1672bd0c</Id>
     </Book>
-    <Book Series="New Avengers" Number="22" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="New Avengers" Number="22" Volume="2005" Year="2006">
       <Id>1148e8d3-c96e-4b35-b3fa-35a948ddb78b</Id>
     </Book>
-    <Book Series="Daily Bugle Civil War Newspaper Special" Number="1" Volume="2006" Year="2006" Format="One-Shot">
+    <Book Series="Daily Bugle Civil War Newspaper Special" Number="1" Volume="2006" Year="2006">
       <Id>17744c60-ac63-4b68-968a-c2fdb12ae8e9</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="29" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="29" Volume="2006" Year="2006">
       <Id>0a370035-81c4-4fd2-84ac-10baa4fa3a26</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="30" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="30" Volume="2006" Year="2006">
       <Id>5e8b8745-94cb-4031-81f7-625822fe226c</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="31" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="31" Volume="2006" Year="2006">
       <Id>5440f7dc-5d6c-4ddc-93e5-ce6e5527b2af</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="534" Volume="1963" Year="2006" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="534" Volume="1963" Year="2006">
       <Id>da9731ee-c8e1-4588-9963-15f893e74586</Id>
     </Book>
-    <Book Series="Civil War: Front Line" Number="5" Volume="2006" Year="2006" Format="Crossover">
+    <Book Series="Civil War: Front Line" Number="5" Volume="2006" Year="2006">
       <Id>aef98b49-0889-4851-8504-3e18c4a9fe9b</Id>
     </Book>
-    <Book Series="New Avengers" Number="23" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="New Avengers" Number="23" Volume="2005" Year="2006">
       <Id>7eafbb88-ec73-4b92-9db3-f44900790c97</Id>
     </Book>
-    <Book Series="Civil War" Number="3" Volume="2006" Year="2006" Format="Crossover">
+    <Book Series="Civil War" Number="3" Volume="2006" Year="2006">
       <Id>7bbd5df4-e746-40d8-9ad1-b135c26c0c20</Id>
     </Book>
-    <Book Series="Civil War" Number="4" Volume="2006" Year="2006" Format="Crossover">
+    <Book Series="Civil War" Number="4" Volume="2006" Year="2006">
       <Id>4ed27e2e-d39c-4e8e-9dd6-ef44419ec683</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="535" Volume="1963" Year="2006" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="535" Volume="1963" Year="2006">
       <Id>1a779dad-42ee-4c4d-ad03-4cb218b0e8ac</Id>
     </Book>
-    <Book Series="New Avengers" Number="24" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="New Avengers" Number="24" Volume="2005" Year="2006">
       <Id>7cd9b1ee-2992-4f7d-8145-c7a502dbeede</Id>
     </Book>
-    <Book Series="Civil War" Number="5" Volume="2006" Year="2006" Format="Crossover">
+    <Book Series="Civil War" Number="5" Volume="2006" Year="2006">
       <Id>52958b4a-aa5d-4429-b844-9ca8c0ba5b02</Id>
     </Book>
-    <Book Series="New Avengers" Number="25" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="New Avengers" Number="25" Volume="2005" Year="2006">
       <Id>82492437-4ce2-4322-a622-d5a9e61f60e3</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="536" Volume="1963" Year="2006" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="536" Volume="1963" Year="2006">
       <Id>927f1dc6-ce2b-492e-8c93-7c247cf5f7f6</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="32" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="32" Volume="2006" Year="2007">
       <Id>179b7573-0707-4e7b-8cd7-af9af5e55a5c</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="33" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="33" Volume="2006" Year="2007">
       <Id>a220952f-4231-429b-8acc-d242853f4eb1</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="34" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="34" Volume="2006" Year="2007">
       <Id>3bd0c32a-f185-4825-abb9-b3930ccb8102</Id>
     </Book>
-    <Book Series="Iron Man" Number="14" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Iron Man" Number="14" Volume="2005" Year="2007">
       <Id>d00ceeeb-fc0a-4f23-94f8-2532e262e853</Id>
     </Book>
-    <Book Series="Friendly Neighborhood Spider-Man" Number="14" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Friendly Neighborhood Spider-Man" Number="14" Volume="2005" Year="2006">
       <Id>c074c2bc-fd86-46d5-8cd9-81d2bd76b221</Id>
     </Book>
-    <Book Series="Friendly Neighborhood Spider-Man" Number="15" Volume="2005" Year="2006" Format="Main Series">
+    <Book Series="Friendly Neighborhood Spider-Man" Number="15" Volume="2005" Year="2006">
       <Id>c13b5adf-40fb-4b2c-bda6-e498fa6438ab</Id>
     </Book>
-    <Book Series="Friendly Neighborhood Spider-Man" Number="16" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Friendly Neighborhood Spider-Man" Number="16" Volume="2005" Year="2007">
       <Id>90899941-9fbb-4c81-b0a2-51b73d3fd1ef</Id>
     </Book>
-    <Book Series="Civil War: Front Line" Number="9" Volume="2006" Year="2007" Format="Crossover">
+    <Book Series="Civil War: Front Line" Number="9" Volume="2006" Year="2007">
       <Id>38793c2d-3b29-4c86-9120-b933f8bb41ac</Id>
     </Book>
-    <Book Series="Civil War" Number="6" Volume="2006" Year="2006" Format="Crossover">
+    <Book Series="Civil War" Number="6" Volume="2006" Year="2006">
       <Id>72de0c39-09f3-43a0-93dd-5d35d3c409c5</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="537" Volume="1963" Year="2007" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="537" Volume="1963" Year="2007">
       <Id>c96e60b4-e5d8-43e2-8dcb-301cb38d72c4</Id>
     </Book>
-    <Book Series="Civil War" Number="7" Volume="2006" Year="2007" Format="Crossover">
+    <Book Series="Civil War" Number="7" Volume="2006" Year="2007">
       <Id>88a586c8-129f-4c95-af85-aeff87628b25</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="538" Volume="1963" Year="2007" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="538" Volume="1963" Year="2007">
       <Id>da824c2a-8d66-4b73-82ce-88f80584b337</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="539" Volume="1963" Year="2007" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="539" Volume="1963" Year="2007">
       <Id>9063cb75-e340-44b0-a0d1-f118e5bec8f3</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="540" Volume="1963" Year="2007" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="540" Volume="1963" Year="2007">
       <Id>6101c08b-e826-45da-867b-4e8f9329ff74</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="541" Volume="1963" Year="2007" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="541" Volume="1963" Year="2007">
       <Id>d267075b-0416-4e5f-a5d8-71300511af37</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="542" Volume="1963" Year="2007" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="542" Volume="1963" Year="2007">
       <Id>1da03b6d-1590-44fb-8af2-05d2e02d047d</Id>
     </Book>
-    <Book Series="Civil War: Front Line" Number="11" Volume="2006" Year="2007" Format="Crossover">
+    <Book Series="Civil War: Front Line" Number="11" Volume="2006" Year="2007">
       <Id>d0372caf-6dd7-4e0d-96d6-9c32a63870c4</Id>
     </Book>
-    <Book Series="Friendly Neighborhood Spider-Man" Number="17" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Friendly Neighborhood Spider-Man" Number="17" Volume="2005" Year="2007">
       <Id>58e0ec56-6c7e-4752-9d1c-b52f0d18ed1e</Id>
     </Book>
-    <Book Series="Friendly Neighborhood Spider-Man" Number="18" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Friendly Neighborhood Spider-Man" Number="18" Volume="2005" Year="2007">
       <Id>46eba842-8ab2-49cd-acae-72da5440f3b7</Id>
     </Book>
-    <Book Series="Friendly Neighborhood Spider-Man" Number="19" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Friendly Neighborhood Spider-Man" Number="19" Volume="2005" Year="2007">
       <Id>d733979b-9d5f-448d-a1fe-05a1d9e0c7db</Id>
     </Book>
-    <Book Series="Friendly Neighborhood Spider-Man" Number="20" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Friendly Neighborhood Spider-Man" Number="20" Volume="2005" Year="2007">
       <Id>49f38bdc-30be-4980-a8cb-68e0ffdab45d</Id>
     </Book>
-    <Book Series="Friendly Neighborhood Spider-Man" Number="21" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Friendly Neighborhood Spider-Man" Number="21" Volume="2005" Year="2007">
       <Id>14fd9913-6cc4-41b4-a969-751caa21dbbd</Id>
     </Book>
-    <Book Series="Friendly Neighborhood Spider-Man" Number="22" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Friendly Neighborhood Spider-Man" Number="22" Volume="2005" Year="2007">
       <Id>d6cd089e-1b4c-4f73-9a1e-e01a052e9bde</Id>
     </Book>
-    <Book Series="Friendly Neighborhood Spider-Man" Number="23" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Friendly Neighborhood Spider-Man" Number="23" Volume="2005" Year="2007">
       <Id>3b3e1b19-e2d3-4312-bb03-0cfb62bedbee</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="35" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="35" Volume="2006" Year="2007">
       <Id>0f2c308e-cddd-4e4b-8617-60546baa5f71</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="36" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="36" Volume="2006" Year="2007">
       <Id>4f1c5b6c-116e-4908-8b32-6d3be591e850</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="37" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="37" Volume="2006" Year="2007">
       <Id>080d0fe1-eea8-4de7-a012-aeb0f6f99e10</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man Annual" Number="1" Volume="2007" Year="2007" Format="Annual">
+    <Book Series="The Sensational Spider-Man Annual" Number="1" Volume="2007" Year="2007">
       <Id>6b6477bf-5cb3-4e32-8561-03a9f36fd649</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="38" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="38" Volume="2006" Year="2007">
       <Id>86ee4358-9917-41bb-90a8-3021a20dcfa8</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="39" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="39" Volume="2006" Year="2007">
       <Id>6fbd9ab4-c34d-47ee-8c49-259001fee0c0</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="40" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="40" Volume="2006" Year="2007">
       <Id>f7c234c0-ad78-4e8a-9d6a-82ee6075a015</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="543" Volume="1963" Year="2007" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="543" Volume="1963" Year="2007">
       <Id>741af43f-a525-4c47-9540-7fb56269eeee</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="544" Volume="1963" Year="2007" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="544" Volume="1963" Year="2007">
       <Id>7be85246-361e-4c6a-9125-d0562cf6cfd1</Id>
     </Book>
-    <Book Series="Friendly Neighborhood Spider-Man" Number="24" Volume="2005" Year="2007" Format="Main Series">
+    <Book Series="Friendly Neighborhood Spider-Man" Number="24" Volume="2005" Year="2007">
       <Id>23939b74-f709-448a-a677-62b54f337363</Id>
     </Book>
-    <Book Series="The Sensational Spider-Man" Number="41" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="The Sensational Spider-Man" Number="41" Volume="2006" Year="2007">
       <Id>df8a3076-9608-4a70-8b90-8a244ce84a0a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="545" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="545" Volume="1963" Year="2008">
       <Id>c9917d64-7411-496f-8eef-10613df03d70</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Spider-Man/Spider-Man 008 (Brand New Day).cbl
+++ b/Marvel/Characters/unsorted/Spider-Man/Spider-Man 008 (Brand New Day).cbl
@@ -1,870 +1,874 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Spider-Man 8 (Brand New Day)</Name>
+  <Name>Spider-Man 008 (Brand New Day)</Name>
+  <NumIssues>289</NumIssues>
   <Books>
     <Book Series="The Amazing Spider-Man" Number="546" Volume="1963" Year="2008">
-      <Id>be04b4b9-b2ad-4751-926a-4eda4b6381d3</Id>
+      <Database Name="cv" Series="2127" Issue="121086" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="547" Volume="1963" Year="2008">
-      <Id>886ec694-1fdc-4ed4-873a-3319d66fed69</Id>
+      <Database Name="cv" Series="2127" Issue="121612" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="548" Volume="1963" Year="2008">
-      <Id>9161f55e-7900-4369-87ad-c5759d437b1e</Id>
+      <Database Name="cv" Series="2127" Issue="121883" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="549" Volume="1963" Year="2008">
-      <Id>1ae58e9a-36bc-4488-bcec-0150f096982a</Id>
+      <Database Name="cv" Series="2127" Issue="122408" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="550" Volume="1963" Year="2008">
-      <Id>78f0d688-fb81-4280-97f9-49ebec71ca4b</Id>
+      <Database Name="cv" Series="2127" Issue="122778" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="551" Volume="1963" Year="2008">
-      <Id>f157ab8d-1ebf-41f2-8d8b-d7aa02edb881</Id>
+      <Database Name="cv" Series="2127" Issue="123372" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="552" Volume="1963" Year="2008">
-      <Id>8d2bdc44-f5e3-48a3-ad06-fc889167cf84</Id>
+      <Database Name="cv" Series="2127" Issue="124674" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="553" Volume="1963" Year="2008">
-      <Id>6509fbce-3a40-447e-a128-454d8d1c1d8e</Id>
+      <Database Name="cv" Series="2127" Issue="125190" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="554" Volume="1963" Year="2008">
-      <Id>361393c2-bff8-4b2e-8fc3-aebc4b4f1cb4</Id>
+      <Database Name="cv" Series="2127" Issue="125665" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="555" Volume="1963" Year="2008">
-      <Id>0c2ef7e2-22a0-4f2c-a24f-454bf3e9bbef</Id>
+      <Database Name="cv" Series="2127" Issue="126383" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="556" Volume="1963" Year="2008">
-      <Id>db720284-730c-4292-9c0f-d729452095a2</Id>
+      <Database Name="cv" Series="2127" Issue="127108" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="557" Volume="1963" Year="2008">
-      <Id>2ae5c60d-f799-44c1-8cda-bc89c936dcb0</Id>
+      <Database Name="cv" Series="2127" Issue="127548" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="558" Volume="1963" Year="2008">
-      <Id>d75b4e5a-c479-4cb6-8bcd-a41ce1471dde</Id>
+      <Database Name="cv" Series="2127" Issue="129657" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="559" Volume="1963" Year="2008">
-      <Id>d0915c23-e681-4ccf-bde6-7f8c424efa97</Id>
+      <Database Name="cv" Series="2127" Issue="130329" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="560" Volume="1963" Year="2008">
-      <Id>536fb3e6-0d45-443b-9fd6-ad055ffb73e2</Id>
+      <Database Name="cv" Series="2127" Issue="130591" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="561" Volume="1963" Year="2008">
-      <Id>915277c9-1a5f-4418-a29d-0069606be54a</Id>
+      <Database Name="cv" Series="2127" Issue="131321" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="562" Volume="1963" Year="2008">
-      <Id>94079b23-2050-4aed-b453-34a167807dc4</Id>
+      <Database Name="cv" Series="2127" Issue="131395" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="563" Volume="1963" Year="2008">
-      <Id>aa4c9f23-4350-46e6-ab04-f14e4829c7b9</Id>
+      <Database Name="cv" Series="2127" Issue="131511" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="564" Volume="1963" Year="2008">
-      <Id>01383922-8100-4e04-b21d-3025d1b98a06</Id>
+      <Database Name="cv" Series="2127" Issue="132217" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="565" Volume="1963" Year="2008">
-      <Id>40f5d555-1791-48e7-97f2-baa4e65608a2</Id>
+      <Database Name="cv" Series="2127" Issue="132937" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="566" Volume="1963" Year="2008">
-      <Id>e35bc660-fc4c-424c-8406-ceff27d165e2</Id>
+      <Database Name="cv" Series="2127" Issue="133680" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="567" Volume="1963" Year="2008">
-      <Id>7e7c508e-fb6e-4dd8-b395-051d12349a9c</Id>
+      <Database Name="cv" Series="2127" Issue="135454" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="568" Volume="1963" Year="2008">
-      <Id>b26531da-71be-496a-a9e5-0e321556c7c0</Id>
+      <Database Name="cv" Series="2127" Issue="136022" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="569" Volume="1963" Year="2008">
-      <Id>295db83f-79ea-4409-9a36-898c258414bd</Id>
+      <Database Name="cv" Series="2127" Issue="136526" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="570" Volume="1963" Year="2008">
-      <Id>96667641-c3ec-4a8e-8ae2-81d1ffa115f6</Id>
+      <Database Name="cv" Series="2127" Issue="137326" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="571" Volume="1963" Year="2008">
-      <Id>d4e04faa-e5dc-48cc-b0ed-ad37d6d88bb5</Id>
+      <Database Name="cv" Series="2127" Issue="138255" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="572" Volume="1963" Year="2008">
-      <Id>49eba1da-284c-4ed3-a032-fcbc2c9a3268</Id>
+      <Database Name="cv" Series="2127" Issue="139000" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="573" Volume="1963" Year="2008">
-      <Id>59ec502b-fdb9-47ba-b854-d1035dbbe839</Id>
+      <Database Name="cv" Series="2127" Issue="140465" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="574" Volume="1963" Year="2008">
-      <Id>1bcd764f-a9c5-4a24-b447-6b20e658ad2c</Id>
+      <Database Name="cv" Series="2127" Issue="140880" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="575" Volume="1963" Year="2008">
-      <Id>725dfca5-a2f4-42d3-a311-97b39ea7b4cb</Id>
+      <Database Name="cv" Series="2127" Issue="141332" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="576" Volume="1963" Year="2009">
-      <Id>5da2a130-6d60-4a69-bca1-c6e63e62eb0e</Id>
+      <Database Name="cv" Series="2127" Issue="141535" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="577" Volume="1963" Year="2009">
-      <Id>fd6c1aa1-b00b-431e-9746-8aa73c7b9a9a</Id>
+      <Database Name="cv" Series="2127" Issue="141999" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="578" Volume="1963" Year="2009">
-      <Id>bd21d06f-18cf-422c-8c6e-72caa3d28e15</Id>
+      <Database Name="cv" Series="2127" Issue="142594" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="579" Volume="1963" Year="2009">
-      <Id>1cebe483-18ff-4bcd-ae48-ba0d61dd8707</Id>
+      <Database Name="cv" Series="2127" Issue="144365" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="580" Volume="1963" Year="2009">
-      <Id>d3eebeeb-3d2d-41aa-b646-9d83d18e0841</Id>
+      <Database Name="cv" Series="2127" Issue="145545" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="581" Volume="1963" Year="2009">
-      <Id>eaf729e4-5d14-4b53-8ab0-c9a69369f6bc</Id>
+      <Database Name="cv" Series="2127" Issue="147327" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="582" Volume="1963" Year="2009">
-      <Id>cade63c3-27d7-4234-9a0d-eb036e8b4cae</Id>
+      <Database Name="cv" Series="2127" Issue="149803" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="583" Volume="1963" Year="2009">
-      <Id>fe3e5dad-f452-4086-a0a6-5948a59c2b32</Id>
+      <Database Name="cv" Series="2127" Issue="149908" />
     </Book>
-    <Book Series="New Avengers" Number="38" Volume="2005" Year="2008">
-      <Id>fa9bf6a4-7535-4a46-860d-30669710bd31</Id>
+    <Book Series="New Avengers" Number="38" Volume="2004" Year="2008">
+      <Database Name="cv" Series="11497" Issue="122774" />
     </Book>
     <Book Series="Secret Invasion Director's Cut" Number="1" Volume="2008" Year="2008">
-      <Id>6a2d34ba-8a32-4b2b-977b-2aacc2692b31</Id>
+      <Database Name="cv" Series="22284" Issue="134003" />
     </Book>
-    <Book Series="New Avengers" Number="41" Volume="2005" Year="2008">
-      <Id>903ec34b-c16c-497d-aa79-c0bf437bdd32</Id>
+    <Book Series="New Avengers" Number="41" Volume="2004" Year="2008">
+      <Database Name="cv" Series="11497" Issue="130973" />
     </Book>
     <Book Series="Secret Invasion" Number="2" Volume="2008" Year="2008">
-      <Id>7ee44784-000e-4c8d-9bd0-8ae2704a66fb</Id>
+      <Database Name="cv" Series="21076" Issue="129598" />
     </Book>
-    <Book Series="New Avengers" Number="42" Volume="2005" Year="2008">
-      <Id>2ad056ba-ff0e-47c0-8b77-1b3fc47c387d</Id>
+    <Book Series="New Avengers" Number="42" Volume="2004" Year="2008">
+      <Database Name="cv" Series="11497" Issue="131808" />
     </Book>
     <Book Series="Secret Invasion: The Amazing Spider-Man" Number="1" Volume="2008" Year="2008">
-      <Id>e3a2c89b-379c-422b-aaff-48a06ed09ccf</Id>
+      <Database Name="cv" Series="22769" Issue="136594" />
     </Book>
     <Book Series="Secret Invasion: The Amazing Spider-Man" Number="2" Volume="2008" Year="2008">
-      <Id>d616f319-927f-46fc-b26b-3de849b515ad</Id>
+      <Database Name="cv" Series="22769" Issue="139385" />
     </Book>
     <Book Series="Secret Invasion: The Amazing Spider-Man" Number="3" Volume="2008" Year="2008">
-      <Id>e2322ece-5de9-41a5-a93b-34b853e0dbd7</Id>
+      <Database Name="cv" Series="22769" Issue="140827" />
     </Book>
     <Book Series="Secret Invasion" Number="3" Volume="2008" Year="2008">
-      <Id>7d646eac-8160-49db-8771-c6fc261fa833</Id>
+      <Database Name="cv" Series="21076" Issue="131297" />
     </Book>
-    <Book Series="New Avengers" Number="43" Volume="2005" Year="2008">
-      <Id>37941224-7445-4935-bf2b-3b2fe0ee311c</Id>
+    <Book Series="New Avengers" Number="43" Volume="2004" Year="2008">
+      <Database Name="cv" Series="11497" Issue="134066" />
     </Book>
     <Book Series="Secret Invasion" Number="4" Volume="2008" Year="2008">
-      <Id>6c6eca88-3515-4f4f-9834-1d97d64355d1</Id>
+      <Database Name="cv" Series="21076" Issue="132926" />
     </Book>
-    <Book Series="New Avengers" Number="44" Volume="2005" Year="2008">
-      <Id>93707050-947c-41d9-8e2b-04e2b0a39114</Id>
+    <Book Series="New Avengers" Number="44" Volume="2004" Year="2008">
+      <Database Name="cv" Series="11497" Issue="136523" />
     </Book>
     <Book Series="Secret Invasion" Number="5" Volume="2008" Year="2008">
-      <Id>6d8808bf-b64d-4b12-b16d-e034d833bafd</Id>
+      <Database Name="cv" Series="21076" Issue="135430" />
     </Book>
-    <Book Series="New Avengers" Number="45" Volume="2005" Year="2008">
-      <Id>d85bf06d-46e2-4a59-821b-bc95b50a466f</Id>
+    <Book Series="New Avengers" Number="45" Volume="2004" Year="2008">
+      <Database Name="cv" Series="11497" Issue="139334" />
     </Book>
     <Book Series="Secret Invasion" Number="6" Volume="2008" Year="2008">
-      <Id>cf384a0e-69b1-4743-b7ae-2e49bcd3b887</Id>
+      <Database Name="cv" Series="21076" Issue="138234" />
     </Book>
-    <Book Series="New Avengers" Number="46" Volume="2005" Year="2008">
-      <Id>afc9673d-7e38-4eea-8617-db42c5c35f9c</Id>
+    <Book Series="New Avengers" Number="46" Volume="2004" Year="2008">
+      <Database Name="cv" Series="11497" Issue="140897" />
     </Book>
     <Book Series="Secret Invasion: Front Line" Number="4" Volume="2008" Year="2008">
-      <Id>56f756c5-6180-47f9-872c-ada0cc2a2f3b</Id>
+      <Database Name="cv" Series="21928" Issue="140549" />
     </Book>
     <Book Series="Secret Invasion" Number="7" Volume="2008" Year="2008">
-      <Id>aed9b2a9-a77c-4c71-8abe-beb2d207326a</Id>
+      <Database Name="cv" Series="21076" Issue="140851" />
     </Book>
-    <Book Series="New Avengers" Number="47" Volume="2005" Year="2009">
-      <Id>d57d1d25-a48f-4a4b-ba5a-1d12e1fdb5ff</Id>
+    <Book Series="New Avengers" Number="47" Volume="2004" Year="2009">
+      <Database Name="cv" Series="11497" Issue="144345" />
     </Book>
     <Book Series="Secret Invasion" Number="8" Volume="2008" Year="2009">
-      <Id>02491013-82d8-4f8b-8748-10994aa8426e</Id>
+      <Database Name="cv" Series="21076" Issue="144233" />
     </Book>
     <Book Series="Secret Invasion: Front Line" Number="5" Volume="2008" Year="2009">
-      <Id>3de22add-397b-4a51-ba27-b005cc586b73</Id>
+      <Database Name="cv" Series="21928" Issue="144346" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="35" Volume="1964" Year="2008">
-      <Id>594a0206-ce67-4394-9453-120d764fff42</Id>
+      <Database Name="cv" Series="2189" Issue="163390" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="584" Volume="1963" Year="2009">
-      <Id>7b04bf20-0797-4564-a539-5cdb6ad6077d</Id>
+      <Database Name="cv" Series="2127" Issue="150515" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="585" Volume="1963" Year="2009">
-      <Id>140ab584-a402-4048-be02-a6d973ff8756</Id>
+      <Database Name="cv" Series="2127" Issue="151129" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="586" Volume="1963" Year="2009">
-      <Id>e1155ec8-0b49-4147-ac7e-508d9ba48bce</Id>
+      <Database Name="cv" Series="2127" Issue="151826" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="587" Volume="1963" Year="2009">
-      <Id>5fa2e77b-e535-4298-a1f9-4113692d4844</Id>
+      <Database Name="cv" Series="2127" Issue="152231" />
     </Book>
     <Book Series="The Amazing Spider-Man:  EXTRA!" Number="1" Volume="2008" Year="2008">
-      <Id>c82676dd-9376-46f6-9aea-9f8f652aa909</Id>
+      <Database Name="cv" Series="22405" Issue="134597" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="588" Volume="1963" Year="2009">
-      <Id>e5edc858-b0a4-4046-aeab-e8bfe98cfaba</Id>
+      <Database Name="cv" Series="2127" Issue="153667" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="589" Volume="1963" Year="2009">
-      <Id>ddacaca2-0d39-48b6-83de-0fcd6a0e9df0</Id>
+      <Database Name="cv" Series="2127" Issue="153955" />
     </Book>
     <Book Series="The Amazing Spider-Man:  EXTRA!" Number="3" Volume="2008" Year="2009">
-      <Id>0bed10b6-2237-4094-8a86-1f13e92194ea</Id>
+      <Database Name="cv" Series="22405" Issue="153668" />
     </Book>
-    <Book Series="Spider-Man &amp; The Human Torch In... Bahia De Los Muertos!" Number="1" Volume="2009" Year="2009">
-      <Id>7a866409-8338-49da-aa53-bc94580f5af0</Id>
+    <Book Series="Spider-Man &#38; The Human Torch In... Bahia De Los Muertos!" Number="1" Volume="2009" Year="2009">
+      <Database Name="cv" Series="26034" Issue="153874" />
     </Book>
     <Book Series="The Amazing Spider-Man:  EXTRA!" Number="2" Volume="2008" Year="2009">
-      <Id>20a50949-74ab-485f-9945-c023784b6882</Id>
+      <Database Name="cv" Series="22405" Issue="150767" />
     </Book>
     <Book Series="Timestorm 2009/2099" Number="1" Volume="2009" Year="2009">
-      <Id>c20e2228-c222-4b2b-a13d-ee053c89e456</Id>
+      <Database Name="cv" Series="26163" Issue="155239" />
     </Book>
     <Book Series="Timestorm 2009/2099" Number="2" Volume="2009" Year="2009">
-      <Id>866c3ed0-3b3c-4bf9-9fca-2e1552117f38</Id>
+      <Database Name="cv" Series="26163" Issue="157769" />
     </Book>
     <Book Series="Timestorm 2009/2099: Spider-Man One-Shot" Number="1" Volume="2009" Year="2009">
-      <Id>fa68e309-97c3-47c9-a4fb-7d91845f9d43</Id>
+      <Database Name="cv" Series="26633" Issue="159389" />
     </Book>
     <Book Series="Timestorm 2009/2099" Number="3" Volume="2009" Year="2009">
-      <Id>e232a55c-9d0c-4361-833b-d4e69b6c7b13</Id>
+      <Database Name="cv" Series="26163" Issue="164067" />
     </Book>
     <Book Series="Timestorm 2009/2099" Number="4" Volume="2009" Year="2009">
-      <Id>83708294-23f1-4f36-a2c8-afb0ae72e2a2</Id>
+      <Database Name="cv" Series="26163" Issue="168315" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="590" Volume="1963" Year="2009">
-      <Id>3e35fab4-96ed-4aee-99e0-8316a850cd30</Id>
+      <Database Name="cv" Series="2127" Issue="154426" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="591" Volume="1963" Year="2009">
-      <Id>32a38227-06e4-4112-b0e5-d7c69daa0a1d</Id>
+      <Database Name="cv" Series="2127" Issue="155455" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="592" Volume="1963" Year="2009">
-      <Id>8c670784-9ecd-45b5-ae60-f80c320161cb</Id>
+      <Database Name="cv" Series="2127" Issue="155748" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="593" Volume="1963" Year="2009">
-      <Id>2fd9a886-dc88-459a-893a-ccd261bd852f</Id>
+      <Database Name="cv" Series="2127" Issue="156678" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="594" Volume="1963" Year="2009">
-      <Id>2d94486a-f952-488a-b218-29f441b2b458</Id>
+      <Database Name="cv" Series="2127" Issue="157778" />
     </Book>
     <Book Series="Dark Reign: Mister Negative" Number="1" Volume="2009" Year="2009">
-      <Id>fe6c6f58-b662-443a-b909-7e6e3d836c7a</Id>
+      <Database Name="cv" Series="26766" Issue="160540" />
     </Book>
     <Book Series="Dark Reign: Mister Negative" Number="2" Volume="2009" Year="2009">
-      <Id>6b17f2f0-0620-4b78-a810-04b2845a36af</Id>
+      <Database Name="cv" Series="26766" Issue="164128" />
     </Book>
     <Book Series="Dark Reign: Mister Negative" Number="3" Volume="2009" Year="2009">
-      <Id>2ef0d2b1-61de-434b-b890-b146a3649fcf</Id>
+      <Database Name="cv" Series="26766" Issue="167442" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="595" Volume="1963" Year="2009">
-      <Id>29dbb757-af88-4c37-8f65-3d0bd0e7df29</Id>
+      <Database Name="cv" Series="2127" Issue="158802" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="596" Volume="1963" Year="2009">
-      <Id>a99ea7ec-30b2-4794-9ce8-854eb19d33f6</Id>
+      <Database Name="cv" Series="2127" Issue="159240" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="597" Volume="1963" Year="2009">
-      <Id>b1c0cb45-31a8-44ef-ad0b-516625be849c</Id>
+      <Database Name="cv" Series="2127" Issue="159759" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="598" Volume="1963" Year="2009">
-      <Id>611f5474-7abd-4666-a67a-9ac211766ab3</Id>
+      <Database Name="cv" Series="2127" Issue="161499" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="599" Volume="1963" Year="2009">
-      <Id>f70c448d-1523-4a33-8a5f-6ed5061c1d9d</Id>
+      <Database Name="cv" Series="2127" Issue="164006" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="36" Volume="1964" Year="2009">
-      <Id>7132d1c3-c6f4-44fa-b06c-f46fa0e7cb44</Id>
+      <Database Name="cv" Series="2189" Issue="163378" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="600" Volume="1963" Year="2009">
-      <Id>a841fe12-053b-454c-81b2-b6c6e20da065</Id>
+      <Database Name="cv" Series="2127" Issue="164777" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="601" Volume="1963" Year="2009">
-      <Id>1e58467a-0cd3-4620-aefa-f3666f01e653</Id>
+      <Database Name="cv" Series="2127" Issue="166136" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="602" Volume="1963" Year="2009">
-      <Id>b2d10213-d496-4ad5-9893-b85b463f7030</Id>
+      <Database Name="cv" Series="2127" Issue="166792" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="603" Volume="1963" Year="2009">
-      <Id>a13d1625-8530-4e9a-bba6-6dcad0035e95</Id>
+      <Database Name="cv" Series="2127" Issue="167368" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="604" Volume="1963" Year="2009">
-      <Id>07ef96ce-cf6a-40fa-9133-7ade503aa498</Id>
+      <Database Name="cv" Series="2127" Issue="170719" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="605" Volume="1963" Year="2009">
-      <Id>2d757bd3-e099-406b-9ccc-d8dce00d479a</Id>
+      <Database Name="cv" Series="2127" Issue="171645" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="606" Volume="1963" Year="2009">
-      <Id>81ee951e-6ea9-494c-9d29-b9cc5142591d</Id>
+      <Database Name="cv" Series="2127" Issue="172378" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="607" Volume="1963" Year="2009">
-      <Id>29b089f9-d38e-415e-ab1d-38275ae6c659</Id>
+      <Database Name="cv" Series="2127" Issue="173423" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="608" Volume="1963" Year="2009">
-      <Id>323a0b0c-8ddd-4560-9fd9-f9b02559dfd0</Id>
+      <Database Name="cv" Series="2127" Issue="174819" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="609" Volume="1963" Year="2009">
-      <Id>d04fa607-84df-4cc7-a80f-367b1765a294</Id>
+      <Database Name="cv" Series="2127" Issue="176838" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="610" Volume="1963" Year="2010">
-      <Id>62bb17c7-1a25-45e9-90a8-fdf7c4dd7703</Id>
+      <Database Name="cv" Series="2127" Issue="181081" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="611" Volume="1963" Year="2010">
-      <Id>5861c045-40b4-41c6-a951-2c3b52f471b5</Id>
+      <Database Name="cv" Series="2127" Issue="182579" />
     </Book>
     <Book Series="Siege" Number="1" Volume="2010" Year="2010">
-      <Id>b8d455d1-f26d-4ec6-b7fa-b9e895270a2e</Id>
+      <Database Name="cv" Series="30904" Issue="191146" />
     </Book>
-    <Book Series="New Avengers" Number="61" Volume="2005" Year="2010">
-      <Id>f60c2106-68ac-415c-a1b0-b0ed593e44d4</Id>
+    <Book Series="New Avengers" Number="61" Volume="2004" Year="2010">
+      <Database Name="cv" Series="11497" Issue="194421" />
     </Book>
-    <Book Series="New Avengers" Number="62" Volume="2005" Year="2010">
-      <Id>817ed059-3350-4890-bbbc-33648c4e47ca</Id>
+    <Book Series="New Avengers" Number="62" Volume="2004" Year="2010">
+      <Database Name="cv" Series="11497" Issue="198259" />
     </Book>
     <Book Series="Siege" Number="2" Volume="2010" Year="2010">
-      <Id>3cec930e-1c4f-415e-81cf-9ab2b7747c0d</Id>
+      <Database Name="cv" Series="30904" Issue="195362" />
     </Book>
     <Book Series="Siege" Number="3" Volume="2010" Year="2010">
-      <Id>68872873-40cf-405e-ae88-f88862ecea71</Id>
+      <Database Name="cv" Series="30904" Issue="200744" />
     </Book>
-    <Book Series="New Avengers" Number="63" Volume="2005" Year="2010">
-      <Id>a30c551c-a7c8-4e66-81c8-ac7b34ee1adf</Id>
+    <Book Series="New Avengers" Number="63" Volume="2004" Year="2010">
+      <Database Name="cv" Series="11497" Issue="201704" />
     </Book>
     <Book Series="Siege: Spider-Man" Number="1" Volume="2010" Year="2010">
-      <Id>7a46cc54-7bc5-475d-97c7-6d490df386d6</Id>
+      <Database Name="cv" Series="32661" Issue="208654" />
     </Book>
-    <Book Series="New Avengers" Number="64" Volume="2005" Year="2010">
-      <Id>3c466d20-8f24-4589-9335-31b4a919644f</Id>
+    <Book Series="New Avengers" Number="64" Volume="2004" Year="2010">
+      <Database Name="cv" Series="11497" Issue="210216" />
     </Book>
     <Book Series="Siege" Number="4" Volume="2010" Year="2010">
-      <Id>6ef76b9b-71f6-44a9-b828-75fc119e1796</Id>
+      <Database Name="cv" Series="30904" Issue="213449" />
     </Book>
     <Book Series="New Avengers Finale" Number="1" Volume="2010" Year="2010">
-      <Id>660e63f7-c392-4775-80cd-07749759010b</Id>
+      <Database Name="cv" Series="33091" Issue="213493" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="612" Volume="1963" Year="2010">
-      <Id>e561efea-2cde-4225-be8e-529821f880d9</Id>
+      <Database Name="cv" Series="2127" Issue="183671" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="613" Volume="1963" Year="2010">
-      <Id>4bcea647-c7af-4ba9-9412-85f62fc8042f</Id>
+      <Database Name="cv" Series="2127" Issue="184769" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="614" Volume="1963" Year="2010">
-      <Id>e8fabb07-32d0-4f61-a327-57ada0cda95f</Id>
+      <Database Name="cv" Series="2127" Issue="186659" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="615" Volume="1963" Year="2010">
-      <Id>5b69faf0-68a2-441c-baab-111697cf6b81</Id>
+      <Database Name="cv" Series="2127" Issue="187607" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="616" Volume="1963" Year="2010">
-      <Id>89e27e27-f999-4d60-88db-351a3ce35ad5</Id>
+      <Database Name="cv" Series="2127" Issue="189487" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="617" Volume="1963" Year="2010">
-      <Id>4c0f3f76-4ea8-416d-97e1-3c9e4fad8bca</Id>
+      <Database Name="cv" Series="2127" Issue="192294" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="618" Volume="1963" Year="2010">
-      <Id>4f3dc45a-d9b5-4a11-b3fe-d9ad80637dfc</Id>
+      <Database Name="cv" Series="2127" Issue="193352" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="619" Volume="1963" Year="2010">
-      <Id>be7cf38f-31fc-4ddd-a667-e6ce353515dc</Id>
+      <Database Name="cv" Series="2127" Issue="194422" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="620" Volume="1963" Year="2010">
-      <Id>4edb937b-4996-4e3e-a8ef-0146d2cbdb93</Id>
+      <Database Name="cv" Series="2127" Issue="196462" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="621" Volume="1963" Year="2010">
-      <Id>b734042b-d2be-4012-90ab-f6d516601053</Id>
+      <Database Name="cv" Series="2127" Issue="197353" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="622" Volume="1963" Year="2010">
-      <Id>f038a989-81ee-4f4f-94eb-2abdbb8933c3</Id>
+      <Database Name="cv" Series="2127" Issue="198252" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="623" Volume="1963" Year="2010">
-      <Id>214ff482-fbb9-4404-abbc-03879aefe60a</Id>
+      <Database Name="cv" Series="2127" Issue="198697" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="624" Volume="1963" Year="2010">
-      <Id>38bfb1fc-aef1-41f9-be3a-5c91c310ae3c</Id>
+      <Database Name="cv" Series="2127" Issue="199902" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="625" Volume="1963" Year="2010">
-      <Id>463ee3dc-dffe-492a-80aa-017f3605a838</Id>
+      <Database Name="cv" Series="2127" Issue="200765" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="626" Volume="1963" Year="2010">
-      <Id>8d910b4b-79ed-4f68-99ed-24c8cb51bcac</Id>
+      <Database Name="cv" Series="2127" Issue="201706" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="627" Volume="1963" Year="2010">
-      <Id>0281ad51-d51d-46e4-b394-2f2bbb729646</Id>
+      <Database Name="cv" Series="2127" Issue="202575" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="628" Volume="1963" Year="2010">
-      <Id>bf1b44ff-b548-4517-bc92-00a1c3bfb556</Id>
+      <Database Name="cv" Series="2127" Issue="208548" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="629" Volume="1963" Year="2010">
-      <Id>519dbc55-c74e-488d-88e9-5a39b40a9b49</Id>
+      <Database Name="cv" Series="2127" Issue="210222" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="630" Volume="1963" Year="2010">
-      <Id>5e9973ce-7f17-4b13-848e-d48a7940b01d</Id>
+      <Database Name="cv" Series="2127" Issue="211974" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="631" Volume="1963" Year="2010">
-      <Id>0acbd4b7-562b-4a7b-914e-70e7abac348f</Id>
+      <Database Name="cv" Series="2127" Issue="213457" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="632" Volume="1963" Year="2010">
-      <Id>8be98a96-ab3f-42c4-9b15-fbc53bb0826f</Id>
+      <Database Name="cv" Series="2127" Issue="216005" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="633" Volume="1963" Year="2010">
-      <Id>ec851359-6c0f-43cc-a511-96bbc276f3db</Id>
+      <Database Name="cv" Series="2127" Issue="219553" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="634" Volume="1963" Year="2010">
-      <Id>154238c0-2b96-4487-90a5-9b2f15ed491e</Id>
+      <Database Name="cv" Series="2127" Issue="219556" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="635" Volume="1963" Year="2010">
-      <Id>6bacef4c-a99b-4639-a5c3-a63f87b1022e</Id>
+      <Database Name="cv" Series="2127" Issue="220583" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="636" Volume="1963" Year="2010">
-      <Id>2feee861-e78f-4031-8c37-09c107e02a1e</Id>
+      <Database Name="cv" Series="2127" Issue="223277" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="637" Volume="1963" Year="2010">
-      <Id>7427af62-5751-47d0-9584-4acf902ff7e9</Id>
+      <Database Name="cv" Series="2127" Issue="224565" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="638" Volume="1963" Year="2010">
-      <Id>dd3ee40a-c5ac-4a7c-825f-4c4cdc159203</Id>
+      <Database Name="cv" Series="2127" Issue="225675" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="639" Volume="1963" Year="2010">
-      <Id>b1bacf01-b9b4-4f27-b2b5-0a04b21414ab</Id>
+      <Database Name="cv" Series="2127" Issue="227715" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="640" Volume="1963" Year="2010">
-      <Id>adb37c52-f597-45de-b3a5-66b8c59882a1</Id>
+      <Database Name="cv" Series="2127" Issue="230259" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="641" Volume="1963" Year="2010">
-      <Id>8ee18725-c41c-4fcc-a3b1-374bbd0482fd</Id>
+      <Database Name="cv" Series="2127" Issue="233834" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="642" Volume="1963" Year="2010">
-      <Id>67736ba6-3c9e-4878-98e1-92c48d0d1c41</Id>
+      <Database Name="cv" Series="2127" Issue="233867" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="643" Volume="1963" Year="2010">
-      <Id>d4520be5-08bd-43df-804c-3058f98d2fbc</Id>
+      <Database Name="cv" Series="2127" Issue="234676" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="644" Volume="1963" Year="2010">
-      <Id>9946c701-5740-4274-90ff-073a0d532c6a</Id>
+      <Database Name="cv" Series="2127" Issue="236285" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="645" Volume="1963" Year="2010">
-      <Id>04a49f42-9a04-4d90-a213-000dbd9688b8</Id>
+      <Database Name="cv" Series="2127" Issue="238243" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="646" Volume="1963" Year="2010">
-      <Id>efd1ada5-44ab-4ea2-b949-4cb823b140c5</Id>
+      <Database Name="cv" Series="2127" Issue="239885" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="647" Volume="1963" Year="2010">
-      <Id>0d16992d-7bb8-49f6-b850-cfbf8ef09a22</Id>
+      <Database Name="cv" Series="2127" Issue="240897" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="648" Volume="1963" Year="2011">
-      <Id>75a20aa7-1e00-4a03-9659-0fcc8111e836</Id>
+      <Database Name="cv" Series="2127" Issue="242262" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="649" Volume="1963" Year="2011">
-      <Id>9a408d69-a5f2-4bd8-bfc5-f171a3a9e83a</Id>
+      <Database Name="cv" Series="2127" Issue="246471" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="650" Volume="1963" Year="2011">
-      <Id>b90c7a3d-24be-49b7-a099-6003f57ade09</Id>
+      <Database Name="cv" Series="2127" Issue="249258" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="651" Volume="1963" Year="2011">
-      <Id>8518c0b4-a73d-4bd8-a6f5-e555c320dfe1</Id>
+      <Database Name="cv" Series="2127" Issue="255922" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="652" Volume="1963" Year="2011">
-      <Id>fa8ed258-eee8-4dc9-a515-e35d47930a75</Id>
+      <Database Name="cv" Series="2127" Issue="258417" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="653" Volume="1963" Year="2011">
-      <Id>9ee305fd-9c36-419a-a640-ca6492f7a46f</Id>
+      <Database Name="cv" Series="2127" Issue="259998" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="654" Volume="1963" Year="2011">
-      <Id>0510edaa-08b4-4594-8de5-7a6072a6a37f</Id>
+      <Database Name="cv" Series="2127" Issue="261239" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="655" Volume="1963" Year="2011">
-      <Id>c6060071-b85a-493c-8c87-b4cc3b2bff3b</Id>
+      <Database Name="cv" Series="2127" Issue="263708" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="656" Volume="1963" Year="2011">
-      <Id>3bc26480-b354-4dee-b710-14874c1d2cf0</Id>
+      <Database Name="cv" Series="2127" Issue="266014" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="657" Volume="1963" Year="2011">
-      <Id>c4d5e1f4-4b3a-4b4d-a52b-fd53d4821031</Id>
+      <Database Name="cv" Series="2127" Issue="267093" />
     </Book>
     <Book Series="FF" Number="1" Volume="2011" Year="2011">
-      <Id>66f13af9-f11c-4514-9ccd-fe5f4c7f1562</Id>
+      <Database Name="cv" Series="39453" Issue="266491" />
     </Book>
     <Book Series="FF" Number="2" Volume="2011" Year="2011">
-      <Id>fc983666-7425-442e-b0fd-772d667ab9f8</Id>
+      <Database Name="cv" Series="39453" Issue="268964" />
     </Book>
     <Book Series="FF" Number="3" Volume="2011" Year="2011">
-      <Id>65edfc92-0ef4-4090-8fd4-f517bde173e2</Id>
+      <Database Name="cv" Series="39453" Issue="269820" />
     </Book>
     <Book Series="FF" Number="4" Volume="2011" Year="2011">
-      <Id>01e8a7e4-ee1a-4f34-a1a2-4e9c011f16e0</Id>
+      <Database Name="cv" Series="39453" Issue="271610" />
     </Book>
     <Book Series="FF" Number="5" Volume="2011" Year="2011">
-      <Id>8b0e2eee-ae71-4bbd-8f7c-ec63a460ac96</Id>
+      <Database Name="cv" Series="39453" Issue="276606" />
     </Book>
     <Book Series="FF" Number="6" Volume="2011" Year="2011">
-      <Id>034ad0cf-e130-40ba-8266-91deb0c732bf</Id>
+      <Database Name="cv" Series="39453" Issue="278717" />
     </Book>
     <Book Series="FF" Number="7" Volume="2011" Year="2011">
-      <Id>a94d18bd-ade3-45e8-8af9-eaca253065c1</Id>
+      <Database Name="cv" Series="39453" Issue="281813" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="658" Volume="1963" Year="2011">
-      <Id>50900b4d-47c9-4cfc-8b3a-5b7f2b58d8ee</Id>
+      <Database Name="cv" Series="2127" Issue="268231" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="659" Volume="1963" Year="2011">
-      <Id>073ed67b-816a-4e0f-a407-f748f939a0e5</Id>
+      <Database Name="cv" Series="2127" Issue="269011" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="660" Volume="1963" Year="2011">
-      <Id>6b5969a3-7950-4789-8df1-9809fe2c37bd</Id>
+      <Database Name="cv" Series="2127" Issue="269832" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="661" Volume="1963" Year="2011">
-      <Id>482fb1e0-5094-42b6-8519-284ffa70d600</Id>
+      <Database Name="cv" Series="2127" Issue="270462" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="662" Volume="1963" Year="2011">
-      <Id>1d16770d-937e-41d8-9e7e-281ad78a5777</Id>
+      <Database Name="cv" Series="2127" Issue="271547" />
     </Book>
     <Book Series="Fear Itself: Spider-Man" Number="1" Volume="2011" Year="2011">
-      <Id>44efdc16-bd11-46fb-8732-3dd24c1517e8</Id>
+      <Database Name="cv" Series="39960" Issue="269489" />
     </Book>
     <Book Series="Fear Itself: Spider-Man" Number="2" Volume="2011" Year="2011">
-      <Id>a6daecfe-e936-4e9f-995d-601ee44b5cf0</Id>
+      <Database Name="cv" Series="39960" Issue="273108" />
     </Book>
     <Book Series="Fear Itself: Spider-Man" Number="3" Volume="2011" Year="2011">
-      <Id>5cd41d73-50b4-4e18-9209-907d603bbc23</Id>
+      <Database Name="cv" Series="39960" Issue="278718" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="663" Volume="1963" Year="2011">
-      <Id>f9649de3-a4d8-4f9d-8df8-1c2841406752</Id>
+      <Database Name="cv" Series="2127" Issue="272428" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="664" Volume="1963" Year="2011">
-      <Id>1d760ee3-d56b-4473-88b7-dce6ee8aeac6</Id>
+      <Database Name="cv" Series="2127" Issue="276636" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="665" Volume="1963" Year="2011">
-      <Id>8d18f16b-c105-4961-96fe-5ec1b65b8778</Id>
+      <Database Name="cv" Series="2127" Issue="278710" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="666" Volume="1963" Year="2011">
-      <Id>07822d71-fbb0-47f6-8ea6-375cb40d2391</Id>
+      <Database Name="cv" Series="2127" Issue="281822" />
     </Book>
     <Book Series="Venom" Number="5" Volume="2011" Year="2011">
-      <Id>c982c392-00da-46b6-b692-4023b0c2dc30</Id>
+      <Database Name="cv" Series="39301" Issue="281845" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="667" Volume="1963" Year="2011">
-      <Id>d959fc44-6511-4cb7-a502-65cd9ea88b66</Id>
+      <Database Name="cv" Series="2127" Issue="285544" />
     </Book>
-    <Book Series="Spider-Island: Cloak &amp; Dagger" Number="1" Volume="2011" Year="2011">
-      <Id>65571093-552f-4904-8a3d-666f0c41b5e9</Id>
+    <Book Series="Spider-Island: Cloak &#38; Dagger" Number="1" Volume="2011" Year="2011">
+      <Database Name="cv" Series="41955" Issue="285497" />
     </Book>
     <Book Series="Spider-Island: Deadly Foes" Number="1" Volume="2011" Year="2011">
-      <Id>691812c3-6694-470e-a061-7e41174daccb</Id>
+      <Database Name="cv" Series="42012" Issue="286181" />
     </Book>
     <Book Series="Venom" Number="6" Volume="2011" Year="2011">
-      <Id>843730d4-2611-49ed-9b8e-c8ce2f36e457</Id>
+      <Database Name="cv" Series="39301" Issue="286935" />
     </Book>
     <Book Series="Spider-Island: Deadly Hands of Kung Fu" Number="1" Volume="2011" Year="2011">
-      <Id>834d9eeb-0908-4686-a171-22cfa5a07d96</Id>
+      <Database Name="cv" Series="42513" Issue="290625" />
     </Book>
-    <Book Series="Spider-Island: The Amazing Spider Girl" Number="1" Volume="2011" Year="2011">
-      <Id>d5e18860-a578-4fb4-bf84-bcb9c3619e83</Id>
+    <Book Series="Spider-Island: The Amazing Spider-Girl" Number="1" Volume="2011" Year="2011">
+      <Database Name="cv" Series="42131" Issue="286920" />
     </Book>
-    <Book Series="Spider-Island: Emergence of Evil - Jackal &amp; Hobgoblin" Number="1" Volume="2011" Year="2011">
-      <Id>79c3bcf0-99c5-4cf3-acd4-a21edd830f3b</Id>
+    <Book Series="Spider-Island: Emergence of Evil - Jackal &#38; Hobgoblin" Number="1" Volume="2011" Year="2011">
+      <Database Name="cv" Series="42547" Issue="290910" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="668" Volume="1963" Year="2011">
-      <Id>825adfd0-2504-474f-bc90-1e629c0b3495</Id>
+      <Database Name="cv" Series="2127" Issue="290665" />
     </Book>
     <Book Series="Amazing Spider-Man: Infested" Number="1" Volume="2011" Year="2011">
-      <Id>cc616ec4-2a11-4fc3-8a17-4c37d035409e</Id>
+      <Database Name="cv" Series="42589" Issue="291101" />
     </Book>
-    <Book Series="Spider-Island: Cloak &amp; Dagger" Number="2" Volume="2011" Year="2011">
-      <Id>46db6fc7-d1b6-4a96-9eeb-4b90dda279dc</Id>
+    <Book Series="Spider-Island: Cloak &#38; Dagger" Number="2" Volume="2011" Year="2011">
+      <Database Name="cv" Series="41955" Issue="293399" />
     </Book>
     <Book Series="Spider-Island: The Avengers" Number="1" Volume="2011" Year="2011">
-      <Id>f4174613-2978-4af3-ac94-e04c68446a02</Id>
+      <Database Name="cv" Series="42663" Issue="292003" />
     </Book>
-    <Book Series="Spider-Island: The Amazing Spider Girl" Number="2" Volume="2011" Year="2011">
-      <Id>00d39f87-aaf8-41c3-875b-243cb62b7713</Id>
+    <Book Series="Spider-Island: The Amazing Spider-Girl" Number="2" Volume="2011" Year="2011">
+      <Database Name="cv" Series="42131" Issue="292619" />
     </Book>
     <Book Series="Spider-Island: I Love New York City" Number="1" Volume="2011" Year="2011">
-      <Id>01d4988c-623c-431f-ba38-bc77f7f2b759</Id>
+      <Database Name="cv" Series="42657" Issue="291609" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="669" Volume="1963" Year="2011">
-      <Id>59e0cb12-9511-4372-ad8b-5aa637901d6f</Id>
+      <Database Name="cv" Series="2127" Issue="292609" />
     </Book>
     <Book Series="Spider-Island: Spider-Woman" Number="1" Volume="2011" Year="2011">
-      <Id>d52fc962-5f37-4d53-bbd4-ae6b4668d567</Id>
+      <Database Name="cv" Series="42978" Issue="293441" />
     </Book>
     <Book Series="Venom" Number="7" Volume="2011" Year="2011">
-      <Id>f63ec885-fdfd-417d-8dd3-36ccad7fb914</Id>
+      <Database Name="cv" Series="39301" Issue="293634" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="670" Volume="1963" Year="2011">
-      <Id>25129d04-9d56-4e25-a713-40543088ef30</Id>
+      <Database Name="cv" Series="2127" Issue="293619" />
     </Book>
     <Book Series="Spider-Island: Deadly Hands of Kung Fu" Number="2" Volume="2011" Year="2011">
-      <Id>14d137c8-ea6a-4b9a-82aa-a06a3f408920</Id>
+      <Database Name="cv" Series="42513" Issue="293788" />
     </Book>
     <Book Series="Spider-Island: Heroes For Hire" Number="1" Volume="2011" Year="2011">
-      <Id>1fa9982b-a3a5-4f86-b8da-97942fca7af3</Id>
+      <Database Name="cv" Series="43159" Issue="294346" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="671" Volume="1963" Year="2011">
-      <Id>f288e795-83d9-478f-9c08-e24a1ffb8d05</Id>
+      <Database Name="cv" Series="2127" Issue="294956" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="672" Volume="1963" Year="2011">
-      <Id>7174ed6e-e45a-4471-94c2-3f99d86dbd2b</Id>
+      <Database Name="cv" Series="2127" Issue="299744" />
+    </Book>
+    <Book Series="Spider-Island: The Amazing Spider-Girl" Number="3" Volume="2011" Year="2011">
+      <Database Name="cv" Series="42131" Issue="299759" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="673" Volume="1963" Year="2012">
-      <Id>7d426a20-237a-48f1-8c89-b2640e1faa31</Id>
+      <Database Name="cv" Series="2127" Issue="301042" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="674" Volume="1963" Year="2012">
-      <Id>6cf98cc3-6b74-4bf9-9f9a-989b4d94a341</Id>
+      <Database Name="cv" Series="2127" Issue="302650" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="675" Volume="1963" Year="2012">
-      <Id>160ed6c2-b29f-48b2-914d-428700846784</Id>
+      <Database Name="cv" Series="2127" Issue="305690" />
     </Book>
     <Book Series="Avenging Spider-Man" Number="1" Volume="2011" Year="2012">
-      <Id>aed5959f-d131-4489-ac8e-d6a58bad19c7</Id>
+      <Database Name="cv" Series="43884" Issue="301508" />
     </Book>
     <Book Series="Avenging Spider-Man" Number="2" Volume="2011" Year="2012">
-      <Id>37cfbb3b-5971-4a7d-81ce-4f3cd06bb5ec</Id>
+      <Database Name="cv" Series="43884" Issue="305691" />
     </Book>
     <Book Series="Avenging Spider-Man" Number="3" Volume="2011" Year="2012">
-      <Id>6e980cef-8a84-465e-b1ae-a7c5e5892a99</Id>
+      <Database Name="cv" Series="43884" Issue="311835" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="676" Volume="1963" Year="2012">
-      <Id>66a2e693-2e30-4ab5-b90e-66c77af2a78c</Id>
+      <Database Name="cv" Series="2127" Issue="307527" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="677" Volume="1963" Year="2012">
-      <Id>8fe56df5-718a-411e-9664-0ba6030a62e9</Id>
+      <Database Name="cv" Series="2127" Issue="310913" />
     </Book>
     <Book Series="Daredevil" Number="8" Volume="2011" Year="2012">
-      <Id>ee8fd394-4cf9-4157-96f7-d009f78a18e2</Id>
+      <Database Name="cv" Series="41410" Issue="311671" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="678" Volume="1963" Year="2012">
-      <Id>a4e4e550-a33e-4104-bf04-9bb15126a26b</Id>
+      <Database Name="cv" Series="2127" Issue="311767" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="679" Volume="1963" Year="2012">
-      <Id>f7e7556b-3641-4b02-bbea-96c100e2282d</Id>
+      <Database Name="cv" Series="2127" Issue="313898" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="679.1" Volume="1963" Year="2012">
-      <Id>8e7542e2-9cc7-4ad0-beb6-72bded153b33</Id>
+      <Database Name="cv" Series="2127" Issue="315750" />
     </Book>
     <Book Series="Avenging Spider-Man" Number="4" Volume="2011" Year="2012">
-      <Id>bbd72a42-8515-43e7-9506-07b5e1ff0ba4</Id>
+      <Database Name="cv" Series="43884" Issue="315803" />
     </Book>
     <Book Series="Avenging Spider-Man" Number="5" Volume="2011" Year="2012">
-      <Id>67c71f6f-d972-4619-bbe7-5d4b46c0c971</Id>
+      <Database Name="cv" Series="43884" Issue="324958" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="680" Volume="1963" Year="2012">
-      <Id>5fd8ee6d-c4d7-42dc-bc66-561fd4d7cdb7</Id>
+      <Database Name="cv" Series="2127" Issue="317747" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="681" Volume="1963" Year="2012">
-      <Id>8a2a3e24-9182-4fbf-af5e-a40ac40201b7</Id>
+      <Database Name="cv" Series="2127" Issue="319360" />
     </Book>
     <Book Series="Avenging Spider-Man" Number="6" Volume="2011" Year="2012">
-      <Id>f3f23314-2884-474f-b524-82fa084a21b2</Id>
+      <Database Name="cv" Series="43884" Issue="329213" />
     </Book>
     <Book Series="The Punisher" Number="10" Volume="2011" Year="2012">
-      <Id>9c3c7981-7a95-49e0-8c72-af0b6dc04a9a</Id>
+      <Database Name="cv" Series="41758" Issue="331857" />
     </Book>
     <Book Series="Daredevil" Number="11" Volume="2011" Year="2012">
-      <Id>174e76e0-8293-457a-90ee-ba967455527d</Id>
+      <Database Name="cv" Series="41410" Issue="333393" />
     </Book>
     <Book Series="Avenging Spider-Man" Number="7" Volume="2011" Year="2012">
-      <Id>5012b146-955e-4427-9f3d-bc82275e3517</Id>
+      <Database Name="cv" Series="43884" Issue="335249" />
     </Book>
     <Book Series="The Amazing Spider-Man Annual" Number="39" Volume="1964" Year="2012">
-      <Id>318b5b4d-f9ae-434e-84bc-398d10905fa1</Id>
+      <Database Name="cv" Series="2189" Issue="337485" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="682" Volume="1963" Year="2012">
-      <Id>ad898ca1-aa4e-4427-a3d4-730ed506e688</Id>
+      <Database Name="cv" Series="2127" Issue="322746" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="683" Volume="1963" Year="2012">
-      <Id>70675487-51b7-476a-bc83-78401c11f2eb</Id>
+      <Database Name="cv" Series="2127" Issue="326838" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="684" Volume="1963" Year="2012">
-      <Id>982fba88-e6e3-49f0-ade5-3afaaf0aa894</Id>
+      <Database Name="cv" Series="2127" Issue="331858" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="685" Volume="1963" Year="2012">
-      <Id>0b1deb19-901a-4f83-94b5-0bbfaa90411f</Id>
+      <Database Name="cv" Series="2127" Issue="334214" />
     </Book>
     <Book Series="Amazing Spider-Man: Ends of the Earth" Number="1" Volume="2012" Year="2012">
-      <Id>e8546824-9141-4e42-9a30-2bc9a7949490</Id>
+      <Database Name="cv" Series="48970" Issue="335956" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="686" Volume="1963" Year="2012">
-      <Id>fd65b9e5-4008-46a6-9292-f5ede984b630</Id>
+      <Database Name="cv" Series="2127" Issue="336589" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="687" Volume="1963" Year="2012">
-      <Id>7bbc53f6-b018-44f8-ab98-aabada5d25d0</Id>
+      <Database Name="cv" Series="2127" Issue="340254" />
     </Book>
     <Book Series="Avenging Spider-Man" Number="8" Volume="2011" Year="2012">
-      <Id>81672e91-fd47-49f3-a15f-5c5f4e07f820</Id>
+      <Database Name="cv" Series="43884" Issue="341809" />
     </Book>
     <Book Series="Avengers Vs. X-Men" Number="1" Volume="2012" Year="2012">
-      <Id>3ee055b9-6dc9-408e-84ab-4be34f7bd85a</Id>
+      <Database Name="cv" Series="47331" Issue="326860" />
     </Book>
     <Book Series="Avengers Vs. X-Men" Number="2" Volume="2012" Year="2012">
-      <Id>a1921a7d-8ab0-48e9-82fb-c6d8f75dd507</Id>
+      <Database Name="cv" Series="47331" Issue="331952" />
     </Book>
     <Book Series="Avengers Vs. X-Men" Number="3" Volume="2012" Year="2012">
-      <Id>80e84dad-9553-4ebb-a739-d90636e3ee79</Id>
+      <Database Name="cv" Series="47331" Issue="334169" />
     </Book>
     <Book Series="Avengers Vs. X-Men" Number="4" Volume="2012" Year="2012">
-      <Id>c9f324ce-f4d1-4d0f-93bb-f49cf8d2e12e</Id>
+      <Database Name="cv" Series="47331" Issue="336045" />
     </Book>
     <Book Series="Avengers Vs. X-Men" Number="5" Volume="2012" Year="2012">
-      <Id>d5e04532-7bd0-43f8-b4b6-838fca87c17b</Id>
+      <Database Name="cv" Series="47331" Issue="338525" />
     </Book>
     <Book Series="Avengers Vs. X-Men" Number="6" Volume="2012" Year="2012">
-      <Id>5f489e6e-8353-4ce0-9c27-f2aec9c0c3d5</Id>
+      <Database Name="cv" Series="47331" Issue="341749" />
     </Book>
     <Book Series="Avengers Vs. X-Men" Number="7" Volume="2012" Year="2012">
-      <Id>db2de910-ad78-4d73-af4c-e846d9ad52f6</Id>
+      <Database Name="cv" Series="47331" Issue="344114" />
     </Book>
     <Book Series="Avengers Vs. X-Men" Number="8" Volume="2012" Year="2012">
-      <Id>4890b435-8d2d-4169-be96-748ee320601e</Id>
+      <Database Name="cv" Series="47331" Issue="346240" />
     </Book>
     <Book Series="New Avengers" Number="25" Volume="2010" Year="2012">
-      <Id>a8ac332c-63fe-45de-9149-9f06f81fb21b</Id>
+      <Database Name="cv" Series="33777" Issue="333450" />
     </Book>
     <Book Series="New Avengers" Number="26" Volume="2010" Year="2012">
-      <Id>a6e89747-9e68-40c7-9064-d21de051b628</Id>
+      <Database Name="cv" Series="33777" Issue="335284" />
     </Book>
     <Book Series="New Avengers" Number="27" Volume="2010" Year="2012">
-      <Id>5f02b221-ee8d-49b3-bb16-fc412583feaa</Id>
+      <Database Name="cv" Series="33777" Issue="341733" />
     </Book>
     <Book Series="New Avengers" Number="28" Volume="2010" Year="2012">
-      <Id>6ccce8a4-24ce-41fb-922f-d7ee876db2d6</Id>
+      <Database Name="cv" Series="33777" Issue="345393" />
     </Book>
     <Book Series="Avengers Vs. X-Men" Number="9" Volume="2012" Year="2012">
-      <Id>c8c9640a-790b-4dee-a6fa-9256278457d4</Id>
+      <Database Name="cv" Series="47331" Issue="348054" />
     </Book>
     <Book Series="Avengers Vs. X-Men" Number="10" Volume="2012" Year="2012">
-      <Id>2b7cfa2a-bf09-4a88-82d9-ca28d40103b9</Id>
+      <Database Name="cv" Series="47331" Issue="351068" />
     </Book>
     <Book Series="Avengers Vs. X-Men" Number="11" Volume="2012" Year="2012">
-      <Id>c389edff-e3ad-42d7-92b0-864483403a8c</Id>
+      <Database Name="cv" Series="47331" Issue="356764" />
     </Book>
     <Book Series="Avengers Vs. X-Men" Number="12" Volume="2012" Year="2012">
-      <Id>28a5a897-c409-48bb-8ac7-910c8b769a0a</Id>
+      <Database Name="cv" Series="47331" Issue="359916" />
     </Book>
     <Book Series="Spider-Men" Number="1" Volume="2012" Year="2012">
-      <Id>e56bbbb7-df25-4d4b-87f5-5d5b76f31c12</Id>
+      <Database Name="cv" Series="49395" Issue="337983" />
     </Book>
     <Book Series="Spider-Men" Number="2" Volume="2012" Year="2012">
-      <Id>813ef871-c7df-4c10-bb30-f713a4bb9dfb</Id>
+      <Database Name="cv" Series="49395" Issue="342839" />
     </Book>
     <Book Series="Spider-Men" Number="3" Volume="2012" Year="2012">
-      <Id>9f4985d4-4944-4104-9aad-7eaa4d24bb4a</Id>
+      <Database Name="cv" Series="49395" Issue="345383" />
     </Book>
     <Book Series="Spider-Men" Number="4" Volume="2012" Year="2012">
-      <Id>07de89f4-e92d-4ef0-b9e2-34670495426d</Id>
+      <Database Name="cv" Series="49395" Issue="349675" />
     </Book>
     <Book Series="Spider-Men" Number="5" Volume="2012" Year="2012">
-      <Id>1515c02c-bc58-415a-b7ae-73465ea39fa4</Id>
+      <Database Name="cv" Series="49395" Issue="357711" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="688" Volume="1963" Year="2012">
-      <Id>d2a4084f-ae70-4d8c-aaa0-ffda4a351f3e</Id>
+      <Database Name="cv" Series="2127" Issue="342871" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="689" Volume="1963" Year="2012">
-      <Id>0deed226-3002-4c78-abb8-9ebcacc61c06</Id>
+      <Database Name="cv" Series="2127" Issue="344049" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="690" Volume="1963" Year="2012">
-      <Id>881f83d2-3cd8-46f2-a53a-9b7e0d647eef</Id>
+      <Database Name="cv" Series="2127" Issue="347224" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="691" Volume="1963" Year="2012">
-      <Id>813604ad-9017-4a77-8832-761fbcc32e1f</Id>
+      <Database Name="cv" Series="2127" Issue="351057" />
     </Book>
     <Book Series="Avenging Spider-Man" Number="9" Volume="2011" Year="2012">
-      <Id>dcd2ba2e-edb3-4df0-b4e6-4e7ece4479a1</Id>
+      <Database Name="cv" Series="43884" Issue="345394" />
     </Book>
     <Book Series="Avenging Spider-Man" Number="10" Volume="2011" Year="2012">
-      <Id>e2930dc8-ca67-4ae5-b01e-4a791272e108</Id>
+      <Database Name="cv" Series="43884" Issue="348057" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="692" Volume="1963" Year="2012">
-      <Id>b539f190-30f1-4579-9f53-176dda8ce1b5</Id>
+      <Database Name="cv" Series="2127" Issue="352573" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="693" Volume="1963" Year="2012">
-      <Id>6453e73b-692c-46a2-a154-33a964b22051</Id>
+      <Database Name="cv" Series="2127" Issue="355887" />
     </Book>
     <Book Series="Avenging Spider-Man" Number="11" Volume="2011" Year="2012">
-      <Id>bdb549ef-6308-4bac-8b41-dddbfc6423ea</Id>
+      <Database Name="cv" Series="43884" Issue="354168" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="694" Volume="1963" Year="2012">
-      <Id>4513774f-789d-42da-b86d-3f0f030d2044</Id>
+      <Database Name="cv" Series="2127" Issue="358932" />
     </Book>
     <Book Series="Avenging Spider-Man" Number="12" Volume="2011" Year="2012">
-      <Id>162d11a0-0909-44a9-9f7f-e7d0f316dd9d</Id>
+      <Database Name="cv" Series="43884" Issue="356765" />
     </Book>
     <Book Series="Avenging Spider-Man" Number="13" Volume="2011" Year="2012">
-      <Id>44f2238c-e163-49f1-80b9-e277e1e3f475</Id>
+      <Database Name="cv" Series="43884" Issue="360928" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="695" Volume="1963" Year="2012">
-      <Id>f1d88e4c-de90-4230-80bb-f5588404381a</Id>
+      <Database Name="cv" Series="2127" Issue="360039" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="696" Volume="1963" Year="2012">
-      <Id>e06d42c8-3bb9-4a80-9ab2-f450f3ac6bee</Id>
+      <Database Name="cv" Series="2127" Issue="363149" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="697" Volume="1963" Year="2013">
-      <Id>3d0d8c80-4f4c-4273-8217-bf68cc4bf729</Id>
+      <Database Name="cv" Series="2127" Issue="367808" />
     </Book>
     <Book Series="Avenging Spider-Man" Number="14" Volume="2011" Year="2013">
-      <Id>a81e371c-988e-4fab-b4d5-d04504b5ffcc</Id>
+      <Database Name="cv" Series="43884" Issue="366188" />
     </Book>
     <Book Series="Avenging Spider-Man" Number="15" Volume="2011" Year="2013">
-      <Id>52a17db0-fc9f-4af6-9a65-bd40841928e0</Id>
+      <Database Name="cv" Series="43884" Issue="371257" />
     </Book>
-    <Book Series="Avengers" Number="1" Volume="2013" Year="2013">
-      <Id>22ca363b-6149-4e73-ae60-1f3d25169934</Id>
+    <Book Series="Avengers" Number="1" Volume="2012" Year="2013">
+      <Database Name="cv" Series="54428" Issue="371103" />
     </Book>
-    <Book Series="Avengers" Number="2" Volume="2013" Year="2013">
-      <Id>89482383-7ac0-4f82-b71a-f420b0cf6ea6</Id>
+    <Book Series="Avengers" Number="2" Volume="2012" Year="2013">
+      <Database Name="cv" Series="54428" Issue="373217" />
     </Book>
-    <Book Series="Avengers" Number="3" Volume="2013" Year="2013">
-      <Id>fa7640d6-d6ee-4e09-9a89-955946a256e8</Id>
+    <Book Series="Avengers" Number="3" Volume="2012" Year="2013">
+      <Database Name="cv" Series="54428" Issue="381411" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="698" Volume="1963" Year="2013">
-      <Id>f331eff8-53ee-458a-8291-ba62ca741fca</Id>
+      <Database Name="cv" Series="2127" Issue="369103" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="699" Volume="1963" Year="2013">
-      <Id>8780ad4f-bd87-46bc-9335-26d30bdb383e</Id>
+      <Database Name="cv" Series="2127" Issue="371256" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="699.1" Volume="1963" Year="2013">
-      <Id>b801789c-543e-4c02-983d-1ca875c8a010</Id>
+      <Database Name="cv" Series="2127" Issue="372452" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="700" Volume="1963" Year="2013">
-      <Id>a09b2b38-5bff-406f-a835-624a0f9d609a</Id>
+      <Database Name="cv" Series="2127" Issue="373805" />
     </Book>
     <Book Series="Avenging Spider-Man" Number="15.1" Volume="2011" Year="2013">
-      <Id>6c27d9dd-69ca-4796-b26e-de6e77cce2a6</Id>
+      <Database Name="cv" Series="43884" Issue="374689" />
     </Book>
     <Book Series="Marvel Knights: Spider-Man" Number="1" Volume="2013" Year="2013">
-      <Id>138ce6dd-7c28-4d55-bd22-be8d166be0aa</Id>
+      <Database Name="cv" Series="67919" Issue="427690" />
     </Book>
     <Book Series="Marvel Knights: Spider-Man" Number="2" Volume="2013" Year="2014">
-      <Id>15c28ee7-f86c-4549-9419-ee13066bb819</Id>
+      <Database Name="cv" Series="67919" Issue="432333" />
     </Book>
     <Book Series="Marvel Knights: Spider-Man" Number="3" Volume="2013" Year="2014">
-      <Id>f50e80ae-845f-4801-8137-3bb36d871ca8</Id>
+      <Database Name="cv" Series="67919" Issue="435586" />
     </Book>
     <Book Series="Marvel Knights: Spider-Man" Number="4" Volume="2013" Year="2014">
-      <Id>fab2c1b8-4598-4266-91e8-1a3bf12c5f6b</Id>
+      <Database Name="cv" Series="67919" Issue="441417" />
     </Book>
     <Book Series="Marvel Knights: Spider-Man" Number="5" Volume="2013" Year="2014">
-      <Id>fb2c094e-ab68-4410-9bb9-a57e8a078d0a</Id>
+      <Database Name="cv" Series="67919" Issue="444532" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="700.1" Volume="1963" Year="2014">
-      <Id>a0b6ce78-b4c8-4f11-968a-61671d4eef45</Id>
+      <Database Name="cv" Series="2127" Issue="435573" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="700.2" Volume="1963" Year="2014">
-      <Id>d9d0011c-9af1-4555-a707-3dd15d24c49f</Id>
+      <Database Name="cv" Series="2127" Issue="436190" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="700.3" Volume="1963" Year="2014">
-      <Id>83319776-ab16-420a-81af-3af92fc2eee6</Id>
+      <Database Name="cv" Series="2127" Issue="436191" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="700.4" Volume="1963" Year="2014">
-      <Id>b4752ec6-0a51-453c-899a-b813609d6464</Id>
+      <Database Name="cv" Series="2127" Issue="437483" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="700.5" Volume="1963" Year="2014">
-      <Id>89ca1da1-4ad7-4f65-b126-0f34c3910210</Id>
+      <Database Name="cv" Series="2127" Issue="437484" />
     </Book>
     <Book Series="Peter Parker" Number="1" Volume="2010" Year="2010">
-      <Id>d90931bb-87fa-40fc-a11e-3e000b8c9502</Id>
+      <Database Name="cv" Series="32170" Issue="201849" />
     </Book>
     <Book Series="Peter Parker" Number="2" Volume="2010" Year="2010">
-      <Id>3d65e23d-cdef-43be-a180-11b5990058f9</Id>
+      <Database Name="cv" Series="32170" Issue="211117" />
     </Book>
     <Book Series="Peter Parker" Number="3" Volume="2010" Year="2010">
-      <Id>274b6567-ad48-4f03-a63b-10f3762e8295</Id>
+      <Database Name="cv" Series="32170" Issue="216451" />
     </Book>
     <Book Series="Peter Parker" Number="4" Volume="2010" Year="2010">
-      <Id>19829a05-901e-46ab-b4c9-cd606640c93a</Id>
+      <Database Name="cv" Series="32170" Issue="220723" />
     </Book>
     <Book Series="Peter Parker" Number="5" Volume="2010" Year="2010">
-      <Id>04fb87fe-9fc1-483c-802e-4b4ab12de97f</Id>
+      <Database Name="cv" Series="32170" Issue="227335" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Spider-Man/Spider-Man 008 (Brand New Day).cbl
+++ b/Marvel/Characters/unsorted/Spider-Man/Spider-Man 008 (Brand New Day).cbl
@@ -2,868 +2,868 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Spider-Man 8 (Brand New Day)</Name>
   <Books>
-    <Book Series="The Amazing Spider-Man" Number="546" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="546" Volume="1963" Year="2008">
       <Id>be04b4b9-b2ad-4751-926a-4eda4b6381d3</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="547" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="547" Volume="1963" Year="2008">
       <Id>886ec694-1fdc-4ed4-873a-3319d66fed69</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="548" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="548" Volume="1963" Year="2008">
       <Id>9161f55e-7900-4369-87ad-c5759d437b1e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="549" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="549" Volume="1963" Year="2008">
       <Id>1ae58e9a-36bc-4488-bcec-0150f096982a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="550" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="550" Volume="1963" Year="2008">
       <Id>78f0d688-fb81-4280-97f9-49ebec71ca4b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="551" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="551" Volume="1963" Year="2008">
       <Id>f157ab8d-1ebf-41f2-8d8b-d7aa02edb881</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="552" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="552" Volume="1963" Year="2008">
       <Id>8d2bdc44-f5e3-48a3-ad06-fc889167cf84</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="553" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="553" Volume="1963" Year="2008">
       <Id>6509fbce-3a40-447e-a128-454d8d1c1d8e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="554" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="554" Volume="1963" Year="2008">
       <Id>361393c2-bff8-4b2e-8fc3-aebc4b4f1cb4</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="555" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="555" Volume="1963" Year="2008">
       <Id>0c2ef7e2-22a0-4f2c-a24f-454bf3e9bbef</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="556" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="556" Volume="1963" Year="2008">
       <Id>db720284-730c-4292-9c0f-d729452095a2</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="557" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="557" Volume="1963" Year="2008">
       <Id>2ae5c60d-f799-44c1-8cda-bc89c936dcb0</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="558" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="558" Volume="1963" Year="2008">
       <Id>d75b4e5a-c479-4cb6-8bcd-a41ce1471dde</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="559" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="559" Volume="1963" Year="2008">
       <Id>d0915c23-e681-4ccf-bde6-7f8c424efa97</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="560" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="560" Volume="1963" Year="2008">
       <Id>536fb3e6-0d45-443b-9fd6-ad055ffb73e2</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="561" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="561" Volume="1963" Year="2008">
       <Id>915277c9-1a5f-4418-a29d-0069606be54a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="562" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="562" Volume="1963" Year="2008">
       <Id>94079b23-2050-4aed-b453-34a167807dc4</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="563" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="563" Volume="1963" Year="2008">
       <Id>aa4c9f23-4350-46e6-ab04-f14e4829c7b9</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="564" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="564" Volume="1963" Year="2008">
       <Id>01383922-8100-4e04-b21d-3025d1b98a06</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="565" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="565" Volume="1963" Year="2008">
       <Id>40f5d555-1791-48e7-97f2-baa4e65608a2</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="566" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="566" Volume="1963" Year="2008">
       <Id>e35bc660-fc4c-424c-8406-ceff27d165e2</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="567" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="567" Volume="1963" Year="2008">
       <Id>7e7c508e-fb6e-4dd8-b395-051d12349a9c</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="568" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="568" Volume="1963" Year="2008">
       <Id>b26531da-71be-496a-a9e5-0e321556c7c0</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="569" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="569" Volume="1963" Year="2008">
       <Id>295db83f-79ea-4409-9a36-898c258414bd</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="570" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="570" Volume="1963" Year="2008">
       <Id>96667641-c3ec-4a8e-8ae2-81d1ffa115f6</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="571" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="571" Volume="1963" Year="2008">
       <Id>d4e04faa-e5dc-48cc-b0ed-ad37d6d88bb5</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="572" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="572" Volume="1963" Year="2008">
       <Id>49eba1da-284c-4ed3-a032-fcbc2c9a3268</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="573" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="573" Volume="1963" Year="2008">
       <Id>59ec502b-fdb9-47ba-b854-d1035dbbe839</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="574" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="574" Volume="1963" Year="2008">
       <Id>1bcd764f-a9c5-4a24-b447-6b20e658ad2c</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="575" Volume="1963" Year="2008" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="575" Volume="1963" Year="2008">
       <Id>725dfca5-a2f4-42d3-a311-97b39ea7b4cb</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="576" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="576" Volume="1963" Year="2009">
       <Id>5da2a130-6d60-4a69-bca1-c6e63e62eb0e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="577" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="577" Volume="1963" Year="2009">
       <Id>fd6c1aa1-b00b-431e-9746-8aa73c7b9a9a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="578" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="578" Volume="1963" Year="2009">
       <Id>bd21d06f-18cf-422c-8c6e-72caa3d28e15</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="579" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="579" Volume="1963" Year="2009">
       <Id>1cebe483-18ff-4bcd-ae48-ba0d61dd8707</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="580" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="580" Volume="1963" Year="2009">
       <Id>d3eebeeb-3d2d-41aa-b646-9d83d18e0841</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="581" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="581" Volume="1963" Year="2009">
       <Id>eaf729e4-5d14-4b53-8ab0-c9a69369f6bc</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="582" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="582" Volume="1963" Year="2009">
       <Id>cade63c3-27d7-4234-9a0d-eb036e8b4cae</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="583" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="583" Volume="1963" Year="2009">
       <Id>fe3e5dad-f452-4086-a0a6-5948a59c2b32</Id>
     </Book>
-    <Book Series="New Avengers" Number="38" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="New Avengers" Number="38" Volume="2005" Year="2008">
       <Id>fa9bf6a4-7535-4a46-860d-30669710bd31</Id>
     </Book>
-    <Book Series="Secret Invasion Director's Cut" Number="1" Volume="2008" Year="2008" Format="Crossover">
+    <Book Series="Secret Invasion Director's Cut" Number="1" Volume="2008" Year="2008">
       <Id>6a2d34ba-8a32-4b2b-977b-2aacc2692b31</Id>
     </Book>
-    <Book Series="New Avengers" Number="41" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="New Avengers" Number="41" Volume="2005" Year="2008">
       <Id>903ec34b-c16c-497d-aa79-c0bf437bdd32</Id>
     </Book>
-    <Book Series="Secret Invasion" Number="2" Volume="2008" Year="2008" Format="Crossover">
+    <Book Series="Secret Invasion" Number="2" Volume="2008" Year="2008">
       <Id>7ee44784-000e-4c8d-9bd0-8ae2704a66fb</Id>
     </Book>
-    <Book Series="New Avengers" Number="42" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="New Avengers" Number="42" Volume="2005" Year="2008">
       <Id>2ad056ba-ff0e-47c0-8b77-1b3fc47c387d</Id>
     </Book>
-    <Book Series="Secret Invasion: The Amazing Spider-Man" Number="1" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="Secret Invasion: The Amazing Spider-Man" Number="1" Volume="2008" Year="2008">
       <Id>e3a2c89b-379c-422b-aaff-48a06ed09ccf</Id>
     </Book>
-    <Book Series="Secret Invasion: The Amazing Spider-Man" Number="2" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="Secret Invasion: The Amazing Spider-Man" Number="2" Volume="2008" Year="2008">
       <Id>d616f319-927f-46fc-b26b-3de849b515ad</Id>
     </Book>
-    <Book Series="Secret Invasion: The Amazing Spider-Man" Number="3" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="Secret Invasion: The Amazing Spider-Man" Number="3" Volume="2008" Year="2008">
       <Id>e2322ece-5de9-41a5-a93b-34b853e0dbd7</Id>
     </Book>
-    <Book Series="Secret Invasion" Number="3" Volume="2008" Year="2008" Format="Crossover">
+    <Book Series="Secret Invasion" Number="3" Volume="2008" Year="2008">
       <Id>7d646eac-8160-49db-8771-c6fc261fa833</Id>
     </Book>
-    <Book Series="New Avengers" Number="43" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="New Avengers" Number="43" Volume="2005" Year="2008">
       <Id>37941224-7445-4935-bf2b-3b2fe0ee311c</Id>
     </Book>
-    <Book Series="Secret Invasion" Number="4" Volume="2008" Year="2008" Format="Crossover">
+    <Book Series="Secret Invasion" Number="4" Volume="2008" Year="2008">
       <Id>6c6eca88-3515-4f4f-9834-1d97d64355d1</Id>
     </Book>
-    <Book Series="New Avengers" Number="44" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="New Avengers" Number="44" Volume="2005" Year="2008">
       <Id>93707050-947c-41d9-8e2b-04e2b0a39114</Id>
     </Book>
-    <Book Series="Secret Invasion" Number="5" Volume="2008" Year="2008" Format="Crossover">
+    <Book Series="Secret Invasion" Number="5" Volume="2008" Year="2008">
       <Id>6d8808bf-b64d-4b12-b16d-e034d833bafd</Id>
     </Book>
-    <Book Series="New Avengers" Number="45" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="New Avengers" Number="45" Volume="2005" Year="2008">
       <Id>d85bf06d-46e2-4a59-821b-bc95b50a466f</Id>
     </Book>
-    <Book Series="Secret Invasion" Number="6" Volume="2008" Year="2008" Format="Crossover">
+    <Book Series="Secret Invasion" Number="6" Volume="2008" Year="2008">
       <Id>cf384a0e-69b1-4743-b7ae-2e49bcd3b887</Id>
     </Book>
-    <Book Series="New Avengers" Number="46" Volume="2005" Year="2008" Format="Main Series">
+    <Book Series="New Avengers" Number="46" Volume="2005" Year="2008">
       <Id>afc9673d-7e38-4eea-8617-db42c5c35f9c</Id>
     </Book>
-    <Book Series="Secret Invasion: Front Line" Number="4" Volume="2008" Year="2008" Format="Crossover">
+    <Book Series="Secret Invasion: Front Line" Number="4" Volume="2008" Year="2008">
       <Id>56f756c5-6180-47f9-872c-ada0cc2a2f3b</Id>
     </Book>
-    <Book Series="Secret Invasion" Number="7" Volume="2008" Year="2008" Format="Crossover">
+    <Book Series="Secret Invasion" Number="7" Volume="2008" Year="2008">
       <Id>aed9b2a9-a77c-4c71-8abe-beb2d207326a</Id>
     </Book>
-    <Book Series="New Avengers" Number="47" Volume="2005" Year="2009" Format="Main Series">
+    <Book Series="New Avengers" Number="47" Volume="2005" Year="2009">
       <Id>d57d1d25-a48f-4a4b-ba5a-1d12e1fdb5ff</Id>
     </Book>
-    <Book Series="Secret Invasion" Number="8" Volume="2008" Year="2009" Format="Crossover">
+    <Book Series="Secret Invasion" Number="8" Volume="2008" Year="2009">
       <Id>02491013-82d8-4f8b-8748-10994aa8426e</Id>
     </Book>
-    <Book Series="Secret Invasion: Front Line" Number="5" Volume="2008" Year="2009" Format="Crossover">
+    <Book Series="Secret Invasion: Front Line" Number="5" Volume="2008" Year="2009">
       <Id>3de22add-397b-4a51-ba27-b005cc586b73</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="35" Volume="1964" Year="2008" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="35" Volume="1964" Year="2008">
       <Id>594a0206-ce67-4394-9453-120d764fff42</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="584" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="584" Volume="1963" Year="2009">
       <Id>7b04bf20-0797-4564-a539-5cdb6ad6077d</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="585" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="585" Volume="1963" Year="2009">
       <Id>140ab584-a402-4048-be02-a6d973ff8756</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="586" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="586" Volume="1963" Year="2009">
       <Id>e1155ec8-0b49-4147-ac7e-508d9ba48bce</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="587" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="587" Volume="1963" Year="2009">
       <Id>5fa2e77b-e535-4298-a1f9-4113692d4844</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man:  EXTRA!" Number="1" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="The Amazing Spider-Man:  EXTRA!" Number="1" Volume="2008" Year="2008">
       <Id>c82676dd-9376-46f6-9aea-9f8f652aa909</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="588" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="588" Volume="1963" Year="2009">
       <Id>e5edc858-b0a4-4046-aeab-e8bfe98cfaba</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="589" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="589" Volume="1963" Year="2009">
       <Id>ddacaca2-0d39-48b6-83de-0fcd6a0e9df0</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man:  EXTRA!" Number="3" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="The Amazing Spider-Man:  EXTRA!" Number="3" Volume="2008" Year="2009">
       <Id>0bed10b6-2237-4094-8a86-1f13e92194ea</Id>
     </Book>
-    <Book Series="Spider-Man &amp; The Human Torch In... Bahia De Los Muertos!" Number="1" Volume="2009" Year="2009" Format="One-Shot">
+    <Book Series="Spider-Man &amp; The Human Torch In... Bahia De Los Muertos!" Number="1" Volume="2009" Year="2009">
       <Id>7a866409-8338-49da-aa53-bc94580f5af0</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man:  EXTRA!" Number="2" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="The Amazing Spider-Man:  EXTRA!" Number="2" Volume="2008" Year="2009">
       <Id>20a50949-74ab-485f-9945-c023784b6882</Id>
     </Book>
-    <Book Series="Timestorm 2009/2099" Number="1" Volume="2009" Year="2009" Format="Crossover">
+    <Book Series="Timestorm 2009/2099" Number="1" Volume="2009" Year="2009">
       <Id>c20e2228-c222-4b2b-a13d-ee053c89e456</Id>
     </Book>
-    <Book Series="Timestorm 2009/2099" Number="2" Volume="2009" Year="2009" Format="Crossover">
+    <Book Series="Timestorm 2009/2099" Number="2" Volume="2009" Year="2009">
       <Id>866c3ed0-3b3c-4bf9-9fca-2e1552117f38</Id>
     </Book>
-    <Book Series="Timestorm 2009/2099: Spider-Man One-Shot" Number="1" Volume="2009" Year="2009" Format="Crossover">
+    <Book Series="Timestorm 2009/2099: Spider-Man One-Shot" Number="1" Volume="2009" Year="2009">
       <Id>fa68e309-97c3-47c9-a4fb-7d91845f9d43</Id>
     </Book>
-    <Book Series="Timestorm 2009/2099" Number="3" Volume="2009" Year="2009" Format="Crossover">
+    <Book Series="Timestorm 2009/2099" Number="3" Volume="2009" Year="2009">
       <Id>e232a55c-9d0c-4361-833b-d4e69b6c7b13</Id>
     </Book>
-    <Book Series="Timestorm 2009/2099" Number="4" Volume="2009" Year="2009" Format="Crossover">
+    <Book Series="Timestorm 2009/2099" Number="4" Volume="2009" Year="2009">
       <Id>83708294-23f1-4f36-a2c8-afb0ae72e2a2</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="590" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="590" Volume="1963" Year="2009">
       <Id>3e35fab4-96ed-4aee-99e0-8316a850cd30</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="591" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="591" Volume="1963" Year="2009">
       <Id>32a38227-06e4-4112-b0e5-d7c69daa0a1d</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="592" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="592" Volume="1963" Year="2009">
       <Id>8c670784-9ecd-45b5-ae60-f80c320161cb</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="593" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="593" Volume="1963" Year="2009">
       <Id>2fd9a886-dc88-459a-893a-ccd261bd852f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="594" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="594" Volume="1963" Year="2009">
       <Id>2d94486a-f952-488a-b218-29f441b2b458</Id>
     </Book>
-    <Book Series="Dark Reign: Mister Negative" Number="1" Volume="2009" Year="2009" Format="Crossover">
+    <Book Series="Dark Reign: Mister Negative" Number="1" Volume="2009" Year="2009">
       <Id>fe6c6f58-b662-443a-b909-7e6e3d836c7a</Id>
     </Book>
-    <Book Series="Dark Reign: Mister Negative" Number="2" Volume="2009" Year="2009" Format="Crossover">
+    <Book Series="Dark Reign: Mister Negative" Number="2" Volume="2009" Year="2009">
       <Id>6b17f2f0-0620-4b78-a810-04b2845a36af</Id>
     </Book>
-    <Book Series="Dark Reign: Mister Negative" Number="3" Volume="2009" Year="2009" Format="Crossover">
+    <Book Series="Dark Reign: Mister Negative" Number="3" Volume="2009" Year="2009">
       <Id>2ef0d2b1-61de-434b-b890-b146a3649fcf</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="595" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="595" Volume="1963" Year="2009">
       <Id>29dbb757-af88-4c37-8f65-3d0bd0e7df29</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="596" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="596" Volume="1963" Year="2009">
       <Id>a99ea7ec-30b2-4794-9ce8-854eb19d33f6</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="597" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="597" Volume="1963" Year="2009">
       <Id>b1c0cb45-31a8-44ef-ad0b-516625be849c</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="598" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="598" Volume="1963" Year="2009">
       <Id>611f5474-7abd-4666-a67a-9ac211766ab3</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="599" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="599" Volume="1963" Year="2009">
       <Id>f70c448d-1523-4a33-8a5f-6ed5061c1d9d</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="36" Volume="1964" Year="2009" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="36" Volume="1964" Year="2009">
       <Id>7132d1c3-c6f4-44fa-b06c-f46fa0e7cb44</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="600" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="600" Volume="1963" Year="2009">
       <Id>a841fe12-053b-454c-81b2-b6c6e20da065</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="601" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="601" Volume="1963" Year="2009">
       <Id>1e58467a-0cd3-4620-aefa-f3666f01e653</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="602" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="602" Volume="1963" Year="2009">
       <Id>b2d10213-d496-4ad5-9893-b85b463f7030</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="603" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="603" Volume="1963" Year="2009">
       <Id>a13d1625-8530-4e9a-bba6-6dcad0035e95</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="604" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="604" Volume="1963" Year="2009">
       <Id>07ef96ce-cf6a-40fa-9133-7ade503aa498</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="605" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="605" Volume="1963" Year="2009">
       <Id>2d757bd3-e099-406b-9ccc-d8dce00d479a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="606" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="606" Volume="1963" Year="2009">
       <Id>81ee951e-6ea9-494c-9d29-b9cc5142591d</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="607" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="607" Volume="1963" Year="2009">
       <Id>29b089f9-d38e-415e-ab1d-38275ae6c659</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="608" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="608" Volume="1963" Year="2009">
       <Id>323a0b0c-8ddd-4560-9fd9-f9b02559dfd0</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="609" Volume="1963" Year="2009" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="609" Volume="1963" Year="2009">
       <Id>d04fa607-84df-4cc7-a80f-367b1765a294</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="610" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="610" Volume="1963" Year="2010">
       <Id>62bb17c7-1a25-45e9-90a8-fdf7c4dd7703</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="611" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="611" Volume="1963" Year="2010">
       <Id>5861c045-40b4-41c6-a951-2c3b52f471b5</Id>
     </Book>
-    <Book Series="Siege" Number="1" Volume="2010" Year="2010" Format="Crossover">
+    <Book Series="Siege" Number="1" Volume="2010" Year="2010">
       <Id>b8d455d1-f26d-4ec6-b7fa-b9e895270a2e</Id>
     </Book>
-    <Book Series="New Avengers" Number="61" Volume="2005" Year="2010" Format="Main Series">
+    <Book Series="New Avengers" Number="61" Volume="2005" Year="2010">
       <Id>f60c2106-68ac-415c-a1b0-b0ed593e44d4</Id>
     </Book>
-    <Book Series="New Avengers" Number="62" Volume="2005" Year="2010" Format="Main Series">
+    <Book Series="New Avengers" Number="62" Volume="2005" Year="2010">
       <Id>817ed059-3350-4890-bbbc-33648c4e47ca</Id>
     </Book>
-    <Book Series="Siege" Number="2" Volume="2010" Year="2010" Format="Crossover">
+    <Book Series="Siege" Number="2" Volume="2010" Year="2010">
       <Id>3cec930e-1c4f-415e-81cf-9ab2b7747c0d</Id>
     </Book>
-    <Book Series="Siege" Number="3" Volume="2010" Year="2010" Format="Crossover">
+    <Book Series="Siege" Number="3" Volume="2010" Year="2010">
       <Id>68872873-40cf-405e-ae88-f88862ecea71</Id>
     </Book>
-    <Book Series="New Avengers" Number="63" Volume="2005" Year="2010" Format="Main Series">
+    <Book Series="New Avengers" Number="63" Volume="2005" Year="2010">
       <Id>a30c551c-a7c8-4e66-81c8-ac7b34ee1adf</Id>
     </Book>
-    <Book Series="Siege: Spider-Man" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="Siege: Spider-Man" Number="1" Volume="2010" Year="2010">
       <Id>7a46cc54-7bc5-475d-97c7-6d490df386d6</Id>
     </Book>
-    <Book Series="New Avengers" Number="64" Volume="2005" Year="2010" Format="Main Series">
+    <Book Series="New Avengers" Number="64" Volume="2005" Year="2010">
       <Id>3c466d20-8f24-4589-9335-31b4a919644f</Id>
     </Book>
-    <Book Series="Siege" Number="4" Volume="2010" Year="2010" Format="Crossover">
+    <Book Series="Siege" Number="4" Volume="2010" Year="2010">
       <Id>6ef76b9b-71f6-44a9-b828-75fc119e1796</Id>
     </Book>
-    <Book Series="New Avengers Finale" Number="1" Volume="2010" Year="2010" Format="One-Shot">
+    <Book Series="New Avengers Finale" Number="1" Volume="2010" Year="2010">
       <Id>660e63f7-c392-4775-80cd-07749759010b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="612" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="612" Volume="1963" Year="2010">
       <Id>e561efea-2cde-4225-be8e-529821f880d9</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="613" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="613" Volume="1963" Year="2010">
       <Id>4bcea647-c7af-4ba9-9412-85f62fc8042f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="614" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="614" Volume="1963" Year="2010">
       <Id>e8fabb07-32d0-4f61-a327-57ada0cda95f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="615" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="615" Volume="1963" Year="2010">
       <Id>5b69faf0-68a2-441c-baab-111697cf6b81</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="616" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="616" Volume="1963" Year="2010">
       <Id>89e27e27-f999-4d60-88db-351a3ce35ad5</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="617" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="617" Volume="1963" Year="2010">
       <Id>4c0f3f76-4ea8-416d-97e1-3c9e4fad8bca</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="618" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="618" Volume="1963" Year="2010">
       <Id>4f3dc45a-d9b5-4a11-b3fe-d9ad80637dfc</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="619" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="619" Volume="1963" Year="2010">
       <Id>be7cf38f-31fc-4ddd-a667-e6ce353515dc</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="620" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="620" Volume="1963" Year="2010">
       <Id>4edb937b-4996-4e3e-a8ef-0146d2cbdb93</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="621" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="621" Volume="1963" Year="2010">
       <Id>b734042b-d2be-4012-90ab-f6d516601053</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="622" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="622" Volume="1963" Year="2010">
       <Id>f038a989-81ee-4f4f-94eb-2abdbb8933c3</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="623" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="623" Volume="1963" Year="2010">
       <Id>214ff482-fbb9-4404-abbc-03879aefe60a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="624" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="624" Volume="1963" Year="2010">
       <Id>38bfb1fc-aef1-41f9-be3a-5c91c310ae3c</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="625" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="625" Volume="1963" Year="2010">
       <Id>463ee3dc-dffe-492a-80aa-017f3605a838</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="626" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="626" Volume="1963" Year="2010">
       <Id>8d910b4b-79ed-4f68-99ed-24c8cb51bcac</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="627" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="627" Volume="1963" Year="2010">
       <Id>0281ad51-d51d-46e4-b394-2f2bbb729646</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="628" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="628" Volume="1963" Year="2010">
       <Id>bf1b44ff-b548-4517-bc92-00a1c3bfb556</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="629" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="629" Volume="1963" Year="2010">
       <Id>519dbc55-c74e-488d-88e9-5a39b40a9b49</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="630" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="630" Volume="1963" Year="2010">
       <Id>5e9973ce-7f17-4b13-848e-d48a7940b01d</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="631" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="631" Volume="1963" Year="2010">
       <Id>0acbd4b7-562b-4a7b-914e-70e7abac348f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="632" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="632" Volume="1963" Year="2010">
       <Id>8be98a96-ab3f-42c4-9b15-fbc53bb0826f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="633" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="633" Volume="1963" Year="2010">
       <Id>ec851359-6c0f-43cc-a511-96bbc276f3db</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="634" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="634" Volume="1963" Year="2010">
       <Id>154238c0-2b96-4487-90a5-9b2f15ed491e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="635" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="635" Volume="1963" Year="2010">
       <Id>6bacef4c-a99b-4639-a5c3-a63f87b1022e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="636" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="636" Volume="1963" Year="2010">
       <Id>2feee861-e78f-4031-8c37-09c107e02a1e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="637" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="637" Volume="1963" Year="2010">
       <Id>7427af62-5751-47d0-9584-4acf902ff7e9</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="638" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="638" Volume="1963" Year="2010">
       <Id>dd3ee40a-c5ac-4a7c-825f-4c4cdc159203</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="639" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="639" Volume="1963" Year="2010">
       <Id>b1bacf01-b9b4-4f27-b2b5-0a04b21414ab</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="640" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="640" Volume="1963" Year="2010">
       <Id>adb37c52-f597-45de-b3a5-66b8c59882a1</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="641" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="641" Volume="1963" Year="2010">
       <Id>8ee18725-c41c-4fcc-a3b1-374bbd0482fd</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="642" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="642" Volume="1963" Year="2010">
       <Id>67736ba6-3c9e-4878-98e1-92c48d0d1c41</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="643" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="643" Volume="1963" Year="2010">
       <Id>d4520be5-08bd-43df-804c-3058f98d2fbc</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="644" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="644" Volume="1963" Year="2010">
       <Id>9946c701-5740-4274-90ff-073a0d532c6a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="645" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="645" Volume="1963" Year="2010">
       <Id>04a49f42-9a04-4d90-a213-000dbd9688b8</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="646" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="646" Volume="1963" Year="2010">
       <Id>efd1ada5-44ab-4ea2-b949-4cb823b140c5</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="647" Volume="1963" Year="2010" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="647" Volume="1963" Year="2010">
       <Id>0d16992d-7bb8-49f6-b850-cfbf8ef09a22</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="648" Volume="1963" Year="2011" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="648" Volume="1963" Year="2011">
       <Id>75a20aa7-1e00-4a03-9659-0fcc8111e836</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="649" Volume="1963" Year="2011" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="649" Volume="1963" Year="2011">
       <Id>9a408d69-a5f2-4bd8-bfc5-f171a3a9e83a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="650" Volume="1963" Year="2011" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="650" Volume="1963" Year="2011">
       <Id>b90c7a3d-24be-49b7-a099-6003f57ade09</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="651" Volume="1963" Year="2011" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="651" Volume="1963" Year="2011">
       <Id>8518c0b4-a73d-4bd8-a6f5-e555c320dfe1</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="652" Volume="1963" Year="2011" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="652" Volume="1963" Year="2011">
       <Id>fa8ed258-eee8-4dc9-a515-e35d47930a75</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="653" Volume="1963" Year="2011" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="653" Volume="1963" Year="2011">
       <Id>9ee305fd-9c36-419a-a640-ca6492f7a46f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="654" Volume="1963" Year="2011" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="654" Volume="1963" Year="2011">
       <Id>0510edaa-08b4-4594-8de5-7a6072a6a37f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="655" Volume="1963" Year="2011" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="655" Volume="1963" Year="2011">
       <Id>c6060071-b85a-493c-8c87-b4cc3b2bff3b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="656" Volume="1963" Year="2011" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="656" Volume="1963" Year="2011">
       <Id>3bc26480-b354-4dee-b710-14874c1d2cf0</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="657" Volume="1963" Year="2011" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="657" Volume="1963" Year="2011">
       <Id>c4d5e1f4-4b3a-4b4d-a52b-fd53d4821031</Id>
     </Book>
-    <Book Series="FF" Number="1" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="FF" Number="1" Volume="2011" Year="2011">
       <Id>66f13af9-f11c-4514-9ccd-fe5f4c7f1562</Id>
     </Book>
-    <Book Series="FF" Number="2" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="FF" Number="2" Volume="2011" Year="2011">
       <Id>fc983666-7425-442e-b0fd-772d667ab9f8</Id>
     </Book>
-    <Book Series="FF" Number="3" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="FF" Number="3" Volume="2011" Year="2011">
       <Id>65edfc92-0ef4-4090-8fd4-f517bde173e2</Id>
     </Book>
-    <Book Series="FF" Number="4" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="FF" Number="4" Volume="2011" Year="2011">
       <Id>01e8a7e4-ee1a-4f34-a1a2-4e9c011f16e0</Id>
     </Book>
-    <Book Series="FF" Number="5" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="FF" Number="5" Volume="2011" Year="2011">
       <Id>8b0e2eee-ae71-4bbd-8f7c-ec63a460ac96</Id>
     </Book>
-    <Book Series="FF" Number="6" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="FF" Number="6" Volume="2011" Year="2011">
       <Id>034ad0cf-e130-40ba-8266-91deb0c732bf</Id>
     </Book>
-    <Book Series="FF" Number="7" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="FF" Number="7" Volume="2011" Year="2011">
       <Id>a94d18bd-ade3-45e8-8af9-eaca253065c1</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="658" Volume="1963" Year="2011" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="658" Volume="1963" Year="2011">
       <Id>50900b4d-47c9-4cfc-8b3a-5b7f2b58d8ee</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="659" Volume="1963" Year="2011" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="659" Volume="1963" Year="2011">
       <Id>073ed67b-816a-4e0f-a407-f748f939a0e5</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="660" Volume="1963" Year="2011" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="660" Volume="1963" Year="2011">
       <Id>6b5969a3-7950-4789-8df1-9809fe2c37bd</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="661" Volume="1963" Year="2011" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="661" Volume="1963" Year="2011">
       <Id>482fb1e0-5094-42b6-8519-284ffa70d600</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="662" Volume="1963" Year="2011" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="662" Volume="1963" Year="2011">
       <Id>1d16770d-937e-41d8-9e7e-281ad78a5777</Id>
     </Book>
-    <Book Series="Fear Itself: Spider-Man" Number="1" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Fear Itself: Spider-Man" Number="1" Volume="2011" Year="2011">
       <Id>44efdc16-bd11-46fb-8732-3dd24c1517e8</Id>
     </Book>
-    <Book Series="Fear Itself: Spider-Man" Number="2" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Fear Itself: Spider-Man" Number="2" Volume="2011" Year="2011">
       <Id>a6daecfe-e936-4e9f-995d-601ee44b5cf0</Id>
     </Book>
-    <Book Series="Fear Itself: Spider-Man" Number="3" Volume="2011" Year="2011" Format="Limited Series">
+    <Book Series="Fear Itself: Spider-Man" Number="3" Volume="2011" Year="2011">
       <Id>5cd41d73-50b4-4e18-9209-907d603bbc23</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="663" Volume="1963" Year="2011" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="663" Volume="1963" Year="2011">
       <Id>f9649de3-a4d8-4f9d-8df8-1c2841406752</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="664" Volume="1963" Year="2011" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="664" Volume="1963" Year="2011">
       <Id>1d760ee3-d56b-4473-88b7-dce6ee8aeac6</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="665" Volume="1963" Year="2011" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="665" Volume="1963" Year="2011">
       <Id>8d18f16b-c105-4961-96fe-5ec1b65b8778</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="666" Volume="1963" Year="2011" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="666" Volume="1963" Year="2011">
       <Id>07822d71-fbb0-47f6-8ea6-375cb40d2391</Id>
     </Book>
-    <Book Series="Venom" Number="5" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Venom" Number="5" Volume="2011" Year="2011">
       <Id>c982c392-00da-46b6-b692-4023b0c2dc30</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="667" Volume="1963" Year="2011" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="667" Volume="1963" Year="2011">
       <Id>d959fc44-6511-4cb7-a502-65cd9ea88b66</Id>
     </Book>
-    <Book Series="Spider-Island: Cloak &amp; Dagger" Number="1" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Spider-Island: Cloak &amp; Dagger" Number="1" Volume="2011" Year="2011">
       <Id>65571093-552f-4904-8a3d-666f0c41b5e9</Id>
     </Book>
-    <Book Series="Spider-Island: Deadly Foes" Number="1" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Spider-Island: Deadly Foes" Number="1" Volume="2011" Year="2011">
       <Id>691812c3-6694-470e-a061-7e41174daccb</Id>
     </Book>
-    <Book Series="Venom" Number="6" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Venom" Number="6" Volume="2011" Year="2011">
       <Id>843730d4-2611-49ed-9b8e-c8ce2f36e457</Id>
     </Book>
-    <Book Series="Spider-Island: Deadly Hands of Kung Fu" Number="1" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Spider-Island: Deadly Hands of Kung Fu" Number="1" Volume="2011" Year="2011">
       <Id>834d9eeb-0908-4686-a171-22cfa5a07d96</Id>
     </Book>
-    <Book Series="Spider-Island: The Amazing Spider Girl" Number="1" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Spider-Island: The Amazing Spider Girl" Number="1" Volume="2011" Year="2011">
       <Id>d5e18860-a578-4fb4-bf84-bcb9c3619e83</Id>
     </Book>
-    <Book Series="Spider-Island: Emergence of Evil - Jackal &amp; Hobgoblin" Number="1" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Spider-Island: Emergence of Evil - Jackal &amp; Hobgoblin" Number="1" Volume="2011" Year="2011">
       <Id>79c3bcf0-99c5-4cf3-acd4-a21edd830f3b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="668" Volume="1963" Year="2011" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="668" Volume="1963" Year="2011">
       <Id>825adfd0-2504-474f-bc90-1e629c0b3495</Id>
     </Book>
-    <Book Series="Amazing Spider-Man: Infested" Number="1" Volume="2011" Year="2011" Format="One-Shot">
+    <Book Series="Amazing Spider-Man: Infested" Number="1" Volume="2011" Year="2011">
       <Id>cc616ec4-2a11-4fc3-8a17-4c37d035409e</Id>
     </Book>
-    <Book Series="Spider-Island: Cloak &amp; Dagger" Number="2" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Spider-Island: Cloak &amp; Dagger" Number="2" Volume="2011" Year="2011">
       <Id>46db6fc7-d1b6-4a96-9eeb-4b90dda279dc</Id>
     </Book>
-    <Book Series="Spider-Island: The Avengers" Number="1" Volume="2011" Year="2011" Format="One-Shot">
+    <Book Series="Spider-Island: The Avengers" Number="1" Volume="2011" Year="2011">
       <Id>f4174613-2978-4af3-ac94-e04c68446a02</Id>
     </Book>
-    <Book Series="Spider-Island: The Amazing Spider Girl" Number="2" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Spider-Island: The Amazing Spider Girl" Number="2" Volume="2011" Year="2011">
       <Id>00d39f87-aaf8-41c3-875b-243cb62b7713</Id>
     </Book>
-    <Book Series="Spider-Island: I Love New York City" Number="1" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Spider-Island: I Love New York City" Number="1" Volume="2011" Year="2011">
       <Id>01d4988c-623c-431f-ba38-bc77f7f2b759</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="669" Volume="1963" Year="2011" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="669" Volume="1963" Year="2011">
       <Id>59e0cb12-9511-4372-ad8b-5aa637901d6f</Id>
     </Book>
-    <Book Series="Spider-Island: Spider-Woman" Number="1" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Spider-Island: Spider-Woman" Number="1" Volume="2011" Year="2011">
       <Id>d52fc962-5f37-4d53-bbd4-ae6b4668d567</Id>
     </Book>
-    <Book Series="Venom" Number="7" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Venom" Number="7" Volume="2011" Year="2011">
       <Id>f63ec885-fdfd-417d-8dd3-36ccad7fb914</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="670" Volume="1963" Year="2011" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="670" Volume="1963" Year="2011">
       <Id>25129d04-9d56-4e25-a713-40543088ef30</Id>
     </Book>
-    <Book Series="Spider-Island: Deadly Hands of Kung Fu" Number="2" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Spider-Island: Deadly Hands of Kung Fu" Number="2" Volume="2011" Year="2011">
       <Id>14d137c8-ea6a-4b9a-82aa-a06a3f408920</Id>
     </Book>
-    <Book Series="Spider-Island: Heroes For Hire" Number="1" Volume="2011" Year="2011" Format="Crossover">
+    <Book Series="Spider-Island: Heroes For Hire" Number="1" Volume="2011" Year="2011">
       <Id>1fa9982b-a3a5-4f86-b8da-97942fca7af3</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="671" Volume="1963" Year="2011" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="671" Volume="1963" Year="2011">
       <Id>f288e795-83d9-478f-9c08-e24a1ffb8d05</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="672" Volume="1963" Year="2011" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="672" Volume="1963" Year="2011">
       <Id>7174ed6e-e45a-4471-94c2-3f99d86dbd2b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="673" Volume="1963" Year="2012" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="673" Volume="1963" Year="2012">
       <Id>7d426a20-237a-48f1-8c89-b2640e1faa31</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="674" Volume="1963" Year="2012" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="674" Volume="1963" Year="2012">
       <Id>6cf98cc3-6b74-4bf9-9f9a-989b4d94a341</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="675" Volume="1963" Year="2012" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="675" Volume="1963" Year="2012">
       <Id>160ed6c2-b29f-48b2-914d-428700846784</Id>
     </Book>
-    <Book Series="Avenging Spider-Man" Number="1" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Avenging Spider-Man" Number="1" Volume="2011" Year="2012">
       <Id>aed5959f-d131-4489-ac8e-d6a58bad19c7</Id>
     </Book>
-    <Book Series="Avenging Spider-Man" Number="2" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Avenging Spider-Man" Number="2" Volume="2011" Year="2012">
       <Id>37cfbb3b-5971-4a7d-81ce-4f3cd06bb5ec</Id>
     </Book>
-    <Book Series="Avenging Spider-Man" Number="3" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Avenging Spider-Man" Number="3" Volume="2011" Year="2012">
       <Id>6e980cef-8a84-465e-b1ae-a7c5e5892a99</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="676" Volume="1963" Year="2012" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="676" Volume="1963" Year="2012">
       <Id>66a2e693-2e30-4ab5-b90e-66c77af2a78c</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="677" Volume="1963" Year="2012" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="677" Volume="1963" Year="2012">
       <Id>8fe56df5-718a-411e-9664-0ba6030a62e9</Id>
     </Book>
-    <Book Series="Daredevil" Number="8" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Daredevil" Number="8" Volume="2011" Year="2012">
       <Id>ee8fd394-4cf9-4157-96f7-d009f78a18e2</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="678" Volume="1963" Year="2012" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="678" Volume="1963" Year="2012">
       <Id>a4e4e550-a33e-4104-bf04-9bb15126a26b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="679" Volume="1963" Year="2012" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="679" Volume="1963" Year="2012">
       <Id>f7e7556b-3641-4b02-bbea-96c100e2282d</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="679.1" Volume="1963" Year="2012" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="679.1" Volume="1963" Year="2012">
       <Id>8e7542e2-9cc7-4ad0-beb6-72bded153b33</Id>
     </Book>
-    <Book Series="Avenging Spider-Man" Number="4" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Avenging Spider-Man" Number="4" Volume="2011" Year="2012">
       <Id>bbd72a42-8515-43e7-9506-07b5e1ff0ba4</Id>
     </Book>
-    <Book Series="Avenging Spider-Man" Number="5" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Avenging Spider-Man" Number="5" Volume="2011" Year="2012">
       <Id>67c71f6f-d972-4619-bbe7-5d4b46c0c971</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="680" Volume="1963" Year="2012" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="680" Volume="1963" Year="2012">
       <Id>5fd8ee6d-c4d7-42dc-bc66-561fd4d7cdb7</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="681" Volume="1963" Year="2012" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="681" Volume="1963" Year="2012">
       <Id>8a2a3e24-9182-4fbf-af5e-a40ac40201b7</Id>
     </Book>
-    <Book Series="Avenging Spider-Man" Number="6" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Avenging Spider-Man" Number="6" Volume="2011" Year="2012">
       <Id>f3f23314-2884-474f-b524-82fa084a21b2</Id>
     </Book>
-    <Book Series="The Punisher" Number="10" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="The Punisher" Number="10" Volume="2011" Year="2012">
       <Id>9c3c7981-7a95-49e0-8c72-af0b6dc04a9a</Id>
     </Book>
-    <Book Series="Daredevil" Number="11" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Daredevil" Number="11" Volume="2011" Year="2012">
       <Id>174e76e0-8293-457a-90ee-ba967455527d</Id>
     </Book>
-    <Book Series="Avenging Spider-Man" Number="7" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Avenging Spider-Man" Number="7" Volume="2011" Year="2012">
       <Id>5012b146-955e-4427-9f3d-bc82275e3517</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Annual" Number="39" Volume="1964" Year="2012" Format="Annual">
+    <Book Series="The Amazing Spider-Man Annual" Number="39" Volume="1964" Year="2012">
       <Id>318b5b4d-f9ae-434e-84bc-398d10905fa1</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="682" Volume="1963" Year="2012" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="682" Volume="1963" Year="2012">
       <Id>ad898ca1-aa4e-4427-a3d4-730ed506e688</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="683" Volume="1963" Year="2012" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="683" Volume="1963" Year="2012">
       <Id>70675487-51b7-476a-bc83-78401c11f2eb</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="684" Volume="1963" Year="2012" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="684" Volume="1963" Year="2012">
       <Id>982fba88-e6e3-49f0-ade5-3afaaf0aa894</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="685" Volume="1963" Year="2012" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="685" Volume="1963" Year="2012">
       <Id>0b1deb19-901a-4f83-94b5-0bbfaa90411f</Id>
     </Book>
-    <Book Series="Amazing Spider-Man: Ends of the Earth" Number="1" Volume="2012" Year="2012" Format="One-Shot">
+    <Book Series="Amazing Spider-Man: Ends of the Earth" Number="1" Volume="2012" Year="2012">
       <Id>e8546824-9141-4e42-9a30-2bc9a7949490</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="686" Volume="1963" Year="2012" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="686" Volume="1963" Year="2012">
       <Id>fd65b9e5-4008-46a6-9292-f5ede984b630</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="687" Volume="1963" Year="2012" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="687" Volume="1963" Year="2012">
       <Id>7bbc53f6-b018-44f8-ab98-aabada5d25d0</Id>
     </Book>
-    <Book Series="Avenging Spider-Man" Number="8" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Avenging Spider-Man" Number="8" Volume="2011" Year="2012">
       <Id>81672e91-fd47-49f3-a15f-5c5f4e07f820</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men" Number="1" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men" Number="1" Volume="2012" Year="2012">
       <Id>3ee055b9-6dc9-408e-84ab-4be34f7bd85a</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men" Number="2" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men" Number="2" Volume="2012" Year="2012">
       <Id>a1921a7d-8ab0-48e9-82fb-c6d8f75dd507</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men" Number="3" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men" Number="3" Volume="2012" Year="2012">
       <Id>80e84dad-9553-4ebb-a739-d90636e3ee79</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men" Number="4" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men" Number="4" Volume="2012" Year="2012">
       <Id>c9f324ce-f4d1-4d0f-93bb-f49cf8d2e12e</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men" Number="5" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men" Number="5" Volume="2012" Year="2012">
       <Id>d5e04532-7bd0-43f8-b4b6-838fca87c17b</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men" Number="6" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men" Number="6" Volume="2012" Year="2012">
       <Id>5f489e6e-8353-4ce0-9c27-f2aec9c0c3d5</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men" Number="7" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men" Number="7" Volume="2012" Year="2012">
       <Id>db2de910-ad78-4d73-af4c-e846d9ad52f6</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men" Number="8" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men" Number="8" Volume="2012" Year="2012">
       <Id>4890b435-8d2d-4169-be96-748ee320601e</Id>
     </Book>
-    <Book Series="New Avengers" Number="25" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="New Avengers" Number="25" Volume="2010" Year="2012">
       <Id>a8ac332c-63fe-45de-9149-9f06f81fb21b</Id>
     </Book>
-    <Book Series="New Avengers" Number="26" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="New Avengers" Number="26" Volume="2010" Year="2012">
       <Id>a6e89747-9e68-40c7-9064-d21de051b628</Id>
     </Book>
-    <Book Series="New Avengers" Number="27" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="New Avengers" Number="27" Volume="2010" Year="2012">
       <Id>5f02b221-ee8d-49b3-bb16-fc412583feaa</Id>
     </Book>
-    <Book Series="New Avengers" Number="28" Volume="2010" Year="2012" Format="Main Series">
+    <Book Series="New Avengers" Number="28" Volume="2010" Year="2012">
       <Id>6ccce8a4-24ce-41fb-922f-d7ee876db2d6</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men" Number="9" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men" Number="9" Volume="2012" Year="2012">
       <Id>c8c9640a-790b-4dee-a6fa-9256278457d4</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men" Number="10" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men" Number="10" Volume="2012" Year="2012">
       <Id>2b7cfa2a-bf09-4a88-82d9-ca28d40103b9</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men" Number="11" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men" Number="11" Volume="2012" Year="2012">
       <Id>c389edff-e3ad-42d7-92b0-864483403a8c</Id>
     </Book>
-    <Book Series="Avengers Vs. X-Men" Number="12" Volume="2012" Year="2012" Format="Crossover">
+    <Book Series="Avengers Vs. X-Men" Number="12" Volume="2012" Year="2012">
       <Id>28a5a897-c409-48bb-8ac7-910c8b769a0a</Id>
     </Book>
-    <Book Series="Spider-Men" Number="1" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Spider-Men" Number="1" Volume="2012" Year="2012">
       <Id>e56bbbb7-df25-4d4b-87f5-5d5b76f31c12</Id>
     </Book>
-    <Book Series="Spider-Men" Number="2" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Spider-Men" Number="2" Volume="2012" Year="2012">
       <Id>813ef871-c7df-4c10-bb30-f713a4bb9dfb</Id>
     </Book>
-    <Book Series="Spider-Men" Number="3" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Spider-Men" Number="3" Volume="2012" Year="2012">
       <Id>9f4985d4-4944-4104-9aad-7eaa4d24bb4a</Id>
     </Book>
-    <Book Series="Spider-Men" Number="4" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Spider-Men" Number="4" Volume="2012" Year="2012">
       <Id>07de89f4-e92d-4ef0-b9e2-34670495426d</Id>
     </Book>
-    <Book Series="Spider-Men" Number="5" Volume="2012" Year="2012" Format="Limited Series">
+    <Book Series="Spider-Men" Number="5" Volume="2012" Year="2012">
       <Id>1515c02c-bc58-415a-b7ae-73465ea39fa4</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="688" Volume="1963" Year="2012" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="688" Volume="1963" Year="2012">
       <Id>d2a4084f-ae70-4d8c-aaa0-ffda4a351f3e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="689" Volume="1963" Year="2012" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="689" Volume="1963" Year="2012">
       <Id>0deed226-3002-4c78-abb8-9ebcacc61c06</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="690" Volume="1963" Year="2012" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="690" Volume="1963" Year="2012">
       <Id>881f83d2-3cd8-46f2-a53a-9b7e0d647eef</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="691" Volume="1963" Year="2012" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="691" Volume="1963" Year="2012">
       <Id>813604ad-9017-4a77-8832-761fbcc32e1f</Id>
     </Book>
-    <Book Series="Avenging Spider-Man" Number="9" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Avenging Spider-Man" Number="9" Volume="2011" Year="2012">
       <Id>dcd2ba2e-edb3-4df0-b4e6-4e7ece4479a1</Id>
     </Book>
-    <Book Series="Avenging Spider-Man" Number="10" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Avenging Spider-Man" Number="10" Volume="2011" Year="2012">
       <Id>e2930dc8-ca67-4ae5-b01e-4a791272e108</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="692" Volume="1963" Year="2012" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="692" Volume="1963" Year="2012">
       <Id>b539f190-30f1-4579-9f53-176dda8ce1b5</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="693" Volume="1963" Year="2012" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="693" Volume="1963" Year="2012">
       <Id>6453e73b-692c-46a2-a154-33a964b22051</Id>
     </Book>
-    <Book Series="Avenging Spider-Man" Number="11" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Avenging Spider-Man" Number="11" Volume="2011" Year="2012">
       <Id>bdb549ef-6308-4bac-8b41-dddbfc6423ea</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="694" Volume="1963" Year="2012" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="694" Volume="1963" Year="2012">
       <Id>4513774f-789d-42da-b86d-3f0f030d2044</Id>
     </Book>
-    <Book Series="Avenging Spider-Man" Number="12" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Avenging Spider-Man" Number="12" Volume="2011" Year="2012">
       <Id>162d11a0-0909-44a9-9f7f-e7d0f316dd9d</Id>
     </Book>
-    <Book Series="Avenging Spider-Man" Number="13" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Avenging Spider-Man" Number="13" Volume="2011" Year="2012">
       <Id>44f2238c-e163-49f1-80b9-e277e1e3f475</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="695" Volume="1963" Year="2012" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="695" Volume="1963" Year="2012">
       <Id>f1d88e4c-de90-4230-80bb-f5588404381a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="696" Volume="1963" Year="2012" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="696" Volume="1963" Year="2012">
       <Id>e06d42c8-3bb9-4a80-9ab2-f450f3ac6bee</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="697" Volume="1963" Year="2013" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="697" Volume="1963" Year="2013">
       <Id>3d0d8c80-4f4c-4273-8217-bf68cc4bf729</Id>
     </Book>
-    <Book Series="Avenging Spider-Man" Number="14" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Avenging Spider-Man" Number="14" Volume="2011" Year="2013">
       <Id>a81e371c-988e-4fab-b4d5-d04504b5ffcc</Id>
     </Book>
-    <Book Series="Avenging Spider-Man" Number="15" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Avenging Spider-Man" Number="15" Volume="2011" Year="2013">
       <Id>52a17db0-fc9f-4af6-9a65-bd40841928e0</Id>
     </Book>
-    <Book Series="Avengers" Number="1" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Avengers" Number="1" Volume="2013" Year="2013">
       <Id>22ca363b-6149-4e73-ae60-1f3d25169934</Id>
     </Book>
-    <Book Series="Avengers" Number="2" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Avengers" Number="2" Volume="2013" Year="2013">
       <Id>89482383-7ac0-4f82-b71a-f420b0cf6ea6</Id>
     </Book>
-    <Book Series="Avengers" Number="3" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Avengers" Number="3" Volume="2013" Year="2013">
       <Id>fa7640d6-d6ee-4e09-9a89-955946a256e8</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="698" Volume="1963" Year="2013" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="698" Volume="1963" Year="2013">
       <Id>f331eff8-53ee-458a-8291-ba62ca741fca</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="699" Volume="1963" Year="2013" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="699" Volume="1963" Year="2013">
       <Id>8780ad4f-bd87-46bc-9335-26d30bdb383e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="699.1" Volume="1963" Year="2013" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="699.1" Volume="1963" Year="2013">
       <Id>b801789c-543e-4c02-983d-1ca875c8a010</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="700" Volume="1963" Year="2013" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="700" Volume="1963" Year="2013">
       <Id>a09b2b38-5bff-406f-a835-624a0f9d609a</Id>
     </Book>
-    <Book Series="Avenging Spider-Man" Number="15.1" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Avenging Spider-Man" Number="15.1" Volume="2011" Year="2013">
       <Id>6c27d9dd-69ca-4796-b26e-de6e77cce2a6</Id>
     </Book>
-    <Book Series="Marvel Knights: Spider-Man" Number="1" Volume="2013" Year="2013" Format="Limited Series">
+    <Book Series="Marvel Knights: Spider-Man" Number="1" Volume="2013" Year="2013">
       <Id>138ce6dd-7c28-4d55-bd22-be8d166be0aa</Id>
     </Book>
-    <Book Series="Marvel Knights: Spider-Man" Number="2" Volume="2013" Year="2014" Format="Limited Series">
+    <Book Series="Marvel Knights: Spider-Man" Number="2" Volume="2013" Year="2014">
       <Id>15c28ee7-f86c-4549-9419-ee13066bb819</Id>
     </Book>
-    <Book Series="Marvel Knights: Spider-Man" Number="3" Volume="2013" Year="2014" Format="Limited Series">
+    <Book Series="Marvel Knights: Spider-Man" Number="3" Volume="2013" Year="2014">
       <Id>f50e80ae-845f-4801-8137-3bb36d871ca8</Id>
     </Book>
-    <Book Series="Marvel Knights: Spider-Man" Number="4" Volume="2013" Year="2014" Format="Limited Series">
+    <Book Series="Marvel Knights: Spider-Man" Number="4" Volume="2013" Year="2014">
       <Id>fab2c1b8-4598-4266-91e8-1a3bf12c5f6b</Id>
     </Book>
-    <Book Series="Marvel Knights: Spider-Man" Number="5" Volume="2013" Year="2014" Format="Limited Series">
+    <Book Series="Marvel Knights: Spider-Man" Number="5" Volume="2013" Year="2014">
       <Id>fb2c094e-ab68-4410-9bb9-a57e8a078d0a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="700.1" Volume="1963" Year="2014" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="700.1" Volume="1963" Year="2014">
       <Id>a0b6ce78-b4c8-4f11-968a-61671d4eef45</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="700.2" Volume="1963" Year="2014" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="700.2" Volume="1963" Year="2014">
       <Id>d9d0011c-9af1-4555-a707-3dd15d24c49f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="700.3" Volume="1963" Year="2014" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="700.3" Volume="1963" Year="2014">
       <Id>83319776-ab16-420a-81af-3af92fc2eee6</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="700.4" Volume="1963" Year="2014" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="700.4" Volume="1963" Year="2014">
       <Id>b4752ec6-0a51-453c-899a-b813609d6464</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="700.5" Volume="1963" Year="2014" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="700.5" Volume="1963" Year="2014">
       <Id>89ca1da1-4ad7-4f65-b126-0f34c3910210</Id>
     </Book>
-    <Book Series="Peter Parker" Number="1" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Peter Parker" Number="1" Volume="2010" Year="2010">
       <Id>d90931bb-87fa-40fc-a11e-3e000b8c9502</Id>
     </Book>
-    <Book Series="Peter Parker" Number="2" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Peter Parker" Number="2" Volume="2010" Year="2010">
       <Id>3d65e23d-cdef-43be-a180-11b5990058f9</Id>
     </Book>
-    <Book Series="Peter Parker" Number="3" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Peter Parker" Number="3" Volume="2010" Year="2010">
       <Id>274b6567-ad48-4f03-a63b-10f3762e8295</Id>
     </Book>
-    <Book Series="Peter Parker" Number="4" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Peter Parker" Number="4" Volume="2010" Year="2010">
       <Id>19829a05-901e-46ab-b4c9-cd606640c93a</Id>
     </Book>
-    <Book Series="Peter Parker" Number="5" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Peter Parker" Number="5" Volume="2010" Year="2010">
       <Id>04fb87fe-9fc1-483c-802e-4b4ab12de97f</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Spider-Man/Spider-Man 009 (Superior_Marvel NOW!).cbl
+++ b/Marvel/Characters/unsorted/Spider-Man/Spider-Man 009 (Superior_Marvel NOW!).cbl
@@ -1,627 +1,628 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Spider-Man 9 (Superior/Marvel NOW!)</Name>
+  <Name>Spider-Man 009 (Superior_Marvel NOW!)</Name>
+  <NumIssues>207</NumIssues>
   <Books>
     <Book Series="Avenging Spider-Man" Number="15.1" Volume="2011" Year="2013">
-      <Id>6c27d9dd-69ca-4796-b26e-de6e77cce2a6</Id>
+      <Database Name="cv" Series="43884" Issue="374689" />
     </Book>
     <Book Series="Superior Spider-Man" Number="1" Volume="2013" Year="2013">
-      <Id>d16af6f5-d5f8-4ec1-a574-993a6f9cff5e</Id>
+      <Database Name="cv" Series="55552" Issue="378868" />
     </Book>
     <Book Series="Daredevil" Number="21" Volume="2011" Year="2013">
-      <Id>ed1030b2-3627-4d1d-ace1-baa1965f65b0</Id>
+      <Database Name="cv" Series="41410" Issue="373300" />
     </Book>
     <Book Series="Daredevil" Number="22" Volume="2011" Year="2013">
-      <Id>a00b9ca5-1370-418a-af47-1a6daa113d32</Id>
+      <Database Name="cv" Series="41410" Issue="380379" />
     </Book>
     <Book Series="Superior Spider-Man" Number="2" Volume="2013" Year="2013">
-      <Id>c81ee100-cc20-419e-a5ec-2b18a7871d76</Id>
+      <Database Name="cv" Series="55552" Issue="382809" />
     </Book>
     <Book Series="Avenging Spider-Man" Number="16" Volume="2011" Year="2013">
-      <Id>d3d93c84-033a-4cfa-9cf3-967e8035efa8</Id>
+      <Database Name="cv" Series="43884" Issue="380350" />
     </Book>
     <Book Series="Superior Spider-Man" Number="3" Volume="2013" Year="2013">
-      <Id>9bfc7ebe-f58f-4cef-9446-5e4ad30a50b7</Id>
+      <Database Name="cv" Series="55552" Issue="384964" />
     </Book>
     <Book Series="Superior Spider-Man" Number="4" Volume="2013" Year="2013">
-      <Id>239c41c5-7eb2-4bd0-9282-669f73c65c43</Id>
+      <Database Name="cv" Series="55552" Issue="387262" />
     </Book>
     <Book Series="Superior Spider-Man" Number="5" Volume="2013" Year="2013">
-      <Id>ed371cbf-5452-463f-b75b-cbf79e13f974</Id>
+      <Database Name="cv" Series="55552" Issue="390453" />
     </Book>
-    <Book Series="Avengers" Number="6" Volume="2013" Year="2013">
-      <Id>254d1ef0-63df-477b-8577-2d52c252c989</Id>
+    <Book Series="Avengers" Number="6" Volume="2012" Year="2013">
+      <Database Name="cv" Series="54428" Issue="387252" />
     </Book>
-    <Book Series="Avengers" Number="7" Volume="2013" Year="2013">
-      <Id>89059ef3-ab9a-4b2e-a996-a3f343db745f</Id>
+    <Book Series="Avengers" Number="7" Volume="2012" Year="2013">
+      <Database Name="cv" Series="54428" Issue="390444" />
     </Book>
-    <Book Series="Avengers" Number="8" Volume="2013" Year="2013">
-      <Id>4b6aa8d7-5fcf-4736-a02e-9e559ef9d99a</Id>
+    <Book Series="Avengers" Number="8" Volume="2012" Year="2013">
+      <Database Name="cv" Series="54428" Issue="394701" />
     </Book>
-    <Book Series="Avengers" Number="9" Volume="2013" Year="2013">
-      <Id>fa659b3b-bc88-4b6e-9b35-3b2aec735125</Id>
+    <Book Series="Avengers" Number="9" Volume="2012" Year="2013">
+      <Database Name="cv" Series="54428" Issue="396422" />
     </Book>
     <Book Series="Avenging Spider-Man" Number="17" Volume="2011" Year="2013">
-      <Id>1706a750-a9d5-465b-aa0e-2abb31af4f03</Id>
+      <Database Name="cv" Series="43884" Issue="388553" />
     </Book>
-    <Book Series="Avengers" Number="12" Volume="2013" Year="2013">
-      <Id>6a6ffbdf-9acf-453d-a9c6-83464345e00e</Id>
+    <Book Series="Avengers" Number="12" Volume="2012" Year="2013">
+      <Database Name="cv" Series="54428" Issue="404693" />
     </Book>
-    <Book Series="Avengers" Number="13" Volume="2013" Year="2013">
-      <Id>447240cd-0bf1-48cc-848a-ca0e664389b8</Id>
+    <Book Series="Avengers" Number="13" Volume="2012" Year="2013">
+      <Database Name="cv" Series="54428" Issue="408990" />
     </Book>
     <Book Series="Avenging Spider-Man" Number="18" Volume="2011" Year="2013">
-      <Id>f65692f4-3313-4039-befb-167b3e68fc4c</Id>
+      <Database Name="cv" Series="43884" Issue="392353" />
     </Book>
     <Book Series="Superior Spider-Man" Number="6" Volume="2013" Year="2013">
-      <Id>fb2843bf-2607-4759-af0e-9147a07165b9</Id>
+      <Database Name="cv" Series="55552" Issue="394712" />
     </Book>
     <Book Series="Age of Ultron" Number="1" Volume="2013" Year="2013">
-      <Id>b8b03a0a-cc2b-410c-9df5-bc747fe3b12e</Id>
+      <Database Name="cv" Series="58436" Issue="390442" />
     </Book>
     <Book Series="Age of Ultron" Number="2" Volume="2013" Year="2013">
-      <Id>a71392df-444c-47d7-97d4-65adbde735fd</Id>
+      <Database Name="cv" Series="58436" Issue="392349" />
     </Book>
     <Book Series="Superior Spider-Man" Number="6AU" Volume="2013" Year="2013">
-      <Id>5b89b079-c64d-45ec-b75c-46d8dca230f9</Id>
+      <Database Name="cv" Series="55552" Issue="395256" />
     </Book>
     <Book Series="Age of Ultron" Number="3" Volume="2013" Year="2013">
-      <Id>3a147f29-19b9-4812-88b4-0a8f45be3516</Id>
+      <Database Name="cv" Series="58436" Issue="395244" />
     </Book>
     <Book Series="Age of Ultron" Number="4" Volume="2013" Year="2013">
-      <Id>632303c3-2d4d-4827-8f49-bc08289d2632</Id>
+      <Database Name="cv" Series="58436" Issue="395699" />
     </Book>
     <Book Series="Age of Ultron" Number="5" Volume="2013" Year="2013">
-      <Id>d7a1757d-bfc7-43e0-8d4c-00912ffebc98</Id>
+      <Database Name="cv" Series="58436" Issue="396420" />
     </Book>
     <Book Series="Age of Ultron" Number="6" Volume="2013" Year="2013">
-      <Id>716bd171-e8ae-4413-b148-edea6ecc113d</Id>
+      <Database Name="cv" Series="58436" Issue="397539" />
     </Book>
     <Book Series="Age of Ultron" Number="7" Volume="2013" Year="2013">
-      <Id>10668746-3e87-44d5-a146-bc23d80d355f</Id>
+      <Database Name="cv" Series="58436" Issue="400144" />
     </Book>
     <Book Series="Age of Ultron" Number="8" Volume="2013" Year="2013">
-      <Id>a71ec767-c7e9-465e-bebf-cecd791c0c97</Id>
+      <Database Name="cv" Series="58436" Issue="402283" />
     </Book>
     <Book Series="Age of Ultron" Number="9" Volume="2013" Year="2013">
-      <Id>77010314-32f6-41ef-bd48-d71f92f386e1</Id>
+      <Database Name="cv" Series="58436" Issue="408988" />
     </Book>
     <Book Series="Age of Ultron" Number="10" Volume="2013" Year="2013">
-      <Id>c1948d13-6c49-4a12-8712-646fc30b4225</Id>
+      <Database Name="cv" Series="58436" Issue="411824" />
     </Book>
     <Book Series="Avenging Spider-Man" Number="19" Volume="2011" Year="2013">
-      <Id>e3283da2-8a16-4da6-93f2-af581a8a0383</Id>
+      <Database Name="cv" Series="43884" Issue="396425" />
     </Book>
     <Book Series="Superior Spider-Man" Number="7" Volume="2013" Year="2013">
-      <Id>3ab2d8ef-5aed-464a-9852-da5ed9a27618</Id>
+      <Database Name="cv" Series="55552" Issue="395704" />
     </Book>
     <Book Series="Superior Spider-Man" Number="8" Volume="2013" Year="2013">
-      <Id>a83112ad-669d-4266-b034-509cedd6b43d</Id>
+      <Database Name="cv" Series="55552" Issue="397550" />
     </Book>
     <Book Series="Superior Spider-Man" Number="9" Volume="2013" Year="2013">
-      <Id>ec625346-8e19-4dce-ab5c-f04ce3be8729</Id>
+      <Database Name="cv" Series="55552" Issue="400152" />
     </Book>
     <Book Series="Superior Spider-Man" Number="10" Volume="2013" Year="2013">
-      <Id>2f536ec0-f6d0-4980-bc44-4d1cbf644b1b</Id>
+      <Database Name="cv" Series="55552" Issue="404702" />
     </Book>
     <Book Series="Avenging Spider-Man" Number="20" Volume="2011" Year="2013">
-      <Id>0a0cb40f-f21d-4cdb-83cd-4782ce463b65</Id>
+      <Database Name="cv" Series="43884" Issue="401204" />
     </Book>
     <Book Series="Avenging Spider-Man" Number="21" Volume="2011" Year="2013">
-      <Id>92d01c31-5aef-4e72-907f-a643cfa001a2</Id>
+      <Database Name="cv" Series="43884" Issue="406971" />
     </Book>
     <Book Series="Superior Spider-Man" Number="11" Volume="2013" Year="2013">
-      <Id>adbd0d2b-70a3-4aeb-a8e0-5985a14beff5</Id>
+      <Database Name="cv" Series="55552" Issue="408999" />
     </Book>
     <Book Series="Superior Spider-Man" Number="12" Volume="2013" Year="2013">
-      <Id>e5c1b773-661a-4eb1-98ec-eec6d40186c2</Id>
+      <Database Name="cv" Series="55552" Issue="411832" />
     </Book>
     <Book Series="Superior Spider-Man" Number="13" Volume="2013" Year="2013">
-      <Id>5e0a1f80-12b1-4d23-b8b5-b1ab89ad7331</Id>
+      <Database Name="cv" Series="55552" Issue="416946" />
     </Book>
     <Book Series="Avenging Spider-Man" Number="22" Volume="2011" Year="2013">
-      <Id>48336899-d82e-4993-83b3-8b227eea69ad</Id>
+      <Database Name="cv" Series="43884" Issue="410784" />
     </Book>
     <Book Series="Superior Spider-Man" Number="14" Volume="2013" Year="2013">
-      <Id>a31e7bfa-ed73-4d58-8e88-984c4e928e94</Id>
+      <Database Name="cv" Series="55552" Issue="418823" />
     </Book>
     <Book Series="Superior Spider-Man Team-Up" Number="1" Volume="2013" Year="2013">
-      <Id>c24be7a5-f84c-494f-bbdc-dd04178ab3f1</Id>
+      <Database Name="cv" Series="65629" Issue="418824" />
     </Book>
     <Book Series="Superior Spider-Man" Number="15" Volume="2013" Year="2013">
-      <Id>4ff0c887-4c97-493b-af8e-b3618db860af</Id>
+      <Database Name="cv" Series="55552" Issue="420647" />
     </Book>
     <Book Series="Superior Spider-Man" Number="16" Volume="2013" Year="2013">
-      <Id>dabb53d6-0716-4f3b-a96a-fab27148dfbe</Id>
+      <Database Name="cv" Series="55552" Issue="422501" />
     </Book>
     <Book Series="Superior Spider-Man Team-Up" Number="2" Volume="2013" Year="2013">
-      <Id>e82d0aa5-6290-4785-a016-6ea3022d65b1</Id>
+      <Database Name="cv" Series="65629" Issue="421695" />
     </Book>
     <Book Series="Scarlet Spider" Number="20" Volume="2012" Year="2013">
-      <Id>388c6847-0ac8-428c-86ee-cf7155d4e424</Id>
+      <Database Name="cv" Series="45101" Issue="421693" />
     </Book>
     <Book Series="Superior Spider-Man" Number="17" Volume="2013" Year="2013">
-      <Id>672be6c5-3c1a-47c9-a931-7253d36c3afe</Id>
+      <Database Name="cv" Series="55552" Issue="424539" />
     </Book>
     <Book Series="Superior Spider-Man" Number="18" Volume="2013" Year="2013">
-      <Id>07c04613-114c-4a29-b08e-3b6f9f68cd20</Id>
+      <Database Name="cv" Series="55552" Issue="425940" />
     </Book>
     <Book Series="Superior Spider-Man" Number="19" Volume="2013" Year="2013">
-      <Id>e2481592-b231-4fea-a74c-5e01f1385c43</Id>
+      <Database Name="cv" Series="55552" Issue="428866" />
     </Book>
     <Book Series="All-New X-Men Special" Number="1" Volume="2013" Year="2013">
-      <Id>db40a7d4-0ab5-4cfa-8313-11c5c01fdc34</Id>
+      <Database Name="cv" Series="67916" Issue="427683" />
     </Book>
     <Book Series="Indestructible Hulk Special" Number="1" Volume="2013" Year="2013">
-      <Id>eb738a1d-ad79-42db-b9d1-1d15d8bfab91</Id>
+      <Database Name="cv" Series="68320" Issue="428862" />
     </Book>
     <Book Series="Superior Spider-Man Team-Up Special" Number="1" Volume="2013" Year="2013">
-      <Id>acfe03ea-b44d-441f-8218-3103227b69c6</Id>
+      <Database Name="cv" Series="68721" Issue="431445" />
     </Book>
-    <Book Series="Avengers" Number="14" Volume="2013" Year="2013">
-      <Id>2af20e87-ad01-4dd9-bad9-448f1d5f890a</Id>
+    <Book Series="Avengers" Number="14" Volume="2012" Year="2013">
+      <Database Name="cv" Series="54428" Issue="411825" />
     </Book>
-    <Book Series="Avengers" Number="15" Volume="2013" Year="2013">
-      <Id>c28cdbc4-c335-48e3-920d-4483cfbeecea</Id>
+    <Book Series="Avengers" Number="15" Volume="2012" Year="2013">
+      <Database Name="cv" Series="54428" Issue="415233" />
     </Book>
-    <Book Series="Avengers" Number="16" Volume="2013" Year="2013">
-      <Id>3e236aeb-4aca-4414-a06a-e479d9fde842</Id>
+    <Book Series="Avengers" Number="16" Volume="2012" Year="2013">
+      <Database Name="cv" Series="54428" Issue="417831" />
     </Book>
-    <Book Series="Avengers" Number="17" Volume="2013" Year="2013">
-      <Id>4033369f-86c6-4fbb-a0ed-3869412cdd15</Id>
+    <Book Series="Avengers" Number="17" Volume="2012" Year="2013">
+      <Database Name="cv" Series="54428" Issue="420634" />
     </Book>
     <Book Series="Mighty Avengers" Number="1" Volume="2013" Year="2013">
-      <Id>f4919bd1-34fc-4ee7-80c8-88cdeae12f2f</Id>
+      <Database Name="cv" Series="67223" Issue="425032" />
     </Book>
     <Book Series="Mighty Avengers" Number="2" Volume="2013" Year="2013">
-      <Id>90ce9b22-8dbe-4dbb-b393-03ba5c4b8475</Id>
+      <Database Name="cv" Series="67223" Issue="427692" />
     </Book>
     <Book Series="Mighty Avengers" Number="3" Volume="2013" Year="2014">
-      <Id>38512e44-4b54-48e7-84fc-8ed061423311</Id>
+      <Database Name="cv" Series="67223" Issue="432335" />
     </Book>
     <Book Series="Superior Spider-Man Team-Up" Number="3" Volume="2013" Year="2013">
-      <Id>5c0c7354-97c0-443b-b389-72ed21757f4c</Id>
+      <Database Name="cv" Series="65629" Issue="426882" />
     </Book>
     <Book Series="Superior Spider-Man Team-Up" Number="4" Volume="2013" Year="2013">
-      <Id>c4acabdf-ace0-4d0c-967f-ce10541a0d7f</Id>
+      <Database Name="cv" Series="65629" Issue="428299" />
     </Book>
     <Book Series="Superior Spider-Man Team-Up" Number="5" Volume="2013" Year="2013">
-      <Id>be8936bd-d4d3-45aa-a01c-64ed42a0949b</Id>
+      <Database Name="cv" Series="65629" Issue="430763" />
     </Book>
     <Book Series="Superior Spider-Man Team-Up" Number="6" Volume="2013" Year="2014">
-      <Id>55851909-db2a-4950-9a70-17628b9335bb</Id>
+      <Database Name="cv" Series="65629" Issue="433850" />
     </Book>
     <Book Series="Superior Spider-Man Team-Up" Number="7" Volume="2013" Year="2014">
-      <Id>285c539c-5f0a-4b54-8c16-ea27ae017d40</Id>
+      <Database Name="cv" Series="65629" Issue="435591" />
     </Book>
     <Book Series="Superior Spider-Man" Number="20" Volume="2013" Year="2013">
-      <Id>1b0d73c5-33e8-4b69-9ade-4d98ec2c6a28</Id>
+      <Database Name="cv" Series="55552" Issue="431444" />
     </Book>
     <Book Series="Superior Spider-Man" Number="21" Volume="2013" Year="2014">
-      <Id>9653dcfb-f0c1-492c-a130-60d7c991cded</Id>
+      <Database Name="cv" Series="55552" Issue="433177" />
     </Book>
     <Book Series="Superior Spider-Man Annual" Number="1" Volume="2013" Year="2014">
-      <Id>1d29d88c-c759-4aab-9f8a-e8db700b9c12</Id>
+      <Database Name="cv" Series="69348" Issue="433849" />
     </Book>
     <Book Series="Superior Spider-Man Team-Up" Number="8" Volume="2013" Year="2014">
-      <Id>fe34a6f1-5f7a-465a-9554-998cd3c8dcfc</Id>
+      <Database Name="cv" Series="65629" Issue="437496" />
     </Book>
     <Book Series="Superior Spider-Man" Number="22" Volume="2013" Year="2014">
-      <Id>1e821b8b-1c39-4b5c-bafb-be21b051b4db</Id>
+      <Database Name="cv" Series="55552" Issue="435066" />
     </Book>
     <Book Series="Superior Spider-Man" Number="23" Volume="2013" Year="2014">
-      <Id>c9f2d6b0-4b05-44a8-9eb7-a87d6ad5fab2</Id>
+      <Database Name="cv" Series="55552" Issue="435590" />
     </Book>
     <Book Series="Superior Spider-Man" Number="24" Volume="2013" Year="2014">
-      <Id>5478f472-83ae-4677-bc60-5a72b2481d24</Id>
+      <Database Name="cv" Series="55552" Issue="437495" />
     </Book>
     <Book Series="Superior Spider-Man" Number="25" Volume="2013" Year="2014">
-      <Id>627dc9d4-7b52-4f49-b371-bdfdeaabbf3b</Id>
+      <Database Name="cv" Series="55552" Issue="442175" />
     </Book>
     <Book Series="Inhumanity: Superior Spider-Man" Number="1" Volume="2014" Year="2014">
-      <Id>121d9715-bc7f-45f8-9479-63e453e7628b</Id>
+      <Database Name="cv" Series="70898" Issue="442168" />
     </Book>
     <Book Series="Superior Spider-Man" Number="26" Volume="2013" Year="2014">
-      <Id>4a7a914b-9a95-4270-bfb9-fa5e55372431</Id>
+      <Database Name="cv" Series="55552" Issue="443987" />
     </Book>
     <Book Series="Superior Spider-Man Team-Up" Number="9" Volume="2013" Year="2014">
-      <Id>e1169edf-fe5e-4284-8a4e-4c7385ba8d67</Id>
+      <Database Name="cv" Series="65629" Issue="442928" />
     </Book>
     <Book Series="Superior Spider-Man Team-Up" Number="10" Volume="2013" Year="2014">
-      <Id>dfd2eeed-fa7a-4f81-8091-45c0562b7e5f</Id>
+      <Database Name="cv" Series="65629" Issue="445822" />
     </Book>
     <Book Series="Superior Spider-Man" Number="27" Volume="2013" Year="2014">
-      <Id>c32911f7-ba8c-4bec-99ea-5e63763d2cdb</Id>
+      <Database Name="cv" Series="55552" Issue="445184" />
     </Book>
     <Book Series="Superior Spider-Man" Number="28" Volume="2013" Year="2014">
-      <Id>eeac5c77-337f-422a-93c7-ce7b8ceb38df</Id>
+      <Database Name="cv" Series="55552" Issue="446490" />
     </Book>
     <Book Series="Superior Spider-Man" Number="29" Volume="2013" Year="2014">
-      <Id>e52e5606-0146-4921-8070-fe27b3d0409b</Id>
+      <Database Name="cv" Series="55552" Issue="447516" />
     </Book>
     <Book Series="Superior Spider-Man Annual" Number="2" Volume="2013" Year="2014">
-      <Id>e5b7894e-99c7-49e5-9da9-04cef2ebc687</Id>
+      <Database Name="cv" Series="69348" Issue="448003" />
     </Book>
     <Book Series="Superior Spider-Man Team-Up" Number="11" Volume="2013" Year="2014">
-      <Id>c49c0ae9-5267-4aa9-ae31-e457f948a628</Id>
+      <Database Name="cv" Series="65629" Issue="448979" />
     </Book>
     <Book Series="Superior Spider-Man Team-Up" Number="12" Volume="2013" Year="2014">
-      <Id>ebfefd6e-70d5-4841-ae65-bc3c59da527c</Id>
+      <Database Name="cv" Series="65629" Issue="451091" />
     </Book>
     <Book Series="Superior Spider-Man" Number="30" Volume="2013" Year="2014">
-      <Id>9ba4b424-dc76-4547-be49-bc7820d3a99a</Id>
+      <Database Name="cv" Series="55552" Issue="448978" />
     </Book>
     <Book Series="Superior Spider-Man" Number="31" Volume="2013" Year="2014">
-      <Id>65fded1a-6e96-41ca-82fe-4d629be495dc</Id>
+      <Database Name="cv" Series="55552" Issue="450554" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="1" Volume="2014" Year="2014">
-      <Id>5cc8b0af-0445-4b6c-9cd9-a0144708b9a8</Id>
+      <Database Name="cv" Series="73420" Issue="451764" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="2" Volume="2014" Year="2014">
-      <Id>6dc1c2d7-a2dc-4520-8b40-15a8dc1d3ff5</Id>
+      <Database Name="cv" Series="73420" Issue="453408" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="3" Volume="2014" Year="2014">
-      <Id>77dce4af-5d72-4309-bbab-58ff07c2ee50</Id>
+      <Database Name="cv" Series="73420" Issue="457637" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="1.1" Volume="2014" Year="2014">
-      <Id>0f4a2c3c-c2d7-46ee-ba03-2951e67ed928</Id>
+      <Database Name="cv" Series="73420" Issue="452306" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="1.2" Volume="2014" Year="2014">
-      <Id>b6dec8f7-e388-44e0-b04d-3093729159f3</Id>
+      <Database Name="cv" Series="73420" Issue="456018" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="1.3" Volume="2014" Year="2014">
-      <Id>d88c1f02-6407-4451-96ec-2dac7f09c4ca</Id>
+      <Database Name="cv" Series="73420" Issue="459162" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="1.4" Volume="2014" Year="2014">
-      <Id>69e4570a-b43f-47b2-be5b-344a111ffc99</Id>
+      <Database Name="cv" Series="73420" Issue="463477" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="1.5" Volume="2014" Year="2014">
-      <Id>024a5b58-855b-402b-bb2c-a24171279121</Id>
+      <Database Name="cv" Series="73420" Issue="466322" />
     </Book>
     <Book Series="Spider-Man 2099" Number="1" Volume="2014" Year="2014">
-      <Id>5f68d833-d965-484e-8d69-20dd624de682</Id>
+      <Database Name="cv" Series="75557" Issue="459176" />
     </Book>
     <Book Series="Spider-Man 2099" Number="2" Volume="2014" Year="2014">
-      <Id>cfb33157-2a8b-4a66-b90a-6d193561d36f</Id>
+      <Database Name="cv" Series="75557" Issue="462257" />
     </Book>
     <Book Series="Spider-Man 2099" Number="3" Volume="2014" Year="2014">
-      <Id>57b3bd57-8150-4b40-8d51-df11f4747aff</Id>
+      <Database Name="cv" Series="75557" Issue="463996" />
     </Book>
     <Book Series="Spider-Man 2099" Number="4" Volume="2014" Year="2014">
-      <Id>bea6bc32-44df-4531-8897-1acc2f9ca9d2</Id>
+      <Database Name="cv" Series="75557" Issue="467042" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="4" Volume="2014" Year="2014">
-      <Id>7fa25826-34a0-4542-a8bb-785ab98733a9</Id>
+      <Database Name="cv" Series="73420" Issue="460309" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="5" Volume="2014" Year="2014">
-      <Id>a93ac88c-686d-4315-90be-6dfd1cc58efa</Id>
+      <Database Name="cv" Series="73420" Issue="462242" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="6" Volume="2014" Year="2014">
-      <Id>fb44e004-1371-4586-a2df-6a61f7db02a6</Id>
+      <Database Name="cv" Series="73420" Issue="464973" />
     </Book>
     <Book Series="Axis: Hobgoblin" Number="1" Volume="2014" Year="2014">
-      <Id>ec0884d1-db5c-466a-83fe-f9c939620703</Id>
+      <Database Name="cv" Series="77691" Issue="468459" />
     </Book>
     <Book Series="Axis: Hobgoblin" Number="2" Volume="2014" Year="2015">
-      <Id>552ff453-a7a0-400b-be56-ddee994405eb</Id>
+      <Database Name="cv" Series="77691" Issue="469827" />
     </Book>
     <Book Series="Axis: Hobgoblin" Number="3" Volume="2014" Year="2015">
-      <Id>b85306cd-d05c-4bf2-8320-0425042ca4c6</Id>
+      <Database Name="cv" Series="77691" Issue="473640" />
     </Book>
     <Book Series="Axis: Carnage" Number="1" Volume="2014" Year="2014">
-      <Id>0f65f5de-13a4-4982-a1f0-b53a5b6ba4a9</Id>
+      <Database Name="cv" Series="77805" Issue="468901" />
     </Book>
     <Book Series="Axis: Carnage" Number="2" Volume="2014" Year="2015">
-      <Id>bcacb49e-e5da-4d05-acb1-831e0f7e9cd5</Id>
+      <Database Name="cv" Series="77805" Issue="470420" />
     </Book>
     <Book Series="Axis: Carnage" Number="3" Volume="2014" Year="2015">
-      <Id>93725b6e-4bf8-4374-ac81-d3f05844ab09</Id>
+      <Database Name="cv" Series="77805" Issue="472903" />
     </Book>
     <Book Series="Superior Spider-Man" Number="32" Volume="2013" Year="2014">
-      <Id>c658f646-ecef-42fe-b86e-1862c04460e2</Id>
+      <Database Name="cv" Series="55552" Issue="461740" />
     </Book>
     <Book Series="Superior Spider-Man" Number="33" Volume="2013" Year="2014">
-      <Id>896745e4-6353-4eac-bdd7-27c5e451a086</Id>
+      <Database Name="cv" Series="55552" Issue="465850" />
     </Book>
     <Book Series="Edge of Spider-Verse" Number="1" Volume="2014" Year="2014">
-      <Id>b7dbde8c-3146-490b-b545-1a6a4fb3b76f</Id>
+      <Database Name="cv" Series="76863" Issue="464979" />
     </Book>
     <Book Series="Edge of Spider-Verse" Number="2" Volume="2014" Year="2014">
-      <Id>a9b30c7f-1583-4beb-a970-158330756ab4</Id>
+      <Database Name="cv" Series="76863" Issue="465842" />
     </Book>
     <Book Series="Edge of Spider-Verse" Number="3" Volume="2014" Year="2014">
-      <Id>3fee145d-cfe7-4135-9e26-2bd3382cc834</Id>
+      <Database Name="cv" Series="76863" Issue="466326" />
     </Book>
     <Book Series="Edge of Spider-Verse" Number="4" Volume="2014" Year="2014">
-      <Id>5f2b813f-da62-47e1-aab8-a34ed734782d</Id>
+      <Database Name="cv" Series="76863" Issue="467035" />
     </Book>
     <Book Series="Edge of Spider-Verse" Number="5" Volume="2014" Year="2014">
-      <Id>0146d82b-6c13-4bff-a03c-4da711598103</Id>
+      <Database Name="cv" Series="76863" Issue="468077" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="7" Volume="2014" Year="2014">
-      <Id>d809c649-daf1-4f38-a289-50a9f78bb370</Id>
+      <Database Name="cv" Series="73420" Issue="467646" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="8" Volume="2014" Year="2014">
-      <Id>58beff0a-81a1-46d4-a78e-2b0c0db6655e</Id>
+      <Database Name="cv" Series="73420" Issue="468455" />
     </Book>
     <Book Series="Spider-Man 2099" Number="5" Volume="2014" Year="2014">
-      <Id>dcbd6535-1d9e-4746-98c4-5439adfc99c7</Id>
+      <Database Name="cv" Series="75557" Issue="468087" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="9" Volume="2014" Year="2015">
-      <Id>875358c4-5510-4722-a70a-31364cf1536b</Id>
+      <Database Name="cv" Series="73420" Issue="469487" />
     </Book>
     <Book Series="Spider-Verse" Number="1" Volume="2014" Year="2015">
-      <Id>bb01cad6-00fb-4eec-9d9a-0ed103d61cfd</Id>
+      <Database Name="cv" Series="78047" Issue="469842" />
     </Book>
     <Book Series="Spider-Verse Team-Up" Number="1" Volume="2014" Year="2015">
-      <Id>63b614bc-fb78-4f6c-be0b-6dc58c5c60dc</Id>
+      <Database Name="cv" Series="77941" Issue="469497" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="10" Volume="2014" Year="2015">
-      <Id>1b8cf03f-4b83-439c-a4ef-4e07c93dd4ba</Id>
+      <Database Name="cv" Series="73420" Issue="470416" />
     </Book>
     <Book Series="Scarlet Spiders" Number="1" Volume="2014" Year="2015">
-      <Id>77fe29a8-4163-4ff1-8705-60ade9ddb29f</Id>
+      <Database Name="cv" Series="78356" Issue="471321" />
     </Book>
     <Book Series="Spider-Woman" Number="1" Volume="2014" Year="2015">
-      <Id>c97e15aa-3c10-40eb-8dc7-7a127e058197</Id>
+      <Database Name="cv" Series="78202" Issue="470434" />
     </Book>
     <Book Series="Spider-Man 2099" Number="6" Volume="2014" Year="2015">
-      <Id>5df55abb-cd8b-4a55-b989-48d42e32fd1c</Id>
+      <Database Name="cv" Series="75557" Issue="471323" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="11" Volume="2014" Year="2015">
-      <Id>1087857b-416e-4e1a-af91-35322bfc41d3</Id>
+      <Database Name="cv" Series="73420" Issue="472897" />
     </Book>
     <Book Series="Spider-Verse Team-Up" Number="2" Volume="2014" Year="2015">
-      <Id>b7b0c565-fa7a-4d67-9b6a-e6369fba71c7</Id>
+      <Database Name="cv" Series="77941" Issue="472912" />
     </Book>
     <Book Series="Scarlet Spiders" Number="2" Volume="2014" Year="2015">
-      <Id>3b9bc658-9567-40c7-8d17-21d2729bb067</Id>
+      <Database Name="cv" Series="78356" Issue="473654" />
     </Book>
     <Book Series="Spider-Woman" Number="2" Volume="2014" Year="2015">
-      <Id>99e553e1-e05b-4acd-8587-7b16d89f8b16</Id>
+      <Database Name="cv" Series="78202" Issue="473656" />
     </Book>
     <Book Series="Spider-Verse" Number="2" Volume="2014" Year="2015">
-      <Id>dcd92581-0534-4772-ad4b-4007bffed305</Id>
+      <Database Name="cv" Series="78047" Issue="475945" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="12" Volume="2014" Year="2015">
-      <Id>2a001d1e-3d5e-4c03-8095-1febf6aa8251</Id>
+      <Database Name="cv" Series="73420" Issue="475450" />
     </Book>
     <Book Series="Spider-Man 2099" Number="7" Volume="2014" Year="2015">
-      <Id>8cd1293b-1a92-4492-82d7-20ee1707d2b8</Id>
+      <Database Name="cv" Series="75557" Issue="475462" />
     </Book>
     <Book Series="Scarlet Spiders" Number="3" Volume="2014" Year="2015">
-      <Id>b10c13b5-62d2-4d67-90aa-11ec0612fda5</Id>
+      <Database Name="cv" Series="78356" Issue="476793" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="13" Volume="2014" Year="2015">
-      <Id>2eb70b8b-1903-4b6f-bf8b-44a4f5e3a5f4</Id>
+      <Database Name="cv" Series="73420" Issue="476779" />
     </Book>
     <Book Series="Spider-Woman" Number="3" Volume="2014" Year="2015">
-      <Id>b5b5b25b-debb-4a34-adb3-760aef047953</Id>
+      <Database Name="cv" Series="78202" Issue="476795" />
     </Book>
     <Book Series="Spider-Verse Team-Up" Number="3" Volume="2014" Year="2015">
-      <Id>9e6acb70-cf77-4801-ad59-9b5c93317e08</Id>
+      <Database Name="cv" Series="77941" Issue="476794" />
     </Book>
     <Book Series="Spider-Man 2099" Number="8" Volume="2014" Year="2015">
-      <Id>1ec4cddc-6e0d-40d0-85d6-3c7c718d87e6</Id>
+      <Database Name="cv" Series="75557" Issue="477854" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="14" Volume="2014" Year="2015">
-      <Id>acf941ea-6f56-4f39-87e6-305cb3181355</Id>
+      <Database Name="cv" Series="73420" Issue="479254" />
     </Book>
     <Book Series="Spider-Woman" Number="4" Volume="2014" Year="2015">
-      <Id>ca42d53d-5da2-41fd-a4c6-677669a1730e</Id>
+      <Database Name="cv" Series="78202" Issue="479263" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="15" Volume="2014" Year="2015">
-      <Id>4ca6a6f0-6d6f-46b5-aad0-1b4ea76442ee</Id>
+      <Database Name="cv" Series="73420" Issue="480668" />
     </Book>
-    <Book Series="Spider-Man &amp; the X-Men" Number="1" Volume="2014" Year="2015">
-      <Id>4e648eae-7adb-47c4-bf04-a18ac9d5092a</Id>
+    <Book Series="Spider-Man &#38; the X-Men" Number="1" Volume="2014" Year="2015">
+      <Database Name="cv" Series="78717" Issue="472911" />
     </Book>
-    <Book Series="Spider-Man &amp; the X-Men" Number="2" Volume="2014" Year="2015">
-      <Id>ccb5a65b-c521-4d0e-99ee-e9230998f91c</Id>
+    <Book Series="Spider-Man &#38; the X-Men" Number="2" Volume="2014" Year="2015">
+      <Database Name="cv" Series="78717" Issue="477855" />
     </Book>
-    <Book Series="Spider-Man &amp; the X-Men" Number="3" Volume="2014" Year="2015">
-      <Id>490d0783-87d0-4055-8c58-2930fa358525</Id>
+    <Book Series="Spider-Man &#38; the X-Men" Number="3" Volume="2014" Year="2015">
+      <Database Name="cv" Series="78717" Issue="480681" />
     </Book>
-    <Book Series="Spider-Man &amp; the X-Men" Number="4" Volume="2014" Year="2015">
-      <Id>dcd89d50-5a4a-4f16-a811-444ce81e2043</Id>
+    <Book Series="Spider-Man &#38; the X-Men" Number="4" Volume="2014" Year="2015">
+      <Database Name="cv" Series="78717" Issue="482165" />
     </Book>
-    <Book Series="Spider-Man &amp; the X-Men" Number="5" Volume="2014" Year="2015">
-      <Id>377546d0-11d9-4ec6-a3fb-0aca9eef6f35</Id>
+    <Book Series="Spider-Man &#38; the X-Men" Number="5" Volume="2014" Year="2015">
+      <Database Name="cv" Series="78717" Issue="486153" />
     </Book>
-    <Book Series="Spider-Man &amp; the X-Men" Number="6" Volume="2014" Year="2015">
-      <Id>7b46f829-33a8-4c4b-9abd-03d5d0f5d532</Id>
+    <Book Series="Spider-Man &#38; the X-Men" Number="6" Volume="2014" Year="2015">
+      <Database Name="cv" Series="78717" Issue="487217" />
     </Book>
     <Book Series="Amazing Spider-Man Annual" Number="1" Volume="2014" Year="2015">
-      <Id>0de757be-3c25-4a7e-9a58-b1a1e72e2903</Id>
+      <Database Name="cv" Series="78715" Issue="472898" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="16.1" Volume="2014" Year="2015">
-      <Id>aa0e65fc-94d3-4876-b4ff-a80a916e2967</Id>
+      <Database Name="cv" Series="73420" Issue="482679" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="17.1" Volume="2014" Year="2015">
-      <Id>27c881d9-9f1e-4ff6-b12e-5e53a9ae6deb</Id>
+      <Database Name="cv" Series="73420" Issue="486716" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="18.1" Volume="2014" Year="2015">
-      <Id>73af4729-5611-461d-8aec-92360262e2da</Id>
+      <Database Name="cv" Series="73420" Issue="490875" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="19.1" Volume="2014" Year="2015">
-      <Id>4dbf0d1c-4776-49bc-a414-3eb357e2e000</Id>
+      <Database Name="cv" Series="73420" Issue="493788" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="20.1" Volume="2014" Year="2015">
-      <Id>a7afa1fb-19d9-4fd1-b8d7-eaf5c49209d7</Id>
+      <Database Name="cv" Series="73420" Issue="497384" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="16" Volume="2014" Year="2015">
-      <Id>f9f91e00-e846-4c2a-ad17-3d9430620b8a</Id>
+      <Database Name="cv" Series="73420" Issue="482150" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="17" Volume="2014" Year="2015">
-      <Id>07a7468a-ee3c-494c-8cc1-8512e94d2564</Id>
+      <Database Name="cv" Series="73420" Issue="484888" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="18" Volume="2014" Year="2015">
-      <Id>124cc225-ded3-4003-944b-3a449e5b1207</Id>
+      <Database Name="cv" Series="73420" Issue="487829" />
     </Book>
     <Book Series="Silk" Number="1" Volume="2015" Year="2015">
-      <Id>fa5cbc19-414d-4dee-bc99-d3433a581dc2</Id>
+      <Database Name="cv" Series="80116" Issue="479982" />
     </Book>
     <Book Series="Silk" Number="2" Volume="2015" Year="2015">
-      <Id>e77287ca-7150-4521-828e-fb27692535be</Id>
+      <Database Name="cv" Series="80116" Issue="482693" />
     </Book>
     <Book Series="Silk" Number="3" Volume="2015" Year="2015">
-      <Id>4d0f4371-e722-4817-87ed-ac8648a72970</Id>
+      <Database Name="cv" Series="80116" Issue="487215" />
     </Book>
     <Book Series="Silk" Number="4" Volume="2015" Year="2015">
-      <Id>ae047203-8345-45b1-9860-43459f1aaa22</Id>
+      <Database Name="cv" Series="80116" Issue="488657" />
     </Book>
     <Book Series="Silk" Number="5" Volume="2015" Year="2015">
-      <Id>14f1ec97-c7a4-454d-ab00-e73435f677fa</Id>
+      <Database Name="cv" Series="80116" Issue="491526" />
     </Book>
     <Book Series="Silk" Number="6" Volume="2015" Year="2015">
-      <Id>902c9163-db84-49bb-a95c-4e1b4480ed8f</Id>
+      <Database Name="cv" Series="80116" Issue="497958" />
     </Book>
     <Book Series="Spider-Woman" Number="5" Volume="2014" Year="2015">
-      <Id>c1d62ae3-9f43-45da-a915-46b2d2f7d95c</Id>
+      <Database Name="cv" Series="78202" Issue="481615" />
     </Book>
     <Book Series="Spider-Woman" Number="6" Volume="2014" Year="2015">
-      <Id>d1a1b962-35a2-4fb8-8fd9-3a8ad0d66fab</Id>
+      <Database Name="cv" Series="78202" Issue="485520" />
     </Book>
     <Book Series="Spider-Woman" Number="7" Volume="2014" Year="2015">
-      <Id>56ebd1e9-fdc4-422e-bb94-a83a34e99520</Id>
+      <Database Name="cv" Series="78202" Issue="487846" />
     </Book>
     <Book Series="Spider-Woman" Number="8" Volume="2014" Year="2015">
-      <Id>7de270a2-56c8-4e95-9b86-660735f7bae2</Id>
+      <Database Name="cv" Series="78202" Issue="490889" />
     </Book>
     <Book Series="Spider-Woman" Number="9" Volume="2014" Year="2015">
-      <Id>7d6406d6-be6a-4f86-ac02-07a5aa762c49</Id>
+      <Database Name="cv" Series="78202" Issue="495808" />
     </Book>
     <Book Series="Spider-Man 2099" Number="9" Volume="2014" Year="2015">
-      <Id>6cd6a807-5123-491c-919b-7e4a93dd57df</Id>
+      <Database Name="cv" Series="75557" Issue="480680" />
     </Book>
     <Book Series="Spider-Man 2099" Number="10" Volume="2014" Year="2015">
-      <Id>10cabbc2-bd16-4a6d-bb13-9e49db79f833</Id>
+      <Database Name="cv" Series="75557" Issue="482164" />
     </Book>
     <Book Series="Spider-Man 2099" Number="11" Volume="2014" Year="2015">
-      <Id>daae95a6-561d-4099-8638-075c9eb7ea30</Id>
+      <Database Name="cv" Series="75557" Issue="485519" />
     </Book>
     <Book Series="Spider-Man 2099" Number="12" Volume="2014" Year="2015">
-      <Id>8ef408d3-c4e0-474d-b24a-c3a13ed39c44</Id>
+      <Database Name="cv" Series="75557" Issue="488658" />
     </Book>
     <Book Series="Spider-Gwen" Number="1" Volume="2015" Year="2015">
-      <Id>077a309a-e6f8-4b0f-bf6e-a575ee1d7e3d</Id>
+      <Database Name="cv" Series="80298" Issue="480679" />
     </Book>
     <Book Series="Spider-Gwen" Number="2" Volume="2015" Year="2015">
-      <Id>46c1c3ae-7bbe-48ce-944a-fb1d138d8599</Id>
+      <Database Name="cv" Series="80298" Issue="482163" />
     </Book>
     <Book Series="Spider-Gwen" Number="3" Volume="2015" Year="2015">
-      <Id>400414af-8b57-4aba-ab58-782a9a26eca2</Id>
+      <Database Name="cv" Series="80298" Issue="484905" />
     </Book>
     <Book Series="Spider-Gwen" Number="4" Volume="2015" Year="2015">
-      <Id>2374d039-bac5-4339-ae18-75db5f2bfa57</Id>
+      <Database Name="cv" Series="80298" Issue="487845" />
     </Book>
     <Book Series="Spider-Gwen" Number="5" Volume="2015" Year="2015">
-      <Id>50f8e97c-2f0b-4f08-b29e-538967286e8b</Id>
+      <Database Name="cv" Series="80298" Issue="491529" />
     </Book>
-    <Book Series="Captain America &amp; the Mighty Avengers" Number="4" Volume="2014" Year="2015">
-      <Id>98b24815-4447-463a-b7b7-3219d100ffb7</Id>
+    <Book Series="Captain America &#38; the Mighty Avengers" Number="4" Volume="2014" Year="2015">
+      <Database Name="cv" Series="78045" Issue="476782" />
     </Book>
-    <Book Series="Captain America &amp; the Mighty Avengers" Number="5" Volume="2014" Year="2015">
-      <Id>215879b8-dca3-4a1e-b8fe-eb946273b1ea</Id>
+    <Book Series="Captain America &#38; the Mighty Avengers" Number="5" Volume="2014" Year="2015">
+      <Database Name="cv" Series="78045" Issue="479969" />
     </Book>
-    <Book Series="Captain America &amp; the Mighty Avengers" Number="6" Volume="2014" Year="2015">
-      <Id>16dbaaf1-320c-423f-8008-1987cea63c44</Id>
+    <Book Series="Captain America &#38; the Mighty Avengers" Number="6" Volume="2014" Year="2015">
+      <Database Name="cv" Series="78045" Issue="482682" />
     </Book>
     <Book Series="The Amazing Spider-Man Special" Number="1" Volume="2015" Year="2015">
-      <Id>6f2b713a-96fa-4ad6-bed1-890162d12594</Id>
+      <Database Name="cv" Series="80596" Issue="482151" />
     </Book>
     <Book Series="Inhuman Special" Number="1" Volume="2015" Year="2015">
-      <Id>cc1bf566-47e2-4f45-b578-f2912c73c5bf</Id>
+      <Database Name="cv" Series="81483" Issue="486725" />
     </Book>
     <Book Series="All-New Captain America Special" Number="1" Volume="2015" Year="2015">
-      <Id>f4018609-cb54-4df3-a25b-ae983cd41514</Id>
+      <Database Name="cv" Series="81829" Issue="487828" />
     </Book>
-    <Book Series="Captain America &amp; the Mighty Avengers" Number="7" Volume="2014" Year="2015">
-      <Id>9c4fdeee-3edf-4379-8c4c-055d1ae723e9</Id>
+    <Book Series="Captain America &#38; the Mighty Avengers" Number="7" Volume="2014" Year="2015">
+      <Database Name="cv" Series="78045" Issue="486146" />
     </Book>
     <Book Series="Spider-Woman" Number="10" Volume="2014" Year="2015">
-      <Id>2fecfc1f-8e11-4e70-9285-2922537631fd</Id>
+      <Database Name="cv" Series="78202" Issue="498398" />
     </Book>
     <Book Series="Silk" Number="7" Volume="2015" Year="2015">
-      <Id>7d138ce4-0e91-4216-b2ce-036f877f10d4</Id>
+      <Database Name="cv" Series="80116" Issue="499043" />
     </Book>
-    <Book Series="Captain America &amp; the Mighty Avengers" Number="8" Volume="2014" Year="2015">
-      <Id>0196a989-701b-4c49-87c8-5e6ea6a9f0db</Id>
+    <Book Series="Captain America &#38; the Mighty Avengers" Number="8" Volume="2014" Year="2015">
+      <Database Name="cv" Series="78045" Issue="488644" />
     </Book>
-    <Book Series="Captain America &amp; the Mighty Avengers" Number="9" Volume="2014" Year="2015">
-      <Id>d6f651b5-fe6a-4eba-8bda-2fb1adc30e0e</Id>
+    <Book Series="Captain America &#38; the Mighty Avengers" Number="9" Volume="2014" Year="2015">
+      <Database Name="cv" Series="78045" Issue="491510" />
     </Book>
     <Book Series="Secret Wars" Number="1" Volume="2015" Year="2015">
-      <Id>3244b4aa-3741-4c19-8ecb-07117f46e2a5</Id>
+      <Database Name="cv" Series="81833" Issue="487843" />
     </Book>
     <Book Series="Secret Wars" Number="2" Volume="2015" Year="2015">
-      <Id>4f4855ba-7a3d-4051-9336-8c200e577f71</Id>
+      <Database Name="cv" Series="81833" Issue="488656" />
     </Book>
     <Book Series="Spider-Verse" Number="1" Volume="2015" Year="2015">
-      <Id>f83d418d-c678-4fdc-8794-92c79336add3</Id>
+      <Database Name="cv" Series="82108" Issue="489327" />
     </Book>
     <Book Series="Spider-Verse" Number="2" Volume="2015" Year="2015">
-      <Id>681bbf95-01f5-46a6-999f-ec4359abc7ad</Id>
+      <Database Name="cv" Series="82108" Issue="491530" />
     </Book>
     <Book Series="Spider-Verse" Number="3" Volume="2015" Year="2015">
-      <Id>b029ea6a-daaf-4f6e-ac5a-f9cb9a3a8dad</Id>
+      <Database Name="cv" Series="82108" Issue="494330" />
     </Book>
     <Book Series="Spider-Verse" Number="4" Volume="2015" Year="2015">
-      <Id>8ee48957-586e-4558-90a3-ba816d3c0417</Id>
+      <Database Name="cv" Series="82108" Issue="497959" />
     </Book>
     <Book Series="Spider-Verse" Number="5" Volume="2015" Year="2015">
-      <Id>11216a4c-3ad3-4207-a4db-fbe2ac9a4095</Id>
+      <Database Name="cv" Series="82108" Issue="500308" />
     </Book>
     <Book Series="Spider-Island" Number="1" Volume="2015" Year="2015">
-      <Id>cbc68c6d-5906-45f2-a72f-35883e73dfcc</Id>
+      <Database Name="cv" Series="83156" Issue="494329" />
     </Book>
     <Book Series="Spider-Island" Number="2" Volume="2015" Year="2015">
-      <Id>5c3ce3ca-e48e-446c-a7fc-99000f00455e</Id>
+      <Database Name="cv" Series="83156" Issue="496890" />
     </Book>
     <Book Series="Spider-Island" Number="3" Volume="2015" Year="2015">
-      <Id>45dbafd3-ddd3-4bfd-879b-fa32c7c0e7f4</Id>
+      <Database Name="cv" Series="83156" Issue="499045" />
     </Book>
     <Book Series="Spider-Island" Number="4" Volume="2015" Year="2015">
-      <Id>4d2bf4ec-8110-40c7-9bad-96368f437902</Id>
+      <Database Name="cv" Series="83156" Issue="500307" />
     </Book>
     <Book Series="Spider-Island" Number="5" Volume="2015" Year="2015">
-      <Id>b732e838-5baf-4fcd-a278-c0b264306645</Id>
+      <Database Name="cv" Series="83156" Issue="502132" />
     </Book>
     <Book Series="Amazing Spider-Man: Renew Your Vows" Number="1" Volume="2015" Year="2015">
-      <Id>46e4a5ff-d342-47f3-9975-1801663dbf3c</Id>
+      <Database Name="cv" Series="82337" Issue="490876" />
     </Book>
     <Book Series="Amazing Spider-Man: Renew Your Vows" Number="2" Volume="2015" Year="2015">
-      <Id>7a551af5-d430-4020-9a56-4c888fab0ed9</Id>
+      <Database Name="cv" Series="82337" Issue="494316" />
     </Book>
     <Book Series="Amazing Spider-Man: Renew Your Vows" Number="3" Volume="2015" Year="2015">
-      <Id>5d5a62b7-8280-48a5-af71-8cd90b4b5121</Id>
+      <Database Name="cv" Series="82337" Issue="496873" />
     </Book>
     <Book Series="Amazing Spider-Man: Renew Your Vows" Number="4" Volume="2015" Year="2015">
-      <Id>b25c58d6-ab16-408a-bc2d-1f98bbfd11cb</Id>
+      <Database Name="cv" Series="82337" Issue="497935" />
     </Book>
     <Book Series="Amazing Spider-Man: Renew Your Vows" Number="5" Volume="2015" Year="2015">
-      <Id>a56fba82-6b50-49b7-8643-fd67c7d34585</Id>
+      <Database Name="cv" Series="82337" Issue="499739" />
     </Book>
     <Book Series="Secret Wars" Number="3" Volume="2015" Year="2015">
-      <Id>855b8600-84dd-4b5d-b56f-d7aac338c9f9</Id>
+      <Database Name="cv" Series="81833" Issue="490887" />
     </Book>
     <Book Series="Secret Wars" Number="4" Volume="2015" Year="2015">
-      <Id>48830bae-ed26-4c6a-8a53-692aa68d96ea</Id>
+      <Database Name="cv" Series="81833" Issue="493798" />
     </Book>
     <Book Series="Secret Wars" Number="5" Volume="2015" Year="2015">
-      <Id>f77b6ab1-a052-4ed0-9ec4-daa98d467829</Id>
+      <Database Name="cv" Series="81833" Issue="497397" />
     </Book>
     <Book Series="Secret Wars" Number="6" Volume="2015" Year="2015">
-      <Id>ca805e46-41b6-425f-9b47-3d4f1d70dc52</Id>
+      <Database Name="cv" Series="81833" Issue="502130" />
     </Book>
     <Book Series="Secret Wars" Number="7" Volume="2015" Year="2016">
-      <Id>26e7f22a-4566-4d7e-b5fe-f9866cb1cbb4</Id>
+      <Database Name="cv" Series="81833" Issue="505522" />
     </Book>
     <Book Series="Secret Wars" Number="8" Volume="2015" Year="2016">
-      <Id>a86052c5-b509-4986-b105-b914ba79b09f</Id>
+      <Database Name="cv" Series="81833" Issue="507780" />
     </Book>
     <Book Series="Secret Wars" Number="9" Volume="2015" Year="2016">
-      <Id>7f2eecca-d885-4705-9ec0-97fdac82fe27</Id>
+      <Database Name="cv" Series="81833" Issue="510951" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Spider-Man/Spider-Man 009 (Superior_Marvel NOW!).cbl
+++ b/Marvel/Characters/unsorted/Spider-Man/Spider-Man 009 (Superior_Marvel NOW!).cbl
@@ -2,625 +2,625 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Spider-Man 9 (Superior/Marvel NOW!)</Name>
   <Books>
-    <Book Series="Avenging Spider-Man" Number="15.1" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Avenging Spider-Man" Number="15.1" Volume="2011" Year="2013">
       <Id>6c27d9dd-69ca-4796-b26e-de6e77cce2a6</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="1" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="1" Volume="2013" Year="2013">
       <Id>d16af6f5-d5f8-4ec1-a574-993a6f9cff5e</Id>
     </Book>
-    <Book Series="Daredevil" Number="21" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Daredevil" Number="21" Volume="2011" Year="2013">
       <Id>ed1030b2-3627-4d1d-ace1-baa1965f65b0</Id>
     </Book>
-    <Book Series="Daredevil" Number="22" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Daredevil" Number="22" Volume="2011" Year="2013">
       <Id>a00b9ca5-1370-418a-af47-1a6daa113d32</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="2" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="2" Volume="2013" Year="2013">
       <Id>c81ee100-cc20-419e-a5ec-2b18a7871d76</Id>
     </Book>
-    <Book Series="Avenging Spider-Man" Number="16" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Avenging Spider-Man" Number="16" Volume="2011" Year="2013">
       <Id>d3d93c84-033a-4cfa-9cf3-967e8035efa8</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="3" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="3" Volume="2013" Year="2013">
       <Id>9bfc7ebe-f58f-4cef-9446-5e4ad30a50b7</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="4" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="4" Volume="2013" Year="2013">
       <Id>239c41c5-7eb2-4bd0-9282-669f73c65c43</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="5" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="5" Volume="2013" Year="2013">
       <Id>ed371cbf-5452-463f-b75b-cbf79e13f974</Id>
     </Book>
-    <Book Series="Avengers" Number="6" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Avengers" Number="6" Volume="2013" Year="2013">
       <Id>254d1ef0-63df-477b-8577-2d52c252c989</Id>
     </Book>
-    <Book Series="Avengers" Number="7" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Avengers" Number="7" Volume="2013" Year="2013">
       <Id>89059ef3-ab9a-4b2e-a996-a3f343db745f</Id>
     </Book>
-    <Book Series="Avengers" Number="8" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Avengers" Number="8" Volume="2013" Year="2013">
       <Id>4b6aa8d7-5fcf-4736-a02e-9e559ef9d99a</Id>
     </Book>
-    <Book Series="Avengers" Number="9" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Avengers" Number="9" Volume="2013" Year="2013">
       <Id>fa659b3b-bc88-4b6e-9b35-3b2aec735125</Id>
     </Book>
-    <Book Series="Avenging Spider-Man" Number="17" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Avenging Spider-Man" Number="17" Volume="2011" Year="2013">
       <Id>1706a750-a9d5-465b-aa0e-2abb31af4f03</Id>
     </Book>
-    <Book Series="Avengers" Number="12" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Avengers" Number="12" Volume="2013" Year="2013">
       <Id>6a6ffbdf-9acf-453d-a9c6-83464345e00e</Id>
     </Book>
-    <Book Series="Avengers" Number="13" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Avengers" Number="13" Volume="2013" Year="2013">
       <Id>447240cd-0bf1-48cc-848a-ca0e664389b8</Id>
     </Book>
-    <Book Series="Avenging Spider-Man" Number="18" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Avenging Spider-Man" Number="18" Volume="2011" Year="2013">
       <Id>f65692f4-3313-4039-befb-167b3e68fc4c</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="6" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="6" Volume="2013" Year="2013">
       <Id>fb2843bf-2607-4759-af0e-9147a07165b9</Id>
     </Book>
-    <Book Series="Age of Ultron" Number="1" Volume="2013" Year="2013" Format="Crossover">
+    <Book Series="Age of Ultron" Number="1" Volume="2013" Year="2013">
       <Id>b8b03a0a-cc2b-410c-9df5-bc747fe3b12e</Id>
     </Book>
-    <Book Series="Age of Ultron" Number="2" Volume="2013" Year="2013" Format="Crossover">
+    <Book Series="Age of Ultron" Number="2" Volume="2013" Year="2013">
       <Id>a71392df-444c-47d7-97d4-65adbde735fd</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="6AU" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="6AU" Volume="2013" Year="2013">
       <Id>5b89b079-c64d-45ec-b75c-46d8dca230f9</Id>
     </Book>
-    <Book Series="Age of Ultron" Number="3" Volume="2013" Year="2013" Format="Crossover">
+    <Book Series="Age of Ultron" Number="3" Volume="2013" Year="2013">
       <Id>3a147f29-19b9-4812-88b4-0a8f45be3516</Id>
     </Book>
-    <Book Series="Age of Ultron" Number="4" Volume="2013" Year="2013" Format="Crossover">
+    <Book Series="Age of Ultron" Number="4" Volume="2013" Year="2013">
       <Id>632303c3-2d4d-4827-8f49-bc08289d2632</Id>
     </Book>
-    <Book Series="Age of Ultron" Number="5" Volume="2013" Year="2013" Format="Crossover">
+    <Book Series="Age of Ultron" Number="5" Volume="2013" Year="2013">
       <Id>d7a1757d-bfc7-43e0-8d4c-00912ffebc98</Id>
     </Book>
-    <Book Series="Age of Ultron" Number="6" Volume="2013" Year="2013" Format="Crossover">
+    <Book Series="Age of Ultron" Number="6" Volume="2013" Year="2013">
       <Id>716bd171-e8ae-4413-b148-edea6ecc113d</Id>
     </Book>
-    <Book Series="Age of Ultron" Number="7" Volume="2013" Year="2013" Format="Crossover">
+    <Book Series="Age of Ultron" Number="7" Volume="2013" Year="2013">
       <Id>10668746-3e87-44d5-a146-bc23d80d355f</Id>
     </Book>
-    <Book Series="Age of Ultron" Number="8" Volume="2013" Year="2013" Format="Crossover">
+    <Book Series="Age of Ultron" Number="8" Volume="2013" Year="2013">
       <Id>a71ec767-c7e9-465e-bebf-cecd791c0c97</Id>
     </Book>
-    <Book Series="Age of Ultron" Number="9" Volume="2013" Year="2013" Format="Crossover">
+    <Book Series="Age of Ultron" Number="9" Volume="2013" Year="2013">
       <Id>77010314-32f6-41ef-bd48-d71f92f386e1</Id>
     </Book>
-    <Book Series="Age of Ultron" Number="10" Volume="2013" Year="2013" Format="Crossover">
+    <Book Series="Age of Ultron" Number="10" Volume="2013" Year="2013">
       <Id>c1948d13-6c49-4a12-8712-646fc30b4225</Id>
     </Book>
-    <Book Series="Avenging Spider-Man" Number="19" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Avenging Spider-Man" Number="19" Volume="2011" Year="2013">
       <Id>e3283da2-8a16-4da6-93f2-af581a8a0383</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="7" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="7" Volume="2013" Year="2013">
       <Id>3ab2d8ef-5aed-464a-9852-da5ed9a27618</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="8" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="8" Volume="2013" Year="2013">
       <Id>a83112ad-669d-4266-b034-509cedd6b43d</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="9" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="9" Volume="2013" Year="2013">
       <Id>ec625346-8e19-4dce-ab5c-f04ce3be8729</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="10" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="10" Volume="2013" Year="2013">
       <Id>2f536ec0-f6d0-4980-bc44-4d1cbf644b1b</Id>
     </Book>
-    <Book Series="Avenging Spider-Man" Number="20" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Avenging Spider-Man" Number="20" Volume="2011" Year="2013">
       <Id>0a0cb40f-f21d-4cdb-83cd-4782ce463b65</Id>
     </Book>
-    <Book Series="Avenging Spider-Man" Number="21" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Avenging Spider-Man" Number="21" Volume="2011" Year="2013">
       <Id>92d01c31-5aef-4e72-907f-a643cfa001a2</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="11" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="11" Volume="2013" Year="2013">
       <Id>adbd0d2b-70a3-4aeb-a8e0-5985a14beff5</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="12" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="12" Volume="2013" Year="2013">
       <Id>e5c1b773-661a-4eb1-98ec-eec6d40186c2</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="13" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="13" Volume="2013" Year="2013">
       <Id>5e0a1f80-12b1-4d23-b8b5-b1ab89ad7331</Id>
     </Book>
-    <Book Series="Avenging Spider-Man" Number="22" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Avenging Spider-Man" Number="22" Volume="2011" Year="2013">
       <Id>48336899-d82e-4993-83b3-8b227eea69ad</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="14" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="14" Volume="2013" Year="2013">
       <Id>a31e7bfa-ed73-4d58-8e88-984c4e928e94</Id>
     </Book>
-    <Book Series="Superior Spider-Man Team-Up" Number="1" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Superior Spider-Man Team-Up" Number="1" Volume="2013" Year="2013">
       <Id>c24be7a5-f84c-494f-bbdc-dd04178ab3f1</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="15" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="15" Volume="2013" Year="2013">
       <Id>4ff0c887-4c97-493b-af8e-b3618db860af</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="16" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="16" Volume="2013" Year="2013">
       <Id>dabb53d6-0716-4f3b-a96a-fab27148dfbe</Id>
     </Book>
-    <Book Series="Superior Spider-Man Team-Up" Number="2" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Superior Spider-Man Team-Up" Number="2" Volume="2013" Year="2013">
       <Id>e82d0aa5-6290-4785-a016-6ea3022d65b1</Id>
     </Book>
-    <Book Series="Scarlet Spider" Number="20" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Scarlet Spider" Number="20" Volume="2012" Year="2013">
       <Id>388c6847-0ac8-428c-86ee-cf7155d4e424</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="17" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="17" Volume="2013" Year="2013">
       <Id>672be6c5-3c1a-47c9-a931-7253d36c3afe</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="18" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="18" Volume="2013" Year="2013">
       <Id>07c04613-114c-4a29-b08e-3b6f9f68cd20</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="19" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="19" Volume="2013" Year="2013">
       <Id>e2481592-b231-4fea-a74c-5e01f1385c43</Id>
     </Book>
-    <Book Series="All-New X-Men Special" Number="1" Volume="2013" Year="2013" Format="One-Shot">
+    <Book Series="All-New X-Men Special" Number="1" Volume="2013" Year="2013">
       <Id>db40a7d4-0ab5-4cfa-8313-11c5c01fdc34</Id>
     </Book>
-    <Book Series="Indestructible Hulk Special" Number="1" Volume="2013" Year="2013" Format="One-Shot">
+    <Book Series="Indestructible Hulk Special" Number="1" Volume="2013" Year="2013">
       <Id>eb738a1d-ad79-42db-b9d1-1d15d8bfab91</Id>
     </Book>
-    <Book Series="Superior Spider-Man Team-Up Special" Number="1" Volume="2013" Year="2013" Format="One-Shot">
+    <Book Series="Superior Spider-Man Team-Up Special" Number="1" Volume="2013" Year="2013">
       <Id>acfe03ea-b44d-441f-8218-3103227b69c6</Id>
     </Book>
-    <Book Series="Avengers" Number="14" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Avengers" Number="14" Volume="2013" Year="2013">
       <Id>2af20e87-ad01-4dd9-bad9-448f1d5f890a</Id>
     </Book>
-    <Book Series="Avengers" Number="15" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Avengers" Number="15" Volume="2013" Year="2013">
       <Id>c28cdbc4-c335-48e3-920d-4483cfbeecea</Id>
     </Book>
-    <Book Series="Avengers" Number="16" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Avengers" Number="16" Volume="2013" Year="2013">
       <Id>3e236aeb-4aca-4414-a06a-e479d9fde842</Id>
     </Book>
-    <Book Series="Avengers" Number="17" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Avengers" Number="17" Volume="2013" Year="2013">
       <Id>4033369f-86c6-4fbb-a0ed-3869412cdd15</Id>
     </Book>
-    <Book Series="Mighty Avengers" Number="1" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Mighty Avengers" Number="1" Volume="2013" Year="2013">
       <Id>f4919bd1-34fc-4ee7-80c8-88cdeae12f2f</Id>
     </Book>
-    <Book Series="Mighty Avengers" Number="2" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Mighty Avengers" Number="2" Volume="2013" Year="2013">
       <Id>90ce9b22-8dbe-4dbb-b393-03ba5c4b8475</Id>
     </Book>
-    <Book Series="Mighty Avengers" Number="3" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Mighty Avengers" Number="3" Volume="2013" Year="2014">
       <Id>38512e44-4b54-48e7-84fc-8ed061423311</Id>
     </Book>
-    <Book Series="Superior Spider-Man Team-Up" Number="3" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Superior Spider-Man Team-Up" Number="3" Volume="2013" Year="2013">
       <Id>5c0c7354-97c0-443b-b389-72ed21757f4c</Id>
     </Book>
-    <Book Series="Superior Spider-Man Team-Up" Number="4" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Superior Spider-Man Team-Up" Number="4" Volume="2013" Year="2013">
       <Id>c4acabdf-ace0-4d0c-967f-ce10541a0d7f</Id>
     </Book>
-    <Book Series="Superior Spider-Man Team-Up" Number="5" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Superior Spider-Man Team-Up" Number="5" Volume="2013" Year="2013">
       <Id>be8936bd-d4d3-45aa-a01c-64ed42a0949b</Id>
     </Book>
-    <Book Series="Superior Spider-Man Team-Up" Number="6" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Superior Spider-Man Team-Up" Number="6" Volume="2013" Year="2014">
       <Id>55851909-db2a-4950-9a70-17628b9335bb</Id>
     </Book>
-    <Book Series="Superior Spider-Man Team-Up" Number="7" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Superior Spider-Man Team-Up" Number="7" Volume="2013" Year="2014">
       <Id>285c539c-5f0a-4b54-8c16-ea27ae017d40</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="20" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="20" Volume="2013" Year="2013">
       <Id>1b0d73c5-33e8-4b69-9ade-4d98ec2c6a28</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="21" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="21" Volume="2013" Year="2014">
       <Id>9653dcfb-f0c1-492c-a130-60d7c991cded</Id>
     </Book>
-    <Book Series="Superior Spider-Man Annual" Number="1" Volume="2013" Year="2014" Format="Annual">
+    <Book Series="Superior Spider-Man Annual" Number="1" Volume="2013" Year="2014">
       <Id>1d29d88c-c759-4aab-9f8a-e8db700b9c12</Id>
     </Book>
-    <Book Series="Superior Spider-Man Team-Up" Number="8" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Superior Spider-Man Team-Up" Number="8" Volume="2013" Year="2014">
       <Id>fe34a6f1-5f7a-465a-9554-998cd3c8dcfc</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="22" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="22" Volume="2013" Year="2014">
       <Id>1e821b8b-1c39-4b5c-bafb-be21b051b4db</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="23" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="23" Volume="2013" Year="2014">
       <Id>c9f2d6b0-4b05-44a8-9eb7-a87d6ad5fab2</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="24" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="24" Volume="2013" Year="2014">
       <Id>5478f472-83ae-4677-bc60-5a72b2481d24</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="25" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="25" Volume="2013" Year="2014">
       <Id>627dc9d4-7b52-4f49-b371-bdfdeaabbf3b</Id>
     </Book>
-    <Book Series="Inhumanity: Superior Spider-Man" Number="1" Volume="2014" Year="2014" Format="One-Shot">
+    <Book Series="Inhumanity: Superior Spider-Man" Number="1" Volume="2014" Year="2014">
       <Id>121d9715-bc7f-45f8-9479-63e453e7628b</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="26" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="26" Volume="2013" Year="2014">
       <Id>4a7a914b-9a95-4270-bfb9-fa5e55372431</Id>
     </Book>
-    <Book Series="Superior Spider-Man Team-Up" Number="9" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Superior Spider-Man Team-Up" Number="9" Volume="2013" Year="2014">
       <Id>e1169edf-fe5e-4284-8a4e-4c7385ba8d67</Id>
     </Book>
-    <Book Series="Superior Spider-Man Team-Up" Number="10" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Superior Spider-Man Team-Up" Number="10" Volume="2013" Year="2014">
       <Id>dfd2eeed-fa7a-4f81-8091-45c0562b7e5f</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="27" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="27" Volume="2013" Year="2014">
       <Id>c32911f7-ba8c-4bec-99ea-5e63763d2cdb</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="28" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="28" Volume="2013" Year="2014">
       <Id>eeac5c77-337f-422a-93c7-ce7b8ceb38df</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="29" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="29" Volume="2013" Year="2014">
       <Id>e52e5606-0146-4921-8070-fe27b3d0409b</Id>
     </Book>
-    <Book Series="Superior Spider-Man Annual" Number="2" Volume="2013" Year="2014" Format="Annual">
+    <Book Series="Superior Spider-Man Annual" Number="2" Volume="2013" Year="2014">
       <Id>e5b7894e-99c7-49e5-9da9-04cef2ebc687</Id>
     </Book>
-    <Book Series="Superior Spider-Man Team-Up" Number="11" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Superior Spider-Man Team-Up" Number="11" Volume="2013" Year="2014">
       <Id>c49c0ae9-5267-4aa9-ae31-e457f948a628</Id>
     </Book>
-    <Book Series="Superior Spider-Man Team-Up" Number="12" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Superior Spider-Man Team-Up" Number="12" Volume="2013" Year="2014">
       <Id>ebfefd6e-70d5-4841-ae65-bc3c59da527c</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="30" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="30" Volume="2013" Year="2014">
       <Id>9ba4b424-dc76-4547-be49-bc7820d3a99a</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="31" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="31" Volume="2013" Year="2014">
       <Id>65fded1a-6e96-41ca-82fe-4d629be495dc</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="1" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="1" Volume="2014" Year="2014">
       <Id>5cc8b0af-0445-4b6c-9cd9-a0144708b9a8</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="2" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="2" Volume="2014" Year="2014">
       <Id>6dc1c2d7-a2dc-4520-8b40-15a8dc1d3ff5</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="3" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="3" Volume="2014" Year="2014">
       <Id>77dce4af-5d72-4309-bbab-58ff07c2ee50</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="1.1" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="1.1" Volume="2014" Year="2014">
       <Id>0f4a2c3c-c2d7-46ee-ba03-2951e67ed928</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="1.2" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="1.2" Volume="2014" Year="2014">
       <Id>b6dec8f7-e388-44e0-b04d-3093729159f3</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="1.3" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="1.3" Volume="2014" Year="2014">
       <Id>d88c1f02-6407-4451-96ec-2dac7f09c4ca</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="1.4" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="1.4" Volume="2014" Year="2014">
       <Id>69e4570a-b43f-47b2-be5b-344a111ffc99</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="1.5" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="1.5" Volume="2014" Year="2014">
       <Id>024a5b58-855b-402b-bb2c-a24171279121</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="1" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="1" Volume="2014" Year="2014">
       <Id>5f68d833-d965-484e-8d69-20dd624de682</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="2" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="2" Volume="2014" Year="2014">
       <Id>cfb33157-2a8b-4a66-b90a-6d193561d36f</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="3" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="3" Volume="2014" Year="2014">
       <Id>57b3bd57-8150-4b40-8d51-df11f4747aff</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="4" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="4" Volume="2014" Year="2014">
       <Id>bea6bc32-44df-4531-8897-1acc2f9ca9d2</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="4" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="4" Volume="2014" Year="2014">
       <Id>7fa25826-34a0-4542-a8bb-785ab98733a9</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="5" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="5" Volume="2014" Year="2014">
       <Id>a93ac88c-686d-4315-90be-6dfd1cc58efa</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="6" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="6" Volume="2014" Year="2014">
       <Id>fb44e004-1371-4586-a2df-6a61f7db02a6</Id>
     </Book>
-    <Book Series="Axis: Hobgoblin" Number="1" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="Axis: Hobgoblin" Number="1" Volume="2014" Year="2014">
       <Id>ec0884d1-db5c-466a-83fe-f9c939620703</Id>
     </Book>
-    <Book Series="Axis: Hobgoblin" Number="2" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="Axis: Hobgoblin" Number="2" Volume="2014" Year="2015">
       <Id>552ff453-a7a0-400b-be56-ddee994405eb</Id>
     </Book>
-    <Book Series="Axis: Hobgoblin" Number="3" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="Axis: Hobgoblin" Number="3" Volume="2014" Year="2015">
       <Id>b85306cd-d05c-4bf2-8320-0425042ca4c6</Id>
     </Book>
-    <Book Series="Axis: Carnage" Number="1" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="Axis: Carnage" Number="1" Volume="2014" Year="2014">
       <Id>0f65f5de-13a4-4982-a1f0-b53a5b6ba4a9</Id>
     </Book>
-    <Book Series="Axis: Carnage" Number="2" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="Axis: Carnage" Number="2" Volume="2014" Year="2015">
       <Id>bcacb49e-e5da-4d05-acb1-831e0f7e9cd5</Id>
     </Book>
-    <Book Series="Axis: Carnage" Number="3" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="Axis: Carnage" Number="3" Volume="2014" Year="2015">
       <Id>93725b6e-4bf8-4374-ac81-d3f05844ab09</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="32" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="32" Volume="2013" Year="2014">
       <Id>c658f646-ecef-42fe-b86e-1862c04460e2</Id>
     </Book>
-    <Book Series="Superior Spider-Man" Number="33" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Superior Spider-Man" Number="33" Volume="2013" Year="2014">
       <Id>896745e4-6353-4eac-bdd7-27c5e451a086</Id>
     </Book>
-    <Book Series="Edge of Spider-Verse" Number="1" Volume="2014" Year="2014" Format="Limited Series">
+    <Book Series="Edge of Spider-Verse" Number="1" Volume="2014" Year="2014">
       <Id>b7dbde8c-3146-490b-b545-1a6a4fb3b76f</Id>
     </Book>
-    <Book Series="Edge of Spider-Verse" Number="2" Volume="2014" Year="2014" Format="Limited Series">
+    <Book Series="Edge of Spider-Verse" Number="2" Volume="2014" Year="2014">
       <Id>a9b30c7f-1583-4beb-a970-158330756ab4</Id>
     </Book>
-    <Book Series="Edge of Spider-Verse" Number="3" Volume="2014" Year="2014" Format="Limited Series">
+    <Book Series="Edge of Spider-Verse" Number="3" Volume="2014" Year="2014">
       <Id>3fee145d-cfe7-4135-9e26-2bd3382cc834</Id>
     </Book>
-    <Book Series="Edge of Spider-Verse" Number="4" Volume="2014" Year="2014" Format="Limited Series">
+    <Book Series="Edge of Spider-Verse" Number="4" Volume="2014" Year="2014">
       <Id>5f2b813f-da62-47e1-aab8-a34ed734782d</Id>
     </Book>
-    <Book Series="Edge of Spider-Verse" Number="5" Volume="2014" Year="2014" Format="Limited Series">
+    <Book Series="Edge of Spider-Verse" Number="5" Volume="2014" Year="2014">
       <Id>0146d82b-6c13-4bff-a03c-4da711598103</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="7" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="7" Volume="2014" Year="2014">
       <Id>d809c649-daf1-4f38-a289-50a9f78bb370</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="8" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="8" Volume="2014" Year="2014">
       <Id>58beff0a-81a1-46d4-a78e-2b0c0db6655e</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="5" Volume="2014" Year="2014" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="5" Volume="2014" Year="2014">
       <Id>dcbd6535-1d9e-4746-98c4-5439adfc99c7</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="9" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="9" Volume="2014" Year="2015">
       <Id>875358c4-5510-4722-a70a-31364cf1536b</Id>
     </Book>
-    <Book Series="Spider-Verse" Number="1" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Verse" Number="1" Volume="2014" Year="2015">
       <Id>bb01cad6-00fb-4eec-9d9a-0ed103d61cfd</Id>
     </Book>
-    <Book Series="Spider-Verse Team-Up" Number="1" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Verse Team-Up" Number="1" Volume="2014" Year="2015">
       <Id>63b614bc-fb78-4f6c-be0b-6dc58c5c60dc</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="10" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="10" Volume="2014" Year="2015">
       <Id>1b8cf03f-4b83-439c-a4ef-4e07c93dd4ba</Id>
     </Book>
-    <Book Series="Scarlet Spiders" Number="1" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Scarlet Spiders" Number="1" Volume="2014" Year="2015">
       <Id>77fe29a8-4163-4ff1-8705-60ade9ddb29f</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="1" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Spider-Woman" Number="1" Volume="2014" Year="2015">
       <Id>c97e15aa-3c10-40eb-8dc7-7a127e058197</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="6" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="6" Volume="2014" Year="2015">
       <Id>5df55abb-cd8b-4a55-b989-48d42e32fd1c</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="11" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="11" Volume="2014" Year="2015">
       <Id>1087857b-416e-4e1a-af91-35322bfc41d3</Id>
     </Book>
-    <Book Series="Spider-Verse Team-Up" Number="2" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Verse Team-Up" Number="2" Volume="2014" Year="2015">
       <Id>b7b0c565-fa7a-4d67-9b6a-e6369fba71c7</Id>
     </Book>
-    <Book Series="Scarlet Spiders" Number="2" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Scarlet Spiders" Number="2" Volume="2014" Year="2015">
       <Id>3b9bc658-9567-40c7-8d17-21d2729bb067</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="2" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Spider-Woman" Number="2" Volume="2014" Year="2015">
       <Id>99e553e1-e05b-4acd-8587-7b16d89f8b16</Id>
     </Book>
-    <Book Series="Spider-Verse" Number="2" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Verse" Number="2" Volume="2014" Year="2015">
       <Id>dcd92581-0534-4772-ad4b-4007bffed305</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="12" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="12" Volume="2014" Year="2015">
       <Id>2a001d1e-3d5e-4c03-8095-1febf6aa8251</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="7" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="7" Volume="2014" Year="2015">
       <Id>8cd1293b-1a92-4492-82d7-20ee1707d2b8</Id>
     </Book>
-    <Book Series="Scarlet Spiders" Number="3" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Scarlet Spiders" Number="3" Volume="2014" Year="2015">
       <Id>b10c13b5-62d2-4d67-90aa-11ec0612fda5</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="13" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="13" Volume="2014" Year="2015">
       <Id>2eb70b8b-1903-4b6f-bf8b-44a4f5e3a5f4</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="3" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Spider-Woman" Number="3" Volume="2014" Year="2015">
       <Id>b5b5b25b-debb-4a34-adb3-760aef047953</Id>
     </Book>
-    <Book Series="Spider-Verse Team-Up" Number="3" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Verse Team-Up" Number="3" Volume="2014" Year="2015">
       <Id>9e6acb70-cf77-4801-ad59-9b5c93317e08</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="8" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="8" Volume="2014" Year="2015">
       <Id>1ec4cddc-6e0d-40d0-85d6-3c7c718d87e6</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="14" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="14" Volume="2014" Year="2015">
       <Id>acf941ea-6f56-4f39-87e6-305cb3181355</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="4" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Spider-Woman" Number="4" Volume="2014" Year="2015">
       <Id>ca42d53d-5da2-41fd-a4c6-677669a1730e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="15" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="15" Volume="2014" Year="2015">
       <Id>4ca6a6f0-6d6f-46b5-aad0-1b4ea76442ee</Id>
     </Book>
-    <Book Series="Spider-Man &amp; the X-Men" Number="1" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Man &amp; the X-Men" Number="1" Volume="2014" Year="2015">
       <Id>4e648eae-7adb-47c4-bf04-a18ac9d5092a</Id>
     </Book>
-    <Book Series="Spider-Man &amp; the X-Men" Number="2" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Man &amp; the X-Men" Number="2" Volume="2014" Year="2015">
       <Id>ccb5a65b-c521-4d0e-99ee-e9230998f91c</Id>
     </Book>
-    <Book Series="Spider-Man &amp; the X-Men" Number="3" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Man &amp; the X-Men" Number="3" Volume="2014" Year="2015">
       <Id>490d0783-87d0-4055-8c58-2930fa358525</Id>
     </Book>
-    <Book Series="Spider-Man &amp; the X-Men" Number="4" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Man &amp; the X-Men" Number="4" Volume="2014" Year="2015">
       <Id>dcd89d50-5a4a-4f16-a811-444ce81e2043</Id>
     </Book>
-    <Book Series="Spider-Man &amp; the X-Men" Number="5" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Man &amp; the X-Men" Number="5" Volume="2014" Year="2015">
       <Id>377546d0-11d9-4ec6-a3fb-0aca9eef6f35</Id>
     </Book>
-    <Book Series="Spider-Man &amp; the X-Men" Number="6" Volume="2014" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Man &amp; the X-Men" Number="6" Volume="2014" Year="2015">
       <Id>7b46f829-33a8-4c4b-9abd-03d5d0f5d532</Id>
     </Book>
-    <Book Series="Amazing Spider-Man Annual" Number="1" Volume="2014" Year="2015" Format="Annual">
+    <Book Series="Amazing Spider-Man Annual" Number="1" Volume="2014" Year="2015">
       <Id>0de757be-3c25-4a7e-9a58-b1a1e72e2903</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="16.1" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="16.1" Volume="2014" Year="2015">
       <Id>aa0e65fc-94d3-4876-b4ff-a80a916e2967</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="17.1" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="17.1" Volume="2014" Year="2015">
       <Id>27c881d9-9f1e-4ff6-b12e-5e53a9ae6deb</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="18.1" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="18.1" Volume="2014" Year="2015">
       <Id>73af4729-5611-461d-8aec-92360262e2da</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="19.1" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="19.1" Volume="2014" Year="2015">
       <Id>4dbf0d1c-4776-49bc-a414-3eb357e2e000</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="20.1" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="20.1" Volume="2014" Year="2015">
       <Id>a7afa1fb-19d9-4fd1-b8d7-eaf5c49209d7</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="16" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="16" Volume="2014" Year="2015">
       <Id>f9f91e00-e846-4c2a-ad17-3d9430620b8a</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="17" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="17" Volume="2014" Year="2015">
       <Id>07a7468a-ee3c-494c-8cc1-8512e94d2564</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="18" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="18" Volume="2014" Year="2015">
       <Id>124cc225-ded3-4003-944b-3a449e5b1207</Id>
     </Book>
-    <Book Series="Silk" Number="1" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Silk" Number="1" Volume="2015" Year="2015">
       <Id>fa5cbc19-414d-4dee-bc99-d3433a581dc2</Id>
     </Book>
-    <Book Series="Silk" Number="2" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Silk" Number="2" Volume="2015" Year="2015">
       <Id>e77287ca-7150-4521-828e-fb27692535be</Id>
     </Book>
-    <Book Series="Silk" Number="3" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Silk" Number="3" Volume="2015" Year="2015">
       <Id>4d0f4371-e722-4817-87ed-ac8648a72970</Id>
     </Book>
-    <Book Series="Silk" Number="4" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Silk" Number="4" Volume="2015" Year="2015">
       <Id>ae047203-8345-45b1-9860-43459f1aaa22</Id>
     </Book>
-    <Book Series="Silk" Number="5" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Silk" Number="5" Volume="2015" Year="2015">
       <Id>14f1ec97-c7a4-454d-ab00-e73435f677fa</Id>
     </Book>
-    <Book Series="Silk" Number="6" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Silk" Number="6" Volume="2015" Year="2015">
       <Id>902c9163-db84-49bb-a95c-4e1b4480ed8f</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="5" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Spider-Woman" Number="5" Volume="2014" Year="2015">
       <Id>c1d62ae3-9f43-45da-a915-46b2d2f7d95c</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="6" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Spider-Woman" Number="6" Volume="2014" Year="2015">
       <Id>d1a1b962-35a2-4fb8-8fd9-3a8ad0d66fab</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="7" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Spider-Woman" Number="7" Volume="2014" Year="2015">
       <Id>56ebd1e9-fdc4-422e-bb94-a83a34e99520</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="8" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Spider-Woman" Number="8" Volume="2014" Year="2015">
       <Id>7de270a2-56c8-4e95-9b86-660735f7bae2</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="9" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Spider-Woman" Number="9" Volume="2014" Year="2015">
       <Id>7d6406d6-be6a-4f86-ac02-07a5aa762c49</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="9" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="9" Volume="2014" Year="2015">
       <Id>6cd6a807-5123-491c-919b-7e4a93dd57df</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="10" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="10" Volume="2014" Year="2015">
       <Id>10cabbc2-bd16-4a6d-bb13-9e49db79f833</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="11" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="11" Volume="2014" Year="2015">
       <Id>daae95a6-561d-4099-8638-075c9eb7ea30</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="12" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="12" Volume="2014" Year="2015">
       <Id>8ef408d3-c4e0-474d-b24a-c3a13ed39c44</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="1" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Gwen" Number="1" Volume="2015" Year="2015">
       <Id>077a309a-e6f8-4b0f-bf6e-a575ee1d7e3d</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="2" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Gwen" Number="2" Volume="2015" Year="2015">
       <Id>46c1c3ae-7bbe-48ce-944a-fb1d138d8599</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="3" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Gwen" Number="3" Volume="2015" Year="2015">
       <Id>400414af-8b57-4aba-ab58-782a9a26eca2</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="4" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Gwen" Number="4" Volume="2015" Year="2015">
       <Id>2374d039-bac5-4339-ae18-75db5f2bfa57</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="5" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Gwen" Number="5" Volume="2015" Year="2015">
       <Id>50f8e97c-2f0b-4f08-b29e-538967286e8b</Id>
     </Book>
-    <Book Series="Captain America &amp; the Mighty Avengers" Number="4" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Captain America &amp; the Mighty Avengers" Number="4" Volume="2014" Year="2015">
       <Id>98b24815-4447-463a-b7b7-3219d100ffb7</Id>
     </Book>
-    <Book Series="Captain America &amp; the Mighty Avengers" Number="5" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Captain America &amp; the Mighty Avengers" Number="5" Volume="2014" Year="2015">
       <Id>215879b8-dca3-4a1e-b8fe-eb946273b1ea</Id>
     </Book>
-    <Book Series="Captain America &amp; the Mighty Avengers" Number="6" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Captain America &amp; the Mighty Avengers" Number="6" Volume="2014" Year="2015">
       <Id>16dbaaf1-320c-423f-8008-1987cea63c44</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man Special" Number="1" Volume="2015" Year="2015" Format="One-Shot">
+    <Book Series="The Amazing Spider-Man Special" Number="1" Volume="2015" Year="2015">
       <Id>6f2b713a-96fa-4ad6-bed1-890162d12594</Id>
     </Book>
-    <Book Series="Inhuman Special" Number="1" Volume="2015" Year="2015" Format="One-Shot">
+    <Book Series="Inhuman Special" Number="1" Volume="2015" Year="2015">
       <Id>cc1bf566-47e2-4f45-b578-f2912c73c5bf</Id>
     </Book>
-    <Book Series="All-New Captain America Special" Number="1" Volume="2015" Year="2015" Format="One-Shot">
+    <Book Series="All-New Captain America Special" Number="1" Volume="2015" Year="2015">
       <Id>f4018609-cb54-4df3-a25b-ae983cd41514</Id>
     </Book>
-    <Book Series="Captain America &amp; the Mighty Avengers" Number="7" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Captain America &amp; the Mighty Avengers" Number="7" Volume="2014" Year="2015">
       <Id>9c4fdeee-3edf-4379-8c4c-055d1ae723e9</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="10" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Spider-Woman" Number="10" Volume="2014" Year="2015">
       <Id>2fecfc1f-8e11-4e70-9285-2922537631fd</Id>
     </Book>
-    <Book Series="Silk" Number="7" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Silk" Number="7" Volume="2015" Year="2015">
       <Id>7d138ce4-0e91-4216-b2ce-036f877f10d4</Id>
     </Book>
-    <Book Series="Captain America &amp; the Mighty Avengers" Number="8" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Captain America &amp; the Mighty Avengers" Number="8" Volume="2014" Year="2015">
       <Id>0196a989-701b-4c49-87c8-5e6ea6a9f0db</Id>
     </Book>
-    <Book Series="Captain America &amp; the Mighty Avengers" Number="9" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Captain America &amp; the Mighty Avengers" Number="9" Volume="2014" Year="2015">
       <Id>d6f651b5-fe6a-4eba-8bda-2fb1adc30e0e</Id>
     </Book>
-    <Book Series="Secret Wars" Number="1" Volume="2015" Year="2015" Format="Crossover">
+    <Book Series="Secret Wars" Number="1" Volume="2015" Year="2015">
       <Id>3244b4aa-3741-4c19-8ecb-07117f46e2a5</Id>
     </Book>
-    <Book Series="Secret Wars" Number="2" Volume="2015" Year="2015" Format="Crossover">
+    <Book Series="Secret Wars" Number="2" Volume="2015" Year="2015">
       <Id>4f4855ba-7a3d-4051-9336-8c200e577f71</Id>
     </Book>
-    <Book Series="Spider-Verse" Number="1" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Verse" Number="1" Volume="2015" Year="2015">
       <Id>f83d418d-c678-4fdc-8794-92c79336add3</Id>
     </Book>
-    <Book Series="Spider-Verse" Number="2" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Verse" Number="2" Volume="2015" Year="2015">
       <Id>681bbf95-01f5-46a6-999f-ec4359abc7ad</Id>
     </Book>
-    <Book Series="Spider-Verse" Number="3" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Verse" Number="3" Volume="2015" Year="2015">
       <Id>b029ea6a-daaf-4f6e-ac5a-f9cb9a3a8dad</Id>
     </Book>
-    <Book Series="Spider-Verse" Number="4" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Verse" Number="4" Volume="2015" Year="2015">
       <Id>8ee48957-586e-4558-90a3-ba816d3c0417</Id>
     </Book>
-    <Book Series="Spider-Verse" Number="5" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Verse" Number="5" Volume="2015" Year="2015">
       <Id>11216a4c-3ad3-4207-a4db-fbe2ac9a4095</Id>
     </Book>
-    <Book Series="Spider-Island" Number="1" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Island" Number="1" Volume="2015" Year="2015">
       <Id>cbc68c6d-5906-45f2-a72f-35883e73dfcc</Id>
     </Book>
-    <Book Series="Spider-Island" Number="2" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Island" Number="2" Volume="2015" Year="2015">
       <Id>5c3ce3ca-e48e-446c-a7fc-99000f00455e</Id>
     </Book>
-    <Book Series="Spider-Island" Number="3" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Island" Number="3" Volume="2015" Year="2015">
       <Id>45dbafd3-ddd3-4bfd-879b-fa32c7c0e7f4</Id>
     </Book>
-    <Book Series="Spider-Island" Number="4" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Island" Number="4" Volume="2015" Year="2015">
       <Id>4d2bf4ec-8110-40c7-9bad-96368f437902</Id>
     </Book>
-    <Book Series="Spider-Island" Number="5" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Spider-Island" Number="5" Volume="2015" Year="2015">
       <Id>b732e838-5baf-4fcd-a278-c0b264306645</Id>
     </Book>
-    <Book Series="Amazing Spider-Man: Renew Your Vows" Number="1" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Amazing Spider-Man: Renew Your Vows" Number="1" Volume="2015" Year="2015">
       <Id>46e4a5ff-d342-47f3-9975-1801663dbf3c</Id>
     </Book>
-    <Book Series="Amazing Spider-Man: Renew Your Vows" Number="2" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Amazing Spider-Man: Renew Your Vows" Number="2" Volume="2015" Year="2015">
       <Id>7a551af5-d430-4020-9a56-4c888fab0ed9</Id>
     </Book>
-    <Book Series="Amazing Spider-Man: Renew Your Vows" Number="3" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Amazing Spider-Man: Renew Your Vows" Number="3" Volume="2015" Year="2015">
       <Id>5d5a62b7-8280-48a5-af71-8cd90b4b5121</Id>
     </Book>
-    <Book Series="Amazing Spider-Man: Renew Your Vows" Number="4" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Amazing Spider-Man: Renew Your Vows" Number="4" Volume="2015" Year="2015">
       <Id>b25c58d6-ab16-408a-bc2d-1f98bbfd11cb</Id>
     </Book>
-    <Book Series="Amazing Spider-Man: Renew Your Vows" Number="5" Volume="2015" Year="2015" Format="Limited Series">
+    <Book Series="Amazing Spider-Man: Renew Your Vows" Number="5" Volume="2015" Year="2015">
       <Id>a56fba82-6b50-49b7-8643-fd67c7d34585</Id>
     </Book>
-    <Book Series="Secret Wars" Number="3" Volume="2015" Year="2015" Format="Crossover">
+    <Book Series="Secret Wars" Number="3" Volume="2015" Year="2015">
       <Id>855b8600-84dd-4b5d-b56f-d7aac338c9f9</Id>
     </Book>
-    <Book Series="Secret Wars" Number="4" Volume="2015" Year="2015" Format="Crossover">
+    <Book Series="Secret Wars" Number="4" Volume="2015" Year="2015">
       <Id>48830bae-ed26-4c6a-8a53-692aa68d96ea</Id>
     </Book>
-    <Book Series="Secret Wars" Number="5" Volume="2015" Year="2015" Format="Crossover">
+    <Book Series="Secret Wars" Number="5" Volume="2015" Year="2015">
       <Id>f77b6ab1-a052-4ed0-9ec4-daa98d467829</Id>
     </Book>
-    <Book Series="Secret Wars" Number="6" Volume="2015" Year="2015" Format="Crossover">
+    <Book Series="Secret Wars" Number="6" Volume="2015" Year="2015">
       <Id>ca805e46-41b6-425f-9b47-3d4f1d70dc52</Id>
     </Book>
-    <Book Series="Secret Wars" Number="7" Volume="2015" Year="2016" Format="Crossover">
+    <Book Series="Secret Wars" Number="7" Volume="2015" Year="2016">
       <Id>26e7f22a-4566-4d7e-b5fe-f9866cb1cbb4</Id>
     </Book>
-    <Book Series="Secret Wars" Number="8" Volume="2015" Year="2016" Format="Crossover">
+    <Book Series="Secret Wars" Number="8" Volume="2015" Year="2016">
       <Id>a86052c5-b509-4986-b105-b914ba79b09f</Id>
     </Book>
-    <Book Series="Secret Wars" Number="9" Volume="2015" Year="2016" Format="Crossover">
+    <Book Series="Secret Wars" Number="9" Volume="2015" Year="2016">
       <Id>7f2eecca-d885-4705-9ec0-97fdac82fe27</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Spider-Man/Spider-Man 010 (All New, All Different).cbl
+++ b/Marvel/Characters/unsorted/Spider-Man/Spider-Man 010 (All New, All Different).cbl
@@ -2,889 +2,889 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Spider-Man 10 (All New, All Different)</Name>
   <Books>
-    <Book Series="Spider-Man" Number="1" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man" Number="1" Volume="2016" Year="2016">
       <Id>12aac861-2dfa-4875-889d-6f3c60d910c1</Id>
     </Book>
-    <Book Series="Spider-Man" Number="2" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man" Number="2" Volume="2016" Year="2016">
       <Id>ff0ff337-06df-45a9-8d80-7407efe8dd08</Id>
     </Book>
-    <Book Series="All-New, All-Different Avengers" Number="1" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New, All-Different Avengers" Number="1" Volume="2015" Year="2016">
       <Id>8e0bbee7-e543-4985-ab12-a27320601dfc</Id>
     </Book>
-    <Book Series="All-New, All-Different Avengers" Number="2" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New, All-Different Avengers" Number="2" Volume="2015" Year="2016">
       <Id>9161e6a6-2260-4a56-8195-c96e67ab6b52</Id>
     </Book>
-    <Book Series="All-New, All-Different Avengers" Number="3" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New, All-Different Avengers" Number="3" Volume="2015" Year="2016">
       <Id>236f4704-5205-448b-9b27-8a6a0e3c96e1</Id>
     </Book>
-    <Book Series="Spider-Man" Number="3" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man" Number="3" Volume="2016" Year="2016">
       <Id>5d278c43-8918-4482-be70-50c8b879fa00</Id>
     </Book>
-    <Book Series="Spider-Man" Number="4" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man" Number="4" Volume="2016" Year="2016">
       <Id>8f5a6758-939f-4a6a-a519-d9b2c9ae5bd5</Id>
     </Book>
-    <Book Series="Spider-Man" Number="5" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man" Number="5" Volume="2016" Year="2016">
       <Id>832d497f-aed5-4b98-a76f-a3ad72dbc4e0</Id>
     </Book>
-    <Book Series="All-New, All-Different Avengers" Number="4" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New, All-Different Avengers" Number="4" Volume="2015" Year="2016">
       <Id>21554257-a3e2-43f7-85c3-0be4ef30dca1</Id>
     </Book>
-    <Book Series="All-New, All-Different Avengers" Number="5" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New, All-Different Avengers" Number="5" Volume="2015" Year="2016">
       <Id>58138964-f2ef-475a-9a74-84448a645e04</Id>
     </Book>
-    <Book Series="All-New, All-Different Avengers" Number="6" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New, All-Different Avengers" Number="6" Volume="2015" Year="2016">
       <Id>068b95c2-b02d-4698-894b-5c9f3b008a66</Id>
     </Book>
-    <Book Series="Silk" Number="1" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Silk" Number="1" Volume="2015" Year="2016">
       <Id>7c65f9df-a968-48ff-8531-f4d4f5d76e83</Id>
     </Book>
-    <Book Series="Silk" Number="2" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Silk" Number="2" Volume="2015" Year="2016">
       <Id>62516469-e22a-414f-ac75-7e9f2a83d2f8</Id>
     </Book>
-    <Book Series="Silk" Number="3" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Silk" Number="3" Volume="2015" Year="2016">
       <Id>e74ace12-0b79-4da1-a698-82e5e774a439</Id>
     </Book>
-    <Book Series="Silk" Number="4" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Silk" Number="4" Volume="2015" Year="2016">
       <Id>1cd0a65b-8efd-405a-a53e-bd433180fdc5</Id>
     </Book>
-    <Book Series="Silk" Number="5" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Silk" Number="5" Volume="2015" Year="2016">
       <Id>39ace92d-8bb4-495d-b2d9-dae5d27b07cb</Id>
     </Book>
-    <Book Series="Silk" Number="6" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Silk" Number="6" Volume="2015" Year="2016">
       <Id>48e440a6-b967-43bb-90f0-5028aced09b2</Id>
     </Book>
-    <Book Series="Amazing Spider-Man &amp; Silk: Spider(Fly) Effect Infinite Comic" Number="1" Volume="2016" Year="2016" Format="Limited Series">
+    <Book Series="Amazing Spider-Man &amp; Silk: Spider(Fly) Effect Infinite Comic" Number="1" Volume="2016" Year="2016">
       <Id>c402d0a0-0078-4cca-b71e-160ca08d7cfa</Id>
     </Book>
-    <Book Series="Amazing Spider-Man &amp; Silk: Spider(Fly) Effect Infinite Comic" Number="2" Volume="2016" Year="2016" Format="Limited Series">
+    <Book Series="Amazing Spider-Man &amp; Silk: Spider(Fly) Effect Infinite Comic" Number="2" Volume="2016" Year="2016">
       <Id>6554fb93-4dc0-4df6-b1be-36f992ccc660</Id>
     </Book>
-    <Book Series="Amazing Spider-Man &amp; Silk: Spider(Fly) Effect Infinite Comic" Number="3" Volume="2016" Year="2016" Format="Limited Series">
+    <Book Series="Amazing Spider-Man &amp; Silk: Spider(Fly) Effect Infinite Comic" Number="3" Volume="2016" Year="2016">
       <Id>db28e410-1e41-4dee-ba8a-595c10f49c75</Id>
     </Book>
-    <Book Series="Amazing Spider-Man &amp; Silk: Spider(Fly) Effect Infinite Comic" Number="4" Volume="2016" Year="2016" Format="Limited Series">
+    <Book Series="Amazing Spider-Man &amp; Silk: Spider(Fly) Effect Infinite Comic" Number="4" Volume="2016" Year="2016">
       <Id>ac2e4750-44c2-4abb-a412-7ae56c0fc596</Id>
     </Book>
-    <Book Series="Amazing Spider-Man &amp; Silk: Spider(Fly) Effect Infinite Comic" Number="5" Volume="2016" Year="2016" Format="Limited Series">
+    <Book Series="Amazing Spider-Man &amp; Silk: Spider(Fly) Effect Infinite Comic" Number="5" Volume="2016" Year="2016">
       <Id>08cd8940-94de-4b6e-92fc-6d02bd1df4b6</Id>
     </Book>
-    <Book Series="Amazing Spider-Man &amp; Silk: Spider(Fly) Effect Infinite Comic" Number="6" Volume="2016" Year="2016" Format="Limited Series">
+    <Book Series="Amazing Spider-Man &amp; Silk: Spider(Fly) Effect Infinite Comic" Number="6" Volume="2016" Year="2016">
       <Id>a6e21e1f-e98f-4c4f-92ea-bc7ba7deb9be</Id>
     </Book>
-    <Book Series="Amazing Spider-Man &amp; Silk: Spider(Fly) Effect Infinite Comic" Number="7" Volume="2016" Year="2016" Format="Limited Series">
+    <Book Series="Amazing Spider-Man &amp; Silk: Spider(Fly) Effect Infinite Comic" Number="7" Volume="2016" Year="2016">
       <Id>e40cc1c6-24fa-4ae8-8bb8-d48c3edd7788</Id>
     </Book>
-    <Book Series="Amazing Spider-Man &amp; Silk: Spider(Fly) Effect Infinite Comic" Number="8" Volume="2016" Year="2016" Format="Limited Series">
+    <Book Series="Amazing Spider-Man &amp; Silk: Spider(Fly) Effect Infinite Comic" Number="8" Volume="2016" Year="2016">
       <Id>9a60efc9-2a5d-40b6-9d3f-b0e0a0a77a35</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="1" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="1" Volume="2015" Year="2015">
       <Id>7a79aa6f-86a7-4cf7-a508-ade14fda6535</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="2" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="2" Volume="2015" Year="2015">
       <Id>39ab9368-9621-4162-8b8b-652c6f2899b3</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="3" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="3" Volume="2015" Year="2016">
       <Id>049f44f6-9267-4406-9658-4e77d3870145</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="4" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="4" Volume="2015" Year="2016">
       <Id>bf8f10e8-ccc6-401e-a521-a0738a1779ff</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="5" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="5" Volume="2015" Year="2016">
       <Id>66417dc8-29e2-4938-bead-0e8f43462944</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="6" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="6" Volume="2015" Year="2016">
       <Id>c962a248-8f4d-4ec4-9c4b-288e27920434</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="7" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="7" Volume="2015" Year="2016">
       <Id>bb910f39-9fcc-47d3-901a-fd4b2b41b639</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="8" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="8" Volume="2015" Year="2016">
       <Id>2f2d26e4-77ac-40d8-b183-88662de8c9f7</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="9" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="9" Volume="2015" Year="2016">
       <Id>f8f67f74-120e-42b7-9c73-31a7bdafd13f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="10" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="10" Volume="2015" Year="2016">
       <Id>57d3d127-bcba-4f57-95d1-2361606c6b52</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="11" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="11" Volume="2015" Year="2016">
       <Id>149f7ecf-1bf8-4de4-a4b5-f1923cbfa36f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="1.1" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="1.1" Volume="2015" Year="2016">
       <Id>b1b48b75-bf6c-4239-83e0-fecfc0eb90bb</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="1.2" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="1.2" Volume="2015" Year="2016">
       <Id>d91a349a-82b3-40bd-8f1a-d5c96bb40bb1</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="1.3" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="1.3" Volume="2015" Year="2016">
       <Id>8c59fb2d-6b02-420a-8a03-f31dbfadec68</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="1.4" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="1.4" Volume="2015" Year="2016">
       <Id>005288e1-3db5-4e3f-acbc-438633789c4f</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="1.5" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="1.5" Volume="2015" Year="2016">
       <Id>9b749334-255e-4f34-824b-5a0b7e901a34</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="1.6" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="1.6" Volume="2015" Year="2016">
       <Id>b7a4e56f-6540-4051-bba1-c31028ecae59</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="1" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="1" Volume="2015" Year="2015">
       <Id>545295c3-f864-474d-96e4-6b14462d364a</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="2" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="2" Volume="2015" Year="2016">
       <Id>cb7fd2f4-fad4-4589-8d10-91a10a60932b</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="3" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="3" Volume="2015" Year="2016">
       <Id>1ce96cb9-457b-4258-85c8-cc2ee26a97d4</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="4" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="4" Volume="2015" Year="2016">
       <Id>0f0f6bf0-a016-4398-96ad-712596e1b44d</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="5" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="5" Volume="2015" Year="2016">
       <Id>f2d7fbd7-ae85-4b33-8006-04f675d42a45</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="6" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="6" Volume="2015" Year="2016">
       <Id>04968a35-842d-4d68-8299-37bd1c46ed37</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="1" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Woman" Number="1" Volume="2015" Year="2016">
       <Id>0bb89b66-ff27-4bb1-a341-6d6a1ead9ce5</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="2" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Woman" Number="2" Volume="2015" Year="2016">
       <Id>d3703693-36fd-433b-babc-24cff8e3a71d</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="3" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Woman" Number="3" Volume="2015" Year="2016">
       <Id>fe54ba1f-835f-4466-9aeb-990a178504ac</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="4" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Woman" Number="4" Volume="2015" Year="2016">
       <Id>edbf1396-fa03-495c-97ee-b7a7696a66b6</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="5" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Woman" Number="5" Volume="2015" Year="2016">
       <Id>2869cc49-3512-41ef-af3a-23bff3ec41e4</Id>
     </Book>
-    <Book Series="Web Warriors" Number="1" Volume="2015" Year="2016" Format="Limited Series">
+    <Book Series="Web Warriors" Number="1" Volume="2015" Year="2016">
       <Id>55ff2ee9-7098-4b28-8b2c-77b4d9aee687</Id>
     </Book>
-    <Book Series="Web Warriors" Number="2" Volume="2015" Year="2016" Format="Limited Series">
+    <Book Series="Web Warriors" Number="2" Volume="2015" Year="2016">
       <Id>0ed83e9c-7310-430e-a58e-ff602c32283a</Id>
     </Book>
-    <Book Series="Web Warriors" Number="3" Volume="2015" Year="2016" Format="Limited Series">
+    <Book Series="Web Warriors" Number="3" Volume="2015" Year="2016">
       <Id>b2760863-2f41-4965-b57c-fc252cd093f4</Id>
     </Book>
-    <Book Series="Web Warriors" Number="4" Volume="2015" Year="2016" Format="Limited Series">
+    <Book Series="Web Warriors" Number="4" Volume="2015" Year="2016">
       <Id>3c9118f3-4085-4cd2-b6a8-d01155ec1a02</Id>
     </Book>
-    <Book Series="Web Warriors" Number="5" Volume="2015" Year="2016" Format="Limited Series">
+    <Book Series="Web Warriors" Number="5" Volume="2015" Year="2016">
       <Id>19de14af-b503-4a88-91d9-f1df670f4abd</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="1" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="1" Volume="2015" Year="2015">
       <Id>5874c39b-44df-4c56-bd19-6739280dc97f</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="2" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="2" Volume="2015" Year="2015">
       <Id>27243a89-ea06-4007-9564-884ae08437a5</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="3" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="3" Volume="2015" Year="2016">
       <Id>e27c5c24-52b5-4910-8021-cc885596d70f</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="4" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="4" Volume="2015" Year="2016">
       <Id>8eff7e51-f1c8-4483-a546-1c77b188889a</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="5" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="5" Volume="2015" Year="2016">
       <Id>6fc8bb59-5c2a-4460-83d8-351074438884</Id>
     </Book>
-    <Book Series="Carnage" Number="1" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Carnage" Number="1" Volume="2015" Year="2016">
       <Id>55ce1d81-3f87-4c82-a2b6-900c1624c155</Id>
     </Book>
-    <Book Series="Carnage" Number="2" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Carnage" Number="2" Volume="2015" Year="2016">
       <Id>fbb77b43-608d-47dd-aa64-b6340e28a50b</Id>
     </Book>
-    <Book Series="Carnage" Number="3" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Carnage" Number="3" Volume="2015" Year="2016">
       <Id>c8ce7024-4b4d-4107-b853-61c903ea97d7</Id>
     </Book>
-    <Book Series="Carnage" Number="4" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Carnage" Number="4" Volume="2015" Year="2016">
       <Id>217a4be5-86ed-464d-80ef-8b86c608e435</Id>
     </Book>
-    <Book Series="Carnage" Number="5" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Carnage" Number="5" Volume="2015" Year="2016">
       <Id>7b2f3d92-2633-4e58-99d1-997ce47a2eb9</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="1" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="1" Volume="2016" Year="2016">
       <Id>f51be8fe-9243-403b-89d3-9645aaed2ef1</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="2" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="2" Volume="2016" Year="2016">
       <Id>a8eb5a19-7961-4f00-93d7-2063009c551a</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="3" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="3" Volume="2016" Year="2016">
       <Id>deee85d3-62c9-49b7-ae0c-dd2c4ff83516</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="4" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="4" Volume="2016" Year="2016">
       <Id>2efb2170-f680-4207-9534-5f04232b5e8f</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="5" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="5" Volume="2016" Year="2016">
       <Id>3cff998b-1163-4e90-a74a-b293b8c42132</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="6" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="6" Volume="2016" Year="2016">
       <Id>3e757424-195b-46d7-9bbd-1e1f86d6c3cd</Id>
     </Book>
-    <Book Series="All-New, All-Different Avengers" Number="8" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New, All-Different Avengers" Number="8" Volume="2015" Year="2016">
       <Id>ad0793a0-e4cb-42a8-85d9-8d154e2dae18</Id>
     </Book>
-    <Book Series="Avengers Standoff: Assault On Pleasant Hill Omega" Number="1" Volume="2016" Year="2016" Format="Limited Series">
+    <Book Series="Avengers Standoff: Assault On Pleasant Hill Omega" Number="1" Volume="2016" Year="2016">
       <Id>1bcbe43b-fd1b-4868-b9fd-8f4bca320539</Id>
     </Book>
-    <Book Series="All-New, All-Different Avengers" Number="9" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New, All-Different Avengers" Number="9" Volume="2015" Year="2016">
       <Id>87db4f74-5a02-4a1c-9c47-7a2629679c6d</Id>
     </Book>
-    <Book Series="All-New, All-Different Avengers" Number="10" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New, All-Different Avengers" Number="10" Volume="2015" Year="2016">
       <Id>e21668f3-5ccb-4062-9bd3-f99d19415b73</Id>
     </Book>
-    <Book Series="All-New, All-Different Avengers" Number="11" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New, All-Different Avengers" Number="11" Volume="2015" Year="2016">
       <Id>e40f7219-5b06-462d-abe9-223d0f1cf110</Id>
     </Book>
-    <Book Series="All-New, All-Different Avengers" Number="12" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="All-New, All-Different Avengers" Number="12" Volume="2015" Year="2016">
       <Id>67654bd9-a2e9-4ad9-b437-8c85020bbd69</Id>
     </Book>
-    <Book Series="Spider-Women Alpha" Number="1" Volume="2016" Year="2016" Format="One-Shot">
+    <Book Series="Spider-Women Alpha" Number="1" Volume="2016" Year="2016">
       <Id>b81895b6-9009-4cc0-8772-31a9dde5078b</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="7" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="7" Volume="2015" Year="2016">
       <Id>64b4e970-f921-4da5-b97f-eb5eb0ed2c6f</Id>
     </Book>
-    <Book Series="Silk" Number="7" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Silk" Number="7" Volume="2015" Year="2016">
       <Id>8271a2e2-e447-46f7-90c1-a7bf7d57ee1e</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="6" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Woman" Number="6" Volume="2015" Year="2016">
       <Id>5bcb8638-af35-400b-bbec-e04ee0b2ac0d</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="8" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="8" Volume="2015" Year="2016">
       <Id>121f8cd8-1db3-4c1e-af5c-de7486ef86d1</Id>
     </Book>
-    <Book Series="Silk" Number="8" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Silk" Number="8" Volume="2015" Year="2016">
       <Id>b5620e54-ec47-4dc9-bf9a-e2e9d1944a9b</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="7" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Woman" Number="7" Volume="2015" Year="2016">
       <Id>76d6d27d-ae6d-47bb-bbdf-d966395823dd</Id>
     </Book>
-    <Book Series="Spider-Women Omega" Number="1" Volume="2016" Year="2016" Format="One-Shot">
+    <Book Series="Spider-Women Omega" Number="1" Volume="2016" Year="2016">
       <Id>5392f415-58c4-4fcc-bbd1-e53ec231ec93</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="8" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Woman" Number="8" Volume="2015" Year="2016">
       <Id>5926f165-43d9-4bca-859d-8b6cd1a2ec78</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="9" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="9" Volume="2015" Year="2016">
       <Id>56386da0-0046-4eb7-a750-cda51d1ea767</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="10" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="10" Volume="2015" Year="2016">
       <Id>80b73f0e-3418-43e1-8721-00fdc2d581be</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="11" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="11" Volume="2015" Year="2016">
       <Id>a190fa93-8dc5-43c6-aa71-3aba297164ae</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="12" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="12" Volume="2015" Year="2016">
       <Id>3d88694f-4442-44b6-9657-ee92b500fb24</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="13" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="13" Volume="2015" Year="2016">
       <Id>60298e8e-61eb-4721-b630-a32d2c788abf</Id>
     </Book>
-    <Book Series="Silk" Number="9" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Silk" Number="9" Volume="2015" Year="2016">
       <Id>cb63d417-4adc-41b9-a0c3-a51c9c365a0e</Id>
     </Book>
-    <Book Series="Silk" Number="10" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Silk" Number="10" Volume="2015" Year="2016">
       <Id>b9f9b261-91fb-47b4-8268-0b08973634fa</Id>
     </Book>
-    <Book Series="Silk" Number="11" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Silk" Number="11" Volume="2015" Year="2016">
       <Id>3fc365d7-2383-433e-9a9f-87f7565eed13</Id>
     </Book>
-    <Book Series="Silk" Number="12" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Silk" Number="12" Volume="2015" Year="2016">
       <Id>1ffeb228-24c6-4607-9077-f064643fc7f6</Id>
     </Book>
-    <Book Series="Silk" Number="13" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Silk" Number="13" Volume="2015" Year="2016">
       <Id>5de8c857-8916-440f-9096-e4dca5b2b0cc</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="6" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="6" Volume="2015" Year="2016">
       <Id>359d1cb9-7104-4f93-9664-739022104c91</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="7" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="7" Volume="2015" Year="2016">
       <Id>a6b372a3-5e46-4ea2-a19a-6f012e3539d8</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="8" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="8" Volume="2015" Year="2016">
       <Id>f29844c8-0453-46fb-922e-81a905e115fc</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="9" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="9" Volume="2015" Year="2016">
       <Id>78b1127f-166f-431b-8f3a-6e07dd6d9bb6</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="10" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="10" Volume="2015" Year="2016">
       <Id>8173367c-6c26-4983-90f0-9a55b3c6b629</Id>
     </Book>
-    <Book Series="Carnage" Number="6" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Carnage" Number="6" Volume="2015" Year="2016">
       <Id>84bb6fa7-b65e-441c-bc59-beb3bbfb6659</Id>
     </Book>
-    <Book Series="Carnage" Number="7" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Carnage" Number="7" Volume="2015" Year="2016">
       <Id>34fdb2b5-b118-4ae6-98b9-b2b03af8d911</Id>
     </Book>
-    <Book Series="Carnage" Number="8" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Carnage" Number="8" Volume="2015" Year="2016">
       <Id>7a4ca0d6-b956-4e97-9a97-6edd64b3d303</Id>
     </Book>
-    <Book Series="Carnage" Number="9" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Carnage" Number="9" Volume="2015" Year="2016">
       <Id>e38c6793-0f09-4e33-86d0-8efb605327d5</Id>
     </Book>
-    <Book Series="Carnage" Number="10" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Carnage" Number="10" Volume="2015" Year="2016">
       <Id>0f55c128-e1a0-4519-8cea-fbb3d6422202</Id>
     </Book>
-    <Book Series="Web Warriors" Number="6" Volume="2015" Year="2016" Format="Limited Series">
+    <Book Series="Web Warriors" Number="6" Volume="2015" Year="2016">
       <Id>af07e624-f690-4bb6-872a-a48db592c64b</Id>
     </Book>
-    <Book Series="Web Warriors" Number="7" Volume="2015" Year="2016" Format="Limited Series">
+    <Book Series="Web Warriors" Number="7" Volume="2015" Year="2016">
       <Id>0cb0428b-1553-49fe-8d18-b19889f2e62d</Id>
     </Book>
-    <Book Series="Web Warriors" Number="8" Volume="2015" Year="2016" Format="Limited Series">
+    <Book Series="Web Warriors" Number="8" Volume="2015" Year="2016">
       <Id>652b9fab-bb57-4e03-b1df-97448a5d2e1c</Id>
     </Book>
-    <Book Series="Web Warriors" Number="9" Volume="2015" Year="2016" Format="Limited Series">
+    <Book Series="Web Warriors" Number="9" Volume="2015" Year="2016">
       <Id>da3213a2-cdd0-4582-9cff-e051fd86f0ef</Id>
     </Book>
-    <Book Series="Web Warriors" Number="10" Volume="2015" Year="2016" Format="Limited Series">
+    <Book Series="Web Warriors" Number="10" Volume="2015" Year="2016">
       <Id>73d05143-e1aa-4f38-a056-114812a580d8</Id>
     </Book>
-    <Book Series="Web Warriors" Number="11" Volume="2015" Year="2016" Format="Limited Series">
+    <Book Series="Web Warriors" Number="11" Volume="2015" Year="2016">
       <Id>480a145b-4ce0-4a64-b534-b80ca59ba952</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="12" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="12" Volume="2015" Year="2016">
       <Id>2eea26fd-d90d-49a0-b539-9c9767c20562</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="13" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="13" Volume="2015" Year="2016">
       <Id>cd7b0091-528c-44f2-8f9d-efe743f92873</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="14" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="14" Volume="2015" Year="2016">
       <Id>8678896c-3601-4d96-8ff3-f02c9fa7ba1e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="15" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="15" Volume="2015" Year="2016">
       <Id>0a37bc32-c6be-45f9-be71-1f86c1b745af</Id>
     </Book>
-    <Book Series="Amazing Spider-Man Annual" Number="1" Volume="2016" Year="2017" Format="Annual">
+    <Book Series="Amazing Spider-Man Annual" Number="1" Volume="2016" Year="2017">
       <Id>b7fd5ffa-fd08-46cc-8292-9fb8e6673042</Id>
     </Book>
-    <Book Series="The Totally Awesome Hulk" Number="8" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="The Totally Awesome Hulk" Number="8" Volume="2015" Year="2016">
       <Id>d8b92e43-8821-4924-b86d-ef693b4ac68e</Id>
     </Book>
-    <Book Series="Civil War II" Number="1" Volume="2016" Year="2016" Format="Crossover">
+    <Book Series="Civil War II" Number="1" Volume="2016" Year="2016">
       <Id>1e1faaa3-336f-4103-85b0-41cc78f95a69</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="9" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Woman" Number="9" Volume="2015" Year="2016">
       <Id>c766f410-e4fa-4957-a4ab-defb3b029a0f</Id>
     </Book>
-    <Book Series="Spider-Man" Number="6" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man" Number="6" Volume="2016" Year="2016">
       <Id>d56b321f-e749-45dd-8910-f8fb40996041</Id>
     </Book>
-    <Book Series="Civil War II: Amazing Spider-Man" Number="1" Volume="2016" Year="2016" Format="Crossover">
+    <Book Series="Civil War II: Amazing Spider-Man" Number="1" Volume="2016" Year="2016">
       <Id>719c74aa-74db-434b-b2c8-0c1e2a704797</Id>
     </Book>
-    <Book Series="Civil War II: Amazing Spider-Man" Number="2" Volume="2016" Year="2016" Format="Crossover">
+    <Book Series="Civil War II: Amazing Spider-Man" Number="2" Volume="2016" Year="2016">
       <Id>e8289a20-c2d9-4ee0-80ce-d880679761e3</Id>
     </Book>
-    <Book Series="Civil War II: Amazing Spider-Man" Number="3" Volume="2016" Year="2016" Format="Crossover">
+    <Book Series="Civil War II: Amazing Spider-Man" Number="3" Volume="2016" Year="2016">
       <Id>f45246b5-bdb8-4c44-87b6-7f56205a7d71</Id>
     </Book>
-    <Book Series="Civil War II: Amazing Spider-Man" Number="4" Volume="2016" Year="2016" Format="Crossover">
+    <Book Series="Civil War II: Amazing Spider-Man" Number="4" Volume="2016" Year="2016">
       <Id>747ee8c9-4d7f-48b8-8e2f-69d07ac43391</Id>
     </Book>
-    <Book Series="Civil War II" Number="2" Volume="2016" Year="2016" Format="Crossover">
+    <Book Series="Civil War II" Number="2" Volume="2016" Year="2016">
       <Id>f8ce50d4-0280-4cfc-863e-f935e8888348</Id>
     </Book>
-    <Book Series="Civil War II" Number="3" Volume="2016" Year="2016" Format="Crossover">
+    <Book Series="Civil War II" Number="3" Volume="2016" Year="2016">
       <Id>e531c6c6-93b1-429a-b3e2-1a3179c984ce</Id>
     </Book>
-    <Book Series="Spider-Man" Number="7" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man" Number="7" Volume="2016" Year="2016">
       <Id>c8589714-3657-40ea-b46c-91f9773adbc4</Id>
     </Book>
-    <Book Series="Spider-Man" Number="8" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man" Number="8" Volume="2016" Year="2016">
       <Id>83497144-65c7-46bd-b61d-7588fa582197</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="10" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Woman" Number="10" Volume="2015" Year="2016">
       <Id>59d0954d-6b98-4eb1-bade-7e66f7b49376</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="11" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Woman" Number="11" Volume="2015" Year="2016">
       <Id>5c1c8ba7-df40-46e0-8d24-5e76b4287b76</Id>
     </Book>
-    <Book Series="Civil War II" Number="4" Volume="2016" Year="2016" Format="Crossover">
+    <Book Series="Civil War II" Number="4" Volume="2016" Year="2016">
       <Id>d7244968-f7d7-4246-bad5-447dd1cfb37b</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="11" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="11" Volume="2015" Year="2016">
       <Id>50274cd9-6c55-4961-ae38-fdde653a9b44</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="12" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="12" Volume="2015" Year="2016">
       <Id>da96a580-7757-4651-864f-bf93f9e92482</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="13" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="13" Volume="2015" Year="2016">
       <Id>713e9c87-9f28-468a-8497-38e8d0fdeba3</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="14" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="14" Volume="2015" Year="2016">
       <Id>2a569eb0-499b-4759-b1ce-2e76920bfc89</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="15" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="15" Volume="2015" Year="2016">
       <Id>9870a478-f486-4df3-8c8b-1b0ce6c17348</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="16" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="16" Volume="2015" Year="2016">
       <Id>cdb40cad-6dc4-4d86-b35b-398dee036d8f</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="17" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="17" Volume="2015" Year="2017">
       <Id>7af9ed0a-bb9f-43c9-9035-c2f052a31dd1</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="18" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="18" Volume="2015" Year="2017">
       <Id>5322f5d7-0307-4989-9aa9-6b6851601acd</Id>
     </Book>
-    <Book Series="Civil War II" Number="5" Volume="2016" Year="2016" Format="Crossover">
+    <Book Series="Civil War II" Number="5" Volume="2016" Year="2016">
       <Id>1a26881e-97e1-4e2b-8cd4-8b5d3ca97295</Id>
     </Book>
-    <Book Series="Civil War II" Number="6" Volume="2016" Year="2016" Format="Crossover">
+    <Book Series="Civil War II" Number="6" Volume="2016" Year="2016">
       <Id>99389268-e40a-419d-b320-730a218f285f</Id>
     </Book>
-    <Book Series="Spider-Man" Number="9" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man" Number="9" Volume="2016" Year="2017">
       <Id>d7deae97-d07c-4aec-a1ee-e83df543f8f8</Id>
     </Book>
-    <Book Series="Civil War II" Number="7" Volume="2016" Year="2017" Format="Crossover">
+    <Book Series="Civil War II" Number="7" Volume="2016" Year="2017">
       <Id>5e2043b9-d846-4a9b-ae0a-9a17fe6c233e</Id>
     </Book>
-    <Book Series="Civil War II" Number="8" Volume="2016" Year="2017" Format="Crossover">
+    <Book Series="Civil War II" Number="8" Volume="2016" Year="2017">
       <Id>6634f12a-96e5-4552-b0f0-08a89186be8a</Id>
     </Book>
-    <Book Series="Spider-Man" Number="10" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man" Number="10" Volume="2016" Year="2017">
       <Id>0e92b5b5-a964-47b7-8f7a-8dfc8abeb319</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="16" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="16" Volume="2015" Year="2016">
       <Id>28b5e1f4-2c2e-4645-a85a-fc7010b4210c</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="17" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="17" Volume="2015" Year="2016">
       <Id>05153fb0-9836-4536-8303-8ffdf5938d78</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="18" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="18" Volume="2015" Year="2016">
       <Id>4e68c648-9770-42f7-88f9-519bff167499</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="19" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="19" Volume="2015" Year="2016">
       <Id>a7438d97-d470-45d5-b0cf-5bf3023c6e0d</Id>
     </Book>
-    <Book Series="The Clone Conspiracy" Number="1" Volume="2016" Year="2016" Format="Limited Series">
+    <Book Series="The Clone Conspiracy" Number="1" Volume="2016" Year="2016">
       <Id>3ffa676b-ba32-4ab8-97e9-cca902db6eac</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="20" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="20" Volume="2015" Year="2016">
       <Id>fc93864f-1ad1-4a29-9a31-0758524b5c2a</Id>
     </Book>
-    <Book Series="The Clone Conspiracy" Number="2" Volume="2016" Year="2017" Format="Limited Series">
+    <Book Series="The Clone Conspiracy" Number="2" Volume="2016" Year="2017">
       <Id>69cb9b68-f070-4184-8021-82f0bb64adc6</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="21" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="21" Volume="2015" Year="2017">
       <Id>3d821c7b-2de8-4d42-beb9-d31fc6ffd83e</Id>
     </Book>
-    <Book Series="Silk" Number="14" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Silk" Number="14" Volume="2015" Year="2017">
       <Id>66a56366-7687-44ac-9dd9-f1630f29ed70</Id>
     </Book>
-    <Book Series="The Clone Conspiracy" Number="3" Volume="2016" Year="2017" Format="Limited Series">
+    <Book Series="The Clone Conspiracy" Number="3" Volume="2016" Year="2017">
       <Id>1ccf99e1-1e7e-4e32-8270-897e3ae07c30</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="22" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="22" Volume="2015" Year="2017">
       <Id>146d1ce4-2cb8-4b2a-bcb2-3c84eb0c3e30</Id>
     </Book>
-    <Book Series="Silk" Number="15" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Silk" Number="15" Volume="2015" Year="2017">
       <Id>1d139be3-dccb-4976-a5ed-3dad236fca41</Id>
     </Book>
-    <Book Series="The Clone Conspiracy" Number="4" Volume="2016" Year="2017" Format="Limited Series">
+    <Book Series="The Clone Conspiracy" Number="4" Volume="2016" Year="2017">
       <Id>85a96fbd-d519-465c-a948-60c862f584d5</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="23" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="23" Volume="2015" Year="2017">
       <Id>742e9db4-b39c-4317-b7c1-3ad8af25e486</Id>
     </Book>
-    <Book Series="Silk" Number="16" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Silk" Number="16" Volume="2015" Year="2017">
       <Id>efbcf9d5-436d-47c7-a9bb-30a15fcf2858</Id>
     </Book>
-    <Book Series="Prowler" Number="1" Volume="2016" Year="2016" Format="Limited Series">
+    <Book Series="Prowler" Number="1" Volume="2016" Year="2016">
       <Id>3beaccc6-8ab6-491e-8715-52202a1c0631</Id>
     </Book>
-    <Book Series="Prowler" Number="2" Volume="2016" Year="2017" Format="Limited Series">
+    <Book Series="Prowler" Number="2" Volume="2016" Year="2017">
       <Id>1f10c5bd-3e32-48b8-a5b5-9895ee9af473</Id>
     </Book>
-    <Book Series="Prowler" Number="3" Volume="2016" Year="2017" Format="Limited Series">
+    <Book Series="Prowler" Number="3" Volume="2016" Year="2017">
       <Id>d437f17a-d9d1-4f3e-baf3-b41164707623</Id>
     </Book>
-    <Book Series="Prowler" Number="4" Volume="2016" Year="2017" Format="Limited Series">
+    <Book Series="Prowler" Number="4" Volume="2016" Year="2017">
       <Id>0a91f5a5-6ca8-4231-a233-fbf495af2f10</Id>
     </Book>
-    <Book Series="The Clone Conspiracy" Number="5" Volume="2016" Year="2017" Format="Limited Series">
+    <Book Series="The Clone Conspiracy" Number="5" Volume="2016" Year="2017">
       <Id>e09d6b79-fa4f-45a1-aea0-4fef10314809</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="24" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="24" Volume="2015" Year="2017">
       <Id>d744933c-a102-42a5-aa58-25fb895d6f5d</Id>
     </Book>
-    <Book Series="Silk" Number="17" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Silk" Number="17" Volume="2015" Year="2017">
       <Id>0e9715f4-057e-41d4-a43b-84e4a728ead0</Id>
     </Book>
-    <Book Series="Prowler" Number="5" Volume="2016" Year="2017" Format="Limited Series">
+    <Book Series="Prowler" Number="5" Volume="2016" Year="2017">
       <Id>1ce812b4-31ff-4a46-9da3-4ce7b618e7ca</Id>
     </Book>
-    <Book Series="The Clone Conspiracy Omega" Number="1" Volume="2017" Year="2017" Format="One-Shot">
+    <Book Series="The Clone Conspiracy Omega" Number="1" Volume="2017" Year="2017">
       <Id>414ed99a-4c35-45de-b7fe-f155d6081b8f</Id>
     </Book>
-    <Book Series="Prowler" Number="6" Volume="2016" Year="2017" Format="Limited Series">
+    <Book Series="Prowler" Number="6" Volume="2016" Year="2017">
       <Id>af9a5ecf-c0e2-4b6b-9a50-be4fa581d08d</Id>
     </Book>
-    <Book Series="Silk" Number="18" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Silk" Number="18" Volume="2015" Year="2017">
       <Id>6c0b4362-a83e-4734-9915-a9aaebe4119b</Id>
     </Book>
-    <Book Series="Silk" Number="19" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Silk" Number="19" Volume="2015" Year="2017">
       <Id>62c6c89a-3608-49ce-8c47-6ab942a9b50d</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="7" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="7" Volume="2016" Year="2016">
       <Id>2f3e708a-6e26-48aa-a234-81a01b716b75</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="8" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="8" Volume="2016" Year="2016">
       <Id>0487ffd2-3b26-41a1-a674-30f3ca21159a</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="9" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="9" Volume="2016" Year="2016">
       <Id>55eccc15-4105-40f9-abba-5416f03a4594</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="10" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="10" Volume="2016" Year="2016">
       <Id>5d7495b4-941e-4677-a770-75fae3e0d447</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="11" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="11" Volume="2016" Year="2017">
       <Id>f701b7a7-ee5e-454a-8463-a384a0c80b71</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="12" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="12" Volume="2016" Year="2017">
       <Id>1e76fddf-dbcb-4e84-aa3f-6d911b0f8bfb</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="13" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="13" Volume="2016" Year="2017">
       <Id>5c494806-1cc8-417a-ab4e-e4aebc41f089</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="14" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="14" Volume="2016" Year="2017">
       <Id>ac88dcd9-5a46-4d90-91a0-1104e758da79</Id>
     </Book>
-    <Book Series="Champions" Number="1" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Champions" Number="1" Volume="2016" Year="2016">
       <Id>92d840fe-f08b-4444-a3ad-ca4da7d0f897</Id>
     </Book>
-    <Book Series="Champions" Number="2" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Champions" Number="2" Volume="2016" Year="2017">
       <Id>e5b35f20-57b5-4214-aa92-c6a48cb51889</Id>
     </Book>
-    <Book Series="Champions" Number="3" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Champions" Number="3" Volume="2016" Year="2017">
       <Id>b2f838f2-4335-485b-ab06-5d094783439e</Id>
     </Book>
-    <Book Series="Champions" Number="4" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Champions" Number="4" Volume="2016" Year="2017">
       <Id>0d49999e-abc3-4b61-bae8-1867910c9fd3</Id>
     </Book>
-    <Book Series="Champions" Number="5" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Champions" Number="5" Volume="2016" Year="2017">
       <Id>1882b925-3401-4ed0-a710-15599b60cbb7</Id>
     </Book>
-    <Book Series="Champions" Number="6" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Champions" Number="6" Volume="2016" Year="2017">
       <Id>3a4523c1-c905-462b-b14e-9a22a4ce4507</Id>
     </Book>
-    <Book Series="Avengers" Number="1" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Avengers" Number="1" Volume="2016" Year="2017">
       <Id>85181f3d-2738-450b-82c1-9bde82913b24</Id>
     </Book>
-    <Book Series="Avengers" Number="2" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Avengers" Number="2" Volume="2016" Year="2017">
       <Id>c3790318-92f4-4e26-8496-95eaf47b8a2c</Id>
     </Book>
-    <Book Series="Avengers" Number="3" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Avengers" Number="3" Volume="2016" Year="2017">
       <Id>4010f0f8-1436-4414-90a6-36d3e7e28f63</Id>
     </Book>
-    <Book Series="Avengers" Number="4" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Avengers" Number="4" Volume="2016" Year="2017">
       <Id>d68b4620-1bf0-4033-b714-9a20c85d8c48</Id>
     </Book>
-    <Book Series="Avengers" Number="5" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Avengers" Number="5" Volume="2016" Year="2017">
       <Id>a483f5fd-1afe-4c5c-b2e6-6d970ae4fac2</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="14" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Spider-Woman" Number="14" Volume="2015" Year="2017">
       <Id>f0969126-dc32-4f51-a4e9-c9f44b40b90d</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="15" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Spider-Woman" Number="15" Volume="2015" Year="2017">
       <Id>a880ddc9-bb3e-495b-b79e-d97e5bce566e</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="16" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Spider-Woman" Number="16" Volume="2015" Year="2017">
       <Id>d9efd537-b375-439c-8595-5f49871e960f</Id>
     </Book>
-    <Book Series="Spider-Woman" Number="17" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Spider-Woman" Number="17" Volume="2015" Year="2017">
       <Id>5021deac-f8f9-4bd6-8766-694f485db518</Id>
     </Book>
-    <Book Series="Venom" Number="1" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Venom" Number="1" Volume="2016" Year="2017">
       <Id>18556a88-cfde-4479-8f55-bc685ef72e99</Id>
     </Book>
-    <Book Series="Venom" Number="2" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Venom" Number="2" Volume="2016" Year="2017">
       <Id>5b8550c3-a050-41a6-88be-1439617f2eb8</Id>
     </Book>
-    <Book Series="Venom" Number="3" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Venom" Number="3" Volume="2016" Year="2017">
       <Id>89ff6d77-94e7-4f47-b332-98661c19977b</Id>
     </Book>
-    <Book Series="Venom" Number="5" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Venom" Number="5" Volume="2016" Year="2017">
       <Id>9a50d367-1dab-4003-afba-2e4a29c7e6f1</Id>
     </Book>
-    <Book Series="Venom" Number="6" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Venom" Number="6" Volume="2016" Year="2017">
       <Id>fba0a7c9-c389-4202-bd4e-aa346b05637c</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="25" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="25" Volume="2015" Year="2017">
       <Id>21ff9f52-1f1f-4096-996d-060b90814cc5</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="26" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="26" Volume="2015" Year="2017">
       <Id>f2a49344-630f-4a38-b3b2-c33c8e68ee6e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="27" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="27" Volume="2015" Year="2017">
       <Id>2e3a0429-5c62-4ef0-8445-1f22ed17dd23</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="28" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="28" Volume="2015" Year="2017">
       <Id>3a8837d4-985c-4b94-80e3-9d8c35f3dd32</Id>
     </Book>
-    <Book Series="Spider-Man" Number="11" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man" Number="11" Volume="2016" Year="2017">
       <Id>eedfaeab-8dd5-4b75-9da3-64174836bf52</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="14" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="14" Volume="2015" Year="2017">
       <Id>149a682a-5a44-47f3-9e76-1cf6bfd50ac0</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="15" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="15" Volume="2015" Year="2017">
       <Id>62469b26-5e9c-4e40-93d0-88b22bb7ba39</Id>
     </Book>
-    <Book Series="Spider-Gwen Annual" Number="1" Volume="2016" Year="2016" Format="Annual">
+    <Book Series="Spider-Gwen Annual" Number="1" Volume="2016" Year="2016">
       <Id>d35a1aed-c147-48c8-a888-f440f3332582</Id>
     </Book>
-    <Book Series="Spider-Man" Number="12" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man" Number="12" Volume="2016" Year="2017">
       <Id>add003e0-2987-4ec8-869b-342ad9571588</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="16" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="16" Volume="2015" Year="2017">
       <Id>cecbc01d-4d45-453b-a596-80148996fb97</Id>
     </Book>
-    <Book Series="Spider-Man" Number="13" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man" Number="13" Volume="2016" Year="2017">
       <Id>524a0da7-b6d2-409d-87c7-7cc6e6c4e867</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="17" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="17" Volume="2015" Year="2017">
       <Id>30862e54-c7d8-4272-b723-1c386943d04e</Id>
     </Book>
-    <Book Series="Spider-Man" Number="14" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man" Number="14" Volume="2016" Year="2017">
       <Id>0af5ddfa-8b74-4fcd-b4a8-afb152d95e4d</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="18" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="18" Volume="2015" Year="2017">
       <Id>0c32e402-3efc-4a75-a8e6-9eb8a0e86f81</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="19" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="19" Volume="2015" Year="2017">
       <Id>07f35741-4480-4e9b-91f1-08f83a659b24</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="20" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="20" Volume="2015" Year="2017">
       <Id>5a4ffdcc-84ac-420c-9caa-d91f6a18f5f3</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="21" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="21" Volume="2015" Year="2017">
       <Id>249ffd50-d9ec-4d9e-aa37-fbd579b65b4c</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="22" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="22" Volume="2015" Year="2017">
       <Id>16f9cd3a-d75c-48c7-8d11-7ff411203426</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="23" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="23" Volume="2015" Year="2017">
       <Id>7c0c5f3d-956d-4e54-abb5-8c61139048b2</Id>
     </Book>
-    <Book Series="Deadpool" Number="28" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Deadpool" Number="28" Volume="2015" Year="2017">
       <Id>d9e8750b-51e3-449d-9cbc-407d7d139def</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="15" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="15" Volume="2016" Year="2017">
       <Id>653935bb-ae6a-4097-b68c-4b729ccd365e</Id>
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="9" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Deadpool &amp; The Mercs For Money" Number="9" Volume="2016" Year="2017">
       <Id>35245e41-63ad-4b55-9bc6-0963ac714e7b</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="16" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="16" Volume="2016" Year="2017">
       <Id>a5bc3fb3-7262-41d1-a9f6-acb6dc3901d8</Id>
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="10" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Deadpool &amp; The Mercs For Money" Number="10" Volume="2016" Year="2017">
       <Id>7442c9b2-9618-4256-8aff-651509ba7be1</Id>
     </Book>
-    <Book Series="Deadpool" Number="29" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Deadpool" Number="29" Volume="2015" Year="2017">
       <Id>ee030fd1-a6ff-4fe4-9888-feabfac9d36f</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="17" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="17" Volume="2016" Year="2017">
       <Id>5aeec02b-1e89-4ff8-9dad-ec2423194341</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="18" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="18" Volume="2016" Year="2017">
       <Id>52fac5ca-73e7-49a0-a79f-bc54919fc259</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="19" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="19" Volume="2016" Year="2017">
       <Id>5b504ac1-d9ee-4fec-9744-a726d795c945</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="20" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="20" Volume="2016" Year="2017">
       <Id>09f1005d-7f14-44db-b391-342b1af955b1</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="21" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="21" Volume="2016" Year="2017">
       <Id>bc766a2a-60c8-4a97-9e55-79c508334108</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="22" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="22" Volume="2016" Year="2017">
       <Id>24231fd3-b252-4acf-9d1a-d7df04c5d8b1</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="20" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="20" Volume="2015" Year="2017">
       <Id>2eb8e5e7-1f2a-4768-91e1-74431cf1c38b</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="21" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="21" Volume="2015" Year="2017">
       <Id>15e3c2bb-ac70-49e3-aa08-9cc6bd37e67d</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="22" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="22" Volume="2015" Year="2017">
       <Id>4e5f13a1-7cbc-4dda-b86f-37b5a4c337af</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="23" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="23" Volume="2015" Year="2017">
       <Id>2691327c-6daa-4fc6-9b1a-3389ac8692e0</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="24" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="24" Volume="2015" Year="2017">
       <Id>3ae88725-bd42-4ad1-a550-f3e26774e489</Id>
     </Book>
-    <Book Series="Spider-Man 2099" Number="25" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man 2099" Number="25" Volume="2015" Year="2017">
       <Id>8d660de0-764a-43fe-9972-c08c36cc1aca</Id>
     </Book>
-    <Book Series="Avengers" Number="1.MU" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Avengers" Number="1.MU" Volume="2016" Year="2017">
       <Id>baeb27c6-7c08-44e0-99e0-5f0566d86715</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="1.MU" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="1.MU" Volume="2016" Year="2017">
       <Id>3f7737f2-7960-410f-a92d-43424b1c856b</Id>
     </Book>
-    <Book Series="Champions" Number="1.MU" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Champions" Number="1.MU" Volume="2016" Year="2017">
       <Id>5b9b0df9-6017-417d-94cb-7834cf55ae0b</Id>
     </Book>
-    <Book Series="Champions" Number="7" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Champions" Number="7" Volume="2016" Year="2017">
       <Id>5a18c1e1-7d76-4fa9-a9eb-e10170a7f8aa</Id>
     </Book>
-    <Book Series="Champions" Number="8" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Champions" Number="8" Volume="2016" Year="2017">
       <Id>47a0d72c-ae56-45f6-914e-0fef3e53800f</Id>
     </Book>
-    <Book Series="Champions" Number="9" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Champions" Number="9" Volume="2016" Year="2017">
       <Id>911d3dee-99c2-414c-adec-e950c09c9bf5</Id>
     </Book>
-    <Book Series="Avengers" Number="7" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Avengers" Number="7" Volume="2016" Year="2017">
       <Id>6ad1e2bd-2459-4921-8ace-39f2819ab673</Id>
     </Book>
-    <Book Series="Avengers" Number="8" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Avengers" Number="8" Volume="2016" Year="2017">
       <Id>8b6b535d-faa8-4e30-9b91-550a474c495a</Id>
     </Book>
-    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="1" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="1" Volume="2017" Year="2017">
       <Id>06f7f662-1af7-4ac8-bf7b-e1eef6b6ea3d</Id>
     </Book>
-    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="2" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="2" Volume="2017" Year="2017">
       <Id>b5ded2f6-f288-4dee-8194-1b9581db356b</Id>
     </Book>
-    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="3" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="3" Volume="2017" Year="2017">
       <Id>2152b28f-7959-4599-b56a-5b6a4bcff5ee</Id>
     </Book>
-    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="4" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="4" Volume="2017" Year="2017">
       <Id>903bd385-7184-434b-86ec-99a41cc6e929</Id>
     </Book>
-    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="5" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="5" Volume="2017" Year="2017">
       <Id>e9f9835c-7a9a-482c-b94e-68fbc556d142</Id>
     </Book>
-    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="6" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="6" Volume="2017" Year="2018">
       <Id>8228418e-2635-4ae8-b345-bcc548df6238</Id>
     </Book>
-    <Book Series="Ben Reilly: Scarlet Spider" Number="1" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Ben Reilly: Scarlet Spider" Number="1" Volume="2017" Year="2017">
       <Id>aed849fe-5ba0-405e-ac63-d24594aea230</Id>
     </Book>
-    <Book Series="Ben Reilly: Scarlet Spider" Number="2" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Ben Reilly: Scarlet Spider" Number="2" Volume="2017" Year="2017">
       <Id>8802b18a-c5a5-4178-b332-c49be24300b9</Id>
     </Book>
-    <Book Series="Ben Reilly: Scarlet Spider" Number="3" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Ben Reilly: Scarlet Spider" Number="3" Volume="2017" Year="2017">
       <Id>d9b88cc0-afd1-4bed-a6ed-6be7d86c6739</Id>
     </Book>
-    <Book Series="Ben Reilly: Scarlet Spider" Number="4" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Ben Reilly: Scarlet Spider" Number="4" Volume="2017" Year="2017">
       <Id>26459d3a-8197-4997-9ee6-2be5dfcd890e</Id>
     </Book>
-    <Book Series="Ben Reilly: Scarlet Spider" Number="5" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Ben Reilly: Scarlet Spider" Number="5" Volume="2017" Year="2017">
       <Id>894890b2-918d-4424-a7f2-5acda1ea036f</Id>
     </Book>
-    <Book Series="Ben Reilly: Scarlet Spider" Number="6" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Ben Reilly: Scarlet Spider" Number="6" Volume="2017" Year="2017">
       <Id>e0bf0e54-e0bb-4fb2-a2e3-ce8d7da26ad6</Id>
     </Book>
-    <Book Series="Ben Reilly: Scarlet Spider" Number="7" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Ben Reilly: Scarlet Spider" Number="7" Volume="2017" Year="2017">
       <Id>7a6366e6-85e7-4c4b-84ea-ae2db9186f99</Id>
     </Book>
-    <Book Series="Ben Reilly: Scarlet Spider" Number="8" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Ben Reilly: Scarlet Spider" Number="8" Volume="2017" Year="2017">
       <Id>5e2c9a84-6cab-4460-b788-fac40def7253</Id>
     </Book>
-    <Book Series="Ben Reilly: Scarlet Spider" Number="9" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Ben Reilly: Scarlet Spider" Number="9" Volume="2017" Year="2017">
       <Id>b5319f09-9421-4f11-ae4b-2681f3c915b7</Id>
     </Book>
-    <Book Series="Spider-Man" Number="15" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man" Number="15" Volume="2016" Year="2017">
       <Id>34791f60-bbd3-426e-a61f-b850d819f002</Id>
     </Book>
-    <Book Series="Spider-Man" Number="16" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man" Number="16" Volume="2016" Year="2017">
       <Id>088a95e2-1036-4917-8615-4f454c4b3015</Id>
     </Book>
-    <Book Series="Spider-Man" Number="17" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man" Number="17" Volume="2016" Year="2017">
       <Id>7324229d-982b-4a82-9731-6b98cdbe9cff</Id>
     </Book>
-    <Book Series="Spider-Man" Number="18" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man" Number="18" Volume="2016" Year="2017">
       <Id>dd15331a-9cd1-4140-ba18-fc26fd7c3b1f</Id>
     </Book>
-    <Book Series="Spider-Man" Number="19" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man" Number="19" Volume="2016" Year="2017">
       <Id>799f4174-1ada-446e-991e-ab04883f8a94</Id>
     </Book>
-    <Book Series="Spider-Man" Number="20" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man" Number="20" Volume="2016" Year="2017">
       <Id>793a82d8-50bb-49af-88f6-cc25bc67e18e</Id>
     </Book>
-    <Book Series="Spider-Man" Number="21" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Spider-Man" Number="21" Volume="2016" Year="2017">
       <Id>83fff4cb-c5c2-4508-b244-baac4143e8af</Id>
     </Book>
-    <Book Series="Spider-Men II" Number="1" Volume="2017" Year="2017" Format="Limited Series">
+    <Book Series="Spider-Men II" Number="1" Volume="2017" Year="2017">
       <Id>f5f595df-ba26-4231-ac09-0bdf98055027</Id>
     </Book>
-    <Book Series="Spider-Men II" Number="2" Volume="2017" Year="2017" Format="Limited Series">
+    <Book Series="Spider-Men II" Number="2" Volume="2017" Year="2017">
       <Id>a46369ce-306a-457e-9433-9d59cc7a8828</Id>
     </Book>
-    <Book Series="Spider-Men II" Number="3" Volume="2017" Year="2017" Format="Limited Series">
+    <Book Series="Spider-Men II" Number="3" Volume="2017" Year="2017">
       <Id>1ea4fb6c-ca5d-4ad8-88eb-a268a8a5165a</Id>
     </Book>
-    <Book Series="Spider-Men II" Number="4" Volume="2017" Year="2018" Format="Limited Series">
+    <Book Series="Spider-Men II" Number="4" Volume="2017" Year="2018">
       <Id>81bc6acc-4465-4ea1-8cfe-7e9f0f15a6c6</Id>
     </Book>
-    <Book Series="Spider-Men II" Number="5" Volume="2017" Year="2018" Format="Limited Series">
+    <Book Series="Spider-Men II" Number="5" Volume="2017" Year="2018">
       <Id>8f2574dd-7d84-4fd6-909c-f38ff4506554</Id>
     </Book>
-    <Book Series="Secret Empire" Number="0" Volume="2017" Year="2017" Format="Crossover">
+    <Book Series="Secret Empire" Number="0" Volume="2017" Year="2017">
       <Id>c9c826f6-1bd1-461e-81de-898c11a43c7c</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="29" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="29" Volume="2015" Year="2017">
       <Id>40e0677f-5ca4-4eb1-9f13-b7940458e89e</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="30" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="30" Volume="2015" Year="2017">
       <Id>cf3050e7-5ed6-44f8-85c7-c0959dd8bfe0</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="31" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="31" Volume="2015" Year="2017">
       <Id>9d9d6724-8998-4964-aed0-75a0bfde3df4</Id>
     </Book>
-    <Book Series="Champions" Number="10" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Champions" Number="10" Volume="2016" Year="2017">
       <Id>c6e3cbca-9e30-4d0e-8198-9b7e097a4755</Id>
     </Book>
-    <Book Series="Secret Empire" Number="1" Volume="2017" Year="2017" Format="Crossover">
+    <Book Series="Secret Empire" Number="1" Volume="2017" Year="2017">
       <Id>326c68a9-af56-48c4-91ec-1329e755e360</Id>
     </Book>
-    <Book Series="Champions" Number="11" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Champions" Number="11" Volume="2016" Year="2017">
       <Id>4885f4ee-35f8-4793-9238-b2561c39b97e</Id>
     </Book>
-    <Book Series="Secret Empire" Number="2" Volume="2017" Year="2017" Format="Crossover">
+    <Book Series="Secret Empire" Number="2" Volume="2017" Year="2017">
       <Id>45ea9f1e-cb67-4a68-a084-d52926e0a441</Id>
     </Book>
-    <Book Series="Secret Empire" Number="3" Volume="2017" Year="2017" Format="Crossover">
+    <Book Series="Secret Empire" Number="3" Volume="2017" Year="2017">
       <Id>af72de8e-8519-4074-8d93-4a37ea0d6458</Id>
     </Book>
-    <Book Series="Secret Empire" Number="4" Volume="2017" Year="2017" Format="Crossover">
+    <Book Series="Secret Empire" Number="4" Volume="2017" Year="2017">
       <Id>0eea1124-bc08-4f03-a42a-52eae450eca2</Id>
     </Book>
-    <Book Series="Secret Empire" Number="5" Volume="2017" Year="2017" Format="Crossover">
+    <Book Series="Secret Empire" Number="5" Volume="2017" Year="2017">
       <Id>6da82f1d-e1ee-4de2-b962-d3fce5a924a9</Id>
     </Book>
-    <Book Series="Secret Empire" Number="6" Volume="2017" Year="2017" Format="Crossover">
+    <Book Series="Secret Empire" Number="6" Volume="2017" Year="2017">
       <Id>5b39aaef-3019-49ea-bd2e-5cdea036a1cc</Id>
     </Book>
-    <Book Series="Secret Empire" Number="7" Volume="2017" Year="2017" Format="Crossover">
+    <Book Series="Secret Empire" Number="7" Volume="2017" Year="2017">
       <Id>4473ce43-2e4e-4167-9e1c-3546fbe731c9</Id>
     </Book>
-    <Book Series="Secret Empire" Number="8" Volume="2017" Year="2017" Format="Crossover">
+    <Book Series="Secret Empire" Number="8" Volume="2017" Year="2017">
       <Id>f3e61c17-d6be-4ab7-ab99-4ced7d939484</Id>
     </Book>
-    <Book Series="Secret Empire" Number="9" Volume="2017" Year="2017" Format="Crossover">
+    <Book Series="Secret Empire" Number="9" Volume="2017" Year="2017">
       <Id>1526a6be-88f4-4969-abb4-7f3226cff65c</Id>
     </Book>
-    <Book Series="Secret Empire" Number="10" Volume="2017" Year="2017" Format="Crossover">
+    <Book Series="Secret Empire" Number="10" Volume="2017" Year="2017">
       <Id>4e965c3b-ff57-49f7-93cb-2284427b7c4d</Id>
     </Book>
-    <Book Series="Avengers" Number="11" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Avengers" Number="11" Volume="2016" Year="2017">
       <Id>3e54db2c-a8ec-4018-9b7d-0e136c26810d</Id>
     </Book>
-    <Book Series="Champions" Number="12" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Champions" Number="12" Volume="2016" Year="2017">
       <Id>1f3a9cb8-818f-4fbf-89c4-9c7ff1a11e48</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="32" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="32" Volume="2015" Year="2017">
       <Id>088e9c32-724f-46cb-9cc5-94495a07a2eb</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Spider-Man/Spider-Man 010 (All New, All Different).cbl
+++ b/Marvel/Characters/unsorted/Spider-Man/Spider-Man 010 (All New, All Different).cbl
@@ -1,891 +1,892 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Spider-Man 10 (All New, All Different)</Name>
+  <Name>Spider-Man 010 (All New, All Different)</Name>
+  <NumIssues>295</NumIssues>
   <Books>
     <Book Series="Spider-Man" Number="1" Volume="2016" Year="2016">
-      <Id>12aac861-2dfa-4875-889d-6f3c60d910c1</Id>
+      <Database Name="cv" Series="87820" Issue="513656" />
     </Book>
     <Book Series="Spider-Man" Number="2" Volume="2016" Year="2016">
-      <Id>ff0ff337-06df-45a9-8d80-7407efe8dd08</Id>
+      <Database Name="cv" Series="87820" Issue="517835" />
     </Book>
     <Book Series="All-New, All-Different Avengers" Number="1" Volume="2015" Year="2016">
-      <Id>8e0bbee7-e543-4985-ab12-a27320601dfc</Id>
+      <Database Name="cv" Series="85928" Issue="505511" />
     </Book>
     <Book Series="All-New, All-Different Avengers" Number="2" Volume="2015" Year="2016">
-      <Id>9161e6a6-2260-4a56-8195-c96e67ab6b52</Id>
+      <Database Name="cv" Series="85928" Issue="507173" />
     </Book>
     <Book Series="All-New, All-Different Avengers" Number="3" Volume="2015" Year="2016">
-      <Id>236f4704-5205-448b-9b27-8a6a0e3c96e1</Id>
+      <Database Name="cv" Series="85928" Issue="510932" />
     </Book>
     <Book Series="Spider-Man" Number="3" Volume="2016" Year="2016">
-      <Id>5d278c43-8918-4482-be70-50c8b879fa00</Id>
+      <Database Name="cv" Series="87820" Issue="523265" />
     </Book>
     <Book Series="Spider-Man" Number="4" Volume="2016" Year="2016">
-      <Id>8f5a6758-939f-4a6a-a519-d9b2c9ae5bd5</Id>
+      <Database Name="cv" Series="87820" Issue="530738" />
     </Book>
     <Book Series="Spider-Man" Number="5" Volume="2016" Year="2016">
-      <Id>832d497f-aed5-4b98-a76f-a3ad72dbc4e0</Id>
+      <Database Name="cv" Series="87820" Issue="537945" />
     </Book>
     <Book Series="All-New, All-Different Avengers" Number="4" Volume="2015" Year="2016">
-      <Id>21554257-a3e2-43f7-85c3-0be4ef30dca1</Id>
+      <Database Name="cv" Series="85928" Issue="512415" />
     </Book>
     <Book Series="All-New, All-Different Avengers" Number="5" Volume="2015" Year="2016">
-      <Id>58138964-f2ef-475a-9a74-84448a645e04</Id>
+      <Database Name="cv" Series="85928" Issue="514428" />
     </Book>
     <Book Series="All-New, All-Different Avengers" Number="6" Volume="2015" Year="2016">
-      <Id>068b95c2-b02d-4698-894b-5c9f3b008a66</Id>
+      <Database Name="cv" Series="85928" Issue="516944" />
     </Book>
     <Book Series="Silk" Number="1" Volume="2015" Year="2016">
-      <Id>7c65f9df-a968-48ff-8531-f4d4f5d76e83</Id>
+      <Database Name="cv" Series="86251" Issue="506662" />
     </Book>
     <Book Series="Silk" Number="2" Volume="2015" Year="2016">
-      <Id>62516469-e22a-414f-ac75-7e9f2a83d2f8</Id>
+      <Database Name="cv" Series="86251" Issue="508436" />
     </Book>
     <Book Series="Silk" Number="3" Volume="2015" Year="2016">
-      <Id>e74ace12-0b79-4da1-a698-82e5e774a439</Id>
+      <Database Name="cv" Series="86251" Issue="510952" />
     </Book>
     <Book Series="Silk" Number="4" Volume="2015" Year="2016">
-      <Id>1cd0a65b-8efd-405a-a53e-bd433180fdc5</Id>
+      <Database Name="cv" Series="86251" Issue="514449" />
     </Book>
     <Book Series="Silk" Number="5" Volume="2015" Year="2016">
-      <Id>39ace92d-8bb4-495d-b2d9-dae5d27b07cb</Id>
+      <Database Name="cv" Series="86251" Issue="516965" />
     </Book>
     <Book Series="Silk" Number="6" Volume="2015" Year="2016">
-      <Id>48e440a6-b967-43bb-90f0-5028aced09b2</Id>
+      <Database Name="cv" Series="86251" Issue="520210" />
     </Book>
-    <Book Series="Amazing Spider-Man &amp; Silk: Spider(Fly) Effect Infinite Comic" Number="1" Volume="2016" Year="2016">
-      <Id>c402d0a0-0078-4cca-b71e-160ca08d7cfa</Id>
+    <Book Series="Amazing Spider-Man &#38; Silk: Spider(Fly) Effect Infinite Comic" Number="1" Volume="2016" Year="2016">
+      <Database Name="cv" Series="87477" Issue="511725" />
     </Book>
-    <Book Series="Amazing Spider-Man &amp; Silk: Spider(Fly) Effect Infinite Comic" Number="2" Volume="2016" Year="2016">
-      <Id>6554fb93-4dc0-4df6-b1be-36f992ccc660</Id>
+    <Book Series="Amazing Spider-Man &#38; Silk: Spider(Fly) Effect Infinite Comic" Number="2" Volume="2016" Year="2016">
+      <Database Name="cv" Series="87477" Issue="513809" />
     </Book>
-    <Book Series="Amazing Spider-Man &amp; Silk: Spider(Fly) Effect Infinite Comic" Number="3" Volume="2016" Year="2016">
-      <Id>db28e410-1e41-4dee-ba8a-595c10f49c75</Id>
+    <Book Series="Amazing Spider-Man &#38; Silk: Spider(Fly) Effect Infinite Comic" Number="3" Volume="2016" Year="2016">
+      <Database Name="cv" Series="87477" Issue="516296" />
     </Book>
-    <Book Series="Amazing Spider-Man &amp; Silk: Spider(Fly) Effect Infinite Comic" Number="4" Volume="2016" Year="2016">
-      <Id>ac2e4750-44c2-4abb-a412-7ae56c0fc596</Id>
+    <Book Series="Amazing Spider-Man &#38; Silk: Spider(Fly) Effect Infinite Comic" Number="4" Volume="2016" Year="2016">
+      <Database Name="cv" Series="87477" Issue="517961" />
     </Book>
-    <Book Series="Amazing Spider-Man &amp; Silk: Spider(Fly) Effect Infinite Comic" Number="5" Volume="2016" Year="2016">
-      <Id>08cd8940-94de-4b6e-92fc-6d02bd1df4b6</Id>
+    <Book Series="Amazing Spider-Man &#38; Silk: Spider(Fly) Effect Infinite Comic" Number="5" Volume="2016" Year="2016">
+      <Database Name="cv" Series="87477" Issue="520426" />
     </Book>
-    <Book Series="Amazing Spider-Man &amp; Silk: Spider(Fly) Effect Infinite Comic" Number="6" Volume="2016" Year="2016">
-      <Id>a6e21e1f-e98f-4c4f-92ea-bc7ba7deb9be</Id>
+    <Book Series="Amazing Spider-Man &#38; Silk: Spider(Fly) Effect Infinite Comic" Number="6" Volume="2016" Year="2016">
+      <Database Name="cv" Series="87477" Issue="523513" />
     </Book>
-    <Book Series="Amazing Spider-Man &amp; Silk: Spider(Fly) Effect Infinite Comic" Number="7" Volume="2016" Year="2016">
-      <Id>e40cc1c6-24fa-4ae8-8bb8-d48c3edd7788</Id>
+    <Book Series="Amazing Spider-Man &#38; Silk: Spider(Fly) Effect Infinite Comic" Number="7" Volume="2016" Year="2016">
+      <Database Name="cv" Series="87477" Issue="526461" />
     </Book>
-    <Book Series="Amazing Spider-Man &amp; Silk: Spider(Fly) Effect Infinite Comic" Number="8" Volume="2016" Year="2016">
-      <Id>9a60efc9-2a5d-40b6-9d3f-b0e0a0a77a35</Id>
+    <Book Series="Amazing Spider-Man &#38; Silk: Spider(Fly) Effect Infinite Comic" Number="8" Volume="2016" Year="2016">
+      <Database Name="cv" Series="87477" Issue="529004" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="1" Volume="2015" Year="2015">
-      <Id>7a79aa6f-86a7-4cf7-a508-ade14fda6535</Id>
+      <Database Name="cv" Series="85076" Issue="502108" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="2" Volume="2015" Year="2015">
-      <Id>39ab9368-9621-4162-8b8b-652c6f2899b3</Id>
+      <Database Name="cv" Series="85076" Issue="503554" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="3" Volume="2015" Year="2016">
-      <Id>049f44f6-9267-4406-9658-4e77d3870145</Id>
+      <Database Name="cv" Series="85076" Issue="504929" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="4" Volume="2015" Year="2016">
-      <Id>bf8f10e8-ccc6-401e-a521-a0738a1779ff</Id>
+      <Database Name="cv" Series="85076" Issue="507766" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="5" Volume="2015" Year="2016">
-      <Id>66417dc8-29e2-4938-bead-0e8f43462944</Id>
+      <Database Name="cv" Series="85076" Issue="508883" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="6" Volume="2015" Year="2016">
-      <Id>c962a248-8f4d-4ec4-9c4b-288e27920434</Id>
+      <Database Name="cv" Series="85076" Issue="509696" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="7" Volume="2015" Year="2016">
-      <Id>bb910f39-9fcc-47d3-901a-fd4b2b41b639</Id>
+      <Database Name="cv" Series="85076" Issue="513638" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="8" Volume="2015" Year="2016">
-      <Id>2f2d26e4-77ac-40d8-b183-88662de8c9f7</Id>
+      <Database Name="cv" Series="85076" Issue="516076" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="9" Volume="2015" Year="2016">
-      <Id>f8f67f74-120e-42b7-9c73-31a7bdafd13f</Id>
+      <Database Name="cv" Series="85076" Issue="518851" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="10" Volume="2015" Year="2016">
-      <Id>57d3d127-bcba-4f57-95d1-2361606c6b52</Id>
+      <Database Name="cv" Series="85076" Issue="525019" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="11" Volume="2015" Year="2016">
-      <Id>149f7ecf-1bf8-4de4-a4b5-f1923cbfa36f</Id>
+      <Database Name="cv" Series="85076" Issue="527131" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="1.1" Volume="2015" Year="2016">
-      <Id>b1b48b75-bf6c-4239-83e0-fecfc0eb90bb</Id>
+      <Database Name="cv" Series="85076" Issue="508423" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="1.2" Volume="2015" Year="2016">
-      <Id>d91a349a-82b3-40bd-8f1a-d5c96bb40bb1</Id>
+      <Database Name="cv" Series="85076" Issue="510604" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="1.3" Volume="2015" Year="2016">
-      <Id>8c59fb2d-6b02-420a-8a03-f31dbfadec68</Id>
+      <Database Name="cv" Series="85076" Issue="516947" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="1.4" Volume="2015" Year="2016">
-      <Id>005288e1-3db5-4e3f-acbc-438633789c4f</Id>
+      <Database Name="cv" Series="85076" Issue="522424" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="1.5" Volume="2015" Year="2016">
-      <Id>9b749334-255e-4f34-824b-5a0b7e901a34</Id>
+      <Database Name="cv" Series="85076" Issue="531873" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="1.6" Volume="2015" Year="2016">
-      <Id>b7a4e56f-6540-4051-bba1-c31028ecae59</Id>
+      <Database Name="cv" Series="85076" Issue="541194" />
     </Book>
     <Book Series="Spider-Gwen" Number="1" Volume="2015" Year="2015">
-      <Id>545295c3-f864-474d-96e4-6b14462d364a</Id>
+      <Database Name="cv" Series="85311" Issue="502872" />
     </Book>
     <Book Series="Spider-Gwen" Number="2" Volume="2015" Year="2016">
-      <Id>cb7fd2f4-fad4-4589-8d10-91a10a60932b</Id>
+      <Database Name="cv" Series="85311" Issue="505523" />
     </Book>
     <Book Series="Spider-Gwen" Number="3" Volume="2015" Year="2016">
-      <Id>1ce96cb9-457b-4258-85c8-cc2ee26a97d4</Id>
+      <Database Name="cv" Series="85311" Issue="507781" />
     </Book>
     <Book Series="Spider-Gwen" Number="4" Volume="2015" Year="2016">
-      <Id>0f0f6bf0-a016-4398-96ad-712596e1b44d</Id>
+      <Database Name="cv" Series="85311" Issue="510502" />
     </Book>
     <Book Series="Spider-Gwen" Number="5" Volume="2015" Year="2016">
-      <Id>f2d7fbd7-ae85-4b33-8006-04f675d42a45</Id>
+      <Database Name="cv" Series="85311" Issue="514450" />
     </Book>
     <Book Series="Spider-Gwen" Number="6" Volume="2015" Year="2016">
-      <Id>04968a35-842d-4d68-8299-37bd1c46ed37</Id>
+      <Database Name="cv" Series="85311" Issue="518865" />
     </Book>
     <Book Series="Spider-Woman" Number="1" Volume="2015" Year="2016">
-      <Id>0bb89b66-ff27-4bb1-a341-6d6a1ead9ce5</Id>
+      <Database Name="cv" Series="86127" Issue="506182" />
     </Book>
     <Book Series="Spider-Woman" Number="2" Volume="2015" Year="2016">
-      <Id>d3703693-36fd-433b-babc-24cff8e3a71d</Id>
+      <Database Name="cv" Series="86127" Issue="508899" />
     </Book>
     <Book Series="Spider-Woman" Number="3" Volume="2015" Year="2016">
-      <Id>fe54ba1f-835f-4466-9aeb-990a178504ac</Id>
+      <Database Name="cv" Series="86127" Issue="512434" />
     </Book>
     <Book Series="Spider-Woman" Number="4" Volume="2015" Year="2016">
-      <Id>edbf1396-fa03-495c-97ee-b7a7696a66b6</Id>
+      <Database Name="cv" Series="86127" Issue="516090" />
     </Book>
     <Book Series="Spider-Woman" Number="5" Volume="2015" Year="2016">
-      <Id>2869cc49-3512-41ef-af3a-23bff3ec41e4</Id>
+      <Database Name="cv" Series="86127" Issue="520211" />
     </Book>
     <Book Series="Web Warriors" Number="1" Volume="2015" Year="2016">
-      <Id>55ff2ee9-7098-4b28-8b2c-77b4d9aee687</Id>
+      <Database Name="cv" Series="85976" Issue="505531" />
     </Book>
     <Book Series="Web Warriors" Number="2" Volume="2015" Year="2016">
-      <Id>0ed83e9c-7310-430e-a58e-ff602c32283a</Id>
+      <Database Name="cv" Series="85976" Issue="508443" />
     </Book>
     <Book Series="Web Warriors" Number="3" Volume="2015" Year="2016">
-      <Id>b2760863-2f41-4965-b57c-fc252cd093f4</Id>
+      <Database Name="cv" Series="85976" Issue="510958" />
     </Book>
     <Book Series="Web Warriors" Number="4" Volume="2015" Year="2016">
-      <Id>3c9118f3-4085-4cd2-b6a8-d01155ec1a02</Id>
+      <Database Name="cv" Series="85976" Issue="516097" />
     </Book>
     <Book Series="Web Warriors" Number="5" Volume="2015" Year="2016">
-      <Id>19de14af-b503-4a88-91d9-f1df670f4abd</Id>
+      <Database Name="cv" Series="85976" Issue="520216" />
     </Book>
     <Book Series="Spider-Man 2099" Number="1" Volume="2015" Year="2015">
-      <Id>5874c39b-44df-4c56-bd19-6739280dc97f</Id>
+      <Database Name="cv" Series="85312" Issue="502873" />
     </Book>
     <Book Series="Spider-Man 2099" Number="2" Volume="2015" Year="2015">
-      <Id>27243a89-ea06-4007-9564-884ae08437a5</Id>
+      <Database Name="cv" Series="85312" Issue="504346" />
     </Book>
     <Book Series="Spider-Man 2099" Number="3" Volume="2015" Year="2016">
-      <Id>e27c5c24-52b5-4910-8021-cc885596d70f</Id>
+      <Database Name="cv" Series="85312" Issue="505524" />
     </Book>
     <Book Series="Spider-Man 2099" Number="4" Volume="2015" Year="2016">
-      <Id>8eff7e51-f1c8-4483-a546-1c77b188889a</Id>
+      <Database Name="cv" Series="85312" Issue="507782" />
     </Book>
     <Book Series="Spider-Man 2099" Number="5" Volume="2015" Year="2016">
-      <Id>6fc8bb59-5c2a-4460-83d8-351074438884</Id>
+      <Database Name="cv" Series="85312" Issue="510104" />
     </Book>
     <Book Series="Carnage" Number="1" Volume="2015" Year="2016">
-      <Id>55ce1d81-3f87-4c82-a2b6-900c1624c155</Id>
+      <Database Name="cv" Series="85938" Issue="505515" />
     </Book>
     <Book Series="Carnage" Number="2" Volume="2015" Year="2016">
-      <Id>fbb77b43-608d-47dd-aa64-b6340e28a50b</Id>
+      <Database Name="cv" Series="85938" Issue="506648" />
     </Book>
     <Book Series="Carnage" Number="3" Volume="2015" Year="2016">
-      <Id>c8ce7024-4b4d-4107-b853-61c903ea97d7</Id>
+      <Database Name="cv" Series="85938" Issue="509698" />
     </Book>
     <Book Series="Carnage" Number="4" Volume="2015" Year="2016">
-      <Id>217a4be5-86ed-464d-80ef-8b86c608e435</Id>
+      <Database Name="cv" Series="85938" Issue="512420" />
     </Book>
     <Book Series="Carnage" Number="5" Volume="2015" Year="2016">
-      <Id>7b2f3d92-2633-4e58-99d1-997ce47a2eb9</Id>
+      <Database Name="cv" Series="85938" Issue="516079" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="1" Volume="2016" Year="2016">
-      <Id>f51be8fe-9243-403b-89d3-9645aaed2ef1</Id>
+      <Database Name="cv" Series="87182" Issue="510503" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="2" Volume="2016" Year="2016">
-      <Id>a8eb5a19-7961-4f00-93d7-2063009c551a</Id>
+      <Database Name="cv" Series="87182" Issue="514452" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="3" Volume="2016" Year="2016">
-      <Id>deee85d3-62c9-49b7-ae0c-dd2c4ff83516</Id>
+      <Database Name="cv" Series="87182" Issue="518867" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="4" Volume="2016" Year="2016">
-      <Id>2efb2170-f680-4207-9534-5f04232b5e8f</Id>
+      <Database Name="cv" Series="87182" Issue="526067" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="5" Volume="2016" Year="2016">
-      <Id>3cff998b-1163-4e90-a74a-b293b8c42132</Id>
+      <Database Name="cv" Series="87182" Issue="531899" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="6" Volume="2016" Year="2016">
-      <Id>3e757424-195b-46d7-9bbd-1e1f86d6c3cd</Id>
+      <Database Name="cv" Series="87182" Issue="537946" />
     </Book>
     <Book Series="All-New, All-Different Avengers" Number="8" Volume="2015" Year="2016">
-      <Id>ad0793a0-e4cb-42a8-85d9-8d154e2dae18</Id>
+      <Database Name="cv" Series="85928" Issue="525016" />
     </Book>
     <Book Series="Avengers Standoff: Assault On Pleasant Hill Omega" Number="1" Volume="2016" Year="2016">
-      <Id>1bcbe43b-fd1b-4868-b9fd-8f4bca320539</Id>
+      <Database Name="cv" Series="89915" Issue="527134" />
     </Book>
     <Book Series="All-New, All-Different Avengers" Number="9" Volume="2015" Year="2016">
-      <Id>87db4f74-5a02-4a1c-9c47-7a2629679c6d</Id>
+      <Database Name="cv" Series="85928" Issue="529647" />
     </Book>
     <Book Series="All-New, All-Different Avengers" Number="10" Volume="2015" Year="2016">
-      <Id>e21668f3-5ccb-4062-9bd3-f99d19415b73</Id>
+      <Database Name="cv" Series="85928" Issue="533024" />
     </Book>
     <Book Series="All-New, All-Different Avengers" Number="11" Volume="2015" Year="2016">
-      <Id>e40f7219-5b06-462d-abe9-223d0f1cf110</Id>
+      <Database Name="cv" Series="85928" Issue="537928" />
     </Book>
     <Book Series="All-New, All-Different Avengers" Number="12" Volume="2015" Year="2016">
-      <Id>67654bd9-a2e9-4ad9-b437-8c85020bbd69</Id>
+      <Database Name="cv" Series="85928" Issue="541193" />
     </Book>
     <Book Series="Spider-Women Alpha" Number="1" Volume="2016" Year="2016">
-      <Id>b81895b6-9009-4cc0-8772-31a9dde5078b</Id>
+      <Database Name="cv" Series="89385" Issue="523267" />
     </Book>
     <Book Series="Spider-Gwen" Number="7" Volume="2015" Year="2016">
-      <Id>64b4e970-f921-4da5-b97f-eb5eb0ed2c6f</Id>
+      <Database Name="cv" Series="85311" Issue="525037" />
     </Book>
     <Book Series="Silk" Number="7" Volume="2015" Year="2016">
-      <Id>8271a2e2-e447-46f7-90c1-a7bf7d57ee1e</Id>
+      <Database Name="cv" Series="86251" Issue="526066" />
     </Book>
     <Book Series="Spider-Woman" Number="6" Volume="2015" Year="2016">
-      <Id>5bcb8638-af35-400b-bbec-e04ee0b2ac0d</Id>
+      <Database Name="cv" Series="86127" Issue="527153" />
     </Book>
     <Book Series="Spider-Gwen" Number="8" Volume="2015" Year="2016">
-      <Id>121f8cd8-1db3-4c1e-af5c-de7486ef86d1</Id>
+      <Database Name="cv" Series="85311" Issue="528520" />
     </Book>
     <Book Series="Silk" Number="8" Volume="2015" Year="2016">
-      <Id>b5620e54-ec47-4dc9-bf9a-e2e9d1944a9b</Id>
+      <Database Name="cv" Series="86251" Issue="529661" />
     </Book>
     <Book Series="Spider-Woman" Number="7" Volume="2015" Year="2016">
-      <Id>76d6d27d-ae6d-47bb-bbdf-d966395823dd</Id>
+      <Database Name="cv" Series="86127" Issue="530739" />
     </Book>
     <Book Series="Spider-Women Omega" Number="1" Volume="2016" Year="2016">
-      <Id>5392f415-58c4-4fcc-bbd1-e53ec231ec93</Id>
+      <Database Name="cv" Series="90891" Issue="533039" />
     </Book>
     <Book Series="Spider-Woman" Number="8" Volume="2015" Year="2016">
-      <Id>5926f165-43d9-4bca-859d-8b6cd1a2ec78</Id>
+      <Database Name="cv" Series="86127" Issue="533037" />
     </Book>
     <Book Series="Spider-Gwen" Number="9" Volume="2015" Year="2016">
-      <Id>56386da0-0046-4eb7-a750-cda51d1ea767</Id>
+      <Database Name="cv" Series="85311" Issue="535362" />
     </Book>
     <Book Series="Spider-Gwen" Number="10" Volume="2015" Year="2016">
-      <Id>80b73f0e-3418-43e1-8721-00fdc2d581be</Id>
+      <Database Name="cv" Series="85311" Issue="541217" />
     </Book>
     <Book Series="Spider-Gwen" Number="11" Volume="2015" Year="2016">
-      <Id>a190fa93-8dc5-43c6-aa71-3aba297164ae</Id>
+      <Database Name="cv" Series="85311" Issue="547292" />
     </Book>
     <Book Series="Spider-Gwen" Number="12" Volume="2015" Year="2016">
-      <Id>3d88694f-4442-44b6-9657-ee92b500fb24</Id>
+      <Database Name="cv" Series="85311" Issue="551316" />
     </Book>
     <Book Series="Spider-Gwen" Number="13" Volume="2015" Year="2016">
-      <Id>60298e8e-61eb-4721-b630-a32d2c788abf</Id>
+      <Database Name="cv" Series="85311" Issue="553969" />
     </Book>
     <Book Series="Silk" Number="9" Volume="2015" Year="2016">
-      <Id>cb63d417-4adc-41b9-a0c3-a51c9c365a0e</Id>
+      <Database Name="cv" Series="86251" Issue="537943" />
     </Book>
     <Book Series="Silk" Number="10" Volume="2015" Year="2016">
-      <Id>b9f9b261-91fb-47b4-8268-0b08973634fa</Id>
+      <Database Name="cv" Series="86251" Issue="539251" />
     </Book>
     <Book Series="Silk" Number="11" Volume="2015" Year="2016">
-      <Id>3fc365d7-2383-433e-9a9f-87f7565eed13</Id>
+      <Database Name="cv" Series="86251" Issue="542628" />
     </Book>
     <Book Series="Silk" Number="12" Volume="2015" Year="2016">
-      <Id>1ffeb228-24c6-4607-9077-f064643fc7f6</Id>
+      <Database Name="cv" Series="86251" Issue="548582" />
     </Book>
     <Book Series="Silk" Number="13" Volume="2015" Year="2016">
-      <Id>5de8c857-8916-440f-9096-e4dca5b2b0cc</Id>
+      <Database Name="cv" Series="86251" Issue="553966" />
     </Book>
     <Book Series="Spider-Man 2099" Number="6" Volume="2015" Year="2016">
-      <Id>359d1cb9-7104-4f93-9664-739022104c91</Id>
+      <Database Name="cv" Series="85312" Issue="514451" />
     </Book>
     <Book Series="Spider-Man 2099" Number="7" Volume="2015" Year="2016">
-      <Id>a6b372a3-5e46-4ea2-a19a-6f012e3539d8</Id>
+      <Database Name="cv" Series="85312" Issue="516966" />
     </Book>
     <Book Series="Spider-Man 2099" Number="8" Volume="2015" Year="2016">
-      <Id>f29844c8-0453-46fb-922e-81a905e115fc</Id>
+      <Database Name="cv" Series="85312" Issue="518866" />
     </Book>
     <Book Series="Spider-Man 2099" Number="9" Volume="2015" Year="2016">
-      <Id>78b1127f-166f-431b-8f3a-6e07dd6d9bb6</Id>
+      <Database Name="cv" Series="85312" Issue="523266" />
     </Book>
     <Book Series="Spider-Man 2099" Number="10" Volume="2015" Year="2016">
-      <Id>8173367c-6c26-4983-90f0-9a55b3c6b629</Id>
+      <Database Name="cv" Series="85312" Issue="528521" />
     </Book>
     <Book Series="Carnage" Number="6" Volume="2015" Year="2016">
-      <Id>84bb6fa7-b65e-441c-bc59-beb3bbfb6659</Id>
+      <Database Name="cv" Series="85938" Issue="521330" />
     </Book>
     <Book Series="Carnage" Number="7" Volume="2015" Year="2016">
-      <Id>34fdb2b5-b118-4ae6-98b9-b2b03af8d911</Id>
+      <Database Name="cv" Series="85938" Issue="527135" />
     </Book>
     <Book Series="Carnage" Number="8" Volume="2015" Year="2016">
-      <Id>7a4ca0d6-b956-4e97-9a97-6edd64b3d303</Id>
+      <Database Name="cv" Series="85938" Issue="531876" />
     </Book>
     <Book Series="Carnage" Number="9" Volume="2015" Year="2016">
-      <Id>e38c6793-0f09-4e33-86d0-8efb605327d5</Id>
+      <Database Name="cv" Series="85938" Issue="537228" />
     </Book>
     <Book Series="Carnage" Number="10" Volume="2015" Year="2016">
-      <Id>0f55c128-e1a0-4519-8cea-fbb3d6422202</Id>
+      <Database Name="cv" Series="85938" Issue="541198" />
     </Book>
     <Book Series="Web Warriors" Number="6" Volume="2015" Year="2016">
-      <Id>af07e624-f690-4bb6-872a-a48db592c64b</Id>
+      <Database Name="cv" Series="85976" Issue="525042" />
     </Book>
     <Book Series="Web Warriors" Number="7" Volume="2015" Year="2016">
-      <Id>0cb0428b-1553-49fe-8d18-b19889f2e62d</Id>
+      <Database Name="cv" Series="85976" Issue="529669" />
     </Book>
     <Book Series="Web Warriors" Number="8" Volume="2015" Year="2016">
-      <Id>652b9fab-bb57-4e03-b1df-97448a5d2e1c</Id>
+      <Database Name="cv" Series="85976" Issue="537253" />
     </Book>
     <Book Series="Web Warriors" Number="9" Volume="2015" Year="2016">
-      <Id>da3213a2-cdd0-4582-9cff-e051fd86f0ef</Id>
+      <Database Name="cv" Series="85976" Issue="539260" />
     </Book>
     <Book Series="Web Warriors" Number="10" Volume="2015" Year="2016">
-      <Id>73d05143-e1aa-4f38-a056-114812a580d8</Id>
+      <Database Name="cv" Series="85976" Issue="544999" />
     </Book>
     <Book Series="Web Warriors" Number="11" Volume="2015" Year="2016">
-      <Id>480a145b-4ce0-4a64-b534-b80ca59ba952</Id>
+      <Database Name="cv" Series="85976" Issue="551326" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="12" Volume="2015" Year="2016">
-      <Id>2eea26fd-d90d-49a0-b539-9c9767c20562</Id>
+      <Database Name="cv" Series="85076" Issue="528499" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="13" Volume="2015" Year="2016">
-      <Id>cd7b0091-528c-44f2-8f9d-efe743f92873</Id>
+      <Database Name="cv" Series="85076" Issue="533026" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="14" Volume="2015" Year="2016">
-      <Id>8678896c-3601-4d96-8ff3-f02c9fa7ba1e</Id>
+      <Database Name="cv" Series="85076" Issue="535347" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="15" Volume="2015" Year="2016">
-      <Id>0a37bc32-c6be-45f9-be71-1f86c1b745af</Id>
+      <Database Name="cv" Series="85076" Issue="538500" />
     </Book>
     <Book Series="Amazing Spider-Man Annual" Number="1" Volume="2016" Year="2017">
-      <Id>b7fd5ffa-fd08-46cc-8292-9fb8e6673042</Id>
+      <Database Name="cv" Series="95808" Issue="558953" />
     </Book>
     <Book Series="The Totally Awesome Hulk" Number="8" Volume="2015" Year="2016">
-      <Id>d8b92e43-8821-4924-b86d-ef693b4ac68e</Id>
+      <Database Name="cv" Series="86408" Issue="538523" />
     </Book>
     <Book Series="Civil War II" Number="1" Volume="2016" Year="2016">
-      <Id>1e1faaa3-336f-4103-85b0-41cc78f95a69</Id>
+      <Database Name="cv" Series="90521" Issue="533027" />
     </Book>
     <Book Series="Spider-Woman" Number="9" Volume="2015" Year="2016">
-      <Id>c766f410-e4fa-4957-a4ab-defb3b029a0f</Id>
+      <Database Name="cv" Series="86127" Issue="538520" />
     </Book>
     <Book Series="Spider-Man" Number="6" Volume="2016" Year="2016">
-      <Id>d56b321f-e749-45dd-8910-f8fb40996041</Id>
+      <Database Name="cv" Series="87820" Issue="540082" />
     </Book>
     <Book Series="Civil War II: Amazing Spider-Man" Number="1" Volume="2016" Year="2016">
-      <Id>719c74aa-74db-434b-b2c8-0c1e2a704797</Id>
+      <Database Name="cv" Series="91090" Issue="534279" />
     </Book>
     <Book Series="Civil War II: Amazing Spider-Man" Number="2" Volume="2016" Year="2016">
-      <Id>e8289a20-c2d9-4ee0-80ce-d880679761e3</Id>
+      <Database Name="cv" Series="91090" Issue="539235" />
     </Book>
     <Book Series="Civil War II: Amazing Spider-Man" Number="3" Volume="2016" Year="2016">
-      <Id>f45246b5-bdb8-4c44-87b6-7f56205a7d71</Id>
+      <Database Name="cv" Series="91090" Issue="544981" />
     </Book>
     <Book Series="Civil War II: Amazing Spider-Man" Number="4" Volume="2016" Year="2016">
-      <Id>747ee8c9-4d7f-48b8-8e2f-69d07ac43391</Id>
+      <Database Name="cv" Series="91090" Issue="549512" />
     </Book>
     <Book Series="Civil War II" Number="2" Volume="2016" Year="2016">
-      <Id>f8ce50d4-0280-4cfc-863e-f935e8888348</Id>
+      <Database Name="cv" Series="90521" Issue="535350" />
     </Book>
     <Book Series="Civil War II" Number="3" Volume="2016" Year="2016">
-      <Id>e531c6c6-93b1-429a-b3e2-1a3179c984ce</Id>
+      <Database Name="cv" Series="90521" Issue="539234" />
     </Book>
     <Book Series="Spider-Man" Number="7" Volume="2016" Year="2016">
-      <Id>c8589714-3657-40ea-b46c-91f9773adbc4</Id>
+      <Database Name="cv" Series="87820" Issue="547293" />
     </Book>
     <Book Series="Spider-Man" Number="8" Volume="2016" Year="2016">
-      <Id>83497144-65c7-46bd-b61d-7588fa582197</Id>
+      <Database Name="cv" Series="87820" Issue="549524" />
     </Book>
     <Book Series="Spider-Woman" Number="10" Volume="2015" Year="2016">
-      <Id>59d0954d-6b98-4eb1-bade-7e66f7b49376</Id>
+      <Database Name="cv" Series="86127" Issue="544992" />
     </Book>
     <Book Series="Spider-Woman" Number="11" Volume="2015" Year="2016">
-      <Id>5c1c8ba7-df40-46e0-8d24-5e76b4287b76</Id>
+      <Database Name="cv" Series="86127" Issue="551318" />
     </Book>
     <Book Series="Civil War II" Number="4" Volume="2016" Year="2016">
-      <Id>d7244968-f7d7-4246-bad5-447dd1cfb37b</Id>
+      <Database Name="cv" Series="90521" Issue="541199" />
     </Book>
     <Book Series="Spider-Man 2099" Number="11" Volume="2015" Year="2016">
-      <Id>50274cd9-6c55-4961-ae38-fdde653a9b44</Id>
+      <Database Name="cv" Series="85312" Issue="533036" />
     </Book>
     <Book Series="Spider-Man 2099" Number="12" Volume="2015" Year="2016">
-      <Id>da96a580-7757-4651-864f-bf93f9e92482</Id>
+      <Database Name="cv" Series="85312" Issue="538519" />
     </Book>
     <Book Series="Spider-Man 2099" Number="13" Volume="2015" Year="2016">
-      <Id>713e9c87-9f28-468a-8497-38e8d0fdeba3</Id>
+      <Database Name="cv" Series="85312" Issue="543756" />
     </Book>
     <Book Series="Spider-Man 2099" Number="14" Volume="2015" Year="2016">
-      <Id>2a569eb0-499b-4759-b1ce-2e76920bfc89</Id>
+      <Database Name="cv" Series="85312" Issue="547294" />
     </Book>
     <Book Series="Spider-Man 2099" Number="15" Volume="2015" Year="2016">
-      <Id>9870a478-f486-4df3-8c8b-1b0ce6c17348</Id>
+      <Database Name="cv" Series="85312" Issue="549525" />
     </Book>
     <Book Series="Spider-Man 2099" Number="16" Volume="2015" Year="2016">
-      <Id>cdb40cad-6dc4-4d86-b35b-398dee036d8f</Id>
+      <Database Name="cv" Series="85312" Issue="552169" />
     </Book>
     <Book Series="Spider-Man 2099" Number="17" Volume="2015" Year="2017">
-      <Id>7af9ed0a-bb9f-43c9-9035-c2f052a31dd1</Id>
+      <Database Name="cv" Series="85312" Issue="556478" />
     </Book>
     <Book Series="Spider-Man 2099" Number="18" Volume="2015" Year="2017">
-      <Id>5322f5d7-0307-4989-9aa9-6b6851601acd</Id>
+      <Database Name="cv" Series="85312" Issue="563726" />
     </Book>
     <Book Series="Civil War II" Number="5" Volume="2016" Year="2016">
-      <Id>1a26881e-97e1-4e2b-8cd4-8b5d3ca97295</Id>
+      <Database Name="cv" Series="90521" Issue="550351" />
     </Book>
     <Book Series="Civil War II" Number="6" Volume="2016" Year="2016">
-      <Id>99389268-e40a-419d-b320-730a218f285f</Id>
+      <Database Name="cv" Series="90521" Issue="555515" />
     </Book>
     <Book Series="Spider-Man" Number="9" Volume="2016" Year="2017">
-      <Id>d7deae97-d07c-4aec-a1ee-e83df543f8f8</Id>
+      <Database Name="cv" Series="87820" Issue="558422" />
     </Book>
     <Book Series="Civil War II" Number="7" Volume="2016" Year="2017">
-      <Id>5e2043b9-d846-4a9b-ae0a-9a17fe6c233e</Id>
+      <Database Name="cv" Series="90521" Issue="558959" />
     </Book>
     <Book Series="Civil War II" Number="8" Volume="2016" Year="2017">
-      <Id>6634f12a-96e5-4552-b0f0-08a89186be8a</Id>
+      <Database Name="cv" Series="90521" Issue="571661" />
     </Book>
     <Book Series="Spider-Man" Number="10" Volume="2016" Year="2017">
-      <Id>0e92b5b5-a964-47b7-8f7a-8dfc8abeb319</Id>
+      <Database Name="cv" Series="87820" Issue="566724" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="16" Volume="2015" Year="2016">
-      <Id>28b5e1f4-2c2e-4645-a85a-fc7010b4210c</Id>
+      <Database Name="cv" Series="85076" Issue="543745" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="17" Volume="2015" Year="2016">
-      <Id>05153fb0-9836-4536-8303-8ffdf5938d78</Id>
+      <Database Name="cv" Series="85076" Issue="547268" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="18" Volume="2015" Year="2016">
-      <Id>4e68c648-9770-42f7-88f9-519bff167499</Id>
+      <Database Name="cv" Series="85076" Issue="550344" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="19" Volume="2015" Year="2016">
-      <Id>a7438d97-d470-45d5-b0cf-5bf3023c6e0d</Id>
+      <Database Name="cv" Series="85076" Issue="552152" />
     </Book>
     <Book Series="The Clone Conspiracy" Number="1" Volume="2016" Year="2016">
-      <Id>3ffa676b-ba32-4ab8-97e9-cca902db6eac</Id>
+      <Database Name="cv" Series="94788" Issue="553001" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="20" Volume="2015" Year="2016">
-      <Id>fc93864f-1ad1-4a29-9a31-0758524b5c2a</Id>
+      <Database Name="cv" Series="85076" Issue="553945" />
     </Book>
     <Book Series="The Clone Conspiracy" Number="2" Volume="2016" Year="2017">
-      <Id>69cb9b68-f070-4184-8021-82f0bb64adc6</Id>
+      <Database Name="cv" Series="94788" Issue="557361" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="21" Volume="2015" Year="2017">
-      <Id>3d821c7b-2de8-4d42-beb9-d31fc6ffd83e</Id>
+      <Database Name="cv" Series="85076" Issue="558408" />
     </Book>
     <Book Series="Silk" Number="14" Volume="2015" Year="2017">
-      <Id>66a56366-7687-44ac-9dd9-f1630f29ed70</Id>
+      <Database Name="cv" Series="86251" Issue="558421" />
     </Book>
     <Book Series="The Clone Conspiracy" Number="3" Volume="2016" Year="2017">
-      <Id>1ccf99e1-1e7e-4e32-8270-897e3ae07c30</Id>
+      <Database Name="cv" Series="94788" Issue="563719" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="22" Volume="2015" Year="2017">
-      <Id>146d1ce4-2cb8-4b2a-bcb2-3c84eb0c3e30</Id>
+      <Database Name="cv" Series="85076" Issue="569323" />
     </Book>
     <Book Series="Silk" Number="15" Volume="2015" Year="2017">
-      <Id>1d139be3-dccb-4976-a5ed-3dad236fca41</Id>
+      <Database Name="cv" Series="86251" Issue="566723" />
     </Book>
     <Book Series="The Clone Conspiracy" Number="4" Volume="2016" Year="2017">
-      <Id>85a96fbd-d519-465c-a948-60c862f584d5</Id>
+      <Database Name="cv" Series="94788" Issue="576619" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="23" Volume="2015" Year="2017">
-      <Id>742e9db4-b39c-4317-b7c1-3ad8af25e486</Id>
+      <Database Name="cv" Series="85076" Issue="576613" />
     </Book>
     <Book Series="Silk" Number="16" Volume="2015" Year="2017">
-      <Id>efbcf9d5-436d-47c7-a9bb-30a15fcf2858</Id>
+      <Database Name="cv" Series="86251" Issue="575881" />
     </Book>
     <Book Series="Prowler" Number="1" Volume="2016" Year="2016">
-      <Id>3beaccc6-8ab6-491e-8715-52202a1c0631</Id>
+      <Database Name="cv" Series="95232" Issue="555536" />
     </Book>
     <Book Series="Prowler" Number="2" Volume="2016" Year="2017">
-      <Id>1f10c5bd-3e32-48b8-a5b5-9895ee9af473</Id>
+      <Database Name="cv" Series="95232" Issue="558973" />
     </Book>
     <Book Series="Prowler" Number="3" Volume="2016" Year="2017">
-      <Id>d437f17a-d9d1-4f3e-baf3-b41164707623</Id>
+      <Database Name="cv" Series="95232" Issue="571680" />
     </Book>
     <Book Series="Prowler" Number="4" Volume="2016" Year="2017">
-      <Id>0a91f5a5-6ca8-4231-a233-fbf495af2f10</Id>
+      <Database Name="cv" Series="95232" Issue="578469" />
     </Book>
     <Book Series="The Clone Conspiracy" Number="5" Volume="2016" Year="2017">
-      <Id>e09d6b79-fa4f-45a1-aea0-4fef10314809</Id>
+      <Database Name="cv" Series="94788" Issue="581550" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="24" Volume="2015" Year="2017">
-      <Id>d744933c-a102-42a5-aa58-25fb895d6f5d</Id>
+      <Database Name="cv" Series="85076" Issue="582516" />
     </Book>
     <Book Series="Silk" Number="17" Volume="2015" Year="2017">
-      <Id>0e9715f4-057e-41d4-a43b-84e4a728ead0</Id>
+      <Database Name="cv" Series="86251" Issue="581567" />
     </Book>
     <Book Series="Prowler" Number="5" Volume="2016" Year="2017">
-      <Id>1ce812b4-31ff-4a46-9da3-4ce7b618e7ca</Id>
+      <Database Name="cv" Series="95232" Issue="582539" />
     </Book>
     <Book Series="The Clone Conspiracy Omega" Number="1" Volume="2017" Year="2017">
-      <Id>414ed99a-4c35-45de-b7fe-f155d6081b8f</Id>
+      <Database Name="cv" Series="99245" Issue="583715" />
     </Book>
     <Book Series="Prowler" Number="6" Volume="2016" Year="2017">
-      <Id>af9a5ecf-c0e2-4b6b-9a50-be4fa581d08d</Id>
+      <Database Name="cv" Series="95232" Issue="588572" />
     </Book>
     <Book Series="Silk" Number="18" Volume="2015" Year="2017">
-      <Id>6c0b4362-a83e-4734-9915-a9aaebe4119b</Id>
+      <Database Name="cv" Series="86251" Issue="583727" />
     </Book>
     <Book Series="Silk" Number="19" Volume="2015" Year="2017">
-      <Id>62c6c89a-3608-49ce-8c47-6ab942a9b50d</Id>
+      <Database Name="cv" Series="86251" Issue="592610" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="7" Volume="2016" Year="2016">
-      <Id>2f3e708a-6e26-48aa-a234-81a01b716b75</Id>
+      <Database Name="cv" Series="87182" Issue="540083" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="8" Volume="2016" Year="2016">
-      <Id>0487ffd2-3b26-41a1-a674-30f3ca21159a</Id>
+      <Database Name="cv" Series="87182" Issue="543757" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="9" Volume="2016" Year="2016">
-      <Id>55eccc15-4105-40f9-abba-5416f03a4594</Id>
+      <Database Name="cv" Series="87182" Issue="551317" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="10" Volume="2016" Year="2016">
-      <Id>5d7495b4-941e-4677-a770-75fae3e0d447</Id>
+      <Database Name="cv" Series="87182" Issue="555539" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="11" Volume="2016" Year="2017">
-      <Id>f701b7a7-ee5e-454a-8463-a384a0c80b71</Id>
+      <Database Name="cv" Series="87182" Issue="557376" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="12" Volume="2016" Year="2017">
-      <Id>1e76fddf-dbcb-4e84-aa3f-6d911b0f8bfb</Id>
+      <Database Name="cv" Series="87182" Issue="571683" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="13" Volume="2016" Year="2017">
-      <Id>5c494806-1cc8-417a-ab4e-e4aebc41f089</Id>
+      <Database Name="cv" Series="87182" Issue="575883" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="14" Volume="2016" Year="2017">
-      <Id>ac88dcd9-5a46-4d90-91a0-1104e758da79</Id>
+      <Database Name="cv" Series="87182" Issue="582545" />
     </Book>
     <Book Series="Champions" Number="1" Volume="2016" Year="2016">
-      <Id>92d840fe-f08b-4444-a3ad-ca4da7d0f897</Id>
+      <Database Name="cv" Series="94612" Issue="552154" />
     </Book>
     <Book Series="Champions" Number="2" Volume="2016" Year="2017">
-      <Id>e5b35f20-57b5-4214-aa92-c6a48cb51889</Id>
+      <Database Name="cv" Series="94612" Issue="556468" />
     </Book>
     <Book Series="Champions" Number="3" Volume="2016" Year="2017">
-      <Id>b2f838f2-4335-485b-ab06-5d094783439e</Id>
+      <Database Name="cv" Series="94612" Issue="563718" />
     </Book>
     <Book Series="Champions" Number="4" Volume="2016" Year="2017">
-      <Id>0d49999e-abc3-4b61-bae8-1867910c9fd3</Id>
+      <Database Name="cv" Series="94612" Issue="574861" />
     </Book>
     <Book Series="Champions" Number="5" Volume="2016" Year="2017">
-      <Id>1882b925-3401-4ed0-a710-15599b60cbb7</Id>
+      <Database Name="cv" Series="94612" Issue="579308" />
     </Book>
     <Book Series="Champions" Number="6" Volume="2016" Year="2017">
-      <Id>3a4523c1-c905-462b-b14e-9a22a4ce4507</Id>
+      <Database Name="cv" Series="94612" Issue="583714" />
     </Book>
     <Book Series="Avengers" Number="1" Volume="2016" Year="2017">
-      <Id>85181f3d-2738-450b-82c1-9bde82913b24</Id>
+      <Database Name="cv" Series="95402" Issue="556467" />
     </Book>
     <Book Series="Avengers" Number="2" Volume="2016" Year="2017">
-      <Id>c3790318-92f4-4e26-8496-95eaf47b8a2c</Id>
+      <Database Name="cv" Series="95402" Issue="563716" />
     </Book>
     <Book Series="Avengers" Number="3" Volume="2016" Year="2017">
-      <Id>4010f0f8-1436-4414-90a6-36d3e7e28f63</Id>
+      <Database Name="cv" Series="95402" Issue="574859" />
     </Book>
     <Book Series="Avengers" Number="4" Volume="2016" Year="2017">
-      <Id>d68b4620-1bf0-4033-b714-9a20c85d8c48</Id>
+      <Database Name="cv" Series="95402" Issue="579305" />
     </Book>
     <Book Series="Avengers" Number="5" Volume="2016" Year="2017">
-      <Id>a483f5fd-1afe-4c5c-b2e6-6d970ae4fac2</Id>
+      <Database Name="cv" Series="95402" Issue="583712" />
     </Book>
     <Book Series="Spider-Woman" Number="14" Volume="2015" Year="2017">
-      <Id>f0969126-dc32-4f51-a4e9-c9f44b40b90d</Id>
+      <Database Name="cv" Series="86127" Issue="571684" />
     </Book>
     <Book Series="Spider-Woman" Number="15" Volume="2015" Year="2017">
-      <Id>a880ddc9-bb3e-495b-b79e-d97e5bce566e</Id>
+      <Database Name="cv" Series="86127" Issue="578474" />
     </Book>
     <Book Series="Spider-Woman" Number="16" Volume="2015" Year="2017">
-      <Id>d9efd537-b375-439c-8595-5f49871e960f</Id>
+      <Database Name="cv" Series="86127" Issue="582546" />
     </Book>
     <Book Series="Spider-Woman" Number="17" Volume="2015" Year="2017">
-      <Id>5021deac-f8f9-4bd6-8766-694f485db518</Id>
+      <Database Name="cv" Series="86127" Issue="589837" />
     </Book>
     <Book Series="Venom" Number="1" Volume="2016" Year="2017">
-      <Id>18556a88-cfde-4479-8f55-bc685ef72e99</Id>
+      <Database Name="cv" Series="95845" Issue="558979" />
     </Book>
     <Book Series="Venom" Number="2" Volume="2016" Year="2017">
-      <Id>5b8550c3-a050-41a6-88be-1439617f2eb8</Id>
+      <Database Name="cv" Series="95845" Issue="569355" />
     </Book>
     <Book Series="Venom" Number="3" Volume="2016" Year="2017">
-      <Id>89ff6d77-94e7-4f47-b332-98661c19977b</Id>
+      <Database Name="cv" Series="95845" Issue="576642" />
     </Book>
     <Book Series="Venom" Number="5" Volume="2016" Year="2017">
-      <Id>9a50d367-1dab-4003-afba-2e4a29c7e6f1</Id>
+      <Database Name="cv" Series="95845" Issue="587423" />
     </Book>
     <Book Series="Venom" Number="6" Volume="2016" Year="2017">
-      <Id>fba0a7c9-c389-4202-bd4e-aa346b05637c</Id>
+      <Database Name="cv" Series="95845" Issue="592617" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="25" Volume="2015" Year="2017">
-      <Id>21ff9f52-1f1f-4096-996d-060b90814cc5</Id>
+      <Database Name="cv" Series="85076" Issue="587400" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="26" Volume="2015" Year="2017">
-      <Id>f2a49344-630f-4a38-b3b2-c33c8e68ee6e</Id>
+      <Database Name="cv" Series="85076" Issue="591745" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="27" Volume="2015" Year="2017">
-      <Id>2e3a0429-5c62-4ef0-8445-1f22ed17dd23</Id>
+      <Database Name="cv" Series="85076" Issue="594955" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="28" Volume="2015" Year="2017">
-      <Id>3a8837d4-985c-4b94-80e3-9d8c35f3dd32</Id>
+      <Database Name="cv" Series="85076" Issue="599855" />
     </Book>
     <Book Series="Spider-Man" Number="11" Volume="2016" Year="2017">
-      <Id>eedfaeab-8dd5-4b75-9da3-64174836bf52</Id>
+      <Database Name="cv" Series="87820" Issue="571682" />
     </Book>
     <Book Series="Spider-Gwen" Number="14" Volume="2015" Year="2017">
-      <Id>149a682a-5a44-47f3-9e76-1cf6bfd50ac0</Id>
+      <Database Name="cv" Series="85311" Issue="558974" />
     </Book>
     <Book Series="Spider-Gwen" Number="15" Volume="2015" Year="2017">
-      <Id>62469b26-5e9c-4e40-93d0-88b22bb7ba39</Id>
+      <Database Name="cv" Series="85311" Issue="569346" />
     </Book>
     <Book Series="Spider-Gwen Annual" Number="1" Volume="2016" Year="2016">
-      <Id>d35a1aed-c147-48c8-a888-f440f3332582</Id>
+      <Database Name="cv" Series="91903" Issue="537944" />
     </Book>
     <Book Series="Spider-Man" Number="12" Volume="2016" Year="2017">
-      <Id>add003e0-2987-4ec8-869b-342ad9571588</Id>
+      <Database Name="cv" Series="87820" Issue="575882" />
     </Book>
     <Book Series="Spider-Gwen" Number="16" Volume="2015" Year="2017">
-      <Id>cecbc01d-4d45-453b-a596-80148996fb97</Id>
+      <Database Name="cv" Series="85311" Issue="576633" />
     </Book>
     <Book Series="Spider-Man" Number="13" Volume="2016" Year="2017">
-      <Id>524a0da7-b6d2-409d-87c7-7cc6e6c4e867</Id>
+      <Database Name="cv" Series="87820" Issue="581568" />
     </Book>
     <Book Series="Spider-Gwen" Number="17" Volume="2015" Year="2017">
-      <Id>30862e54-c7d8-4272-b723-1c386943d04e</Id>
+      <Database Name="cv" Series="85311" Issue="582544" />
     </Book>
     <Book Series="Spider-Man" Number="14" Volume="2016" Year="2017">
-      <Id>0af5ddfa-8b74-4fcd-b4a8-afb152d95e4d</Id>
+      <Database Name="cv" Series="87820" Issue="587417" />
     </Book>
     <Book Series="Spider-Gwen" Number="18" Volume="2015" Year="2017">
-      <Id>0c32e402-3efc-4a75-a8e6-9eb8a0e86f81</Id>
+      <Database Name="cv" Series="85311" Issue="588574" />
     </Book>
     <Book Series="Spider-Gwen" Number="19" Volume="2015" Year="2017">
-      <Id>07f35741-4480-4e9b-91f1-08f83a659b24</Id>
+      <Database Name="cv" Series="85311" Issue="594122" />
     </Book>
     <Book Series="Spider-Gwen" Number="20" Volume="2015" Year="2017">
-      <Id>5a4ffdcc-84ac-420c-9caa-d91f6a18f5f3</Id>
+      <Database Name="cv" Series="85311" Issue="598386" />
     </Book>
     <Book Series="Spider-Gwen" Number="21" Volume="2015" Year="2017">
-      <Id>249ffd50-d9ec-4d9e-aa37-fbd579b65b4c</Id>
+      <Database Name="cv" Series="85311" Issue="605128" />
     </Book>
     <Book Series="Spider-Gwen" Number="22" Volume="2015" Year="2017">
-      <Id>16f9cd3a-d75c-48c7-8d11-7ff411203426</Id>
+      <Database Name="cv" Series="85311" Issue="610536" />
     </Book>
     <Book Series="Spider-Gwen" Number="23" Volume="2015" Year="2017">
-      <Id>7c0c5f3d-956d-4e54-abb5-8c61139048b2</Id>
+      <Database Name="cv" Series="85311" Issue="617850" />
     </Book>
     <Book Series="Deadpool" Number="28" Volume="2015" Year="2017">
-      <Id>d9e8750b-51e3-449d-9cbc-407d7d139def</Id>
+      <Database Name="cv" Series="85750" Issue="583716" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="15" Volume="2016" Year="2017">
-      <Id>653935bb-ae6a-4097-b68c-4b729ccd365e</Id>
+      <Database Name="cv" Series="87182" Issue="585093" />
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="9" Volume="2016" Year="2017">
-      <Id>35245e41-63ad-4b55-9bc6-0963ac714e7b</Id>
+    <Book Series="Deadpool &#38; The Mercs For Money" Number="9" Volume="2016" Year="2017">
+      <Database Name="cv" Series="92360" Issue="589825" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="16" Volume="2016" Year="2017">
-      <Id>a5bc3fb3-7262-41d1-a9f6-acb6dc3901d8</Id>
+      <Database Name="cv" Series="87182" Issue="590805" />
     </Book>
-    <Book Series="Deadpool &amp; The Mercs For Money" Number="10" Volume="2016" Year="2017">
-      <Id>7442c9b2-9618-4256-8aff-651509ba7be1</Id>
+    <Book Series="Deadpool &#38; The Mercs For Money" Number="10" Volume="2016" Year="2017">
+      <Database Name="cv" Series="92360" Issue="591753" />
     </Book>
     <Book Series="Deadpool" Number="29" Volume="2015" Year="2017">
-      <Id>ee030fd1-a6ff-4fe4-9888-feabfac9d36f</Id>
+      <Database Name="cv" Series="85750" Issue="592595" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="17" Volume="2016" Year="2017">
-      <Id>5aeec02b-1e89-4ff8-9dad-ec2423194341</Id>
+      <Database Name="cv" Series="87182" Issue="594125" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="18" Volume="2016" Year="2017">
-      <Id>52fac5ca-73e7-49a0-a79f-bc54919fc259</Id>
+      <Database Name="cv" Series="87182" Issue="599875" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="19" Volume="2016" Year="2017">
-      <Id>5b504ac1-d9ee-4fec-9744-a726d795c945</Id>
+      <Database Name="cv" Series="87182" Issue="606637" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="20" Volume="2016" Year="2017">
-      <Id>09f1005d-7f14-44db-b391-342b1af955b1</Id>
+      <Database Name="cv" Series="87182" Issue="612051" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="21" Volume="2016" Year="2017">
-      <Id>bc766a2a-60c8-4a97-9e55-79c508334108</Id>
+      <Database Name="cv" Series="87182" Issue="619637" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="22" Volume="2016" Year="2017">
-      <Id>24231fd3-b252-4acf-9d1a-d7df04c5d8b1</Id>
+      <Database Name="cv" Series="87182" Issue="626296" />
     </Book>
     <Book Series="Spider-Man 2099" Number="20" Volume="2015" Year="2017">
-      <Id>2eb8e5e7-1f2a-4768-91e1-74431cf1c38b</Id>
+      <Database Name="cv" Series="85312" Issue="579323" />
     </Book>
     <Book Series="Spider-Man 2099" Number="21" Volume="2015" Year="2017">
-      <Id>15e3c2bb-ac70-49e3-aa08-9cc6bd37e67d</Id>
+      <Database Name="cv" Series="85312" Issue="583729" />
     </Book>
     <Book Series="Spider-Man 2099" Number="22" Volume="2015" Year="2017">
-      <Id>4e5f13a1-7cbc-4dda-b86f-37b5a4c337af</Id>
+      <Database Name="cv" Series="85312" Issue="591767" />
     </Book>
     <Book Series="Spider-Man 2099" Number="23" Volume="2015" Year="2017">
-      <Id>2691327c-6daa-4fc6-9b1a-3389ac8692e0</Id>
+      <Database Name="cv" Series="85312" Issue="594124" />
     </Book>
     <Book Series="Spider-Man 2099" Number="24" Volume="2015" Year="2017">
-      <Id>3ae88725-bd42-4ad1-a550-f3e26774e489</Id>
+      <Database Name="cv" Series="85312" Issue="603138" />
     </Book>
     <Book Series="Spider-Man 2099" Number="25" Volume="2015" Year="2017">
-      <Id>8d660de0-764a-43fe-9972-c08c36cc1aca</Id>
+      <Database Name="cv" Series="85312" Issue="609361" />
     </Book>
     <Book Series="Avengers" Number="1.MU" Volume="2016" Year="2017">
-      <Id>baeb27c6-7c08-44e0-99e0-5f0566d86715</Id>
+      <Database Name="cv" Series="95402" Issue="578450" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="1.MU" Volume="2016" Year="2017">
-      <Id>3f7737f2-7960-410f-a92d-43424b1c856b</Id>
+      <Database Name="cv" Series="87182" Issue="578473" />
     </Book>
     <Book Series="Champions" Number="1.MU" Volume="2016" Year="2017">
-      <Id>5b9b0df9-6017-417d-94cb-7834cf55ae0b</Id>
+      <Database Name="cv" Series="94612" Issue="582520" />
     </Book>
     <Book Series="Champions" Number="7" Volume="2016" Year="2017">
-      <Id>5a18c1e1-7d76-4fa9-a9eb-e10170a7f8aa</Id>
+      <Database Name="cv" Series="94612" Issue="590791" />
     </Book>
     <Book Series="Champions" Number="8" Volume="2016" Year="2017">
-      <Id>47a0d72c-ae56-45f6-914e-0fef3e53800f</Id>
+      <Database Name="cv" Series="94612" Issue="594108" />
     </Book>
     <Book Series="Champions" Number="9" Volume="2016" Year="2017">
-      <Id>911d3dee-99c2-414c-adec-e950c09c9bf5</Id>
+      <Database Name="cv" Series="94612" Issue="599860" />
     </Book>
     <Book Series="Avengers" Number="7" Volume="2016" Year="2017">
-      <Id>6ad1e2bd-2459-4921-8ace-39f2819ab673</Id>
+      <Database Name="cv" Series="95402" Issue="594959" />
     </Book>
     <Book Series="Avengers" Number="8" Volume="2016" Year="2017">
-      <Id>8b6b535d-faa8-4e30-9b91-550a474c495a</Id>
+      <Database Name="cv" Series="95402" Issue="599857" />
     </Book>
     <Book Series="Peter Parker: The Spectacular Spider-Man" Number="1" Volume="2017" Year="2017">
-      <Id>06f7f662-1af7-4ac8-bf7b-e1eef6b6ea3d</Id>
+      <Database Name="cv" Series="102272" Issue="603132" />
     </Book>
     <Book Series="Peter Parker: The Spectacular Spider-Man" Number="2" Volume="2017" Year="2017">
-      <Id>b5ded2f6-f288-4dee-8194-1b9581db356b</Id>
+      <Database Name="cv" Series="102272" Issue="609356" />
     </Book>
     <Book Series="Peter Parker: The Spectacular Spider-Man" Number="3" Volume="2017" Year="2017">
-      <Id>2152b28f-7959-4599-b56a-5b6a4bcff5ee</Id>
+      <Database Name="cv" Series="102272" Issue="616198" />
     </Book>
     <Book Series="Peter Parker: The Spectacular Spider-Man" Number="4" Volume="2017" Year="2017">
-      <Id>903bd385-7184-434b-86ec-99a41cc6e929</Id>
+      <Database Name="cv" Series="102272" Issue="622948" />
     </Book>
     <Book Series="Peter Parker: The Spectacular Spider-Man" Number="5" Volume="2017" Year="2017">
-      <Id>e9f9835c-7a9a-482c-b94e-68fbc556d142</Id>
+      <Database Name="cv" Series="102272" Issue="630531" />
     </Book>
     <Book Series="Peter Parker: The Spectacular Spider-Man" Number="6" Volume="2017" Year="2018">
-      <Id>8228418e-2635-4ae8-b345-bcc548df6238</Id>
+      <Database Name="cv" Series="102272" Issue="634541" />
     </Book>
     <Book Series="Ben Reilly: Scarlet Spider" Number="1" Volume="2017" Year="2017">
-      <Id>aed849fe-5ba0-405e-ac63-d24594aea230</Id>
+      <Database Name="cv" Series="100966" Issue="593250" />
     </Book>
     <Book Series="Ben Reilly: Scarlet Spider" Number="2" Volume="2017" Year="2017">
-      <Id>8802b18a-c5a5-4178-b332-c49be24300b9</Id>
+      <Database Name="cv" Series="100966" Issue="597184" />
     </Book>
     <Book Series="Ben Reilly: Scarlet Spider" Number="3" Volume="2017" Year="2017">
-      <Id>d9b88cc0-afd1-4bed-a6ed-6be7d86c6739</Id>
+      <Database Name="cv" Series="100966" Issue="601786" />
     </Book>
     <Book Series="Ben Reilly: Scarlet Spider" Number="4" Volume="2017" Year="2017">
-      <Id>26459d3a-8197-4997-9ee6-2be5dfcd890e</Id>
+      <Database Name="cv" Series="100966" Issue="605106" />
     </Book>
     <Book Series="Ben Reilly: Scarlet Spider" Number="5" Volume="2017" Year="2017">
-      <Id>894890b2-918d-4424-a7f2-5acda1ea036f</Id>
+      <Database Name="cv" Series="100966" Issue="610517" />
     </Book>
     <Book Series="Ben Reilly: Scarlet Spider" Number="6" Volume="2017" Year="2017">
-      <Id>e0bf0e54-e0bb-4fb2-a2e3-ce8d7da26ad6</Id>
+      <Database Name="cv" Series="100966" Issue="616184" />
     </Book>
     <Book Series="Ben Reilly: Scarlet Spider" Number="7" Volume="2017" Year="2017">
-      <Id>7a6366e6-85e7-4c4b-84ea-ae2db9186f99</Id>
+      <Database Name="cv" Series="100966" Issue="621658" />
     </Book>
     <Book Series="Ben Reilly: Scarlet Spider" Number="8" Volume="2017" Year="2017">
-      <Id>5e2c9a84-6cab-4460-b788-fac40def7253</Id>
+      <Database Name="cv" Series="100966" Issue="625299" />
     </Book>
     <Book Series="Ben Reilly: Scarlet Spider" Number="9" Volume="2017" Year="2017">
-      <Id>b5319f09-9421-4f11-ae4b-2681f3c915b7</Id>
+      <Database Name="cv" Series="100966" Issue="632490" />
     </Book>
     <Book Series="Spider-Man" Number="15" Volume="2016" Year="2017">
-      <Id>34791f60-bbd3-426e-a61f-b850d819f002</Id>
+      <Database Name="cv" Series="87820" Issue="590804" />
     </Book>
     <Book Series="Spider-Man" Number="16" Volume="2016" Year="2017">
-      <Id>088a95e2-1036-4917-8615-4f454c4b3015</Id>
+      <Database Name="cv" Series="87820" Issue="594123" />
     </Book>
     <Book Series="Spider-Man" Number="17" Volume="2016" Year="2017">
-      <Id>7324229d-982b-4a82-9731-6b98cdbe9cff</Id>
+      <Database Name="cv" Series="87820" Issue="599873" />
     </Book>
     <Book Series="Spider-Man" Number="18" Volume="2016" Year="2017">
-      <Id>dd15331a-9cd1-4140-ba18-fc26fd7c3b1f</Id>
+      <Database Name="cv" Series="87820" Issue="606636" />
     </Book>
     <Book Series="Spider-Man" Number="19" Volume="2016" Year="2017">
-      <Id>799f4174-1ada-446e-991e-ab04883f8a94</Id>
+      <Database Name="cv" Series="87820" Issue="612050" />
     </Book>
     <Book Series="Spider-Man" Number="20" Volume="2016" Year="2017">
-      <Id>793a82d8-50bb-49af-88f6-cc25bc67e18e</Id>
+      <Database Name="cv" Series="87820" Issue="619636" />
     </Book>
     <Book Series="Spider-Man" Number="21" Volume="2016" Year="2017">
-      <Id>83fff4cb-c5c2-4508-b244-baac4143e8af</Id>
+      <Database Name="cv" Series="87820" Issue="626295" />
     </Book>
     <Book Series="Spider-Men II" Number="1" Volume="2017" Year="2017">
-      <Id>f5f595df-ba26-4231-ac09-0bdf98055027</Id>
+      <Database Name="cv" Series="102777" Issue="608256" />
     </Book>
     <Book Series="Spider-Men II" Number="2" Volume="2017" Year="2017">
-      <Id>a46369ce-306a-457e-9433-9d59cc7a8828</Id>
+      <Database Name="cv" Series="102777" Issue="615031" />
     </Book>
     <Book Series="Spider-Men II" Number="3" Volume="2017" Year="2017">
-      <Id>1ea4fb6c-ca5d-4ad8-88eb-a268a8a5165a</Id>
+      <Database Name="cv" Series="102777" Issue="622951" />
     </Book>
     <Book Series="Spider-Men II" Number="4" Volume="2017" Year="2018">
-      <Id>81bc6acc-4465-4ea1-8cfe-7e9f0f15a6c6</Id>
+      <Database Name="cv" Series="102777" Issue="638607" />
     </Book>
     <Book Series="Spider-Men II" Number="5" Volume="2017" Year="2018">
-      <Id>8f2574dd-7d84-4fd6-909c-f38ff4506554</Id>
+      <Database Name="cv" Series="102777" Issue="649744" />
     </Book>
     <Book Series="Secret Empire" Number="0" Volume="2017" Year="2017">
-      <Id>c9c826f6-1bd1-461e-81de-898c11a43c7c</Id>
+      <Database Name="cv" Series="100840" Issue="592609" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="29" Volume="2015" Year="2017">
-      <Id>40e0677f-5ca4-4eb1-9f13-b7940458e89e</Id>
+      <Database Name="cv" Series="85076" Issue="605105" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="30" Volume="2015" Year="2017">
-      <Id>cf3050e7-5ed6-44f8-85c7-c0959dd8bfe0</Id>
+      <Database Name="cv" Series="85076" Issue="608237" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="31" Volume="2015" Year="2017">
-      <Id>9d9d6724-8998-4964-aed0-75a0bfde3df4</Id>
+      <Database Name="cv" Series="85076" Issue="613783" />
     </Book>
     <Book Series="Champions" Number="10" Volume="2016" Year="2017">
-      <Id>c6e3cbca-9e30-4d0e-8198-9b7e097a4755</Id>
+      <Database Name="cv" Series="94612" Issue="606621" />
     </Book>
     <Book Series="Secret Empire" Number="1" Volume="2017" Year="2017">
-      <Id>326c68a9-af56-48c4-91ec-1329e755e360</Id>
+      <Database Name="cv" Series="100840" Issue="594120" />
     </Book>
     <Book Series="Champions" Number="11" Volume="2016" Year="2017">
-      <Id>4885f4ee-35f8-4793-9238-b2561c39b97e</Id>
+      <Database Name="cv" Series="94612" Issue="612035" />
     </Book>
     <Book Series="Secret Empire" Number="2" Volume="2017" Year="2017">
-      <Id>45ea9f1e-cb67-4a68-a084-d52926e0a441</Id>
+      <Database Name="cv" Series="100840" Issue="595700" />
     </Book>
     <Book Series="Secret Empire" Number="3" Volume="2017" Year="2017">
-      <Id>af72de8e-8519-4074-8d93-4a37ea0d6458</Id>
+      <Database Name="cv" Series="100840" Issue="598383" />
     </Book>
     <Book Series="Secret Empire" Number="4" Volume="2017" Year="2017">
-      <Id>0eea1124-bc08-4f03-a42a-52eae450eca2</Id>
+      <Database Name="cv" Series="100840" Issue="601800" />
     </Book>
     <Book Series="Secret Empire" Number="5" Volume="2017" Year="2017">
-      <Id>6da82f1d-e1ee-4de2-b962-d3fce5a924a9</Id>
+      <Database Name="cv" Series="100840" Issue="605127" />
     </Book>
     <Book Series="Secret Empire" Number="6" Volume="2017" Year="2017">
-      <Id>5b39aaef-3019-49ea-bd2e-5cdea036a1cc</Id>
+      <Database Name="cv" Series="100840" Issue="609359" />
     </Book>
     <Book Series="Secret Empire" Number="7" Volume="2017" Year="2017">
-      <Id>4473ce43-2e4e-4167-9e1c-3546fbe731c9</Id>
+      <Database Name="cv" Series="100840" Issue="610534" />
     </Book>
     <Book Series="Secret Empire" Number="8" Volume="2017" Year="2017">
-      <Id>f3e61c17-d6be-4ab7-ab99-4ced7d939484</Id>
+      <Database Name="cv" Series="100840" Issue="613803" />
     </Book>
     <Book Series="Secret Empire" Number="9" Volume="2017" Year="2017">
-      <Id>1526a6be-88f4-4969-abb4-7f3226cff65c</Id>
+      <Database Name="cv" Series="100840" Issue="616200" />
     </Book>
     <Book Series="Secret Empire" Number="10" Volume="2017" Year="2017">
-      <Id>4e965c3b-ff57-49f7-93cb-2284427b7c4d</Id>
+      <Database Name="cv" Series="100840" Issue="617849" />
     </Book>
     <Book Series="Avengers" Number="11" Volume="2016" Year="2017">
-      <Id>3e54db2c-a8ec-4018-9b7d-0e136c26810d</Id>
+      <Database Name="cv" Series="95402" Issue="622934" />
     </Book>
     <Book Series="Champions" Number="12" Volume="2016" Year="2017">
-      <Id>1f3a9cb8-818f-4fbf-89c4-9c7ff1a11e48</Id>
+      <Database Name="cv" Series="94612" Issue="619618" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="32" Volume="2015" Year="2017">
-      <Id>088e9c32-724f-46cb-9cc5-94495a07a2eb</Id>
+      <Database Name="cv" Series="85076" Issue="621656" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Spider-Man/Spider-Man 011 (Legacy).cbl
+++ b/Marvel/Characters/unsorted/Spider-Man/Spider-Man 011 (Legacy).cbl
@@ -2,415 +2,415 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Spider-Man 11 (Legacy)</Name>
   <Books>
-    <Book Series="Generations: Miles Morales: Spider-Man &amp; Peter Parker: Spider-Man" Number="1" Volume="2017" Year="2017" Format="One-Shot">
+    <Book Series="Generations: Miles Morales: Spider-Man &amp; Peter Parker: Spider-Man" Number="1" Volume="2017" Year="2017">
       <Id>c8cf256b-84ff-4d4d-85fc-fa1cbbcb2c09</Id>
     </Book>
-    <Book Series="Champions" Number="13" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Champions" Number="13" Volume="2016" Year="2017">
       <Id>1b80e1bc-282b-4c6e-8533-35cda1731b95</Id>
     </Book>
-    <Book Series="Champions" Number="14" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Champions" Number="14" Volume="2016" Year="2018">
       <Id>8c1861bb-912b-4771-ba80-b41f64d0dc16</Id>
     </Book>
-    <Book Series="Champions" Number="15" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Champions" Number="15" Volume="2016" Year="2018">
       <Id>0200a1d5-19bc-458c-b60a-75ccb5e421c3</Id>
     </Book>
-    <Book Series="Champions" Number="16" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Champions" Number="16" Volume="2016" Year="2018">
       <Id>eec4ad29-cf04-40ac-847f-62db8e9e8cd1</Id>
     </Book>
-    <Book Series="Champions" Number="17" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Champions" Number="17" Volume="2016" Year="2018">
       <Id>e95ec113-df23-4f7d-b08b-b576b959fc33</Id>
     </Book>
-    <Book Series="Venom" Number="150" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Venom" Number="150" Volume="2016" Year="2017">
       <Id>f4e8c898-4d4d-4e14-86a3-dd603aac3c68</Id>
     </Book>
-    <Book Series="Champions" Number="18" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Champions" Number="18" Volume="2016" Year="2018">
       <Id>d31eb547-6906-4b83-a1e6-5c79ad3207d3</Id>
     </Book>
-    <Book Series="Venom" Number="151" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Venom" Number="151" Volume="2016" Year="2017">
       <Id>8e4109b9-dcae-4730-99ff-27510d4fa1ae</Id>
     </Book>
-    <Book Series="Venom" Number="152" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Venom" Number="152" Volume="2016" Year="2017">
       <Id>27fa476f-d809-4b07-9fc1-ed1d15095e58</Id>
     </Book>
-    <Book Series="Venom" Number="153" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Venom" Number="153" Volume="2016" Year="2017">
       <Id>c9d466c4-29f7-4ddc-b528-10ead01d4264</Id>
     </Book>
-    <Book Series="Venom" Number="154" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Venom" Number="154" Volume="2016" Year="2017">
       <Id>d209858e-2d3c-4042-9cad-291f367fabc9</Id>
     </Book>
-    <Book Series="Venom" Number="155" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Venom" Number="155" Volume="2016" Year="2017">
       <Id>d4c0b2a1-9c93-4a53-b1a1-429b0f895a69</Id>
     </Book>
-    <Book Series="Venom" Number="156" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Venom" Number="156" Volume="2016" Year="2017">
       <Id>fe679d93-8a78-4154-b570-ba2e8afe0b5b</Id>
     </Book>
-    <Book Series="Venom" Number="157" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Venom" Number="157" Volume="2016" Year="2018">
       <Id>0a048d0b-d475-47c2-8ecd-edb4cb146eb1</Id>
     </Book>
-    <Book Series="Venom" Number="158" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Venom" Number="158" Volume="2016" Year="2018">
       <Id>bd8e60c3-d9ef-4802-ba9a-831044847358</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="789" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="789" Volume="2015" Year="2017">
       <Id>df5b406f-cbc0-4f25-bdbd-bbd7798b9525</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="790" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="790" Volume="2015" Year="2017">
       <Id>5572bbbe-7a91-4771-a5e0-b558cbb2d5a3</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="791" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="791" Volume="2015" Year="2018">
       <Id>fdfa139d-bae7-48f6-991b-58ffd11205bb</Id>
     </Book>
-    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="297" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="297" Volume="2017" Year="2018">
       <Id>5e6ee357-fae8-41c5-9d46-25e68552f429</Id>
     </Book>
-    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="298" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="298" Volume="2017" Year="2018">
       <Id>35fa4f91-76c6-46e6-a2c6-a08aedc36d44</Id>
     </Book>
-    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="299" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="299" Volume="2017" Year="2018">
       <Id>dd7140cd-5f73-4c85-824a-2d3681fec7a2</Id>
     </Book>
-    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="300" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="300" Volume="2017" Year="2018">
       <Id>ae6018b1-10a4-487b-b375-3ff8599f2ed2</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="23" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="23" Volume="2016" Year="2018">
       <Id>5d8e6c69-073f-4f43-9850-2abb571bfd1e</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="24" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="24" Volume="2016" Year="2018">
       <Id>c73d9d4d-799c-4dc6-a53f-e294bbfe4059</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="25" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="25" Volume="2016" Year="2018">
       <Id>19c9b02f-7840-4950-897c-64cc0cda2ce4</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="26" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="26" Volume="2016" Year="2018">
       <Id>621b457d-8667-4f62-92ad-a76964b52c44</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="27" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="27" Volume="2016" Year="2018">
       <Id>7a7f390d-53d7-4344-81f9-ba1afbfe7fa3</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="28" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="28" Volume="2016" Year="2018">
       <Id>e68693bd-2849-4510-94ce-94a384b98386</Id>
     </Book>
-    <Book Series="Spider-Man" Number="234" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man" Number="234" Volume="2016" Year="2018">
       <Id>7299493f-291e-4574-8100-5275bb32c09d</Id>
     </Book>
-    <Book Series="Spider-Man" Number="235" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man" Number="235" Volume="2016" Year="2018">
       <Id>e599e92c-f56e-47dd-a04b-c04a0bc994a9</Id>
     </Book>
-    <Book Series="Spider-Man" Number="236" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man" Number="236" Volume="2016" Year="2018">
       <Id>6f0b76f1-6144-4cb9-8c6c-af102fd96ac1</Id>
     </Book>
-    <Book Series="Spider-Man" Number="237" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man" Number="237" Volume="2016" Year="2018">
       <Id>406093ad-09b3-4283-8726-528452b0bad4</Id>
     </Book>
-    <Book Series="Spider-Man" Number="238" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man" Number="238" Volume="2016" Year="2018">
       <Id>383e0a2d-6764-4ac5-9b81-7393c03204b2</Id>
     </Book>
-    <Book Series="Spider-Man" Number="239" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man" Number="239" Volume="2016" Year="2018">
       <Id>df240cb1-72a2-44e8-a9af-9afb8e26e13f</Id>
     </Book>
-    <Book Series="Spider-Man" Number="240" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man" Number="240" Volume="2016" Year="2018">
       <Id>5b5306fb-95c1-4249-8d18-729de1d82c75</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="24" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="24" Volume="2015" Year="2017">
       <Id>3fc5a6e2-20eb-4b8a-88e4-08650345048b</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="25" Volume="2015" Year="2017" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="25" Volume="2015" Year="2017">
       <Id>a2b63a23-68b5-452e-a014-1b53b62b8890</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="26" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="26" Volume="2015" Year="2018">
       <Id>d3153755-814e-4125-bf3c-f401c8195e3a</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="27" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="27" Volume="2015" Year="2018">
       <Id>da228ad8-d50a-44a7-9414-5c4dcf883610</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="28" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="28" Volume="2015" Year="2018">
       <Id>2c743726-8167-424d-ad4b-c3401b8361e8</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="29" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="29" Volume="2015" Year="2018">
       <Id>7216ad37-2127-48bb-bc60-82882369f3ab</Id>
     </Book>
-    <Book Series="Ben Reilly: Scarlet Spider" Number="10" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Ben Reilly: Scarlet Spider" Number="10" Volume="2017" Year="2018">
       <Id>5f9888f3-60b7-4b38-b3d7-a93fff0345c5</Id>
     </Book>
-    <Book Series="Ben Reilly: Scarlet Spider" Number="11" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Ben Reilly: Scarlet Spider" Number="11" Volume="2017" Year="2018">
       <Id>72e3d3aa-d3bc-4b23-90cd-465b53f01172</Id>
     </Book>
-    <Book Series="Ben Reilly: Scarlet Spider" Number="12" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Ben Reilly: Scarlet Spider" Number="12" Volume="2017" Year="2018">
       <Id>76cda315-c68d-46d5-9715-df13f78e070c</Id>
     </Book>
-    <Book Series="Ben Reilly: Scarlet Spider" Number="13" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Ben Reilly: Scarlet Spider" Number="13" Volume="2017" Year="2018">
       <Id>942430b9-65e9-41d7-870a-a5b65ef840f9</Id>
     </Book>
-    <Book Series="Ben Reilly: Scarlet Spider" Number="14" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Ben Reilly: Scarlet Spider" Number="14" Volume="2017" Year="2018">
       <Id>89821ef1-dd19-4cd1-96b8-e356b1247e50</Id>
     </Book>
-    <Book Series="Amazing Spider-Man: Venom Inc. Alpha" Number="1" Volume="2017" Year="2018" Format="One-Shot">
+    <Book Series="Amazing Spider-Man: Venom Inc. Alpha" Number="1" Volume="2017" Year="2018">
       <Id>7021e79b-11ca-473c-926c-00b5ec552511</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="792" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="792" Volume="2015" Year="2018">
       <Id>9b3c5ac5-de97-485d-bb64-dce7153d4e95</Id>
     </Book>
-    <Book Series="Venom" Number="159" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Venom" Number="159" Volume="2016" Year="2018">
       <Id>bfb6ce60-895b-46ba-9c49-73f653cc162b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="793" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="793" Volume="2015" Year="2018">
       <Id>33ff4e22-7fd4-4ff6-8755-b0b81ef51f68</Id>
     </Book>
-    <Book Series="Venom" Number="160" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Venom" Number="160" Volume="2016" Year="2018">
       <Id>635f0ecd-8f32-4057-bb1a-0eb14c4e2e56</Id>
     </Book>
-    <Book Series="Amazing Spider-Man: Venom Inc. Omega" Number="1" Volume="2018" Year="2018" Format="One-Shot">
+    <Book Series="Amazing Spider-Man: Venom Inc. Omega" Number="1" Volume="2018" Year="2018">
       <Id>fa220e2f-37ea-4111-88fd-593a46a102c1</Id>
     </Book>
-    <Book Series="Champions" Number="19" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Champions" Number="19" Volume="2016" Year="2018">
       <Id>86f5a635-2cb5-47b4-ad81-e2bce121bcb6</Id>
     </Book>
-    <Book Series="Champions" Number="20" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Champions" Number="20" Volume="2016" Year="2018">
       <Id>0b54d0e9-a0b8-4a13-9fcb-1656d694f318</Id>
     </Book>
-    <Book Series="Champions" Number="21" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Champions" Number="21" Volume="2016" Year="2018">
       <Id>312c2248-528c-4921-a760-c83895caa3e5</Id>
     </Book>
-    <Book Series="Champions" Number="22" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Champions" Number="22" Volume="2016" Year="2018">
       <Id>0d3aec3f-fc30-4239-afea-96b2c18b6cbc</Id>
     </Book>
-    <Book Series="Champions" Number="23" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Champions" Number="23" Volume="2016" Year="2018">
       <Id>9c4153b5-0f5c-45d5-be65-cbf7be994cdb</Id>
     </Book>
-    <Book Series="Champions" Number="24" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Champions" Number="24" Volume="2016" Year="2018">
       <Id>1e7d801e-7bf7-42c3-851a-6d28e70c5d47</Id>
     </Book>
-    <Book Series="Champions" Number="25" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Champions" Number="25" Volume="2016" Year="2018">
       <Id>7b792590-935c-4ad4-a4b7-bffe8291e2ec</Id>
     </Book>
-    <Book Series="Champions" Number="26" Volume="2016" Year="2019" Format="Main Series">
+    <Book Series="Champions" Number="26" Volume="2016" Year="2019">
       <Id>3a157b92-ca7a-4c09-bdea-57154272b019</Id>
     </Book>
-    <Book Series="Champions" Number="27" Volume="2016" Year="2019" Format="Main Series">
+    <Book Series="Champions" Number="27" Volume="2016" Year="2019">
       <Id>6115f2a0-e686-4540-a960-d13d550164df</Id>
     </Book>
-    <Book Series="Doctor Strange: Damnation" Number="1" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Doctor Strange: Damnation" Number="1" Volume="2018" Year="2018">
       <Id>6e62437e-9fe6-4942-aa73-e644641a5be7</Id>
     </Book>
-    <Book Series="Doctor Strange: Damnation" Number="2" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Doctor Strange: Damnation" Number="2" Volume="2018" Year="2018">
       <Id>04d1101c-ee9b-43d0-9584-65e771220b26</Id>
     </Book>
-    <Book Series="Ben Reilly: Scarlet Spider" Number="15" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Ben Reilly: Scarlet Spider" Number="15" Volume="2017" Year="2018">
       <Id>52d96d6a-4725-494c-9933-c73323f5e66c</Id>
     </Book>
-    <Book Series="Doctor Strange: Damnation" Number="3" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Doctor Strange: Damnation" Number="3" Volume="2018" Year="2018">
       <Id>3d25bdaa-2b9a-487f-ace7-331580015a15</Id>
     </Book>
-    <Book Series="Ben Reilly: Scarlet Spider" Number="16" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Ben Reilly: Scarlet Spider" Number="16" Volume="2017" Year="2018">
       <Id>cba3d33b-edd3-4c6b-b6af-86dbad869df9</Id>
     </Book>
-    <Book Series="Ben Reilly: Scarlet Spider" Number="17" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Ben Reilly: Scarlet Spider" Number="17" Volume="2017" Year="2018">
       <Id>e30b084c-90fb-410b-9eec-fb8b12b5db78</Id>
     </Book>
-    <Book Series="Doctor Strange: Damnation" Number="4" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Doctor Strange: Damnation" Number="4" Volume="2018" Year="2018">
       <Id>562dbfe2-afbc-4dab-95d4-83406b5b1588</Id>
     </Book>
-    <Book Series="Edge of Venomverse" Number="1" Volume="2017" Year="2017" Format="Limited Series">
+    <Book Series="Edge of Venomverse" Number="1" Volume="2017" Year="2017">
       <Id>6bc2873a-a04b-41be-9675-beffb2ca6ffc</Id>
     </Book>
-    <Book Series="Edge of Venomverse" Number="2" Volume="2017" Year="2017" Format="Limited Series">
+    <Book Series="Edge of Venomverse" Number="2" Volume="2017" Year="2017">
       <Id>04ba88a0-94f4-4757-a465-fa771ee2942d</Id>
     </Book>
-    <Book Series="Edge of Venomverse" Number="3" Volume="2017" Year="2017" Format="Limited Series">
+    <Book Series="Edge of Venomverse" Number="3" Volume="2017" Year="2017">
       <Id>815b4164-f2b7-47d7-b0e8-9b0160532e78</Id>
     </Book>
-    <Book Series="Edge of Venomverse" Number="4" Volume="2017" Year="2017" Format="Limited Series">
+    <Book Series="Edge of Venomverse" Number="4" Volume="2017" Year="2017">
       <Id>30ba0ea8-2ef6-4109-8022-90fe2da64d7d</Id>
     </Book>
-    <Book Series="Edge of Venomverse" Number="5" Volume="2017" Year="2017" Format="Limited Series">
+    <Book Series="Edge of Venomverse" Number="5" Volume="2017" Year="2017">
       <Id>9f0dd5c6-be11-4927-91e2-e00c8b40f20b</Id>
     </Book>
-    <Book Series="Venomverse: War Stories" Number="1" Volume="2017" Year="2017" Format="One-Shot">
+    <Book Series="Venomverse: War Stories" Number="1" Volume="2017" Year="2017">
       <Id>494dd3a0-94a6-45ab-9912-89a76d39f6e9</Id>
     </Book>
-    <Book Series="Venomverse" Number="1" Volume="2017" Year="2017" Format="Limited Series">
+    <Book Series="Venomverse" Number="1" Volume="2017" Year="2017">
       <Id>134146af-e87f-4ae5-8cee-00b451e1c298</Id>
     </Book>
-    <Book Series="Venomverse" Number="2" Volume="2017" Year="2017" Format="Limited Series">
+    <Book Series="Venomverse" Number="2" Volume="2017" Year="2017">
       <Id>f65fbf29-a50c-4113-9e21-3ae4e155ce45</Id>
     </Book>
-    <Book Series="Venomverse" Number="3" Volume="2017" Year="2017" Format="Limited Series">
+    <Book Series="Venomverse" Number="3" Volume="2017" Year="2017">
       <Id>ff633cc7-531b-4593-9337-481613d1b93c</Id>
     </Book>
-    <Book Series="Venomverse" Number="4" Volume="2017" Year="2017" Format="Limited Series">
+    <Book Series="Venomverse" Number="4" Volume="2017" Year="2017">
       <Id>b0fb797d-dfec-44d1-95a7-4da25df2f177</Id>
     </Book>
-    <Book Series="Venomverse" Number="5" Volume="2017" Year="2017" Format="Limited Series">
+    <Book Series="Venomverse" Number="5" Volume="2017" Year="2017">
       <Id>e5ceadbf-08fc-4e43-b724-54ec0e11c666</Id>
     </Book>
-    <Book Series="Venom" Number="162" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Venom" Number="162" Volume="2016" Year="2018">
       <Id>6dea5b55-14ef-4d4a-b496-d80190b0052b</Id>
     </Book>
-    <Book Series="Venom" Number="163" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Venom" Number="163" Volume="2016" Year="2018">
       <Id>883f8a38-8eee-4e76-b804-4b14f365c627</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="29" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="29" Volume="2016" Year="2018">
       <Id>eb9d8e1f-d241-4bf9-b76b-1b90e0c689f4</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="30" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="30" Volume="2016" Year="2018">
       <Id>b6240def-8f97-4a6e-a686-2b225edb3a7d</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="31" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="31" Volume="2016" Year="2018">
       <Id>2e904d86-c32c-4395-8e0b-b889ed6b709a</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="32" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="32" Volume="2016" Year="2018">
       <Id>14c842f8-4827-4d62-9029-c5db347b25ce</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="33" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="33" Volume="2016" Year="2018">
       <Id>075534c1-d7a2-4abe-b6c3-b4e4cdfaab55</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="34" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="34" Volume="2016" Year="2018">
       <Id>636317a6-5a88-4686-bf5f-3155deef3f39</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="35" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="35" Volume="2016" Year="2018">
       <Id>d21398a1-7984-4565-8ecf-12aa5f1e5a2a</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="36" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="36" Volume="2016" Year="2018">
       <Id>abd8cefe-0154-4bcb-95c9-95a8a53f2a22</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="37" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="37" Volume="2016" Year="2018">
       <Id>9f97e4cc-0bb1-4bdd-aa66-e55e23938c4c</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="38" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="38" Volume="2016" Year="2018">
       <Id>f3965b22-3869-4971-99ef-052b83217284</Id>
     </Book>
-    <Book Series="Spider-Man/Deadpool" Number="39" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Spider-Man/Deadpool" Number="39" Volume="2016" Year="2018">
       <Id>6e71bb47-84e6-4349-b92f-fd1eb4a6ccb4</Id>
     </Book>
-    <Book Series="Ben Reilly: Scarlet Spider" Number="18" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Ben Reilly: Scarlet Spider" Number="18" Volume="2017" Year="2018">
       <Id>8f9fe327-4a18-4d32-a9f6-9abb353d381e</Id>
     </Book>
-    <Book Series="Ben Reilly: Scarlet Spider" Number="19" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Ben Reilly: Scarlet Spider" Number="19" Volume="2017" Year="2018">
       <Id>f4a8d0fa-6bc6-4498-acfe-f9ecbce84f4d</Id>
     </Book>
-    <Book Series="Ben Reilly: Scarlet Spider" Number="20" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Ben Reilly: Scarlet Spider" Number="20" Volume="2017" Year="2018">
       <Id>7e04a273-3184-431d-aa92-ecfc189d4976</Id>
     </Book>
-    <Book Series="Ben Reilly: Scarlet Spider" Number="21" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Ben Reilly: Scarlet Spider" Number="21" Volume="2017" Year="2018">
       <Id>14544034-b3ea-4fc4-918d-d22ef0bbbef0</Id>
     </Book>
-    <Book Series="Ben Reilly: Scarlet Spider" Number="22" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Ben Reilly: Scarlet Spider" Number="22" Volume="2017" Year="2018">
       <Id>f4051f48-e278-4b7a-ac10-0a55eb20e68b</Id>
     </Book>
-    <Book Series="Ben Reilly: Scarlet Spider" Number="23" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Ben Reilly: Scarlet Spider" Number="23" Volume="2017" Year="2018">
       <Id>15a515c4-48c0-46b5-bf03-e72bc502183f</Id>
     </Book>
-    <Book Series="Ben Reilly: Scarlet Spider" Number="24" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Ben Reilly: Scarlet Spider" Number="24" Volume="2017" Year="2018">
       <Id>e2a9ebff-7f1f-4030-a8d7-0acb35409d33</Id>
     </Book>
-    <Book Series="Ben Reilly: Scarlet Spider" Number="25" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Ben Reilly: Scarlet Spider" Number="25" Volume="2017" Year="2018">
       <Id>a43ae6dc-abc0-4277-9384-2ff3e944edcd</Id>
     </Book>
-    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="301" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="301" Volume="2017" Year="2018">
       <Id>e6724acf-6b1c-432d-9968-f9cb1d7af678</Id>
     </Book>
-    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="302" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="302" Volume="2017" Year="2018">
       <Id>a9949b01-588a-4faa-8b28-9b36e8161a8d</Id>
     </Book>
-    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="303" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="303" Volume="2017" Year="2018">
       <Id>80eaeebd-e755-44ca-8321-0951fcc77970</Id>
     </Book>
-    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="304" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="304" Volume="2017" Year="2018">
       <Id>827b2cf8-3a4b-4672-87aa-8e6e2218324e</Id>
     </Book>
-    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="305" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="305" Volume="2017" Year="2018">
       <Id>9e9e684e-c875-462a-bdfe-b848c5847bde</Id>
     </Book>
-    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="306" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="306" Volume="2017" Year="2018">
       <Id>0955c78b-af1e-4cea-bad7-78aa19eb883a</Id>
     </Book>
-    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="307" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="307" Volume="2017" Year="2018">
       <Id>96765591-198b-46bb-b1f7-207e6229accc</Id>
     </Book>
-    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="308" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="308" Volume="2017" Year="2018">
       <Id>a71af456-9351-4f78-8646-07145ffc40d0</Id>
     </Book>
-    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="309" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="309" Volume="2017" Year="2018">
       <Id>56a5e19e-d4c1-4202-ab41-16c584423a20</Id>
     </Book>
-    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="310" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Peter Parker: The Spectacular Spider-Man" Number="310" Volume="2017" Year="2018">
       <Id>4199766a-9b25-43b1-9d27-35ea4ef46256</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="794" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="794" Volume="2015" Year="2018">
       <Id>8de2592b-d498-4c18-b215-526ff5219b47</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="795" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="795" Volume="2015" Year="2018">
       <Id>68301dee-8837-41d6-88f7-e68707ac6976</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="796" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="796" Volume="2015" Year="2018">
       <Id>5e780a19-404d-47bc-bfc4-52818e37a3df</Id>
     </Book>
-    <Book Series="Amazing Spider-Man Annual" Number="42" Volume="2016" Year="2018" Format="Annual">
+    <Book Series="Amazing Spider-Man Annual" Number="42" Volume="2016" Year="2018">
       <Id>b101b76e-23b8-4371-9493-430d71e15de6</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="797" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="797" Volume="2015" Year="2018">
       <Id>b2aac780-ea47-4757-bb05-7b131be4c1d5</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="798" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="798" Volume="2015" Year="2018">
       <Id>de3565bd-cbef-4c73-9d40-217edaf3994b</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="799" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="799" Volume="2015" Year="2018">
       <Id>c487289a-8399-4674-b283-5a8c6cdb1a9d</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="800" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="800" Volume="2015" Year="2018">
       <Id>f9e0af31-cba6-42bd-b749-aeffbedf9e50</Id>
     </Book>
-    <Book Series="The Amazing Spider-Man" Number="801" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="The Amazing Spider-Man" Number="801" Volume="2015" Year="2018">
       <Id>4d86c237-c7fa-4e69-bc85-da7a0c573c21</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="30" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="30" Volume="2015" Year="2018">
       <Id>8767af7d-f255-4b98-ab21-1264b09e113d</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="31" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="31" Volume="2015" Year="2018">
       <Id>e1786942-2d72-45b8-87b1-27f346e7fc80</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="32" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="32" Volume="2015" Year="2018">
       <Id>b083ed0e-15d9-47f8-92c1-84012d97b8a5</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="33" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="33" Volume="2015" Year="2018">
       <Id>9a090b6e-c1d9-45c9-a3c4-875f846f0d83</Id>
     </Book>
-    <Book Series="Spider-Gwen" Number="34" Volume="2015" Year="2018" Format="Main Series">
+    <Book Series="Spider-Gwen" Number="34" Volume="2015" Year="2018">
       <Id>3043899d-74f5-4af5-ad60-bc14c0c0f12a</Id>
     </Book>
-    <Book Series="Venom" Number="161" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Venom" Number="161" Volume="2016" Year="2018">
       <Id>19ba3f7f-cdb3-46aa-97bf-b3ec8b08df59</Id>
     </Book>
-    <Book Series="Venom" Number="164" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Venom" Number="164" Volume="2016" Year="2018">
       <Id>01823e84-62f2-4525-adf0-70c518291a39</Id>
     </Book>
-    <Book Series="Venom" Number="165" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Venom" Number="165" Volume="2016" Year="2018">
       <Id>35dba9d2-3beb-4325-a2eb-f3a4b7888002</Id>
     </Book>
-    <Book Series="Venomized" Number="1" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Venomized" Number="1" Volume="2018" Year="2018">
       <Id>4124ab29-3529-469b-9d94-124b240137cc</Id>
     </Book>
-    <Book Series="Venomized" Number="2" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Venomized" Number="2" Volume="2018" Year="2018">
       <Id>224c2893-d284-487d-ade5-27bcc4791220</Id>
     </Book>
-    <Book Series="Venomized" Number="3" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Venomized" Number="3" Volume="2018" Year="2018">
       <Id>13c11b25-5580-4b8f-9b6e-716383e209ee</Id>
     </Book>
-    <Book Series="Venomized" Number="4" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Venomized" Number="4" Volume="2018" Year="2018">
       <Id>7b3212d2-b3d7-4fb5-9a66-f797db5cf5f2</Id>
     </Book>
-    <Book Series="Venomized" Number="5" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Venomized" Number="5" Volume="2018" Year="2018">
       <Id>6429f343-00a7-4e32-b9db-60f0f2670c78</Id>
     </Book>
-    <Book Series="Hunt For Wolverine: Adamantium Agenda" Number="1" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Hunt For Wolverine: Adamantium Agenda" Number="1" Volume="2018" Year="2018">
       <Id>6277ebe4-8405-4b16-94e4-e55f5a93012c</Id>
     </Book>
-    <Book Series="Hunt For Wolverine: Adamantium Agenda" Number="2" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Hunt For Wolverine: Adamantium Agenda" Number="2" Volume="2018" Year="2018">
       <Id>f6bc5c7c-8ee1-4b62-b94b-69a61d8c3d40</Id>
     </Book>
-    <Book Series="Hunt For Wolverine: Adamantium Agenda" Number="3" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Hunt For Wolverine: Adamantium Agenda" Number="3" Volume="2018" Year="2018">
       <Id>8114c526-f7fd-4a68-be3c-38806572fd3b</Id>
     </Book>
-    <Book Series="Hunt For Wolverine: Adamantium Agenda" Number="4" Volume="2018" Year="2018" Format="Limited Series">
+    <Book Series="Hunt For Wolverine: Adamantium Agenda" Number="4" Volume="2018" Year="2018">
       <Id>b37df063-5899-4be6-bbaa-1bbc0f7ee688</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Spider-Man/Spider-Man 011 (Legacy).cbl
+++ b/Marvel/Characters/unsorted/Spider-Man/Spider-Man 011 (Legacy).cbl
@@ -1,417 +1,418 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Spider-Man 11 (Legacy)</Name>
+  <Name>Spider-Man 011 (Legacy)</Name>
+  <NumIssues>137</NumIssues>
   <Books>
-    <Book Series="Generations: Miles Morales: Spider-Man &amp; Peter Parker: Spider-Man" Number="1" Volume="2017" Year="2017">
-      <Id>c8cf256b-84ff-4d4d-85fc-fa1cbbcb2c09</Id>
+    <Book Series="Generations: Miles Morales: Spider-Man &#38; Peter Parker: Spider-Man" Number="1" Volume="2017" Year="2017">
+      <Database Name="cv" Series="104612" Issue="625306" />
     </Book>
-    <Book Series="Champions" Number="13" Volume="2016" Year="2017">
-      <Id>1b80e1bc-282b-4c6e-8533-35cda1731b95</Id>
+    <Book Series="Champions" Number="13" Volume="2015" Year="0">
+      <Database Name="cv" Series="141587" Issue="906620" />
     </Book>
-    <Book Series="Champions" Number="14" Volume="2016" Year="2018">
-      <Id>8c1861bb-912b-4771-ba80-b41f64d0dc16</Id>
+    <Book Series="Champions" Number="14" Volume="2015" Year="0">
+      <Database Name="cv" Series="141587" Issue="906621" />
     </Book>
-    <Book Series="Champions" Number="15" Volume="2016" Year="2018">
-      <Id>0200a1d5-19bc-458c-b60a-75ccb5e421c3</Id>
+    <Book Series="Champions" Number="15" Volume="2015" Year="0">
+      <Database Name="cv" Series="141587" Issue="906622" />
     </Book>
-    <Book Series="Champions" Number="16" Volume="2016" Year="2018">
-      <Id>eec4ad29-cf04-40ac-847f-62db8e9e8cd1</Id>
+    <Book Series="Champions" Number="16" Volume="2015" Year="0">
+      <Database Name="cv" Series="141587" Issue="906611" />
     </Book>
-    <Book Series="Champions" Number="17" Volume="2016" Year="2018">
-      <Id>e95ec113-df23-4f7d-b08b-b576b959fc33</Id>
+    <Book Series="Champions" Number="17" Volume="2015" Year="0">
+      <Database Name="cv" Series="141587" Issue="906612" />
     </Book>
     <Book Series="Venom" Number="150" Volume="2016" Year="2017">
-      <Id>f4e8c898-4d4d-4e14-86a3-dd603aac3c68</Id>
+      <Database Name="cv" Series="95845" Issue="597207" />
     </Book>
     <Book Series="Champions" Number="18" Volume="2016" Year="2018">
-      <Id>d31eb547-6906-4b83-a1e6-5c79ad3207d3</Id>
+      <Database Name="cv" Series="94612" Issue="664294" />
     </Book>
     <Book Series="Venom" Number="151" Volume="2016" Year="2017">
-      <Id>8e4109b9-dcae-4730-99ff-27510d4fa1ae</Id>
+      <Database Name="cv" Series="95845" Issue="601809" />
     </Book>
     <Book Series="Venom" Number="152" Volume="2016" Year="2017">
-      <Id>27fa476f-d809-4b07-9fc1-ed1d15095e58</Id>
+      <Database Name="cv" Series="95845" Issue="608263" />
     </Book>
     <Book Series="Venom" Number="153" Volume="2016" Year="2017">
-      <Id>c9d466c4-29f7-4ddc-b528-10ead01d4264</Id>
+      <Database Name="cv" Series="95845" Issue="613809" />
     </Book>
     <Book Series="Venom" Number="154" Volume="2016" Year="2017">
-      <Id>d209858e-2d3c-4042-9cad-291f367fabc9</Id>
+      <Database Name="cv" Series="95845" Issue="622959" />
     </Book>
     <Book Series="Venom" Number="155" Volume="2016" Year="2017">
-      <Id>d4c0b2a1-9c93-4a53-b1a1-429b0f895a69</Id>
+      <Database Name="cv" Series="95845" Issue="626303" />
     </Book>
     <Book Series="Venom" Number="156" Volume="2016" Year="2017">
-      <Id>fe679d93-8a78-4154-b570-ba2e8afe0b5b</Id>
+      <Database Name="cv" Series="95845" Issue="630539" />
     </Book>
     <Book Series="Venom" Number="157" Volume="2016" Year="2018">
-      <Id>0a048d0b-d475-47c2-8ecd-edb4cb146eb1</Id>
+      <Database Name="cv" Series="95845" Issue="636390" />
     </Book>
     <Book Series="Venom" Number="158" Volume="2016" Year="2018">
-      <Id>bd8e60c3-d9ef-4802-ba9a-831044847358</Id>
+      <Database Name="cv" Series="95845" Issue="643047" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="789" Volume="2015" Year="2017">
-      <Id>df5b406f-cbc0-4f25-bdbd-bbd7798b9525</Id>
+      <Database Name="cv" Series="85076" Issue="628575" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="790" Volume="2015" Year="2017">
-      <Id>5572bbbe-7a91-4771-a5e0-b558cbb2d5a3</Id>
+      <Database Name="cv" Series="85076" Issue="632488" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="791" Volume="2015" Year="2018">
-      <Id>fdfa139d-bae7-48f6-991b-58ffd11205bb</Id>
+      <Database Name="cv" Series="85076" Issue="638587" />
     </Book>
     <Book Series="Peter Parker: The Spectacular Spider-Man" Number="297" Volume="2017" Year="2018">
-      <Id>5e6ee357-fae8-41c5-9d46-25e68552f429</Id>
+      <Database Name="cv" Series="102272" Issue="638604" />
     </Book>
     <Book Series="Peter Parker: The Spectacular Spider-Man" Number="298" Volume="2017" Year="2018">
-      <Id>35fa4f91-76c6-46e6-a2c6-a08aedc36d44</Id>
+      <Database Name="cv" Series="102272" Issue="647952" />
     </Book>
     <Book Series="Peter Parker: The Spectacular Spider-Man" Number="299" Volume="2017" Year="2018">
-      <Id>dd7140cd-5f73-4c85-824a-2d3681fec7a2</Id>
+      <Database Name="cv" Series="102272" Issue="654059" />
     </Book>
     <Book Series="Peter Parker: The Spectacular Spider-Man" Number="300" Volume="2017" Year="2018">
-      <Id>ae6018b1-10a4-487b-b375-3ff8599f2ed2</Id>
+      <Database Name="cv" Series="102272" Issue="661158" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="23" Volume="2016" Year="2018">
-      <Id>5d8e6c69-073f-4f43-9850-2abb571bfd1e</Id>
+      <Database Name="cv" Series="87182" Issue="636383" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="24" Volume="2016" Year="2018">
-      <Id>c73d9d4d-799c-4dc6-a53f-e294bbfe4059</Id>
+      <Database Name="cv" Series="87182" Issue="641416" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="25" Volume="2016" Year="2018">
-      <Id>19c9b02f-7840-4950-897c-64cc0cda2ce4</Id>
+      <Database Name="cv" Series="87182" Issue="649743" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="26" Volume="2016" Year="2018">
-      <Id>621b457d-8667-4f62-92ad-a76964b52c44</Id>
+      <Database Name="cv" Series="87182" Issue="652641" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="27" Volume="2016" Year="2018">
-      <Id>7a7f390d-53d7-4344-81f9-ba1afbfe7fa3</Id>
+      <Database Name="cv" Series="87182" Issue="658732" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="28" Volume="2016" Year="2018">
-      <Id>e68693bd-2849-4510-94ce-94a384b98386</Id>
+      <Database Name="cv" Series="87182" Issue="661160" />
     </Book>
     <Book Series="Spider-Man" Number="234" Volume="2016" Year="2018">
-      <Id>7299493f-291e-4574-8100-5275bb32c09d</Id>
+      <Database Name="cv" Series="87820" Issue="634543" />
     </Book>
     <Book Series="Spider-Man" Number="235" Volume="2016" Year="2018">
-      <Id>e599e92c-f56e-47dd-a04b-c04a0bc994a9</Id>
+      <Database Name="cv" Series="87820" Issue="644513" />
     </Book>
     <Book Series="Spider-Man" Number="236" Volume="2016" Year="2018">
-      <Id>6f0b76f1-6144-4cb9-8c6c-af102fd96ac1</Id>
+      <Database Name="cv" Series="87820" Issue="650926" />
     </Book>
     <Book Series="Spider-Man" Number="237" Volume="2016" Year="2018">
-      <Id>406093ad-09b3-4283-8726-528452b0bad4</Id>
+      <Database Name="cv" Series="87820" Issue="658731" />
     </Book>
     <Book Series="Spider-Man" Number="238" Volume="2016" Year="2018">
-      <Id>383e0a2d-6764-4ac5-9b81-7393c03204b2</Id>
+      <Database Name="cv" Series="87820" Issue="662096" />
     </Book>
     <Book Series="Spider-Man" Number="239" Volume="2016" Year="2018">
-      <Id>df240cb1-72a2-44e8-a9af-9afb8e26e13f</Id>
+      <Database Name="cv" Series="87820" Issue="664922" />
     </Book>
     <Book Series="Spider-Man" Number="240" Volume="2016" Year="2018">
-      <Id>5b5306fb-95c1-4249-8d18-729de1d82c75</Id>
+      <Database Name="cv" Series="87820" Issue="668783" />
     </Book>
     <Book Series="Spider-Gwen" Number="24" Volume="2015" Year="2017">
-      <Id>3fc5a6e2-20eb-4b8a-88e4-08650345048b</Id>
+      <Database Name="cv" Series="85311" Issue="625323" />
     </Book>
     <Book Series="Spider-Gwen" Number="25" Volume="2015" Year="2017">
-      <Id>a2b63a23-68b5-452e-a014-1b53b62b8890</Id>
+      <Database Name="cv" Series="85311" Issue="630533" />
     </Book>
     <Book Series="Spider-Gwen" Number="26" Volume="2015" Year="2018">
-      <Id>d3153755-814e-4125-bf3c-f401c8195e3a</Id>
+      <Database Name="cv" Series="85311" Issue="643042" />
     </Book>
     <Book Series="Spider-Gwen" Number="27" Volume="2015" Year="2018">
-      <Id>da228ad8-d50a-44a7-9414-5c4dcf883610</Id>
+      <Database Name="cv" Series="85311" Issue="647953" />
     </Book>
     <Book Series="Spider-Gwen" Number="28" Volume="2015" Year="2018">
-      <Id>2c743726-8167-424d-ad4b-c3401b8361e8</Id>
+      <Database Name="cv" Series="85311" Issue="656715" />
     </Book>
     <Book Series="Spider-Gwen" Number="29" Volume="2015" Year="2018">
-      <Id>7216ad37-2127-48bb-bc60-82882369f3ab</Id>
+      <Database Name="cv" Series="85311" Issue="661159" />
     </Book>
     <Book Series="Ben Reilly: Scarlet Spider" Number="10" Volume="2017" Year="2018">
-      <Id>5f9888f3-60b7-4b38-b3d7-a93fff0345c5</Id>
+      <Database Name="cv" Series="100966" Issue="638589" />
     </Book>
     <Book Series="Ben Reilly: Scarlet Spider" Number="11" Volume="2017" Year="2018">
-      <Id>72e3d3aa-d3bc-4b23-90cd-465b53f01172</Id>
+      <Database Name="cv" Series="100966" Issue="646180" />
     </Book>
     <Book Series="Ben Reilly: Scarlet Spider" Number="12" Volume="2017" Year="2018">
-      <Id>76cda315-c68d-46d5-9715-df13f78e070c</Id>
+      <Database Name="cv" Series="100966" Issue="649725" />
     </Book>
     <Book Series="Ben Reilly: Scarlet Spider" Number="13" Volume="2017" Year="2018">
-      <Id>942430b9-65e9-41d7-870a-a5b65ef840f9</Id>
+      <Database Name="cv" Series="100966" Issue="656697" />
     </Book>
     <Book Series="Ben Reilly: Scarlet Spider" Number="14" Volume="2017" Year="2018">
-      <Id>89821ef1-dd19-4cd1-96b8-e356b1247e50</Id>
+      <Database Name="cv" Series="100966" Issue="660008" />
     </Book>
     <Book Series="Amazing Spider-Man: Venom Inc. Alpha" Number="1" Volume="2017" Year="2018">
-      <Id>7021e79b-11ca-473c-926c-00b5ec552511</Id>
+      <Database Name="cv" Series="106662" Issue="644495" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="792" Volume="2015" Year="2018">
-      <Id>9b3c5ac5-de97-485d-bb64-dce7153d4e95</Id>
+      <Database Name="cv" Series="85076" Issue="646179" />
     </Book>
     <Book Series="Venom" Number="159" Volume="2016" Year="2018">
-      <Id>bfb6ce60-895b-46ba-9c49-73f653cc162b</Id>
+      <Database Name="cv" Series="95845" Issue="647962" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="793" Volume="2015" Year="2018">
-      <Id>33ff4e22-7fd4-4ff6-8755-b0b81ef51f68</Id>
+      <Database Name="cv" Series="85076" Issue="649722" />
     </Book>
     <Book Series="Venom" Number="160" Volume="2016" Year="2018">
-      <Id>635f0ecd-8f32-4057-bb1a-0eb14c4e2e56</Id>
+      <Database Name="cv" Series="95845" Issue="652644" />
     </Book>
     <Book Series="Amazing Spider-Man: Venom Inc. Omega" Number="1" Volume="2018" Year="2018">
-      <Id>fa220e2f-37ea-4111-88fd-593a46a102c1</Id>
+      <Database Name="cv" Series="107934" Issue="654047" />
     </Book>
     <Book Series="Champions" Number="19" Volume="2016" Year="2018">
-      <Id>86f5a635-2cb5-47b4-ad81-e2bce121bcb6</Id>
+      <Database Name="cv" Series="94612" Issue="665908" />
     </Book>
     <Book Series="Champions" Number="20" Volume="2016" Year="2018">
-      <Id>0b54d0e9-a0b8-4a13-9fcb-1656d694f318</Id>
+      <Database Name="cv" Series="94612" Issue="670741" />
     </Book>
     <Book Series="Champions" Number="21" Volume="2016" Year="2018">
-      <Id>312c2248-528c-4921-a760-c83895caa3e5</Id>
+      <Database Name="cv" Series="94612" Issue="674127" />
     </Book>
     <Book Series="Champions" Number="22" Volume="2016" Year="2018">
-      <Id>0d3aec3f-fc30-4239-afea-96b2c18b6cbc</Id>
+      <Database Name="cv" Series="94612" Issue="676693" />
     </Book>
     <Book Series="Champions" Number="23" Volume="2016" Year="2018">
-      <Id>9c4153b5-0f5c-45d5-be65-cbf7be994cdb</Id>
+      <Database Name="cv" Series="94612" Issue="679405" />
     </Book>
     <Book Series="Champions" Number="24" Volume="2016" Year="2018">
-      <Id>1e7d801e-7bf7-42c3-851a-6d28e70c5d47</Id>
+      <Database Name="cv" Series="94612" Issue="684900" />
     </Book>
     <Book Series="Champions" Number="25" Volume="2016" Year="2018">
-      <Id>7b792590-935c-4ad4-a4b7-bffe8291e2ec</Id>
+      <Database Name="cv" Series="94612" Issue="687005" />
     </Book>
     <Book Series="Champions" Number="26" Volume="2016" Year="2019">
-      <Id>3a157b92-ca7a-4c09-bdea-57154272b019</Id>
+      <Database Name="cv" Series="94612" Issue="691373" />
     </Book>
     <Book Series="Champions" Number="27" Volume="2016" Year="2019">
-      <Id>6115f2a0-e686-4540-a960-d13d550164df</Id>
+      <Database Name="cv" Series="94612" Issue="694908" />
     </Book>
     <Book Series="Doctor Strange: Damnation" Number="1" Volume="2018" Year="2018">
-      <Id>6e62437e-9fe6-4942-aa73-e644641a5be7</Id>
+      <Database Name="cv" Series="108809" Issue="660660" />
     </Book>
     <Book Series="Doctor Strange: Damnation" Number="2" Volume="2018" Year="2018">
-      <Id>04d1101c-ee9b-43d0-9584-65e771220b26</Id>
+      <Database Name="cv" Series="108809" Issue="662087" />
     </Book>
     <Book Series="Ben Reilly: Scarlet Spider" Number="15" Volume="2017" Year="2018">
-      <Id>52d96d6a-4725-494c-9933-c73323f5e66c</Id>
+      <Database Name="cv" Series="100966" Issue="662739" />
     </Book>
     <Book Series="Doctor Strange: Damnation" Number="3" Volume="2018" Year="2018">
-      <Id>3d25bdaa-2b9a-487f-ace7-331580015a15</Id>
+      <Database Name="cv" Series="108809" Issue="663570" />
     </Book>
     <Book Series="Ben Reilly: Scarlet Spider" Number="16" Volume="2017" Year="2018">
-      <Id>cba3d33b-edd3-4c6b-b6af-86dbad869df9</Id>
+      <Database Name="cv" Series="100966" Issue="664291" />
     </Book>
     <Book Series="Ben Reilly: Scarlet Spider" Number="17" Volume="2017" Year="2018">
-      <Id>e30b084c-90fb-410b-9eec-fb8b12b5db78</Id>
+      <Database Name="cv" Series="100966" Issue="665905" />
     </Book>
     <Book Series="Doctor Strange: Damnation" Number="4" Volume="2018" Year="2018">
-      <Id>562dbfe2-afbc-4dab-95d4-83406b5b1588</Id>
+      <Database Name="cv" Series="108809" Issue="667639" />
     </Book>
     <Book Series="Edge of Venomverse" Number="1" Volume="2017" Year="2017">
-      <Id>6bc2873a-a04b-41be-9675-beffb2ca6ffc</Id>
+      <Database Name="cv" Series="102455" Issue="605112" />
     </Book>
     <Book Series="Edge of Venomverse" Number="2" Volume="2017" Year="2017">
-      <Id>04ba88a0-94f4-4757-a465-fa771ee2942d</Id>
+      <Database Name="cv" Series="102455" Issue="608244" />
     </Book>
     <Book Series="Edge of Venomverse" Number="3" Volume="2017" Year="2017">
-      <Id>815b4164-f2b7-47d7-b0e8-9b0160532e78</Id>
+      <Database Name="cv" Series="102455" Issue="610523" />
     </Book>
     <Book Series="Edge of Venomverse" Number="4" Volume="2017" Year="2017">
-      <Id>30ba0ea8-2ef6-4109-8022-90fe2da64d7d</Id>
+      <Database Name="cv" Series="102455" Issue="613789" />
     </Book>
     <Book Series="Edge of Venomverse" Number="5" Volume="2017" Year="2017">
-      <Id>9f0dd5c6-be11-4927-91e2-e00c8b40f20b</Id>
+      <Database Name="cv" Series="102455" Issue="616190" />
     </Book>
     <Book Series="Venomverse: War Stories" Number="1" Volume="2017" Year="2017">
-      <Id>494dd3a0-94a6-45ab-9912-89a76d39f6e9</Id>
+      <Database Name="cv" Series="104089" Issue="619645" />
     </Book>
     <Book Series="Venomverse" Number="1" Volume="2017" Year="2017">
-      <Id>134146af-e87f-4ae5-8cee-00b451e1c298</Id>
+      <Database Name="cv" Series="104088" Issue="619644" />
     </Book>
     <Book Series="Venomverse" Number="2" Volume="2017" Year="2017">
-      <Id>f65fbf29-a50c-4113-9e21-3ae4e155ce45</Id>
+      <Database Name="cv" Series="104088" Issue="621683" />
     </Book>
     <Book Series="Venomverse" Number="3" Volume="2017" Year="2017">
-      <Id>ff633cc7-531b-4593-9337-481613d1b93c</Id>
+      <Database Name="cv" Series="104088" Issue="622960" />
     </Book>
     <Book Series="Venomverse" Number="4" Volume="2017" Year="2017">
-      <Id>b0fb797d-dfec-44d1-95a7-4da25df2f177</Id>
+      <Database Name="cv" Series="104088" Issue="625331" />
     </Book>
     <Book Series="Venomverse" Number="5" Volume="2017" Year="2017">
-      <Id>e5ceadbf-08fc-4e43-b724-54ec0e11c666</Id>
+      <Database Name="cv" Series="104088" Issue="626304" />
     </Book>
     <Book Series="Venom" Number="162" Volume="2016" Year="2018">
-      <Id>6dea5b55-14ef-4d4a-b496-d80190b0052b</Id>
+      <Database Name="cv" Series="95845" Issue="660673" />
     </Book>
     <Book Series="Venom" Number="163" Volume="2016" Year="2018">
-      <Id>883f8a38-8eee-4e76-b804-4b14f365c627</Id>
+      <Database Name="cv" Series="95845" Issue="662102" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="29" Volume="2016" Year="2018">
-      <Id>eb9d8e1f-d241-4bf9-b76b-1b90e0c689f4</Id>
+      <Database Name="cv" Series="87182" Issue="662753" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="30" Volume="2016" Year="2018">
-      <Id>b6240def-8f97-4a6e-a686-2b225edb3a7d</Id>
+      <Database Name="cv" Series="87182" Issue="664309" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="31" Volume="2016" Year="2018">
-      <Id>2e904d86-c32c-4395-8e0b-b889ed6b709a</Id>
+      <Database Name="cv" Series="87182" Issue="665920" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="32" Volume="2016" Year="2018">
-      <Id>14c842f8-4827-4d62-9029-c5db347b25ce</Id>
+      <Database Name="cv" Series="87182" Issue="669458" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="33" Volume="2016" Year="2018">
-      <Id>075534c1-d7a2-4abe-b6c3-b4e4cdfaab55</Id>
+      <Database Name="cv" Series="87182" Issue="670755" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="34" Volume="2016" Year="2018">
-      <Id>636317a6-5a88-4686-bf5f-3155deef3f39</Id>
+      <Database Name="cv" Series="87182" Issue="673032" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="35" Volume="2016" Year="2018">
-      <Id>d21398a1-7984-4565-8ecf-12aa5f1e5a2a</Id>
+      <Database Name="cv" Series="87182" Issue="675987" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="36" Volume="2016" Year="2018">
-      <Id>abd8cefe-0154-4bcb-95c9-95a8a53f2a22</Id>
+      <Database Name="cv" Series="87182" Issue="677294" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="37" Volume="2016" Year="2018">
-      <Id>9f97e4cc-0bb1-4bdd-aa66-e55e23938c4c</Id>
+      <Database Name="cv" Series="87182" Issue="679418" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="38" Volume="2016" Year="2018">
-      <Id>f3965b22-3869-4971-99ef-052b83217284</Id>
+      <Database Name="cv" Series="87182" Issue="683835" />
     </Book>
     <Book Series="Spider-Man/Deadpool" Number="39" Volume="2016" Year="2018">
-      <Id>6e71bb47-84e6-4349-b92f-fd1eb4a6ccb4</Id>
+      <Database Name="cv" Series="87182" Issue="686393" />
     </Book>
     <Book Series="Ben Reilly: Scarlet Spider" Number="18" Volume="2017" Year="2018">
-      <Id>8f9fe327-4a18-4d32-a9f6-9abb353d381e</Id>
+      <Database Name="cv" Series="100966" Issue="670108" />
     </Book>
     <Book Series="Ben Reilly: Scarlet Spider" Number="19" Volume="2017" Year="2018">
-      <Id>f4a8d0fa-6bc6-4498-acfe-f9ecbce84f4d</Id>
+      <Database Name="cv" Series="100966" Issue="672276" />
     </Book>
     <Book Series="Ben Reilly: Scarlet Spider" Number="20" Volume="2017" Year="2018">
-      <Id>7e04a273-3184-431d-aa92-ecfc189d4976</Id>
+      <Database Name="cv" Series="100966" Issue="674124" />
     </Book>
     <Book Series="Ben Reilly: Scarlet Spider" Number="21" Volume="2017" Year="2018">
-      <Id>14544034-b3ea-4fc4-918d-d22ef0bbbef0</Id>
+      <Database Name="cv" Series="100966" Issue="675971" />
     </Book>
     <Book Series="Ben Reilly: Scarlet Spider" Number="22" Volume="2017" Year="2018">
-      <Id>f4051f48-e278-4b7a-ac10-0a55eb20e68b</Id>
+      <Database Name="cv" Series="100966" Issue="678526" />
     </Book>
     <Book Series="Ben Reilly: Scarlet Spider" Number="23" Volume="2017" Year="2018">
-      <Id>15a515c4-48c0-46b5-bf03-e72bc502183f</Id>
+      <Database Name="cv" Series="100966" Issue="683821" />
     </Book>
     <Book Series="Ben Reilly: Scarlet Spider" Number="24" Volume="2017" Year="2018">
-      <Id>e2a9ebff-7f1f-4030-a8d7-0acb35409d33</Id>
+      <Database Name="cv" Series="100966" Issue="686372" />
     </Book>
     <Book Series="Ben Reilly: Scarlet Spider" Number="25" Volume="2017" Year="2018">
-      <Id>a43ae6dc-abc0-4277-9384-2ff3e944edcd</Id>
+      <Database Name="cv" Series="100966" Issue="688311" />
     </Book>
     <Book Series="Peter Parker: The Spectacular Spider-Man" Number="301" Volume="2017" Year="2018">
-      <Id>e6724acf-6b1c-432d-9968-f9cb1d7af678</Id>
+      <Database Name="cv" Series="102272" Issue="662751" />
     </Book>
     <Book Series="Peter Parker: The Spectacular Spider-Man" Number="302" Volume="2017" Year="2018">
-      <Id>a9949b01-588a-4faa-8b28-9b36e8161a8d</Id>
+      <Database Name="cv" Series="102272" Issue="664308" />
     </Book>
     <Book Series="Peter Parker: The Spectacular Spider-Man" Number="303" Volume="2017" Year="2018">
-      <Id>80eaeebd-e755-44ca-8321-0951fcc77970</Id>
+      <Database Name="cv" Series="102272" Issue="667653" />
     </Book>
     <Book Series="Peter Parker: The Spectacular Spider-Man" Number="304" Volume="2017" Year="2018">
-      <Id>827b2cf8-3a4b-4672-87aa-8e6e2218324e</Id>
+      <Database Name="cv" Series="102272" Issue="669456" />
     </Book>
     <Book Series="Peter Parker: The Spectacular Spider-Man" Number="305" Volume="2017" Year="2018">
-      <Id>9e9e684e-c875-462a-bdfe-b848c5847bde</Id>
+      <Database Name="cv" Series="102272" Issue="673028" />
     </Book>
     <Book Series="Peter Parker: The Spectacular Spider-Man" Number="306" Volume="2017" Year="2018">
-      <Id>0955c78b-af1e-4cea-bad7-78aa19eb883a</Id>
+      <Database Name="cv" Series="102272" Issue="675152" />
     </Book>
     <Book Series="Peter Parker: The Spectacular Spider-Man" Number="307" Volume="2017" Year="2018">
-      <Id>96765591-198b-46bb-b1f7-207e6229accc</Id>
+      <Database Name="cv" Series="102272" Issue="677290" />
     </Book>
     <Book Series="Peter Parker: The Spectacular Spider-Man" Number="308" Volume="2017" Year="2018">
-      <Id>a71af456-9351-4f78-8646-07145ffc40d0</Id>
+      <Database Name="cv" Series="102272" Issue="680001" />
     </Book>
     <Book Series="Peter Parker: The Spectacular Spider-Man" Number="309" Volume="2017" Year="2018">
-      <Id>56a5e19e-d4c1-4202-ab41-16c584423a20</Id>
+      <Database Name="cv" Series="102272" Issue="684916" />
     </Book>
     <Book Series="Peter Parker: The Spectacular Spider-Man" Number="310" Volume="2017" Year="2018">
-      <Id>4199766a-9b25-43b1-9d27-35ea4ef46256</Id>
+      <Database Name="cv" Series="102272" Issue="686389" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="794" Volume="2015" Year="2018">
-      <Id>8de2592b-d498-4c18-b215-526ff5219b47</Id>
+      <Database Name="cv" Series="85076" Issue="655497" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="795" Volume="2015" Year="2018">
-      <Id>68301dee-8837-41d6-88f7-e68707ac6976</Id>
+      <Database Name="cv" Series="85076" Issue="658715" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="796" Volume="2015" Year="2018">
-      <Id>5e780a19-404d-47bc-bfc4-52818e37a3df</Id>
+      <Database Name="cv" Series="85076" Issue="660651" />
     </Book>
     <Book Series="Amazing Spider-Man Annual" Number="42" Volume="2016" Year="2018">
-      <Id>b101b76e-23b8-4371-9493-430d71e15de6</Id>
+      <Database Name="cv" Series="95808" Issue="660005" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="797" Volume="2015" Year="2018">
-      <Id>b2aac780-ea47-4757-bb05-7b131be4c1d5</Id>
+      <Database Name="cv" Series="85076" Issue="662080" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="798" Volume="2015" Year="2018">
-      <Id>de3565bd-cbef-4c73-9d40-217edaf3994b</Id>
+      <Database Name="cv" Series="85076" Issue="664905" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="799" Volume="2015" Year="2018">
-      <Id>c487289a-8399-4674-b283-5a8c6cdb1a9d</Id>
+      <Database Name="cv" Series="85076" Issue="666798" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="800" Volume="2015" Year="2018">
-      <Id>f9e0af31-cba6-42bd-b749-aeffbedf9e50</Id>
+      <Database Name="cv" Series="85076" Issue="671325" />
     </Book>
     <Book Series="The Amazing Spider-Man" Number="801" Volume="2015" Year="2018">
-      <Id>4d86c237-c7fa-4e69-bc85-da7a0c573c21</Id>
+      <Database Name="cv" Series="85076" Issue="674119" />
     </Book>
     <Book Series="Spider-Gwen" Number="30" Volume="2015" Year="2018">
-      <Id>8767af7d-f255-4b98-ab21-1264b09e113d</Id>
+      <Database Name="cv" Series="85311" Issue="663583" />
     </Book>
     <Book Series="Spider-Gwen" Number="31" Volume="2015" Year="2018">
-      <Id>e1786942-2d72-45b8-87b1-27f346e7fc80</Id>
+      <Database Name="cv" Series="85311" Issue="667654" />
     </Book>
     <Book Series="Spider-Gwen" Number="32" Volume="2015" Year="2018">
-      <Id>b083ed0e-15d9-47f8-92c1-84012d97b8a5</Id>
+      <Database Name="cv" Series="85311" Issue="671339" />
     </Book>
     <Book Series="Spider-Gwen" Number="33" Volume="2015" Year="2018">
-      <Id>9a090b6e-c1d9-45c9-a3c4-875f846f0d83</Id>
+      <Database Name="cv" Series="85311" Issue="674137" />
     </Book>
     <Book Series="Spider-Gwen" Number="34" Volume="2015" Year="2018">
-      <Id>3043899d-74f5-4af5-ad60-bc14c0c0f12a</Id>
+      <Database Name="cv" Series="85311" Issue="677293" />
     </Book>
     <Book Series="Venom" Number="161" Volume="2016" Year="2018">
-      <Id>19ba3f7f-cdb3-46aa-97bf-b3ec8b08df59</Id>
+      <Database Name="cv" Series="95845" Issue="658736" />
     </Book>
     <Book Series="Venom" Number="164" Volume="2016" Year="2018">
-      <Id>01823e84-62f2-4525-adf0-70c518291a39</Id>
+      <Database Name="cv" Series="95845" Issue="664929" />
     </Book>
     <Book Series="Venom" Number="165" Volume="2016" Year="2018">
-      <Id>35dba9d2-3beb-4325-a2eb-f3a4b7888002</Id>
+      <Database Name="cv" Series="95845" Issue="667664" />
     </Book>
     <Book Series="Venomized" Number="1" Volume="2018" Year="2018">
-      <Id>4124ab29-3529-469b-9d94-124b240137cc</Id>
+      <Database Name="cv" Series="109637" Issue="664930" />
     </Book>
     <Book Series="Venomized" Number="2" Volume="2018" Year="2018">
-      <Id>224c2893-d284-487d-ade5-27bcc4791220</Id>
+      <Database Name="cv" Series="109637" Issue="665928" />
     </Book>
     <Book Series="Venomized" Number="3" Volume="2018" Year="2018">
-      <Id>13c11b25-5580-4b8f-9b6e-716383e209ee</Id>
+      <Database Name="cv" Series="109637" Issue="666817" />
     </Book>
     <Book Series="Venomized" Number="4" Volume="2018" Year="2018">
-      <Id>7b3212d2-b3d7-4fb5-9a66-f797db5cf5f2</Id>
+      <Database Name="cv" Series="109637" Issue="667665" />
     </Book>
     <Book Series="Venomized" Number="5" Volume="2018" Year="2018">
-      <Id>6429f343-00a7-4e32-b9db-60f0f2670c78</Id>
+      <Database Name="cv" Series="109637" Issue="668788" />
     </Book>
     <Book Series="Hunt For Wolverine: Adamantium Agenda" Number="1" Volume="2018" Year="2018">
-      <Id>6277ebe4-8405-4b16-94e4-e55f5a93012c</Id>
+      <Database Name="cv" Series="110748" Issue="669451" />
     </Book>
     <Book Series="Hunt For Wolverine: Adamantium Agenda" Number="2" Volume="2018" Year="2018">
-      <Id>f6bc5c7c-8ee1-4b62-b94b-69a61d8c3d40</Id>
+      <Database Name="cv" Series="110748" Issue="673019" />
     </Book>
     <Book Series="Hunt For Wolverine: Adamantium Agenda" Number="3" Volume="2018" Year="2018">
-      <Id>8114c526-f7fd-4a68-be3c-38806572fd3b</Id>
+      <Database Name="cv" Series="110748" Issue="676700" />
     </Book>
     <Book Series="Hunt For Wolverine: Adamantium Agenda" Number="4" Volume="2018" Year="2018">
-      <Id>b37df063-5899-4be6-bbaa-1bbc0f7ee688</Id>
+      <Database Name="cv" Series="110748" Issue="679413" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Sub-Mariner/Sub-Mariner 001.cbl
+++ b/Marvel/Characters/unsorted/Sub-Mariner/Sub-Mariner 001.cbl
@@ -1,105 +1,106 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Sub-Mariner 1</Name>
+  <Name>Sub-Mariner 001</Name>
+  <NumIssues>33</NumIssues>
   <Books>
     <Book Series="Marvel Masterworks: Golden Age Sub-Mariner" Number="1" Volume="2005" Year="2005">
-      <Id>67747662-5252-4cef-8922-7fbb176142d4</Id>
+      <Database Name="cv" Series="35189" Issue="232060" />
     </Book>
     <Book Series="Marvel Masterworks: Golden Age Sub-Mariner" Number="2" Volume="2005" Year="2007">
-      <Id>b89e8cf6-c2e1-4f6b-a4ab-b02470ad5727</Id>
+      <Database Name="cv" Series="35189" Issue="232062" />
     </Book>
     <Book Series="Marvel Masterworks: Golden Age Sub-Mariner" Number="3" Volume="2005" Year="2009">
-      <Id>659ad4c1-70e3-424c-a8b1-25cee3dd6895</Id>
+      <Database Name="cv" Series="35189" Issue="232064" />
     </Book>
     <Book Series="Marvel Masterworks: The Sub-Mariner" Number="1" Volume="2002" Year="2002">
-      <Id>d81ae8ec-208d-47b9-925f-5aded6766786</Id>
+      <Database Name="cv" Series="35188" Issue="232261" />
     </Book>
     <Book Series="Marvel Masterworks: The Sub-Mariner" Number="2" Volume="2002" Year="2007">
-      <Id>dcb6ef2f-fc69-40ae-85cc-7466ef7f78fa</Id>
+      <Database Name="cv" Series="35188" Issue="232081" />
     </Book>
     <Book Series="Marvel Masterworks: The Sub-Mariner" Number="3" Volume="2002" Year="2009">
-      <Id>30c1e772-e10f-4839-8274-4c28f44960af</Id>
+      <Database Name="cv" Series="35188" Issue="232082" />
     </Book>
     <Book Series="Marvel Masterworks: The Sub-Mariner" Number="4" Volume="2002" Year="2011">
-      <Id>9b5b8ff0-23b0-4593-a60e-cf031dfecc8f</Id>
+      <Database Name="cv" Series="35188" Issue="265711" />
     </Book>
     <Book Series="Sub-Mariner" Number="26" Volume="1968" Year="1970">
-      <Id>4823e73a-bbc4-4d02-b4f7-262a9e6af877</Id>
+      <Database Name="cv" Series="2413" Issue="10865" />
     </Book>
     <Book Series="Sub-Mariner" Number="27" Volume="1968" Year="1970">
-      <Id>209c26ee-1aef-4f54-b2cd-25f6dd75cbf6</Id>
+      <Database Name="cv" Series="2413" Issue="10908" />
     </Book>
     <Book Series="Sub-Mariner" Number="28" Volume="1968" Year="1970">
-      <Id>83d91278-304a-4aea-8361-4561a02d63bb</Id>
+      <Database Name="cv" Series="2413" Issue="10962" />
     </Book>
     <Book Series="Sub-Mariner" Number="29" Volume="1968" Year="1970">
-      <Id>b2b63b32-19e1-4d2c-a2dd-02132e467802</Id>
+      <Database Name="cv" Series="2413" Issue="11012" />
     </Book>
     <Book Series="Sub-Mariner" Number="30" Volume="1968" Year="1970">
-      <Id>6987c868-6051-4000-a2ef-ea3558e01eca</Id>
+      <Database Name="cv" Series="2413" Issue="11062" />
     </Book>
     <Book Series="Sub-Mariner" Number="31" Volume="1968" Year="1970">
-      <Id>ece10152-3018-4649-8ab7-6be3d6371086</Id>
+      <Database Name="cv" Series="2413" Issue="11108" />
     </Book>
     <Book Series="Sub-Mariner" Number="32" Volume="1968" Year="1970">
-      <Id>51622d25-3cda-4ea1-9c92-ccb8c9f8b106</Id>
+      <Database Name="cv" Series="2413" Issue="11165" />
     </Book>
     <Book Series="Sub-Mariner" Number="33" Volume="1968" Year="1971">
-      <Id>e322eb3d-6735-43d2-a1b6-88e6e4b0c3b3</Id>
+      <Database Name="cv" Series="2413" Issue="11231" />
     </Book>
     <Book Series="Sub-Mariner" Number="34" Volume="1968" Year="1971">
-      <Id>eab58567-b521-4025-b4bc-879a8d1235ab</Id>
+      <Database Name="cv" Series="2413" Issue="11285" />
     </Book>
     <Book Series="Sub-Mariner" Number="35" Volume="1968" Year="1971">
-      <Id>edb54501-068f-4cc8-93f5-66386c48f4ab</Id>
+      <Database Name="cv" Series="2413" Issue="11334" />
     </Book>
     <Book Series="Sub-Mariner" Number="36" Volume="1968" Year="1971">
-      <Id>dae0cba5-cc41-4c2b-9fec-7e8cb015f0a7</Id>
+      <Database Name="cv" Series="2413" Issue="11389" />
     </Book>
     <Book Series="Sub-Mariner" Number="37" Volume="1968" Year="1971">
-      <Id>877b7aac-79ad-434c-a04c-2a68fbee04af</Id>
+      <Database Name="cv" Series="2413" Issue="11439" />
     </Book>
     <Book Series="Sub-Mariner" Number="38" Volume="1968" Year="1971">
-      <Id>445e5534-6284-438f-8c9a-69a663a77757</Id>
+      <Database Name="cv" Series="2413" Issue="11496" />
     </Book>
     <Book Series="Sub-Mariner" Number="39" Volume="1968" Year="1971">
-      <Id>6df94c0b-ac1c-43cd-8e1d-2c79e61b4e79</Id>
+      <Database Name="cv" Series="2413" Issue="11553" />
     </Book>
     <Book Series="Sub-Mariner" Number="40" Volume="1968" Year="1971">
-      <Id>e268273c-1297-441c-bfb6-2d4e50bfa0aa</Id>
+      <Database Name="cv" Series="2413" Issue="11609" />
     </Book>
     <Book Series="Sub-Mariner" Number="41" Volume="1968" Year="1971">
-      <Id>35130606-81a5-40b7-a0fc-478eed01d919</Id>
+      <Database Name="cv" Series="2413" Issue="11673" />
     </Book>
     <Book Series="Sub-Mariner" Number="42" Volume="1968" Year="1971">
-      <Id>a902e58e-ecd4-404f-9b5d-d62cd69f538a</Id>
+      <Database Name="cv" Series="2413" Issue="11727" />
     </Book>
     <Book Series="Sub-Mariner" Number="43" Volume="1968" Year="1971">
-      <Id>17af2a39-475a-4c2b-88fc-342836979d9d</Id>
+      <Database Name="cv" Series="2413" Issue="11795" />
     </Book>
     <Book Series="Sub-Mariner" Number="44" Volume="1968" Year="1971">
-      <Id>950c85e8-fa8d-4c18-bdc1-8c8a1e5c2cbc</Id>
+      <Database Name="cv" Series="2413" Issue="11850" />
     </Book>
     <Book Series="Sub-Mariner" Number="45" Volume="1968" Year="1972">
-      <Id>1abf392f-6eed-4f8d-89ef-84ffbc6e0f71</Id>
+      <Database Name="cv" Series="2413" Issue="11930" />
     </Book>
     <Book Series="Sub-Mariner" Number="46" Volume="1968" Year="1972">
-      <Id>95a6f1b4-3f55-4fc2-82be-e7cfc72bdd8e</Id>
+      <Database Name="cv" Series="2413" Issue="12001" />
     </Book>
     <Book Series="Sub-Mariner" Number="47" Volume="1968" Year="1972">
-      <Id>542300b6-68ca-4510-bb89-558d75fcd784</Id>
+      <Database Name="cv" Series="2413" Issue="12062" />
     </Book>
     <Book Series="Sub-Mariner" Number="48" Volume="1968" Year="1972">
-      <Id>d6413e52-81a2-45de-8602-6acf3080de1a</Id>
+      <Database Name="cv" Series="2413" Issue="12128" />
     </Book>
     <Book Series="Sub-Mariner" Number="49" Volume="1968" Year="1972">
-      <Id>ec6a21b7-e907-4eb8-85c5-1afeafcfca31</Id>
+      <Database Name="cv" Series="2413" Issue="12202" />
     </Book>
     <Book Series="Marvel Masterworks: The Sub-Mariner" Number="7" Volume="2002" Year="2016">
-      <Id>4e8dc5b3-3dd9-46ef-babe-3f95543b6f08</Id>
+      <Database Name="cv" Series="35188" Issue="510946" />
     </Book>
     <Book Series="Marvel Masterworks: The Sub-Mariner" Number="8" Volume="2002" Year="2018">
-      <Id>a2f01548-1ef6-49f6-94cd-132bb47aaf35</Id>
+      <Database Name="cv" Series="35188" Issue="654055" />
     </Book>
   </Books>
   <Matchers />

--- a/Marvel/Characters/unsorted/Sub-Mariner/Sub-Mariner 001.cbl
+++ b/Marvel/Characters/unsorted/Sub-Mariner/Sub-Mariner 001.cbl
@@ -2,103 +2,103 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Sub-Mariner 1</Name>
   <Books>
-    <Book Series="Marvel Masterworks: Golden Age Sub-Mariner" Number="1" Volume="2005" Year="2005" Format="TPB">
+    <Book Series="Marvel Masterworks: Golden Age Sub-Mariner" Number="1" Volume="2005" Year="2005">
       <Id>67747662-5252-4cef-8922-7fbb176142d4</Id>
     </Book>
-    <Book Series="Marvel Masterworks: Golden Age Sub-Mariner" Number="2" Volume="2005" Year="2007" Format="TPB">
+    <Book Series="Marvel Masterworks: Golden Age Sub-Mariner" Number="2" Volume="2005" Year="2007">
       <Id>b89e8cf6-c2e1-4f6b-a4ab-b02470ad5727</Id>
     </Book>
-    <Book Series="Marvel Masterworks: Golden Age Sub-Mariner" Number="3" Volume="2005" Year="2009" Format="TPB">
+    <Book Series="Marvel Masterworks: Golden Age Sub-Mariner" Number="3" Volume="2005" Year="2009">
       <Id>659ad4c1-70e3-424c-a8b1-25cee3dd6895</Id>
     </Book>
-    <Book Series="Marvel Masterworks: The Sub-Mariner" Number="1" Volume="2002" Year="2002" Format="Main Series">
+    <Book Series="Marvel Masterworks: The Sub-Mariner" Number="1" Volume="2002" Year="2002">
       <Id>d81ae8ec-208d-47b9-925f-5aded6766786</Id>
     </Book>
-    <Book Series="Marvel Masterworks: The Sub-Mariner" Number="2" Volume="2002" Year="2007" Format="Main Series">
+    <Book Series="Marvel Masterworks: The Sub-Mariner" Number="2" Volume="2002" Year="2007">
       <Id>dcb6ef2f-fc69-40ae-85cc-7466ef7f78fa</Id>
     </Book>
-    <Book Series="Marvel Masterworks: The Sub-Mariner" Number="3" Volume="2002" Year="2009" Format="Main Series">
+    <Book Series="Marvel Masterworks: The Sub-Mariner" Number="3" Volume="2002" Year="2009">
       <Id>30c1e772-e10f-4839-8274-4c28f44960af</Id>
     </Book>
-    <Book Series="Marvel Masterworks: The Sub-Mariner" Number="4" Volume="2002" Year="2011" Format="Main Series">
+    <Book Series="Marvel Masterworks: The Sub-Mariner" Number="4" Volume="2002" Year="2011">
       <Id>9b5b8ff0-23b0-4593-a60e-cf031dfecc8f</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="26" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="26" Volume="1968" Year="1970">
       <Id>4823e73a-bbc4-4d02-b4f7-262a9e6af877</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="27" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="27" Volume="1968" Year="1970">
       <Id>209c26ee-1aef-4f54-b2cd-25f6dd75cbf6</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="28" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="28" Volume="1968" Year="1970">
       <Id>83d91278-304a-4aea-8361-4561a02d63bb</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="29" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="29" Volume="1968" Year="1970">
       <Id>b2b63b32-19e1-4d2c-a2dd-02132e467802</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="30" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="30" Volume="1968" Year="1970">
       <Id>6987c868-6051-4000-a2ef-ea3558e01eca</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="31" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="31" Volume="1968" Year="1970">
       <Id>ece10152-3018-4649-8ab7-6be3d6371086</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="32" Volume="1968" Year="1970" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="32" Volume="1968" Year="1970">
       <Id>51622d25-3cda-4ea1-9c92-ccb8c9f8b106</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="33" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="33" Volume="1968" Year="1971">
       <Id>e322eb3d-6735-43d2-a1b6-88e6e4b0c3b3</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="34" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="34" Volume="1968" Year="1971">
       <Id>eab58567-b521-4025-b4bc-879a8d1235ab</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="35" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="35" Volume="1968" Year="1971">
       <Id>edb54501-068f-4cc8-93f5-66386c48f4ab</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="36" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="36" Volume="1968" Year="1971">
       <Id>dae0cba5-cc41-4c2b-9fec-7e8cb015f0a7</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="37" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="37" Volume="1968" Year="1971">
       <Id>877b7aac-79ad-434c-a04c-2a68fbee04af</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="38" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="38" Volume="1968" Year="1971">
       <Id>445e5534-6284-438f-8c9a-69a663a77757</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="39" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="39" Volume="1968" Year="1971">
       <Id>6df94c0b-ac1c-43cd-8e1d-2c79e61b4e79</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="40" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="40" Volume="1968" Year="1971">
       <Id>e268273c-1297-441c-bfb6-2d4e50bfa0aa</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="41" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="41" Volume="1968" Year="1971">
       <Id>35130606-81a5-40b7-a0fc-478eed01d919</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="42" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="42" Volume="1968" Year="1971">
       <Id>a902e58e-ecd4-404f-9b5d-d62cd69f538a</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="43" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="43" Volume="1968" Year="1971">
       <Id>17af2a39-475a-4c2b-88fc-342836979d9d</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="44" Volume="1968" Year="1971" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="44" Volume="1968" Year="1971">
       <Id>950c85e8-fa8d-4c18-bdc1-8c8a1e5c2cbc</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="45" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="45" Volume="1968" Year="1972">
       <Id>1abf392f-6eed-4f8d-89ef-84ffbc6e0f71</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="46" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="46" Volume="1968" Year="1972">
       <Id>95a6f1b4-3f55-4fc2-82be-e7cfc72bdd8e</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="47" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="47" Volume="1968" Year="1972">
       <Id>542300b6-68ca-4510-bb89-558d75fcd784</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="48" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="48" Volume="1968" Year="1972">
       <Id>d6413e52-81a2-45de-8602-6acf3080de1a</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="49" Volume="1968" Year="1972" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="49" Volume="1968" Year="1972">
       <Id>ec6a21b7-e907-4eb8-85c5-1afeafcfca31</Id>
     </Book>
-    <Book Series="Marvel Masterworks: The Sub-Mariner" Number="7" Volume="2002" Year="2016" Format="TPB">
+    <Book Series="Marvel Masterworks: The Sub-Mariner" Number="7" Volume="2002" Year="2016">
       <Id>4e8dc5b3-3dd9-46ef-babe-3f95543b6f08</Id>
     </Book>
-    <Book Series="Marvel Masterworks: The Sub-Mariner" Number="8" Volume="2002" Year="2018" Format="TPB">
+    <Book Series="Marvel Masterworks: The Sub-Mariner" Number="8" Volume="2002" Year="2018">
       <Id>a2f01548-1ef6-49f6-94cd-132bb47aaf35</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Sub-Mariner/Sub-Mariner 002.cbl
+++ b/Marvel/Characters/unsorted/Sub-Mariner/Sub-Mariner 002.cbl
@@ -2,478 +2,478 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Sub-Mariner 2</Name>
   <Books>
-    <Book Series="Prince Namor, the Sub-Mariner" Number="1" Volume="1984" Year="1984" Format="Limited Series">
+    <Book Series="Prince Namor, the Sub-Mariner" Number="1" Volume="1984" Year="1984">
       <Id>5cfa736b-d606-4864-935e-86bc521a8e84</Id>
     </Book>
-    <Book Series="Prince Namor, the Sub-Mariner" Number="2" Volume="1984" Year="1984" Format="Limited Series">
+    <Book Series="Prince Namor, the Sub-Mariner" Number="2" Volume="1984" Year="1984">
       <Id>87931bf0-a62b-4d3c-8abe-68c05449e2c2</Id>
     </Book>
-    <Book Series="Prince Namor, the Sub-Mariner" Number="3" Volume="1984" Year="1984" Format="Limited Series">
+    <Book Series="Prince Namor, the Sub-Mariner" Number="3" Volume="1984" Year="1984">
       <Id>c6431692-df26-4718-bf27-b8b5663b37f7</Id>
     </Book>
-    <Book Series="Prince Namor, the Sub-Mariner" Number="4" Volume="1984" Year="1984" Format="Limited Series">
+    <Book Series="Prince Namor, the Sub-Mariner" Number="4" Volume="1984" Year="1984">
       <Id>55c7e4f0-4ce9-476e-a070-ffa1b6dc8430</Id>
     </Book>
-    <Book Series="Saga of the Sub-Mariner" Number="1" Volume="1988" Year="1988" Format="Limited Series">
+    <Book Series="Saga of the Sub-Mariner" Number="1" Volume="1988" Year="1988">
       <Id>094d6be7-2ff6-4373-9a5a-2a7a9ac9a47e</Id>
     </Book>
-    <Book Series="Saga of the Sub-Mariner" Number="2" Volume="1988" Year="1988" Format="Limited Series">
+    <Book Series="Saga of the Sub-Mariner" Number="2" Volume="1988" Year="1988">
       <Id>a5d3967b-433f-4ed2-b412-9e4d4f3e17c3</Id>
     </Book>
-    <Book Series="Saga of the Sub-Mariner" Number="3" Volume="1988" Year="1989" Format="Limited Series">
+    <Book Series="Saga of the Sub-Mariner" Number="3" Volume="1988" Year="1989">
       <Id>52d2cb47-a3e4-4997-b80c-4b9d9e557201</Id>
     </Book>
-    <Book Series="Saga of the Sub-Mariner" Number="4" Volume="1988" Year="1989" Format="Limited Series">
+    <Book Series="Saga of the Sub-Mariner" Number="4" Volume="1988" Year="1989">
       <Id>40e4d422-d3dc-4c2e-b55c-721fa890ea6c</Id>
     </Book>
-    <Book Series="Saga of the Sub-Mariner" Number="5" Volume="1988" Year="1989" Format="Limited Series">
+    <Book Series="Saga of the Sub-Mariner" Number="5" Volume="1988" Year="1989">
       <Id>2f19d5c5-fefa-405f-8de6-e1bd4e7c82e2</Id>
     </Book>
-    <Book Series="Saga of the Sub-Mariner" Number="6" Volume="1988" Year="1989" Format="Limited Series">
+    <Book Series="Saga of the Sub-Mariner" Number="6" Volume="1988" Year="1989">
       <Id>e0206b01-0b0f-453e-b497-ebdabd82d8df</Id>
     </Book>
-    <Book Series="Saga of the Sub-Mariner" Number="7" Volume="1988" Year="1989" Format="Limited Series">
+    <Book Series="Saga of the Sub-Mariner" Number="7" Volume="1988" Year="1989">
       <Id>7c578c92-6462-4c92-b6e5-ae6a52ba2ac5</Id>
     </Book>
-    <Book Series="Saga of the Sub-Mariner" Number="8" Volume="1988" Year="1989" Format="Limited Series">
+    <Book Series="Saga of the Sub-Mariner" Number="8" Volume="1988" Year="1989">
       <Id>b9171696-70ce-42da-b980-ac1beb88da92</Id>
     </Book>
-    <Book Series="Saga of the Sub-Mariner" Number="9" Volume="1988" Year="1989" Format="Limited Series">
+    <Book Series="Saga of the Sub-Mariner" Number="9" Volume="1988" Year="1989">
       <Id>03a742dd-8dea-42c7-8c74-1c48bdcd759f</Id>
     </Book>
-    <Book Series="Saga of the Sub-Mariner" Number="10" Volume="1988" Year="1989" Format="Limited Series">
+    <Book Series="Saga of the Sub-Mariner" Number="10" Volume="1988" Year="1989">
       <Id>e7c6ecc4-63c8-4f9f-afc3-6dd6d6327422</Id>
     </Book>
-    <Book Series="Saga of the Sub-Mariner" Number="11" Volume="1988" Year="1989" Format="Limited Series">
+    <Book Series="Saga of the Sub-Mariner" Number="11" Volume="1988" Year="1989">
       <Id>8b9826cf-38a1-4a44-9538-0659a207d7ee</Id>
     </Book>
-    <Book Series="Saga of the Sub-Mariner" Number="12" Volume="1988" Year="1989" Format="Limited Series">
+    <Book Series="Saga of the Sub-Mariner" Number="12" Volume="1988" Year="1989">
       <Id>ef575a8a-b2f0-42ab-b70e-46ca6f722858</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="1" Volume="1990" Year="1990" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="1" Volume="1990" Year="1990">
       <Id>45d1e2a7-3427-47d6-a01c-54a40d18a528</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="2" Volume="1990" Year="1990" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="2" Volume="1990" Year="1990">
       <Id>ecb4d5aa-e139-4963-b63b-d9fa389afa86</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="3" Volume="1990" Year="1990" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="3" Volume="1990" Year="1990">
       <Id>9ac70c8c-28c9-4236-bb7e-b4fc3bce9f02</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="4" Volume="1990" Year="1990" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="4" Volume="1990" Year="1990">
       <Id>f417a1b9-05ff-4939-98c6-365e4b66dd9b</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="5" Volume="1990" Year="1990" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="5" Volume="1990" Year="1990">
       <Id>6c9ff5cb-5e34-450d-8af4-31fad00fa3c5</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="6" Volume="1990" Year="1990" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="6" Volume="1990" Year="1990">
       <Id>3794a4b0-aaf2-4cb2-b9aa-66992d18f96a</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="7" Volume="1990" Year="1990" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="7" Volume="1990" Year="1990">
       <Id>5138e1d9-b743-44cd-8d12-1a6565b2eb2f</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="8" Volume="1990" Year="1990" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="8" Volume="1990" Year="1990">
       <Id>2442937d-b0de-4fb7-8ad0-975106d3ad73</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="9" Volume="1990" Year="1990" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="9" Volume="1990" Year="1990">
       <Id>c7b0402d-3728-42b7-8bda-ff30cd2846a0</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="10" Volume="1990" Year="1991" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="10" Volume="1990" Year="1991">
       <Id>92b29c20-6f66-4a2a-a5a6-bb9c28705d82</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="11" Volume="1990" Year="1991" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="11" Volume="1990" Year="1991">
       <Id>a01c8839-8610-46c7-bc1f-359cbf1e1383</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="12" Volume="1990" Year="1991" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="12" Volume="1990" Year="1991">
       <Id>94e74eb7-2269-4bed-b7d8-daadd816c698</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="13" Volume="1990" Year="1991" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="13" Volume="1990" Year="1991">
       <Id>d68cf149-9bc0-4249-aebf-983d22cd08e9</Id>
     </Book>
-    <Book Series="Namor, The Sub-Mariner Annual" Number="1" Volume="1991" Year="1991" Format="Annual">
+    <Book Series="Namor, The Sub-Mariner Annual" Number="1" Volume="1991" Year="1991">
       <Id>178afa21-5ef4-4ab8-9a8f-d6adaf28c56a</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="14" Volume="1990" Year="1991" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="14" Volume="1990" Year="1991">
       <Id>c94d002d-7342-4879-8f22-bd336bf46d08</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="15" Volume="1990" Year="1991" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="15" Volume="1990" Year="1991">
       <Id>de875283-5629-453d-a5c7-599439c6c29c</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="16" Volume="1990" Year="1991" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="16" Volume="1990" Year="1991">
       <Id>465691db-1646-4df0-b52b-c0a1329fad6d</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="17" Volume="1990" Year="1991" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="17" Volume="1990" Year="1991">
       <Id>d6ac4c13-4ea9-4354-81ac-1a3917f242f0</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="18" Volume="1990" Year="1991" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="18" Volume="1990" Year="1991">
       <Id>2fabbc24-c17c-47c3-b429-1ef0705e362e</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="19" Volume="1990" Year="1991" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="19" Volume="1990" Year="1991">
       <Id>fb567250-9eb1-480e-92ac-04f492c2a5cd</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="20" Volume="1990" Year="1991" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="20" Volume="1990" Year="1991">
       <Id>79c43ddd-7588-4d52-8cbb-7d3bb04195f0</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="21" Volume="1990" Year="1991" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="21" Volume="1990" Year="1991">
       <Id>747bfcd6-03d2-4bd4-9468-e5aa028380de</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="22" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="22" Volume="1990" Year="1992">
       <Id>5ce95bd7-ae6e-45b5-a61e-3acb3bcb65a7</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="23" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="23" Volume="1990" Year="1992">
       <Id>3be38db7-08dc-4b3e-ac3e-93cc69074b44</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="24" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="24" Volume="1990" Year="1992">
       <Id>ee86cd82-689a-4bfb-8f2a-243cf2e191e4</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="25" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="25" Volume="1990" Year="1992">
       <Id>c02daf57-e6e8-42ce-88e0-cb752874200d</Id>
     </Book>
-    <Book Series="Namor, The Sub-Mariner Annual" Number="2" Volume="1991" Year="1992" Format="Annual">
+    <Book Series="Namor, The Sub-Mariner Annual" Number="2" Volume="1991" Year="1992">
       <Id>528c4994-7ac4-4888-be59-a58f5716ae92</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="26" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="26" Volume="1990" Year="1992">
       <Id>49fdd806-0ac5-4a94-9583-c488acc1b629</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="27" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="27" Volume="1990" Year="1992">
       <Id>7c8f7fb5-0a76-4ab6-ba90-d5918097e99f</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="28" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="28" Volume="1990" Year="1992">
       <Id>3b6aa3ec-924c-45da-9aa4-a8ea5b270561</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="29" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="29" Volume="1990" Year="1992">
       <Id>d7e0ee06-9de2-4368-a414-1bc1e2ddf2d0</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="30" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="30" Volume="1990" Year="1992">
       <Id>d3da334b-df70-4045-8d6a-39336ff8848e</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="31" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="31" Volume="1990" Year="1992">
       <Id>48ae9251-72b1-42e7-a07f-0eaf129bf8a7</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="32" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="32" Volume="1990" Year="1992">
       <Id>ac1849bd-8439-4dd2-a5f9-9ead87426cb5</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="33" Volume="1990" Year="1992" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="33" Volume="1990" Year="1992">
       <Id>b5637e3c-0840-4ba7-b14c-7b6ec54ab06e</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="34" Volume="1990" Year="1993" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="34" Volume="1990" Year="1993">
       <Id>8b2425d2-350d-4662-9e6e-aa401d74abf4</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="35" Volume="1990" Year="1993" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="35" Volume="1990" Year="1993">
       <Id>f7c9bd84-2e8d-4bd7-be19-c611b7683a7d</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="36" Volume="1990" Year="1993" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="36" Volume="1990" Year="1993">
       <Id>423f5b20-ac64-4d06-9f04-c294f41c0858</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="37" Volume="1990" Year="1993" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="37" Volume="1990" Year="1993">
       <Id>e3f56ba3-9011-4308-9033-eec5203ceb6e</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="38" Volume="1990" Year="1993" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="38" Volume="1990" Year="1993">
       <Id>5eb891a3-635b-4a90-a93f-189c0f3f756c</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="39" Volume="1990" Year="1993" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="39" Volume="1990" Year="1993">
       <Id>419b222b-3b97-4133-be82-2a7c00f0e0e4</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="40" Volume="1990" Year="1993" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="40" Volume="1990" Year="1993">
       <Id>262d43da-4068-44fe-ad95-8c6c8fe97290</Id>
     </Book>
-    <Book Series="Namor, The Sub-Mariner Annual" Number="3" Volume="1991" Year="1993" Format="Annual">
+    <Book Series="Namor, The Sub-Mariner Annual" Number="3" Volume="1991" Year="1993">
       <Id>9ca2c931-a493-4e86-9907-e68cc74ff6aa</Id>
     </Book>
-    <Book Series="The Invaders" Number="1" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="The Invaders" Number="1" Volume="1993" Year="1993">
       <Id>4f961c1b-708d-456c-8b85-96ab1b361431</Id>
     </Book>
-    <Book Series="The Invaders" Number="2" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="The Invaders" Number="2" Volume="1993" Year="1993">
       <Id>32f58e08-8310-442e-82fa-1058a22391c3</Id>
     </Book>
-    <Book Series="The Invaders" Number="3" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="The Invaders" Number="3" Volume="1993" Year="1993">
       <Id>912342ed-76c7-4dd1-940c-750b72730d2c</Id>
     </Book>
-    <Book Series="The Invaders" Number="4" Volume="1993" Year="1993" Format="Limited Series">
+    <Book Series="The Invaders" Number="4" Volume="1993" Year="1993">
       <Id>16939798-be47-407e-bca2-d88fdb7cba7f</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="41" Volume="1990" Year="1993" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="41" Volume="1990" Year="1993">
       <Id>c416bfcc-1a0a-4b2f-bd95-5a34a27d15ae</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="42" Volume="1990" Year="1993" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="42" Volume="1990" Year="1993">
       <Id>e9f24bf9-9123-412b-a16d-f025e1529f6c</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="43" Volume="1990" Year="1993" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="43" Volume="1990" Year="1993">
       <Id>afff7cd8-5a1f-4cb0-8894-f14496ab3c6a</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="44" Volume="1990" Year="1993" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="44" Volume="1990" Year="1993">
       <Id>dde6dda9-153f-41aa-aea0-b0435097362f</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="45" Volume="1990" Year="1993" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="45" Volume="1990" Year="1993">
       <Id>47cd9f74-f212-43d5-a04f-773954a3dc13</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="46" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="46" Volume="1990" Year="1994">
       <Id>1b527627-1a32-4ff2-8df7-1abeb4f24c96</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="47" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="47" Volume="1990" Year="1994">
       <Id>e1bf876b-51e5-4b9a-8ada-dde38e8ee66e</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="385" Volume="1961" Year="1994" Format="Main Series">
+    <Book Series="Fantastic Four" Number="385" Volume="1961" Year="1994">
       <Id>7847c24a-1a4f-4357-b4dd-7ce59adcc379</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="48" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="48" Volume="1990" Year="1994">
       <Id>0a5f9d3b-5230-4fe5-a45f-1d4a40c82d1c</Id>
     </Book>
-    <Book Series="Fantastic Four" Number="386" Volume="1961" Year="1994" Format="Main Series">
+    <Book Series="Fantastic Four" Number="386" Volume="1961" Year="1994">
       <Id>5289297e-3389-4e9b-a644-45453ff7750b</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="49" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="49" Volume="1990" Year="1994">
       <Id>2ac26df0-988c-43b2-9f07-43705bb9bab2</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="50" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="50" Volume="1990" Year="1994">
       <Id>91aae117-0bc0-4190-90c7-5b9b00b8282e</Id>
     </Book>
-    <Book Series="Namor, The Sub-Mariner Annual" Number="4" Volume="1991" Year="1994" Format="Annual">
+    <Book Series="Namor, The Sub-Mariner Annual" Number="4" Volume="1991" Year="1994">
       <Id>a9e7e0c5-e77c-4b23-8ddb-cd2417e3690d</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="51" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="51" Volume="1990" Year="1994">
       <Id>99f27dc7-b52f-4bed-9d42-ca92d0d382cd</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="52" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="52" Volume="1990" Year="1994">
       <Id>f7fb30f3-dff9-4c43-9caf-c856c019d569</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="53" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="53" Volume="1990" Year="1994">
       <Id>df22deca-6825-42e8-a5df-5274d933b477</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="54" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="54" Volume="1990" Year="1994">
       <Id>bb7ce00c-98b9-4a9e-ba5a-08344786db4d</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="55" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="55" Volume="1990" Year="1994">
       <Id>888f1272-f3f2-4fc2-a796-7b0468977118</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="56" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="56" Volume="1990" Year="1994">
       <Id>a0838e83-2796-4ba0-8b03-6affc51aaff2</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="57" Volume="1990" Year="1994" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="57" Volume="1990" Year="1994">
       <Id>bf2baa35-44d9-4b82-b3cc-57772d9fe456</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="58" Volume="1990" Year="1995" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="58" Volume="1990" Year="1995">
       <Id>23222e06-e78c-416c-8434-e239bdb1f916</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="59" Volume="1990" Year="1995" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="59" Volume="1990" Year="1995">
       <Id>08f87e07-d598-4886-83c1-78840eb1a207</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="60" Volume="1990" Year="1995" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="60" Volume="1990" Year="1995">
       <Id>224f1fc7-4856-4b7a-9fc7-0dc404cf0fc3</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="61" Volume="1990" Year="1995" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="61" Volume="1990" Year="1995">
       <Id>b54d659f-402a-433c-b409-b66755207e33</Id>
     </Book>
-    <Book Series="Namor, the Sub-Mariner" Number="62" Volume="1990" Year="1995" Format="Main Series">
+    <Book Series="Namor, the Sub-Mariner" Number="62" Volume="1990" Year="1995">
       <Id>6876fe15-44de-4b58-99ac-39aa6b9d27d6</Id>
     </Book>
-    <Book Series="Defenders" Number="1" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Defenders" Number="1" Volume="2001" Year="2001">
       <Id>ef4d058e-f964-4332-9e14-bfd0c583399e</Id>
     </Book>
-    <Book Series="Defenders" Number="2" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Defenders" Number="2" Volume="2001" Year="2001">
       <Id>9dca83ec-b3a3-43d6-8016-d5b29f257f90</Id>
     </Book>
-    <Book Series="Defenders" Number="3" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Defenders" Number="3" Volume="2001" Year="2001">
       <Id>04cc5b5a-87fc-4d7d-b4b5-92b7bb986ce8</Id>
     </Book>
-    <Book Series="Defenders" Number="4" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Defenders" Number="4" Volume="2001" Year="2001">
       <Id>2be553af-6122-42c9-ac4d-917e8ccd5a61</Id>
     </Book>
-    <Book Series="Defenders" Number="5" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Defenders" Number="5" Volume="2001" Year="2001">
       <Id>75f167d3-2e79-43be-bebf-a36fe1dc4910</Id>
     </Book>
-    <Book Series="Defenders" Number="6" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Defenders" Number="6" Volume="2001" Year="2001">
       <Id>bb5c15a4-97ea-4a69-8e93-49fe373e9582</Id>
     </Book>
-    <Book Series="Defenders" Number="7" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Defenders" Number="7" Volume="2001" Year="2001">
       <Id>e689f681-eb03-4202-93a9-a92957159c8a</Id>
     </Book>
-    <Book Series="Defenders" Number="8" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Defenders" Number="8" Volume="2001" Year="2001">
       <Id>24b2d436-2a5d-4c30-8d49-b664c617b568</Id>
     </Book>
-    <Book Series="Defenders" Number="9" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Defenders" Number="9" Volume="2001" Year="2001">
       <Id>bfdd6a82-2ebb-4d61-8e46-e807efc8f20c</Id>
     </Book>
-    <Book Series="Defenders" Number="10" Volume="2001" Year="2001" Format="Limited Series">
+    <Book Series="Defenders" Number="10" Volume="2001" Year="2001">
       <Id>9500df92-e09c-4c14-acc9-d8bf614b8d97</Id>
     </Book>
-    <Book Series="Defenders" Number="11" Volume="2001" Year="2002" Format="Limited Series">
+    <Book Series="Defenders" Number="11" Volume="2001" Year="2002">
       <Id>256fe514-1d3a-4a00-8e1a-381c0b6ee8d7</Id>
     </Book>
-    <Book Series="Defenders" Number="12" Volume="2001" Year="2002" Format="Limited Series">
+    <Book Series="Defenders" Number="12" Volume="2001" Year="2002">
       <Id>88a8226e-fa7c-4949-b380-76f2b72e086a</Id>
     </Book>
-    <Book Series="The Order" Number="1" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="The Order" Number="1" Volume="2002" Year="2002">
       <Id>ee9f9db9-0e76-4f5a-af25-b1f5c9343c85</Id>
     </Book>
-    <Book Series="The Order" Number="2" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="The Order" Number="2" Volume="2002" Year="2002">
       <Id>ac5eb691-f5d3-4975-93f5-cbc9430cc61c</Id>
     </Book>
-    <Book Series="The Order" Number="3" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="The Order" Number="3" Volume="2002" Year="2002">
       <Id>99e63d04-ac07-4baf-b6c0-d6ea52b1dbc7</Id>
     </Book>
-    <Book Series="The Order" Number="4" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="The Order" Number="4" Volume="2002" Year="2002">
       <Id>cebec8ea-97dc-4732-9ba9-160c6d105bc8</Id>
     </Book>
-    <Book Series="The Order" Number="5" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="The Order" Number="5" Volume="2002" Year="2002">
       <Id>b34cc60f-bd21-4222-8ba1-ad64619140e2</Id>
     </Book>
-    <Book Series="The Order" Number="6" Volume="2002" Year="2002" Format="Limited Series">
+    <Book Series="The Order" Number="6" Volume="2002" Year="2002">
       <Id>f36cc04f-dde3-4104-bd26-9fc02a2fbf80</Id>
     </Book>
-    <Book Series="Namor" Number="1" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Namor" Number="1" Volume="2003" Year="2003">
       <Id>c6972cca-4c91-4be3-8544-84fc7124d537</Id>
     </Book>
-    <Book Series="Namor" Number="2" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Namor" Number="2" Volume="2003" Year="2003">
       <Id>1f7c5250-f629-474a-b0ec-99c8a56ac2f4</Id>
     </Book>
-    <Book Series="Namor" Number="3" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Namor" Number="3" Volume="2003" Year="2003">
       <Id>08ab507a-9779-42b2-9fae-e28e79f84b37</Id>
     </Book>
-    <Book Series="Namor" Number="4" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Namor" Number="4" Volume="2003" Year="2003">
       <Id>3ec2e04f-8dbe-479c-a946-10293124e8b2</Id>
     </Book>
-    <Book Series="Namor" Number="5" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Namor" Number="5" Volume="2003" Year="2003">
       <Id>2e993e66-e853-48cd-b666-80fc8f5f765f</Id>
     </Book>
-    <Book Series="Namor" Number="6" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Namor" Number="6" Volume="2003" Year="2003">
       <Id>0f5f5651-b6a4-45c5-a87a-7434b700a67d</Id>
     </Book>
-    <Book Series="Namor" Number="7" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Namor" Number="7" Volume="2003" Year="2003">
       <Id>7abea74f-c48b-41eb-909d-f9172ff44508</Id>
     </Book>
-    <Book Series="Namor" Number="8" Volume="2003" Year="2003" Format="Main Series">
+    <Book Series="Namor" Number="8" Volume="2003" Year="2003">
       <Id>666956e7-e5c5-4868-99a1-9de62b6a6e8c</Id>
     </Book>
-    <Book Series="Namor" Number="9" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Namor" Number="9" Volume="2003" Year="2004">
       <Id>c9fe8419-ded4-47a8-a9d2-99b21f8facfb</Id>
     </Book>
-    <Book Series="Namor" Number="10" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Namor" Number="10" Volume="2003" Year="2004">
       <Id>f7529a23-2460-4c5d-9852-564533232b9d</Id>
     </Book>
-    <Book Series="Namor" Number="11" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Namor" Number="11" Volume="2003" Year="2004">
       <Id>ca968de1-5908-4e4b-89d1-25619d3237a0</Id>
     </Book>
-    <Book Series="Namor" Number="12" Volume="2003" Year="2004" Format="Main Series">
+    <Book Series="Namor" Number="12" Volume="2003" Year="2004">
       <Id>fc508476-a315-4ef6-83a5-769a1cff88e2</Id>
     </Book>
-    <Book Series="The New Invaders" Number="1" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="The New Invaders" Number="1" Volume="2004" Year="2004">
       <Id>90264c54-d33b-41d5-bc7d-b8f6704e4798</Id>
     </Book>
-    <Book Series="The New Invaders" Number="2" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="The New Invaders" Number="2" Volume="2004" Year="2004">
       <Id>4b6899ca-6548-42a2-ab72-22c80cdc5816</Id>
     </Book>
-    <Book Series="The New Invaders" Number="3" Volume="2004" Year="2004" Format="Main Series">
+    <Book Series="The New Invaders" Number="3" Volume="2004" Year="2004">
       <Id>8684e982-8937-44c4-aab2-0f937e350f04</Id>
     </Book>
-    <Book Series="The New Invaders" Number="4" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="The New Invaders" Number="4" Volume="2004" Year="2005">
       <Id>ade9a0ca-056e-414a-92c6-b13c757fbdfb</Id>
     </Book>
-    <Book Series="The New Invaders" Number="5" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="The New Invaders" Number="5" Volume="2004" Year="2005">
       <Id>13955919-fb12-4544-aa97-fbf742a1cde5</Id>
     </Book>
-    <Book Series="The New Invaders" Number="6" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="The New Invaders" Number="6" Volume="2004" Year="2005">
       <Id>dd391446-a17f-46a1-bf39-c96d83ce4c17</Id>
     </Book>
-    <Book Series="The New Invaders" Number="7" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="The New Invaders" Number="7" Volume="2004" Year="2005">
       <Id>bc8e72a0-d49e-4ff6-a1aa-b706880993d8</Id>
     </Book>
-    <Book Series="The New Invaders" Number="8" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="The New Invaders" Number="8" Volume="2004" Year="2005">
       <Id>3bbd0696-0cc8-40cf-941b-0a1f67fe7337</Id>
     </Book>
-    <Book Series="The New Invaders" Number="9" Volume="2004" Year="2005" Format="Main Series">
+    <Book Series="The New Invaders" Number="9" Volume="2004" Year="2005">
       <Id>a7e337dc-217e-425e-8c8a-f3a5b1b33472</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="1" Volume="2007" Year="2007" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="1" Volume="2007" Year="2007">
       <Id>900805ec-ddd2-4525-8517-604ce9080de7</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="2" Volume="2007" Year="2007" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="2" Volume="2007" Year="2007">
       <Id>373fd426-7d9d-4421-96f1-b6b4d8a177d6</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="3" Volume="2007" Year="2007" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="3" Volume="2007" Year="2007">
       <Id>1fa6aaec-39ce-4d79-a279-19c7f3360f5d</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="4" Volume="2007" Year="2007" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="4" Volume="2007" Year="2007">
       <Id>100c09c5-30dc-470e-8ae3-257bd0cfa006</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="5" Volume="2007" Year="2007" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="5" Volume="2007" Year="2007">
       <Id>46d68c41-e59a-4e0b-8a53-66aed0ae42b7</Id>
     </Book>
-    <Book Series="Sub-Mariner" Number="6" Volume="2007" Year="2008" Format="Main Series">
+    <Book Series="Sub-Mariner" Number="6" Volume="2007" Year="2008">
       <Id>33f1c244-8f28-4cdd-a22a-7df0afdc6b10</Id>
     </Book>
-    <Book Series="New Avengers: Illuminati" Number="1" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="New Avengers: Illuminati" Number="1" Volume="2007" Year="2007">
       <Id>d3d02016-9271-4148-9a99-f4e00d4b1d29</Id>
     </Book>
-    <Book Series="New Avengers: Illuminati" Number="2" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="New Avengers: Illuminati" Number="2" Volume="2007" Year="2007">
       <Id>8effd6ed-5a54-4f8c-b136-b44939b61241</Id>
     </Book>
-    <Book Series="New Avengers: Illuminati" Number="3" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="New Avengers: Illuminati" Number="3" Volume="2007" Year="2007">
       <Id>59690bf6-7dea-4520-ba99-f05eaf1cbcef</Id>
     </Book>
-    <Book Series="New Avengers: Illuminati" Number="4" Volume="2007" Year="2007" Format="Limited Series">
+    <Book Series="New Avengers: Illuminati" Number="4" Volume="2007" Year="2007">
       <Id>5bc79504-bd9b-472e-888d-568e1f9a8919</Id>
     </Book>
-    <Book Series="New Avengers: Illuminati" Number="5" Volume="2007" Year="2008" Format="Limited Series">
+    <Book Series="New Avengers: Illuminati" Number="5" Volume="2007" Year="2008">
       <Id>24b3f352-6666-4219-9094-fb500d08bb0c</Id>
     </Book>
-    <Book Series="Sub-Mariner: The Depths" Number="2" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="Sub-Mariner: The Depths" Number="2" Volume="2008" Year="2008">
       <Id>29c94fc9-cff7-4bb3-8626-af9574c4b413</Id>
     </Book>
-    <Book Series="Sub-Mariner: The Depths" Number="3" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="Sub-Mariner: The Depths" Number="3" Volume="2008" Year="2009">
       <Id>91f10c22-282e-43cf-9492-4350d5622442</Id>
     </Book>
-    <Book Series="Sub-Mariner: The Depths" Number="4" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="Sub-Mariner: The Depths" Number="4" Volume="2008" Year="2009">
       <Id>4eb02fc4-d442-45b2-aedd-cd87a38992cf</Id>
     </Book>
-    <Book Series="Sub-Mariner: The Depths" Number="5" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="Sub-Mariner: The Depths" Number="5" Volume="2008" Year="2009">
       <Id>d8c73063-586d-4aa1-9ed6-3db0b25767ea</Id>
     </Book>
-    <Book Series="Invaders Now!" Number="1" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Invaders Now!" Number="1" Volume="2010" Year="2010">
       <Id>bf8f8e0a-400c-46ed-9abf-ed71ffb4b983</Id>
     </Book>
-    <Book Series="Invaders Now!" Number="2" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Invaders Now!" Number="2" Volume="2010" Year="2010">
       <Id>0afee5e8-c575-4d89-88d6-1fbe2b8cba37</Id>
     </Book>
-    <Book Series="Invaders Now!" Number="3" Volume="2010" Year="2011" Format="Limited Series">
+    <Book Series="Invaders Now!" Number="3" Volume="2010" Year="2011">
       <Id>a6be4676-59a9-47f2-b2d5-83a3b1a09833</Id>
     </Book>
-    <Book Series="Invaders Now!" Number="4" Volume="2010" Year="2011" Format="Limited Series">
+    <Book Series="Invaders Now!" Number="4" Volume="2010" Year="2011">
       <Id>59e7161a-7c0d-4fb9-8d28-6789befe7b60</Id>
     </Book>
-    <Book Series="Invaders Now!" Number="5" Volume="2010" Year="2011" Format="Limited Series">
+    <Book Series="Invaders Now!" Number="5" Volume="2010" Year="2011">
       <Id>33111dba-2796-4bf2-b204-81dbf50da6f8</Id>
     </Book>
-    <Book Series="Namor: The First Mutant" Number="1" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="Namor: The First Mutant" Number="1" Volume="2010" Year="2010">
       <Id>3538ef05-ac93-4096-8255-d0a29e643327</Id>
     </Book>
-    <Book Series="Namor: The First Mutant" Number="2" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="Namor: The First Mutant" Number="2" Volume="2010" Year="2010">
       <Id>335654d4-3d9a-46c3-ad1d-4fe96d7552d8</Id>
     </Book>
-    <Book Series="Namor: The First Mutant" Number="3" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="Namor: The First Mutant" Number="3" Volume="2010" Year="2010">
       <Id>c3ef4b21-9733-4a26-a9d8-9c2f4db9cb59</Id>
     </Book>
-    <Book Series="Namor: The First Mutant" Number="4" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Namor: The First Mutant" Number="4" Volume="2010" Year="2011">
       <Id>6eba1136-8406-421f-bc5e-3f5e1ed624cf</Id>
     </Book>
-    <Book Series="Namor: The First Mutant" Number="5" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Namor: The First Mutant" Number="5" Volume="2010" Year="2011">
       <Id>a4e131f0-ebd5-41ed-885a-e48c85571756</Id>
     </Book>
-    <Book Series="Namor: The First Mutant" Number="6" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Namor: The First Mutant" Number="6" Volume="2010" Year="2011">
       <Id>d731e93d-fe1e-4760-814c-db4b68442fb8</Id>
     </Book>
-    <Book Series="Namor: The First Mutant" Number="7" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Namor: The First Mutant" Number="7" Volume="2010" Year="2011">
       <Id>9ad5b6b8-b994-4651-99da-c1869668e566</Id>
     </Book>
-    <Book Series="Namor: The First Mutant" Number="8" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Namor: The First Mutant" Number="8" Volume="2010" Year="2011">
       <Id>453e497e-8c08-4ab0-aca8-2c02c037b83c</Id>
     </Book>
-    <Book Series="Namor: The First Mutant" Number="9" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Namor: The First Mutant" Number="9" Volume="2010" Year="2011">
       <Id>3c9065e3-62c7-4faf-98d5-3d9e6809d985</Id>
     </Book>
-    <Book Series="Namor: The First Mutant" Number="10" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Namor: The First Mutant" Number="10" Volume="2010" Year="2011">
       <Id>1180342e-d035-4e37-b656-10303d6bc6b7</Id>
     </Book>
-    <Book Series="Namor: The First Mutant" Number="11" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Namor: The First Mutant" Number="11" Volume="2010" Year="2011">
       <Id>3b32dfeb-66db-4f65-bd32-a2c753f08539</Id>
     </Book>
   </Books>

--- a/Marvel/Characters/unsorted/Sub-Mariner/Sub-Mariner 002.cbl
+++ b/Marvel/Characters/unsorted/Sub-Mariner/Sub-Mariner 002.cbl
@@ -1,480 +1,481 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Sub-Mariner 2</Name>
+  <Name>Sub-Mariner 002</Name>
+  <NumIssues>158</NumIssues>
   <Books>
     <Book Series="Prince Namor, the Sub-Mariner" Number="1" Volume="1984" Year="1984">
-      <Id>5cfa736b-d606-4864-935e-86bc521a8e84</Id>
+      <Database Name="cv" Series="3359" Issue="24701" />
     </Book>
     <Book Series="Prince Namor, the Sub-Mariner" Number="2" Volume="1984" Year="1984">
-      <Id>87931bf0-a62b-4d3c-8abe-68c05449e2c2</Id>
+      <Database Name="cv" Series="3359" Issue="24800" />
     </Book>
     <Book Series="Prince Namor, the Sub-Mariner" Number="3" Volume="1984" Year="1984">
-      <Id>c6431692-df26-4718-bf27-b8b5663b37f7</Id>
+      <Database Name="cv" Series="3359" Issue="24901" />
     </Book>
     <Book Series="Prince Namor, the Sub-Mariner" Number="4" Volume="1984" Year="1984">
-      <Id>55c7e4f0-4ce9-476e-a070-ffa1b6dc8430</Id>
+      <Database Name="cv" Series="3359" Issue="25006" />
     </Book>
     <Book Series="Saga of the Sub-Mariner" Number="1" Volume="1988" Year="1988">
-      <Id>094d6be7-2ff6-4373-9a5a-2a7a9ac9a47e</Id>
+      <Database Name="cv" Series="4067" Issue="30317" />
     </Book>
     <Book Series="Saga of the Sub-Mariner" Number="2" Volume="1988" Year="1988">
-      <Id>a5d3967b-433f-4ed2-b412-9e4d4f3e17c3</Id>
+      <Database Name="cv" Series="4067" Issue="30439" />
     </Book>
     <Book Series="Saga of the Sub-Mariner" Number="3" Volume="1988" Year="1989">
-      <Id>52d2cb47-a3e4-4997-b80c-4b9d9e557201</Id>
+      <Database Name="cv" Series="4067" Issue="30787" />
     </Book>
     <Book Series="Saga of the Sub-Mariner" Number="4" Volume="1988" Year="1989">
-      <Id>40e4d422-d3dc-4c2e-b55c-721fa890ea6c</Id>
+      <Database Name="cv" Series="4067" Issue="30897" />
     </Book>
     <Book Series="Saga of the Sub-Mariner" Number="5" Volume="1988" Year="1989">
-      <Id>2f19d5c5-fefa-405f-8de6-e1bd4e7c82e2</Id>
+      <Database Name="cv" Series="4067" Issue="30997" />
     </Book>
     <Book Series="Saga of the Sub-Mariner" Number="6" Volume="1988" Year="1989">
-      <Id>e0206b01-0b0f-453e-b497-ebdabd82d8df</Id>
+      <Database Name="cv" Series="4067" Issue="31109" />
     </Book>
     <Book Series="Saga of the Sub-Mariner" Number="7" Volume="1988" Year="1989">
-      <Id>7c578c92-6462-4c92-b6e5-ae6a52ba2ac5</Id>
+      <Database Name="cv" Series="4067" Issue="31220" />
     </Book>
     <Book Series="Saga of the Sub-Mariner" Number="8" Volume="1988" Year="1989">
-      <Id>b9171696-70ce-42da-b980-ac1beb88da92</Id>
+      <Database Name="cv" Series="4067" Issue="31331" />
     </Book>
     <Book Series="Saga of the Sub-Mariner" Number="9" Volume="1988" Year="1989">
-      <Id>03a742dd-8dea-42c7-8c74-1c48bdcd759f</Id>
+      <Database Name="cv" Series="4067" Issue="31443" />
     </Book>
     <Book Series="Saga of the Sub-Mariner" Number="10" Volume="1988" Year="1989">
-      <Id>e7c6ecc4-63c8-4f9f-afc3-6dd6d6327422</Id>
+      <Database Name="cv" Series="4067" Issue="31548" />
     </Book>
     <Book Series="Saga of the Sub-Mariner" Number="11" Volume="1988" Year="1989">
-      <Id>8b9826cf-38a1-4a44-9538-0659a207d7ee</Id>
+      <Database Name="cv" Series="4067" Issue="31664" />
     </Book>
     <Book Series="Saga of the Sub-Mariner" Number="12" Volume="1988" Year="1989">
-      <Id>ef575a8a-b2f0-42ab-b70e-46ca6f722858</Id>
+      <Database Name="cv" Series="4067" Issue="31775" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="1" Volume="1990" Year="1990">
-      <Id>45d1e2a7-3427-47d6-a01c-54a40d18a528</Id>
+      <Database Name="cv" Series="4406" Issue="32633" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="2" Volume="1990" Year="1990">
-      <Id>ecb4d5aa-e139-4963-b63b-d9fa389afa86</Id>
+      <Database Name="cv" Series="4406" Issue="32730" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="3" Volume="1990" Year="1990">
-      <Id>9ac70c8c-28c9-4236-bb7e-b4fc3bce9f02</Id>
+      <Database Name="cv" Series="4406" Issue="32845" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="4" Volume="1990" Year="1990">
-      <Id>f417a1b9-05ff-4939-98c6-365e4b66dd9b</Id>
+      <Database Name="cv" Series="4406" Issue="32969" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="5" Volume="1990" Year="1990">
-      <Id>6c9ff5cb-5e34-450d-8af4-31fad00fa3c5</Id>
+      <Database Name="cv" Series="4406" Issue="33084" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="6" Volume="1990" Year="1990">
-      <Id>3794a4b0-aaf2-4cb2-b9aa-66992d18f96a</Id>
+      <Database Name="cv" Series="4406" Issue="33200" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="7" Volume="1990" Year="1990">
-      <Id>5138e1d9-b743-44cd-8d12-1a6565b2eb2f</Id>
+      <Database Name="cv" Series="4406" Issue="33322" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="8" Volume="1990" Year="1990">
-      <Id>2442937d-b0de-4fb7-8ad0-975106d3ad73</Id>
+      <Database Name="cv" Series="4406" Issue="33432" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="9" Volume="1990" Year="1990">
-      <Id>c7b0402d-3728-42b7-8bda-ff30cd2846a0</Id>
+      <Database Name="cv" Series="4406" Issue="33539" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="10" Volume="1990" Year="1991">
-      <Id>92b29c20-6f66-4a2a-a5a6-bb9c28705d82</Id>
+      <Database Name="cv" Series="4406" Issue="33783" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="11" Volume="1990" Year="1991">
-      <Id>a01c8839-8610-46c7-bc1f-359cbf1e1383</Id>
+      <Database Name="cv" Series="4406" Issue="33882" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="12" Volume="1990" Year="1991">
-      <Id>94e74eb7-2269-4bed-b7d8-daadd816c698</Id>
+      <Database Name="cv" Series="4406" Issue="33998" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="13" Volume="1990" Year="1991">
-      <Id>d68cf149-9bc0-4249-aebf-983d22cd08e9</Id>
+      <Database Name="cv" Series="4406" Issue="34102" />
     </Book>
     <Book Series="Namor, The Sub-Mariner Annual" Number="1" Volume="1991" Year="1991">
-      <Id>178afa21-5ef4-4ab8-9a8f-d6adaf28c56a</Id>
+      <Database Name="cv" Series="9432" Issue="77411" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="14" Volume="1990" Year="1991">
-      <Id>c94d002d-7342-4879-8f22-bd336bf46d08</Id>
+      <Database Name="cv" Series="4406" Issue="34205" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="15" Volume="1990" Year="1991">
-      <Id>de875283-5629-453d-a5c7-599439c6c29c</Id>
+      <Database Name="cv" Series="4406" Issue="34304" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="16" Volume="1990" Year="1991">
-      <Id>465691db-1646-4df0-b52b-c0a1329fad6d</Id>
+      <Database Name="cv" Series="4406" Issue="34420" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="17" Volume="1990" Year="1991">
-      <Id>d6ac4c13-4ea9-4354-81ac-1a3917f242f0</Id>
+      <Database Name="cv" Series="4406" Issue="34534" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="18" Volume="1990" Year="1991">
-      <Id>2fabbc24-c17c-47c3-b429-1ef0705e362e</Id>
+      <Database Name="cv" Series="4406" Issue="34652" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="19" Volume="1990" Year="1991">
-      <Id>fb567250-9eb1-480e-92ac-04f492c2a5cd</Id>
+      <Database Name="cv" Series="4406" Issue="34769" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="20" Volume="1990" Year="1991">
-      <Id>79c43ddd-7588-4d52-8cbb-7d3bb04195f0</Id>
+      <Database Name="cv" Series="4406" Issue="34884" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="21" Volume="1990" Year="1991">
-      <Id>747bfcd6-03d2-4bd4-9468-e5aa028380de</Id>
+      <Database Name="cv" Series="4406" Issue="35004" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="22" Volume="1990" Year="1992">
-      <Id>5ce95bd7-ae6e-45b5-a61e-3acb3bcb65a7</Id>
+      <Database Name="cv" Series="4406" Issue="35263" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="23" Volume="1990" Year="1992">
-      <Id>3be38db7-08dc-4b3e-ac3e-93cc69074b44</Id>
+      <Database Name="cv" Series="4406" Issue="132716" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="24" Volume="1990" Year="1992">
-      <Id>ee86cd82-689a-4bfb-8f2a-243cf2e191e4</Id>
+      <Database Name="cv" Series="4406" Issue="137546" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="25" Volume="1990" Year="1992">
-      <Id>c02daf57-e6e8-42ce-88e0-cb752874200d</Id>
+      <Database Name="cv" Series="4406" Issue="137547" />
     </Book>
     <Book Series="Namor, The Sub-Mariner Annual" Number="2" Volume="1991" Year="1992">
-      <Id>528c4994-7ac4-4888-be59-a58f5716ae92</Id>
+      <Database Name="cv" Series="9432" Issue="77412" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="26" Volume="1990" Year="1992">
-      <Id>49fdd806-0ac5-4a94-9583-c488acc1b629</Id>
+      <Database Name="cv" Series="4406" Issue="137548" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="27" Volume="1990" Year="1992">
-      <Id>7c8f7fb5-0a76-4ab6-ba90-d5918097e99f</Id>
+      <Database Name="cv" Series="4406" Issue="136125" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="28" Volume="1990" Year="1992">
-      <Id>3b6aa3ec-924c-45da-9aa4-a8ea5b270561</Id>
+      <Database Name="cv" Series="4406" Issue="137549" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="29" Volume="1990" Year="1992">
-      <Id>d7e0ee06-9de2-4368-a414-1bc1e2ddf2d0</Id>
+      <Database Name="cv" Series="4406" Issue="137550" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="30" Volume="1990" Year="1992">
-      <Id>d3da334b-df70-4045-8d6a-39336ff8848e</Id>
+      <Database Name="cv" Series="4406" Issue="137551" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="31" Volume="1990" Year="1992">
-      <Id>48ae9251-72b1-42e7-a07f-0eaf129bf8a7</Id>
+      <Database Name="cv" Series="4406" Issue="73838" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="32" Volume="1990" Year="1992">
-      <Id>ac1849bd-8439-4dd2-a5f9-9ead87426cb5</Id>
+      <Database Name="cv" Series="4406" Issue="73839" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="33" Volume="1990" Year="1992">
-      <Id>b5637e3c-0840-4ba7-b14c-7b6ec54ab06e</Id>
+      <Database Name="cv" Series="4406" Issue="73840" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="34" Volume="1990" Year="1993">
-      <Id>8b2425d2-350d-4662-9e6e-aa401d74abf4</Id>
+      <Database Name="cv" Series="4406" Issue="73841" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="35" Volume="1990" Year="1993">
-      <Id>f7c9bd84-2e8d-4bd7-be19-c611b7683a7d</Id>
+      <Database Name="cv" Series="4406" Issue="73842" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="36" Volume="1990" Year="1993">
-      <Id>423f5b20-ac64-4d06-9f04-c294f41c0858</Id>
+      <Database Name="cv" Series="4406" Issue="73843" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="37" Volume="1990" Year="1993">
-      <Id>e3f56ba3-9011-4308-9033-eec5203ceb6e</Id>
+      <Database Name="cv" Series="4406" Issue="73844" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="38" Volume="1990" Year="1993">
-      <Id>5eb891a3-635b-4a90-a93f-189c0f3f756c</Id>
+      <Database Name="cv" Series="4406" Issue="73845" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="39" Volume="1990" Year="1993">
-      <Id>419b222b-3b97-4133-be82-2a7c00f0e0e4</Id>
+      <Database Name="cv" Series="4406" Issue="73846" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="40" Volume="1990" Year="1993">
-      <Id>262d43da-4068-44fe-ad95-8c6c8fe97290</Id>
+      <Database Name="cv" Series="4406" Issue="73847" />
     </Book>
     <Book Series="Namor, The Sub-Mariner Annual" Number="3" Volume="1991" Year="1993">
-      <Id>9ca2c931-a493-4e86-9907-e68cc74ff6aa</Id>
+      <Database Name="cv" Series="9432" Issue="77413" />
     </Book>
     <Book Series="The Invaders" Number="1" Volume="1993" Year="1993">
-      <Id>4f961c1b-708d-456c-8b85-96ab1b361431</Id>
+      <Database Name="cv" Series="5020" Issue="37228" />
     </Book>
     <Book Series="The Invaders" Number="2" Volume="1993" Year="1993">
-      <Id>32f58e08-8310-442e-82fa-1058a22391c3</Id>
+      <Database Name="cv" Series="5020" Issue="37365" />
     </Book>
     <Book Series="The Invaders" Number="3" Volume="1993" Year="1993">
-      <Id>912342ed-76c7-4dd1-940c-750b72730d2c</Id>
+      <Database Name="cv" Series="5020" Issue="37518" />
     </Book>
     <Book Series="The Invaders" Number="4" Volume="1993" Year="1993">
-      <Id>16939798-be47-407e-bca2-d88fdb7cba7f</Id>
+      <Database Name="cv" Series="5020" Issue="37659" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="41" Volume="1990" Year="1993">
-      <Id>c416bfcc-1a0a-4b2f-bd95-5a34a27d15ae</Id>
+      <Database Name="cv" Series="4406" Issue="111409" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="42" Volume="1990" Year="1993">
-      <Id>e9f24bf9-9123-412b-a16d-f025e1529f6c</Id>
+      <Database Name="cv" Series="4406" Issue="137552" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="43" Volume="1990" Year="1993">
-      <Id>afff7cd8-5a1f-4cb0-8894-f14496ab3c6a</Id>
+      <Database Name="cv" Series="4406" Issue="137553" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="44" Volume="1990" Year="1993">
-      <Id>dde6dda9-153f-41aa-aea0-b0435097362f</Id>
+      <Database Name="cv" Series="4406" Issue="137554" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="45" Volume="1990" Year="1993">
-      <Id>47cd9f74-f212-43d5-a04f-773954a3dc13</Id>
+      <Database Name="cv" Series="4406" Issue="137555" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="46" Volume="1990" Year="1994">
-      <Id>1b527627-1a32-4ff2-8df7-1abeb4f24c96</Id>
+      <Database Name="cv" Series="4406" Issue="66988" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="47" Volume="1990" Year="1994">
-      <Id>e1bf876b-51e5-4b9a-8ada-dde38e8ee66e</Id>
+      <Database Name="cv" Series="4406" Issue="66989" />
     </Book>
     <Book Series="Fantastic Four" Number="385" Volume="1961" Year="1994">
-      <Id>7847c24a-1a4f-4357-b4dd-7ce59adcc379</Id>
+      <Database Name="cv" Series="2045" Issue="136915" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="48" Volume="1990" Year="1994">
-      <Id>0a5f9d3b-5230-4fe5-a45f-1d4a40c82d1c</Id>
+      <Database Name="cv" Series="4406" Issue="66990" />
     </Book>
     <Book Series="Fantastic Four" Number="386" Volume="1961" Year="1994">
-      <Id>5289297e-3389-4e9b-a644-45453ff7750b</Id>
+      <Database Name="cv" Series="2045" Issue="136916" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="49" Volume="1990" Year="1994">
-      <Id>2ac26df0-988c-43b2-9f07-43705bb9bab2</Id>
+      <Database Name="cv" Series="4406" Issue="66991" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="50" Volume="1990" Year="1994">
-      <Id>91aae117-0bc0-4190-90c7-5b9b00b8282e</Id>
+      <Database Name="cv" Series="4406" Issue="107564" />
     </Book>
     <Book Series="Namor, The Sub-Mariner Annual" Number="4" Volume="1991" Year="1994">
-      <Id>a9e7e0c5-e77c-4b23-8ddb-cd2417e3690d</Id>
+      <Database Name="cv" Series="9432" Issue="77414" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="51" Volume="1990" Year="1994">
-      <Id>99f27dc7-b52f-4bed-9d42-ca92d0d382cd</Id>
+      <Database Name="cv" Series="4406" Issue="137556" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="52" Volume="1990" Year="1994">
-      <Id>f7fb30f3-dff9-4c43-9caf-c856c019d569</Id>
+      <Database Name="cv" Series="4406" Issue="137557" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="53" Volume="1990" Year="1994">
-      <Id>df22deca-6825-42e8-a5df-5274d933b477</Id>
+      <Database Name="cv" Series="4406" Issue="137558" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="54" Volume="1990" Year="1994">
-      <Id>bb7ce00c-98b9-4a9e-ba5a-08344786db4d</Id>
+      <Database Name="cv" Series="4406" Issue="137559" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="55" Volume="1990" Year="1994">
-      <Id>888f1272-f3f2-4fc2-a796-7b0468977118</Id>
+      <Database Name="cv" Series="4406" Issue="73858" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="56" Volume="1990" Year="1994">
-      <Id>a0838e83-2796-4ba0-8b03-6affc51aaff2</Id>
+      <Database Name="cv" Series="4406" Issue="137560" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="57" Volume="1990" Year="1994">
-      <Id>bf2baa35-44d9-4b82-b3cc-57772d9fe456</Id>
+      <Database Name="cv" Series="4406" Issue="73859" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="58" Volume="1990" Year="1995">
-      <Id>23222e06-e78c-416c-8434-e239bdb1f916</Id>
+      <Database Name="cv" Series="4406" Issue="73860" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="59" Volume="1990" Year="1995">
-      <Id>08f87e07-d598-4886-83c1-78840eb1a207</Id>
+      <Database Name="cv" Series="4406" Issue="73861" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="60" Volume="1990" Year="1995">
-      <Id>224f1fc7-4856-4b7a-9fc7-0dc404cf0fc3</Id>
+      <Database Name="cv" Series="4406" Issue="73862" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="61" Volume="1990" Year="1995">
-      <Id>b54d659f-402a-433c-b409-b66755207e33</Id>
+      <Database Name="cv" Series="4406" Issue="73863" />
     </Book>
     <Book Series="Namor, the Sub-Mariner" Number="62" Volume="1990" Year="1995">
-      <Id>6876fe15-44de-4b58-99ac-39aa6b9d27d6</Id>
+      <Database Name="cv" Series="4406" Issue="73864" />
     </Book>
     <Book Series="Defenders" Number="1" Volume="2001" Year="2001">
-      <Id>ef4d058e-f964-4332-9e14-bfd0c583399e</Id>
+      <Database Name="cv" Series="6645" Issue="47448" />
     </Book>
     <Book Series="Defenders" Number="2" Volume="2001" Year="2001">
-      <Id>9dca83ec-b3a3-43d6-8016-d5b29f257f90</Id>
+      <Database Name="cv" Series="6645" Issue="47449" />
     </Book>
     <Book Series="Defenders" Number="3" Volume="2001" Year="2001">
-      <Id>04cc5b5a-87fc-4d7d-b4b5-92b7bb986ce8</Id>
+      <Database Name="cv" Series="6645" Issue="53491" />
     </Book>
     <Book Series="Defenders" Number="4" Volume="2001" Year="2001">
-      <Id>2be553af-6122-42c9-ac4d-917e8ccd5a61</Id>
+      <Database Name="cv" Series="6645" Issue="53492" />
     </Book>
     <Book Series="Defenders" Number="5" Volume="2001" Year="2001">
-      <Id>75f167d3-2e79-43be-bebf-a36fe1dc4910</Id>
+      <Database Name="cv" Series="6645" Issue="53493" />
     </Book>
     <Book Series="Defenders" Number="6" Volume="2001" Year="2001">
-      <Id>bb5c15a4-97ea-4a69-8e93-49fe373e9582</Id>
+      <Database Name="cv" Series="6645" Issue="53494" />
     </Book>
     <Book Series="Defenders" Number="7" Volume="2001" Year="2001">
-      <Id>e689f681-eb03-4202-93a9-a92957159c8a</Id>
+      <Database Name="cv" Series="6645" Issue="53495" />
     </Book>
     <Book Series="Defenders" Number="8" Volume="2001" Year="2001">
-      <Id>24b2d436-2a5d-4c30-8d49-b664c617b568</Id>
+      <Database Name="cv" Series="6645" Issue="53496" />
     </Book>
     <Book Series="Defenders" Number="9" Volume="2001" Year="2001">
-      <Id>bfdd6a82-2ebb-4d61-8e46-e807efc8f20c</Id>
+      <Database Name="cv" Series="6645" Issue="53497" />
     </Book>
     <Book Series="Defenders" Number="10" Volume="2001" Year="2001">
-      <Id>9500df92-e09c-4c14-acc9-d8bf614b8d97</Id>
+      <Database Name="cv" Series="6645" Issue="53498" />
     </Book>
     <Book Series="Defenders" Number="11" Volume="2001" Year="2002">
-      <Id>256fe514-1d3a-4a00-8e1a-381c0b6ee8d7</Id>
+      <Database Name="cv" Series="6645" Issue="63775" />
     </Book>
     <Book Series="Defenders" Number="12" Volume="2001" Year="2002">
-      <Id>88a8226e-fa7c-4949-b380-76f2b72e086a</Id>
+      <Database Name="cv" Series="6645" Issue="63776" />
     </Book>
     <Book Series="The Order" Number="1" Volume="2002" Year="2002">
-      <Id>ee9f9db9-0e76-4f5a-af25-b1f5c9343c85</Id>
+      <Database Name="cv" Series="9496" Issue="78208" />
     </Book>
     <Book Series="The Order" Number="2" Volume="2002" Year="2002">
-      <Id>ac5eb691-f5d3-4975-93f5-cbc9430cc61c</Id>
+      <Database Name="cv" Series="9496" Issue="78209" />
     </Book>
     <Book Series="The Order" Number="3" Volume="2002" Year="2002">
-      <Id>99e63d04-ac07-4baf-b6c0-d6ea52b1dbc7</Id>
+      <Database Name="cv" Series="9496" Issue="78210" />
     </Book>
     <Book Series="The Order" Number="4" Volume="2002" Year="2002">
-      <Id>cebec8ea-97dc-4732-9ba9-160c6d105bc8</Id>
+      <Database Name="cv" Series="9496" Issue="78211" />
     </Book>
     <Book Series="The Order" Number="5" Volume="2002" Year="2002">
-      <Id>b34cc60f-bd21-4222-8ba1-ad64619140e2</Id>
+      <Database Name="cv" Series="9496" Issue="78212" />
     </Book>
     <Book Series="The Order" Number="6" Volume="2002" Year="2002">
-      <Id>f36cc04f-dde3-4104-bd26-9fc02a2fbf80</Id>
+      <Database Name="cv" Series="9496" Issue="78213" />
     </Book>
     <Book Series="Namor" Number="1" Volume="2003" Year="2003">
-      <Id>c6972cca-4c91-4be3-8544-84fc7124d537</Id>
+      <Database Name="cv" Series="22134" Issue="133166" />
     </Book>
     <Book Series="Namor" Number="2" Volume="2003" Year="2003">
-      <Id>1f7c5250-f629-474a-b0ec-99c8a56ac2f4</Id>
+      <Database Name="cv" Series="22134" Issue="133170" />
     </Book>
     <Book Series="Namor" Number="3" Volume="2003" Year="2003">
-      <Id>08ab507a-9779-42b2-9fae-e28e79f84b37</Id>
+      <Database Name="cv" Series="22134" Issue="133171" />
     </Book>
     <Book Series="Namor" Number="4" Volume="2003" Year="2003">
-      <Id>3ec2e04f-8dbe-479c-a946-10293124e8b2</Id>
+      <Database Name="cv" Series="22134" Issue="133173" />
     </Book>
     <Book Series="Namor" Number="5" Volume="2003" Year="2003">
-      <Id>2e993e66-e853-48cd-b666-80fc8f5f765f</Id>
+      <Database Name="cv" Series="22134" Issue="133174" />
     </Book>
     <Book Series="Namor" Number="6" Volume="2003" Year="2003">
-      <Id>0f5f5651-b6a4-45c5-a87a-7434b700a67d</Id>
+      <Database Name="cv" Series="22134" Issue="133175" />
     </Book>
     <Book Series="Namor" Number="7" Volume="2003" Year="2003">
-      <Id>7abea74f-c48b-41eb-909d-f9172ff44508</Id>
+      <Database Name="cv" Series="22134" Issue="133176" />
     </Book>
     <Book Series="Namor" Number="8" Volume="2003" Year="2003">
-      <Id>666956e7-e5c5-4868-99a1-9de62b6a6e8c</Id>
+      <Database Name="cv" Series="22134" Issue="133168" />
     </Book>
     <Book Series="Namor" Number="9" Volume="2003" Year="2004">
-      <Id>c9fe8419-ded4-47a8-a9d2-99b21f8facfb</Id>
+      <Database Name="cv" Series="22134" Issue="133178" />
     </Book>
     <Book Series="Namor" Number="10" Volume="2003" Year="2004">
-      <Id>f7529a23-2460-4c5d-9852-564533232b9d</Id>
+      <Database Name="cv" Series="22134" Issue="133179" />
     </Book>
     <Book Series="Namor" Number="11" Volume="2003" Year="2004">
-      <Id>ca968de1-5908-4e4b-89d1-25619d3237a0</Id>
+      <Database Name="cv" Series="22134" Issue="133180" />
     </Book>
     <Book Series="Namor" Number="12" Volume="2003" Year="2004">
-      <Id>fc508476-a315-4ef6-83a5-769a1cff88e2</Id>
+      <Database Name="cv" Series="22134" Issue="133181" />
     </Book>
     <Book Series="The New Invaders" Number="1" Volume="2004" Year="2004">
-      <Id>90264c54-d33b-41d5-bc7d-b8f6704e4798</Id>
+      <Database Name="cv" Series="11309" Issue="99285" />
     </Book>
     <Book Series="The New Invaders" Number="2" Volume="2004" Year="2004">
-      <Id>4b6899ca-6548-42a2-ab72-22c80cdc5816</Id>
+      <Database Name="cv" Series="11309" Issue="99286" />
     </Book>
     <Book Series="The New Invaders" Number="3" Volume="2004" Year="2004">
-      <Id>8684e982-8937-44c4-aab2-0f937e350f04</Id>
+      <Database Name="cv" Series="11309" Issue="99287" />
     </Book>
     <Book Series="The New Invaders" Number="4" Volume="2004" Year="2005">
-      <Id>ade9a0ca-056e-414a-92c6-b13c757fbdfb</Id>
+      <Database Name="cv" Series="11309" Issue="99288" />
     </Book>
     <Book Series="The New Invaders" Number="5" Volume="2004" Year="2005">
-      <Id>13955919-fb12-4544-aa97-fbf742a1cde5</Id>
+      <Database Name="cv" Series="11309" Issue="99289" />
     </Book>
     <Book Series="The New Invaders" Number="6" Volume="2004" Year="2005">
-      <Id>dd391446-a17f-46a1-bf39-c96d83ce4c17</Id>
+      <Database Name="cv" Series="11309" Issue="99290" />
     </Book>
     <Book Series="The New Invaders" Number="7" Volume="2004" Year="2005">
-      <Id>bc8e72a0-d49e-4ff6-a1aa-b706880993d8</Id>
+      <Database Name="cv" Series="11309" Issue="127737" />
     </Book>
     <Book Series="The New Invaders" Number="8" Volume="2004" Year="2005">
-      <Id>3bbd0696-0cc8-40cf-941b-0a1f67fe7337</Id>
+      <Database Name="cv" Series="11309" Issue="127750" />
     </Book>
     <Book Series="The New Invaders" Number="9" Volume="2004" Year="2005">
-      <Id>a7e337dc-217e-425e-8c8a-f3a5b1b33472</Id>
+      <Database Name="cv" Series="11309" Issue="127751" />
     </Book>
     <Book Series="Sub-Mariner" Number="1" Volume="2007" Year="2007">
-      <Id>900805ec-ddd2-4525-8517-604ce9080de7</Id>
+      <Database Name="cv" Series="18687" Issue="110438" />
     </Book>
     <Book Series="Sub-Mariner" Number="2" Volume="2007" Year="2007">
-      <Id>373fd426-7d9d-4421-96f1-b6b4d8a177d6</Id>
+      <Database Name="cv" Series="18687" Issue="111491" />
     </Book>
     <Book Series="Sub-Mariner" Number="3" Volume="2007" Year="2007">
-      <Id>1fa6aaec-39ce-4d79-a279-19c7f3360f5d</Id>
+      <Database Name="cv" Series="18687" Issue="113542" />
     </Book>
     <Book Series="Sub-Mariner" Number="4" Volume="2007" Year="2007">
-      <Id>100c09c5-30dc-470e-8ae3-257bd0cfa006</Id>
+      <Database Name="cv" Series="18687" Issue="114991" />
     </Book>
     <Book Series="Sub-Mariner" Number="5" Volume="2007" Year="2007">
-      <Id>46d68c41-e59a-4e0b-8a53-66aed0ae42b7</Id>
+      <Database Name="cv" Series="18687" Issue="116377" />
     </Book>
     <Book Series="Sub-Mariner" Number="6" Volume="2007" Year="2008">
-      <Id>33f1c244-8f28-4cdd-a22a-7df0afdc6b10</Id>
+      <Database Name="cv" Series="18687" Issue="118644" />
     </Book>
     <Book Series="New Avengers: Illuminati" Number="1" Volume="2007" Year="2007">
-      <Id>d3d02016-9271-4148-9a99-f4e00d4b1d29</Id>
+      <Database Name="cv" Series="18113" Issue="106129" />
     </Book>
     <Book Series="New Avengers: Illuminati" Number="2" Volume="2007" Year="2007">
-      <Id>8effd6ed-5a54-4f8c-b136-b44939b61241</Id>
+      <Database Name="cv" Series="18113" Issue="106630" />
     </Book>
     <Book Series="New Avengers: Illuminati" Number="3" Volume="2007" Year="2007">
-      <Id>59690bf6-7dea-4520-ba99-f05eaf1cbcef</Id>
+      <Database Name="cv" Series="18113" Issue="110053" />
     </Book>
     <Book Series="New Avengers: Illuminati" Number="4" Volume="2007" Year="2007">
-      <Id>5bc79504-bd9b-472e-888d-568e1f9a8919</Id>
+      <Database Name="cv" Series="18113" Issue="112408" />
     </Book>
     <Book Series="New Avengers: Illuminati" Number="5" Volume="2007" Year="2008">
-      <Id>24b3f352-6666-4219-9094-fb500d08bb0c</Id>
+      <Database Name="cv" Series="18113" Issue="116954" />
     </Book>
     <Book Series="Sub-Mariner: The Depths" Number="2" Volume="2008" Year="2008">
-      <Id>29c94fc9-cff7-4bb3-8626-af9574c4b413</Id>
+      <Database Name="cv" Series="22858" Issue="139679" />
     </Book>
     <Book Series="Sub-Mariner: The Depths" Number="3" Volume="2008" Year="2009">
-      <Id>91f10c22-282e-43cf-9492-4350d5622442</Id>
+      <Database Name="cv" Series="22858" Issue="141618" />
     </Book>
     <Book Series="Sub-Mariner: The Depths" Number="4" Volume="2008" Year="2009">
-      <Id>4eb02fc4-d442-45b2-aedd-cd87a38992cf</Id>
+      <Database Name="cv" Series="22858" Issue="149840" />
     </Book>
     <Book Series="Sub-Mariner: The Depths" Number="5" Volume="2008" Year="2009">
-      <Id>d8c73063-586d-4aa1-9ed6-3db0b25767ea</Id>
+      <Database Name="cv" Series="22858" Issue="153187" />
     </Book>
     <Book Series="Invaders Now!" Number="1" Volume="2010" Year="2010">
-      <Id>bf8f8e0a-400c-46ed-9abf-ed71ffb4b983</Id>
+      <Database Name="cv" Series="35423" Issue="233803" />
     </Book>
     <Book Series="Invaders Now!" Number="2" Volume="2010" Year="2010">
-      <Id>0afee5e8-c575-4d89-88d6-1fbe2b8cba37</Id>
+      <Database Name="cv" Series="35423" Issue="238552" />
     </Book>
     <Book Series="Invaders Now!" Number="3" Volume="2010" Year="2011">
-      <Id>a6be4676-59a9-47f2-b2d5-83a3b1a09833</Id>
+      <Database Name="cv" Series="35423" Issue="243895" />
     </Book>
     <Book Series="Invaders Now!" Number="4" Volume="2010" Year="2011">
-      <Id>59e7161a-7c0d-4fb9-8d28-6789befe7b60</Id>
+      <Database Name="cv" Series="35423" Issue="248523" />
     </Book>
     <Book Series="Invaders Now!" Number="5" Volume="2010" Year="2011">
-      <Id>33111dba-2796-4bf2-b204-81dbf50da6f8</Id>
+      <Database Name="cv" Series="35423" Issue="261349" />
     </Book>
     <Book Series="Namor: The First Mutant" Number="1" Volume="2010" Year="2010">
-      <Id>3538ef05-ac93-4096-8255-d0a29e643327</Id>
+      <Database Name="cv" Series="34839" Issue="231613" />
     </Book>
     <Book Series="Namor: The First Mutant" Number="2" Volume="2010" Year="2010">
-      <Id>335654d4-3d9a-46c3-ad1d-4fe96d7552d8</Id>
+      <Database Name="cv" Series="34839" Issue="236298" />
     </Book>
     <Book Series="Namor: The First Mutant" Number="3" Volume="2010" Year="2010">
-      <Id>c3ef4b21-9733-4a26-a9d8-9c2f4db9cb59</Id>
+      <Database Name="cv" Series="34839" Issue="240600" />
     </Book>
     <Book Series="Namor: The First Mutant" Number="4" Volume="2010" Year="2011">
-      <Id>6eba1136-8406-421f-bc5e-3f5e1ed624cf</Id>
+      <Database Name="cv" Series="34839" Issue="246427" />
     </Book>
     <Book Series="Namor: The First Mutant" Number="5" Volume="2010" Year="2011">
-      <Id>a4e131f0-ebd5-41ed-885a-e48c85571756</Id>
+      <Database Name="cv" Series="34839" Issue="250623" />
     </Book>
     <Book Series="Namor: The First Mutant" Number="6" Volume="2010" Year="2011">
-      <Id>d731e93d-fe1e-4760-814c-db4b68442fb8</Id>
+      <Database Name="cv" Series="34839" Issue="259138" />
     </Book>
     <Book Series="Namor: The First Mutant" Number="7" Volume="2010" Year="2011">
-      <Id>9ad5b6b8-b994-4651-99da-c1869668e566</Id>
+      <Database Name="cv" Series="34839" Issue="263746" />
     </Book>
     <Book Series="Namor: The First Mutant" Number="8" Volume="2010" Year="2011">
-      <Id>453e497e-8c08-4ab0-aca8-2c02c037b83c</Id>
+      <Database Name="cv" Series="34839" Issue="266490" />
     </Book>
     <Book Series="Namor: The First Mutant" Number="9" Volume="2010" Year="2011">
-      <Id>3c9065e3-62c7-4faf-98d5-3d9e6809d985</Id>
+      <Database Name="cv" Series="34839" Issue="268983" />
     </Book>
     <Book Series="Namor: The First Mutant" Number="10" Volume="2010" Year="2011">
-      <Id>1180342e-d035-4e37-b656-10303d6bc6b7</Id>
+      <Database Name="cv" Series="34839" Issue="271431" />
     </Book>
     <Book Series="Namor: The First Mutant" Number="11" Volume="2010" Year="2011">
-      <Id>3b32dfeb-66db-4f65-bd32-a2c753f08539</Id>
+      <Database Name="cv" Series="34839" Issue="275808" />
     </Book>
   </Books>
   <Matchers />


### PR DESCRIPTION
- In the Captain Marvel list, Issue 24 and Issue 25 were not published in the main series but printed under Marvel Super-Heroes.
- Changes to Amazing Spider-Man issue numbers are down to legacy numbering differences
- The Micronauts file had a lot of issue duplication, hence the big diff