### PR TITLE
CV ID Mapping - DC/Characters/unsorted/B

### DIFF
--- a/DC/Characters/unsorted/Batgirl/Batgirl 001 (Pre-Crisis).cbl
+++ b/DC/Characters/unsorted/Batgirl/Batgirl 001 (Pre-Crisis).cbl
@@ -2,184 +2,184 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Batgirl 1 (Pre-Crisis)</Name>
   <Books>
-    <Book Series="Batgirl Barbara Gordon Archives" Number="1" Volume="1" Format="TPB">
+    <Book Series="Batgirl Barbara Gordon Archives" Number="1" Volume="1">
       <Id>ce547c26-2ef5-4fab-b5c2-9397431d5359</Id>
     </Book>
-    <Book Series="Batgirl Barbara Gordon Archives" Number="2" Volume="2" Format="TPB">
+    <Book Series="Batgirl Barbara Gordon Archives" Number="2" Volume="2">
       <Id>91f8aa06-9cd4-4890-8b86-f6a1966ebc60</Id>
     </Book>
-    <Book Series="The Batman Family" Number="1" Volume="1975" Year="1975" Format="Main Series">
+    <Book Series="The Batman Family" Number="1" Volume="1975" Year="1975">
       <Id>7a16fc22-0829-4ac4-a577-fa8a76dc9abc</Id>
     </Book>
-    <Book Series="The Batman Family" Number="2" Volume="1975" Year="1975" Format="Main Series">
+    <Book Series="The Batman Family" Number="2" Volume="1975" Year="1975">
       <Id>08f86f6b-fcf9-4743-adc4-5cf47d08aac9</Id>
     </Book>
-    <Book Series="The Batman Family" Number="3" Volume="1975" Year="1976" Format="Main Series">
+    <Book Series="The Batman Family" Number="3" Volume="1975" Year="1976">
       <Id>a54c600b-3b03-451e-aa4f-59e10dfb360d</Id>
     </Book>
-    <Book Series="The Batman Family" Number="4" Volume="1975" Year="1976" Format="Main Series">
+    <Book Series="The Batman Family" Number="4" Volume="1975" Year="1976">
       <Id>82e93dd9-e06e-4bcf-a0ff-90cbd66e2e32</Id>
     </Book>
-    <Book Series="The Batman Family" Number="5" Volume="1975" Year="1976" Format="Main Series">
+    <Book Series="The Batman Family" Number="5" Volume="1975" Year="1976">
       <Id>189a8702-7e06-4c5e-b996-33a4d32c223c</Id>
     </Book>
-    <Book Series="The Batman Family" Number="6" Volume="1975" Year="1976" Format="Main Series">
+    <Book Series="The Batman Family" Number="6" Volume="1975" Year="1976">
       <Id>37926a22-5c61-4694-875f-dad149c9ea5d</Id>
     </Book>
-    <Book Series="The Batman Family" Number="7" Volume="1975" Year="1976" Format="Main Series">
+    <Book Series="The Batman Family" Number="7" Volume="1975" Year="1976">
       <Id>bb6188b8-e008-46f3-8c90-d7239ef6ff50</Id>
     </Book>
-    <Book Series="The Batman Family" Number="8" Volume="1975" Year="1976" Format="Main Series">
+    <Book Series="The Batman Family" Number="8" Volume="1975" Year="1976">
       <Id>ada42a40-44f3-4e8d-b57c-81d6d2cbf0a1</Id>
     </Book>
-    <Book Series="The Batman Family" Number="9" Volume="1975" Year="1977" Format="Main Series">
+    <Book Series="The Batman Family" Number="9" Volume="1975" Year="1977">
       <Id>c2c1e279-b895-4c12-b4ed-d4cdfda838dd</Id>
     </Book>
-    <Book Series="The Batman Family" Number="10" Volume="1975" Year="1977" Format="Main Series">
+    <Book Series="The Batman Family" Number="10" Volume="1975" Year="1977">
       <Id>95f9745e-fdf1-4733-a114-937fdd3c0d2a</Id>
     </Book>
-    <Book Series="The Batman Family" Number="11" Volume="1975" Year="1977" Format="Main Series">
+    <Book Series="The Batman Family" Number="11" Volume="1975" Year="1977">
       <Id>51a55dea-bfc8-443d-aa69-037bc5727c0b</Id>
     </Book>
-    <Book Series="The Batman Family" Number="12" Volume="1975" Year="1977" Format="Main Series">
+    <Book Series="The Batman Family" Number="12" Volume="1975" Year="1977">
       <Id>0f930027-c91d-405a-b3c9-077e5e7bae61</Id>
     </Book>
-    <Book Series="The Batman Family" Number="13" Volume="1975" Year="1977" Format="Main Series">
+    <Book Series="The Batman Family" Number="13" Volume="1975" Year="1977">
       <Id>1f070f94-cfc4-4989-80b2-16b432cf409d</Id>
     </Book>
-    <Book Series="The Batman Family" Number="14" Volume="1975" Year="1977" Format="Main Series">
+    <Book Series="The Batman Family" Number="14" Volume="1975" Year="1977">
       <Id>d33c94cd-169f-4e4e-8105-7765947d0b3d</Id>
     </Book>
-    <Book Series="The Batman Family" Number="15" Volume="1975" Year="1978" Format="Main Series">
+    <Book Series="The Batman Family" Number="15" Volume="1975" Year="1978">
       <Id>71658e5e-d4de-46bc-908e-cd822a5c250f</Id>
     </Book>
-    <Book Series="The Batman Family" Number="16" Volume="1975" Year="1978" Format="Main Series">
+    <Book Series="The Batman Family" Number="16" Volume="1975" Year="1978">
       <Id>49259879-f5c1-484e-9fa0-070dbaea1cf7</Id>
     </Book>
-    <Book Series="The Batman Family" Number="17" Volume="1975" Year="1978" Format="Main Series">
+    <Book Series="The Batman Family" Number="17" Volume="1975" Year="1978">
       <Id>346e00a6-f39f-4130-8bf2-39fd4246f00f</Id>
     </Book>
-    <Book Series="The Batman Family" Number="18" Volume="1975" Year="1978" Format="Main Series">
+    <Book Series="The Batman Family" Number="18" Volume="1975" Year="1978">
       <Id>81531dc8-d4fa-4835-98a3-2025d3384df1</Id>
     </Book>
-    <Book Series="The Batman Family" Number="19" Volume="1975" Year="1978" Format="Main Series">
+    <Book Series="The Batman Family" Number="19" Volume="1975" Year="1978">
       <Id>b82052d1-2b9b-4245-9a84-b229eeb8bb72</Id>
     </Book>
-    <Book Series="The Batman Family" Number="20" Volume="1975" Year="1978" Format="Main Series">
+    <Book Series="The Batman Family" Number="20" Volume="1975" Year="1978">
       <Id>9ad7fd0e-baf8-4e9b-bbc8-617456700db2</Id>
     </Book>
-    <Book Series="Detective Comics" Number="481" Volume="1937" Year="1979" Format="Main Series">
+    <Book Series="Detective Comics" Number="481" Volume="1937" Year="1979">
       <Id>4c7b73f5-cfbb-4f56-a63f-e973e9b50757</Id>
     </Book>
-    <Book Series="Detective Comics" Number="482" Volume="1937" Year="1979" Format="Main Series">
+    <Book Series="Detective Comics" Number="482" Volume="1937" Year="1979">
       <Id>8b532e1f-9bd5-422f-ba7e-4c8c8fa5ad2b</Id>
     </Book>
-    <Book Series="Detective Comics" Number="483" Volume="1937" Year="1979" Format="Main Series">
+    <Book Series="Detective Comics" Number="483" Volume="1937" Year="1979">
       <Id>6f6e9394-3873-41e9-b5b2-555e359b150f</Id>
     </Book>
-    <Book Series="Batman" Number="311" Volume="1940" Year="1979" Format="Main Series">
+    <Book Series="Batman" Number="311" Volume="1940" Year="1979">
       <Id>ac8d5661-bf5d-4446-b336-dec187653c44</Id>
     </Book>
-    <Book Series="Detective Comics" Number="484" Volume="1937" Year="1979" Format="Main Series">
+    <Book Series="Detective Comics" Number="484" Volume="1937" Year="1979">
       <Id>22119ec6-a284-49ed-9797-89590fe72306</Id>
     </Book>
-    <Book Series="Detective Comics" Number="485" Volume="1937" Year="1979" Format="Main Series">
+    <Book Series="Detective Comics" Number="485" Volume="1937" Year="1979">
       <Id>e35af864-1156-4513-977a-67d548cd0fda</Id>
     </Book>
-    <Book Series="Detective Comics" Number="486" Volume="1937" Year="1979" Format="Main Series">
+    <Book Series="Detective Comics" Number="486" Volume="1937" Year="1979">
       <Id>a5541cd3-dd62-4570-8692-766ca654a579</Id>
     </Book>
-    <Book Series="Detective Comics" Number="487" Volume="1937" Year="1979" Format="Main Series">
+    <Book Series="Detective Comics" Number="487" Volume="1937" Year="1979">
       <Id>c885689a-be54-4e0e-958a-a795bc3ed651</Id>
     </Book>
-    <Book Series="Detective Comics" Number="488" Volume="1937" Year="1980" Format="Main Series">
+    <Book Series="Detective Comics" Number="488" Volume="1937" Year="1980">
       <Id>7dea85a9-9598-44e0-9582-680650c40604</Id>
     </Book>
-    <Book Series="DC Comics Presents" Number="19" Volume="1978" Year="1980" Format="Main Series">
+    <Book Series="DC Comics Presents" Number="19" Volume="1978" Year="1980">
       <Id>80018d72-3003-4293-ba86-4400fe5b6b1c</Id>
     </Book>
-    <Book Series="Detective Comics" Number="489" Volume="1937" Year="1980" Format="Main Series">
+    <Book Series="Detective Comics" Number="489" Volume="1937" Year="1980">
       <Id>c70a743e-7b2b-4e1b-8d5e-76200fdf46bb</Id>
     </Book>
-    <Book Series="Detective Comics" Number="490" Volume="1937" Year="1980" Format="Main Series">
+    <Book Series="Detective Comics" Number="490" Volume="1937" Year="1980">
       <Id>08d6fdf0-19bd-4696-9d31-d21f65a86673</Id>
     </Book>
-    <Book Series="Detective Comics" Number="491" Volume="1937" Year="1980" Format="Main Series">
+    <Book Series="Detective Comics" Number="491" Volume="1937" Year="1980">
       <Id>53180c9a-5a7b-4974-b961-c5b38c16f882</Id>
     </Book>
-    <Book Series="Detective Comics" Number="492" Volume="1937" Year="1980" Format="Main Series">
+    <Book Series="Detective Comics" Number="492" Volume="1937" Year="1980">
       <Id>c07f4b06-d26a-4a08-9506-51eac6d5d664</Id>
     </Book>
-    <Book Series="Detective Comics" Number="493" Volume="1937" Year="1980" Format="Main Series">
+    <Book Series="Detective Comics" Number="493" Volume="1937" Year="1980">
       <Id>b19474ba-dd84-4f9a-82b3-1cbbadf31783</Id>
     </Book>
-    <Book Series="Detective Comics" Number="494" Volume="1937" Year="1980" Format="Main Series">
+    <Book Series="Detective Comics" Number="494" Volume="1937" Year="1980">
       <Id>a89a8570-d2a9-4564-88ac-cec751d82b17</Id>
     </Book>
-    <Book Series="Detective Comics" Number="495" Volume="1937" Year="1980" Format="Main Series">
+    <Book Series="Detective Comics" Number="495" Volume="1937" Year="1980">
       <Id>4556a363-c767-46a1-bd8f-0f1434e98bfd</Id>
     </Book>
-    <Book Series="Detective Comics" Number="496" Volume="1937" Year="1980" Format="Main Series">
+    <Book Series="Detective Comics" Number="496" Volume="1937" Year="1980">
       <Id>5a0ec1d0-7336-4c7f-a258-486723ed395b</Id>
     </Book>
-    <Book Series="Detective Comics" Number="497" Volume="1937" Year="1980" Format="Main Series">
+    <Book Series="Detective Comics" Number="497" Volume="1937" Year="1980">
       <Id>68d58925-6d58-47c7-ac6c-c86c24bb5528</Id>
     </Book>
-    <Book Series="Detective Comics" Number="498" Volume="1937" Year="1981" Format="Main Series">
+    <Book Series="Detective Comics" Number="498" Volume="1937" Year="1981">
       <Id>47cb3933-f0c0-4032-86d2-9f9a7b297c3d</Id>
     </Book>
-    <Book Series="Detective Comics" Number="499" Volume="1937" Year="1981" Format="Main Series">
+    <Book Series="Detective Comics" Number="499" Volume="1937" Year="1981">
       <Id>cce44e8d-aa50-461e-bb4a-dc098f16e3de</Id>
     </Book>
-    <Book Series="Detective Comics" Number="501" Volume="1937" Year="1981" Format="Main Series">
+    <Book Series="Detective Comics" Number="501" Volume="1937" Year="1981">
       <Id>97e20a59-964a-4970-b805-31b88880710e</Id>
     </Book>
-    <Book Series="Detective Comics" Number="502" Volume="1937" Year="1981" Format="Main Series">
+    <Book Series="Detective Comics" Number="502" Volume="1937" Year="1981">
       <Id>5544b12d-6130-4aaa-aa61-f0128a59f8fd</Id>
     </Book>
-    <Book Series="Detective Comics" Number="503" Volume="1937" Year="1981" Format="Main Series">
+    <Book Series="Detective Comics" Number="503" Volume="1937" Year="1981">
       <Id>ae3aba3f-5169-4a68-a821-e30ec40abeff</Id>
     </Book>
-    <Book Series="Detective Comics" Number="505" Volume="1937" Year="1981" Format="Main Series">
+    <Book Series="Detective Comics" Number="505" Volume="1937" Year="1981">
       <Id>1cd84eb9-c928-4d90-a481-07839e6f1e2d</Id>
     </Book>
-    <Book Series="Detective Comics" Number="506" Volume="1937" Year="1981" Format="Main Series">
+    <Book Series="Detective Comics" Number="506" Volume="1937" Year="1981">
       <Id>7f0fd158-9585-4478-b0ef-1068b6f476ee</Id>
     </Book>
-    <Book Series="Detective Comics" Number="508" Volume="1937" Year="1981" Format="Main Series">
+    <Book Series="Detective Comics" Number="508" Volume="1937" Year="1981">
       <Id>3789754d-b363-4e86-a9e1-bda293d654e4</Id>
     </Book>
-    <Book Series="Detective Comics" Number="509" Volume="1937" Year="1981" Format="Main Series">
+    <Book Series="Detective Comics" Number="509" Volume="1937" Year="1981">
       <Id>1cea95de-a80b-40c3-8ae7-0f3aae5f901a</Id>
     </Book>
-    <Book Series="Detective Comics" Number="510" Volume="1937" Year="1982" Format="Main Series">
+    <Book Series="Detective Comics" Number="510" Volume="1937" Year="1982">
       <Id>3a69c19f-73ad-4c81-843d-670ed872822f</Id>
     </Book>
-    <Book Series="Detective Comics" Number="512" Volume="1937" Year="1982" Format="Main Series">
+    <Book Series="Detective Comics" Number="512" Volume="1937" Year="1982">
       <Id>747cf7a8-4b97-4c8e-8450-708e46f267e9</Id>
     </Book>
-    <Book Series="Detective Comics" Number="513" Volume="1937" Year="1982" Format="Main Series">
+    <Book Series="Detective Comics" Number="513" Volume="1937" Year="1982">
       <Id>9cc62b30-a5f0-449e-9f43-76c1c2d88317</Id>
     </Book>
-    <Book Series="Detective Comics" Number="514" Volume="1937" Year="1982" Format="Main Series">
+    <Book Series="Detective Comics" Number="514" Volume="1937" Year="1982">
       <Id>16916f17-6886-4f29-b6a6-b72baa961a0f</Id>
     </Book>
-    <Book Series="Detective Comics" Number="515" Volume="1937" Year="1982" Format="Main Series">
+    <Book Series="Detective Comics" Number="515" Volume="1937" Year="1982">
       <Id>1e7f70f8-8339-4372-8464-d6dcae10881d</Id>
     </Book>
-    <Book Series="Detective Comics" Number="516" Volume="1937" Year="1982" Format="Main Series">
+    <Book Series="Detective Comics" Number="516" Volume="1937" Year="1982">
       <Id>f47dcb04-e119-4311-8da3-ebd3b38c8595</Id>
     </Book>
-    <Book Series="Detective Comics" Number="517" Volume="1937" Year="1982" Format="Main Series">
+    <Book Series="Detective Comics" Number="517" Volume="1937" Year="1982">
       <Id>6c7e82d7-e05a-45a3-a0bb-90c1f6bb5875</Id>
     </Book>
-    <Book Series="Detective Comics" Number="518" Volume="1937" Year="1982" Format="Main Series">
+    <Book Series="Detective Comics" Number="518" Volume="1937" Year="1982">
       <Id>70ccbfe6-28f1-4376-ae1b-d2e39bb8329b</Id>
     </Book>
-    <Book Series="Detective Comics" Number="519" Volume="1937" Year="1982" Format="Main Series">
+    <Book Series="Detective Comics" Number="519" Volume="1937" Year="1982">
       <Id>0c9522ba-4226-4b91-9770-94ad3ec4ac23</Id>
     </Book>
-    <Book Series="Detective Comics" Number="526" Volume="1937" Year="1983" Format="Main Series">
+    <Book Series="Detective Comics" Number="526" Volume="1937" Year="1983">
       <Id>1b109368-adc4-4390-a450-f5086e6f0b49</Id>
     </Book>
   </Books>

--- a/DC/Characters/unsorted/Batgirl/Batgirl 001 (Pre-Crisis).cbl
+++ b/DC/Characters/unsorted/Batgirl/Batgirl 001 (Pre-Crisis).cbl
@@ -1,186 +1,187 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Batgirl 1 (Pre-Crisis)</Name>
+  <Name>Batgirl 001 (Pre-Crisis)</Name>
+  <NumIssues>60</NumIssues>
   <Books>
-    <Book Series="Batgirl Barbara Gordon Archives" Number="1" Volume="1">
-      <Id>ce547c26-2ef5-4fab-b5c2-9397431d5359</Id>
+    <Book Series="Batgirl: The Bronze Age Omnibus" Number="1" Volume="2017" Year="2017">
+      <Database Name="cv" Series="107132" Issue="647903" />
     </Book>
-    <Book Series="Batgirl Barbara Gordon Archives" Number="2" Volume="2">
-      <Id>91f8aa06-9cd4-4890-8b86-f6a1966ebc60</Id>
+    <Book Series="Batgirl: The Bronze Age Omnibus" Number="2" Volume="2017" Year="2019">
+      <Database Name="cv" Series="107132" Issue="704778" />
     </Book>
     <Book Series="The Batman Family" Number="1" Volume="1975" Year="1975">
-      <Id>7a16fc22-0829-4ac4-a577-fa8a76dc9abc</Id>
+      <Database Name="cv" Series="2727" Issue="15632" />
     </Book>
     <Book Series="The Batman Family" Number="2" Volume="1975" Year="1975">
-      <Id>08f86f6b-fcf9-4743-adc4-5cf47d08aac9</Id>
+      <Database Name="cv" Series="2727" Issue="15741" />
     </Book>
     <Book Series="The Batman Family" Number="3" Volume="1975" Year="1976">
-      <Id>a54c600b-3b03-451e-aa4f-59e10dfb360d</Id>
+      <Database Name="cv" Series="2727" Issue="15960" />
     </Book>
     <Book Series="The Batman Family" Number="4" Volume="1975" Year="1976">
-      <Id>82e93dd9-e06e-4bcf-a0ff-90cbd66e2e32</Id>
+      <Database Name="cv" Series="2727" Issue="16126" />
     </Book>
     <Book Series="The Batman Family" Number="5" Volume="1975" Year="1976">
-      <Id>189a8702-7e06-4c5e-b996-33a4d32c223c</Id>
+      <Database Name="cv" Series="2727" Issue="16301" />
     </Book>
     <Book Series="The Batman Family" Number="6" Volume="1975" Year="1976">
-      <Id>37926a22-5c61-4694-875f-dad149c9ea5d</Id>
+      <Database Name="cv" Series="2727" Issue="16465" />
     </Book>
     <Book Series="The Batman Family" Number="7" Volume="1975" Year="1976">
-      <Id>bb6188b8-e008-46f3-8c90-d7239ef6ff50</Id>
+      <Database Name="cv" Series="2727" Issue="16639" />
     </Book>
     <Book Series="The Batman Family" Number="8" Volume="1975" Year="1976">
-      <Id>ada42a40-44f3-4e8d-b57c-81d6d2cbf0a1</Id>
+      <Database Name="cv" Series="2727" Issue="16825" />
     </Book>
     <Book Series="The Batman Family" Number="9" Volume="1975" Year="1977">
-      <Id>c2c1e279-b895-4c12-b4ed-d4cdfda838dd</Id>
+      <Database Name="cv" Series="2727" Issue="17055" />
     </Book>
     <Book Series="The Batman Family" Number="10" Volume="1975" Year="1977">
-      <Id>95f9745e-fdf1-4733-a114-937fdd3c0d2a</Id>
+      <Database Name="cv" Series="2727" Issue="17231" />
     </Book>
     <Book Series="The Batman Family" Number="11" Volume="1975" Year="1977">
-      <Id>51a55dea-bfc8-443d-aa69-037bc5727c0b</Id>
+      <Database Name="cv" Series="2727" Issue="17393" />
     </Book>
     <Book Series="The Batman Family" Number="12" Volume="1975" Year="1977">
-      <Id>0f930027-c91d-405a-b3c9-077e5e7bae61</Id>
+      <Database Name="cv" Series="2727" Issue="17557" />
     </Book>
     <Book Series="The Batman Family" Number="13" Volume="1975" Year="1977">
-      <Id>1f070f94-cfc4-4989-80b2-16b432cf409d</Id>
+      <Database Name="cv" Series="2727" Issue="17734" />
     </Book>
     <Book Series="The Batman Family" Number="14" Volume="1975" Year="1977">
-      <Id>d33c94cd-169f-4e4e-8105-7765947d0b3d</Id>
+      <Database Name="cv" Series="2727" Issue="17830" />
     </Book>
-    <Book Series="The Batman Family" Number="15" Volume="1975" Year="1978">
-      <Id>71658e5e-d4de-46bc-908e-cd822a5c250f</Id>
+    <Book Series="The Batman Family" Number="15" Volume="1975" Year="1977">
+      <Database Name="cv" Series="2727" Issue="18003" />
     </Book>
     <Book Series="The Batman Family" Number="16" Volume="1975" Year="1978">
-      <Id>49259879-f5c1-484e-9fa0-070dbaea1cf7</Id>
+      <Database Name="cv" Series="2727" Issue="18210" />
     </Book>
     <Book Series="The Batman Family" Number="17" Volume="1975" Year="1978">
-      <Id>346e00a6-f39f-4130-8bf2-39fd4246f00f</Id>
+      <Database Name="cv" Series="2727" Issue="18368" />
     </Book>
     <Book Series="The Batman Family" Number="18" Volume="1975" Year="1978">
-      <Id>81531dc8-d4fa-4835-98a3-2025d3384df1</Id>
+      <Database Name="cv" Series="2727" Issue="18539" />
     </Book>
     <Book Series="The Batman Family" Number="19" Volume="1975" Year="1978">
-      <Id>b82052d1-2b9b-4245-9a84-b229eeb8bb72</Id>
+      <Database Name="cv" Series="2727" Issue="18698" />
     </Book>
     <Book Series="The Batman Family" Number="20" Volume="1975" Year="1978">
-      <Id>9ad7fd0e-baf8-4e9b-bbc8-617456700db2</Id>
+      <Database Name="cv" Series="2727" Issue="18857" />
     </Book>
     <Book Series="Detective Comics" Number="481" Volume="1937" Year="1979">
-      <Id>4c7b73f5-cfbb-4f56-a63f-e973e9b50757</Id>
+      <Database Name="cv" Series="18058" Issue="112809" />
     </Book>
     <Book Series="Detective Comics" Number="482" Volume="1937" Year="1979">
-      <Id>8b532e1f-9bd5-422f-ba7e-4c8c8fa5ad2b</Id>
+      <Database Name="cv" Series="18058" Issue="112364" />
     </Book>
     <Book Series="Detective Comics" Number="483" Volume="1937" Year="1979">
-      <Id>6f6e9394-3873-41e9-b5b2-555e359b150f</Id>
+      <Database Name="cv" Series="18058" Issue="112365" />
     </Book>
     <Book Series="Batman" Number="311" Volume="1940" Year="1979">
-      <Id>ac8d5661-bf5d-4446-b336-dec187653c44</Id>
+      <Database Name="cv" Series="796" Issue="19475" />
     </Book>
     <Book Series="Detective Comics" Number="484" Volume="1937" Year="1979">
-      <Id>22119ec6-a284-49ed-9797-89590fe72306</Id>
+      <Database Name="cv" Series="18058" Issue="112810" />
     </Book>
     <Book Series="Detective Comics" Number="485" Volume="1937" Year="1979">
-      <Id>e35af864-1156-4513-977a-67d548cd0fda</Id>
+      <Database Name="cv" Series="18058" Issue="112832" />
     </Book>
     <Book Series="Detective Comics" Number="486" Volume="1937" Year="1979">
-      <Id>a5541cd3-dd62-4570-8692-766ca654a579</Id>
+      <Database Name="cv" Series="18058" Issue="112833" />
     </Book>
-    <Book Series="Detective Comics" Number="487" Volume="1937" Year="1979">
-      <Id>c885689a-be54-4e0e-958a-a795bc3ed651</Id>
+    <Book Series="Detective Comics" Number="487" Volume="1937" Year="1980">
+      <Database Name="cv" Series="18058" Issue="112834" />
     </Book>
     <Book Series="Detective Comics" Number="488" Volume="1937" Year="1980">
-      <Id>7dea85a9-9598-44e0-9582-680650c40604</Id>
+      <Database Name="cv" Series="18058" Issue="112835" />
     </Book>
     <Book Series="DC Comics Presents" Number="19" Volume="1978" Year="1980">
-      <Id>80018d72-3003-4293-ba86-4400fe5b6b1c</Id>
+      <Database Name="cv" Series="2943" Issue="20210" />
     </Book>
     <Book Series="Detective Comics" Number="489" Volume="1937" Year="1980">
-      <Id>c70a743e-7b2b-4e1b-8d5e-76200fdf46bb</Id>
+      <Database Name="cv" Series="18058" Issue="112836" />
     </Book>
     <Book Series="Detective Comics" Number="490" Volume="1937" Year="1980">
-      <Id>08d6fdf0-19bd-4696-9d31-d21f65a86673</Id>
+      <Database Name="cv" Series="18058" Issue="112837" />
     </Book>
     <Book Series="Detective Comics" Number="491" Volume="1937" Year="1980">
-      <Id>53180c9a-5a7b-4974-b961-c5b38c16f882</Id>
+      <Database Name="cv" Series="18058" Issue="112900" />
     </Book>
     <Book Series="Detective Comics" Number="492" Volume="1937" Year="1980">
-      <Id>c07f4b06-d26a-4a08-9506-51eac6d5d664</Id>
+      <Database Name="cv" Series="18058" Issue="112901" />
     </Book>
     <Book Series="Detective Comics" Number="493" Volume="1937" Year="1980">
-      <Id>b19474ba-dd84-4f9a-82b3-1cbbadf31783</Id>
+      <Database Name="cv" Series="18058" Issue="112902" />
     </Book>
     <Book Series="Detective Comics" Number="494" Volume="1937" Year="1980">
-      <Id>a89a8570-d2a9-4564-88ac-cec751d82b17</Id>
+      <Database Name="cv" Series="18058" Issue="112903" />
     </Book>
     <Book Series="Detective Comics" Number="495" Volume="1937" Year="1980">
-      <Id>4556a363-c767-46a1-bd8f-0f1434e98bfd</Id>
+      <Database Name="cv" Series="18058" Issue="112904" />
     </Book>
     <Book Series="Detective Comics" Number="496" Volume="1937" Year="1980">
-      <Id>5a0ec1d0-7336-4c7f-a258-486723ed395b</Id>
+      <Database Name="cv" Series="18058" Issue="112905" />
     </Book>
     <Book Series="Detective Comics" Number="497" Volume="1937" Year="1980">
-      <Id>68d58925-6d58-47c7-ac6c-c86c24bb5528</Id>
+      <Database Name="cv" Series="18058" Issue="112906" />
     </Book>
     <Book Series="Detective Comics" Number="498" Volume="1937" Year="1981">
-      <Id>47cb3933-f0c0-4032-86d2-9f9a7b297c3d</Id>
+      <Database Name="cv" Series="18058" Issue="112907" />
     </Book>
     <Book Series="Detective Comics" Number="499" Volume="1937" Year="1981">
-      <Id>cce44e8d-aa50-461e-bb4a-dc098f16e3de</Id>
+      <Database Name="cv" Series="18058" Issue="112908" />
     </Book>
     <Book Series="Detective Comics" Number="501" Volume="1937" Year="1981">
-      <Id>97e20a59-964a-4970-b805-31b88880710e</Id>
+      <Database Name="cv" Series="18058" Issue="112909" />
     </Book>
     <Book Series="Detective Comics" Number="502" Volume="1937" Year="1981">
-      <Id>5544b12d-6130-4aaa-aa61-f0128a59f8fd</Id>
+      <Database Name="cv" Series="18058" Issue="112910" />
     </Book>
     <Book Series="Detective Comics" Number="503" Volume="1937" Year="1981">
-      <Id>ae3aba3f-5169-4a68-a821-e30ec40abeff</Id>
+      <Database Name="cv" Series="18058" Issue="112911" />
     </Book>
     <Book Series="Detective Comics" Number="505" Volume="1937" Year="1981">
-      <Id>1cd84eb9-c928-4d90-a481-07839e6f1e2d</Id>
+      <Database Name="cv" Series="18058" Issue="112913" />
     </Book>
     <Book Series="Detective Comics" Number="506" Volume="1937" Year="1981">
-      <Id>7f0fd158-9585-4478-b0ef-1068b6f476ee</Id>
+      <Database Name="cv" Series="18058" Issue="112914" />
     </Book>
     <Book Series="Detective Comics" Number="508" Volume="1937" Year="1981">
-      <Id>3789754d-b363-4e86-a9e1-bda293d654e4</Id>
+      <Database Name="cv" Series="18058" Issue="112916" />
     </Book>
     <Book Series="Detective Comics" Number="509" Volume="1937" Year="1981">
-      <Id>1cea95de-a80b-40c3-8ae7-0f3aae5f901a</Id>
+      <Database Name="cv" Series="18058" Issue="112917" />
     </Book>
     <Book Series="Detective Comics" Number="510" Volume="1937" Year="1982">
-      <Id>3a69c19f-73ad-4c81-843d-670ed872822f</Id>
+      <Database Name="cv" Series="18058" Issue="112918" />
     </Book>
     <Book Series="Detective Comics" Number="512" Volume="1937" Year="1982">
-      <Id>747cf7a8-4b97-4c8e-8450-708e46f267e9</Id>
+      <Database Name="cv" Series="18058" Issue="112919" />
     </Book>
     <Book Series="Detective Comics" Number="513" Volume="1937" Year="1982">
-      <Id>9cc62b30-a5f0-449e-9f43-76c1c2d88317</Id>
+      <Database Name="cv" Series="18058" Issue="112922" />
     </Book>
     <Book Series="Detective Comics" Number="514" Volume="1937" Year="1982">
-      <Id>16916f17-6886-4f29-b6a6-b72baa961a0f</Id>
+      <Database Name="cv" Series="18058" Issue="106646" />
     </Book>
     <Book Series="Detective Comics" Number="515" Volume="1937" Year="1982">
-      <Id>1e7f70f8-8339-4372-8464-d6dcae10881d</Id>
+      <Database Name="cv" Series="18058" Issue="112923" />
     </Book>
     <Book Series="Detective Comics" Number="516" Volume="1937" Year="1982">
-      <Id>f47dcb04-e119-4311-8da3-ebd3b38c8595</Id>
+      <Database Name="cv" Series="18058" Issue="112924" />
     </Book>
     <Book Series="Detective Comics" Number="517" Volume="1937" Year="1982">
-      <Id>6c7e82d7-e05a-45a3-a0bb-90c1f6bb5875</Id>
+      <Database Name="cv" Series="18058" Issue="112930" />
     </Book>
     <Book Series="Detective Comics" Number="518" Volume="1937" Year="1982">
-      <Id>70ccbfe6-28f1-4376-ae1b-d2e39bb8329b</Id>
+      <Database Name="cv" Series="18058" Issue="112931" />
     </Book>
     <Book Series="Detective Comics" Number="519" Volume="1937" Year="1982">
-      <Id>0c9522ba-4226-4b91-9770-94ad3ec4ac23</Id>
+      <Database Name="cv" Series="18058" Issue="112932" />
     </Book>
     <Book Series="Detective Comics" Number="526" Volume="1937" Year="1983">
-      <Id>1b109368-adc4-4390-a450-f5086e6f0b49</Id>
+      <Database Name="cv" Series="18058" Issue="112940" />
     </Book>
   </Books>
   <Matchers />

--- a/DC/Characters/unsorted/Batgirl/Batgirl 002 (Post-Crisis).cbl
+++ b/DC/Characters/unsorted/Batgirl/Batgirl 002 (Post-Crisis).cbl
@@ -2,34 +2,34 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Batgirl 2 (Post-Crisis)</Name>
   <Books>
-    <Book Series="Batgirl Year One" Number="1" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Batgirl Year One" Number="1" Volume="2003" Year="2003">
       <Id>b9426ceb-e71e-4c8a-b06c-2cb3e53a01b4</Id>
     </Book>
-    <Book Series="Batgirl Year One" Number="2" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Batgirl Year One" Number="2" Volume="2003" Year="2003">
       <Id>9f7f6ca4-8108-4adb-824e-e6c38bbe1a2b</Id>
     </Book>
-    <Book Series="Batgirl Year One" Number="3" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Batgirl Year One" Number="3" Volume="2003" Year="2003">
       <Id>5a3ef5fc-c49f-4915-aee1-c67f60763623</Id>
     </Book>
-    <Book Series="Batgirl Year One" Number="4" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Batgirl Year One" Number="4" Volume="2003" Year="2003">
       <Id>179399ad-01b7-4c2a-92ca-b8cceaea4027</Id>
     </Book>
-    <Book Series="Batgirl Year One" Number="5" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Batgirl Year One" Number="5" Volume="2003" Year="2003">
       <Id>64aff155-453f-4341-804c-67493031924f</Id>
     </Book>
-    <Book Series="Batgirl Year One" Number="6" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Batgirl Year One" Number="6" Volume="2003" Year="2003">
       <Id>981faee4-65ed-4d25-b2d5-8755bdc694dc</Id>
     </Book>
-    <Book Series="Batgirl Year One" Number="7" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Batgirl Year One" Number="7" Volume="2003" Year="2003">
       <Id>8729179f-08e4-4da8-9a3a-6580f1b1a58b</Id>
     </Book>
-    <Book Series="Batgirl Year One" Number="8" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Batgirl Year One" Number="8" Volume="2003" Year="2003">
       <Id>02e1c40e-93f6-407b-971d-a0a760ad4ad3</Id>
     </Book>
-    <Book Series="Batgirl Year One" Number="9" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Batgirl Year One" Number="9" Volume="2003" Year="2003">
       <Id>c18f4d6a-c60e-4366-844d-bae3cf0a2abf</Id>
     </Book>
-    <Book Series="The Batman Chronicles" Number="9" Volume="1995" Year="1997" Format="Main Series">
+    <Book Series="The Batman Chronicles" Number="9" Volume="1995" Year="1997">
       <Id>be87c7ee-6c89-4974-bc95-6a44e2435c7c</Id>
     </Book>
     <Book Series="Legends of the DC Universe" Number="10" Volume="1998" Year="1998">
@@ -38,295 +38,295 @@
     <Book Series="Legends of the DC Universe" Number="11" Volume="1998" Year="1998">
       <Id>d2ea88d6-8aa6-4eaf-b85e-8f4016481c6e</Id>
     </Book>
-    <Book Series="Batman: Batgirl" Number="1" Volume="1997" Year="1997" Format="One-Shot">
+    <Book Series="Batman: Batgirl" Number="1" Volume="1997" Year="1997">
       <Id>25ba3455-cb8c-4886-8427-57224bf39ce3</Id>
     </Book>
-    <Book Series="Batman: Batgirl" Number="1" Volume="1998" Year="1998" Format="One-Shot">
+    <Book Series="Batman: Batgirl" Number="1" Volume="1998" Year="1998">
       <Id>5ba47d75-215b-42db-98e2-25e17ba570ab</Id>
     </Book>
-    <Book Series="Batgirl Special" Number="1" Volume="1988" Year="1988" Format="One-Shot">
+    <Book Series="Batgirl Special" Number="1" Volume="1988" Year="1988">
       <Id>219de499-b68d-4c8d-a89f-6d61a243b957</Id>
     </Book>
-    <Book Series="Batman: The Killing Joke: The Deluxe Edition" Number="1" Volume="2008" Year="2008" Format="Graphic Novel">
+    <Book Series="Batman: The Killing Joke: The Deluxe Edition" Number="1" Volume="2008" Year="2008">
       <Id>a7b7555a-d089-4f49-8081-5287011c6ea2</Id>
     </Book>
-    <Book Series="The Batman Chronicles" Number="5" Volume="1995" Year="1996" Format="Main Series">
+    <Book Series="The Batman Chronicles" Number="5" Volume="1995" Year="1996">
       <Id>83ea408e-3dc2-45d9-8ab6-abd2132bab1e</Id>
     </Book>
-    <Book Series="Batman" Number="567" Volume="1940" Year="1999" Format="Main Series">
+    <Book Series="Batman" Number="567" Volume="1940" Year="1999">
       <Id>2e9a56be-7a52-4dba-8804-9cf49e611fa8</Id>
     </Book>
-    <Book Series="Detective Comics" Number="734" Volume="1937" Year="1999" Format="Main Series">
+    <Book Series="Detective Comics" Number="734" Volume="1937" Year="1999">
       <Id>3e0d7fd3-ba6c-4070-a8ea-14accf40c65c</Id>
     </Book>
-    <Book Series="Batman: Legends of the Dark Knight" Number="120" Volume="1992" Year="1999" Format="Main Series">
+    <Book Series="Batman: Legends of the Dark Knight" Number="120" Volume="1992" Year="1999">
       <Id>f65c2f2b-f29b-462b-b744-485dd12bc252</Id>
     </Book>
-    <Book Series="Batgirl" Number="1" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Batgirl" Number="1" Volume="2000" Year="2000">
       <Id>ce599a88-e410-45b0-9880-dbb67c09105a</Id>
     </Book>
-    <Book Series="Batgirl" Number="2" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Batgirl" Number="2" Volume="2000" Year="2000">
       <Id>ad9492d7-caec-49cf-b7ed-0ce96b52a2a3</Id>
     </Book>
-    <Book Series="Batgirl" Number="3" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Batgirl" Number="3" Volume="2000" Year="2000">
       <Id>193a014d-bfb9-4532-b357-191fe60d300e</Id>
     </Book>
-    <Book Series="Batgirl" Number="4" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Batgirl" Number="4" Volume="2000" Year="2000">
       <Id>345e0726-06e3-45c5-935d-1ebddb2ef1a6</Id>
     </Book>
-    <Book Series="Batgirl" Number="5" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Batgirl" Number="5" Volume="2000" Year="2000">
       <Id>dd2762f5-b768-47e7-b5f2-69aa9157d86c</Id>
     </Book>
-    <Book Series="Batgirl" Number="6" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Batgirl" Number="6" Volume="2000" Year="2000">
       <Id>eee606b8-2e08-4e5c-a5be-246c2ec3d1ca</Id>
     </Book>
-    <Book Series="Batgirl" Number="7" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Batgirl" Number="7" Volume="2000" Year="2000">
       <Id>3b835781-0646-43ba-a06f-e9e7efc05683</Id>
     </Book>
-    <Book Series="Batgirl" Number="8" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Batgirl" Number="8" Volume="2000" Year="2000">
       <Id>d801be4f-a873-4bee-920f-af104edf367e</Id>
     </Book>
-    <Book Series="Batgirl" Number="9" Volume="2000" Year="2000" Format="Main Series">
+    <Book Series="Batgirl" Number="9" Volume="2000" Year="2000">
       <Id>ab7e6ecf-76d8-48d0-a1e4-fdb6b3218654</Id>
     </Book>
-    <Book Series="Batgirl" Number="10" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Batgirl" Number="10" Volume="2000" Year="2001">
       <Id>1d4d9d1a-a8bc-4797-b5e1-56bd886c05d7</Id>
     </Book>
-    <Book Series="Batgirl" Number="11" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Batgirl" Number="11" Volume="2000" Year="2001">
       <Id>b5a38346-acdb-4854-95d2-bc5f85ede9bc</Id>
     </Book>
-    <Book Series="Batgirl" Number="12" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Batgirl" Number="12" Volume="2000" Year="2001">
       <Id>d4b58d6d-91e3-493e-905b-512b2990a204</Id>
     </Book>
-    <Book Series="Batgirl" Number="13" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Batgirl" Number="13" Volume="2000" Year="2001">
       <Id>68d5167c-b425-418d-8658-52bd5b3fcea9</Id>
     </Book>
-    <Book Series="Batgirl" Number="14" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Batgirl" Number="14" Volume="2000" Year="2001">
       <Id>bc02f9bd-1ad1-49f4-a7ed-31ebe26fc4dc</Id>
     </Book>
-    <Book Series="Batgirl" Number="15" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Batgirl" Number="15" Volume="2000" Year="2001">
       <Id>b156ae0f-d414-428b-8c70-e565ca4efc61</Id>
     </Book>
-    <Book Series="Batgirl" Number="16" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Batgirl" Number="16" Volume="2000" Year="2001">
       <Id>4c2114c7-0195-4ca4-9874-6fd99d5be0d0</Id>
     </Book>
-    <Book Series="Batgirl" Number="17" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Batgirl" Number="17" Volume="2000" Year="2001">
       <Id>3d8e5580-b9b7-458b-88a4-e0d363b70914</Id>
     </Book>
-    <Book Series="Batgirl" Number="18" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Batgirl" Number="18" Volume="2000" Year="2001">
       <Id>55d7e42a-94b1-4236-8b7a-da648429bfb8</Id>
     </Book>
-    <Book Series="Batgirl" Number="19" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Batgirl" Number="19" Volume="2000" Year="2001">
       <Id>1e0794e1-79e0-4077-a35f-004c0bb2958c</Id>
     </Book>
-    <Book Series="Batgirl" Number="20" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Batgirl" Number="20" Volume="2000" Year="2001">
       <Id>f68c44d9-5d71-4d5b-bd27-a02c81d74095</Id>
     </Book>
-    <Book Series="Batgirl" Number="21" Volume="2000" Year="2001" Format="Main Series">
+    <Book Series="Batgirl" Number="21" Volume="2000" Year="2001">
       <Id>aee39818-cd9a-4d57-9fc5-14448c82aa1c</Id>
     </Book>
-    <Book Series="Batgirl" Number="22" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Batgirl" Number="22" Volume="2000" Year="2002">
       <Id>d9e4ffc0-d61d-49ff-aa06-97761083b170</Id>
     </Book>
-    <Book Series="Batgirl" Number="23" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Batgirl" Number="23" Volume="2000" Year="2002">
       <Id>aacb0039-a955-4bc1-a127-37e3da6cd999</Id>
     </Book>
-    <Book Series="Batgirl" Number="24" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Batgirl" Number="24" Volume="2000" Year="2002">
       <Id>d4e6984a-f38f-4167-a7aa-3fade4f052f3</Id>
     </Book>
-    <Book Series="Batgirl" Number="25" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Batgirl" Number="25" Volume="2000" Year="2002">
       <Id>8c3a2605-ca48-42ca-a9dd-d83eb1a635cf</Id>
     </Book>
-    <Book Series="Batgirl" Number="26" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Batgirl" Number="26" Volume="2000" Year="2002">
       <Id>4c9b24fa-0164-496b-b5de-a9b754efede7</Id>
     </Book>
-    <Book Series="Batgirl" Number="27" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Batgirl" Number="27" Volume="2000" Year="2002">
       <Id>9c25de3a-cc66-465a-b3f2-6ec50ec71bec</Id>
     </Book>
-    <Book Series="Batgirl" Number="28" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Batgirl" Number="28" Volume="2000" Year="2002">
       <Id>4690be26-fa8f-40f8-93d0-16fefae4cc99</Id>
     </Book>
-    <Book Series="Batgirl" Number="29" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Batgirl" Number="29" Volume="2000" Year="2002">
       <Id>6033d41e-1f70-44e6-b133-22ba21a4a1f1</Id>
     </Book>
-    <Book Series="Batgirl" Number="30" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Batgirl" Number="30" Volume="2000" Year="2002">
       <Id>c8307057-10eb-490b-9d28-ca99404e88ee</Id>
     </Book>
-    <Book Series="Batgirl" Number="31" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Batgirl" Number="31" Volume="2000" Year="2002">
       <Id>a7d98b90-324c-425c-a685-61fb1ca3d6b9</Id>
     </Book>
-    <Book Series="Batgirl" Number="32" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Batgirl" Number="32" Volume="2000" Year="2002">
       <Id>2053efda-fa51-47ae-92de-3e95f15188e0</Id>
     </Book>
-    <Book Series="Batgirl" Number="33" Volume="2000" Year="2002" Format="Main Series">
+    <Book Series="Batgirl" Number="33" Volume="2000" Year="2002">
       <Id>6a4c9b0b-68ce-447d-801c-bac51ede4fc1</Id>
     </Book>
-    <Book Series="Batgirl" Number="34" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Batgirl" Number="34" Volume="2000" Year="2003">
       <Id>859f61ed-d11d-4a6b-8b3f-6240c1d11e5d</Id>
     </Book>
-    <Book Series="Batgirl" Number="35" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Batgirl" Number="35" Volume="2000" Year="2003">
       <Id>98e228bd-6410-47c9-947a-0d7e5a9c1a35</Id>
     </Book>
-    <Book Series="Batgirl" Number="36" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Batgirl" Number="36" Volume="2000" Year="2003">
       <Id>87820acc-84f1-452c-9304-b4f4b59f53d0</Id>
     </Book>
-    <Book Series="Batgirl" Number="37" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Batgirl" Number="37" Volume="2000" Year="2003">
       <Id>015d59c6-d9c9-44b0-92c4-e0c2952880bb</Id>
     </Book>
-    <Book Series="Batgirl" Number="38" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Batgirl" Number="38" Volume="2000" Year="2003">
       <Id>dee3d12d-78ed-4c25-8885-61fb79bb4ad7</Id>
     </Book>
-    <Book Series="Batgirl" Number="39" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Batgirl" Number="39" Volume="2000" Year="2003">
       <Id>e8c1f913-53b4-4165-95d5-72d4406d0802</Id>
     </Book>
-    <Book Series="Batgirl" Number="40" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Batgirl" Number="40" Volume="2000" Year="2003">
       <Id>7c54e7c4-616c-4951-ad07-71cc84649b4f</Id>
     </Book>
-    <Book Series="Batgirl" Number="41" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Batgirl" Number="41" Volume="2000" Year="2003">
       <Id>add68bb6-75bd-422e-9817-d1a725fa79f2</Id>
     </Book>
-    <Book Series="Batgirl" Number="42" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Batgirl" Number="42" Volume="2000" Year="2003">
       <Id>cf8d29cf-06db-4539-b79c-9e637623e0f7</Id>
     </Book>
-    <Book Series="Batgirl" Number="43" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Batgirl" Number="43" Volume="2000" Year="2003">
       <Id>73e67ef9-e434-47fa-87a7-4abb4eb4c557</Id>
     </Book>
-    <Book Series="Batgirl" Number="44" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Batgirl" Number="44" Volume="2000" Year="2003">
       <Id>87958841-6dae-4255-a332-5e2b80ea88d1</Id>
     </Book>
-    <Book Series="Batgirl" Number="45" Volume="2000" Year="2003" Format="Main Series">
+    <Book Series="Batgirl" Number="45" Volume="2000" Year="2003">
       <Id>bd2ab23c-eaaf-4831-8088-813ff962b033</Id>
     </Book>
-    <Book Series="Batgirl" Number="46" Volume="2000" Year="2004" Format="Main Series">
+    <Book Series="Batgirl" Number="46" Volume="2000" Year="2004">
       <Id>5ad863c9-090a-4c14-bb9a-e657349f0ad3</Id>
     </Book>
-    <Book Series="Batgirl" Number="47" Volume="2000" Year="2004" Format="Main Series">
+    <Book Series="Batgirl" Number="47" Volume="2000" Year="2004">
       <Id>4fbbf666-654a-47a2-a696-3c0be94af958</Id>
     </Book>
-    <Book Series="Batgirl" Number="48" Volume="2000" Year="2004" Format="Main Series">
+    <Book Series="Batgirl" Number="48" Volume="2000" Year="2004">
       <Id>1755391a-2533-4c70-925f-ce351d4cdf1d</Id>
     </Book>
-    <Book Series="Batgirl" Number="49" Volume="2000" Year="2004" Format="Main Series">
+    <Book Series="Batgirl" Number="49" Volume="2000" Year="2004">
       <Id>37215250-5926-4532-8817-8bcc36ffe8ec</Id>
     </Book>
-    <Book Series="Batgirl" Number="50" Volume="2000" Year="2004" Format="Main Series">
+    <Book Series="Batgirl" Number="50" Volume="2000" Year="2004">
       <Id>ec38a8e8-fb1a-426e-9730-42078d5ef115</Id>
     </Book>
-    <Book Series="Batgirl" Number="51" Volume="2000" Year="2004" Format="Main Series">
+    <Book Series="Batgirl" Number="51" Volume="2000" Year="2004">
       <Id>439b1329-6cab-4f69-9f38-346c2fc15ca0</Id>
     </Book>
-    <Book Series="Batgirl" Number="52" Volume="2000" Year="2004" Format="Main Series">
+    <Book Series="Batgirl" Number="52" Volume="2000" Year="2004">
       <Id>5433fbe7-f603-44a6-8747-0c674ed3b7e0</Id>
     </Book>
-    <Book Series="Batgirl" Number="53" Volume="2000" Year="2004" Format="Main Series">
+    <Book Series="Batgirl" Number="53" Volume="2000" Year="2004">
       <Id>a01c9cbe-9c34-458d-8087-b224fa81c0dc</Id>
     </Book>
-    <Book Series="Batgirl" Number="54" Volume="2000" Year="2004" Format="Main Series">
+    <Book Series="Batgirl" Number="54" Volume="2000" Year="2004">
       <Id>af774aa8-6fef-4d18-a9bf-6fa0497735df</Id>
     </Book>
-    <Book Series="Batgirl" Number="55" Volume="2000" Year="2004" Format="Main Series">
+    <Book Series="Batgirl" Number="55" Volume="2000" Year="2004">
       <Id>f3bd0759-37c9-45bb-b877-b6b407778d62</Id>
     </Book>
-    <Book Series="Batgirl" Number="56" Volume="2000" Year="2004" Format="Main Series">
+    <Book Series="Batgirl" Number="56" Volume="2000" Year="2004">
       <Id>37c785a4-93ec-4f8b-a4b7-4ca1d2eedb3f</Id>
     </Book>
-    <Book Series="Batgirl" Number="57" Volume="2000" Year="2004" Format="Main Series">
+    <Book Series="Batgirl" Number="57" Volume="2000" Year="2004">
       <Id>3cbada10-dfcd-45eb-b98c-5099b84bcb28</Id>
     </Book>
     <Book Series="Robin" Number="132" Volume="1993" Year="2005">
       <Id>1d8bcce8-5881-4e75-b98a-8fc9baa6dfca</Id>
     </Book>
-    <Book Series="Batgirl" Number="58" Volume="2000" Year="2005" Format="Main Series">
+    <Book Series="Batgirl" Number="58" Volume="2000" Year="2005">
       <Id>71bfa0c8-b7c8-416b-882a-953bb3fe048c</Id>
     </Book>
     <Book Series="Robin" Number="133" Volume="1993" Year="2005">
       <Id>8d222832-fdef-4aaf-a294-b1efe53267a0</Id>
     </Book>
-    <Book Series="Batgirl" Number="59" Volume="2000" Year="2005" Format="Main Series">
+    <Book Series="Batgirl" Number="59" Volume="2000" Year="2005">
       <Id>530e284a-9313-4d70-9cc7-c914d0f305ac</Id>
     </Book>
-    <Book Series="Batgirl" Number="60" Volume="2000" Year="2005" Format="Main Series">
+    <Book Series="Batgirl" Number="60" Volume="2000" Year="2005">
       <Id>80c23662-29bf-4c02-b9f1-91b92d8ccc5f</Id>
     </Book>
-    <Book Series="Batgirl" Number="61" Volume="2000" Year="2005" Format="Main Series">
+    <Book Series="Batgirl" Number="61" Volume="2000" Year="2005">
       <Id>54b56c65-7b17-45fb-9f19-0868cab0938c</Id>
     </Book>
-    <Book Series="Batgirl" Number="62" Volume="2000" Year="2005" Format="Main Series">
+    <Book Series="Batgirl" Number="62" Volume="2000" Year="2005">
       <Id>19e76e2a-5da8-404c-a633-b7405bd2ca01</Id>
     </Book>
-    <Book Series="Batgirl" Number="63" Volume="2000" Year="2005" Format="Main Series">
+    <Book Series="Batgirl" Number="63" Volume="2000" Year="2005">
       <Id>4dfcc083-ce20-4760-b2f7-9a527096c458</Id>
     </Book>
-    <Book Series="Batgirl" Number="64" Volume="2000" Year="2005" Format="Main Series">
+    <Book Series="Batgirl" Number="64" Volume="2000" Year="2005">
       <Id>749970af-b4f2-4f8c-96a9-de7af30c7f41</Id>
     </Book>
-    <Book Series="Batgirl" Number="65" Volume="2000" Year="2005" Format="Main Series">
+    <Book Series="Batgirl" Number="65" Volume="2000" Year="2005">
       <Id>d034e2d1-456b-41cd-985d-a19dd3f69787</Id>
     </Book>
-    <Book Series="Batgirl" Number="66" Volume="2000" Year="2005" Format="Main Series">
+    <Book Series="Batgirl" Number="66" Volume="2000" Year="2005">
       <Id>7872e652-3896-408e-8313-11523e58365d</Id>
     </Book>
-    <Book Series="Batgirl" Number="67" Volume="2000" Year="2005" Format="Main Series">
+    <Book Series="Batgirl" Number="67" Volume="2000" Year="2005">
       <Id>392fa4ca-f2ab-4200-b5bc-dbe19819e069</Id>
     </Book>
-    <Book Series="Batgirl" Number="68" Volume="2000" Year="2005" Format="Main Series">
+    <Book Series="Batgirl" Number="68" Volume="2000" Year="2005">
       <Id>6d37bcbf-3a80-4ccc-9f89-23f970fa77ad</Id>
     </Book>
-    <Book Series="Batgirl" Number="69" Volume="2000" Year="2005" Format="Main Series">
+    <Book Series="Batgirl" Number="69" Volume="2000" Year="2005">
       <Id>0eaf91db-9087-4f14-984c-e3016fb1c371</Id>
     </Book>
-    <Book Series="Batgirl" Number="70" Volume="2000" Year="2006" Format="Main Series">
+    <Book Series="Batgirl" Number="70" Volume="2000" Year="2006">
       <Id>d09360de-b06f-4b11-a4b3-e48b00e301dc</Id>
     </Book>
-    <Book Series="Batgirl" Number="71" Volume="2000" Year="2006" Format="Main Series">
+    <Book Series="Batgirl" Number="71" Volume="2000" Year="2006">
       <Id>38d19059-6275-41f0-b343-3160c245715a</Id>
     </Book>
-    <Book Series="Batgirl" Number="72" Volume="2000" Year="2006" Format="Main Series">
+    <Book Series="Batgirl" Number="72" Volume="2000" Year="2006">
       <Id>ec285f0f-d1b6-4c7f-a26e-bcd6f26d8852</Id>
     </Book>
-    <Book Series="Batgirl" Number="73" Volume="2000" Year="2006" Format="Main Series">
+    <Book Series="Batgirl" Number="73" Volume="2000" Year="2006">
       <Id>409d25c2-4ab5-47df-8cbf-0ffafc555142</Id>
     </Book>
-    <Book Series="Batgirl" Number="1" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="Batgirl" Number="1" Volume="2008" Year="2008">
       <Id>aebbe97b-8ae2-4708-a5ec-4f0f1fc04b78</Id>
     </Book>
-    <Book Series="Batgirl" Number="2" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="Batgirl" Number="2" Volume="2008" Year="2008">
       <Id>2f71f18f-ed08-47dc-958e-8bc17c6eddeb</Id>
     </Book>
-    <Book Series="Batgirl" Number="3" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="Batgirl" Number="3" Volume="2008" Year="2008">
       <Id>61cbf28c-c955-40c4-b131-92cc36b94437</Id>
     </Book>
-    <Book Series="Batgirl" Number="4" Volume="2008" Year="2008" Format="Limited Series">
+    <Book Series="Batgirl" Number="4" Volume="2008" Year="2008">
       <Id>946d70b3-fc8f-45f0-81cc-55db115e0e82</Id>
     </Book>
-    <Book Series="Batgirl" Number="5" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="Batgirl" Number="5" Volume="2008" Year="2009">
       <Id>61b29ef3-3070-467c-b05d-7cfc857ece8b</Id>
     </Book>
-    <Book Series="Batgirl" Number="6" Volume="2008" Year="2009" Format="Limited Series">
+    <Book Series="Batgirl" Number="6" Volume="2008" Year="2009">
       <Id>75d6858a-2a44-4dd0-9ebf-9eb9653a3c76</Id>
     </Book>
-    <Book Series="Batgirl" Number="1" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Batgirl" Number="1" Volume="2009" Year="2009">
       <Id>61bfb626-fd7c-4ed6-8c27-fb00c31307f0</Id>
     </Book>
-    <Book Series="Batgirl" Number="2" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Batgirl" Number="2" Volume="2009" Year="2009">
       <Id>f20f7152-daef-40e2-866d-c9e7401f5ed8</Id>
     </Book>
-    <Book Series="Batgirl" Number="3" Volume="2009" Year="2009" Format="Main Series">
+    <Book Series="Batgirl" Number="3" Volume="2009" Year="2009">
       <Id>5cd890f3-6e4b-41d6-8817-6bc9cc74a6a3</Id>
     </Book>
-    <Book Series="Batgirl" Number="4" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Batgirl" Number="4" Volume="2009" Year="2010">
       <Id>9a6c3a2e-6c6e-4c7c-960e-c63bc28bc905</Id>
     </Book>
-    <Book Series="Batgirl" Number="5" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Batgirl" Number="5" Volume="2009" Year="2010">
       <Id>fca00a54-a2de-482f-9c91-1dd582441bb3</Id>
     </Book>
-    <Book Series="Batgirl" Number="6" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Batgirl" Number="6" Volume="2009" Year="2010">
       <Id>fe0c1cbd-5c08-4b78-a1be-1f536f961f83</Id>
     </Book>
-    <Book Series="Batgirl" Number="7" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Batgirl" Number="7" Volume="2009" Year="2010">
       <Id>db93f04c-447f-4d14-bb26-5d041737de81</Id>
     </Book>
-    <Book Series="Batgirl" Number="8" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Batgirl" Number="8" Volume="2009" Year="2010">
       <Id>dafd2b72-a6b6-4bb5-b468-7592af93f06a</Id>
     </Book>
     <Book Series="Red Robin" Number="9" Volume="2009" Year="2010">
@@ -341,58 +341,58 @@
     <Book Series="Red Robin" Number="12" Volume="2009" Year="2010">
       <Id>16a333e6-18b4-4ab9-88c3-e697da86de79</Id>
     </Book>
-    <Book Series="Batgirl" Number="9" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Batgirl" Number="9" Volume="2009" Year="2010">
       <Id>d3aa486a-c3b0-4222-a59e-c7d56bec45e5</Id>
     </Book>
-    <Book Series="Batgirl" Number="10" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Batgirl" Number="10" Volume="2009" Year="2010">
       <Id>90740007-ecbd-420d-9ad5-07cd9d74ed81</Id>
     </Book>
-    <Book Series="Batgirl" Number="11" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Batgirl" Number="11" Volume="2009" Year="2010">
       <Id>ffa01516-2de2-4bcd-b5c4-498a4c524afd</Id>
     </Book>
-    <Book Series="Batgirl" Number="12" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Batgirl" Number="12" Volume="2009" Year="2010">
       <Id>fec9d090-0d95-49a4-adfc-9aacc5d35289</Id>
     </Book>
-    <Book Series="Batgirl" Number="13" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Batgirl" Number="13" Volume="2009" Year="2010">
       <Id>28e653d0-a5f8-4350-8272-58cde2ffd795</Id>
     </Book>
-    <Book Series="Batgirl" Number="14" Volume="2009" Year="2010" Format="Main Series">
+    <Book Series="Batgirl" Number="14" Volume="2009" Year="2010">
       <Id>9952ff90-03a4-44e0-ab24-f19aa2b9d339</Id>
     </Book>
-    <Book Series="Bruce Wayne: The Road Home: Batgirl" Number="1" Volume="2010" Year="2010" Format="Crossover">
+    <Book Series="Bruce Wayne: The Road Home: Batgirl" Number="1" Volume="2010" Year="2010">
       <Id>89674b51-4e36-4032-b98b-2ceb843f83a2</Id>
     </Book>
-    <Book Series="Bruce Wayne: The Road Home: Oracle" Number="1" Volume="2010" Year="2010" Format="Crossover">
+    <Book Series="Bruce Wayne: The Road Home: Oracle" Number="1" Volume="2010" Year="2010">
       <Id>695b34b6-4c07-4cb6-b088-781d91f7bcef</Id>
     </Book>
-    <Book Series="Batgirl" Number="15" Volume="2009" Year="2011" Format="Main Series">
+    <Book Series="Batgirl" Number="15" Volume="2009" Year="2011">
       <Id>9be388cf-cd14-4219-815d-0b2661c645cc</Id>
     </Book>
-    <Book Series="Batgirl" Number="16" Volume="2009" Year="2011" Format="Main Series">
+    <Book Series="Batgirl" Number="16" Volume="2009" Year="2011">
       <Id>b10da3fb-f0c1-45d9-8096-26d2c0633991</Id>
     </Book>
-    <Book Series="Batgirl" Number="17" Volume="2009" Year="2011" Format="Main Series">
+    <Book Series="Batgirl" Number="17" Volume="2009" Year="2011">
       <Id>0f741201-7edb-4e02-9c1e-602b0900b9b9</Id>
     </Book>
-    <Book Series="Batgirl" Number="18" Volume="2009" Year="2011" Format="Main Series">
+    <Book Series="Batgirl" Number="18" Volume="2009" Year="2011">
       <Id>eb82b511-48f8-4ed2-bdcf-a4f72dfaa5ee</Id>
     </Book>
-    <Book Series="Batgirl" Number="19" Volume="2009" Year="2011" Format="Main Series">
+    <Book Series="Batgirl" Number="19" Volume="2009" Year="2011">
       <Id>1a0bd956-b264-4cef-999c-ecdb5b92c503</Id>
     </Book>
-    <Book Series="Batgirl" Number="20" Volume="2009" Year="2011" Format="Main Series">
+    <Book Series="Batgirl" Number="20" Volume="2009" Year="2011">
       <Id>f70ea144-af21-4ca0-aedb-78cef748fda2</Id>
     </Book>
-    <Book Series="Batgirl" Number="21" Volume="2009" Year="2011" Format="Main Series">
+    <Book Series="Batgirl" Number="21" Volume="2009" Year="2011">
       <Id>df44b6b5-8c33-4820-9252-bed5bf2e31e9</Id>
     </Book>
-    <Book Series="Batgirl" Number="22" Volume="2009" Year="2011" Format="Main Series">
+    <Book Series="Batgirl" Number="22" Volume="2009" Year="2011">
       <Id>720925a7-f1f1-474c-b50a-a1cb7a2ee587</Id>
     </Book>
-    <Book Series="Batgirl" Number="23" Volume="2009" Year="2011" Format="Main Series">
+    <Book Series="Batgirl" Number="23" Volume="2009" Year="2011">
       <Id>15c1f462-b4b1-41f5-94d0-3747d4fa6cba</Id>
     </Book>
-    <Book Series="Batgirl" Number="24" Volume="2009" Year="2011" Format="Main Series">
+    <Book Series="Batgirl" Number="24" Volume="2009" Year="2011">
       <Id>9854575a-9a52-41aa-abef-9dffc4537180</Id>
     </Book>
   </Books>

--- a/DC/Characters/unsorted/Batgirl/Batgirl 002 (Post-Crisis).cbl
+++ b/DC/Characters/unsorted/Batgirl/Batgirl 002 (Post-Crisis).cbl
@@ -1,399 +1,400 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Batgirl 2 (Post-Crisis)</Name>
+  <Name>Batgirl 002 (Post-Crisis)</Name>
+  <NumIssues>131</NumIssues>
   <Books>
     <Book Series="Batgirl Year One" Number="1" Volume="2003" Year="2003">
-      <Id>b9426ceb-e71e-4c8a-b06c-2cb3e53a01b4</Id>
+      <Database Name="cv" Series="10088" Issue="134881" />
     </Book>
     <Book Series="Batgirl Year One" Number="2" Volume="2003" Year="2003">
-      <Id>9f7f6ca4-8108-4adb-824e-e6c38bbe1a2b</Id>
+      <Database Name="cv" Series="10088" Issue="134882" />
     </Book>
     <Book Series="Batgirl Year One" Number="3" Volume="2003" Year="2003">
-      <Id>5a3ef5fc-c49f-4915-aee1-c67f60763623</Id>
+      <Database Name="cv" Series="10088" Issue="134883" />
     </Book>
     <Book Series="Batgirl Year One" Number="4" Volume="2003" Year="2003">
-      <Id>179399ad-01b7-4c2a-92ca-b8cceaea4027</Id>
+      <Database Name="cv" Series="10088" Issue="134884" />
     </Book>
     <Book Series="Batgirl Year One" Number="5" Volume="2003" Year="2003">
-      <Id>64aff155-453f-4341-804c-67493031924f</Id>
+      <Database Name="cv" Series="10088" Issue="94196" />
     </Book>
     <Book Series="Batgirl Year One" Number="6" Volume="2003" Year="2003">
-      <Id>981faee4-65ed-4d25-b2d5-8755bdc694dc</Id>
+      <Database Name="cv" Series="10088" Issue="94197" />
     </Book>
     <Book Series="Batgirl Year One" Number="7" Volume="2003" Year="2003">
-      <Id>8729179f-08e4-4da8-9a3a-6580f1b1a58b</Id>
+      <Database Name="cv" Series="10088" Issue="94198" />
     </Book>
     <Book Series="Batgirl Year One" Number="8" Volume="2003" Year="2003">
-      <Id>02e1c40e-93f6-407b-971d-a0a760ad4ad3</Id>
+      <Database Name="cv" Series="10088" Issue="94199" />
     </Book>
     <Book Series="Batgirl Year One" Number="9" Volume="2003" Year="2003">
-      <Id>c18f4d6a-c60e-4366-844d-bae3cf0a2abf</Id>
+      <Database Name="cv" Series="10088" Issue="94200" />
     </Book>
     <Book Series="The Batman Chronicles" Number="9" Volume="1995" Year="1997">
-      <Id>be87c7ee-6c89-4974-bc95-6a44e2435c7c</Id>
+      <Database Name="cv" Series="6598" Issue="173359" />
     </Book>
     <Book Series="Legends of the DC Universe" Number="10" Volume="1998" Year="1998">
-      <Id>c1d0386d-47a3-4f33-9266-8a643daf9bc1</Id>
+      <Database Name="cv" Series="7262" Issue="51645" />
     </Book>
     <Book Series="Legends of the DC Universe" Number="11" Volume="1998" Year="1998">
-      <Id>d2ea88d6-8aa6-4eaf-b85e-8f4016481c6e</Id>
+      <Database Name="cv" Series="7262" Issue="51646" />
     </Book>
     <Book Series="Batman: Batgirl" Number="1" Volume="1997" Year="1997">
-      <Id>25ba3455-cb8c-4886-8427-57224bf39ce3</Id>
+      <Database Name="cv" Series="28021" Issue="171822" />
     </Book>
     <Book Series="Batman: Batgirl" Number="1" Volume="1998" Year="1998">
-      <Id>5ba47d75-215b-42db-98e2-25e17ba570ab</Id>
+      <Database Name="cv" Series="25378" Issue="149829" />
     </Book>
     <Book Series="Batgirl Special" Number="1" Volume="1988" Year="1988">
-      <Id>219de499-b68d-4c8d-a89f-6d61a243b957</Id>
+      <Database Name="cv" Series="28070" Issue="172329" />
     </Book>
     <Book Series="Batman: The Killing Joke: The Deluxe Edition" Number="1" Volume="2008" Year="2008">
-      <Id>a7b7555a-d089-4f49-8081-5287011c6ea2</Id>
+      <Database Name="cv" Series="56750" Issue="384478" />
     </Book>
     <Book Series="The Batman Chronicles" Number="5" Volume="1995" Year="1996">
-      <Id>83ea408e-3dc2-45d9-8ab6-abd2132bab1e</Id>
+      <Database Name="cv" Series="6598" Issue="75531" />
     </Book>
     <Book Series="Batman" Number="567" Volume="1940" Year="1999">
-      <Id>2e9a56be-7a52-4dba-8804-9cf49e611fa8</Id>
+      <Database Name="cv" Series="796" Issue="45915" />
     </Book>
     <Book Series="Detective Comics" Number="734" Volume="1937" Year="1999">
-      <Id>3e0d7fd3-ba6c-4070-a8ea-14accf40c65c</Id>
+      <Database Name="cv" Series="18058" Issue="113208" />
     </Book>
     <Book Series="Batman: Legends of the Dark Knight" Number="120" Volume="1992" Year="1999">
-      <Id>f65c2f2b-f29b-462b-b744-485dd12bc252</Id>
+      <Database Name="cv" Series="4720" Issue="45953" />
     </Book>
     <Book Series="Batgirl" Number="1" Volume="2000" Year="2000">
-      <Id>ce599a88-e410-45b0-9880-dbb67c09105a</Id>
+      <Database Name="cv" Series="7205" Issue="75503" />
     </Book>
     <Book Series="Batgirl" Number="2" Volume="2000" Year="2000">
-      <Id>ad9492d7-caec-49cf-b7ed-0ce96b52a2a3</Id>
+      <Database Name="cv" Series="7205" Issue="75504" />
     </Book>
     <Book Series="Batgirl" Number="3" Volume="2000" Year="2000">
-      <Id>193a014d-bfb9-4532-b357-191fe60d300e</Id>
+      <Database Name="cv" Series="7205" Issue="121118" />
     </Book>
     <Book Series="Batgirl" Number="4" Volume="2000" Year="2000">
-      <Id>345e0726-06e3-45c5-935d-1ebddb2ef1a6</Id>
+      <Database Name="cv" Series="7205" Issue="75505" />
     </Book>
     <Book Series="Batgirl" Number="5" Volume="2000" Year="2000">
-      <Id>dd2762f5-b768-47e7-b5f2-69aa9157d86c</Id>
+      <Database Name="cv" Series="7205" Issue="75506" />
     </Book>
     <Book Series="Batgirl" Number="6" Volume="2000" Year="2000">
-      <Id>eee606b8-2e08-4e5c-a5be-246c2ec3d1ca</Id>
+      <Database Name="cv" Series="7205" Issue="75507" />
     </Book>
     <Book Series="Batgirl" Number="7" Volume="2000" Year="2000">
-      <Id>3b835781-0646-43ba-a06f-e9e7efc05683</Id>
+      <Database Name="cv" Series="7205" Issue="75508" />
     </Book>
     <Book Series="Batgirl" Number="8" Volume="2000" Year="2000">
-      <Id>d801be4f-a873-4bee-920f-af104edf367e</Id>
+      <Database Name="cv" Series="7205" Issue="75509" />
     </Book>
     <Book Series="Batgirl" Number="9" Volume="2000" Year="2000">
-      <Id>ab7e6ecf-76d8-48d0-a1e4-fdb6b3218654</Id>
+      <Database Name="cv" Series="7205" Issue="75510" />
     </Book>
     <Book Series="Batgirl" Number="10" Volume="2000" Year="2001">
-      <Id>1d4d9d1a-a8bc-4797-b5e1-56bd886c05d7</Id>
+      <Database Name="cv" Series="7205" Issue="75511" />
     </Book>
     <Book Series="Batgirl" Number="11" Volume="2000" Year="2001">
-      <Id>b5a38346-acdb-4854-95d2-bc5f85ede9bc</Id>
+      <Database Name="cv" Series="7205" Issue="75512" />
     </Book>
     <Book Series="Batgirl" Number="12" Volume="2000" Year="2001">
-      <Id>d4b58d6d-91e3-493e-905b-512b2990a204</Id>
+      <Database Name="cv" Series="7205" Issue="121088" />
     </Book>
     <Book Series="Batgirl" Number="13" Volume="2000" Year="2001">
-      <Id>68d5167c-b425-418d-8658-52bd5b3fcea9</Id>
+      <Database Name="cv" Series="7205" Issue="149985" />
     </Book>
     <Book Series="Batgirl" Number="14" Volume="2000" Year="2001">
-      <Id>bc02f9bd-1ad1-49f4-a7ed-31ebe26fc4dc</Id>
+      <Database Name="cv" Series="7205" Issue="121080" />
     </Book>
     <Book Series="Batgirl" Number="15" Volume="2000" Year="2001">
-      <Id>b156ae0f-d414-428b-8c70-e565ca4efc61</Id>
+      <Database Name="cv" Series="7205" Issue="121081" />
     </Book>
     <Book Series="Batgirl" Number="16" Volume="2000" Year="2001">
-      <Id>4c2114c7-0195-4ca4-9874-6fd99d5be0d0</Id>
+      <Database Name="cv" Series="7205" Issue="121082" />
     </Book>
     <Book Series="Batgirl" Number="17" Volume="2000" Year="2001">
-      <Id>3d8e5580-b9b7-458b-88a4-e0d363b70914</Id>
+      <Database Name="cv" Series="7205" Issue="121083" />
     </Book>
     <Book Series="Batgirl" Number="18" Volume="2000" Year="2001">
-      <Id>55d7e42a-94b1-4236-8b7a-da648429bfb8</Id>
+      <Database Name="cv" Series="7205" Issue="121084" />
     </Book>
     <Book Series="Batgirl" Number="19" Volume="2000" Year="2001">
-      <Id>1e0794e1-79e0-4077-a35f-004c0bb2958c</Id>
+      <Database Name="cv" Series="7205" Issue="121089" />
     </Book>
     <Book Series="Batgirl" Number="20" Volume="2000" Year="2001">
-      <Id>f68c44d9-5d71-4d5b-bd27-a02c81d74095</Id>
+      <Database Name="cv" Series="7205" Issue="121102" />
     </Book>
     <Book Series="Batgirl" Number="21" Volume="2000" Year="2001">
-      <Id>aee39818-cd9a-4d57-9fc5-14448c82aa1c</Id>
+      <Database Name="cv" Series="7205" Issue="121090" />
     </Book>
     <Book Series="Batgirl" Number="22" Volume="2000" Year="2002">
-      <Id>d9e4ffc0-d61d-49ff-aa06-97761083b170</Id>
+      <Database Name="cv" Series="7205" Issue="75523" />
     </Book>
     <Book Series="Batgirl" Number="23" Volume="2000" Year="2002">
-      <Id>aacb0039-a955-4bc1-a127-37e3da6cd999</Id>
+      <Database Name="cv" Series="7205" Issue="75524" />
     </Book>
     <Book Series="Batgirl" Number="24" Volume="2000" Year="2002">
-      <Id>d4e6984a-f38f-4167-a7aa-3fade4f052f3</Id>
+      <Database Name="cv" Series="7205" Issue="51379" />
     </Book>
     <Book Series="Batgirl" Number="25" Volume="2000" Year="2002">
-      <Id>8c3a2605-ca48-42ca-a9dd-d83eb1a635cf</Id>
+      <Database Name="cv" Series="7205" Issue="121085" />
     </Book>
     <Book Series="Batgirl" Number="26" Volume="2000" Year="2002">
-      <Id>4c9b24fa-0164-496b-b5de-a9b754efede7</Id>
+      <Database Name="cv" Series="7205" Issue="121091" />
     </Book>
     <Book Series="Batgirl" Number="27" Volume="2000" Year="2002">
-      <Id>9c25de3a-cc66-465a-b3f2-6ec50ec71bec</Id>
+      <Database Name="cv" Series="7205" Issue="121092" />
     </Book>
     <Book Series="Batgirl" Number="28" Volume="2000" Year="2002">
-      <Id>4690be26-fa8f-40f8-93d0-16fefae4cc99</Id>
+      <Database Name="cv" Series="7205" Issue="121106" />
     </Book>
     <Book Series="Batgirl" Number="29" Volume="2000" Year="2002">
-      <Id>6033d41e-1f70-44e6-b133-22ba21a4a1f1</Id>
+      <Database Name="cv" Series="7205" Issue="121108" />
     </Book>
     <Book Series="Batgirl" Number="30" Volume="2000" Year="2002">
-      <Id>c8307057-10eb-490b-9d28-ca99404e88ee</Id>
+      <Database Name="cv" Series="7205" Issue="121110" />
     </Book>
     <Book Series="Batgirl" Number="31" Volume="2000" Year="2002">
-      <Id>a7d98b90-324c-425c-a685-61fb1ca3d6b9</Id>
+      <Database Name="cv" Series="7205" Issue="121111" />
     </Book>
     <Book Series="Batgirl" Number="32" Volume="2000" Year="2002">
-      <Id>2053efda-fa51-47ae-92de-3e95f15188e0</Id>
+      <Database Name="cv" Series="7205" Issue="91323" />
     </Book>
     <Book Series="Batgirl" Number="33" Volume="2000" Year="2002">
-      <Id>6a4c9b0b-68ce-447d-801c-bac51ede4fc1</Id>
+      <Database Name="cv" Series="7205" Issue="91324" />
     </Book>
     <Book Series="Batgirl" Number="34" Volume="2000" Year="2003">
-      <Id>859f61ed-d11d-4a6b-8b3f-6240c1d11e5d</Id>
+      <Database Name="cv" Series="7205" Issue="91325" />
     </Book>
     <Book Series="Batgirl" Number="35" Volume="2000" Year="2003">
-      <Id>98e228bd-6410-47c9-947a-0d7e5a9c1a35</Id>
+      <Database Name="cv" Series="7205" Issue="91326" />
     </Book>
     <Book Series="Batgirl" Number="36" Volume="2000" Year="2003">
-      <Id>87820acc-84f1-452c-9304-b4f4b59f53d0</Id>
+      <Database Name="cv" Series="7205" Issue="91327" />
     </Book>
     <Book Series="Batgirl" Number="37" Volume="2000" Year="2003">
-      <Id>015d59c6-d9c9-44b0-92c4-e0c2952880bb</Id>
+      <Database Name="cv" Series="7205" Issue="91328" />
     </Book>
     <Book Series="Batgirl" Number="38" Volume="2000" Year="2003">
-      <Id>dee3d12d-78ed-4c25-8885-61fb79bb4ad7</Id>
+      <Database Name="cv" Series="7205" Issue="91329" />
     </Book>
     <Book Series="Batgirl" Number="39" Volume="2000" Year="2003">
-      <Id>e8c1f913-53b4-4165-95d5-72d4406d0802</Id>
+      <Database Name="cv" Series="7205" Issue="91330" />
     </Book>
     <Book Series="Batgirl" Number="40" Volume="2000" Year="2003">
-      <Id>7c54e7c4-616c-4951-ad07-71cc84649b4f</Id>
+      <Database Name="cv" Series="7205" Issue="91331" />
     </Book>
     <Book Series="Batgirl" Number="41" Volume="2000" Year="2003">
-      <Id>add68bb6-75bd-422e-9817-d1a725fa79f2</Id>
+      <Database Name="cv" Series="7205" Issue="91332" />
     </Book>
     <Book Series="Batgirl" Number="42" Volume="2000" Year="2003">
-      <Id>cf8d29cf-06db-4539-b79c-9e637623e0f7</Id>
+      <Database Name="cv" Series="7205" Issue="91333" />
     </Book>
     <Book Series="Batgirl" Number="43" Volume="2000" Year="2003">
-      <Id>73e67ef9-e434-47fa-87a7-4abb4eb4c557</Id>
+      <Database Name="cv" Series="7205" Issue="91334" />
     </Book>
     <Book Series="Batgirl" Number="44" Volume="2000" Year="2003">
-      <Id>87958841-6dae-4255-a332-5e2b80ea88d1</Id>
+      <Database Name="cv" Series="7205" Issue="91335" />
     </Book>
     <Book Series="Batgirl" Number="45" Volume="2000" Year="2003">
-      <Id>bd2ab23c-eaaf-4831-8088-813ff962b033</Id>
+      <Database Name="cv" Series="7205" Issue="91336" />
     </Book>
     <Book Series="Batgirl" Number="46" Volume="2000" Year="2004">
-      <Id>5ad863c9-090a-4c14-bb9a-e657349f0ad3</Id>
+      <Database Name="cv" Series="7205" Issue="91337" />
     </Book>
     <Book Series="Batgirl" Number="47" Volume="2000" Year="2004">
-      <Id>4fbbf666-654a-47a2-a696-3c0be94af958</Id>
+      <Database Name="cv" Series="7205" Issue="91338" />
     </Book>
     <Book Series="Batgirl" Number="48" Volume="2000" Year="2004">
-      <Id>1755391a-2533-4c70-925f-ce351d4cdf1d</Id>
+      <Database Name="cv" Series="7205" Issue="91339" />
     </Book>
     <Book Series="Batgirl" Number="49" Volume="2000" Year="2004">
-      <Id>37215250-5926-4532-8817-8bcc36ffe8ec</Id>
+      <Database Name="cv" Series="7205" Issue="91340" />
     </Book>
     <Book Series="Batgirl" Number="50" Volume="2000" Year="2004">
-      <Id>ec38a8e8-fb1a-426e-9730-42078d5ef115</Id>
+      <Database Name="cv" Series="7205" Issue="91341" />
     </Book>
     <Book Series="Batgirl" Number="51" Volume="2000" Year="2004">
-      <Id>439b1329-6cab-4f69-9f38-346c2fc15ca0</Id>
+      <Database Name="cv" Series="7205" Issue="96333" />
     </Book>
     <Book Series="Batgirl" Number="52" Volume="2000" Year="2004">
-      <Id>5433fbe7-f603-44a6-8747-0c674ed3b7e0</Id>
+      <Database Name="cv" Series="7205" Issue="96334" />
     </Book>
     <Book Series="Batgirl" Number="53" Volume="2000" Year="2004">
-      <Id>a01c9cbe-9c34-458d-8087-b224fa81c0dc</Id>
+      <Database Name="cv" Series="7205" Issue="96335" />
     </Book>
     <Book Series="Batgirl" Number="54" Volume="2000" Year="2004">
-      <Id>af774aa8-6fef-4d18-a9bf-6fa0497735df</Id>
+      <Database Name="cv" Series="7205" Issue="100876" />
     </Book>
     <Book Series="Batgirl" Number="55" Volume="2000" Year="2004">
-      <Id>f3bd0759-37c9-45bb-b877-b6b407778d62</Id>
+      <Database Name="cv" Series="7205" Issue="100877" />
     </Book>
     <Book Series="Batgirl" Number="56" Volume="2000" Year="2004">
-      <Id>37c785a4-93ec-4f8b-a4b7-4ca1d2eedb3f</Id>
+      <Database Name="cv" Series="7205" Issue="100878" />
     </Book>
     <Book Series="Batgirl" Number="57" Volume="2000" Year="2004">
-      <Id>3cbada10-dfcd-45eb-b98c-5099b84bcb28</Id>
+      <Database Name="cv" Series="7205" Issue="100879" />
     </Book>
     <Book Series="Robin" Number="132" Volume="1993" Year="2005">
-      <Id>1d8bcce8-5881-4e75-b98a-8fc9baa6dfca</Id>
+      <Database Name="cv" Series="4975" Issue="92343" />
     </Book>
     <Book Series="Batgirl" Number="58" Volume="2000" Year="2005">
-      <Id>71bfa0c8-b7c8-416b-882a-953bb3fe048c</Id>
+      <Database Name="cv" Series="7205" Issue="100880" />
     </Book>
     <Book Series="Robin" Number="133" Volume="1993" Year="2005">
-      <Id>8d222832-fdef-4aaf-a294-b1efe53267a0</Id>
+      <Database Name="cv" Series="4975" Issue="92344" />
     </Book>
     <Book Series="Batgirl" Number="59" Volume="2000" Year="2005">
-      <Id>530e284a-9313-4d70-9cc7-c914d0f305ac</Id>
+      <Database Name="cv" Series="7205" Issue="100881" />
     </Book>
     <Book Series="Batgirl" Number="60" Volume="2000" Year="2005">
-      <Id>80c23662-29bf-4c02-b9f1-91b92d8ccc5f</Id>
+      <Database Name="cv" Series="7205" Issue="100882" />
     </Book>
     <Book Series="Batgirl" Number="61" Volume="2000" Year="2005">
-      <Id>54b56c65-7b17-45fb-9f19-0868cab0938c</Id>
+      <Database Name="cv" Series="7205" Issue="100883" />
     </Book>
     <Book Series="Batgirl" Number="62" Volume="2000" Year="2005">
-      <Id>19e76e2a-5da8-404c-a633-b7405bd2ca01</Id>
+      <Database Name="cv" Series="7205" Issue="100884" />
     </Book>
     <Book Series="Batgirl" Number="63" Volume="2000" Year="2005">
-      <Id>4dfcc083-ce20-4760-b2f7-9a527096c458</Id>
+      <Database Name="cv" Series="7205" Issue="100885" />
     </Book>
     <Book Series="Batgirl" Number="64" Volume="2000" Year="2005">
-      <Id>749970af-b4f2-4f8c-96a9-de7af30c7f41</Id>
+      <Database Name="cv" Series="7205" Issue="121094" />
     </Book>
     <Book Series="Batgirl" Number="65" Volume="2000" Year="2005">
-      <Id>d034e2d1-456b-41cd-985d-a19dd3f69787</Id>
+      <Database Name="cv" Series="7205" Issue="121095" />
     </Book>
     <Book Series="Batgirl" Number="66" Volume="2000" Year="2005">
-      <Id>7872e652-3896-408e-8313-11523e58365d</Id>
+      <Database Name="cv" Series="7205" Issue="121096" />
     </Book>
     <Book Series="Batgirl" Number="67" Volume="2000" Year="2005">
-      <Id>392fa4ca-f2ab-4200-b5bc-dbe19819e069</Id>
+      <Database Name="cv" Series="7205" Issue="121097" />
     </Book>
     <Book Series="Batgirl" Number="68" Volume="2000" Year="2005">
-      <Id>6d37bcbf-3a80-4ccc-9f89-23f970fa77ad</Id>
+      <Database Name="cv" Series="7205" Issue="121098" />
     </Book>
     <Book Series="Batgirl" Number="69" Volume="2000" Year="2005">
-      <Id>0eaf91db-9087-4f14-984c-e3016fb1c371</Id>
+      <Database Name="cv" Series="7205" Issue="121112" />
     </Book>
     <Book Series="Batgirl" Number="70" Volume="2000" Year="2006">
-      <Id>d09360de-b06f-4b11-a4b3-e48b00e301dc</Id>
+      <Database Name="cv" Series="7205" Issue="121113" />
     </Book>
     <Book Series="Batgirl" Number="71" Volume="2000" Year="2006">
-      <Id>38d19059-6275-41f0-b343-3160c245715a</Id>
+      <Database Name="cv" Series="7205" Issue="121114" />
     </Book>
     <Book Series="Batgirl" Number="72" Volume="2000" Year="2006">
-      <Id>ec285f0f-d1b6-4c7f-a26e-bcd6f26d8852</Id>
+      <Database Name="cv" Series="7205" Issue="121116" />
     </Book>
     <Book Series="Batgirl" Number="73" Volume="2000" Year="2006">
-      <Id>409d25c2-4ab5-47df-8cbf-0ffafc555142</Id>
+      <Database Name="cv" Series="7205" Issue="121117" />
     </Book>
     <Book Series="Batgirl" Number="1" Volume="2008" Year="2008">
-      <Id>aebbe97b-8ae2-4708-a5ec-4f0f1fc04b78</Id>
+      <Database Name="cv" Series="22245" Issue="133731" />
     </Book>
     <Book Series="Batgirl" Number="2" Volume="2008" Year="2008">
-      <Id>2f71f18f-ed08-47dc-958e-8bc17c6eddeb</Id>
+      <Database Name="cv" Series="22245" Issue="136050" />
     </Book>
     <Book Series="Batgirl" Number="3" Volume="2008" Year="2008">
-      <Id>61cbf28c-c955-40c4-b131-92cc36b94437</Id>
+      <Database Name="cv" Series="22245" Issue="138994" />
     </Book>
     <Book Series="Batgirl" Number="4" Volume="2008" Year="2008">
-      <Id>946d70b3-fc8f-45f0-81cc-55db115e0e82</Id>
+      <Database Name="cv" Series="22245" Issue="141214" />
     </Book>
     <Book Series="Batgirl" Number="5" Volume="2008" Year="2009">
-      <Id>61b29ef3-3070-467c-b05d-7cfc857ece8b</Id>
+      <Database Name="cv" Series="22245" Issue="142740" />
     </Book>
     <Book Series="Batgirl" Number="6" Volume="2008" Year="2009">
-      <Id>75d6858a-2a44-4dd0-9ebf-9eb9653a3c76</Id>
+      <Database Name="cv" Series="22245" Issue="148356" />
     </Book>
     <Book Series="Batgirl" Number="1" Volume="2009" Year="2009">
-      <Id>61bfb626-fd7c-4ed6-8c27-fb00c31307f0</Id>
+      <Database Name="cv" Series="27457" Issue="167360" />
     </Book>
     <Book Series="Batgirl" Number="2" Volume="2009" Year="2009">
-      <Id>f20f7152-daef-40e2-866d-c9e7401f5ed8</Id>
+      <Database Name="cv" Series="27457" Issue="171414" />
     </Book>
     <Book Series="Batgirl" Number="3" Volume="2009" Year="2009">
-      <Id>5cd890f3-6e4b-41d6-8817-6bc9cc74a6a3</Id>
+      <Database Name="cv" Series="27457" Issue="176018" />
     </Book>
     <Book Series="Batgirl" Number="4" Volume="2009" Year="2010">
-      <Id>9a6c3a2e-6c6e-4c7c-960e-c63bc28bc905</Id>
+      <Database Name="cv" Series="27457" Issue="182564" />
     </Book>
     <Book Series="Batgirl" Number="5" Volume="2009" Year="2010">
-      <Id>fca00a54-a2de-482f-9c91-1dd582441bb3</Id>
+      <Database Name="cv" Series="27457" Issue="186732" />
     </Book>
     <Book Series="Batgirl" Number="6" Volume="2009" Year="2010">
-      <Id>fe0c1cbd-5c08-4b78-a1be-1f536f961f83</Id>
+      <Database Name="cv" Series="27457" Issue="192403" />
     </Book>
     <Book Series="Batgirl" Number="7" Volume="2009" Year="2010">
-      <Id>db93f04c-447f-4d14-bb26-5d041737de81</Id>
+      <Database Name="cv" Series="27457" Issue="196464" />
     </Book>
     <Book Series="Batgirl" Number="8" Volume="2009" Year="2010">
-      <Id>dafd2b72-a6b6-4bb5-b468-7592af93f06a</Id>
+      <Database Name="cv" Series="27457" Issue="199698" />
     </Book>
     <Book Series="Red Robin" Number="9" Volume="2009" Year="2010">
-      <Id>1bd3e370-0141-4cd4-8d2a-f0be6f3cd171</Id>
+      <Database Name="cv" Series="26651" Issue="195392" />
     </Book>
     <Book Series="Red Robin" Number="10" Volume="2009" Year="2010">
-      <Id>e1c39feb-0569-4714-8fba-7c28630b4b99</Id>
+      <Database Name="cv" Series="26651" Issue="199690" />
     </Book>
     <Book Series="Red Robin" Number="11" Volume="2009" Year="2010">
-      <Id>c4f9d92f-c9a9-413b-b665-3037adf78a38</Id>
+      <Database Name="cv" Series="26651" Issue="204538" />
     </Book>
     <Book Series="Red Robin" Number="12" Volume="2009" Year="2010">
-      <Id>16a333e6-18b4-4ab9-88c3-e697da86de79</Id>
+      <Database Name="cv" Series="26651" Issue="211844" />
     </Book>
     <Book Series="Batgirl" Number="9" Volume="2009" Year="2010">
-      <Id>d3aa486a-c3b0-4222-a59e-c7d56bec45e5</Id>
+      <Database Name="cv" Series="27457" Issue="206639" />
     </Book>
     <Book Series="Batgirl" Number="10" Volume="2009" Year="2010">
-      <Id>90740007-ecbd-420d-9ad5-07cd9d74ed81</Id>
+      <Database Name="cv" Series="27457" Issue="213450" />
     </Book>
     <Book Series="Batgirl" Number="11" Volume="2009" Year="2010">
-      <Id>ffa01516-2de2-4bcd-b5c4-498a4c524afd</Id>
+      <Database Name="cv" Series="27457" Issue="218282" />
     </Book>
     <Book Series="Batgirl" Number="12" Volume="2009" Year="2010">
-      <Id>fec9d090-0d95-49a4-adfc-9aacc5d35289</Id>
+      <Database Name="cv" Series="27457" Issue="224579" />
     </Book>
     <Book Series="Batgirl" Number="13" Volume="2009" Year="2010">
-      <Id>28e653d0-a5f8-4350-8272-58cde2ffd795</Id>
+      <Database Name="cv" Series="27457" Issue="228846" />
     </Book>
     <Book Series="Batgirl" Number="14" Volume="2009" Year="2010">
-      <Id>9952ff90-03a4-44e0-ab24-f19aa2b9d339</Id>
+      <Database Name="cv" Series="27457" Issue="233657" />
     </Book>
     <Book Series="Bruce Wayne: The Road Home: Batgirl" Number="1" Volume="2010" Year="2010">
-      <Id>89674b51-4e36-4032-b98b-2ceb843f83a2</Id>
+      <Database Name="cv" Series="36065" Issue="238155" />
     </Book>
     <Book Series="Bruce Wayne: The Road Home: Oracle" Number="1" Volume="2010" Year="2010">
-      <Id>695b34b6-4c07-4cb6-b088-781d91f7bcef</Id>
+      <Database Name="cv" Series="36338" Issue="239802" />
     </Book>
     <Book Series="Batgirl" Number="15" Volume="2009" Year="2011">
-      <Id>9be388cf-cd14-4219-815d-0b2661c645cc</Id>
+      <Database Name="cv" Series="27457" Issue="241776" />
     </Book>
     <Book Series="Batgirl" Number="16" Volume="2009" Year="2011">
-      <Id>b10da3fb-f0c1-45d9-8096-26d2c0633991</Id>
+      <Database Name="cv" Series="27457" Issue="248430" />
     </Book>
     <Book Series="Batgirl" Number="17" Volume="2009" Year="2011">
-      <Id>0f741201-7edb-4e02-9c1e-602b0900b9b9</Id>
+      <Database Name="cv" Series="27457" Issue="255878" />
     </Book>
     <Book Series="Batgirl" Number="18" Volume="2009" Year="2011">
-      <Id>eb82b511-48f8-4ed2-bdcf-a4f72dfaa5ee</Id>
+      <Database Name="cv" Series="27457" Issue="261219" />
     </Book>
     <Book Series="Batgirl" Number="19" Volume="2009" Year="2011">
-      <Id>1a0bd956-b264-4cef-999c-ecdb5b92c503</Id>
+      <Database Name="cv" Series="27457" Issue="265494" />
     </Book>
     <Book Series="Batgirl" Number="20" Volume="2009" Year="2011">
-      <Id>f70ea144-af21-4ca0-aedb-78cef748fda2</Id>
+      <Database Name="cv" Series="27457" Issue="268210" />
     </Book>
     <Book Series="Batgirl" Number="21" Volume="2009" Year="2011">
-      <Id>df44b6b5-8c33-4820-9252-bed5bf2e31e9</Id>
+      <Database Name="cv" Series="27457" Issue="269823" />
     </Book>
     <Book Series="Batgirl" Number="22" Volume="2009" Year="2011">
-      <Id>720925a7-f1f1-474c-b50a-a1cb7a2ee587</Id>
+      <Database Name="cv" Series="27457" Issue="274395" />
     </Book>
     <Book Series="Batgirl" Number="23" Volume="2009" Year="2011">
-      <Id>15c1f462-b4b1-41f5-94d0-3747d4fa6cba</Id>
+      <Database Name="cv" Series="27457" Issue="278609" />
     </Book>
     <Book Series="Batgirl" Number="24" Volume="2009" Year="2011">
-      <Id>9854575a-9a52-41aa-abef-9dffc4537180</Id>
+      <Database Name="cv" Series="27457" Issue="285342" />
     </Book>
   </Books>
   <Matchers />

--- a/DC/Characters/unsorted/Batgirl/Batgirl 003 (New52_Rebirth).cbl
+++ b/DC/Characters/unsorted/Batgirl/Batgirl 003 (New52_Rebirth).cbl
@@ -2,502 +2,502 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Batgirl 3 (New52/Rebirth)</Name>
   <Books>
-    <Book Series="Batgirl" Number="0" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Batgirl" Number="0" Volume="2011" Year="2012">
       <Id>3ba42244-5594-4455-9538-c8a581f92c2e</Id>
     </Book>
-    <Book Series="Batgirl" Number="1" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Batgirl" Number="1" Volume="2011" Year="2011">
       <Id>4303e867-db39-4061-89aa-c18827c295b1</Id>
     </Book>
-    <Book Series="Batgirl" Number="2" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Batgirl" Number="2" Volume="2011" Year="2011">
       <Id>df33ac3b-af6e-42ad-856c-0f58d712ffa6</Id>
     </Book>
-    <Book Series="Batgirl" Number="3" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Batgirl" Number="3" Volume="2011" Year="2012">
       <Id>1a0d0905-4a2e-46f8-bd1f-41394828f528</Id>
     </Book>
-    <Book Series="Batgirl" Number="4" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Batgirl" Number="4" Volume="2011" Year="2012">
       <Id>a74eddea-b15e-42bf-88d3-ee5c423bc439</Id>
     </Book>
-    <Book Series="Batgirl" Number="5" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Batgirl" Number="5" Volume="2011" Year="2012">
       <Id>fd7fab02-c732-45a0-8442-9cec46d67cdd</Id>
     </Book>
-    <Book Series="Batgirl" Number="6" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Batgirl" Number="6" Volume="2011" Year="2012">
       <Id>4116610c-8515-4bef-a9ca-e30cbecd6563</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="4" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Birds of Prey" Number="4" Volume="2011" Year="2012">
       <Id>588f2dd8-22e8-456e-8f35-acba61d35fcc</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="5" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Birds of Prey" Number="5" Volume="2011" Year="2012">
       <Id>9033dfd9-8860-486b-b278-d0b774714597</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="6" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Birds of Prey" Number="6" Volume="2011" Year="2012">
       <Id>bab2d534-853b-4a8c-945f-efebd8dbc096</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="7" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Birds of Prey" Number="7" Volume="2011" Year="2012">
       <Id>6ff6ef9c-11a5-415a-af61-b2a46f4a9d44</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="8" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Birds of Prey" Number="8" Volume="2011" Year="2012">
       <Id>995b395e-8c08-449e-94d1-979959cc2b08</Id>
     </Book>
-    <Book Series="Batgirl" Number="7" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Batgirl" Number="7" Volume="2011" Year="2012">
       <Id>c7686f0a-f435-49b5-b963-216afeb103df</Id>
     </Book>
-    <Book Series="Batgirl" Number="8" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Batgirl" Number="8" Volume="2011" Year="2012">
       <Id>e1c8993f-219c-4d0b-9ee3-f0a65b58007b</Id>
     </Book>
-    <Book Series="Nightwing" Number="4" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Nightwing" Number="4" Volume="2011" Year="2012">
       <Id>c18696d2-d40b-4b9b-8f02-3f86537eaa21</Id>
     </Book>
-    <Book Series="Batgirl" Number="9" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Batgirl" Number="9" Volume="2011" Year="2012">
       <Id>7ac4890a-c782-4454-8959-8896ff18e355</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="9" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Birds of Prey" Number="9" Volume="2011" Year="2012">
       <Id>1c6611eb-dc6e-4cd3-ab55-76d4bd406181</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="10" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Birds of Prey" Number="10" Volume="2011" Year="2012">
       <Id>803c45fa-220b-42b6-8b6d-0b82841080ae</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="11" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Birds of Prey" Number="11" Volume="2011" Year="2012">
       <Id>be30d390-89cf-4072-a8b1-7c76e9e66aed</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="12" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Birds of Prey" Number="12" Volume="2011" Year="2012">
       <Id>eac173cf-8cdf-4cd7-9011-197f48522de6</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="0" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Birds of Prey" Number="0" Volume="2011" Year="2012">
       <Id>f9b8d0d1-0212-42aa-a3c8-12fe7d335196</Id>
     </Book>
-    <Book Series="Batgirl" Number="10" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Batgirl" Number="10" Volume="2011" Year="2012">
       <Id>ed0b025f-1eb3-40a9-a9d8-c963c3263ed5</Id>
     </Book>
-    <Book Series="Batgirl" Number="11" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Batgirl" Number="11" Volume="2011" Year="2012">
       <Id>85afcef6-c760-458f-8ccb-3c1c0c15b193</Id>
     </Book>
-    <Book Series="Batgirl" Number="12" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Batgirl" Number="12" Volume="2011" Year="2012">
       <Id>9e957ecf-5bc3-4e97-8c3a-4c5293db88e1</Id>
     </Book>
-    <Book Series="Batgirl" Number="13" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Batgirl" Number="13" Volume="2011" Year="2012">
       <Id>90cf348e-fcf1-484c-b857-b3d24a083e50</Id>
     </Book>
-    <Book Series="Batgirl Annual" Number="1" Volume="2012" Year="2012" Format="Annual">
+    <Book Series="Batgirl Annual" Number="1" Volume="2012" Year="2012">
       <Id>d93a697f-429d-4b07-87b5-fb0b11b144e6</Id>
     </Book>
-    <Book Series="Batgirl" Number="14" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Batgirl" Number="14" Volume="2011" Year="2013">
       <Id>3e000e25-1933-462e-9941-309380ea82ac</Id>
     </Book>
-    <Book Series="Batgirl" Number="15" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Batgirl" Number="15" Volume="2011" Year="2013">
       <Id>87257c0c-9b95-446d-a6e7-6b61ddcc48b5</Id>
     </Book>
-    <Book Series="Batgirl" Number="16" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Batgirl" Number="16" Volume="2011" Year="2013">
       <Id>f8e26eb2-2003-4dec-824c-c6155d3aa1ef</Id>
     </Book>
-    <Book Series="Batman" Number="17" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Batman" Number="17" Volume="2011" Year="2013">
       <Id>0b62065c-8456-495a-b576-932f606f5794</Id>
     </Book>
-    <Book Series="Young Romance: The New 52 Valentine's Day Special" Number="1" Volume="2013" Year="2013" Format="One-Shot">
+    <Book Series="Young Romance: The New 52 Valentine's Day Special" Number="1" Volume="2013" Year="2013">
       <Id>36685852-e55d-4095-9763-6ed42f433af6</Id>
     </Book>
-    <Book Series="Batgirl" Number="17" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Batgirl" Number="17" Volume="2011" Year="2013">
       <Id>038ffcfb-c074-44d6-ae83-99201a902f63</Id>
     </Book>
-    <Book Series="Batgirl" Number="18" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Batgirl" Number="18" Volume="2011" Year="2013">
       <Id>3a064896-2d75-4f0b-9ac4-ba82c3a8d915</Id>
     </Book>
-    <Book Series="Batgirl" Number="19" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Batgirl" Number="19" Volume="2011" Year="2013">
       <Id>119a131d-650d-4de5-87e4-5ac052d524ae</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="13" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Birds of Prey" Number="13" Volume="2011" Year="2012">
       <Id>d144f1e5-88e9-433d-a436-2eb611c78861</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="14" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Birds of Prey" Number="14" Volume="2011" Year="2013">
       <Id>85ece657-8f89-457c-9cec-79b8c5603d30</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="15" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Birds of Prey" Number="15" Volume="2011" Year="2013">
       <Id>2a6d2a4a-b64f-4234-ba17-feae071c8e24</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="16" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Birds of Prey" Number="16" Volume="2011" Year="2013">
       <Id>184f9876-335b-43b8-a6ad-15d8ad891373</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="17" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Birds of Prey" Number="17" Volume="2011" Year="2013">
       <Id>33bd1d64-4d16-4d60-a7fb-e679d07e628a</Id>
     </Book>
-    <Book Series="Batgirl" Number="20" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Batgirl" Number="20" Volume="2011" Year="2013">
       <Id>4a9f1146-d723-47c2-83df-7c4d9a9aa4f1</Id>
     </Book>
-    <Book Series="Batgirl" Number="21" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Batgirl" Number="21" Volume="2011" Year="2013">
       <Id>e23d322c-6765-4f57-a189-4af57c0c6063</Id>
     </Book>
-    <Book Series="Batgirl" Number="22" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Batgirl" Number="22" Volume="2011" Year="2013">
       <Id>f0d01221-ce22-4b00-b17a-77ba4501c5b9</Id>
     </Book>
-    <Book Series="Batgirl" Number="23" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Batgirl" Number="23" Volume="2011" Year="2013">
       <Id>cc4c5e40-9f4a-4c17-ab75-c1100c487f7a</Id>
     </Book>
-    <Book Series="Batgirl" Number="24" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Batgirl" Number="24" Volume="2011" Year="2013">
       <Id>5130979c-c900-49d3-9da1-4636437dd628</Id>
     </Book>
-    <Book Series="Batgirl" Number="25" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Batgirl" Number="25" Volume="2011" Year="2014">
       <Id>16e7a504-b93e-4c3a-a555-87a08225a645</Id>
     </Book>
-    <Book Series="Batgirl" Number="26" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Batgirl" Number="26" Volume="2011" Year="2014">
       <Id>8ca3d084-c5ba-4f86-8af9-007e6b45f220</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="18" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Birds of Prey" Number="18" Volume="2011" Year="2013">
       <Id>db452413-b7f7-441b-8694-1cf79d772219</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="19" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Birds of Prey" Number="19" Volume="2011" Year="2013">
       <Id>3e9b957b-b7ed-488c-8115-820bd3e52463</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="20" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Birds of Prey" Number="20" Volume="2011" Year="2013">
       <Id>d4537145-6201-452b-a7c5-9f504cdc416e</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="21" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Birds of Prey" Number="21" Volume="2011" Year="2013">
       <Id>12ec0705-8f75-43f9-b3bb-5ee34ec19ab8</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="22" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Birds of Prey" Number="22" Volume="2011" Year="2013">
       <Id>9b7cda88-0284-4e26-bf59-3ec1d335f45b</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="23" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Birds of Prey" Number="23" Volume="2011" Year="2013">
       <Id>03165305-0daf-4683-a348-0f72a0f6e19e</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="24" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Birds of Prey" Number="24" Volume="2011" Year="2013">
       <Id>c9a89ce3-1b71-419b-9215-e2277b3f663e</Id>
     </Book>
-    <Book Series="Batgirl" Number="27" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Batgirl" Number="27" Volume="2011" Year="2014">
       <Id>3945d16c-6d9f-46e1-a718-988acf634d62</Id>
     </Book>
-    <Book Series="Batgirl" Number="28" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Batgirl" Number="28" Volume="2011" Year="2014">
       <Id>0f9dadb8-523c-458a-88f9-ba2acb73e411</Id>
     </Book>
-    <Book Series="Batgirl" Number="29" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Batgirl" Number="29" Volume="2011" Year="2014">
       <Id>f92122a5-f77e-4ede-a328-be66864b0110</Id>
     </Book>
-    <Book Series="Batgirl Annual" Number="2" Volume="2012" Year="2014" Format="Annual">
+    <Book Series="Batgirl Annual" Number="2" Volume="2012" Year="2014">
       <Id>e50258f3-aeae-47b7-9d0d-9027e57ad594</Id>
     </Book>
-    <Book Series="Batgirl" Number="30" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Batgirl" Number="30" Volume="2011" Year="2014">
       <Id>33f82ca8-f5d3-4c86-bda1-cedb98f7aaf2</Id>
     </Book>
-    <Book Series="Batgirl" Number="31" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Batgirl" Number="31" Volume="2011" Year="2014">
       <Id>c7bd6386-73fc-4262-94ec-01df6892eaac</Id>
     </Book>
-    <Book Series="Batgirl" Number="32" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Batgirl" Number="32" Volume="2011" Year="2014">
       <Id>164ec21d-f359-4130-b16e-d793b6eafb3b</Id>
     </Book>
-    <Book Series="Batgirl" Number="33" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Batgirl" Number="33" Volume="2011" Year="2014">
       <Id>b38c0d6b-0002-4410-a953-8cb08c418d82</Id>
     </Book>
-    <Book Series="Batgirl" Number="34" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Batgirl" Number="34" Volume="2011" Year="2014">
       <Id>d0aee27b-9209-4d88-9dd8-59dd3e0e8fd3</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="25" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Birds of Prey" Number="25" Volume="2011" Year="2014">
       <Id>17194e42-a45a-4a96-a4c1-1405a3228ed9</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="26" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Birds of Prey" Number="26" Volume="2011" Year="2014">
       <Id>4a0cc5e0-eac0-47a4-bb5e-11468d9cfbdc</Id>
     </Book>
-    <Book Series="Batgirl: Futures End" Number="1" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="Batgirl: Futures End" Number="1" Volume="2014" Year="2014">
       <Id>7b59c224-c47a-43f5-a77e-24132a05ed6d</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="27" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Birds of Prey" Number="27" Volume="2011" Year="2014">
       <Id>22e760c8-9054-459b-bf73-9133c52d7a83</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="28" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Birds of Prey" Number="28" Volume="2011" Year="2014">
       <Id>b79c32f3-41b4-41c5-b28c-8cbca9e5bdde</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="29" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Birds of Prey" Number="29" Volume="2011" Year="2014">
       <Id>dc5f3e4c-7b7a-4a4c-8c51-63f9b72c2a40</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="30" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Birds of Prey" Number="30" Volume="2011" Year="2014">
       <Id>ab2d2fd5-6159-4c5c-98a4-a0e76532788c</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="31" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Birds of Prey" Number="31" Volume="2011" Year="2014">
       <Id>736874f6-1c33-49c5-867f-ccbb57785e6b</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="32" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Birds of Prey" Number="32" Volume="2011" Year="2014">
       <Id>e35aab2b-11c3-419c-9444-a48e78b8c513</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="33" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Birds of Prey" Number="33" Volume="2011" Year="2014">
       <Id>ebac43c0-57a9-4555-bf75-1a82d4969182</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="34" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Birds of Prey" Number="34" Volume="2011" Year="2014">
       <Id>847343d5-6b2b-402a-8265-f120c526ac2c</Id>
     </Book>
-    <Book Series="Batgirl" Number="35" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Batgirl" Number="35" Volume="2011" Year="2014">
       <Id>d9080cc7-2bab-4013-b1d9-5a153e7756da</Id>
     </Book>
-    <Book Series="Batgirl" Number="36" Volume="2011" Year="2015" Format="Main Series">
+    <Book Series="Batgirl" Number="36" Volume="2011" Year="2015">
       <Id>be36084e-a2ce-47a0-b881-5ea7417afece</Id>
     </Book>
-    <Book Series="Batgirl" Number="37" Volume="2011" Year="2015" Format="Main Series">
+    <Book Series="Batgirl" Number="37" Volume="2011" Year="2015">
       <Id>1f3e8a5c-ca9e-4bd7-93bc-6fbaee306872</Id>
     </Book>
-    <Book Series="Batgirl" Number="38" Volume="2011" Year="2015" Format="Main Series">
+    <Book Series="Batgirl" Number="38" Volume="2011" Year="2015">
       <Id>7eb43900-b36d-490c-ba0f-77e1e02eccef</Id>
     </Book>
-    <Book Series="Batgirl" Number="39" Volume="2011" Year="2015" Format="Main Series">
+    <Book Series="Batgirl" Number="39" Volume="2011" Year="2015">
       <Id>e9cc18d4-828c-41f0-a2db-42caf917eb5b</Id>
     </Book>
-    <Book Series="Secret Origins" Number="10" Volume="2014" Year="2015" Format="Main Series">
+    <Book Series="Secret Origins" Number="10" Volume="2014" Year="2015">
       <Id>2355ee37-0621-49b1-baf1-4cde07e24600</Id>
     </Book>
-    <Book Series="Batgirl" Number="40" Volume="2011" Year="2015" Format="Main Series">
+    <Book Series="Batgirl" Number="40" Volume="2011" Year="2015">
       <Id>6daab8fc-46f6-4635-858b-53d1417aeb9a</Id>
     </Book>
-    <Book Series="Batgirl: Endgame" Number="1" Volume="2015" Year="2015" Format="One-Shot">
+    <Book Series="Batgirl: Endgame" Number="1" Volume="2015" Year="2015">
       <Id>ecd7d8b0-6b90-4352-870d-7af75574023c</Id>
     </Book>
-    <Book Series="Batgirl" Number="41" Volume="2011" Year="2015" Format="Main Series">
+    <Book Series="Batgirl" Number="41" Volume="2011" Year="2015">
       <Id>8600b070-581b-487c-b3a1-c7ed90092db1</Id>
     </Book>
-    <Book Series="Batgirl" Number="42" Volume="2011" Year="2015" Format="Main Series">
+    <Book Series="Batgirl" Number="42" Volume="2011" Year="2015">
       <Id>7c709cb1-d3e9-4ba8-b762-2544e22979e5</Id>
     </Book>
-    <Book Series="Batgirl Annual" Number="3" Volume="2012" Year="2015" Format="Annual">
+    <Book Series="Batgirl Annual" Number="3" Volume="2012" Year="2015">
       <Id>bdbe854c-2676-4f0b-b0c2-079c1d52e988</Id>
     </Book>
-    <Book Series="Batgirl" Number="43" Volume="2011" Year="2015" Format="Main Series">
+    <Book Series="Batgirl" Number="43" Volume="2011" Year="2015">
       <Id>e55e6476-4317-4193-a834-b857973f2287</Id>
     </Book>
-    <Book Series="Batgirl" Number="44" Volume="2011" Year="2015" Format="Main Series">
+    <Book Series="Batgirl" Number="44" Volume="2011" Year="2015">
       <Id>856e667f-e178-4b7f-b87e-1a2bfe060969</Id>
     </Book>
-    <Book Series="Batgirl" Number="45" Volume="2011" Year="2015" Format="Main Series">
+    <Book Series="Batgirl" Number="45" Volume="2011" Year="2015">
       <Id>f355e7c0-825d-4404-9fa8-6fffe19f229f</Id>
     </Book>
-    <Book Series="Batgirl" Number="46" Volume="2011" Year="2016" Format="Main Series">
+    <Book Series="Batgirl" Number="46" Volume="2011" Year="2016">
       <Id>d1d9c73f-a496-4182-9c71-c5772065aca6</Id>
     </Book>
-    <Book Series="Batgirl" Number="47" Volume="2011" Year="2016" Format="Main Series">
+    <Book Series="Batgirl" Number="47" Volume="2011" Year="2016">
       <Id>bf697ffc-d99d-426d-8788-8afacdb136a8</Id>
     </Book>
-    <Book Series="Batgirl" Number="48" Volume="2011" Year="2016" Format="Main Series">
+    <Book Series="Batgirl" Number="48" Volume="2011" Year="2016">
       <Id>8554d001-63c4-4e38-852d-69aad987419c</Id>
     </Book>
-    <Book Series="Batgirl" Number="49" Volume="2011" Year="2016" Format="Main Series">
+    <Book Series="Batgirl" Number="49" Volume="2011" Year="2016">
       <Id>028e74ff-ebfd-4f89-9fd4-f4a577209b93</Id>
     </Book>
-    <Book Series="Batgirl" Number="50" Volume="2011" Year="2016" Format="Main Series">
+    <Book Series="Batgirl" Number="50" Volume="2011" Year="2016">
       <Id>38151308-8cb8-4a6b-9fb6-039d40d61d00</Id>
     </Book>
-    <Book Series="Batgirl" Number="51" Volume="2011" Year="2016" Format="Main Series">
+    <Book Series="Batgirl" Number="51" Volume="2011" Year="2016">
       <Id>d3a0d32c-a873-47f5-858a-c2981f9b4c80</Id>
     </Book>
-    <Book Series="Batgirl" Number="52" Volume="2011" Year="2016" Format="Main Series">
+    <Book Series="Batgirl" Number="52" Volume="2011" Year="2016">
       <Id>2757e4e2-9f8e-463a-bcf2-9744db6f5585</Id>
     </Book>
-    <Book Series="Convergence Batgirl" Number="1" Volume="2015" Year="2015" Format="Crossover">
+    <Book Series="Convergence Batgirl" Number="1" Volume="2015" Year="2015">
       <Id>a47f0f20-271e-4d9c-9a22-8b1e8888aaba</Id>
     </Book>
-    <Book Series="Convergence Batgirl" Number="2" Volume="2015" Year="2015" Format="Crossover">
+    <Book Series="Convergence Batgirl" Number="2" Volume="2015" Year="2015">
       <Id>a351a4b9-e6f9-4d8c-8974-c46c53db6461</Id>
     </Book>
-    <Book Series="Batgirl" Number="1" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Batgirl" Number="1" Volume="2016" Year="2016">
       <Id>f7b35584-5850-4d59-8160-f1f2b1a2bdc7</Id>
     </Book>
-    <Book Series="Batgirl" Number="2" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Batgirl" Number="2" Volume="2016" Year="2016">
       <Id>99986c1a-c494-4e87-93ab-5e0a7354a9eb</Id>
     </Book>
-    <Book Series="Batgirl" Number="3" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Batgirl" Number="3" Volume="2016" Year="2016">
       <Id>3870c79c-7aa0-41c0-83c4-d8632322690d</Id>
     </Book>
-    <Book Series="Batgirl" Number="4" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Batgirl" Number="4" Volume="2016" Year="2016">
       <Id>5165a313-6adf-455a-a724-28687f9d6c57</Id>
     </Book>
-    <Book Series="Batgirl" Number="5" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl" Number="5" Volume="2016" Year="2017">
       <Id>f90f951f-8fef-4193-8cdb-0317bf4cb231</Id>
     </Book>
-    <Book Series="Batgirl" Number="6" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl" Number="6" Volume="2016" Year="2017">
       <Id>09acb25d-f72b-48c4-a5f2-ac28da07e695</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey: Rebirth" Number="1" Volume="2016" Year="2016" Format="One-Shot">
+    <Book Series="Batgirl and the Birds of Prey: Rebirth" Number="1" Volume="2016" Year="2016">
       <Id>4d4319a0-82ee-480a-b37d-cb9ae27f4ec2</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="1" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="1" Volume="2016" Year="2016">
       <Id>aa35299a-9fee-4ab0-9328-0aaca222681f</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="2" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="2" Volume="2016" Year="2016">
       <Id>b4d7d669-9a36-4858-a6fa-4d6e580a5524</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="3" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="3" Volume="2016" Year="2016">
       <Id>dcedf4f8-7357-4956-a5bf-9551c13e1b02</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="4" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="4" Volume="2016" Year="2017">
       <Id>f8b8cb5c-30da-4588-9bfa-e93288a5547c</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="5" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="5" Volume="2016" Year="2017">
       <Id>addce30a-f01d-437d-927e-9525cf7ab83e</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="6" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="6" Volume="2016" Year="2017">
       <Id>ace25f88-dd49-402e-a56e-ca00c55ea067</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="7" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="7" Volume="2016" Year="2017">
       <Id>69fd2336-905b-44e5-a6bd-2a7b1aceaf95</Id>
     </Book>
-    <Book Series="Batgirl Annual" Number="1" Volume="2017" Year="2017" Format="Annual">
+    <Book Series="Batgirl Annual" Number="1" Volume="2017" Year="2017">
       <Id>1cab25de-c1e5-4031-86a8-f65d8590b046</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="8" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="8" Volume="2016" Year="2017">
       <Id>c84bba86-cb04-455c-9e90-91de4910ba4a</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="9" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="9" Volume="2016" Year="2017">
       <Id>c94489bf-02f6-4dfd-8a27-ab2957663d7b</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="10" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="10" Volume="2016" Year="2017">
       <Id>d6e648c3-d7fe-42be-a4ad-25b0f62fd6d4</Id>
     </Book>
-    <Book Series="Batgirl" Number="7" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl" Number="7" Volume="2016" Year="2017">
       <Id>895b804b-d069-41ac-8500-edb0b1b4f9fe</Id>
     </Book>
-    <Book Series="Batgirl" Number="8" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl" Number="8" Volume="2016" Year="2017">
       <Id>049258ce-7113-47b9-b0a8-6c5e6180c7fb</Id>
     </Book>
-    <Book Series="Batgirl" Number="9" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl" Number="9" Volume="2016" Year="2017">
       <Id>ac6fb22b-bb8b-4df2-aa09-f89bfaf971ed</Id>
     </Book>
-    <Book Series="Batgirl" Number="10" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl" Number="10" Volume="2016" Year="2017">
       <Id>917e1cc2-a4ee-4fc6-a173-a38cb42898b8</Id>
     </Book>
-    <Book Series="Batgirl" Number="11" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl" Number="11" Volume="2016" Year="2017">
       <Id>de3f8f6f-13e7-4bda-88c2-0b0bb7c6ea59</Id>
     </Book>
-    <Book Series="Batgirl" Number="12" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl" Number="12" Volume="2016" Year="2017">
       <Id>ecd27e78-2543-4e4d-b658-a67d90b1d728</Id>
     </Book>
-    <Book Series="Supergirl" Number="9" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Supergirl" Number="9" Volume="2016" Year="2017">
       <Id>5723a5ff-8add-446d-9ad0-71a0ad39cd0a</Id>
     </Book>
-    <Book Series="Supergirl" Number="10" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Supergirl" Number="10" Volume="2016" Year="2017">
       <Id>18ca0c14-bb25-491a-a5f2-deb2f4045bea</Id>
     </Book>
-    <Book Series="Supergirl" Number="11" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Supergirl" Number="11" Volume="2016" Year="2017">
       <Id>4849b5b1-f6e7-49e1-bea9-6c468968ba12</Id>
     </Book>
-    <Book Series="Batgirl" Number="13" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl" Number="13" Volume="2016" Year="2017">
       <Id>09a9ac07-1d83-4eda-8565-144e229f8275</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="11" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="11" Volume="2016" Year="2017">
       <Id>18a0d5a2-bd2d-48e0-8b8e-992d1532adfc</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="12" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="12" Volume="2016" Year="2017">
       <Id>c11b5691-712a-46ce-8749-2beab724cc23</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="13" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="13" Volume="2016" Year="2017">
       <Id>9e940ad2-ff5a-466f-8dde-d05f9d70d9a7</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="14" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="14" Volume="2016" Year="2017">
       <Id>d671f6b7-8271-445e-aad9-eaa6a5a49aad</Id>
     </Book>
-    <Book Series="Batgirl" Number="14" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl" Number="14" Volume="2016" Year="2017">
       <Id>7a9d8f52-91c9-42cd-bc13-e2db0a6f8e3c</Id>
     </Book>
-    <Book Series="Batgirl" Number="15" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl" Number="15" Volume="2016" Year="2017">
       <Id>c36cccdd-1bff-4cef-9cf0-cf99e5646781</Id>
     </Book>
-    <Book Series="Batgirl" Number="16" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl" Number="16" Volume="2016" Year="2017">
       <Id>22495906-83f0-404f-a4fc-954eaffa0b02</Id>
     </Book>
-    <Book Series="Batgirl" Number="17" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batgirl" Number="17" Volume="2016" Year="2018">
       <Id>02fa99a9-220f-41d9-a81e-894e8364a9a9</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="15" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="15" Volume="2016" Year="2017">
       <Id>62bd4563-4a51-471c-be4e-763a785c359c</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="16" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="16" Volume="2016" Year="2018">
       <Id>46ab6e1a-cb53-48c6-be9c-06e1793fb460</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="17" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="17" Volume="2016" Year="2018">
       <Id>3563ed5d-b10b-46fc-b9a4-83b27a946f41</Id>
     </Book>
-    <Book Series="Batgirl" Number="18" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batgirl" Number="18" Volume="2016" Year="2018">
       <Id>64e31e22-9872-40d7-8e7f-78f54bf1497e</Id>
     </Book>
-    <Book Series="Batgirl" Number="19" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batgirl" Number="19" Volume="2016" Year="2018">
       <Id>896fd2f4-025d-4547-92f3-4121791a2685</Id>
     </Book>
-    <Book Series="Batgirl" Number="20" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batgirl" Number="20" Volume="2016" Year="2018">
       <Id>a620f122-b6b3-436c-974f-7512c3723555</Id>
     </Book>
-    <Book Series="Batgirl" Number="21" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batgirl" Number="21" Volume="2016" Year="2018">
       <Id>677a2694-ba50-4795-b937-ee2028e3ff7f</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="19" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="19" Volume="2016" Year="2018">
       <Id>69a4e359-4241-4765-b1cb-720918387867</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="20" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="20" Volume="2016" Year="2018">
       <Id>512ecad0-8681-4ad4-8411-0f74f53b34c7</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="21" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="21" Volume="2016" Year="2018">
       <Id>2159a898-7137-4bb0-8dd5-36231e69d6cb</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="22" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="22" Volume="2016" Year="2018">
       <Id>23ca719d-54b3-4c4d-8d43-817d10f6a0e2</Id>
     </Book>
-    <Book Series="Batgirl" Number="22" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batgirl" Number="22" Volume="2016" Year="2018">
       <Id>74574501-1c24-4b9b-9706-2fb719facd22</Id>
     </Book>
-    <Book Series="Batgirl" Number="23" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batgirl" Number="23" Volume="2016" Year="2018">
       <Id>78ed6f31-be06-491a-9755-e2ecd697bc1c</Id>
     </Book>
-    <Book Series="Batman: Prelude to the Wedding: Batgirl vs. Riddler" Number="1" Volume="2018" Year="2018" Format="One-Shot">
+    <Book Series="Batman: Prelude to the Wedding: Batgirl vs. Riddler" Number="1" Volume="2018" Year="2018">
       <Id>b87cf294-6f7a-4053-9738-626a092b6ff4</Id>
     </Book>
-    <Book Series="Batgirl" Number="24" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batgirl" Number="24" Volume="2016" Year="2018">
       <Id>addc9592-407b-4796-84c0-9505114ae677</Id>
     </Book>
-    <Book Series="Batgirl" Number="25" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batgirl" Number="25" Volume="2016" Year="2018">
       <Id>0caba5ca-5fb9-4a59-b3c0-b9bbb064efc9</Id>
     </Book>
-    <Book Series="Batgirl Annual" Number="2" Volume="2017" Year="2018" Format="Annual">
+    <Book Series="Batgirl Annual" Number="2" Volume="2017" Year="2018">
       <Id>46323269-1e5f-4ea6-be01-f8f5e384cee4</Id>
     </Book>
-    <Book Series="Batgirl" Number="26" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batgirl" Number="26" Volume="2016" Year="2018">
       <Id>1975023b-04fe-459e-9c2a-098395a92833</Id>
     </Book>
-    <Book Series="Batgirl" Number="27" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batgirl" Number="27" Volume="2016" Year="2018">
       <Id>6c4068a3-36a9-4dc9-9fd7-ab7651af2e9c</Id>
     </Book>
-    <Book Series="Batgirl" Number="28" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batgirl" Number="28" Volume="2016" Year="2018">
       <Id>102ebde3-b0d1-44f8-87d4-cae3f0bed69f</Id>
     </Book>
-    <Book Series="Batgirl" Number="29" Volume="2016" Year="2019" Format="Main Series">
+    <Book Series="Batgirl" Number="29" Volume="2016" Year="2019">
       <Id>18d60e2e-061c-4c19-899b-08a5eb81debc</Id>
     </Book>
-    <Book Series="Batgirl" Number="30" Volume="2016" Year="2019" Format="Main Series">
+    <Book Series="Batgirl" Number="30" Volume="2016" Year="2019">
       <Id>9fcde856-50d3-4e6f-8780-742643c6887d</Id>
     </Book>
-    <Book Series="Batgirl" Number="31" Volume="2016" Year="2019" Format="Main Series">
+    <Book Series="Batgirl" Number="31" Volume="2016" Year="2019">
       <Id>84c1e1eb-46ba-4dfe-8fe4-71c150c6a5d5</Id>
     </Book>
-    <Book Series="Batgirl" Number="32" Volume="2016" Year="2019" Format="Main Series">
+    <Book Series="Batgirl" Number="32" Volume="2016" Year="2019">
       <Id>c939ff39-4c6f-462a-b55c-84fed6f3ca09</Id>
     </Book>
-    <Book Series="Batgirl" Number="33" Volume="2016" Year="2019" Format="Main Series">
+    <Book Series="Batgirl" Number="33" Volume="2016" Year="2019">
       <Id>1d2b4e8d-1580-477a-99b7-61212695afd8</Id>
     </Book>
-    <Book Series="Batgirl" Number="34" Volume="2016" Year="2019" Format="Main Series">
+    <Book Series="Batgirl" Number="34" Volume="2016" Year="2019">
       <Id>51c8d923-e0cd-4eab-b149-a4b3c974ee37</Id>
     </Book>
-    <Book Series="Batgirl" Number="35" Volume="2016" Year="2019" Format="Main Series">
+    <Book Series="Batgirl" Number="35" Volume="2016" Year="2019">
       <Id>2431e8c1-b0db-4078-9c75-24dc9ddca008</Id>
     </Book>
-    <Book Series="Batgirl" Number="36" Volume="2016" Year="2019" Format="Main Series">
+    <Book Series="Batgirl" Number="36" Volume="2016" Year="2019">
       <Id>f4b6e202-1044-4795-993e-538bf01628b3</Id>
     </Book>
-    <Book Series="Batgirl" Number="37" Volume="2016" Year="2019" Format="Main Series">
+    <Book Series="Batgirl" Number="37" Volume="2016" Year="2019">
       <Id>fad56695-327d-4175-9d8e-d7a45bfa7385</Id>
     </Book>
-    <Book Series="Batgirl" Number="38" Volume="2016" Year="2019" Format="Main Series">
+    <Book Series="Batgirl" Number="38" Volume="2016" Year="2019">
       <Id>486422dc-992f-4d32-914e-6216ecdaea3c</Id>
     </Book>
-    <Book Series="Batgirl" Number="39" Volume="2016" Year="2019" Format="Main Series">
+    <Book Series="Batgirl" Number="39" Volume="2016" Year="2019">
       <Id>218a9852-32cd-4c7a-b8e1-ae8b4d0811e3</Id>
     </Book>
-    <Book Series="Batgirl" Number="40" Volume="2016" Year="2019" Format="Main Series">
+    <Book Series="Batgirl" Number="40" Volume="2016" Year="2019">
       <Id>f39317d3-acb0-4ffb-8131-3b203620151c</Id>
     </Book>
-    <Book Series="Batgirl" Number="41" Volume="2016" Year="2020" Format="Main Series">
+    <Book Series="Batgirl" Number="41" Volume="2016" Year="2020">
       <Id>985e76fe-6b39-401e-a91b-0298d2528852</Id>
     </Book>
-    <Book Series="Batgirl" Number="42" Volume="2016" Year="2020" Format="Main Series">
+    <Book Series="Batgirl" Number="42" Volume="2016" Year="2020">
       <Id>34b1de13-4753-4e4a-b44b-9e7bd03fc83c</Id>
     </Book>
   </Books>

--- a/DC/Characters/unsorted/Batgirl/Batgirl 003 (New52_Rebirth).cbl
+++ b/DC/Characters/unsorted/Batgirl/Batgirl 003 (New52_Rebirth).cbl
@@ -1,504 +1,505 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Batgirl 3 (New52/Rebirth)</Name>
+  <Name>Batgirl 003 (New52_Rebirth)</Name>
+  <NumIssues>166</NumIssues>
   <Books>
     <Book Series="Batgirl" Number="0" Volume="2011" Year="2012">
-      <Id>3ba42244-5594-4455-9538-c8a581f92c2e</Id>
+      <Database Name="cv" Series="42604" Issue="356719" />
     </Book>
     <Book Series="Batgirl" Number="1" Volume="2011" Year="2011">
-      <Id>4303e867-db39-4061-89aa-c18827c295b1</Id>
+      <Database Name="cv" Series="42604" Issue="291171" />
     </Book>
     <Book Series="Batgirl" Number="2" Volume="2011" Year="2011">
-      <Id>df33ac3b-af6e-42ad-856c-0f58d712ffa6</Id>
+      <Database Name="cv" Series="42604" Issue="294820" />
     </Book>
     <Book Series="Batgirl" Number="3" Volume="2011" Year="2012">
-      <Id>1a0d0905-4a2e-46f8-bd1f-41394828f528</Id>
+      <Database Name="cv" Series="42604" Issue="301534" />
     </Book>
     <Book Series="Batgirl" Number="4" Volume="2011" Year="2012">
-      <Id>a74eddea-b15e-42bf-88d3-ee5c423bc439</Id>
+      <Database Name="cv" Series="42604" Issue="306479" />
     </Book>
     <Book Series="Batgirl" Number="5" Volume="2011" Year="2012">
-      <Id>fd7fab02-c732-45a0-8442-9cec46d67cdd</Id>
+      <Database Name="cv" Series="42604" Issue="310552" />
     </Book>
     <Book Series="Batgirl" Number="6" Volume="2011" Year="2012">
-      <Id>4116610c-8515-4bef-a9ca-e30cbecd6563</Id>
+      <Database Name="cv" Series="42604" Issue="314975" />
     </Book>
     <Book Series="Birds of Prey" Number="4" Volume="2011" Year="2012">
-      <Id>588f2dd8-22e8-456e-8f35-acba61d35fcc</Id>
+      <Database Name="cv" Series="42806" Issue="307456" />
     </Book>
     <Book Series="Birds of Prey" Number="5" Volume="2011" Year="2012">
-      <Id>9033dfd9-8860-486b-b278-d0b774714597</Id>
+      <Database Name="cv" Series="42806" Issue="311663" />
     </Book>
     <Book Series="Birds of Prey" Number="6" Volume="2011" Year="2012">
-      <Id>bab2d534-853b-4a8c-945f-efebd8dbc096</Id>
+      <Database Name="cv" Series="42806" Issue="315711" />
     </Book>
     <Book Series="Birds of Prey" Number="7" Volume="2011" Year="2012">
-      <Id>6ff6ef9c-11a5-415a-af61-b2a46f4a9d44</Id>
+      <Database Name="cv" Series="42806" Issue="322740" />
     </Book>
     <Book Series="Birds of Prey" Number="8" Volume="2011" Year="2012">
-      <Id>995b395e-8c08-449e-94d1-979959cc2b08</Id>
+      <Database Name="cv" Series="42806" Issue="331844" />
     </Book>
     <Book Series="Batgirl" Number="7" Volume="2011" Year="2012">
-      <Id>c7686f0a-f435-49b5-b963-216afeb103df</Id>
+      <Database Name="cv" Series="42604" Issue="321187" />
     </Book>
     <Book Series="Batgirl" Number="8" Volume="2011" Year="2012">
-      <Id>e1c8993f-219c-4d0b-9ee3-f0a65b58007b</Id>
+      <Database Name="cv" Series="42604" Issue="329245" />
     </Book>
     <Book Series="Nightwing" Number="4" Volume="2011" Year="2012">
-      <Id>c18696d2-d40b-4b9b-8f02-3f86537eaa21</Id>
+      <Database Name="cv" Series="42720" Issue="307468" />
     </Book>
     <Book Series="Batgirl" Number="9" Volume="2011" Year="2012">
-      <Id>7ac4890a-c782-4454-8959-8896ff18e355</Id>
+      <Database Name="cv" Series="42604" Issue="335019" />
     </Book>
     <Book Series="Birds of Prey" Number="9" Volume="2011" Year="2012">
-      <Id>1c6611eb-dc6e-4cd3-ab55-76d4bd406181</Id>
+      <Database Name="cv" Series="42806" Issue="335896" />
     </Book>
     <Book Series="Birds of Prey" Number="10" Volume="2011" Year="2012">
-      <Id>803c45fa-220b-42b6-8b6d-0b82841080ae</Id>
+      <Database Name="cv" Series="42806" Issue="341638" />
     </Book>
     <Book Series="Birds of Prey" Number="11" Volume="2011" Year="2012">
-      <Id>be30d390-89cf-4072-a8b1-7c76e9e66aed</Id>
+      <Database Name="cv" Series="42806" Issue="346224" />
     </Book>
     <Book Series="Birds of Prey" Number="12" Volume="2011" Year="2012">
-      <Id>eac173cf-8cdf-4cd7-9011-197f48522de6</Id>
+      <Database Name="cv" Series="42806" Issue="350902" />
     </Book>
     <Book Series="Birds of Prey" Number="0" Volume="2011" Year="2012">
-      <Id>f9b8d0d1-0212-42aa-a3c8-12fe7d335196</Id>
+      <Database Name="cv" Series="42806" Issue="357622" />
     </Book>
     <Book Series="Batgirl" Number="10" Volume="2011" Year="2012">
-      <Id>ed0b025f-1eb3-40a9-a9d8-c963c3263ed5</Id>
+      <Database Name="cv" Series="42604" Issue="340428" />
     </Book>
     <Book Series="Batgirl" Number="11" Volume="2011" Year="2012">
-      <Id>85afcef6-c760-458f-8ccb-3c1c0c15b193</Id>
+      <Database Name="cv" Series="42604" Issue="345344" />
     </Book>
     <Book Series="Batgirl" Number="12" Volume="2011" Year="2012">
-      <Id>9e957ecf-5bc3-4e97-8c3a-4c5293db88e1</Id>
+      <Database Name="cv" Series="42604" Issue="349623" />
     </Book>
     <Book Series="Batgirl" Number="13" Volume="2011" Year="2012">
-      <Id>90cf348e-fcf1-484c-b857-b3d24a083e50</Id>
+      <Database Name="cv" Series="42604" Issue="360791" />
     </Book>
     <Book Series="Batgirl Annual" Number="1" Volume="2012" Year="2012">
-      <Id>d93a697f-429d-4b07-87b5-fb0b11b144e6</Id>
+      <Database Name="cv" Series="53505" Issue="364092" />
     </Book>
     <Book Series="Batgirl" Number="14" Volume="2011" Year="2013">
-      <Id>3e000e25-1933-462e-9941-309380ea82ac</Id>
+      <Database Name="cv" Series="42604" Issue="367688" />
     </Book>
     <Book Series="Batgirl" Number="15" Volume="2011" Year="2013">
-      <Id>87257c0c-9b95-446d-a6e7-6b61ddcc48b5</Id>
+      <Database Name="cv" Series="42604" Issue="372337" />
     </Book>
     <Book Series="Batgirl" Number="16" Volume="2011" Year="2013">
-      <Id>f8e26eb2-2003-4dec-824c-c6155d3aa1ef</Id>
+      <Database Name="cv" Series="42604" Issue="380318" />
     </Book>
     <Book Series="Batman" Number="17" Volume="2011" Year="2013">
-      <Id>0b62065c-8456-495a-b576-932f606f5794</Id>
+      <Database Name="cv" Series="42721" Issue="386088" />
     </Book>
-    <Book Series="Young Romance: The New 52 Valentine's Day Special" Number="1" Volume="2013" Year="2013">
-      <Id>36685852-e55d-4095-9763-6ed42f433af6</Id>
+    <Book Series="Young Romance: The New 52 Valentine&apos;s Day Special" Number="1" Volume="2013" Year="2013">
+      <Database Name="cv" Series="56853" Issue="384921" />
     </Book>
     <Book Series="Batgirl" Number="17" Volume="2011" Year="2013">
-      <Id>038ffcfb-c074-44d6-ae83-99201a902f63</Id>
+      <Database Name="cv" Series="42604" Issue="386090" />
     </Book>
     <Book Series="Batgirl" Number="18" Volume="2011" Year="2013">
-      <Id>3a064896-2d75-4f0b-9ac4-ba82c3a8d915</Id>
+      <Database Name="cv" Series="42604" Issue="392310" />
     </Book>
     <Book Series="Batgirl" Number="19" Volume="2011" Year="2013">
-      <Id>119a131d-650d-4de5-87e4-5ac052d524ae</Id>
+      <Database Name="cv" Series="42604" Issue="396379" />
     </Book>
     <Book Series="Birds of Prey" Number="13" Volume="2011" Year="2012">
-      <Id>d144f1e5-88e9-433d-a436-2eb611c78861</Id>
+      <Database Name="cv" Series="42806" Issue="362282" />
     </Book>
     <Book Series="Birds of Prey" Number="14" Volume="2011" Year="2013">
-      <Id>85ece657-8f89-457c-9cec-79b8c5603d30</Id>
+      <Database Name="cv" Series="42806" Issue="369030" />
     </Book>
     <Book Series="Birds of Prey" Number="15" Volume="2011" Year="2013">
-      <Id>2a6d2a4a-b64f-4234-ba17-feae071c8e24</Id>
+      <Database Name="cv" Series="42806" Issue="373259" />
     </Book>
     <Book Series="Birds of Prey" Number="16" Volume="2011" Year="2013">
-      <Id>184f9876-335b-43b8-a6ad-15d8ad891373</Id>
+      <Database Name="cv" Series="42806" Issue="381524" />
     </Book>
     <Book Series="Birds of Prey" Number="17" Volume="2011" Year="2013">
-      <Id>33bd1d64-4d16-4d60-a7fb-e679d07e628a</Id>
+      <Database Name="cv" Series="42806" Issue="387211" />
     </Book>
     <Book Series="Batgirl" Number="20" Volume="2011" Year="2013">
-      <Id>4a9f1146-d723-47c2-83df-7c4d9a9aa4f1</Id>
+      <Database Name="cv" Series="42604" Issue="402240" />
     </Book>
     <Book Series="Batgirl" Number="21" Volume="2011" Year="2013">
-      <Id>e23d322c-6765-4f57-a189-4af57c0c6063</Id>
+      <Database Name="cv" Series="42604" Issue="410270" />
     </Book>
     <Book Series="Batgirl" Number="22" Volume="2011" Year="2013">
-      <Id>f0d01221-ce22-4b00-b17a-77ba4501c5b9</Id>
+      <Database Name="cv" Series="42604" Issue="416905" />
     </Book>
     <Book Series="Batgirl" Number="23" Volume="2011" Year="2013">
-      <Id>cc4c5e40-9f4a-4c17-ab75-c1100c487f7a</Id>
+      <Database Name="cv" Series="42604" Issue="421653" />
     </Book>
     <Book Series="Batgirl" Number="24" Volume="2011" Year="2013">
-      <Id>5130979c-c900-49d3-9da1-4636437dd628</Id>
+      <Database Name="cv" Series="42604" Issue="428253" />
     </Book>
     <Book Series="Batgirl" Number="25" Volume="2011" Year="2014">
-      <Id>16e7a504-b93e-4c3a-a555-87a08225a645</Id>
+      <Database Name="cv" Series="42604" Issue="433109" />
     </Book>
     <Book Series="Batgirl" Number="26" Volume="2011" Year="2014">
-      <Id>8ca3d084-c5ba-4f86-8af9-007e6b45f220</Id>
+      <Database Name="cv" Series="42604" Issue="436147" />
     </Book>
     <Book Series="Birds of Prey" Number="18" Volume="2011" Year="2013">
-      <Id>db452413-b7f7-441b-8694-1cf79d772219</Id>
+      <Database Name="cv" Series="42806" Issue="394648" />
     </Book>
     <Book Series="Birds of Prey" Number="19" Volume="2011" Year="2013">
-      <Id>3e9b957b-b7ed-488c-8115-820bd3e52463</Id>
+      <Database Name="cv" Series="42806" Issue="397491" />
     </Book>
     <Book Series="Birds of Prey" Number="20" Volume="2011" Year="2013">
-      <Id>d4537145-6201-452b-a7c5-9f504cdc416e</Id>
+      <Database Name="cv" Series="42806" Issue="402241" />
     </Book>
     <Book Series="Birds of Prey" Number="21" Volume="2011" Year="2013">
-      <Id>12ec0705-8f75-43f9-b3bb-5ee34ec19ab8</Id>
+      <Database Name="cv" Series="42806" Issue="411787" />
     </Book>
     <Book Series="Birds of Prey" Number="22" Volume="2011" Year="2013">
-      <Id>9b7cda88-0284-4e26-bf59-3ec1d335f45b</Id>
+      <Database Name="cv" Series="42806" Issue="417793" />
     </Book>
     <Book Series="Birds of Prey" Number="23" Volume="2011" Year="2013">
-      <Id>03165305-0daf-4683-a348-0f72a0f6e19e</Id>
+      <Database Name="cv" Series="42806" Issue="422440" />
     </Book>
     <Book Series="Birds of Prey" Number="24" Volume="2011" Year="2013">
-      <Id>c9a89ce3-1b71-419b-9215-e2277b3f663e</Id>
+      <Database Name="cv" Series="42806" Issue="428829" />
     </Book>
     <Book Series="Batgirl" Number="27" Volume="2011" Year="2014">
-      <Id>3945d16c-6d9f-46e1-a718-988acf634d62</Id>
+      <Database Name="cv" Series="42604" Issue="442106" />
     </Book>
     <Book Series="Batgirl" Number="28" Volume="2011" Year="2014">
-      <Id>0f9dadb8-523c-458a-88f9-ba2acb73e411</Id>
+      <Database Name="cv" Series="42604" Issue="445143" />
     </Book>
     <Book Series="Batgirl" Number="29" Volume="2011" Year="2014">
-      <Id>f92122a5-f77e-4ede-a328-be66864b0110</Id>
+      <Database Name="cv" Series="42604" Issue="447466" />
     </Book>
     <Book Series="Batgirl Annual" Number="2" Volume="2012" Year="2014">
-      <Id>e50258f3-aeae-47b7-9d0d-9027e57ad594</Id>
+      <Database Name="cv" Series="53505" Issue="451721" />
     </Book>
     <Book Series="Batgirl" Number="30" Volume="2011" Year="2014">
-      <Id>33f82ca8-f5d3-4c86-bda1-cedb98f7aaf2</Id>
+      <Database Name="cv" Series="42604" Issue="450036" />
     </Book>
     <Book Series="Batgirl" Number="31" Volume="2011" Year="2014">
-      <Id>c7bd6386-73fc-4262-94ec-01df6892eaac</Id>
+      <Database Name="cv" Series="42604" Issue="452803" />
     </Book>
     <Book Series="Batgirl" Number="32" Volume="2011" Year="2014">
-      <Id>164ec21d-f359-4130-b16e-d793b6eafb3b</Id>
+      <Database Name="cv" Series="42604" Issue="455970" />
     </Book>
     <Book Series="Batgirl" Number="33" Volume="2011" Year="2014">
-      <Id>b38c0d6b-0002-4410-a953-8cb08c418d82</Id>
+      <Database Name="cv" Series="42604" Issue="459114" />
     </Book>
     <Book Series="Batgirl" Number="34" Volume="2011" Year="2014">
-      <Id>d0aee27b-9209-4d88-9dd8-59dd3e0e8fd3</Id>
+      <Database Name="cv" Series="42604" Issue="462199" />
     </Book>
     <Book Series="Birds of Prey" Number="25" Volume="2011" Year="2014">
-      <Id>17194e42-a45a-4a96-a4c1-1405a3228ed9</Id>
+      <Database Name="cv" Series="42806" Issue="433793" />
     </Book>
     <Book Series="Birds of Prey" Number="26" Volume="2011" Year="2014">
-      <Id>4a0cc5e0-eac0-47a4-bb5e-11468d9cfbdc</Id>
+      <Database Name="cv" Series="42806" Issue="437423" />
     </Book>
     <Book Series="Batgirl: Futures End" Number="1" Volume="2014" Year="2014">
-      <Id>7b59c224-c47a-43f5-a77e-24132a05ed6d</Id>
+      <Database Name="cv" Series="76839" Issue="464933" />
     </Book>
     <Book Series="Birds of Prey" Number="27" Volume="2011" Year="2014">
-      <Id>22e760c8-9054-459b-bf73-9133c52d7a83</Id>
+      <Database Name="cv" Series="42806" Issue="442878" />
     </Book>
     <Book Series="Birds of Prey" Number="28" Volume="2011" Year="2014">
-      <Id>b79c32f3-41b4-41c5-b28c-8cbca9e5bdde</Id>
+      <Database Name="cv" Series="42806" Issue="445770" />
     </Book>
     <Book Series="Birds of Prey" Number="29" Volume="2011" Year="2014">
-      <Id>dc5f3e4c-7b7a-4a4c-8c51-63f9b72c2a40</Id>
+      <Database Name="cv" Series="42806" Issue="447950" />
     </Book>
     <Book Series="Birds of Prey" Number="30" Volume="2011" Year="2014">
-      <Id>ab2d2fd5-6159-4c5c-98a4-a0e76532788c</Id>
+      <Database Name="cv" Series="42806" Issue="450510" />
     </Book>
     <Book Series="Birds of Prey" Number="31" Volume="2011" Year="2014">
-      <Id>736874f6-1c33-49c5-867f-ccbb57785e6b</Id>
+      <Database Name="cv" Series="42806" Issue="453358" />
     </Book>
     <Book Series="Birds of Prey" Number="32" Volume="2011" Year="2014">
-      <Id>e35aab2b-11c3-419c-9444-a48e78b8c513</Id>
+      <Database Name="cv" Series="42806" Issue="455972" />
     </Book>
     <Book Series="Birds of Prey" Number="33" Volume="2011" Year="2014">
-      <Id>ebac43c0-57a9-4555-bf75-1a82d4969182</Id>
+      <Database Name="cv" Series="42806" Issue="459116" />
     </Book>
     <Book Series="Birds of Prey" Number="34" Volume="2011" Year="2014">
-      <Id>847343d5-6b2b-402a-8265-f120c526ac2c</Id>
+      <Database Name="cv" Series="42806" Issue="462202" />
     </Book>
     <Book Series="Batgirl" Number="35" Volume="2011" Year="2014">
-      <Id>d9080cc7-2bab-4013-b1d9-5a153e7756da</Id>
+      <Database Name="cv" Series="42604" Issue="467594" />
     </Book>
     <Book Series="Batgirl" Number="36" Volume="2011" Year="2015">
-      <Id>be36084e-a2ce-47a0-b881-5ea7417afece</Id>
+      <Database Name="cv" Series="42604" Issue="469789" />
     </Book>
     <Book Series="Batgirl" Number="37" Volume="2011" Year="2015">
-      <Id>1f3e8a5c-ca9e-4bd7-93bc-6fbaee306872</Id>
+      <Database Name="cv" Series="42604" Issue="472833" />
     </Book>
     <Book Series="Batgirl" Number="38" Volume="2011" Year="2015">
-      <Id>7eb43900-b36d-490c-ba0f-77e1e02eccef</Id>
+      <Database Name="cv" Series="42604" Issue="475886" />
     </Book>
     <Book Series="Batgirl" Number="39" Volume="2011" Year="2015">
-      <Id>e9cc18d4-828c-41f0-a2db-42caf917eb5b</Id>
+      <Database Name="cv" Series="42604" Issue="479926" />
     </Book>
     <Book Series="Secret Origins" Number="10" Volume="2014" Year="2015">
-      <Id>2355ee37-0621-49b1-baf1-4cde07e24600</Id>
+      <Database Name="cv" Series="73215" Issue="480635" />
     </Book>
     <Book Series="Batgirl" Number="40" Volume="2011" Year="2015">
-      <Id>6daab8fc-46f6-4635-858b-53d1417aeb9a</Id>
+      <Database Name="cv" Series="42604" Issue="482614" />
     </Book>
     <Book Series="Batgirl: Endgame" Number="1" Volume="2015" Year="2015">
-      <Id>ecd7d8b0-6b90-4352-870d-7af75574023c</Id>
+      <Database Name="cv" Series="80711" Issue="482615" />
     </Book>
     <Book Series="Batgirl" Number="41" Volume="2011" Year="2015">
-      <Id>8600b070-581b-487c-b3a1-c7ed90092db1</Id>
+      <Database Name="cv" Series="42604" Issue="492998" />
     </Book>
     <Book Series="Batgirl" Number="42" Volume="2011" Year="2015">
-      <Id>7c709cb1-d3e9-4ba8-b762-2544e22979e5</Id>
+      <Database Name="cv" Series="42604" Issue="496369" />
     </Book>
     <Book Series="Batgirl Annual" Number="3" Volume="2012" Year="2015">
-      <Id>bdbe854c-2676-4f0b-b0c2-079c1d52e988</Id>
+      <Database Name="cv" Series="53505" Issue="496370" />
     </Book>
     <Book Series="Batgirl" Number="43" Volume="2011" Year="2015">
-      <Id>e55e6476-4317-4193-a834-b857973f2287</Id>
+      <Database Name="cv" Series="42604" Issue="498357" />
     </Book>
     <Book Series="Batgirl" Number="44" Volume="2011" Year="2015">
-      <Id>856e667f-e178-4b7f-b87e-1a2bfe060969</Id>
+      <Database Name="cv" Series="42604" Issue="500997" />
     </Book>
     <Book Series="Batgirl" Number="45" Volume="2011" Year="2015">
-      <Id>f355e7c0-825d-4404-9fa8-6fffe19f229f</Id>
+      <Database Name="cv" Series="42604" Issue="504302" />
     </Book>
     <Book Series="Batgirl" Number="46" Volume="2011" Year="2016">
-      <Id>d1d9c73f-a496-4182-9c71-c5772065aca6</Id>
+      <Database Name="cv" Series="42604" Issue="507411" />
     </Book>
     <Book Series="Batgirl" Number="47" Volume="2011" Year="2016">
-      <Id>bf697ffc-d99d-426d-8788-8afacdb136a8</Id>
+      <Database Name="cv" Series="42604" Issue="511480" />
     </Book>
     <Book Series="Batgirl" Number="48" Volume="2011" Year="2016">
-      <Id>8554d001-63c4-4e38-852d-69aad987419c</Id>
+      <Database Name="cv" Series="42604" Issue="513616" />
     </Book>
     <Book Series="Batgirl" Number="49" Volume="2011" Year="2016">
-      <Id>028e74ff-ebfd-4f89-9fd4-f4a577209b93</Id>
+      <Database Name="cv" Series="42604" Issue="516915" />
     </Book>
     <Book Series="Batgirl" Number="50" Volume="2011" Year="2016">
-      <Id>38151308-8cb8-4a6b-9fb6-039d40d61d00</Id>
+      <Database Name="cv" Series="42604" Issue="523217" />
     </Book>
     <Book Series="Batgirl" Number="51" Volume="2011" Year="2016">
-      <Id>d3a0d32c-a873-47f5-858a-c2981f9b4c80</Id>
+      <Database Name="cv" Series="42604" Issue="527102" />
     </Book>
     <Book Series="Batgirl" Number="52" Volume="2011" Year="2016">
-      <Id>2757e4e2-9f8e-463a-bcf2-9744db6f5585</Id>
+      <Database Name="cv" Series="42604" Issue="531848" />
     </Book>
     <Book Series="Convergence Batgirl" Number="1" Volume="2015" Year="2015">
-      <Id>a47f0f20-271e-4d9c-9a22-8b1e8888aaba</Id>
+      <Database Name="cv" Series="81215" Issue="485467" />
     </Book>
     <Book Series="Convergence Batgirl" Number="2" Volume="2015" Year="2015">
-      <Id>a351a4b9-e6f9-4d8c-8974-c46c53db6461</Id>
+      <Database Name="cv" Series="81215" Issue="487780" />
     </Book>
     <Book Series="Batgirl" Number="1" Volume="2016" Year="2016">
-      <Id>f7b35584-5850-4d59-8160-f1f2b1a2bdc7</Id>
+      <Database Name="cv" Series="92542" Issue="541156" />
     </Book>
     <Book Series="Batgirl" Number="2" Volume="2016" Year="2016">
-      <Id>99986c1a-c494-4e87-93ab-5e0a7354a9eb</Id>
+      <Database Name="cv" Series="92542" Issue="546025" />
     </Book>
     <Book Series="Batgirl" Number="3" Volume="2016" Year="2016">
-      <Id>3870c79c-7aa0-41c0-83c4-d8632322690d</Id>
+      <Database Name="cv" Series="92542" Issue="551263" />
     </Book>
     <Book Series="Batgirl" Number="4" Volume="2016" Year="2016">
-      <Id>5165a313-6adf-455a-a724-28687f9d6c57</Id>
+      <Database Name="cv" Series="92542" Issue="555481" />
     </Book>
     <Book Series="Batgirl" Number="5" Volume="2016" Year="2017">
-      <Id>f90f951f-8fef-4193-8cdb-0317bf4cb231</Id>
+      <Database Name="cv" Series="92542" Issue="558926" />
     </Book>
     <Book Series="Batgirl" Number="6" Volume="2016" Year="2017">
-      <Id>09acb25d-f72b-48c4-a5f2-ac28da07e695</Id>
+      <Database Name="cv" Series="92542" Issue="571625" />
     </Book>
-    <Book Series="Batgirl and the Birds of Prey: Rebirth" Number="1" Volume="2016" Year="2016">
-      <Id>4d4319a0-82ee-480a-b37d-cb9ae27f4ec2</Id>
+    <Book Series="Batgirl &amp; the Birds of Prey: Rebirth" Number="1" Volume="2016" Year="2016">
+      <Database Name="cv" Series="92351" Issue="540045" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="1" Volume="2016" Year="2016">
-      <Id>aa35299a-9fee-4ab0-9328-0aaca222681f</Id>
+      <Database Name="cv" Series="93179" Issue="544954" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="2" Volume="2016" Year="2016">
-      <Id>b4d7d669-9a36-4858-a6fa-4d6e580a5524</Id>
+      <Database Name="cv" Series="93179" Issue="549483" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="3" Volume="2016" Year="2016">
-      <Id>dcedf4f8-7357-4956-a5bf-9551c13e1b02</Id>
+      <Database Name="cv" Series="93179" Issue="552967" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="4" Volume="2016" Year="2017">
-      <Id>f8b8cb5c-30da-4588-9bfa-e93288a5547c</Id>
+      <Database Name="cv" Series="93179" Issue="557330" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="5" Volume="2016" Year="2017">
-      <Id>addce30a-f01d-437d-927e-9525cf7ab83e</Id>
+      <Database Name="cv" Series="93179" Issue="566670" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="6" Volume="2016" Year="2017">
-      <Id>ace25f88-dd49-402e-a56e-ca00c55ea067</Id>
+      <Database Name="cv" Series="93179" Issue="575827" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="7" Volume="2016" Year="2017">
-      <Id>69fd2336-905b-44e5-a6bd-2a7b1aceaf95</Id>
+      <Database Name="cv" Series="93179" Issue="580711" />
     </Book>
-    <Book Series="Batgirl Annual" Number="1" Volume="2017" Year="2017">
-      <Id>1cab25de-c1e5-4031-86a8-f65d8590b046</Id>
+    <Book Series="Batgirl Annual" Number="1" Volume="2016" Year="2017">
+      <Database Name="cv" Series="100356" Issue="589801" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="8" Volume="2016" Year="2017">
-      <Id>c84bba86-cb04-455c-9e90-91de4910ba4a</Id>
+      <Database Name="cv" Series="93179" Issue="585054" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="9" Volume="2016" Year="2017">
-      <Id>c94489bf-02f6-4dfd-8a27-ab2957663d7b</Id>
+      <Database Name="cv" Series="93179" Issue="591718" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="10" Volume="2016" Year="2017">
-      <Id>d6e648c3-d7fe-42be-a4ad-25b0f62fd6d4</Id>
+      <Database Name="cv" Series="93179" Issue="594927" />
     </Book>
     <Book Series="Batgirl" Number="7" Volume="2016" Year="2017">
-      <Id>895b804b-d069-41ac-8500-edb0b1b4f9fe</Id>
+      <Database Name="cv" Series="92542" Issue="578416" />
     </Book>
     <Book Series="Batgirl" Number="8" Volume="2016" Year="2017">
-      <Id>049258ce-7113-47b9-b0a8-6c5e6180c7fb</Id>
+      <Database Name="cv" Series="92542" Issue="582486" />
     </Book>
     <Book Series="Batgirl" Number="9" Volume="2016" Year="2017">
-      <Id>ac6fb22b-bb8b-4df2-aa09-f89bfaf971ed</Id>
+      <Database Name="cv" Series="92542" Issue="588527" />
     </Book>
     <Book Series="Batgirl" Number="10" Volume="2016" Year="2017">
-      <Id>917e1cc2-a4ee-4fc6-a173-a38cb42898b8</Id>
+      <Database Name="cv" Series="92542" Issue="593219" />
     </Book>
     <Book Series="Batgirl" Number="11" Volume="2016" Year="2017">
-      <Id>de3f8f6f-13e7-4bda-88c2-0b0bb7c6ea59</Id>
+      <Database Name="cv" Series="92542" Issue="597155" />
     </Book>
     <Book Series="Batgirl" Number="12" Volume="2016" Year="2017">
-      <Id>ecd27e78-2543-4e4d-b658-a67d90b1d728</Id>
+      <Database Name="cv" Series="92542" Issue="605047" />
     </Book>
     <Book Series="Supergirl" Number="9" Volume="2016" Year="2017">
-      <Id>5723a5ff-8add-446d-9ad0-71a0ad39cd0a</Id>
+      <Database Name="cv" Series="93948" Issue="594947" />
     </Book>
     <Book Series="Supergirl" Number="10" Volume="2016" Year="2017">
-      <Id>18ca0c14-bb25-491a-a5f2-deb2f4045bea</Id>
+      <Database Name="cv" Series="93948" Issue="601775" />
     </Book>
     <Book Series="Supergirl" Number="11" Volume="2016" Year="2017">
-      <Id>4849b5b1-f6e7-49e1-bea9-6c468968ba12</Id>
+      <Database Name="cv" Series="93948" Issue="608192" />
     </Book>
     <Book Series="Batgirl" Number="13" Volume="2016" Year="2017">
-      <Id>09a9ac07-1d83-4eda-8565-144e229f8275</Id>
+      <Database Name="cv" Series="92542" Issue="610455" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="11" Volume="2016" Year="2017">
-      <Id>18a0d5a2-bd2d-48e0-8b8e-992d1532adfc</Id>
+      <Database Name="cv" Series="93179" Issue="601755" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="12" Volume="2016" Year="2017">
-      <Id>c11b5691-712a-46ce-8749-2beab724cc23</Id>
+      <Database Name="cv" Series="93179" Issue="608170" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="13" Volume="2016" Year="2017">
-      <Id>9e940ad2-ff5a-466f-8dde-d05f9d70d9a7</Id>
+      <Database Name="cv" Series="93179" Issue="613732" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="14" Volume="2016" Year="2017">
-      <Id>d671f6b7-8271-445e-aad9-eaa6a5a49aad</Id>
+      <Database Name="cv" Series="93179" Issue="621579" />
     </Book>
     <Book Series="Batgirl" Number="14" Volume="2016" Year="2017">
-      <Id>7a9d8f52-91c9-42cd-bc13-e2db0a6f8e3c</Id>
+      <Database Name="cv" Series="92542" Issue="616136" />
     </Book>
     <Book Series="Batgirl" Number="15" Volume="2016" Year="2017">
-      <Id>c36cccdd-1bff-4cef-9cf0-cf99e5646781</Id>
+      <Database Name="cv" Series="92542" Issue="625269" />
     </Book>
     <Book Series="Batgirl" Number="16" Volume="2016" Year="2017">
-      <Id>22495906-83f0-404f-a4fc-954eaffa0b02</Id>
+      <Database Name="cv" Series="92542" Issue="632455" />
     </Book>
     <Book Series="Batgirl" Number="17" Volume="2016" Year="2018">
-      <Id>02fa99a9-220f-41d9-a81e-894e8364a9a9</Id>
+      <Database Name="cv" Series="92542" Issue="641369" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="15" Volume="2016" Year="2017">
-      <Id>62bd4563-4a51-471c-be4e-763a785c359c</Id>
+      <Database Name="cv" Series="93179" Issue="628542" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="16" Volume="2016" Year="2018">
-      <Id>46ab6e1a-cb53-48c6-be9c-06e1793fb460</Id>
+      <Database Name="cv" Series="93179" Issue="636334" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="17" Volume="2016" Year="2018">
-      <Id>3563ed5d-b10b-46fc-b9a4-83b27a946f41</Id>
+      <Database Name="cv" Series="93179" Issue="646151" />
     </Book>
     <Book Series="Batgirl" Number="18" Volume="2016" Year="2018">
-      <Id>64e31e22-9872-40d7-8e7f-78f54bf1497e</Id>
+      <Database Name="cv" Series="92542" Issue="649691" />
     </Book>
     <Book Series="Batgirl" Number="19" Volume="2016" Year="2018">
-      <Id>896fd2f4-025d-4547-92f3-4121791a2685</Id>
+      <Database Name="cv" Series="92542" Issue="655466" />
     </Book>
     <Book Series="Batgirl" Number="20" Volume="2016" Year="2018">
-      <Id>a620f122-b6b3-436c-974f-7512c3723555</Id>
+      <Database Name="cv" Series="92542" Issue="661107" />
     </Book>
     <Book Series="Batgirl" Number="21" Volume="2016" Year="2018">
-      <Id>677a2694-ba50-4795-b937-ee2028e3ff7f</Id>
+      <Database Name="cv" Series="92542" Issue="664254" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="19" Volume="2016" Year="2018">
-      <Id>69a4e359-4241-4765-b1cb-720918387867</Id>
+      <Database Name="cv" Series="93179" Issue="659973" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="20" Volume="2016" Year="2018">
-      <Id>512ecad0-8681-4ad4-8411-0f74f53b34c7</Id>
+      <Database Name="cv" Series="93179" Issue="662707" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="21" Volume="2016" Year="2018">
-      <Id>2159a898-7137-4bb0-8dd5-36231e69d6cb</Id>
+      <Database Name="cv" Series="93179" Issue="665873" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="22" Volume="2016" Year="2018">
-      <Id>23ca719d-54b3-4c4d-8d43-817d10f6a0e2</Id>
+      <Database Name="cv" Series="93179" Issue="669422" />
     </Book>
     <Book Series="Batgirl" Number="22" Volume="2016" Year="2018">
-      <Id>74574501-1c24-4b9b-9706-2fb719facd22</Id>
+      <Database Name="cv" Series="92542" Issue="667596" />
     </Book>
     <Book Series="Batgirl" Number="23" Volume="2016" Year="2018">
-      <Id>78ed6f31-be06-491a-9755-e2ecd697bc1c</Id>
+      <Database Name="cv" Series="92542" Issue="670714" />
     </Book>
     <Book Series="Batman: Prelude to the Wedding: Batgirl vs. Riddler" Number="1" Volume="2018" Year="2018">
-      <Id>b87cf294-6f7a-4053-9738-626a092b6ff4</Id>
+      <Database Name="cv" Series="111576" Issue="672987" />
     </Book>
     <Book Series="Batgirl" Number="24" Volume="2016" Year="2018">
-      <Id>addc9592-407b-4796-84c0-9505114ae677</Id>
+      <Database Name="cv" Series="92542" Issue="675111" />
     </Book>
     <Book Series="Batgirl" Number="25" Volume="2016" Year="2018">
-      <Id>0caba5ca-5fb9-4a59-b3c0-b9bbb064efc9</Id>
+      <Database Name="cv" Series="92542" Issue="679965" />
     </Book>
-    <Book Series="Batgirl Annual" Number="2" Volume="2017" Year="2018">
-      <Id>46323269-1e5f-4ea6-be01-f8f5e384cee4</Id>
+    <Book Series="Batgirl Annual" Number="2" Volume="2016" Year="2018">
+      <Database Name="cv" Series="100356" Issue="682631" />
     </Book>
     <Book Series="Batgirl" Number="26" Volume="2016" Year="2018">
-      <Id>1975023b-04fe-459e-9c2a-098395a92833</Id>
+      <Database Name="cv" Series="92542" Issue="682630" />
     </Book>
     <Book Series="Batgirl" Number="27" Volume="2016" Year="2018">
-      <Id>6c4068a3-36a9-4dc9-9fd7-ab7651af2e9c</Id>
+      <Database Name="cv" Series="92542" Issue="686343" />
     </Book>
     <Book Series="Batgirl" Number="28" Volume="2016" Year="2018">
-      <Id>102ebde3-b0d1-44f8-87d4-cae3f0bed69f</Id>
+      <Database Name="cv" Series="92542" Issue="689837" />
     </Book>
     <Book Series="Batgirl" Number="29" Volume="2016" Year="2019">
-      <Id>18d60e2e-061c-4c19-899b-08a5eb81debc</Id>
+      <Database Name="cv" Series="92542" Issue="693426" />
     </Book>
     <Book Series="Batgirl" Number="30" Volume="2016" Year="2019">
-      <Id>9fcde856-50d3-4e6f-8780-742643c6887d</Id>
+      <Database Name="cv" Series="92542" Issue="696324" />
     </Book>
     <Book Series="Batgirl" Number="31" Volume="2016" Year="2019">
-      <Id>84c1e1eb-46ba-4dfe-8fe4-71c150c6a5d5</Id>
+      <Database Name="cv" Series="92542" Issue="699366" />
     </Book>
     <Book Series="Batgirl" Number="32" Volume="2016" Year="2019">
-      <Id>c939ff39-4c6f-462a-b55c-84fed6f3ca09</Id>
+      <Database Name="cv" Series="92542" Issue="701905" />
     </Book>
     <Book Series="Batgirl" Number="33" Volume="2016" Year="2019">
-      <Id>1d2b4e8d-1580-477a-99b7-61212695afd8</Id>
+      <Database Name="cv" Series="92542" Issue="704777" />
     </Book>
     <Book Series="Batgirl" Number="34" Volume="2016" Year="2019">
-      <Id>51c8d923-e0cd-4eab-b149-a4b3c974ee37</Id>
+      <Database Name="cv" Series="92542" Issue="706919" />
     </Book>
     <Book Series="Batgirl" Number="35" Volume="2016" Year="2019">
-      <Id>2431e8c1-b0db-4078-9c75-24dc9ddca008</Id>
+      <Database Name="cv" Series="92542" Issue="709693" />
     </Book>
     <Book Series="Batgirl" Number="36" Volume="2016" Year="2019">
-      <Id>f4b6e202-1044-4795-993e-538bf01628b3</Id>
+      <Database Name="cv" Series="92542" Issue="712942" />
     </Book>
     <Book Series="Batgirl" Number="37" Volume="2016" Year="2019">
-      <Id>fad56695-327d-4175-9d8e-d7a45bfa7385</Id>
+      <Database Name="cv" Series="92542" Issue="714154" />
     </Book>
     <Book Series="Batgirl" Number="38" Volume="2016" Year="2019">
-      <Id>486422dc-992f-4d32-914e-6216ecdaea3c</Id>
+      <Database Name="cv" Series="92542" Issue="717387" />
     </Book>
     <Book Series="Batgirl" Number="39" Volume="2016" Year="2019">
-      <Id>218a9852-32cd-4c7a-b8e1-ae8b4d0811e3</Id>
+      <Database Name="cv" Series="92542" Issue="720033" />
     </Book>
     <Book Series="Batgirl" Number="40" Volume="2016" Year="2019">
-      <Id>f39317d3-acb0-4ffb-8131-3b203620151c</Id>
+      <Database Name="cv" Series="92542" Issue="723823" />
     </Book>
     <Book Series="Batgirl" Number="41" Volume="2016" Year="2020">
-      <Id>985e76fe-6b39-401e-a91b-0298d2528852</Id>
+      <Database Name="cv" Series="92542" Issue="728891" />
     </Book>
     <Book Series="Batgirl" Number="42" Volume="2016" Year="2020">
-      <Id>34b1de13-4753-4e4a-b44b-9e7bd03fc83c</Id>
+      <Database Name="cv" Series="92542" Issue="731924" />
     </Book>
   </Books>
   <Matchers />

--- a/DC/Characters/unsorted/Batman Beyond/Batman Beyond 001.cbl
+++ b/DC/Characters/unsorted/Batman Beyond/Batman Beyond 001.cbl
@@ -2,769 +2,769 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Batman Beyond 1</Name>
   <Books>
-    <Book Series="Batman Beyond" Number="1" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Batman Beyond" Number="1" Volume="2010" Year="2010">
       <Id>2bbf3eec-60de-412b-81fc-5e536a078e4e</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="2" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Batman Beyond" Number="2" Volume="2010" Year="2010">
       <Id>468cfe9f-a9f8-4f8a-8127-68645e48e891</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="3" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Batman Beyond" Number="3" Volume="2010" Year="2010">
       <Id>ceff2992-cf59-4b2c-8410-c1f69b9ba4c1</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="4" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Batman Beyond" Number="4" Volume="2010" Year="2010">
       <Id>7b499e4c-2b93-4359-b1ce-26f05e2b17b9</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="5" Volume="2010" Year="2010" Format="Limited Series">
+    <Book Series="Batman Beyond" Number="5" Volume="2010" Year="2010">
       <Id>c6e3e6da-28c9-4f37-9010-31047f9c6459</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="6" Volume="2010" Year="2011" Format="Limited Series">
+    <Book Series="Batman Beyond" Number="6" Volume="2010" Year="2011">
       <Id>5958d1c9-20e4-4f9d-a6bf-a2159ef8f350</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="1" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Batman Beyond" Number="1" Volume="2011" Year="2011">
       <Id>4ba2df90-df9f-4b74-9908-3b3df65fc530</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="2" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Batman Beyond" Number="2" Volume="2011" Year="2011">
       <Id>5cf4c0d6-de87-4887-a3ec-fb20fda69acf</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="3" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Batman Beyond" Number="3" Volume="2011" Year="2011">
       <Id>16d221b3-0b08-45d7-a176-a2ce2abe3eb7</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="4" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Batman Beyond" Number="4" Volume="2011" Year="2011">
       <Id>d32c4190-0386-4c84-be24-77b23a8ff6b0</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="5" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Batman Beyond" Number="5" Volume="2011" Year="2011">
       <Id>285178a1-8e1f-435f-adfc-c4cb21c22163</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="6" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Batman Beyond" Number="6" Volume="2011" Year="2011">
       <Id>53744696-af52-4a53-81e5-34c23bf7fd40</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="7" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Batman Beyond" Number="7" Volume="2011" Year="2011">
       <Id>d1f6e820-a96d-495e-82ca-a37c29d7336c</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="8" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Batman Beyond" Number="8" Volume="2011" Year="2011">
       <Id>e313d593-bb97-4933-9bbb-36ba32c732eb</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="1" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Batman Beyond" Number="1" Volume="2012" Year="2012">
       <Id>887c44c1-1186-4425-bdee-9372fb7bea1a</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="2" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Batman Beyond" Number="2" Volume="2012" Year="2012">
       <Id>dab2b6b9-4a88-4037-9661-ee88eee66b01</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="3" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Batman Beyond" Number="3" Volume="2012" Year="2012">
       <Id>92a549fd-841e-4c40-b2f5-c4e0182381dd</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="4" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Batman Beyond" Number="4" Volume="2012" Year="2012">
       <Id>2e1d0fb8-9a3f-4bc3-9af3-35bad5f3af60</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="5" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Batman Beyond" Number="5" Volume="2012" Year="2012">
       <Id>8eeacd91-0fba-4858-8e1f-cce704dc89bb</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="6" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Batman Beyond" Number="6" Volume="2012" Year="2012">
       <Id>5b5bc211-5096-4d5a-99db-95698c174edd</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="7" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Batman Beyond" Number="7" Volume="2012" Year="2012">
       <Id>16c305b4-99f4-45ef-920e-93888758f4d3</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="8" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Batman Beyond" Number="8" Volume="2012" Year="2012">
       <Id>755cf1d9-9c62-4c2b-92ab-a5f3888ac47c</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="9" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Batman Beyond" Number="9" Volume="2012" Year="2012">
       <Id>e18e9eda-bd5b-419a-a4c5-d67f0259f75f</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="10" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Batman Beyond" Number="10" Volume="2012" Year="2012">
       <Id>72744de9-db0d-41c9-8019-db915a889f4f</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="11" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Batman Beyond" Number="11" Volume="2012" Year="2012">
       <Id>21689435-f502-4f2c-bf38-dcd03e53cdfb</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="12" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Batman Beyond" Number="12" Volume="2012" Year="2012">
       <Id>193998e4-cfd1-48bb-a344-7b1c60d63e47</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="13" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Batman Beyond" Number="13" Volume="2012" Year="2012">
       <Id>e28b1e42-a538-474d-8d70-024d6602831f</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="14" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Batman Beyond" Number="14" Volume="2012" Year="2012">
       <Id>3e2e4752-9058-4614-b5ad-72e2189924b3</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="15" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Batman Beyond" Number="15" Volume="2012" Year="2012">
       <Id>26ef391d-6d3e-4395-8f9b-8e53b2354197</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="16" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Batman Beyond" Number="16" Volume="2012" Year="2012">
       <Id>3e331f6b-14b8-43e9-999a-dfc1ca26052c</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="17" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Batman Beyond" Number="17" Volume="2012" Year="2013">
       <Id>28e4cdb6-de1d-4315-8337-6caf5fa07142</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="18" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Batman Beyond" Number="18" Volume="2012" Year="2013">
       <Id>b67ad46e-3af1-4682-bf93-111d06440c03</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="19" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Batman Beyond" Number="19" Volume="2012" Year="2013">
       <Id>d58b1d84-2c72-4a28-ae94-0c2901fe4257</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="20" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Batman Beyond" Number="20" Volume="2012" Year="2013">
       <Id>1081fec8-d1e3-49b4-ac63-1a6d33ddd394</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="21" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Batman Beyond" Number="21" Volume="2012" Year="2013">
       <Id>b9dabbdd-6b14-4c8f-b3f8-6d4cd3849e95</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="22" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Batman Beyond" Number="22" Volume="2012" Year="2013">
       <Id>559bf2b4-0753-42af-8bbe-cd5969a25a6f</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="23" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Batman Beyond" Number="23" Volume="2012" Year="2013">
       <Id>0c23b773-1a41-4e5d-94de-5506791bcf00</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="24" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Batman Beyond" Number="24" Volume="2012" Year="2013">
       <Id>585c205c-5e2f-4cfa-b0b9-18792d8700be</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="25" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Batman Beyond" Number="25" Volume="2012" Year="2013">
       <Id>4d1d7956-e732-4d1d-98fa-a8bcbe9e48cc</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="26" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Batman Beyond" Number="26" Volume="2012" Year="2013">
       <Id>290c2f4b-4235-45ea-85e8-9c991e0ba73b</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="27" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Batman Beyond" Number="27" Volume="2012" Year="2013">
       <Id>ceac987c-9ab1-40c6-8681-a56404af2915</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="28" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Batman Beyond" Number="28" Volume="2012" Year="2013">
       <Id>8fef96b8-a036-4fca-b20e-ffbdfb1e7ffb</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="29" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Batman Beyond" Number="29" Volume="2012" Year="2013">
       <Id>dce82faa-a85b-41a2-9480-4bc467178de2</Id>
     </Book>
-    <Book Series="Superman Beyond" Number="0" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Superman Beyond" Number="0" Volume="2011" Year="2011">
       <Id>e9d70b33-1b03-4e7b-b07c-f9f24e74172c</Id>
     </Book>
-    <Book Series="Superman Beyond" Number="1" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Superman Beyond" Number="1" Volume="2011" Year="2012">
       <Id>00301839-af44-44c0-8fec-fddc2e7868ce</Id>
     </Book>
-    <Book Series="Superman Beyond" Number="3" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Superman Beyond" Number="3" Volume="2011" Year="2012">
       <Id>89c239a1-a004-4df1-b8b5-b29589dea2bb</Id>
     </Book>
-    <Book Series="Superman Beyond" Number="4" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Superman Beyond" Number="4" Volume="2011" Year="2012">
       <Id>e0420fb6-376a-4c22-a2ab-cee8ebd9988e</Id>
     </Book>
-    <Book Series="Superman Beyond" Number="5" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Superman Beyond" Number="5" Volume="2011" Year="2012">
       <Id>00851b63-67c4-41e5-a43b-16b65388c83c</Id>
     </Book>
-    <Book Series="Superman Beyond" Number="6" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Superman Beyond" Number="6" Volume="2011" Year="2012">
       <Id>ce9a713f-a1bc-4f32-8640-e41cdb358fcc</Id>
     </Book>
-    <Book Series="Superman Beyond" Number="7" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Superman Beyond" Number="7" Volume="2011" Year="2012">
       <Id>b25078b3-9cca-4649-a457-86c627039e33</Id>
     </Book>
-    <Book Series="Superman Beyond" Number="8" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Superman Beyond" Number="8" Volume="2011" Year="2012">
       <Id>2f9ee7f9-7324-4e81-8bf1-669a7b2f271a</Id>
     </Book>
-    <Book Series="Superman Beyond" Number="9" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Superman Beyond" Number="9" Volume="2011" Year="2012">
       <Id>6c0aae57-403b-4e18-bfe4-02812008f597</Id>
     </Book>
-    <Book Series="Superman Beyond" Number="10" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Superman Beyond" Number="10" Volume="2011" Year="2012">
       <Id>c30e4388-cc8e-4811-a012-f1c5302938d4</Id>
     </Book>
-    <Book Series="Superman Beyond" Number="11" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Superman Beyond" Number="11" Volume="2011" Year="2012">
       <Id>ce47980b-3161-4c4e-8952-492aa2e2e2f2</Id>
     </Book>
-    <Book Series="Superman Beyond" Number="12" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Superman Beyond" Number="12" Volume="2011" Year="2012">
       <Id>a3728502-f041-4343-ba0b-7364082b786d</Id>
     </Book>
-    <Book Series="Superman Beyond" Number="13" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Superman Beyond" Number="13" Volume="2011" Year="2013">
       <Id>377b7c78-41fb-4009-8b28-c59cb9cc8c4f</Id>
     </Book>
-    <Book Series="Superman Beyond" Number="14" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Superman Beyond" Number="14" Volume="2011" Year="2013">
       <Id>e69fa4af-670f-4cdb-a10b-75ad9bf35207</Id>
     </Book>
-    <Book Series="Superman Beyond" Number="15" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Superman Beyond" Number="15" Volume="2011" Year="2013">
       <Id>03ae2339-9222-4301-b337-98e5c844566c</Id>
     </Book>
-    <Book Series="Superman Beyond" Number="16" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Superman Beyond" Number="16" Volume="2011" Year="2013">
       <Id>59c7b770-98a2-407a-b509-235218bb7529</Id>
     </Book>
-    <Book Series="Superman Beyond" Number="17" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Superman Beyond" Number="17" Volume="2011" Year="2013">
       <Id>3160b429-eee5-4ba2-8154-e00ebbdb3eea</Id>
     </Book>
-    <Book Series="Superman Beyond" Number="18" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Superman Beyond" Number="18" Volume="2011" Year="2013">
       <Id>fbdffb69-c695-4070-a05b-6de379fb74bd</Id>
     </Book>
-    <Book Series="Superman Beyond" Number="19" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Superman Beyond" Number="19" Volume="2011" Year="2013">
       <Id>56fcedfd-d52c-4276-8841-8b78c4052205</Id>
     </Book>
-    <Book Series="Superman Beyond" Number="20" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Superman Beyond" Number="20" Volume="2011" Year="2013">
       <Id>134acb87-7ec5-4035-853f-a0cf58d4648b</Id>
     </Book>
-    <Book Series="Justice League Beyond" Number="1" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Justice League Beyond" Number="1" Volume="2012" Year="2012">
       <Id>249aba98-6eb7-44a6-a8e1-13a7950627a6</Id>
     </Book>
-    <Book Series="Justice League Beyond" Number="2" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Justice League Beyond" Number="2" Volume="2012" Year="2012">
       <Id>03a408d5-1618-4059-99c6-859928233873</Id>
     </Book>
-    <Book Series="Justice League Beyond" Number="3" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Justice League Beyond" Number="3" Volume="2012" Year="2012">
       <Id>a10a1a9c-dbce-4997-b40e-abcbb80c50b4</Id>
     </Book>
-    <Book Series="Justice League Beyond" Number="4" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Justice League Beyond" Number="4" Volume="2012" Year="2012">
       <Id>a1ea5065-0e1b-45a1-bfc7-ce36b121746c</Id>
     </Book>
-    <Book Series="Justice League Beyond" Number="5" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Justice League Beyond" Number="5" Volume="2012" Year="2012">
       <Id>f05f8f91-3c34-41d7-b7df-f3641dc63a44</Id>
     </Book>
-    <Book Series="Justice League Beyond" Number="6" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Justice League Beyond" Number="6" Volume="2012" Year="2012">
       <Id>264af152-4a47-45f7-9228-68447a939d48</Id>
     </Book>
-    <Book Series="Justice League Beyond" Number="7" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Justice League Beyond" Number="7" Volume="2012" Year="2012">
       <Id>0c48b2fc-1a58-43b4-9323-afb20d3f5d3a</Id>
     </Book>
-    <Book Series="Justice League Beyond" Number="8" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Justice League Beyond" Number="8" Volume="2012" Year="2012">
       <Id>247651cc-170b-4a72-8038-464273ccd9a5</Id>
     </Book>
-    <Book Series="Justice League Beyond" Number="9" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Justice League Beyond" Number="9" Volume="2012" Year="2012">
       <Id>2f6ccda9-88cc-4e9c-9dee-5e250a554d37</Id>
     </Book>
-    <Book Series="Justice League Beyond" Number="10" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Justice League Beyond" Number="10" Volume="2012" Year="2012">
       <Id>94cac4a2-d06b-4eab-9825-2b2f47a061be</Id>
     </Book>
-    <Book Series="Justice League Beyond" Number="11" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Justice League Beyond" Number="11" Volume="2012" Year="2012">
       <Id>a7d63dc6-b657-4950-b8b2-b53a171179b6</Id>
     </Book>
-    <Book Series="Justice League Beyond" Number="12" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Justice League Beyond" Number="12" Volume="2012" Year="2012">
       <Id>c8704287-9d9d-4bac-b962-6c0fedb037fb</Id>
     </Book>
-    <Book Series="Justice League Beyond" Number="13" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Justice League Beyond" Number="13" Volume="2012" Year="2012">
       <Id>857ae1be-5720-4ea5-9105-b0cde3da8a6a</Id>
     </Book>
-    <Book Series="Justice League Beyond" Number="14" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Justice League Beyond" Number="14" Volume="2012" Year="2012">
       <Id>55cd42cc-8fe1-4689-aba5-516dae189503</Id>
     </Book>
-    <Book Series="Justice League Beyond" Number="15" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Justice League Beyond" Number="15" Volume="2012" Year="2012">
       <Id>c2ae34cd-56a3-40af-92a6-825a094b5142</Id>
     </Book>
-    <Book Series="Justice League Beyond" Number="16" Volume="2012" Year="2012" Format="Main Series">
+    <Book Series="Justice League Beyond" Number="16" Volume="2012" Year="2012">
       <Id>974fed9d-b9b6-4ca5-8620-4183ce6082a2</Id>
     </Book>
-    <Book Series="Justice League Beyond" Number="17" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Justice League Beyond" Number="17" Volume="2012" Year="2013">
       <Id>b9b49232-34b3-437b-bf88-42652801463d</Id>
     </Book>
-    <Book Series="Justice League Beyond" Number="18" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Justice League Beyond" Number="18" Volume="2012" Year="2013">
       <Id>ec9ea765-8261-4715-b00b-6592e74c81e8</Id>
     </Book>
-    <Book Series="Justice League Beyond" Number="19" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Justice League Beyond" Number="19" Volume="2012" Year="2013">
       <Id>752d092f-ff91-4e2a-877b-521e97fc5a8e</Id>
     </Book>
-    <Book Series="Justice League Beyond" Number="20" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Justice League Beyond" Number="20" Volume="2012" Year="2013">
       <Id>fa47ac94-3e31-4984-9fc9-fb1d9376eebe</Id>
     </Book>
-    <Book Series="Justice League Beyond" Number="21" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Justice League Beyond" Number="21" Volume="2012" Year="2013">
       <Id>c5ceeba5-19cc-4726-acfe-641fa2f128b7</Id>
     </Book>
-    <Book Series="Justice League Beyond" Number="22" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Justice League Beyond" Number="22" Volume="2012" Year="2013">
       <Id>48e410e8-794e-49dd-b1f0-c7b741142e40</Id>
     </Book>
-    <Book Series="Justice League Beyond" Number="23" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Justice League Beyond" Number="23" Volume="2012" Year="2013">
       <Id>d2010866-8825-4855-aa61-a23605186ab2</Id>
     </Book>
-    <Book Series="Justice League Beyond" Number="24" Volume="2012" Year="2013" Format="Main Series">
+    <Book Series="Justice League Beyond" Number="24" Volume="2012" Year="2013">
       <Id>5681eaa2-15d8-4439-b187-414be507eef8</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="1" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="1" Volume="2013" Year="2013">
       <Id>3ced0d0b-9850-414e-b5d8-184b85c171ab</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="2" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="2" Volume="2013" Year="2013">
       <Id>dd7d4d2d-c97d-407e-b428-44f4508ada75</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="3" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="3" Volume="2013" Year="2013">
       <Id>3d2a8b6e-96b1-481f-acbf-bf6a1840cd0c</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="4" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="4" Volume="2013" Year="2013">
       <Id>d9753e21-ff01-4ebd-bd5b-4d912d453f8a</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="5" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="5" Volume="2013" Year="2013">
       <Id>575f001c-cfa2-419b-a58e-557e684ecbf0</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="6" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="6" Volume="2013" Year="2013">
       <Id>802d346f-b5ea-4d74-a4ca-5bf26f2b839e</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="7" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="7" Volume="2013" Year="2013">
       <Id>ceb2df0c-5f0f-44aa-b57d-8037a522de83</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="8" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="8" Volume="2013" Year="2013">
       <Id>04087e7f-17af-4c7a-8910-1a1464876288</Id>
     </Book>
-    <Book Series="Justice League Beyond 2.0" Number="1" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Justice League Beyond 2.0" Number="1" Volume="2013" Year="2013">
       <Id>a0495636-e6da-4d03-875a-a02875c9feb9</Id>
     </Book>
-    <Book Series="Justice League Beyond 2.0" Number="2" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Justice League Beyond 2.0" Number="2" Volume="2013" Year="2013">
       <Id>7e2a4d47-4022-47ec-a404-6c0f0c4a6da4</Id>
     </Book>
-    <Book Series="Justice League Beyond 2.0" Number="3" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Justice League Beyond 2.0" Number="3" Volume="2013" Year="2013">
       <Id>493ba240-3f66-4c0f-831c-96438fdc692d</Id>
     </Book>
-    <Book Series="Justice League Beyond 2.0" Number="4" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Justice League Beyond 2.0" Number="4" Volume="2013" Year="2013">
       <Id>cc966aba-8c91-4561-aad5-cd0335e40b59</Id>
     </Book>
-    <Book Series="Justice League Beyond 2.0" Number="5" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Justice League Beyond 2.0" Number="5" Volume="2013" Year="2013">
       <Id>db841d38-f34b-475a-a433-93c96d2f89be</Id>
     </Book>
-    <Book Series="Justice League Beyond 2.0" Number="6" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Justice League Beyond 2.0" Number="6" Volume="2013" Year="2013">
       <Id>f793570c-3a7c-4226-934d-bea2e5b12c21</Id>
     </Book>
-    <Book Series="Justice League Beyond 2.0" Number="7" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Justice League Beyond 2.0" Number="7" Volume="2013" Year="2013">
       <Id>9bfa3902-f702-4eca-9bbe-a4160de14d59</Id>
     </Book>
-    <Book Series="Justice League Beyond 2.0" Number="8" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Justice League Beyond 2.0" Number="8" Volume="2013" Year="2013">
       <Id>d1147d2e-712a-482f-b54b-426915e3ef10</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="9" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="9" Volume="2013" Year="2013">
       <Id>69af836a-5bbc-4777-9e23-a64893d7207b</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="10" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="10" Volume="2013" Year="2013">
       <Id>fe36d817-bc13-4cb6-9c8e-5e875d79a212</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="11" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="11" Volume="2013" Year="2014">
       <Id>37e7134a-ab58-41f5-ae9b-2879ba67baee</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="12" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="12" Volume="2013" Year="2014">
       <Id>48754c5d-8bf4-4f29-8366-7fe304b30cde</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="13" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="13" Volume="2013" Year="2014">
       <Id>746c6f23-51a4-4ff2-a7cd-75f8aef2d988</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="14" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="14" Volume="2013" Year="2014">
       <Id>12382107-6a93-4784-b82c-d5e0c94dcd6d</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="15" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="15" Volume="2013" Year="2014">
       <Id>b18186c9-4698-42f1-819f-1fdd8de7c7a8</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="16" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="16" Volume="2013" Year="2014">
       <Id>d8f58f09-29c9-4e83-8db7-83674e4d9c2a</Id>
     </Book>
-    <Book Series="Justice League Beyond 2.0" Number="9" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Justice League Beyond 2.0" Number="9" Volume="2013" Year="2013">
       <Id>28170edd-8a1c-4bb2-85c4-9d27d57c8d2f</Id>
     </Book>
-    <Book Series="Justice League Beyond 2.0" Number="10" Volume="2013" Year="2013" Format="Main Series">
+    <Book Series="Justice League Beyond 2.0" Number="10" Volume="2013" Year="2013">
       <Id>2ea749d3-0e0b-4e11-81de-0892f2c070d5</Id>
     </Book>
-    <Book Series="Justice League Beyond 2.0" Number="11" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Justice League Beyond 2.0" Number="11" Volume="2013" Year="2014">
       <Id>437ec171-201c-4ced-867c-2434497281e9</Id>
     </Book>
-    <Book Series="Justice League Beyond 2.0" Number="12" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Justice League Beyond 2.0" Number="12" Volume="2013" Year="2014">
       <Id>e45210bf-50a4-4908-90a6-45f8ab6497ea</Id>
     </Book>
-    <Book Series="Justice League Beyond 2.0" Number="13" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Justice League Beyond 2.0" Number="13" Volume="2013" Year="2014">
       <Id>8fd31ae7-98a1-4ca5-9007-dfc40cd93779</Id>
     </Book>
-    <Book Series="Justice League Beyond 2.0" Number="14" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Justice League Beyond 2.0" Number="14" Volume="2013" Year="2014">
       <Id>3bbb98c0-b114-4947-8061-d1fe4b6af24c</Id>
     </Book>
-    <Book Series="Justice League Beyond 2.0" Number="15" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Justice League Beyond 2.0" Number="15" Volume="2013" Year="2014">
       <Id>dea06e75-493f-4b90-b996-97c77457329b</Id>
     </Book>
-    <Book Series="Justice League Beyond 2.0" Number="16" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Justice League Beyond 2.0" Number="16" Volume="2013" Year="2014">
       <Id>698f333f-a217-4598-a81c-27f34ddc048a</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="17" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="17" Volume="2013" Year="2014">
       <Id>9daed2bf-86b9-4e62-b1b9-a93ad1d887e4</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="18" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="18" Volume="2013" Year="2014">
       <Id>4d5af4da-6828-441f-b8b0-afc96f28f6d1</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="19" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="19" Volume="2013" Year="2014">
       <Id>39b958ec-a10b-4b13-9324-7c769efd7061</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="20" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="20" Volume="2013" Year="2014">
       <Id>6428c2a5-2414-426e-9c62-d8cdb81bf0f7</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="21" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="21" Volume="2013" Year="2014">
       <Id>ffc2d414-b832-4f64-8c97-73c3a4893eef</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="22" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="22" Volume="2013" Year="2014">
       <Id>e9151f9e-f299-4ecb-b7b9-bb13ed359417</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="23" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="23" Volume="2013" Year="2014">
       <Id>cb26868d-4dea-41dd-ad99-74f39b7c450a</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="24" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="24" Volume="2013" Year="2014">
       <Id>5d63b851-aa30-4b65-a336-0f6427658421</Id>
     </Book>
-    <Book Series="Justice League Beyond 2.0" Number="17" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Justice League Beyond 2.0" Number="17" Volume="2013" Year="2014">
       <Id>ca6fdefe-a3ae-4866-a272-f6f65c606e5f</Id>
     </Book>
-    <Book Series="Justice League Beyond 2.0" Number="18" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Justice League Beyond 2.0" Number="18" Volume="2013" Year="2014">
       <Id>e2790f44-0063-4f86-9ea1-c47354f57c70</Id>
     </Book>
-    <Book Series="Justice League Beyond 2.0" Number="19" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Justice League Beyond 2.0" Number="19" Volume="2013" Year="2014">
       <Id>3ef85191-25ad-48a3-8e58-c6157ebe1969</Id>
     </Book>
-    <Book Series="Justice League Beyond 2.0" Number="20" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Justice League Beyond 2.0" Number="20" Volume="2013" Year="2014">
       <Id>a7f1e5e3-aae4-4bcc-bab2-b4264e40430f</Id>
     </Book>
-    <Book Series="Justice League Beyond 2.0" Number="21" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Justice League Beyond 2.0" Number="21" Volume="2013" Year="2014">
       <Id>a19a5f04-42eb-4d64-9ad1-bc3824d8c0b1</Id>
     </Book>
-    <Book Series="Justice League Beyond 2.0" Number="22" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Justice League Beyond 2.0" Number="22" Volume="2013" Year="2014">
       <Id>e4073d30-5ca6-4396-a4a4-ab1b955237b2</Id>
     </Book>
-    <Book Series="Justice League Beyond 2.0" Number="23" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Justice League Beyond 2.0" Number="23" Volume="2013" Year="2014">
       <Id>c7bb4ede-4ff6-4ff1-8be8-fb582052342c</Id>
     </Book>
-    <Book Series="Justice League Beyond 2.0" Number="24" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Justice League Beyond 2.0" Number="24" Volume="2013" Year="2014">
       <Id>1f1656ba-97a1-4681-b0e6-6086f21c2a44</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="25" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="25" Volume="2013" Year="2014">
       <Id>9741a279-976c-4b8a-b789-488f03004ca4</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="26" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="26" Volume="2013" Year="2014">
       <Id>01fefb36-6c98-4743-97c8-a12de50244f1</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="27" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="27" Volume="2013" Year="2014">
       <Id>13679ed1-596f-4a8a-85be-5258cfb01209</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="28" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="28" Volume="2013" Year="2014">
       <Id>45331d94-745f-46d2-866c-7b568ec84386</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="30" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="30" Volume="2013" Year="2014">
       <Id>27de98d8-9ec4-4aee-b4e4-a667b9e14cd4</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="31" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="31" Volume="2013" Year="2014">
       <Id>d9341a93-a126-44bd-a4d7-255f47d77995</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="32" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="32" Volume="2013" Year="2014">
       <Id>5898a16b-4952-4e23-9b5d-ab6e2146755c</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="33" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="33" Volume="2013" Year="2014">
       <Id>6eb2d5f5-fc62-4643-883e-bca85e529b1f</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="34" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="34" Volume="2013" Year="2014">
       <Id>9deabdef-6c50-4f74-823a-95283ee3146b</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="35" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="35" Volume="2013" Year="2014">
       <Id>6462228a-f8f9-4ec8-a4c0-f511fc0d0111</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="36" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="36" Volume="2013" Year="2014">
       <Id>037d6945-a62c-4f3b-bd77-19fdd873b4cb</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="37" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="37" Volume="2013" Year="2014">
       <Id>21588552-39bc-47de-b273-ee368a70b692</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="38" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="38" Volume="2013" Year="2014">
       <Id>5d1a26ea-12e2-4f70-a73f-d52863131f69</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="39" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="39" Volume="2013" Year="2014">
       <Id>5ee77412-f95f-4fde-95d9-d14c56acb791</Id>
     </Book>
-    <Book Series="Batman Beyond 2.0" Number="40" Volume="2013" Year="2014" Format="Main Series">
+    <Book Series="Batman Beyond 2.0" Number="40" Volume="2013" Year="2014">
       <Id>6f023d42-d8f1-4236-bbb8-eab18e43f7fd</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="0" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="0" Volume="2014" Year="2014">
       <Id>32aec0f4-f990-481a-bdab-f1010418b20a</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="1" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="1" Volume="2014" Year="2014">
       <Id>41d96171-a4a6-4d86-8d10-b3462a83b5e5</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="2" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="2" Volume="2014" Year="2014">
       <Id>87ec9c4c-7cfb-4f15-bc48-2b9d055291d4</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="3" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="3" Volume="2014" Year="2014">
       <Id>44f3a70f-be15-455c-953d-e02a687cfcdd</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="4" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="4" Volume="2014" Year="2014">
       <Id>16e9c86c-9c5f-41bb-9b55-7f3c3e8808c0</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="5" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="5" Volume="2014" Year="2014">
       <Id>eac17c16-030f-4a4e-812b-f7575502d5d0</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="6" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="6" Volume="2014" Year="2014">
       <Id>809f1557-e900-4793-9e33-d9b93cd027c8</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="7" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="7" Volume="2014" Year="2014">
       <Id>1cd87247-474c-4b4f-a9b5-751c4fb4efbf</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="8" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="8" Volume="2014" Year="2014">
       <Id>c254ec99-5b9c-4aa6-a761-43a60446eb4b</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="9" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="9" Volume="2014" Year="2014">
       <Id>b04ce320-3e7c-47c7-99f2-2651f120c6c0</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="10" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="10" Volume="2014" Year="2014">
       <Id>8875619f-a95f-497e-aa2e-b156dc968b14</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="11" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="11" Volume="2014" Year="2014">
       <Id>f570d94c-1b6e-4ebf-935c-06d7ec31aa73</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="12" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="12" Volume="2014" Year="2014">
       <Id>c9f66e2a-596f-41dc-ace7-70f996146255</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="13" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="13" Volume="2014" Year="2014">
       <Id>03f70e9b-019f-4b3b-8fce-65b799a7580f</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="14" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="14" Volume="2014" Year="2014">
       <Id>78f5aa0b-c725-4401-8b4b-6c51266a426e</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="15" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="15" Volume="2014" Year="2014">
       <Id>4826c921-71cb-40ea-b237-bc7e0306a27e</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="16" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="16" Volume="2014" Year="2014">
       <Id>e9846389-b313-4f91-b901-076f1ac20e04</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="17" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="17" Volume="2014" Year="2014">
       <Id>4029430f-fb4c-4450-ba92-ba6267624bbb</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="18" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="18" Volume="2014" Year="2014">
       <Id>3bee960f-0cac-4b77-8210-02ad92092337</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="19" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="19" Volume="2014" Year="2014">
       <Id>f56e8345-7f50-4ac9-887c-9465eb35a83b</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="20" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="20" Volume="2014" Year="2014">
       <Id>e377e30f-8295-405d-b0d8-1721affe9e8f</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="21" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="21" Volume="2014" Year="2014">
       <Id>720689d4-95d6-4efe-b9f9-7ca5b3e1c390</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="22" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="22" Volume="2014" Year="2014">
       <Id>9c0da7d6-6c7c-4ca2-87ee-62b128091933</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="23" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="23" Volume="2014" Year="2014">
       <Id>4c8dfcee-7bf1-44a4-a577-d72b197367c1</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="24" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="24" Volume="2014" Year="2014">
       <Id>cba85f51-e132-4f6a-9b2b-e5da788f8f8f</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="25" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="25" Volume="2014" Year="2014">
       <Id>21feb2bc-1868-4603-96b2-af5d0ebe2ef6</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="26" Volume="2014" Year="2014" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="26" Volume="2014" Year="2014">
       <Id>18b46769-f179-4dc6-9233-370f4afd44a1</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="27" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="27" Volume="2014" Year="2015">
       <Id>d780adce-d5e8-471f-8e05-c6bfbb34c3e7</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="28" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="28" Volume="2014" Year="2015">
       <Id>8f5313d6-74d1-403a-ad18-252461bf20d6</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="29" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="29" Volume="2014" Year="2015">
       <Id>99a41ad1-1430-4669-a6ea-7484c96ebe9e</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="30" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="30" Volume="2014" Year="2015">
       <Id>394fb400-71d0-4a8f-923a-6d28814f05d4</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="31" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="31" Volume="2014" Year="2015">
       <Id>05038eeb-9774-45b6-a0eb-50c8620f472c</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="32" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="32" Volume="2014" Year="2015">
       <Id>bf130495-6577-4872-a8a8-83589f002fab</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="33" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="33" Volume="2014" Year="2015">
       <Id>3fce4c56-f3df-46a7-a1db-f8154bda08d1</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="34" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="34" Volume="2014" Year="2015">
       <Id>caa5a523-a887-4584-92a9-f847a189aeba</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="35" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="35" Volume="2014" Year="2015">
       <Id>0d7ab352-0712-445b-9d58-b24f9869eba8</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="36" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="36" Volume="2014" Year="2015">
       <Id>4baa097c-a561-4a82-98ca-a3e0ee2ca3d5</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="37" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="37" Volume="2014" Year="2015">
       <Id>6e3c988e-c61f-4151-bdc1-b5ae37935dbd</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="38" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="38" Volume="2014" Year="2015">
       <Id>5a85bc1a-9734-4b1f-9c31-72cffa32f231</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="39" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="39" Volume="2014" Year="2015">
       <Id>0cf5f3a6-efd9-4662-9df2-7b4c6a8624e9</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="40" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="40" Volume="2014" Year="2015">
       <Id>06bfa6e1-8979-44d5-9508-3ce6307c4d3e</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="41" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="41" Volume="2014" Year="2015">
       <Id>c34e2196-706f-4cf9-bb0a-b1fbfc69e2fb</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="42" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="42" Volume="2014" Year="2015">
       <Id>296dc388-d6a6-4ca8-943e-bd073356d472</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="43" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="43" Volume="2014" Year="2015">
       <Id>935804e4-234b-4947-823c-3b5150ef309f</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="44" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="44" Volume="2014" Year="2015">
       <Id>45b0aa23-0581-4fd1-a253-3ec4d7e92abb</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="45" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="45" Volume="2014" Year="2015">
       <Id>2125ff98-9e48-4f9e-9537-cda7238aecfd</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="46" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="46" Volume="2014" Year="2015">
       <Id>d113fd2b-82b9-40f3-8c18-9e23a2e594dc</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="47" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="47" Volume="2014" Year="2015">
       <Id>98a1f776-ca93-483a-b83d-a731ab7079a4</Id>
     </Book>
-    <Book Series="The New 52: Futures End" Number="48" Volume="2014" Year="2015" Format="Crossover">
+    <Book Series="The New 52: Futures End" Number="48" Volume="2014" Year="2015">
       <Id>3cb81166-98b4-4b71-8713-ac66ddcd088e</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="1" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Batman Beyond" Number="1" Volume="2015" Year="2015">
       <Id>0ace0136-f4ef-4161-8420-6826666ba110</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="2" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Batman Beyond" Number="2" Volume="2015" Year="2015">
       <Id>5cf82906-64df-4fe0-9495-5a44860b3325</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="3" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Batman Beyond" Number="3" Volume="2015" Year="2015">
       <Id>f9fdc5ea-e4ea-4561-a8a6-8c85a642afb0</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="4" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Batman Beyond" Number="4" Volume="2015" Year="2015">
       <Id>a1553066-e8ae-467a-9eac-604aeaca4e75</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="5" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Batman Beyond" Number="5" Volume="2015" Year="2015">
       <Id>0b5ccf46-5582-4682-880c-34c7943c1940</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="6" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Batman Beyond" Number="6" Volume="2015" Year="2016">
       <Id>2aa0185b-4a0c-47ae-a883-9c02b281b31f</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="7" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Batman Beyond" Number="7" Volume="2015" Year="2016">
       <Id>24ec81a8-77bd-4bee-8f54-5dcb5795093c</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="8" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Batman Beyond" Number="8" Volume="2015" Year="2016">
       <Id>6b0effa7-f360-4f1d-bd98-406ccffe86d9</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="9" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Batman Beyond" Number="9" Volume="2015" Year="2016">
       <Id>4118f8ba-abbe-48f9-b3da-29cb4808e9fd</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="10" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Batman Beyond" Number="10" Volume="2015" Year="2016">
       <Id>484436e7-7250-4fdd-8404-c8dad5aa3708</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="11" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Batman Beyond" Number="11" Volume="2015" Year="2016">
       <Id>d967b280-560f-48b6-9464-21a93c17813b</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="12" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Batman Beyond" Number="12" Volume="2015" Year="2016">
       <Id>a3af7668-4d9c-4400-ad83-8d332eb26dee</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="13" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Batman Beyond" Number="13" Volume="2015" Year="2016">
       <Id>12c6ffc8-0adf-4ec4-8b7c-bf21e97d3af9</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="14" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Batman Beyond" Number="14" Volume="2015" Year="2016">
       <Id>ba15c6fd-bb70-41b9-b34a-9bf4c6bf583e</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="15" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Batman Beyond" Number="15" Volume="2015" Year="2016">
       <Id>294f7cc9-04e3-4a38-9bea-a8346ddc8691</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="16" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Batman Beyond" Number="16" Volume="2015" Year="2016">
       <Id>d723a54e-64de-40b9-bfe1-7c67dd7c10bb</Id>
     </Book>
-    <Book Series="Batman Beyond: Rebirth" Number="1" Volume="2016" Year="2016" Format="One-Shot">
+    <Book Series="Batman Beyond: Rebirth" Number="1" Volume="2016" Year="2016">
       <Id>04376827-1896-4ffb-b12f-de48da589b6f</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="1" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Batman Beyond" Number="1" Volume="2016" Year="2016">
       <Id>1d046a7d-d937-4e36-bb8b-66526a9d80dd</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="2" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batman Beyond" Number="2" Volume="2016" Year="2017">
       <Id>58d29a8c-9527-4bd9-876d-8ad37c487405</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="3" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batman Beyond" Number="3" Volume="2016" Year="2017">
       <Id>9edf686a-6d79-4c88-9c33-c8cb55f819e7</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="4" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batman Beyond" Number="4" Volume="2016" Year="2017">
       <Id>058af3e9-34dd-4017-a51c-cd203aa6466c</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="5" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batman Beyond" Number="5" Volume="2016" Year="2017">
       <Id>5607924a-a781-4e4a-badd-a48334c3f7ca</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="6" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batman Beyond" Number="6" Volume="2016" Year="2017">
       <Id>c4cc5490-37a8-4a27-aa40-fb33d84a3cdd</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="7" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batman Beyond" Number="7" Volume="2016" Year="2017">
       <Id>1fa9201c-7015-4b86-b432-cb79d5b0182b</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="8" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batman Beyond" Number="8" Volume="2016" Year="2017">
       <Id>234bb76c-9589-491a-81ec-eaa00d3bcfdd</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="9" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batman Beyond" Number="9" Volume="2016" Year="2017">
       <Id>024c9aff-94d7-4410-92d4-3befae7d0457</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="10" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batman Beyond" Number="10" Volume="2016" Year="2017">
       <Id>9ca0f491-1516-4fcc-9a91-0e5e971ea8ac</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="11" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batman Beyond" Number="11" Volume="2016" Year="2017">
       <Id>bdf2fb6f-6c12-47a9-8a33-b4b693396813</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="12" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batman Beyond" Number="12" Volume="2016" Year="2017">
       <Id>92c48206-27ef-4665-ac41-decee33dd6c6</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="13" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batman Beyond" Number="13" Volume="2016" Year="2017">
       <Id>83da05d0-7440-4eeb-8f17-a1177e89d36d</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="14" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batman Beyond" Number="14" Volume="2016" Year="2018">
       <Id>564a5617-6bcd-41ea-8d20-c0d8a38c74de</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="15" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batman Beyond" Number="15" Volume="2016" Year="2018">
       <Id>b17883df-2e0e-4534-8206-1f8ff50c5239</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="16" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batman Beyond" Number="16" Volume="2016" Year="2018">
       <Id>7c359ae2-5101-45ac-b5c5-abc880bcc023</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="17" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batman Beyond" Number="17" Volume="2016" Year="2018">
       <Id>4cd5a173-e27d-406d-acd0-7d16a7c55856</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="18" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batman Beyond" Number="18" Volume="2016" Year="2018">
       <Id>01e0ab84-e4ec-4a39-a12c-603ae52ecb53</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="19" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batman Beyond" Number="19" Volume="2016" Year="2018">
       <Id>8526a8be-b430-4b87-8b0e-f73c6b4e475b</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="20" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batman Beyond" Number="20" Volume="2016" Year="2018">
       <Id>f9b0ccaa-1d0c-48f2-be06-8f77c5516050</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="21" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batman Beyond" Number="21" Volume="2016" Year="2018">
       <Id>eb3d5ff8-770d-4185-90d2-9636aaca9b97</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="22" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batman Beyond" Number="22" Volume="2016" Year="2018">
       <Id>87804dca-e5a4-4408-b1a1-f61dcca3f76d</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="23" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batman Beyond" Number="23" Volume="2016" Year="2018">
       <Id>182c3d81-b642-406c-bb73-c7d3a1110be4</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="24" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batman Beyond" Number="24" Volume="2016" Year="2018">
       <Id>6ca5a34d-ad86-4f14-bfc5-a46e3973824c</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="25" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batman Beyond" Number="25" Volume="2016" Year="2018">
       <Id>87ed133e-b397-4960-812c-ab58604e66fe</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="26" Volume="2016" Year="2019" Format="Main Series">
+    <Book Series="Batman Beyond" Number="26" Volume="2016" Year="2019">
       <Id>d9f67050-eac4-43c0-bb72-a43302ecd761</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="27" Volume="2016" Year="2019" Format="Main Series">
+    <Book Series="Batman Beyond" Number="27" Volume="2016" Year="2019">
       <Id>bae43c01-70eb-47f1-87a3-dbbcc040a0fd</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="28" Volume="2016" Year="2019" Format="Main Series">
+    <Book Series="Batman Beyond" Number="28" Volume="2016" Year="2019">
       <Id>42c04292-2841-464c-b757-fb4d3556745b</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="29" Volume="2016" Year="2019" Format="Main Series">
+    <Book Series="Batman Beyond" Number="29" Volume="2016" Year="2019">
       <Id>f69e487a-62f8-4f0e-9c8f-cf7962d04933</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="30" Volume="2016" Year="2019" Format="Main Series">
+    <Book Series="Batman Beyond" Number="30" Volume="2016" Year="2019">
       <Id>da7e2bd9-1929-43e9-8d45-5289dffc956a</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="31" Volume="2016" Year="2019" Format="Main Series">
+    <Book Series="Batman Beyond" Number="31" Volume="2016" Year="2019">
       <Id>d46d12c8-47d7-41e4-b55d-4641b99df7f0</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="32" Volume="2016" Year="2019" Format="Main Series">
+    <Book Series="Batman Beyond" Number="32" Volume="2016" Year="2019">
       <Id>8b22f7b7-df92-46da-bf68-9b71c34d889e</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="33" Volume="2016" Year="2019" Format="Main Series">
+    <Book Series="Batman Beyond" Number="33" Volume="2016" Year="2019">
       <Id>c103f227-b2ef-4d72-9d12-123220083b9f</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="34" Volume="2016" Year="2019" Format="Main Series">
+    <Book Series="Batman Beyond" Number="34" Volume="2016" Year="2019">
       <Id>7fd41fc3-e6e5-4533-820d-1c44639fc59e</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="35" Volume="2016" Year="2019" Format="Main Series">
+    <Book Series="Batman Beyond" Number="35" Volume="2016" Year="2019">
       <Id>ac646dcf-212d-4a20-9bdb-d6f11bdca779</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="36" Volume="2016" Year="2019" Format="Main Series">
+    <Book Series="Batman Beyond" Number="36" Volume="2016" Year="2019">
       <Id>e0a90ce7-117f-42d9-b48e-470261b9ee6d</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="37" Volume="2016" Year="2019" Format="Main Series">
+    <Book Series="Batman Beyond" Number="37" Volume="2016" Year="2019">
       <Id>05ced9e9-722a-47a7-af1e-4ea8523f8d38</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="38" Volume="2016" Year="2020" Format="Main Series">
+    <Book Series="Batman Beyond" Number="38" Volume="2016" Year="2020">
       <Id>f5f3a13c-52fc-42ff-b215-de2d83f0baa5</Id>
     </Book>
-    <Book Series="Batman Beyond" Number="39" Volume="2016" Year="2020" Format="Main Series">
+    <Book Series="Batman Beyond" Number="39" Volume="2016" Year="2020">
       <Id>999d9017-ad68-412f-810f-f6fddc303bbd</Id>
     </Book>
   </Books>

--- a/DC/Characters/unsorted/Batman Beyond/Batman Beyond 001.cbl
+++ b/DC/Characters/unsorted/Batman Beyond/Batman Beyond 001.cbl
@@ -1,771 +1,844 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Batman Beyond 1</Name>
+  <Name>Batman Beyond 001</Name>
+  <NumIssues>279</NumIssues>
   <Books>
     <Book Series="Batman Beyond" Number="1" Volume="2010" Year="2010">
-      <Id>2bbf3eec-60de-412b-81fc-5e536a078e4e</Id>
+      <Database Name="cv" Series="34005" Issue="221794" />
     </Book>
     <Book Series="Batman Beyond" Number="2" Volume="2010" Year="2010">
-      <Id>468cfe9f-a9f8-4f8a-8127-68645e48e891</Id>
+      <Database Name="cv" Series="34005" Issue="225777" />
     </Book>
     <Book Series="Batman Beyond" Number="3" Volume="2010" Year="2010">
-      <Id>ceff2992-cf59-4b2c-8410-c1f69b9ba4c1</Id>
+      <Database Name="cv" Series="34005" Issue="230083" />
     </Book>
     <Book Series="Batman Beyond" Number="4" Volume="2010" Year="2010">
-      <Id>7b499e4c-2b93-4359-b1ce-26f05e2b17b9</Id>
+      <Database Name="cv" Series="34005" Issue="234619" />
     </Book>
     <Book Series="Batman Beyond" Number="5" Volume="2010" Year="2010">
-      <Id>c6e3e6da-28c9-4f37-9010-31047f9c6459</Id>
+      <Database Name="cv" Series="34005" Issue="239028" />
     </Book>
     <Book Series="Batman Beyond" Number="6" Volume="2010" Year="2011">
-      <Id>5958d1c9-20e4-4f9d-a6bf-a2159ef8f350</Id>
+      <Database Name="cv" Series="34005" Issue="246410" />
     </Book>
     <Book Series="Batman Beyond" Number="1" Volume="2011" Year="2011">
-      <Id>4ba2df90-df9f-4b74-9908-3b3df65fc530</Id>
+      <Database Name="cv" Series="38094" Issue="254653" />
     </Book>
     <Book Series="Batman Beyond" Number="2" Volume="2011" Year="2011">
-      <Id>5cf4c0d6-de87-4887-a3ec-fb20fda69acf</Id>
+      <Database Name="cv" Series="38094" Issue="259833" />
     </Book>
     <Book Series="Batman Beyond" Number="3" Volume="2011" Year="2011">
-      <Id>16d221b3-0b08-45d7-a176-a2ce2abe3eb7</Id>
+      <Database Name="cv" Series="38094" Issue="264590" />
     </Book>
     <Book Series="Batman Beyond" Number="4" Volume="2011" Year="2011">
-      <Id>d32c4190-0386-4c84-be24-77b23a8ff6b0</Id>
+      <Database Name="cv" Series="38094" Issue="267553" />
     </Book>
     <Book Series="Batman Beyond" Number="5" Volume="2011" Year="2011">
-      <Id>285178a1-8e1f-435f-adfc-c4cb21c22163</Id>
+      <Database Name="cv" Series="38094" Issue="269464" />
     </Book>
     <Book Series="Batman Beyond" Number="6" Volume="2011" Year="2011">
-      <Id>53744696-af52-4a53-81e5-34c23bf7fd40</Id>
+      <Database Name="cv" Series="38094" Issue="272430" />
     </Book>
     <Book Series="Batman Beyond" Number="7" Volume="2011" Year="2011">
-      <Id>d1f6e820-a96d-495e-82ca-a37c29d7336c</Id>
+      <Database Name="cv" Series="38094" Issue="277434" />
     </Book>
     <Book Series="Batman Beyond" Number="8" Volume="2011" Year="2011">
-      <Id>e313d593-bb97-4933-9bbb-36ba32c732eb</Id>
+      <Database Name="cv" Series="38094" Issue="283823" />
     </Book>
     <Book Series="Batman Beyond" Number="1" Volume="2012" Year="2012">
-      <Id>887c44c1-1186-4425-bdee-9372fb7bea1a</Id>
+      <Database Name="cv" Series="45872" Issue="315827" />
     </Book>
     <Book Series="Batman Beyond" Number="2" Volume="2012" Year="2012">
-      <Id>dab2b6b9-4a88-4037-9661-ee88eee66b01</Id>
+      <Database Name="cv" Series="45872" Issue="316810" />
     </Book>
     <Book Series="Batman Beyond" Number="3" Volume="2012" Year="2012">
-      <Id>92a549fd-841e-4c40-b2f5-c4e0182381dd</Id>
+      <Database Name="cv" Series="45872" Issue="323364" />
     </Book>
     <Book Series="Batman Beyond" Number="4" Volume="2012" Year="2012">
-      <Id>2e1d0fb8-9a3f-4bc3-9af3-35bad5f3af60</Id>
+      <Database Name="cv" Series="45872" Issue="324957" />
     </Book>
     <Book Series="Batman Beyond" Number="5" Volume="2012" Year="2012">
-      <Id>8eeacd91-0fba-4858-8e1f-cce704dc89bb</Id>
+      <Database Name="cv" Series="45872" Issue="329588" />
     </Book>
     <Book Series="Batman Beyond" Number="6" Volume="2012" Year="2012">
-      <Id>5b5bc211-5096-4d5a-99db-95698c174edd</Id>
+      <Database Name="cv" Series="45872" Issue="336058" />
     </Book>
     <Book Series="Batman Beyond" Number="7" Volume="2012" Year="2012">
-      <Id>16c305b4-99f4-45ef-920e-93888758f4d3</Id>
+      <Database Name="cv" Series="45872" Issue="340871" />
     </Book>
     <Book Series="Batman Beyond" Number="8" Volume="2012" Year="2012">
-      <Id>755cf1d9-9c62-4c2b-92ab-a5f3888ac47c</Id>
+      <Database Name="cv" Series="45872" Issue="342361" />
     </Book>
     <Book Series="Batman Beyond" Number="9" Volume="2012" Year="2012">
-      <Id>e18e9eda-bd5b-419a-a4c5-d67f0259f75f</Id>
+      <Database Name="cv" Series="45872" Issue="345650" />
     </Book>
     <Book Series="Batman Beyond" Number="10" Volume="2012" Year="2012">
-      <Id>72744de9-db0d-41c9-8019-db915a889f4f</Id>
+      <Database Name="cv" Series="45872" Issue="351548" />
     </Book>
     <Book Series="Batman Beyond" Number="11" Volume="2012" Year="2012">
-      <Id>21689435-f502-4f2c-bf38-dcd03e53cdfb</Id>
+      <Database Name="cv" Series="45872" Issue="357077" />
     </Book>
     <Book Series="Batman Beyond" Number="12" Volume="2012" Year="2012">
-      <Id>193998e4-cfd1-48bb-a344-7b1c60d63e47</Id>
+      <Database Name="cv" Series="45872" Issue="357891" />
     </Book>
     <Book Series="Batman Beyond" Number="13" Volume="2012" Year="2012">
-      <Id>e28b1e42-a538-474d-8d70-024d6602831f</Id>
+      <Database Name="cv" Series="45872" Issue="362089" />
     </Book>
     <Book Series="Batman Beyond" Number="14" Volume="2012" Year="2012">
-      <Id>3e2e4752-9058-4614-b5ad-72e2189924b3</Id>
+      <Database Name="cv" Series="45872" Issue="369973" />
     </Book>
     <Book Series="Batman Beyond" Number="15" Volume="2012" Year="2012">
-      <Id>26ef391d-6d3e-4395-8f9b-8e53b2354197</Id>
+      <Database Name="cv" Series="45872" Issue="372956" />
     </Book>
     <Book Series="Batman Beyond" Number="16" Volume="2012" Year="2012">
-      <Id>3e331f6b-14b8-43e9-999a-dfc1ca26052c</Id>
+      <Database Name="cv" Series="45872" Issue="373980" />
     </Book>
     <Book Series="Batman Beyond" Number="17" Volume="2012" Year="2013">
-      <Id>28e4cdb6-de1d-4315-8337-6caf5fa07142</Id>
+      <Database Name="cv" Series="45872" Issue="379975" />
     </Book>
     <Book Series="Batman Beyond" Number="18" Volume="2012" Year="2013">
-      <Id>b67ad46e-3af1-4682-bf93-111d06440c03</Id>
+      <Database Name="cv" Series="45872" Issue="386813" />
     </Book>
     <Book Series="Batman Beyond" Number="19" Volume="2012" Year="2013">
-      <Id>d58b1d84-2c72-4a28-ae94-0c2901fe4257</Id>
+      <Database Name="cv" Series="45872" Issue="391788" />
     </Book>
     <Book Series="Batman Beyond" Number="20" Volume="2012" Year="2013">
-      <Id>1081fec8-d1e3-49b4-ac63-1a6d33ddd394</Id>
+      <Database Name="cv" Series="45872" Issue="393948" />
     </Book>
     <Book Series="Batman Beyond" Number="21" Volume="2012" Year="2013">
-      <Id>b9dabbdd-6b14-4c8f-b3f8-6d4cd3849e95</Id>
+      <Database Name="cv" Series="45872" Issue="397181" />
     </Book>
     <Book Series="Batman Beyond" Number="22" Volume="2012" Year="2013">
-      <Id>559bf2b4-0753-42af-8bbe-cd5969a25a6f</Id>
+      <Database Name="cv" Series="45872" Issue="401856" />
     </Book>
     <Book Series="Batman Beyond" Number="23" Volume="2012" Year="2013">
-      <Id>0c23b773-1a41-4e5d-94de-5506791bcf00</Id>
+      <Database Name="cv" Series="45872" Issue="403993" />
     </Book>
     <Book Series="Batman Beyond" Number="24" Volume="2012" Year="2013">
-      <Id>585c205c-5e2f-4cfa-b0b9-18792d8700be</Id>
+      <Database Name="cv" Series="45872" Issue="409698" />
     </Book>
     <Book Series="Batman Beyond" Number="25" Volume="2012" Year="2013">
-      <Id>4d1d7956-e732-4d1d-98fa-a8bcbe9e48cc</Id>
+      <Database Name="cv" Series="45872" Issue="411509" />
     </Book>
     <Book Series="Batman Beyond" Number="26" Volume="2012" Year="2013">
-      <Id>290c2f4b-4235-45ea-85e8-9c991e0ba73b</Id>
+      <Database Name="cv" Series="45872" Issue="416677" />
     </Book>
     <Book Series="Batman Beyond" Number="27" Volume="2012" Year="2013">
-      <Id>ceac987c-9ab1-40c6-8681-a56404af2915</Id>
+      <Database Name="cv" Series="45872" Issue="417317" />
     </Book>
     <Book Series="Batman Beyond" Number="28" Volume="2012" Year="2013">
-      <Id>8fef96b8-a036-4fca-b20e-ffbdfb1e7ffb</Id>
+      <Database Name="cv" Series="45872" Issue="418509" />
     </Book>
     <Book Series="Batman Beyond" Number="29" Volume="2012" Year="2013">
-      <Id>dce82faa-a85b-41a2-9480-4bc467178de2</Id>
+      <Database Name="cv" Series="45872" Issue="419544" />
     </Book>
     <Book Series="Superman Beyond" Number="0" Volume="2011" Year="2011">
-      <Id>e9d70b33-1b03-4e7b-b07c-f9f24e74172c</Id>
+      <Database Name="cv" Series="42288" Issue="288565" />
     </Book>
     <Book Series="Superman Beyond" Number="1" Volume="2011" Year="2012">
-      <Id>00301839-af44-44c0-8fec-fddc2e7868ce</Id>
+      <Database Name="cv" Series="42288" Issue="332066" />
     </Book>
     <Book Series="Superman Beyond" Number="3" Volume="2011" Year="2012">
-      <Id>89c239a1-a004-4df1-b8b5-b29589dea2bb</Id>
+      <Database Name="cv" Series="42288" Issue="336840" />
     </Book>
     <Book Series="Superman Beyond" Number="4" Volume="2011" Year="2012">
-      <Id>e0420fb6-376a-4c22-a2ab-cee8ebd9988e</Id>
+      <Database Name="cv" Series="42288" Issue="343050" />
     </Book>
     <Book Series="Superman Beyond" Number="5" Volume="2011" Year="2012">
-      <Id>00851b63-67c4-41e5-a43b-16b65388c83c</Id>
+      <Database Name="cv" Series="42288" Issue="346651" />
     </Book>
     <Book Series="Superman Beyond" Number="6" Volume="2011" Year="2012">
-      <Id>ce9a713f-a1bc-4f32-8640-e41cdb358fcc</Id>
+      <Database Name="cv" Series="42288" Issue="347511" />
     </Book>
     <Book Series="Superman Beyond" Number="7" Volume="2011" Year="2012">
-      <Id>b25078b3-9cca-4649-a457-86c627039e33</Id>
+      <Database Name="cv" Series="42288" Issue="353099" />
     </Book>
     <Book Series="Superman Beyond" Number="8" Volume="2011" Year="2012">
-      <Id>2f9ee7f9-7324-4e81-8bf1-669a7b2f271a</Id>
+      <Database Name="cv" Series="42288" Issue="359256" />
     </Book>
     <Book Series="Superman Beyond" Number="9" Volume="2011" Year="2012">
-      <Id>6c0aae57-403b-4e18-bfe4-02812008f597</Id>
+      <Database Name="cv" Series="42288" Issue="362819" />
     </Book>
     <Book Series="Superman Beyond" Number="10" Volume="2011" Year="2012">
-      <Id>c30e4388-cc8e-4811-a012-f1c5302938d4</Id>
+      <Database Name="cv" Series="42288" Issue="363698" />
     </Book>
     <Book Series="Superman Beyond" Number="11" Volume="2011" Year="2012">
-      <Id>ce47980b-3161-4c4e-8952-492aa2e2e2f2</Id>
+      <Database Name="cv" Series="42288" Issue="370969" />
     </Book>
     <Book Series="Superman Beyond" Number="12" Volume="2011" Year="2012">
-      <Id>a3728502-f041-4343-ba0b-7364082b786d</Id>
+      <Database Name="cv" Series="42288" Issue="376015" />
     </Book>
     <Book Series="Superman Beyond" Number="13" Volume="2011" Year="2013">
-      <Id>377b7c78-41fb-4009-8b28-c59cb9cc8c4f</Id>
+      <Database Name="cv" Series="42288" Issue="381085" />
     </Book>
     <Book Series="Superman Beyond" Number="14" Volume="2011" Year="2013">
-      <Id>e69fa4af-670f-4cdb-a10b-75ad9bf35207</Id>
+      <Database Name="cv" Series="42288" Issue="382403" />
     </Book>
     <Book Series="Superman Beyond" Number="15" Volume="2011" Year="2013">
-      <Id>03ae2339-9222-4301-b337-98e5c844566c</Id>
+      <Database Name="cv" Series="42288" Issue="388168" />
     </Book>
     <Book Series="Superman Beyond" Number="16" Volume="2011" Year="2013">
-      <Id>59c7b770-98a2-407a-b509-235218bb7529</Id>
+      <Database Name="cv" Series="42288" Issue="395318" />
     </Book>
     <Book Series="Superman Beyond" Number="17" Volume="2011" Year="2013">
-      <Id>3160b429-eee5-4ba2-8154-e00ebbdb3eea</Id>
+      <Database Name="cv" Series="42288" Issue="398199" />
     </Book>
     <Book Series="Superman Beyond" Number="18" Volume="2011" Year="2013">
-      <Id>fbdffb69-c695-4070-a05b-6de379fb74bd</Id>
+      <Database Name="cv" Series="42288" Issue="399796" />
     </Book>
     <Book Series="Superman Beyond" Number="19" Volume="2011" Year="2013">
-      <Id>56fcedfd-d52c-4276-8841-8b78c4052205</Id>
+      <Database Name="cv" Series="42288" Issue="406396" />
     </Book>
     <Book Series="Superman Beyond" Number="20" Volume="2011" Year="2013">
-      <Id>134acb87-7ec5-4035-853f-a0cf58d4648b</Id>
+      <Database Name="cv" Series="42288" Issue="413267" />
     </Book>
     <Book Series="Justice League Beyond" Number="1" Volume="2012" Year="2012">
-      <Id>249aba98-6eb7-44a6-a8e1-13a7950627a6</Id>
+      <Database Name="cv" Series="45573" Issue="313905" />
     </Book>
     <Book Series="Justice League Beyond" Number="2" Volume="2012" Year="2012">
-      <Id>03a408d5-1618-4059-99c6-859928233873</Id>
+      <Database Name="cv" Series="45573" Issue="315125" />
     </Book>
     <Book Series="Justice League Beyond" Number="3" Volume="2012" Year="2012">
-      <Id>a10a1a9c-dbce-4997-b40e-abcbb80c50b4</Id>
+      <Database Name="cv" Series="45573" Issue="319560" />
     </Book>
     <Book Series="Justice League Beyond" Number="4" Volume="2012" Year="2012">
-      <Id>a1ea5065-0e1b-45a1-bfc7-ce36b121746c</Id>
+      <Database Name="cv" Series="45573" Issue="321729" />
     </Book>
     <Book Series="Justice League Beyond" Number="5" Volume="2012" Year="2012">
-      <Id>f05f8f91-3c34-41d7-b7df-f3641dc63a44</Id>
+      <Database Name="cv" Series="45573" Issue="327306" />
     </Book>
     <Book Series="Justice League Beyond" Number="6" Volume="2012" Year="2012">
-      <Id>264af152-4a47-45f7-9228-68447a939d48</Id>
+      <Database Name="cv" Series="45573" Issue="334362" />
     </Book>
     <Book Series="Justice League Beyond" Number="7" Volume="2012" Year="2012">
-      <Id>0c48b2fc-1a58-43b4-9323-afb20d3f5d3a</Id>
+      <Database Name="cv" Series="45573" Issue="335297" />
     </Book>
     <Book Series="Justice League Beyond" Number="8" Volume="2012" Year="2012">
-      <Id>247651cc-170b-4a72-8038-464273ccd9a5</Id>
+      <Database Name="cv" Series="45573" Issue="338996" />
     </Book>
     <Book Series="Justice League Beyond" Number="9" Volume="2012" Year="2012">
-      <Id>2f6ccda9-88cc-4e9c-9dee-5e250a554d37</Id>
+      <Database Name="cv" Series="45573" Issue="344436" />
     </Book>
     <Book Series="Justice League Beyond" Number="10" Volume="2012" Year="2012">
-      <Id>94cac4a2-d06b-4eab-9825-2b2f47a061be</Id>
+      <Database Name="cv" Series="45573" Issue="348333" />
     </Book>
     <Book Series="Justice League Beyond" Number="11" Volume="2012" Year="2012">
-      <Id>a7d63dc6-b657-4950-b8b2-b53a171179b6</Id>
+      <Database Name="cv" Series="45573" Issue="350160" />
     </Book>
     <Book Series="Justice League Beyond" Number="12" Volume="2012" Year="2012">
-      <Id>c8704287-9d9d-4bac-b962-6c0fedb037fb</Id>
+      <Database Name="cv" Series="45573" Issue="356024" />
     </Book>
     <Book Series="Justice League Beyond" Number="13" Volume="2012" Year="2012">
-      <Id>857ae1be-5720-4ea5-9105-b0cde3da8a6a</Id>
+      <Database Name="cv" Series="45573" Issue="360062" />
     </Book>
     <Book Series="Justice League Beyond" Number="14" Volume="2012" Year="2012">
-      <Id>55cd42cc-8fe1-4689-aba5-516dae189503</Id>
+      <Database Name="cv" Series="45573" Issue="366638" />
     </Book>
     <Book Series="Justice League Beyond" Number="15" Volume="2012" Year="2012">
-      <Id>c2ae34cd-56a3-40af-92a6-825a094b5142</Id>
+      <Database Name="cv" Series="45573" Issue="368704" />
     </Book>
     <Book Series="Justice League Beyond" Number="16" Volume="2012" Year="2012">
-      <Id>974fed9d-b9b6-4ca5-8620-4183ce6082a2</Id>
+      <Database Name="cv" Series="45573" Issue="372044" />
     </Book>
     <Book Series="Justice League Beyond" Number="17" Volume="2012" Year="2013">
-      <Id>b9b49232-34b3-437b-bf88-42652801463d</Id>
+      <Database Name="cv" Series="45573" Issue="377657" />
     </Book>
     <Book Series="Justice League Beyond" Number="18" Volume="2012" Year="2013">
-      <Id>ec9ea765-8261-4715-b00b-6592e74c81e8</Id>
+      <Database Name="cv" Series="45573" Issue="384306" />
     </Book>
     <Book Series="Justice League Beyond" Number="19" Volume="2012" Year="2013">
-      <Id>752d092f-ff91-4e2a-877b-521e97fc5a8e</Id>
+      <Database Name="cv" Series="45573" Issue="385695" />
     </Book>
     <Book Series="Justice League Beyond" Number="20" Volume="2012" Year="2013">
-      <Id>fa47ac94-3e31-4984-9fc9-fb1d9376eebe</Id>
+      <Database Name="cv" Series="45573" Issue="389956" />
     </Book>
     <Book Series="Justice League Beyond" Number="21" Volume="2012" Year="2013">
-      <Id>c5ceeba5-19cc-4726-acfe-641fa2f128b7</Id>
+      <Database Name="cv" Series="45573" Issue="395595" />
     </Book>
     <Book Series="Justice League Beyond" Number="22" Volume="2012" Year="2013">
-      <Id>48e410e8-794e-49dd-b1f0-c7b741142e40</Id>
+      <Database Name="cv" Series="45573" Issue="396127" />
     </Book>
     <Book Series="Justice League Beyond" Number="23" Volume="2012" Year="2013">
-      <Id>d2010866-8825-4855-aa61-a23605186ab2</Id>
+      <Database Name="cv" Series="45573" Issue="400991" />
     </Book>
     <Book Series="Justice League Beyond" Number="24" Volume="2012" Year="2013">
-      <Id>5681eaa2-15d8-4439-b187-414be507eef8</Id>
+      <Database Name="cv" Series="45573" Issue="407710" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="1" Volume="2013" Year="2013">
-      <Id>3ced0d0b-9850-414e-b5d8-184b85c171ab</Id>
+      <Database Name="cv" Series="66022" Issue="420488" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="2" Volume="2013" Year="2013">
-      <Id>dd7d4d2d-c97d-407e-b428-44f4508ada75</Id>
+      <Database Name="cv" Series="66022" Issue="422126" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="3" Volume="2013" Year="2013">
-      <Id>3d2a8b6e-96b1-481f-acbf-bf6a1840cd0c</Id>
+      <Database Name="cv" Series="66022" Issue="424859" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="4" Volume="2013" Year="2013">
-      <Id>d9753e21-ff01-4ebd-bd5b-4d912d453f8a</Id>
+      <Database Name="cv" Series="66022" Issue="426325" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="5" Volume="2013" Year="2013">
-      <Id>575f001c-cfa2-419b-a58e-557e684ecbf0</Id>
+      <Database Name="cv" Series="66022" Issue="428204" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="6" Volume="2013" Year="2013">
-      <Id>802d346f-b5ea-4d74-a4ca-5bf26f2b839e</Id>
+      <Database Name="cv" Series="66022" Issue="430340" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="7" Volume="2013" Year="2013">
-      <Id>ceb2df0c-5f0f-44aa-b57d-8037a522de83</Id>
+      <Database Name="cv" Series="66022" Issue="431726" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="8" Volume="2013" Year="2013">
-      <Id>04087e7f-17af-4c7a-8910-1a1464876288</Id>
+      <Database Name="cv" Series="66022" Issue="433529" />
     </Book>
     <Book Series="Justice League Beyond 2.0" Number="1" Volume="2013" Year="2013">
-      <Id>a0495636-e6da-4d03-875a-a02875c9feb9</Id>
+      <Database Name="cv" Series="66176" Issue="421243" />
     </Book>
     <Book Series="Justice League Beyond 2.0" Number="2" Volume="2013" Year="2013">
-      <Id>7e2a4d47-4022-47ec-a404-6c0f0c4a6da4</Id>
+      <Database Name="cv" Series="66176" Issue="423211" />
     </Book>
     <Book Series="Justice League Beyond 2.0" Number="3" Volume="2013" Year="2013">
-      <Id>493ba240-3f66-4c0f-831c-96438fdc692d</Id>
+      <Database Name="cv" Series="66176" Issue="425473" />
     </Book>
     <Book Series="Justice League Beyond 2.0" Number="4" Volume="2013" Year="2013">
-      <Id>cc966aba-8c91-4561-aad5-cd0335e40b59</Id>
+      <Database Name="cv" Series="66176" Issue="427252" />
     </Book>
     <Book Series="Justice League Beyond 2.0" Number="5" Volume="2013" Year="2013">
-      <Id>db841d38-f34b-475a-a433-93c96d2f89be</Id>
+      <Database Name="cv" Series="66176" Issue="428586" />
     </Book>
     <Book Series="Justice League Beyond 2.0" Number="6" Volume="2013" Year="2013">
-      <Id>f793570c-3a7c-4226-934d-bea2e5b12c21</Id>
+      <Database Name="cv" Series="66176" Issue="431225" />
     </Book>
     <Book Series="Justice League Beyond 2.0" Number="7" Volume="2013" Year="2013">
-      <Id>9bfa3902-f702-4eca-9bbe-a4160de14d59</Id>
+      <Database Name="cv" Series="66176" Issue="433015" />
     </Book>
     <Book Series="Justice League Beyond 2.0" Number="8" Volume="2013" Year="2013">
-      <Id>d1147d2e-712a-482f-b54b-426915e3ef10</Id>
+      <Database Name="cv" Series="66176" Issue="434869" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="9" Volume="2013" Year="2013">
-      <Id>69af836a-5bbc-4777-9e23-a64893d7207b</Id>
+      <Database Name="cv" Series="66022" Issue="435975" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="10" Volume="2013" Year="2013">
-      <Id>fe36d817-bc13-4cb6-9c8e-5e875d79a212</Id>
+      <Database Name="cv" Series="66022" Issue="438265" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="11" Volume="2013" Year="2014">
-      <Id>37e7134a-ab58-41f5-ae9b-2879ba67baee</Id>
+      <Database Name="cv" Series="66022" Issue="441253" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="12" Volume="2013" Year="2014">
-      <Id>48754c5d-8bf4-4f29-8366-7fe304b30cde</Id>
+      <Database Name="cv" Series="66022" Issue="442537" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="13" Volume="2013" Year="2014">
-      <Id>746c6f23-51a4-4ff2-a7cd-75f8aef2d988</Id>
+      <Database Name="cv" Series="66022" Issue="444200" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="14" Volume="2013" Year="2014">
-      <Id>12382107-6a93-4784-b82c-d5e0c94dcd6d</Id>
+      <Database Name="cv" Series="66022" Issue="445416" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="15" Volume="2013" Year="2014">
-      <Id>b18186c9-4698-42f1-819f-1fdd8de7c7a8</Id>
+      <Database Name="cv" Series="66022" Issue="446750" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="16" Volume="2013" Year="2014">
-      <Id>d8f58f09-29c9-4e83-8db7-83674e4d9c2a</Id>
+      <Database Name="cv" Series="66022" Issue="447782" />
     </Book>
     <Book Series="Justice League Beyond 2.0" Number="9" Volume="2013" Year="2013">
-      <Id>28170edd-8a1c-4bb2-85c4-9d27d57c8d2f</Id>
+      <Database Name="cv" Series="66176" Issue="436586" />
     </Book>
     <Book Series="Justice League Beyond 2.0" Number="10" Volume="2013" Year="2013">
-      <Id>2ea749d3-0e0b-4e11-81de-0892f2c070d5</Id>
+      <Database Name="cv" Series="66176" Issue="440084" />
     </Book>
     <Book Series="Justice League Beyond 2.0" Number="11" Volume="2013" Year="2014">
-      <Id>437ec171-201c-4ced-867c-2434497281e9</Id>
+      <Database Name="cv" Series="66176" Issue="441860" />
     </Book>
     <Book Series="Justice League Beyond 2.0" Number="12" Volume="2013" Year="2014">
-      <Id>e45210bf-50a4-4908-90a6-45f8ab6497ea</Id>
+      <Database Name="cv" Series="66176" Issue="443400" />
     </Book>
     <Book Series="Justice League Beyond 2.0" Number="13" Volume="2013" Year="2014">
-      <Id>8fd31ae7-98a1-4ca5-9007-dfc40cd93779</Id>
+      <Database Name="cv" Series="66176" Issue="445015" />
     </Book>
     <Book Series="Justice League Beyond 2.0" Number="14" Volume="2013" Year="2014">
-      <Id>3bbb98c0-b114-4947-8061-d1fe4b6af24c</Id>
+      <Database Name="cv" Series="66176" Issue="446131" />
     </Book>
     <Book Series="Justice League Beyond 2.0" Number="15" Volume="2013" Year="2014">
-      <Id>dea06e75-493f-4b90-b996-97c77457329b</Id>
+      <Database Name="cv" Series="66176" Issue="447286" />
     </Book>
     <Book Series="Justice League Beyond 2.0" Number="16" Volume="2013" Year="2014">
-      <Id>698f333f-a217-4598-a81c-27f34ddc048a</Id>
+      <Database Name="cv" Series="66176" Issue="448280" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="17" Volume="2013" Year="2014">
-      <Id>9daed2bf-86b9-4e62-b1b9-a93ad1d887e4</Id>
+      <Database Name="cv" Series="66022" Issue="449296" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="18" Volume="2013" Year="2014">
-      <Id>4d5af4da-6828-441f-b8b0-afc96f28f6d1</Id>
+      <Database Name="cv" Series="66022" Issue="450320" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="19" Volume="2013" Year="2014">
-      <Id>39b958ec-a10b-4b13-9324-7c769efd7061</Id>
+      <Database Name="cv" Series="66022" Issue="451362" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="20" Volume="2013" Year="2014">
-      <Id>6428c2a5-2414-426e-9c62-d8cdb81bf0f7</Id>
+      <Database Name="cv" Series="66022" Issue="452565" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="21" Volume="2013" Year="2014">
-      <Id>ffc2d414-b832-4f64-8c97-73c3a4893eef</Id>
+      <Database Name="cv" Series="66022" Issue="453771" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="22" Volume="2013" Year="2014">
-      <Id>e9151f9e-f299-4ecb-b7b9-bb13ed359417</Id>
+      <Database Name="cv" Series="66022" Issue="455858" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="23" Volume="2013" Year="2014">
-      <Id>cb26868d-4dea-41dd-ad99-74f39b7c450a</Id>
+      <Database Name="cv" Series="66022" Issue="457129" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="24" Volume="2013" Year="2014">
-      <Id>5d63b851-aa30-4b65-a336-0f6427658421</Id>
+      <Database Name="cv" Series="66022" Issue="458881" />
     </Book>
     <Book Series="Justice League Beyond 2.0" Number="17" Volume="2013" Year="2014">
-      <Id>ca6fdefe-a3ae-4866-a272-f6f65c606e5f</Id>
+      <Database Name="cv" Series="66176" Issue="449891" />
     </Book>
     <Book Series="Justice League Beyond 2.0" Number="18" Volume="2013" Year="2014">
-      <Id>e2790f44-0063-4f86-9ea1-c47354f57c70</Id>
+      <Database Name="cv" Series="66176" Issue="450853" />
     </Book>
     <Book Series="Justice League Beyond 2.0" Number="19" Volume="2013" Year="2014">
-      <Id>3ef85191-25ad-48a3-8e58-c6157ebe1969</Id>
+      <Database Name="cv" Series="66176" Issue="452092" />
     </Book>
     <Book Series="Justice League Beyond 2.0" Number="20" Volume="2013" Year="2014">
-      <Id>a7f1e5e3-aae4-4bcc-bab2-b4264e40430f</Id>
+      <Database Name="cv" Series="66176" Issue="453210" />
     </Book>
     <Book Series="Justice League Beyond 2.0" Number="21" Volume="2013" Year="2014">
-      <Id>a19a5f04-42eb-4d64-9ad1-bc3824d8c0b1</Id>
+      <Database Name="cv" Series="66176" Issue="455245" />
     </Book>
     <Book Series="Justice League Beyond 2.0" Number="22" Volume="2013" Year="2014">
-      <Id>e4073d30-5ca6-4396-a4a4-ab1b955237b2</Id>
+      <Database Name="cv" Series="66176" Issue="456328" />
     </Book>
     <Book Series="Justice League Beyond 2.0" Number="23" Volume="2013" Year="2014">
-      <Id>c7bb4ede-4ff6-4ff1-8be8-fb582052342c</Id>
+      <Database Name="cv" Series="66176" Issue="458129" />
     </Book>
     <Book Series="Justice League Beyond 2.0" Number="24" Volume="2013" Year="2014">
-      <Id>1f1656ba-97a1-4681-b0e6-6086f21c2a44</Id>
+      <Database Name="cv" Series="66176" Issue="459446" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="25" Volume="2013" Year="2014">
-      <Id>9741a279-976c-4b8a-b789-488f03004ca4</Id>
+      <Database Name="cv" Series="66022" Issue="459966" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="26" Volume="2013" Year="2014">
-      <Id>01fefb36-6c98-4743-97c8-a12de50244f1</Id>
+      <Database Name="cv" Series="66022" Issue="460745" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="27" Volume="2013" Year="2014">
-      <Id>13679ed1-596f-4a8a-85be-5258cfb01209</Id>
+      <Database Name="cv" Series="66022" Issue="461345" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="28" Volume="2013" Year="2014">
-      <Id>45331d94-745f-46d2-866c-7b568ec84386</Id>
+      <Database Name="cv" Series="66022" Issue="462082" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="30" Volume="2013" Year="2014">
-      <Id>27de98d8-9ec4-4aee-b4e4-a667b9e14cd4</Id>
+      <Database Name="cv" Series="66022" Issue="463131" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="31" Volume="2013" Year="2014">
-      <Id>d9341a93-a126-44bd-a4d7-255f47d77995</Id>
+      <Database Name="cv" Series="66022" Issue="463766" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="32" Volume="2013" Year="2014">
-      <Id>5898a16b-4952-4e23-9b5d-ab6e2146755c</Id>
+      <Database Name="cv" Series="66022" Issue="464570" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="33" Volume="2013" Year="2014">
-      <Id>6eb2d5f5-fc62-4643-883e-bca85e529b1f</Id>
+      <Database Name="cv" Series="66022" Issue="465422" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="34" Volume="2013" Year="2014">
-      <Id>9deabdef-6c50-4f74-823a-95283ee3146b</Id>
+      <Database Name="cv" Series="66022" Issue="466141" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="35" Volume="2013" Year="2014">
-      <Id>6462228a-f8f9-4ec8-a4c0-f511fc0d0111</Id>
+      <Database Name="cv" Series="66022" Issue="466694" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="36" Volume="2013" Year="2014">
-      <Id>037d6945-a62c-4f3b-bd77-19fdd873b4cb</Id>
+      <Database Name="cv" Series="66022" Issue="467489" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="37" Volume="2013" Year="2014">
-      <Id>21588552-39bc-47de-b273-ee368a70b692</Id>
+      <Database Name="cv" Series="66022" Issue="467901" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="38" Volume="2013" Year="2014">
-      <Id>5d1a26ea-12e2-4f70-a73f-d52863131f69</Id>
+      <Database Name="cv" Series="66022" Issue="468354" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="39" Volume="2013" Year="2014">
-      <Id>5ee77412-f95f-4fde-95d9-d14c56acb791</Id>
+      <Database Name="cv" Series="66022" Issue="468777" />
     </Book>
     <Book Series="Batman Beyond 2.0" Number="40" Volume="2013" Year="2014">
-      <Id>6f023d42-d8f1-4236-bbb8-eab18e43f7fd</Id>
+      <Database Name="cv" Series="66022" Issue="469294" />
     </Book>
     <Book Series="The New 52: Futures End" Number="0" Volume="2014" Year="2014">
-      <Id>32aec0f4-f990-481a-bdab-f1010418b20a</Id>
+      <Database Name="cv" Series="73528" Issue="452026" />
     </Book>
     <Book Series="The New 52: Futures End" Number="1" Volume="2014" Year="2014">
-      <Id>41d96171-a4a6-4d86-8d10-b3462a83b5e5</Id>
+      <Database Name="cv" Series="73528" Issue="452261" />
     </Book>
     <Book Series="The New 52: Futures End" Number="2" Volume="2014" Year="2014">
-      <Id>87ec9c4c-7cfb-4f15-bc48-2b9d055291d4</Id>
+      <Database Name="cv" Series="73528" Issue="452806" />
     </Book>
     <Book Series="The New 52: Futures End" Number="3" Volume="2014" Year="2014">
-      <Id>44f3a70f-be15-455c-953d-e02a687cfcdd</Id>
+      <Database Name="cv" Series="73528" Issue="453360" />
     </Book>
     <Book Series="The New 52: Futures End" Number="4" Volume="2014" Year="2014">
-      <Id>16e9c86c-9c5f-41bb-9b55-7f3c3e8808c0</Id>
+      <Database Name="cv" Series="73528" Issue="454045" />
     </Book>
     <Book Series="The New 52: Futures End" Number="5" Volume="2014" Year="2014">
-      <Id>eac17c16-030f-4a4e-812b-f7575502d5d0</Id>
+      <Database Name="cv" Series="73528" Issue="455434" />
     </Book>
     <Book Series="The New 52: Futures End" Number="6" Volume="2014" Year="2014">
-      <Id>809f1557-e900-4793-9e33-d9b93cd027c8</Id>
+      <Database Name="cv" Series="73528" Issue="455975" />
     </Book>
     <Book Series="The New 52: Futures End" Number="7" Volume="2014" Year="2014">
-      <Id>1cd87247-474c-4b4f-a9b5-751c4fb4efbf</Id>
+      <Database Name="cv" Series="73528" Issue="456499" />
     </Book>
     <Book Series="The New 52: Futures End" Number="8" Volume="2014" Year="2014">
-      <Id>c254ec99-5b9c-4aa6-a761-43a60446eb4b</Id>
+      <Database Name="cv" Series="73528" Issue="457579" />
     </Book>
     <Book Series="The New 52: Futures End" Number="9" Volume="2014" Year="2014">
-      <Id>b04ce320-3e7c-47c7-99f2-2651f120c6c0</Id>
+      <Database Name="cv" Series="73528" Issue="458564" />
     </Book>
     <Book Series="The New 52: Futures End" Number="10" Volume="2014" Year="2014">
-      <Id>8875619f-a95f-497e-aa2e-b156dc968b14</Id>
+      <Database Name="cv" Series="73528" Issue="459119" />
     </Book>
     <Book Series="The New 52: Futures End" Number="11" Volume="2014" Year="2014">
-      <Id>f570d94c-1b6e-4ebf-935c-06d7ec31aa73</Id>
+      <Database Name="cv" Series="73528" Issue="459628" />
     </Book>
     <Book Series="The New 52: Futures End" Number="12" Volume="2014" Year="2014">
-      <Id>c9f66e2a-596f-41dc-ace7-70f996146255</Id>
+      <Database Name="cv" Series="73528" Issue="460265" />
     </Book>
     <Book Series="The New 52: Futures End" Number="13" Volume="2014" Year="2014">
-      <Id>03f70e9b-019f-4b3b-8fce-65b799a7580f</Id>
+      <Database Name="cv" Series="73528" Issue="461066" />
     </Book>
     <Book Series="The New 52: Futures End" Number="14" Volume="2014" Year="2014">
-      <Id>78f5aa0b-c725-4401-8b4b-6c51266a426e</Id>
+      <Database Name="cv" Series="73528" Issue="461687" />
     </Book>
     <Book Series="The New 52: Futures End" Number="15" Volume="2014" Year="2014">
-      <Id>4826c921-71cb-40ea-b237-bc7e0306a27e</Id>
+      <Database Name="cv" Series="73528" Issue="462204" />
     </Book>
     <Book Series="The New 52: Futures End" Number="16" Volume="2014" Year="2014">
-      <Id>e9846389-b313-4f91-b901-076f1ac20e04</Id>
+      <Database Name="cv" Series="73528" Issue="462849" />
     </Book>
     <Book Series="The New 52: Futures End" Number="17" Volume="2014" Year="2014">
-      <Id>4029430f-fb4c-4450-ba92-ba6267624bbb</Id>
+      <Database Name="cv" Series="73528" Issue="463427" />
     </Book>
     <Book Series="The New 52: Futures End" Number="18" Volume="2014" Year="2014">
-      <Id>3bee960f-0cac-4b77-8210-02ad92092337</Id>
+      <Database Name="cv" Series="73528" Issue="463943" />
     </Book>
     <Book Series="The New 52: Futures End" Number="19" Volume="2014" Year="2014">
-      <Id>f56e8345-7f50-4ac9-887c-9465eb35a83b</Id>
+      <Database Name="cv" Series="73528" Issue="464938" />
     </Book>
     <Book Series="The New 52: Futures End" Number="20" Volume="2014" Year="2014">
-      <Id>e377e30f-8295-405d-b0d8-1721affe9e8f</Id>
+      <Database Name="cv" Series="73528" Issue="465802" />
     </Book>
     <Book Series="The New 52: Futures End" Number="21" Volume="2014" Year="2014">
-      <Id>720689d4-95d6-4efe-b9f9-7ca5b3e1c390</Id>
+      <Database Name="cv" Series="73528" Issue="466275" />
     </Book>
     <Book Series="The New 52: Futures End" Number="22" Volume="2014" Year="2014">
-      <Id>9c0da7d6-6c7c-4ca2-87ee-62b128091933</Id>
+      <Database Name="cv" Series="73528" Issue="466982" />
     </Book>
     <Book Series="The New 52: Futures End" Number="23" Volume="2014" Year="2014">
-      <Id>4c8dfcee-7bf1-44a4-a577-d72b197367c1</Id>
+      <Database Name="cv" Series="73528" Issue="467600" />
     </Book>
     <Book Series="The New 52: Futures End" Number="24" Volume="2014" Year="2014">
-      <Id>cba85f51-e132-4f6a-9b2b-e5da788f8f8f</Id>
+      <Database Name="cv" Series="73528" Issue="468021" />
     </Book>
     <Book Series="The New 52: Futures End" Number="25" Volume="2014" Year="2014">
-      <Id>21feb2bc-1868-4603-96b2-af5d0ebe2ef6</Id>
+      <Database Name="cv" Series="73528" Issue="468412" />
     </Book>
     <Book Series="The New 52: Futures End" Number="26" Volume="2014" Year="2014">
-      <Id>18b46769-f179-4dc6-9233-370f4afd44a1</Id>
+      <Database Name="cv" Series="73528" Issue="468862" />
     </Book>
     <Book Series="The New 52: Futures End" Number="27" Volume="2014" Year="2015">
-      <Id>d780adce-d5e8-471f-8e05-c6bfbb34c3e7</Id>
+      <Database Name="cv" Series="73528" Issue="469429" />
     </Book>
     <Book Series="The New 52: Futures End" Number="28" Volume="2014" Year="2015">
-      <Id>8f5313d6-74d1-403a-ad18-252461bf20d6</Id>
+      <Database Name="cv" Series="73528" Issue="469794" />
     </Book>
     <Book Series="The New 52: Futures End" Number="29" Volume="2014" Year="2015">
-      <Id>99a41ad1-1430-4669-a6ea-7484c96ebe9e</Id>
+      <Database Name="cv" Series="73528" Issue="470370" />
     </Book>
     <Book Series="The New 52: Futures End" Number="30" Volume="2014" Year="2015">
-      <Id>394fb400-71d0-4a8f-923a-6d28814f05d4</Id>
+      <Database Name="cv" Series="73528" Issue="471254" />
     </Book>
     <Book Series="The New 52: Futures End" Number="31" Volume="2014" Year="2015">
-      <Id>05038eeb-9774-45b6-a0eb-50c8620f472c</Id>
+      <Database Name="cv" Series="73528" Issue="471917" />
     </Book>
     <Book Series="The New 52: Futures End" Number="32" Volume="2014" Year="2015">
-      <Id>bf130495-6577-4872-a8a8-83589f002fab</Id>
+      <Database Name="cv" Series="73528" Issue="472837" />
     </Book>
     <Book Series="The New 52: Futures End" Number="33" Volume="2014" Year="2015">
-      <Id>3fce4c56-f3df-46a7-a1db-f8154bda08d1</Id>
+      <Database Name="cv" Series="73528" Issue="473589" />
     </Book>
     <Book Series="The New 52: Futures End" Number="34" Volume="2014" Year="2015">
-      <Id>caa5a523-a887-4584-92a9-f847a189aeba</Id>
+      <Database Name="cv" Series="73528" Issue="474561" />
     </Book>
     <Book Series="The New 52: Futures End" Number="35" Volume="2014" Year="2015">
-      <Id>0d7ab352-0712-445b-9d58-b24f9869eba8</Id>
+      <Database Name="cv" Series="73528" Issue="475075" />
     </Book>
     <Book Series="The New 52: Futures End" Number="36" Volume="2014" Year="2015">
-      <Id>4baa097c-a561-4a82-98ca-a3e0ee2ca3d5</Id>
+      <Database Name="cv" Series="73528" Issue="475413" />
     </Book>
     <Book Series="The New 52: Futures End" Number="37" Volume="2014" Year="2015">
-      <Id>6e3c988e-c61f-4151-bdc1-b5ae37935dbd</Id>
+      <Database Name="cv" Series="73528" Issue="475898" />
     </Book>
     <Book Series="The New 52: Futures End" Number="38" Volume="2014" Year="2015">
-      <Id>5a85bc1a-9734-4b1f-9c31-72cffa32f231</Id>
+      <Database Name="cv" Series="73528" Issue="476744" />
     </Book>
     <Book Series="The New 52: Futures End" Number="39" Volume="2014" Year="2015">
-      <Id>0cf5f3a6-efd9-4662-9df2-7b4c6a8624e9</Id>
+      <Database Name="cv" Series="73528" Issue="477795" />
     </Book>
     <Book Series="The New 52: Futures End" Number="40" Volume="2014" Year="2015">
-      <Id>06bfa6e1-8979-44d5-9508-3ce6307c4d3e</Id>
+      <Database Name="cv" Series="73528" Issue="478567" />
     </Book>
     <Book Series="The New 52: Futures End" Number="41" Volume="2014" Year="2015">
-      <Id>c34e2196-706f-4cf9-bb0a-b1fbfc69e2fb</Id>
+      <Database Name="cv" Series="73528" Issue="479202" />
     </Book>
     <Book Series="The New 52: Futures End" Number="42" Volume="2014" Year="2015">
-      <Id>296dc388-d6a6-4ca8-943e-bd073356d472</Id>
+      <Database Name="cv" Series="73528" Issue="479932" />
     </Book>
     <Book Series="The New 52: Futures End" Number="43" Volume="2014" Year="2015">
-      <Id>935804e4-234b-4947-823c-3b5150ef309f</Id>
+      <Database Name="cv" Series="73528" Issue="480630" />
     </Book>
     <Book Series="The New 52: Futures End" Number="44" Volume="2014" Year="2015">
-      <Id>45b0aa23-0581-4fd1-a253-3ec4d7e92abb</Id>
+      <Database Name="cv" Series="73528" Issue="481566" />
     </Book>
     <Book Series="The New 52: Futures End" Number="45" Volume="2014" Year="2015">
-      <Id>2125ff98-9e48-4f9e-9537-cda7238aecfd</Id>
+      <Database Name="cv" Series="73528" Issue="482117" />
     </Book>
     <Book Series="The New 52: Futures End" Number="46" Volume="2014" Year="2015">
-      <Id>d113fd2b-82b9-40f3-8c18-9e23a2e594dc</Id>
+      <Database Name="cv" Series="73528" Issue="482620" />
     </Book>
     <Book Series="The New 52: Futures End" Number="47" Volume="2014" Year="2015">
-      <Id>98a1f776-ca93-483a-b83d-a731ab7079a4</Id>
+      <Database Name="cv" Series="73528" Issue="483306" />
     </Book>
     <Book Series="The New 52: Futures End" Number="48" Volume="2014" Year="2015">
-      <Id>3cb81166-98b4-4b71-8713-ac66ddcd088e</Id>
+      <Database Name="cv" Series="73528" Issue="484843" />
     </Book>
     <Book Series="Batman Beyond" Number="1" Volume="2015" Year="2015">
-      <Id>0ace0136-f4ef-4161-8420-6826666ba110</Id>
+      <Database Name="cv" Series="82383" Issue="490834" />
     </Book>
     <Book Series="Batman Beyond" Number="2" Volume="2015" Year="2015">
-      <Id>5cf82906-64df-4fe0-9495-5a44860b3325</Id>
+      <Database Name="cv" Series="82383" Issue="493754" />
     </Book>
     <Book Series="Batman Beyond" Number="3" Volume="2015" Year="2015">
-      <Id>f9fdc5ea-e4ea-4561-a8a6-8c85a642afb0</Id>
+      <Database Name="cv" Series="82383" Issue="496856" />
     </Book>
     <Book Series="Batman Beyond" Number="4" Volume="2015" Year="2015">
-      <Id>a1553066-e8ae-467a-9eac-604aeaca4e75</Id>
+      <Database Name="cv" Series="82383" Issue="499014" />
     </Book>
     <Book Series="Batman Beyond" Number="5" Volume="2015" Year="2015">
-      <Id>0b5ccf46-5582-4682-880c-34c7943c1940</Id>
+      <Database Name="cv" Series="82383" Issue="502081" />
     </Book>
     <Book Series="Batman Beyond" Number="6" Volume="2015" Year="2016">
-      <Id>2aa0185b-4a0c-47ae-a883-9c02b281b31f</Id>
+      <Database Name="cv" Series="82383" Issue="505191" />
     </Book>
     <Book Series="Batman Beyond" Number="7" Volume="2015" Year="2016">
-      <Id>24ec81a8-77bd-4bee-8f54-5dcb5795093c</Id>
+      <Database Name="cv" Series="82383" Issue="507144" />
     </Book>
     <Book Series="Batman Beyond" Number="8" Volume="2015" Year="2016">
-      <Id>6b0effa7-f360-4f1d-bd98-406ccffe86d9</Id>
+      <Database Name="cv" Series="82383" Issue="510472" />
     </Book>
     <Book Series="Batman Beyond" Number="9" Volume="2015" Year="2016">
-      <Id>4118f8ba-abbe-48f9-b3da-29cb4808e9fd</Id>
+      <Database Name="cv" Series="82383" Issue="513620" />
     </Book>
     <Book Series="Batman Beyond" Number="10" Volume="2015" Year="2016">
-      <Id>484436e7-7250-4fdd-8404-c8dad5aa3708</Id>
+      <Database Name="cv" Series="82383" Issue="517807" />
     </Book>
     <Book Series="Batman Beyond" Number="11" Volume="2015" Year="2016">
-      <Id>d967b280-560f-48b6-9464-21a93c17813b</Id>
+      <Database Name="cv" Series="82383" Issue="523219" />
     </Book>
     <Book Series="Batman Beyond" Number="12" Volume="2015" Year="2016">
-      <Id>a3af7668-4d9c-4400-ad83-8d332eb26dee</Id>
+      <Database Name="cv" Series="82383" Issue="528477" />
     </Book>
     <Book Series="Batman Beyond" Number="13" Volume="2015" Year="2016">
-      <Id>12c6ffc8-0adf-4ec4-8b7c-bf21e97d3af9</Id>
+      <Database Name="cv" Series="82383" Issue="533005" />
     </Book>
     <Book Series="Batman Beyond" Number="14" Volume="2015" Year="2016">
-      <Id>ba15c6fd-bb70-41b9-b34a-9bf4c6bf583e</Id>
+      <Database Name="cv" Series="82383" Issue="538483" />
     </Book>
     <Book Series="Batman Beyond" Number="15" Volume="2015" Year="2016">
-      <Id>294f7cc9-04e3-4a38-9bea-a8346ddc8691</Id>
+      <Database Name="cv" Series="82383" Issue="542598" />
     </Book>
     <Book Series="Batman Beyond" Number="16" Volume="2015" Year="2016">
-      <Id>d723a54e-64de-40b9-bfe1-7c67dd7c10bb</Id>
+      <Database Name="cv" Series="82383" Issue="548551" />
     </Book>
     <Book Series="Batman Beyond: Rebirth" Number="1" Volume="2016" Year="2016">
-      <Id>04376827-1896-4ffb-b12f-de48da589b6f</Id>
+      <Database Name="cv" Series="94407" Issue="551266" />
     </Book>
     <Book Series="Batman Beyond" Number="1" Volume="2016" Year="2016">
-      <Id>1d046a7d-d937-4e36-bb8b-66526a9d80dd</Id>
+      <Database Name="cv" Series="95201" Issue="555483" />
     </Book>
     <Book Series="Batman Beyond" Number="2" Volume="2016" Year="2017">
-      <Id>58d29a8c-9527-4bd9-876d-8ad37c487405</Id>
+      <Database Name="cv" Series="95201" Issue="558928" />
     </Book>
     <Book Series="Batman Beyond" Number="3" Volume="2016" Year="2017">
-      <Id>9edf686a-6d79-4c88-9c33-c8cb55f819e7</Id>
+      <Database Name="cv" Series="95201" Issue="571626" />
     </Book>
     <Book Series="Batman Beyond" Number="4" Volume="2016" Year="2017">
-      <Id>058af3e9-34dd-4017-a51c-cd203aa6466c</Id>
+      <Database Name="cv" Series="95201" Issue="578419" />
     </Book>
     <Book Series="Batman Beyond" Number="5" Volume="2016" Year="2017">
-      <Id>5607924a-a781-4e4a-badd-a48334c3f7ca</Id>
+      <Database Name="cv" Series="95201" Issue="582488" />
     </Book>
     <Book Series="Batman Beyond" Number="6" Volume="2016" Year="2017">
-      <Id>c4cc5490-37a8-4a27-aa40-fb33d84a3cdd</Id>
+      <Database Name="cv" Series="95201" Issue="588531" />
     </Book>
     <Book Series="Batman Beyond" Number="7" Volume="2016" Year="2017">
-      <Id>1fa9201c-7015-4b86-b432-cb79d5b0182b</Id>
+      <Database Name="cv" Series="95201" Issue="593220" />
     </Book>
     <Book Series="Batman Beyond" Number="8" Volume="2016" Year="2017">
-      <Id>234bb76c-9589-491a-81ec-eaa00d3bcfdd</Id>
+      <Database Name="cv" Series="95201" Issue="597157" />
     </Book>
     <Book Series="Batman Beyond" Number="9" Volume="2016" Year="2017">
-      <Id>024c9aff-94d7-4410-92d4-3befae7d0457</Id>
+      <Database Name="cv" Series="95201" Issue="605049" />
     </Book>
     <Book Series="Batman Beyond" Number="10" Volume="2016" Year="2017">
-      <Id>9ca0f491-1516-4fcc-9a91-0e5e971ea8ac</Id>
+      <Database Name="cv" Series="95201" Issue="610456" />
     </Book>
     <Book Series="Batman Beyond" Number="11" Volume="2016" Year="2017">
-      <Id>bdf2fb6f-6c12-47a9-8a33-b4b693396813</Id>
+      <Database Name="cv" Series="95201" Issue="616137" />
     </Book>
     <Book Series="Batman Beyond" Number="12" Volume="2016" Year="2017">
-      <Id>92c48206-27ef-4665-ac41-decee33dd6c6</Id>
+      <Database Name="cv" Series="95201" Issue="625271" />
     </Book>
     <Book Series="Batman Beyond" Number="13" Volume="2016" Year="2017">
-      <Id>83da05d0-7440-4eeb-8f17-a1177e89d36d</Id>
+      <Database Name="cv" Series="95201" Issue="632456" />
     </Book>
     <Book Series="Batman Beyond" Number="14" Volume="2016" Year="2018">
-      <Id>564a5617-6bcd-41ea-8d20-c0d8a38c74de</Id>
+      <Database Name="cv" Series="95201" Issue="641370" />
     </Book>
     <Book Series="Batman Beyond" Number="15" Volume="2016" Year="2018">
-      <Id>b17883df-2e0e-4534-8206-1f8ff50c5239</Id>
+      <Database Name="cv" Series="95201" Issue="649692" />
     </Book>
     <Book Series="Batman Beyond" Number="16" Volume="2016" Year="2018">
-      <Id>7c359ae2-5101-45ac-b5c5-abc880bcc023</Id>
+      <Database Name="cv" Series="95201" Issue="655467" />
     </Book>
     <Book Series="Batman Beyond" Number="17" Volume="2016" Year="2018">
-      <Id>4cd5a173-e27d-406d-acd0-7d16a7c55856</Id>
+      <Database Name="cv" Series="95201" Issue="661108" />
     </Book>
     <Book Series="Batman Beyond" Number="18" Volume="2016" Year="2018">
-      <Id>01e0ab84-e4ec-4a39-a12c-603ae52ecb53</Id>
+      <Database Name="cv" Series="95201" Issue="664256" />
     </Book>
     <Book Series="Batman Beyond" Number="19" Volume="2016" Year="2018">
-      <Id>8526a8be-b430-4b87-8b0e-f73c6b4e475b</Id>
+      <Database Name="cv" Series="95201" Issue="667598" />
     </Book>
     <Book Series="Batman Beyond" Number="20" Volume="2016" Year="2018">
-      <Id>f9b0ccaa-1d0c-48f2-be06-8f77c5516050</Id>
+      <Database Name="cv" Series="95201" Issue="670715" />
     </Book>
     <Book Series="Batman Beyond" Number="21" Volume="2016" Year="2018">
-      <Id>eb3d5ff8-770d-4185-90d2-9636aaca9b97</Id>
+      <Database Name="cv" Series="95201" Issue="675112" />
     </Book>
     <Book Series="Batman Beyond" Number="22" Volume="2016" Year="2018">
-      <Id>87804dca-e5a4-4408-b1a1-f61dcca3f76d</Id>
+      <Database Name="cv" Series="95201" Issue="677941" />
     </Book>
     <Book Series="Batman Beyond" Number="23" Volume="2016" Year="2018">
-      <Id>182c3d81-b642-406c-bb73-c7d3a1110be4</Id>
+      <Database Name="cv" Series="95201" Issue="680698" />
     </Book>
     <Book Series="Batman Beyond" Number="24" Volume="2016" Year="2018">
-      <Id>6ca5a34d-ad86-4f14-bfc5-a46e3973824c</Id>
+      <Database Name="cv" Series="95201" Issue="686344" />
     </Book>
     <Book Series="Batman Beyond" Number="25" Volume="2016" Year="2018">
-      <Id>87ed133e-b397-4960-812c-ab58604e66fe</Id>
+      <Database Name="cv" Series="95201" Issue="689838" />
     </Book>
     <Book Series="Batman Beyond" Number="26" Volume="2016" Year="2019">
-      <Id>d9f67050-eac4-43c0-bb72-a43302ecd761</Id>
+      <Database Name="cv" Series="95201" Issue="693427" />
     </Book>
     <Book Series="Batman Beyond" Number="27" Volume="2016" Year="2019">
-      <Id>bae43c01-70eb-47f1-87a3-dbbcc040a0fd</Id>
+      <Database Name="cv" Series="95201" Issue="696325" />
     </Book>
     <Book Series="Batman Beyond" Number="28" Volume="2016" Year="2019">
-      <Id>42c04292-2841-464c-b757-fb4d3556745b</Id>
+      <Database Name="cv" Series="95201" Issue="699367" />
     </Book>
     <Book Series="Batman Beyond" Number="29" Volume="2016" Year="2019">
-      <Id>f69e487a-62f8-4f0e-9c8f-cf7962d04933</Id>
+      <Database Name="cv" Series="95201" Issue="701906" />
     </Book>
     <Book Series="Batman Beyond" Number="30" Volume="2016" Year="2019">
-      <Id>da7e2bd9-1929-43e9-8d45-5289dffc956a</Id>
+      <Database Name="cv" Series="95201" Issue="704779" />
     </Book>
     <Book Series="Batman Beyond" Number="31" Volume="2016" Year="2019">
-      <Id>d46d12c8-47d7-41e4-b55d-4641b99df7f0</Id>
+      <Database Name="cv" Series="95201" Issue="706921" />
     </Book>
     <Book Series="Batman Beyond" Number="32" Volume="2016" Year="2019">
-      <Id>8b22f7b7-df92-46da-bf68-9b71c34d889e</Id>
+      <Database Name="cv" Series="95201" Issue="709694" />
     </Book>
     <Book Series="Batman Beyond" Number="33" Volume="2016" Year="2019">
-      <Id>c103f227-b2ef-4d72-9d12-123220083b9f</Id>
+      <Database Name="cv" Series="95201" Issue="712418" />
     </Book>
     <Book Series="Batman Beyond" Number="34" Volume="2016" Year="2019">
-      <Id>7fd41fc3-e6e5-4533-820d-1c44639fc59e</Id>
+      <Database Name="cv" Series="95201" Issue="714155" />
     </Book>
     <Book Series="Batman Beyond" Number="35" Volume="2016" Year="2019">
-      <Id>ac646dcf-212d-4a20-9bdb-d6f11bdca779</Id>
+      <Database Name="cv" Series="95201" Issue="717388" />
     </Book>
     <Book Series="Batman Beyond" Number="36" Volume="2016" Year="2019">
-      <Id>e0a90ce7-117f-42d9-b48e-470261b9ee6d</Id>
+      <Database Name="cv" Series="95201" Issue="720034" />
     </Book>
     <Book Series="Batman Beyond" Number="37" Volume="2016" Year="2019">
-      <Id>05ced9e9-722a-47a7-af1e-4ea8523f8d38</Id>
+      <Database Name="cv" Series="95201" Issue="723824" />
     </Book>
     <Book Series="Batman Beyond" Number="38" Volume="2016" Year="2020">
-      <Id>f5f3a13c-52fc-42ff-b215-de2d83f0baa5</Id>
+      <Database Name="cv" Series="95201" Issue="728892" />
     </Book>
     <Book Series="Batman Beyond" Number="39" Volume="2016" Year="2020">
-      <Id>999d9017-ad68-412f-810f-f6fddc303bbd</Id>
+      <Database Name="cv" Series="95201" Issue="731925" />
+    </Book>
+    <Book Series="Batman Beyond" Number="40" Volume="2016" Year="2020">
+      <Database Name="cv" Series="95201" Issue="734531" />
+    </Book>
+    <Book Series="Batman Beyond" Number="41" Volume="2016" Year="2020">
+      <Database Name="cv" Series="95201" Issue="738536" />
+    </Book>
+    <Book Series="Batman Beyond" Number="42" Volume="2016" Year="2020">
+      <Database Name="cv" Series="95201" Issue="743308" />
+    </Book>
+    <Book Series="Batman Beyond" Number="43" Volume="2016" Year="2020">
+      <Database Name="cv" Series="95201" Issue="763282" />
+    </Book>
+    <Book Series="Batman Beyond" Number="44" Volume="2016" Year="2020">
+      <Database Name="cv" Series="95201" Issue="769598" />
+    </Book>
+    <Book Series="Batman Beyond" Number="45" Volume="2016" Year="2020">
+      <Database Name="cv" Series="95201" Issue="781014" />
+    </Book>
+    <Book Series="Batman Beyond" Number="46" Volume="2016" Year="2020">
+      <Database Name="cv" Series="95201" Issue="795920" />
+    </Book>
+    <Book Series="Batman Beyond" Number="47" Volume="2016" Year="2020">
+      <Database Name="cv" Series="95201" Issue="802692" />
+    </Book>
+    <Book Series="Batman Beyond" Number="48" Volume="2016" Year="2020">
+      <Database Name="cv" Series="95201" Issue="814044" />
+    </Book>
+    <Book Series="Batman Beyond" Number="49" Volume="2016" Year="2021">
+      <Database Name="cv" Series="95201" Issue="819309" />
+    </Book>
+    <Book Series="Batman Beyond" Number="50" Volume="2016" Year="2021">
+      <Database Name="cv" Series="95201" Issue="821756" />
+    </Book>
+    <Book Series="Batman: Urban Legends" Number="7" Volume="2021" Year="2021">
+      <Database Name="cv" Series="134303" Issue="884629" />
+    </Book>
+    <Book Series="Batman Beyond: Neo-Year" Number="1" Volume="2022" Year="2022">
+      <Database Name="cv" Series="142127" Issue="914517" />
+    </Book>
+    <Book Series="Batman Beyond: Neo-Year" Number="2" Volume="2022" Year="2022">
+      <Database Name="cv" Series="142127" Issue="920646" />
+    </Book>
+    <Book Series="Batman Beyond: Neo-Year" Number="3" Volume="2022" Year="2022">
+      <Database Name="cv" Series="142127" Issue="929553" />
+    </Book>
+    <Book Series="Batman Beyond: Neo-Year" Number="4" Volume="2022" Year="2022">
+      <Database Name="cv" Series="142127" Issue="934926" />
+    </Book>
+    <Book Series="Batman Beyond: Neo-Year" Number="5" Volume="2022" Year="2022">
+      <Database Name="cv" Series="142127" Issue="939715" />
+    </Book>
+    <Book Series="Batman Beyond: Neo-Year" Number="6" Volume="2022" Year="2022">
+      <Database Name="cv" Series="142127" Issue="946063" />
+    </Book>
+    <Book Series="Batman Beyond: Neo-Gothic" Number="1" Volume="2023" Year="2023">
+      <Database Name="cv" Series="152510" Issue="1003557" />
+    </Book>
+    <Book Series="Batman Beyond: Neo-Gothic" Number="2" Volume="2023" Year="2023">
+      <Database Name="cv" Series="152510" Issue="1010061" />
+    </Book>
+    <Book Series="Batman Beyond: Neo-Gothic" Number="3" Volume="2023" Year="2023">
+      <Database Name="cv" Series="152510" Issue="1017983" />
+    </Book>
+    <Book Series="Batman Beyond: Neo-Gothic" Number="4" Volume="2023" Year="2023">
+      <Database Name="cv" Series="152510" Issue="1026513" />
+    </Book>
+    <Book Series="Batman Beyond: Neo-Gothic" Number="5" Volume="2023" Year="2024">
+      <Database Name="cv" Series="152510" Issue="1031582" />
+    </Book>
+    <Book Series="Batman Beyond: Neo-Gothic" Number="6" Volume="2023" Year="2024">
+      <Database Name="cv" Series="152510" Issue="1038105" />
     </Book>
   </Books>
   <Matchers />

--- a/DC/Characters/unsorted/Batwoman/Batwoman.cbl
+++ b/DC/Characters/unsorted/Batwoman/Batwoman.cbl
@@ -1,210 +1,211 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Batwoman</Name>
+  <NumIssues>68</NumIssues>
   <Books>
     <Book Series="Crime Bible: The Five Lessons of Blood" Number="3" Volume="2007" Year="2008">
-      <Id>d1270fd7-7bed-423b-973b-6de806ab62a4</Id>
+      <Database Name="cv" Series="19448" Issue="122018" />
     </Book>
     <Book Series="Batwoman: Elegy" Number="1" Volume="2010" Year="2010">
-      <Id>8c8a13db-7ae6-4012-97ed-8156b5b98d45</Id>
+      <Database Name="cv" Series="32225" Issue="202238" />
     </Book>
     <Book Series="Detective Comics" Number="861" Volume="1937" Year="2010">
-      <Id>fb4c2657-a8a4-4542-b02d-b410f4ce82bd</Id>
+      <Database Name="cv" Series="18058" Issue="194485" />
     </Book>
     <Book Series="Detective Comics" Number="862" Volume="1937" Year="2010">
-      <Id>0e757f8e-ca2f-47bc-9a6a-b1aae8d68fb3</Id>
+      <Database Name="cv" Series="18058" Issue="198865" />
     </Book>
     <Book Series="Detective Comics" Number="863" Volume="1937" Year="2010">
-      <Id>f810f28b-e4fc-4765-81dc-8dcf44aafc8c</Id>
+      <Database Name="cv" Series="18058" Issue="202576" />
     </Book>
     <Book Series="Batwoman" Number="0" Volume="2011" Year="2011">
-      <Id>ba8c4550-858a-49cf-9e1f-3b8697d0c242</Id>
+      <Database Name="cv" Series="36950" Issue="246454" />
     </Book>
     <Book Series="Batwoman" Number="25" Volume="2011" Year="2014">
-      <Id>13193405-c28d-4135-bf94-647d07751343</Id>
+      <Database Name="cv" Series="36950" Issue="433788" />
     </Book>
     <Book Series="Batwoman" Number="1" Volume="2011" Year="2011">
-      <Id>45258b8a-c8f9-4453-abba-e05ee29bfa34</Id>
+      <Database Name="cv" Series="36950" Issue="292565" />
     </Book>
     <Book Series="Batwoman" Number="2" Volume="2011" Year="2011">
-      <Id>6512c3da-07f1-40b9-aa62-1606d5fd913b</Id>
+      <Database Name="cv" Series="36950" Issue="294821" />
     </Book>
     <Book Series="Batwoman" Number="3" Volume="2011" Year="2012">
-      <Id>ed53fa85-8b19-4358-bd44-241e2cc85618</Id>
+      <Database Name="cv" Series="36950" Issue="301648" />
     </Book>
     <Book Series="Batwoman" Number="4" Volume="2011" Year="2012">
-      <Id>d975ac2d-bfe3-4f36-a3bd-be9f8a67ac31</Id>
+      <Database Name="cv" Series="36950" Issue="306481" />
     </Book>
     <Book Series="Batwoman" Number="5" Volume="2011" Year="2012">
-      <Id>80000922-a927-45d3-a3fc-580519abdd6e</Id>
+      <Database Name="cv" Series="36950" Issue="310752" />
     </Book>
     <Book Series="Batwoman" Number="6" Volume="2011" Year="2012">
-      <Id>a69bc25d-d029-40fa-a2d5-3eac50595e7c</Id>
+      <Database Name="cv" Series="36950" Issue="314712" />
     </Book>
     <Book Series="Batwoman" Number="7" Volume="2011" Year="2012">
-      <Id>ecc03311-7964-442d-acb4-9e73aa67fd1d</Id>
+      <Database Name="cv" Series="36950" Issue="321189" />
     </Book>
     <Book Series="Batwoman" Number="8" Volume="2011" Year="2012">
-      <Id>25752445-2f92-4dde-8a30-34fe39d90804</Id>
+      <Database Name="cv" Series="36950" Issue="327563" />
     </Book>
     <Book Series="Batwoman" Number="9" Volume="2011" Year="2012">
-      <Id>66bc7536-524e-4979-9093-a9f09127ca29</Id>
+      <Database Name="cv" Series="36950" Issue="335899" />
     </Book>
     <Book Series="Batwoman" Number="10" Volume="2011" Year="2012">
-      <Id>606ae990-8d8a-474d-b9c1-57b083fe3aed</Id>
+      <Database Name="cv" Series="36950" Issue="341641" />
     </Book>
     <Book Series="Batwoman" Number="11" Volume="2011" Year="2012">
-      <Id>e55323d0-bfc2-4c5d-ae1c-ea3a156766a9</Id>
+      <Database Name="cv" Series="36950" Issue="346226" />
     </Book>
     <Book Series="Batwoman" Number="12" Volume="2011" Year="2012">
-      <Id>2e841cad-777f-4116-a903-c733153c88a4</Id>
+      <Database Name="cv" Series="36950" Issue="350901" />
     </Book>
     <Book Series="Batwoman" Number="0" Volume="2011" Year="2012">
-      <Id>b4d154d0-b5f1-48a0-b5ac-cbcb964f4c09</Id>
+      <Database Name="cv" Series="36950" Issue="357623" />
     </Book>
     <Book Series="Batwoman" Number="13" Volume="2011" Year="2012">
-      <Id>741e1475-e66c-4cec-8f99-b0d7af270574</Id>
+      <Database Name="cv" Series="36950" Issue="362160" />
     </Book>
     <Book Series="Batwoman" Number="14" Volume="2011" Year="2013">
-      <Id>ce07d00e-fd27-473d-839b-cfa84f5a8cdc</Id>
+      <Database Name="cv" Series="36950" Issue="369032" />
     </Book>
     <Book Series="Batwoman" Number="15" Volume="2011" Year="2013">
-      <Id>9e151f19-4e28-4d92-a6a6-be5f45f5820b</Id>
+      <Database Name="cv" Series="36950" Issue="373260" />
     </Book>
     <Book Series="Batwoman" Number="16" Volume="2011" Year="2013">
-      <Id>37499976-c838-40da-847a-548a44bf171a</Id>
+      <Database Name="cv" Series="36950" Issue="381381" />
     </Book>
     <Book Series="Batwoman" Number="17" Volume="2011" Year="2013">
-      <Id>ffb9b545-70ee-4d71-b4ae-5a392971a676</Id>
+      <Database Name="cv" Series="36950" Issue="387212" />
     </Book>
     <Book Series="Batwoman" Number="18" Volume="2011" Year="2013">
-      <Id>bb73a018-35b5-499d-b9a6-49143a8e4db0</Id>
+      <Database Name="cv" Series="36950" Issue="394649" />
     </Book>
     <Book Series="Batwoman" Number="19" Volume="2011" Year="2013">
-      <Id>9bbb167e-5db8-4154-8896-dc20214eabab</Id>
+      <Database Name="cv" Series="36950" Issue="397490" />
     </Book>
     <Book Series="Batwoman" Number="20" Volume="2011" Year="2013">
-      <Id>39b8997a-8618-46fb-848f-57e7e5e4c708</Id>
+      <Database Name="cv" Series="36950" Issue="402252" />
     </Book>
     <Book Series="Batwoman" Number="21" Volume="2011" Year="2013">
-      <Id>6516b7da-13fc-4774-b42f-6f12f36784d1</Id>
+      <Database Name="cv" Series="36950" Issue="411786" />
     </Book>
     <Book Series="Batwoman" Number="22" Volume="2011" Year="2013">
-      <Id>ba589972-9cfd-4f2c-a031-734026fe86c4</Id>
+      <Database Name="cv" Series="36950" Issue="417792" />
     </Book>
     <Book Series="Batwoman" Number="23" Volume="2011" Year="2013">
-      <Id>4bd32dc9-0ca7-443e-a5f2-2db1976ab627</Id>
+      <Database Name="cv" Series="36950" Issue="422433" />
     </Book>
     <Book Series="Batwoman" Number="24" Volume="2011" Year="2013">
-      <Id>50f6ea0a-ae23-431b-9c91-134f100b3ab7</Id>
+      <Database Name="cv" Series="36950" Issue="428822" />
     </Book>
     <Book Series="Batwoman Annual" Number="1" Volume="2014" Year="2014">
-      <Id>d7274440-c73e-4b5e-a1c2-0ac5136f0ece</Id>
+      <Database Name="cv" Series="73393" Issue="451723" />
     </Book>
     <Book Series="Batwoman" Number="26" Volume="2011" Year="2014">
-      <Id>93d1ce78-a947-4175-a0c6-9d501f5ecf4b</Id>
+      <Database Name="cv" Series="36950" Issue="440195" />
     </Book>
     <Book Series="Batwoman" Number="27" Volume="2011" Year="2014">
-      <Id>35f8f041-0924-4f83-a3ef-9e1af0184041</Id>
+      <Database Name="cv" Series="36950" Issue="442871" />
     </Book>
     <Book Series="Batwoman" Number="28" Volume="2011" Year="2014">
-      <Id>1b700f86-5b4e-48b2-a23f-589a5348feae</Id>
+      <Database Name="cv" Series="36950" Issue="445764" />
     </Book>
     <Book Series="Batwoman" Number="29" Volume="2011" Year="2014">
-      <Id>db4ac902-660d-469c-af6f-f698d06d669c</Id>
+      <Database Name="cv" Series="36950" Issue="447949" />
     </Book>
     <Book Series="Batwoman" Number="30" Volume="2011" Year="2014">
-      <Id>7f7265d6-2c8b-498f-9504-aa73e84b724d</Id>
+      <Database Name="cv" Series="36950" Issue="450509" />
     </Book>
     <Book Series="Batwoman" Number="31" Volume="2011" Year="2014">
-      <Id>875171ff-96d3-4f53-bc8b-5fd4ed4d9510</Id>
+      <Database Name="cv" Series="36950" Issue="453357" />
     </Book>
     <Book Series="Batwoman" Number="32" Volume="2011" Year="2014">
-      <Id>ba1f7892-bd23-4d21-b828-8e15941f96b2</Id>
+      <Database Name="cv" Series="36950" Issue="456498" />
     </Book>
     <Book Series="Batwoman" Number="33" Volume="2011" Year="2014">
-      <Id>3475d037-bac6-45b8-8121-373170177a74</Id>
+      <Database Name="cv" Series="36950" Issue="459627" />
     </Book>
     <Book Series="Batwoman" Number="34" Volume="2011" Year="2014">
-      <Id>9c41b529-0b4c-4783-90eb-9541cdda1f61</Id>
+      <Database Name="cv" Series="36950" Issue="462848" />
     </Book>
     <Book Series="Batwoman" Number="35" Volume="2011" Year="2014">
-      <Id>07ac72b4-0074-487d-bb37-7e4c26ec9991</Id>
+      <Database Name="cv" Series="36950" Issue="468019" />
     </Book>
     <Book Series="Batwoman" Number="36" Volume="2011" Year="2015">
-      <Id>4a92d3eb-1968-40ca-bd24-9523bbd9e16b</Id>
+      <Database Name="cv" Series="36950" Issue="470368" />
     </Book>
     <Book Series="Batwoman" Number="37" Volume="2011" Year="2015">
-      <Id>c59347da-f206-491a-9609-64112f9026a2</Id>
+      <Database Name="cv" Series="36950" Issue="473586" />
     </Book>
     <Book Series="Batwoman" Number="38" Volume="2011" Year="2015">
-      <Id>52ae83d9-48c2-462b-8c27-9843d8b04c84</Id>
+      <Database Name="cv" Series="36950" Issue="476742" />
     </Book>
     <Book Series="Batwoman" Number="39" Volume="2011" Year="2015">
-      <Id>d94f75b1-bc21-4a60-b411-b79e0ed9efcd</Id>
+      <Database Name="cv" Series="36950" Issue="479930" />
     </Book>
     <Book Series="Batwoman" Number="40" Volume="2011" Year="2015">
-      <Id>3171f1e4-0ab0-432c-8ec5-c1d0500906b1</Id>
+      <Database Name="cv" Series="36950" Issue="482618" />
     </Book>
     <Book Series="Batwoman Annual" Number="2" Volume="2014" Year="2015">
-      <Id>78b0df0f-9ac2-4627-b9e2-ece8b414f441</Id>
+      <Database Name="cv" Series="73393" Issue="484840" />
     </Book>
     <Book Series="Batwoman: Rebirth" Number="1" Volume="2017" Year="2017">
-      <Id>01dcf20c-97f6-454b-902b-6aeca7df05c4</Id>
+      <Database Name="cv" Series="98884" Issue="581521" />
     </Book>
     <Book Series="Batwoman" Number="1" Volume="2017" Year="2017">
-      <Id>ce1a0a73-f626-493f-8e96-d9a7d3cea442</Id>
+      <Database Name="cv" Series="99849" Issue="587380" />
     </Book>
     <Book Series="Batwoman" Number="2" Volume="2017" Year="2017">
-      <Id>389e455e-5c99-4d68-bd6e-aefb1d019650</Id>
+      <Database Name="cv" Series="99849" Issue="592567" />
     </Book>
     <Book Series="Batwoman" Number="3" Volume="2017" Year="2017">
-      <Id>eda5a6e3-cca4-452d-b1d5-e84961bc2204</Id>
+      <Database Name="cv" Series="99849" Issue="595660" />
     </Book>
     <Book Series="Batwoman" Number="4" Volume="2017" Year="2017">
-      <Id>b8ceaab5-37cf-4061-b759-32905610ab72</Id>
+      <Database Name="cv" Series="99849" Issue="603084" />
     </Book>
     <Book Series="Batwoman" Number="5" Volume="2017" Year="2017">
-      <Id>e6113384-8952-4a26-b7a5-b30b4ed697a4</Id>
+      <Database Name="cv" Series="99849" Issue="609277" />
     </Book>
     <Book Series="Batwoman" Number="6" Volume="2017" Year="2017">
-      <Id>934506f4-e069-4301-908f-c272db9a75dd</Id>
+      <Database Name="cv" Series="99849" Issue="614969" />
     </Book>
     <Book Series="Batwoman" Number="7" Volume="2017" Year="2017">
-      <Id>e99b11b3-8520-4bc6-97ca-5e439098f330</Id>
+      <Database Name="cv" Series="99849" Issue="622874" />
     </Book>
     <Book Series="Batwoman" Number="8" Volume="2017" Year="2017">
-      <Id>00860959-095f-4b88-9d0d-8dbdf9a9193d</Id>
+      <Database Name="cv" Series="99849" Issue="630487" />
     </Book>
     <Book Series="Batwoman" Number="9" Volume="2017" Year="2018">
-      <Id>90a15fc9-c70f-4003-a021-553f755bf4f3</Id>
+      <Database Name="cv" Series="99849" Issue="638567" />
     </Book>
     <Book Series="Batwoman" Number="10" Volume="2017" Year="2018">
-      <Id>5d157797-15aa-4aa2-ade6-a53136855f88</Id>
+      <Database Name="cv" Series="99849" Issue="647908" />
     </Book>
     <Book Series="Batwoman" Number="11" Volume="2017" Year="2018">
-      <Id>042725bf-bf86-439d-a825-55b87b0c7062</Id>
+      <Database Name="cv" Series="99849" Issue="654029" />
     </Book>
     <Book Series="Batwoman" Number="12" Volume="2017" Year="2018">
-      <Id>e6610da1-f9e1-4362-9f80-4dc6f0d0352b</Id>
+      <Database Name="cv" Series="99849" Issue="660625" />
     </Book>
     <Book Series="Batwoman" Number="13" Volume="2017" Year="2018">
-      <Id>18a0a137-caf9-44a2-b94f-7bb19ae85aec</Id>
+      <Database Name="cv" Series="99849" Issue="663542" />
     </Book>
     <Book Series="Batwoman" Number="14" Volume="2017" Year="2018">
-      <Id>7ddbabcc-d710-4d48-97dd-0e2428271759</Id>
+      <Database Name="cv" Series="99849" Issue="666772" />
     </Book>
     <Book Series="Batwoman" Number="15" Volume="2017" Year="2018">
-      <Id>f651b842-5649-421d-96c0-046f86ada075</Id>
+      <Database Name="cv" Series="99849" Issue="670083" />
     </Book>
     <Book Series="Batwoman" Number="16" Volume="2017" Year="2018">
-      <Id>831e78c5-9919-466a-a921-567bbd62a7e9</Id>
+      <Database Name="cv" Series="99849" Issue="674099" />
     </Book>
     <Book Series="Batwoman" Number="17" Volume="2017" Year="2018">
-      <Id>606dc189-74a7-445e-945c-87d2aa640cbc</Id>
+      <Database Name="cv" Series="99849" Issue="677254" />
     </Book>
     <Book Series="Batwoman" Number="18" Volume="2017" Year="2018">
-      <Id>6f310640-abbf-407d-9fa2-99f1ecc8e0b0</Id>
+      <Database Name="cv" Series="99849" Issue="679968" />
     </Book>
   </Books>
   <Matchers />

--- a/DC/Characters/unsorted/Batwoman/Batwoman.cbl
+++ b/DC/Characters/unsorted/Batwoman/Batwoman.cbl
@@ -2,208 +2,208 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Batwoman</Name>
   <Books>
-    <Book Series="Crime Bible: The Five Lessons of Blood" Number="3" Volume="2007" Year="2008" Format="Crossover">
+    <Book Series="Crime Bible: The Five Lessons of Blood" Number="3" Volume="2007" Year="2008">
       <Id>d1270fd7-7bed-423b-973b-6de806ab62a4</Id>
     </Book>
-    <Book Series="Batwoman: Elegy" Number="1" Volume="2010" Year="2010" Format="TPB">
+    <Book Series="Batwoman: Elegy" Number="1" Volume="2010" Year="2010">
       <Id>8c8a13db-7ae6-4012-97ed-8156b5b98d45</Id>
     </Book>
-    <Book Series="Detective Comics" Number="861" Volume="1937" Year="2010" Format="Main Series">
+    <Book Series="Detective Comics" Number="861" Volume="1937" Year="2010">
       <Id>fb4c2657-a8a4-4542-b02d-b410f4ce82bd</Id>
     </Book>
-    <Book Series="Detective Comics" Number="862" Volume="1937" Year="2010" Format="Main Series">
+    <Book Series="Detective Comics" Number="862" Volume="1937" Year="2010">
       <Id>0e757f8e-ca2f-47bc-9a6a-b1aae8d68fb3</Id>
     </Book>
-    <Book Series="Detective Comics" Number="863" Volume="1937" Year="2010" Format="Main Series">
+    <Book Series="Detective Comics" Number="863" Volume="1937" Year="2010">
       <Id>f810f28b-e4fc-4765-81dc-8dcf44aafc8c</Id>
     </Book>
-    <Book Series="Batwoman" Number="0" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Batwoman" Number="0" Volume="2011" Year="2011">
       <Id>ba8c4550-858a-49cf-9e1f-3b8697d0c242</Id>
     </Book>
-    <Book Series="Batwoman" Number="25" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Batwoman" Number="25" Volume="2011" Year="2014">
       <Id>13193405-c28d-4135-bf94-647d07751343</Id>
     </Book>
-    <Book Series="Batwoman" Number="1" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Batwoman" Number="1" Volume="2011" Year="2011">
       <Id>45258b8a-c8f9-4453-abba-e05ee29bfa34</Id>
     </Book>
-    <Book Series="Batwoman" Number="2" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Batwoman" Number="2" Volume="2011" Year="2011">
       <Id>6512c3da-07f1-40b9-aa62-1606d5fd913b</Id>
     </Book>
-    <Book Series="Batwoman" Number="3" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Batwoman" Number="3" Volume="2011" Year="2012">
       <Id>ed53fa85-8b19-4358-bd44-241e2cc85618</Id>
     </Book>
-    <Book Series="Batwoman" Number="4" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Batwoman" Number="4" Volume="2011" Year="2012">
       <Id>d975ac2d-bfe3-4f36-a3bd-be9f8a67ac31</Id>
     </Book>
-    <Book Series="Batwoman" Number="5" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Batwoman" Number="5" Volume="2011" Year="2012">
       <Id>80000922-a927-45d3-a3fc-580519abdd6e</Id>
     </Book>
-    <Book Series="Batwoman" Number="6" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Batwoman" Number="6" Volume="2011" Year="2012">
       <Id>a69bc25d-d029-40fa-a2d5-3eac50595e7c</Id>
     </Book>
-    <Book Series="Batwoman" Number="7" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Batwoman" Number="7" Volume="2011" Year="2012">
       <Id>ecc03311-7964-442d-acb4-9e73aa67fd1d</Id>
     </Book>
-    <Book Series="Batwoman" Number="8" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Batwoman" Number="8" Volume="2011" Year="2012">
       <Id>25752445-2f92-4dde-8a30-34fe39d90804</Id>
     </Book>
-    <Book Series="Batwoman" Number="9" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Batwoman" Number="9" Volume="2011" Year="2012">
       <Id>66bc7536-524e-4979-9093-a9f09127ca29</Id>
     </Book>
-    <Book Series="Batwoman" Number="10" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Batwoman" Number="10" Volume="2011" Year="2012">
       <Id>606ae990-8d8a-474d-b9c1-57b083fe3aed</Id>
     </Book>
-    <Book Series="Batwoman" Number="11" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Batwoman" Number="11" Volume="2011" Year="2012">
       <Id>e55323d0-bfc2-4c5d-ae1c-ea3a156766a9</Id>
     </Book>
-    <Book Series="Batwoman" Number="12" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Batwoman" Number="12" Volume="2011" Year="2012">
       <Id>2e841cad-777f-4116-a903-c733153c88a4</Id>
     </Book>
-    <Book Series="Batwoman" Number="0" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Batwoman" Number="0" Volume="2011" Year="2012">
       <Id>b4d154d0-b5f1-48a0-b5ac-cbcb964f4c09</Id>
     </Book>
-    <Book Series="Batwoman" Number="13" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Batwoman" Number="13" Volume="2011" Year="2012">
       <Id>741e1475-e66c-4cec-8f99-b0d7af270574</Id>
     </Book>
-    <Book Series="Batwoman" Number="14" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Batwoman" Number="14" Volume="2011" Year="2013">
       <Id>ce07d00e-fd27-473d-839b-cfa84f5a8cdc</Id>
     </Book>
-    <Book Series="Batwoman" Number="15" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Batwoman" Number="15" Volume="2011" Year="2013">
       <Id>9e151f19-4e28-4d92-a6a6-be5f45f5820b</Id>
     </Book>
-    <Book Series="Batwoman" Number="16" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Batwoman" Number="16" Volume="2011" Year="2013">
       <Id>37499976-c838-40da-847a-548a44bf171a</Id>
     </Book>
-    <Book Series="Batwoman" Number="17" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Batwoman" Number="17" Volume="2011" Year="2013">
       <Id>ffb9b545-70ee-4d71-b4ae-5a392971a676</Id>
     </Book>
-    <Book Series="Batwoman" Number="18" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Batwoman" Number="18" Volume="2011" Year="2013">
       <Id>bb73a018-35b5-499d-b9a6-49143a8e4db0</Id>
     </Book>
-    <Book Series="Batwoman" Number="19" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Batwoman" Number="19" Volume="2011" Year="2013">
       <Id>9bbb167e-5db8-4154-8896-dc20214eabab</Id>
     </Book>
-    <Book Series="Batwoman" Number="20" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Batwoman" Number="20" Volume="2011" Year="2013">
       <Id>39b8997a-8618-46fb-848f-57e7e5e4c708</Id>
     </Book>
-    <Book Series="Batwoman" Number="21" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Batwoman" Number="21" Volume="2011" Year="2013">
       <Id>6516b7da-13fc-4774-b42f-6f12f36784d1</Id>
     </Book>
-    <Book Series="Batwoman" Number="22" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Batwoman" Number="22" Volume="2011" Year="2013">
       <Id>ba589972-9cfd-4f2c-a031-734026fe86c4</Id>
     </Book>
-    <Book Series="Batwoman" Number="23" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Batwoman" Number="23" Volume="2011" Year="2013">
       <Id>4bd32dc9-0ca7-443e-a5f2-2db1976ab627</Id>
     </Book>
-    <Book Series="Batwoman" Number="24" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Batwoman" Number="24" Volume="2011" Year="2013">
       <Id>50f6ea0a-ae23-431b-9c91-134f100b3ab7</Id>
     </Book>
-    <Book Series="Batwoman Annual" Number="1" Volume="2014" Year="2014" Format="Annual">
+    <Book Series="Batwoman Annual" Number="1" Volume="2014" Year="2014">
       <Id>d7274440-c73e-4b5e-a1c2-0ac5136f0ece</Id>
     </Book>
-    <Book Series="Batwoman" Number="26" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Batwoman" Number="26" Volume="2011" Year="2014">
       <Id>93d1ce78-a947-4175-a0c6-9d501f5ecf4b</Id>
     </Book>
-    <Book Series="Batwoman" Number="27" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Batwoman" Number="27" Volume="2011" Year="2014">
       <Id>35f8f041-0924-4f83-a3ef-9e1af0184041</Id>
     </Book>
-    <Book Series="Batwoman" Number="28" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Batwoman" Number="28" Volume="2011" Year="2014">
       <Id>1b700f86-5b4e-48b2-a23f-589a5348feae</Id>
     </Book>
-    <Book Series="Batwoman" Number="29" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Batwoman" Number="29" Volume="2011" Year="2014">
       <Id>db4ac902-660d-469c-af6f-f698d06d669c</Id>
     </Book>
-    <Book Series="Batwoman" Number="30" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Batwoman" Number="30" Volume="2011" Year="2014">
       <Id>7f7265d6-2c8b-498f-9504-aa73e84b724d</Id>
     </Book>
-    <Book Series="Batwoman" Number="31" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Batwoman" Number="31" Volume="2011" Year="2014">
       <Id>875171ff-96d3-4f53-bc8b-5fd4ed4d9510</Id>
     </Book>
-    <Book Series="Batwoman" Number="32" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Batwoman" Number="32" Volume="2011" Year="2014">
       <Id>ba1f7892-bd23-4d21-b828-8e15941f96b2</Id>
     </Book>
-    <Book Series="Batwoman" Number="33" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Batwoman" Number="33" Volume="2011" Year="2014">
       <Id>3475d037-bac6-45b8-8121-373170177a74</Id>
     </Book>
-    <Book Series="Batwoman" Number="34" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Batwoman" Number="34" Volume="2011" Year="2014">
       <Id>9c41b529-0b4c-4783-90eb-9541cdda1f61</Id>
     </Book>
-    <Book Series="Batwoman" Number="35" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Batwoman" Number="35" Volume="2011" Year="2014">
       <Id>07ac72b4-0074-487d-bb37-7e4c26ec9991</Id>
     </Book>
-    <Book Series="Batwoman" Number="36" Volume="2011" Year="2015" Format="Main Series">
+    <Book Series="Batwoman" Number="36" Volume="2011" Year="2015">
       <Id>4a92d3eb-1968-40ca-bd24-9523bbd9e16b</Id>
     </Book>
-    <Book Series="Batwoman" Number="37" Volume="2011" Year="2015" Format="Main Series">
+    <Book Series="Batwoman" Number="37" Volume="2011" Year="2015">
       <Id>c59347da-f206-491a-9609-64112f9026a2</Id>
     </Book>
-    <Book Series="Batwoman" Number="38" Volume="2011" Year="2015" Format="Main Series">
+    <Book Series="Batwoman" Number="38" Volume="2011" Year="2015">
       <Id>52ae83d9-48c2-462b-8c27-9843d8b04c84</Id>
     </Book>
-    <Book Series="Batwoman" Number="39" Volume="2011" Year="2015" Format="Main Series">
+    <Book Series="Batwoman" Number="39" Volume="2011" Year="2015">
       <Id>d94f75b1-bc21-4a60-b411-b79e0ed9efcd</Id>
     </Book>
-    <Book Series="Batwoman" Number="40" Volume="2011" Year="2015" Format="Main Series">
+    <Book Series="Batwoman" Number="40" Volume="2011" Year="2015">
       <Id>3171f1e4-0ab0-432c-8ec5-c1d0500906b1</Id>
     </Book>
-    <Book Series="Batwoman Annual" Number="2" Volume="2014" Year="2015" Format="Annual">
+    <Book Series="Batwoman Annual" Number="2" Volume="2014" Year="2015">
       <Id>78b0df0f-9ac2-4627-b9e2-ece8b414f441</Id>
     </Book>
-    <Book Series="Batwoman: Rebirth" Number="1" Volume="2017" Year="2017" Format="One-Shot">
+    <Book Series="Batwoman: Rebirth" Number="1" Volume="2017" Year="2017">
       <Id>01dcf20c-97f6-454b-902b-6aeca7df05c4</Id>
     </Book>
-    <Book Series="Batwoman" Number="1" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Batwoman" Number="1" Volume="2017" Year="2017">
       <Id>ce1a0a73-f626-493f-8e96-d9a7d3cea442</Id>
     </Book>
-    <Book Series="Batwoman" Number="2" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Batwoman" Number="2" Volume="2017" Year="2017">
       <Id>389e455e-5c99-4d68-bd6e-aefb1d019650</Id>
     </Book>
-    <Book Series="Batwoman" Number="3" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Batwoman" Number="3" Volume="2017" Year="2017">
       <Id>eda5a6e3-cca4-452d-b1d5-e84961bc2204</Id>
     </Book>
-    <Book Series="Batwoman" Number="4" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Batwoman" Number="4" Volume="2017" Year="2017">
       <Id>b8ceaab5-37cf-4061-b759-32905610ab72</Id>
     </Book>
-    <Book Series="Batwoman" Number="5" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Batwoman" Number="5" Volume="2017" Year="2017">
       <Id>e6113384-8952-4a26-b7a5-b30b4ed697a4</Id>
     </Book>
-    <Book Series="Batwoman" Number="6" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Batwoman" Number="6" Volume="2017" Year="2017">
       <Id>934506f4-e069-4301-908f-c272db9a75dd</Id>
     </Book>
-    <Book Series="Batwoman" Number="7" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Batwoman" Number="7" Volume="2017" Year="2017">
       <Id>e99b11b3-8520-4bc6-97ca-5e439098f330</Id>
     </Book>
-    <Book Series="Batwoman" Number="8" Volume="2017" Year="2017" Format="Main Series">
+    <Book Series="Batwoman" Number="8" Volume="2017" Year="2017">
       <Id>00860959-095f-4b88-9d0d-8dbdf9a9193d</Id>
     </Book>
-    <Book Series="Batwoman" Number="9" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Batwoman" Number="9" Volume="2017" Year="2018">
       <Id>90a15fc9-c70f-4003-a021-553f755bf4f3</Id>
     </Book>
-    <Book Series="Batwoman" Number="10" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Batwoman" Number="10" Volume="2017" Year="2018">
       <Id>5d157797-15aa-4aa2-ade6-a53136855f88</Id>
     </Book>
-    <Book Series="Batwoman" Number="11" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Batwoman" Number="11" Volume="2017" Year="2018">
       <Id>042725bf-bf86-439d-a825-55b87b0c7062</Id>
     </Book>
-    <Book Series="Batwoman" Number="12" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Batwoman" Number="12" Volume="2017" Year="2018">
       <Id>e6610da1-f9e1-4362-9f80-4dc6f0d0352b</Id>
     </Book>
-    <Book Series="Batwoman" Number="13" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Batwoman" Number="13" Volume="2017" Year="2018">
       <Id>18a0a137-caf9-44a2-b94f-7bb19ae85aec</Id>
     </Book>
-    <Book Series="Batwoman" Number="14" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Batwoman" Number="14" Volume="2017" Year="2018">
       <Id>7ddbabcc-d710-4d48-97dd-0e2428271759</Id>
     </Book>
-    <Book Series="Batwoman" Number="15" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Batwoman" Number="15" Volume="2017" Year="2018">
       <Id>f651b842-5649-421d-96c0-046f86ada075</Id>
     </Book>
-    <Book Series="Batwoman" Number="16" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Batwoman" Number="16" Volume="2017" Year="2018">
       <Id>831e78c5-9919-466a-a921-567bbd62a7e9</Id>
     </Book>
-    <Book Series="Batwoman" Number="17" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Batwoman" Number="17" Volume="2017" Year="2018">
       <Id>606dc189-74a7-445e-945c-87d2aa640cbc</Id>
     </Book>
-    <Book Series="Batwoman" Number="18" Volume="2017" Year="2018" Format="Main Series">
+    <Book Series="Batwoman" Number="18" Volume="2017" Year="2018">
       <Id>6f310640-abbf-407d-9fa2-99f1ecc8e0b0</Id>
     </Book>
   </Books>

--- a/DC/Characters/unsorted/Birds of Prey/Birds of Prey 001 (Post-Crisis).cbl
+++ b/DC/Characters/unsorted/Birds of Prey/Birds of Prey 001 (Post-Crisis).cbl
@@ -2,475 +2,475 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Birds of Prey 1 (Post-Crisis)</Name>
   <Books>
-    <Book Series="Birds of Prey: Black Canary/Oracle" Number="1" Volume="1996" Year="1996" Format="One-Shot">
+    <Book Series="Birds of Prey: Black Canary/Oracle" Number="1" Volume="1996" Year="1996">
       <Id>848ff6ac-3321-4069-846e-6ce91e47aa34</Id>
     </Book>
-    <Book Series="Showcase '96" Number="3" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Showcase '96" Number="3" Volume="1996" Year="1996">
       <Id>8b6fce2c-bfd7-40c5-9d55-7a584cdea408</Id>
     </Book>
-    <Book Series="Birds of Prey: Manhunt" Number="1" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Birds of Prey: Manhunt" Number="1" Volume="1996" Year="1996">
       <Id>9ab557f2-3f59-415e-b212-4176cc1e43d7</Id>
     </Book>
-    <Book Series="Birds of Prey: Manhunt" Number="2" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Birds of Prey: Manhunt" Number="2" Volume="1996" Year="1996">
       <Id>11ee9088-64a9-4f78-9450-465292c22a84</Id>
     </Book>
-    <Book Series="Birds of Prey: Manhunt" Number="3" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Birds of Prey: Manhunt" Number="3" Volume="1996" Year="1996">
       <Id>bebfc1c2-1678-4f58-95e8-ab083be4e11b</Id>
     </Book>
-    <Book Series="Birds of Prey: Manhunt" Number="4" Volume="1996" Year="1996" Format="Limited Series">
+    <Book Series="Birds of Prey: Manhunt" Number="4" Volume="1996" Year="1996">
       <Id>6f86ca0e-50c6-42b8-975a-ad4632d12d38</Id>
     </Book>
-    <Book Series="Birds of Prey: Revolution" Number="1" Volume="1997" Year="1997" Format="One-Shot">
+    <Book Series="Birds of Prey: Revolution" Number="1" Volume="1997" Year="1997">
       <Id>669f808e-97ef-4d9f-866a-1f0368571dcc</Id>
     </Book>
-    <Book Series="Birds of Prey: Wolves" Number="1" Volume="1997" Year="1997" Format="One-Shot">
+    <Book Series="Birds of Prey: Wolves" Number="1" Volume="1997" Year="1997">
       <Id>3308a1e1-cada-4240-aca7-ebf15d5978be</Id>
     </Book>
-    <Book Series="Birds of Prey: Black Canary/Batgirl" Number="1" Volume="1998" Year="1998" Format="One-Shot">
+    <Book Series="Birds of Prey: Black Canary/Batgirl" Number="1" Volume="1998" Year="1998">
       <Id>7fe5eb62-6cde-4cb8-bce4-c56578b38e4d</Id>
     </Book>
-    <Book Series="Birds of Prey: The Ravens" Number="1" Volume="1998" Year="1998" Format="One-Shot">
+    <Book Series="Birds of Prey: The Ravens" Number="1" Volume="1998" Year="1998">
       <Id>97df0a5d-23a0-45a5-85a6-f50e8d6bc239</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="1" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Birds of Prey" Number="1" Volume="1999" Year="1999">
       <Id>dde35d8d-2f52-40fb-ad14-fe644ec64481</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="2" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Birds of Prey" Number="2" Volume="1999" Year="1999">
       <Id>cabce9c0-8361-4ac3-98b6-1043165f4725</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="3" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Birds of Prey" Number="3" Volume="1999" Year="1999">
       <Id>87f3c885-5a00-4a18-849d-1506abbeee26</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="4" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Birds of Prey" Number="4" Volume="1999" Year="1999">
       <Id>9339779b-02a8-4217-87e3-258970733f8f</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="5" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Birds of Prey" Number="5" Volume="1999" Year="1999">
       <Id>e637265f-75ad-4985-8fef-d76911b567b9</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="6" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Birds of Prey" Number="6" Volume="1999" Year="1999">
       <Id>d7abcb14-b226-48a4-8300-9d362b197a78</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="7" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Birds of Prey" Number="7" Volume="1999" Year="1999">
       <Id>a315bc29-77d0-4208-a3bc-2e47ed4de888</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="8" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Birds of Prey" Number="8" Volume="1999" Year="1999">
       <Id>cf38bd0d-f70e-4bc8-97ef-a416f406b530</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="9" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Birds of Prey" Number="9" Volume="1999" Year="1999">
       <Id>4b1a814d-6602-45ec-944d-a2933cd6bc9b</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="10" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Birds of Prey" Number="10" Volume="1999" Year="1999">
       <Id>4d358b66-7bb7-48db-ac46-65f71a340c56</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="11" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Birds of Prey" Number="11" Volume="1999" Year="1999">
       <Id>71a4d5ea-1cc2-48e2-bfb4-5bdeeb7819b9</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="12" Volume="1999" Year="1999" Format="Main Series">
+    <Book Series="Birds of Prey" Number="12" Volume="1999" Year="1999">
       <Id>8d8fa03f-c2eb-4de6-93f8-406e9f191c61</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="13" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Birds of Prey" Number="13" Volume="1999" Year="2000">
       <Id>738f6603-1656-45f6-af28-75951791cf1f</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="14" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Birds of Prey" Number="14" Volume="1999" Year="2000">
       <Id>c376e156-57ca-4574-ac2d-1b32f484883d</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="15" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Birds of Prey" Number="15" Volume="1999" Year="2000">
       <Id>705ed358-205c-4dc2-bc82-ef1ec4fd799a</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="16" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Birds of Prey" Number="16" Volume="1999" Year="2000">
       <Id>e01540b1-3a84-425c-9c88-0366e9d2d516</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="17" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Birds of Prey" Number="17" Volume="1999" Year="2000">
       <Id>a3c4dcb3-bada-42ac-9118-fa798808ba89</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="18" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Birds of Prey" Number="18" Volume="1999" Year="2000">
       <Id>52e37660-ab53-48b4-a98b-b61e8243d1e6</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="19" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Birds of Prey" Number="19" Volume="1999" Year="2000">
       <Id>f87ea291-2da1-458c-ab38-c910b0df339f</Id>
     </Book>
-    <Book Series="Nightwing" Number="45" Volume="1996" Year="2000" Format="Main Series">
+    <Book Series="Nightwing" Number="45" Volume="1996" Year="2000">
       <Id>7b23f5b2-5eb4-43a9-85bd-d32ad4ea7d0b</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="20" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Birds of Prey" Number="20" Volume="1999" Year="2000">
       <Id>2ad9b095-cc0f-4cfd-85ab-353808d0ebf7</Id>
     </Book>
-    <Book Series="Nightwing" Number="46" Volume="1996" Year="2000" Format="Main Series">
+    <Book Series="Nightwing" Number="46" Volume="1996" Year="2000">
       <Id>ecba30fb-e6e2-4963-8f16-9601e1bf30d8</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="21" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Birds of Prey" Number="21" Volume="1999" Year="2000">
       <Id>c9ca76d5-8407-45ce-b938-94646f8f18bd</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="22" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Birds of Prey" Number="22" Volume="1999" Year="2000">
       <Id>e350e306-764d-487b-9dd8-7bc185e58d6e</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="23" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Birds of Prey" Number="23" Volume="1999" Year="2000">
       <Id>ec4222d7-7b26-491a-b55a-31883987fd56</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="24" Volume="1999" Year="2000" Format="Main Series">
+    <Book Series="Birds of Prey" Number="24" Volume="1999" Year="2000">
       <Id>79650258-3401-48c4-a233-fc6dd938fdc2</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="25" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Birds of Prey" Number="25" Volume="1999" Year="2001">
       <Id>c22a3902-4b1d-4bd9-bfed-265c6fc7bcaa</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="26" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Birds of Prey" Number="26" Volume="1999" Year="2001">
       <Id>1e92c9ea-4663-450f-a440-4023dc850258</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="27" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Birds of Prey" Number="27" Volume="1999" Year="2001">
       <Id>c64b0199-3ea5-4946-9cea-8ea655e0a3ef</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="28" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Birds of Prey" Number="28" Volume="1999" Year="2001">
       <Id>270eac4e-e72d-43c1-b9a4-f0f79bb34a1b</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="29" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Birds of Prey" Number="29" Volume="1999" Year="2001">
       <Id>7a3cfb12-34ba-46fe-96e7-7c54d45942cf</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="30" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Birds of Prey" Number="30" Volume="1999" Year="2001">
       <Id>e4c9f7eb-088d-40af-bc67-f1233a7efef5</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="31" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Birds of Prey" Number="31" Volume="1999" Year="2001">
       <Id>68f6c1b3-b553-40ec-8857-cf13ed12f665</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="32" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Birds of Prey" Number="32" Volume="1999" Year="2001">
       <Id>e7e61fb4-554c-4ad9-8442-243dde97d7d8</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="33" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Birds of Prey" Number="33" Volume="1999" Year="2001">
       <Id>aac21029-ba2c-4060-922f-a61a4ae8d3ed</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="34" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Birds of Prey" Number="34" Volume="1999" Year="2001">
       <Id>59ee4cfd-c83b-44ff-8a5f-8aa54b0d8d7c</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="35" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Birds of Prey" Number="35" Volume="1999" Year="2001">
       <Id>9b45cbf2-e5f2-42e6-9002-69f83b44f09b</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="36" Volume="1999" Year="2001" Format="Main Series">
+    <Book Series="Birds of Prey" Number="36" Volume="1999" Year="2001">
       <Id>e83948bc-2253-444f-9977-4f5e2bce1815</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="37" Volume="1999" Year="2002" Format="Main Series">
+    <Book Series="Birds of Prey" Number="37" Volume="1999" Year="2002">
       <Id>06e9e872-0016-45b2-8f5d-513928113580</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="38" Volume="1999" Year="2002" Format="Main Series">
+    <Book Series="Birds of Prey" Number="38" Volume="1999" Year="2002">
       <Id>452014e6-67b1-4a95-bf08-2c3e6fdb8e42</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="39" Volume="1999" Year="2002" Format="Main Series">
+    <Book Series="Birds of Prey" Number="39" Volume="1999" Year="2002">
       <Id>c19046aa-9d02-4672-9d7a-fe5b33bd9270</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="40" Volume="1999" Year="2002" Format="Main Series">
+    <Book Series="Birds of Prey" Number="40" Volume="1999" Year="2002">
       <Id>282d93fe-40ff-42e8-89c0-0fed4c4cd8f3</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="41" Volume="1999" Year="2002" Format="Main Series">
+    <Book Series="Birds of Prey" Number="41" Volume="1999" Year="2002">
       <Id>c3c53be9-1a55-4e4d-981b-8b17c8767912</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="42" Volume="1999" Year="2002" Format="Main Series">
+    <Book Series="Birds of Prey" Number="42" Volume="1999" Year="2002">
       <Id>f99a64f5-a0c5-41c2-aa13-22b7e7c79b0c</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="43" Volume="1999" Year="2002" Format="Main Series">
+    <Book Series="Birds of Prey" Number="43" Volume="1999" Year="2002">
       <Id>3c0f7c26-3612-4bd3-81e9-d54125653b1f</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="44" Volume="1999" Year="2002" Format="Main Series">
+    <Book Series="Birds of Prey" Number="44" Volume="1999" Year="2002">
       <Id>869d829f-46c3-4c60-bb86-00f13d94dda8</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="45" Volume="1999" Year="2002" Format="Main Series">
+    <Book Series="Birds of Prey" Number="45" Volume="1999" Year="2002">
       <Id>ea6ea2b9-7caf-41a2-909d-c933a90b2245</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="46" Volume="1999" Year="2002" Format="Main Series">
+    <Book Series="Birds of Prey" Number="46" Volume="1999" Year="2002">
       <Id>e21631f6-0607-4b3f-98a2-06041ddbcf81</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="47" Volume="1999" Year="2002" Format="Main Series">
+    <Book Series="Birds of Prey" Number="47" Volume="1999" Year="2002">
       <Id>32a866d1-4ce7-4a7e-9365-dff4d656bd72</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="48" Volume="1999" Year="2002" Format="Main Series">
+    <Book Series="Birds of Prey" Number="48" Volume="1999" Year="2002">
       <Id>90d71093-71a2-4051-b023-92259e285cb7</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="49" Volume="1999" Year="2003" Format="Main Series">
+    <Book Series="Birds of Prey" Number="49" Volume="1999" Year="2003">
       <Id>e9800bcc-4028-4d8a-a8f0-f18724e1a559</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="50" Volume="1999" Year="2003" Format="Main Series">
+    <Book Series="Birds of Prey" Number="50" Volume="1999" Year="2003">
       <Id>46d8cd4e-20a7-4e36-ba1b-0c65bd123825</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="51" Volume="1999" Year="2003" Format="Main Series">
+    <Book Series="Birds of Prey" Number="51" Volume="1999" Year="2003">
       <Id>c8aad475-3e07-43e0-befe-e4818c45d956</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="52" Volume="1999" Year="2003" Format="Main Series">
+    <Book Series="Birds of Prey" Number="52" Volume="1999" Year="2003">
       <Id>01f4a813-653c-434f-a60b-bdfe5d421c0e</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="53" Volume="1999" Year="2003" Format="Main Series">
+    <Book Series="Birds of Prey" Number="53" Volume="1999" Year="2003">
       <Id>79367732-992e-455d-97da-7161ceb0ed66</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="54" Volume="1999" Year="2003" Format="Main Series">
+    <Book Series="Birds of Prey" Number="54" Volume="1999" Year="2003">
       <Id>9e1c52a3-61e3-4ed6-9916-ee4b8cf1f4dc</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="55" Volume="1999" Year="2003" Format="Main Series">
+    <Book Series="Birds of Prey" Number="55" Volume="1999" Year="2003">
       <Id>102841e1-ad01-4340-8faa-c89fc669fed6</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="56" Volume="1999" Year="2003" Format="Main Series">
+    <Book Series="Birds of Prey" Number="56" Volume="1999" Year="2003">
       <Id>7a12a1ac-9a7a-4a95-93cd-26627e88a007</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="57" Volume="1999" Year="2003" Format="Main Series">
+    <Book Series="Birds of Prey" Number="57" Volume="1999" Year="2003">
       <Id>9a3f6a2c-c02e-490b-81c7-b0ee23e3a202</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="58" Volume="1999" Year="2003" Format="Main Series">
+    <Book Series="Birds of Prey" Number="58" Volume="1999" Year="2003">
       <Id>f86e139d-4328-48ac-8a19-b3759baf0171</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="59" Volume="1999" Year="2003" Format="Main Series">
+    <Book Series="Birds of Prey" Number="59" Volume="1999" Year="2003">
       <Id>b0be405f-dbf3-4698-a9ad-82287608a471</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="60" Volume="1999" Year="2003" Format="Main Series">
+    <Book Series="Birds of Prey" Number="60" Volume="1999" Year="2003">
       <Id>2066ae0a-547f-4dc6-9017-772181f198cf</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="61" Volume="1999" Year="2004" Format="Main Series">
+    <Book Series="Birds of Prey" Number="61" Volume="1999" Year="2004">
       <Id>aac0dc3b-bf39-4350-9fb2-600a8d4bd549</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="62" Volume="1999" Year="2004" Format="Main Series">
+    <Book Series="Birds of Prey" Number="62" Volume="1999" Year="2004">
       <Id>7add3164-a25a-4c85-add4-72105bc6eda0</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="63" Volume="1999" Year="2004" Format="Main Series">
+    <Book Series="Birds of Prey" Number="63" Volume="1999" Year="2004">
       <Id>dc9295f9-cf22-46ae-89b1-6fc2fccbfd02</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="64" Volume="1999" Year="2004" Format="Main Series">
+    <Book Series="Birds of Prey" Number="64" Volume="1999" Year="2004">
       <Id>69ab567d-fcd1-4e4a-84c6-f10cd3c15934</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="65" Volume="1999" Year="2004" Format="Main Series">
+    <Book Series="Birds of Prey" Number="65" Volume="1999" Year="2004">
       <Id>add6bd95-5af2-422d-b9ed-86da8d6c38ac</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="66" Volume="1999" Year="2004" Format="Main Series">
+    <Book Series="Birds of Prey" Number="66" Volume="1999" Year="2004">
       <Id>0f5ba06f-118a-4343-9ffa-13ad83dfc289</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="67" Volume="1999" Year="2004" Format="Main Series">
+    <Book Series="Birds of Prey" Number="67" Volume="1999" Year="2004">
       <Id>bb221aa8-77ba-47af-a263-7c77937f66b5</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="68" Volume="1999" Year="2004" Format="Main Series">
+    <Book Series="Birds of Prey" Number="68" Volume="1999" Year="2004">
       <Id>b7963af4-2031-4981-8f83-5841b79cc0b7</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="69" Volume="1999" Year="2004" Format="Main Series">
+    <Book Series="Birds of Prey" Number="69" Volume="1999" Year="2004">
       <Id>165bec73-62f9-44ad-a7df-ac4edffabd83</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="70" Volume="1999" Year="2004" Format="Main Series">
+    <Book Series="Birds of Prey" Number="70" Volume="1999" Year="2004">
       <Id>4bde5ec2-bd5b-498e-8462-4e354620c904</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="71" Volume="1999" Year="2004" Format="Main Series">
+    <Book Series="Birds of Prey" Number="71" Volume="1999" Year="2004">
       <Id>1ba4b690-cb2b-41df-bd83-f65b5c33d1d5</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="72" Volume="1999" Year="2004" Format="Main Series">
+    <Book Series="Birds of Prey" Number="72" Volume="1999" Year="2004">
       <Id>aa35c5a2-4e1e-4708-a0e4-0ffec0efe0c7</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="73" Volume="1999" Year="2004" Format="Main Series">
+    <Book Series="Birds of Prey" Number="73" Volume="1999" Year="2004">
       <Id>1f5eabba-2717-4bec-9f63-1754f2798280</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="74" Volume="1999" Year="2004" Format="Main Series">
+    <Book Series="Birds of Prey" Number="74" Volume="1999" Year="2004">
       <Id>c335b228-a391-47dd-9cc9-5a58951b48f0</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="75" Volume="1999" Year="2004" Format="Main Series">
+    <Book Series="Birds of Prey" Number="75" Volume="1999" Year="2004">
       <Id>2735470f-3511-40e2-8c80-985c97942357</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="76" Volume="1999" Year="2005" Format="Main Series">
+    <Book Series="Birds of Prey" Number="76" Volume="1999" Year="2005">
       <Id>f0e72fae-13c1-45f0-a225-c47f368ebed4</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="77" Volume="1999" Year="2005" Format="Main Series">
+    <Book Series="Birds of Prey" Number="77" Volume="1999" Year="2005">
       <Id>7dad2905-5067-4620-bfd9-1cf4042701f4</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="78" Volume="1999" Year="2005" Format="Main Series">
+    <Book Series="Birds of Prey" Number="78" Volume="1999" Year="2005">
       <Id>0d5ad968-fc8b-4ed4-aa1b-4ab3bfa583e8</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="79" Volume="1999" Year="2005" Format="Main Series">
+    <Book Series="Birds of Prey" Number="79" Volume="1999" Year="2005">
       <Id>1d2c53a5-38c2-4727-83cf-1671d6f95893</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="80" Volume="1999" Year="2005" Format="Main Series">
+    <Book Series="Birds of Prey" Number="80" Volume="1999" Year="2005">
       <Id>4251955d-af20-48c5-92da-894df39cbbbb</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="81" Volume="1999" Year="2005" Format="Main Series">
+    <Book Series="Birds of Prey" Number="81" Volume="1999" Year="2005">
       <Id>e9af1163-1348-45b5-b1f2-c7a87d9f5881</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="82" Volume="1999" Year="2005" Format="Main Series">
+    <Book Series="Birds of Prey" Number="82" Volume="1999" Year="2005">
       <Id>ce411ded-61ef-47c6-857b-fd6eec5bf517</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="83" Volume="1999" Year="2005" Format="Main Series">
+    <Book Series="Birds of Prey" Number="83" Volume="1999" Year="2005">
       <Id>04387f0e-f35a-4be9-aebf-f0320fe3366c</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="84" Volume="1999" Year="2005" Format="Main Series">
+    <Book Series="Birds of Prey" Number="84" Volume="1999" Year="2005">
       <Id>1648fcca-826a-48ad-8177-33850158c75e</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="85" Volume="1999" Year="2005" Format="Main Series">
+    <Book Series="Birds of Prey" Number="85" Volume="1999" Year="2005">
       <Id>3cfa8b53-14f9-4b1b-9b5c-1ebd7aff94fa</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="86" Volume="1999" Year="2005" Format="Main Series">
+    <Book Series="Birds of Prey" Number="86" Volume="1999" Year="2005">
       <Id>03afff69-ca79-42da-a465-b0b28dc654fc</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="87" Volume="1999" Year="2005" Format="Main Series">
+    <Book Series="Birds of Prey" Number="87" Volume="1999" Year="2005">
       <Id>8dd4c44b-b530-4d9d-a3dd-d609ddb777b1</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="88" Volume="1999" Year="2006" Format="Main Series">
+    <Book Series="Birds of Prey" Number="88" Volume="1999" Year="2006">
       <Id>58477ac0-0d4b-4b30-8979-baa87c79cabb</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="89" Volume="1999" Year="2006" Format="Main Series">
+    <Book Series="Birds of Prey" Number="89" Volume="1999" Year="2006">
       <Id>71f30c55-9954-4683-872f-b3f3182e192f</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="90" Volume="1999" Year="2006" Format="Main Series">
+    <Book Series="Birds of Prey" Number="90" Volume="1999" Year="2006">
       <Id>e7391c77-c660-4e1f-b27d-4a7cdb0162b6</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="91" Volume="1999" Year="2006" Format="Main Series">
+    <Book Series="Birds of Prey" Number="91" Volume="1999" Year="2006">
       <Id>6093335b-836e-4e96-a855-3458105e3018</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="92" Volume="1999" Year="2006" Format="Main Series">
+    <Book Series="Birds of Prey" Number="92" Volume="1999" Year="2006">
       <Id>c62f457d-b8d3-4213-a2b4-a3a8f34362ff</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="93" Volume="1999" Year="2006" Format="Main Series">
+    <Book Series="Birds of Prey" Number="93" Volume="1999" Year="2006">
       <Id>c3762c6a-402a-4f35-abc5-6c5f535fc625</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="94" Volume="1999" Year="2006" Format="Main Series">
+    <Book Series="Birds of Prey" Number="94" Volume="1999" Year="2006">
       <Id>da7266ce-1d96-4a47-82d7-722ac1428a7a</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="95" Volume="1999" Year="2006" Format="Main Series">
+    <Book Series="Birds of Prey" Number="95" Volume="1999" Year="2006">
       <Id>e6f3a637-b670-420f-abb1-93740c2766f1</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="96" Volume="1999" Year="2006" Format="Main Series">
+    <Book Series="Birds of Prey" Number="96" Volume="1999" Year="2006">
       <Id>67a5df7b-0903-4443-a404-d144f170013d</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="97" Volume="1999" Year="2006" Format="Main Series">
+    <Book Series="Birds of Prey" Number="97" Volume="1999" Year="2006">
       <Id>424c5dc4-5996-4b35-81be-7ba99ab77f5e</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="98" Volume="1999" Year="2006" Format="Main Series">
+    <Book Series="Birds of Prey" Number="98" Volume="1999" Year="2006">
       <Id>3b09bd7e-c42d-4953-8bba-aaf272955069</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="99" Volume="1999" Year="2006" Format="Main Series">
+    <Book Series="Birds of Prey" Number="99" Volume="1999" Year="2006">
       <Id>7204cd62-ee6f-4057-b452-effd404d5358</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="100" Volume="1999" Year="2007" Format="Main Series">
+    <Book Series="Birds of Prey" Number="100" Volume="1999" Year="2007">
       <Id>de114cf1-53d0-46f7-9e92-864e4f5fe4fc</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="101" Volume="1999" Year="2007" Format="Main Series">
+    <Book Series="Birds of Prey" Number="101" Volume="1999" Year="2007">
       <Id>78da2b14-a04f-448f-afc4-e5b2fe36c722</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="102" Volume="1999" Year="2007" Format="Main Series">
+    <Book Series="Birds of Prey" Number="102" Volume="1999" Year="2007">
       <Id>85706e5a-6cc5-4025-ade1-74da01b19a81</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="103" Volume="1999" Year="2007" Format="Main Series">
+    <Book Series="Birds of Prey" Number="103" Volume="1999" Year="2007">
       <Id>23d24d22-ca7a-4215-b335-df832d1ea1c5</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="104" Volume="1999" Year="2007" Format="Main Series">
+    <Book Series="Birds of Prey" Number="104" Volume="1999" Year="2007">
       <Id>3ecd1bf4-1ec1-4987-be75-6999bc3f2edf</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="105" Volume="1999" Year="2007" Format="Main Series">
+    <Book Series="Birds of Prey" Number="105" Volume="1999" Year="2007">
       <Id>91b12404-b568-4dfe-8b2d-1cea6619aac2</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="106" Volume="1999" Year="2007" Format="Main Series">
+    <Book Series="Birds of Prey" Number="106" Volume="1999" Year="2007">
       <Id>0e6caff8-37d4-4a0e-848b-619aff68e31a</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="107" Volume="1999" Year="2007" Format="Main Series">
+    <Book Series="Birds of Prey" Number="107" Volume="1999" Year="2007">
       <Id>9d9a9725-39b3-4111-aa10-c561cd3e787b</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="108" Volume="1999" Year="2007" Format="Main Series">
+    <Book Series="Birds of Prey" Number="108" Volume="1999" Year="2007">
       <Id>68c4c0b4-c623-4935-a482-5a87ac19ce4f</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="109" Volume="1999" Year="2007" Format="Main Series">
+    <Book Series="Birds of Prey" Number="109" Volume="1999" Year="2007">
       <Id>43ac52d7-2835-47d8-9e5b-f90ba50d6fc0</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="110" Volume="1999" Year="2007" Format="Main Series">
+    <Book Series="Birds of Prey" Number="110" Volume="1999" Year="2007">
       <Id>3b8e24bb-c8ae-45f9-b589-c2c2798f1cf0</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="111" Volume="1999" Year="2007" Format="Main Series">
+    <Book Series="Birds of Prey" Number="111" Volume="1999" Year="2007">
       <Id>68bfe98c-4a3c-438f-a696-2f29f2a856c3</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="112" Volume="1999" Year="2008" Format="Main Series">
+    <Book Series="Birds of Prey" Number="112" Volume="1999" Year="2008">
       <Id>4d961dbc-7081-440c-8450-2778e3337900</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="113" Volume="1999" Year="2008" Format="Main Series">
+    <Book Series="Birds of Prey" Number="113" Volume="1999" Year="2008">
       <Id>0c7873f7-84c0-4251-bd50-ef1abf08311f</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="114" Volume="1999" Year="2008" Format="Main Series">
+    <Book Series="Birds of Prey" Number="114" Volume="1999" Year="2008">
       <Id>57a7f8b5-5323-4e69-b16e-3c0ec9c7c375</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="115" Volume="1999" Year="2008" Format="Main Series">
+    <Book Series="Birds of Prey" Number="115" Volume="1999" Year="2008">
       <Id>9c8c437d-1486-4917-9a74-8968e1a074a3</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="116" Volume="1999" Year="2008" Format="Main Series">
+    <Book Series="Birds of Prey" Number="116" Volume="1999" Year="2008">
       <Id>1d911263-1b83-4009-aa4b-d6b277b4c67f</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="117" Volume="1999" Year="2008" Format="Main Series">
+    <Book Series="Birds of Prey" Number="117" Volume="1999" Year="2008">
       <Id>a6318d7c-579f-4c90-8524-e66812aa8115</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="118" Volume="1999" Year="2008" Format="Main Series">
+    <Book Series="Birds of Prey" Number="118" Volume="1999" Year="2008">
       <Id>4fb49303-3f05-429b-b52d-c43d4bec8fea</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="119" Volume="1999" Year="2008" Format="Main Series">
+    <Book Series="Birds of Prey" Number="119" Volume="1999" Year="2008">
       <Id>b9304775-68e4-4157-a893-f5c3d97f9ecf</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="120" Volume="1999" Year="2008" Format="Main Series">
+    <Book Series="Birds of Prey" Number="120" Volume="1999" Year="2008">
       <Id>b26034ee-19c6-4cac-997b-7b26bbb4a87c</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="121" Volume="1999" Year="2008" Format="Main Series">
+    <Book Series="Birds of Prey" Number="121" Volume="1999" Year="2008">
       <Id>bccac6ba-9395-4dc3-8335-72c2d25fb389</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="122" Volume="1999" Year="2008" Format="Main Series">
+    <Book Series="Birds of Prey" Number="122" Volume="1999" Year="2008">
       <Id>04e45c59-ee70-4740-b43b-65ee0ac1c8de</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="123" Volume="1999" Year="2008" Format="Main Series">
+    <Book Series="Birds of Prey" Number="123" Volume="1999" Year="2008">
       <Id>d81f7f34-d50b-4269-9d98-9c83ecb3fe14</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="124" Volume="1999" Year="2009" Format="Main Series">
+    <Book Series="Birds of Prey" Number="124" Volume="1999" Year="2009">
       <Id>b5d4d345-9c0c-4bf7-a9d0-3db633e441fb</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="125" Volume="1999" Year="2009" Format="Main Series">
+    <Book Series="Birds of Prey" Number="125" Volume="1999" Year="2009">
       <Id>f60f8964-571d-4ba7-8a47-133fdcf08e0b</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="126" Volume="1999" Year="2009" Format="Main Series">
+    <Book Series="Birds of Prey" Number="126" Volume="1999" Year="2009">
       <Id>36b94d64-1208-4c47-8a81-0600b2690f55</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="127" Volume="1999" Year="2009" Format="Main Series">
+    <Book Series="Birds of Prey" Number="127" Volume="1999" Year="2009">
       <Id>740f4d47-9b2f-4e49-9cb1-1a0deeeb6e82</Id>
     </Book>
-    <Book Series="Oracle: The Cure" Number="1" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="Oracle: The Cure" Number="1" Volume="2009" Year="2009">
       <Id>ad701315-542f-450e-836b-3cb2baaca0dc</Id>
     </Book>
-    <Book Series="Oracle: The Cure" Number="2" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="Oracle: The Cure" Number="2" Volume="2009" Year="2009">
       <Id>fdcb023b-74fa-49bb-a355-08491d37f0e8</Id>
     </Book>
-    <Book Series="Oracle: The Cure" Number="3" Volume="2009" Year="2009" Format="Limited Series">
+    <Book Series="Oracle: The Cure" Number="3" Volume="2009" Year="2009">
       <Id>7d7479d5-4613-44d7-aee2-5b09d8e8c060</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="1" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="Birds of Prey" Number="1" Volume="2010" Year="2010">
       <Id>73ad27d3-5461-4cec-98a4-60a7893d6d9a</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="2" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="Birds of Prey" Number="2" Volume="2010" Year="2010">
       <Id>028f3c73-d7ec-41d6-9f07-2cdf7c393dd7</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="3" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="Birds of Prey" Number="3" Volume="2010" Year="2010">
       <Id>5589a7f3-e588-42da-9461-cb150d3fbf51</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="4" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="Birds of Prey" Number="4" Volume="2010" Year="2010">
       <Id>3ecf5c47-1a38-4e48-825e-b3cb551c5a4b</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="5" Volume="2010" Year="2010" Format="Main Series">
+    <Book Series="Birds of Prey" Number="5" Volume="2010" Year="2010">
       <Id>d4b72d53-4b42-4ade-a6f0-6396211032c9</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="6" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Birds of Prey" Number="6" Volume="2010" Year="2011">
       <Id>6d014a27-a309-4a82-98aa-d5c1976875d4</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="7" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Birds of Prey" Number="7" Volume="2010" Year="2011">
       <Id>5318df32-df34-4f71-99af-1ef759a7ed5c</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="8" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Birds of Prey" Number="8" Volume="2010" Year="2011">
       <Id>26172a92-8104-42f6-8e97-855295fa7649</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="9" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Birds of Prey" Number="9" Volume="2010" Year="2011">
       <Id>66352c64-cbd9-4857-b3cc-e6cf4f7cc2c5</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="10" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Birds of Prey" Number="10" Volume="2010" Year="2011">
       <Id>5ef43974-88f2-4378-bac2-86eef9ed417f</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="11" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Birds of Prey" Number="11" Volume="2010" Year="2011">
       <Id>e4215ac2-5e25-4209-8e95-48280892bbd6</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="12" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Birds of Prey" Number="12" Volume="2010" Year="2011">
       <Id>144c4fda-b6cf-4799-9280-9b2280d7b864</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="13" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Birds of Prey" Number="13" Volume="2010" Year="2011">
       <Id>bb750a66-bda5-42e3-b5c5-1913fa3fdf79</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="14" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Birds of Prey" Number="14" Volume="2010" Year="2011">
       <Id>c34b69dd-a55b-4fa7-a6e1-18c92a9ce3f8</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="15" Volume="2010" Year="2011" Format="Main Series">
+    <Book Series="Birds of Prey" Number="15" Volume="2010" Year="2011">
       <Id>624f6767-f567-4145-8986-43197849c314</Id>
     </Book>
   </Books>

--- a/DC/Characters/unsorted/Birds of Prey/Birds of Prey 001 (Post-Crisis).cbl
+++ b/DC/Characters/unsorted/Birds of Prey/Birds of Prey 001 (Post-Crisis).cbl
@@ -1,477 +1,478 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Birds of Prey 1 (Post-Crisis)</Name>
+  <Name>Birds of Prey 001 (Post-Crisis)</Name>
+  <NumIssues>157</NumIssues>
   <Books>
-    <Book Series="Birds of Prey: Black Canary/Oracle" Number="1" Volume="1996" Year="1996">
-      <Id>848ff6ac-3321-4069-846e-6ce91e47aa34</Id>
+    <Book Series="Black Canary/Oracle: Birds of Prey" Number="1" Volume="1996" Year="1996">
+      <Database Name="cv" Series="18997" Issue="112867" />
     </Book>
-    <Book Series="Showcase '96" Number="3" Volume="1996" Year="1996">
-      <Id>8b6fce2c-bfd7-40c5-9d55-7a584cdea408</Id>
+    <Book Series="Showcase &apos;96" Number="3" Volume="1996" Year="1996">
+      <Database Name="cv" Series="22889" Issue="137447" />
     </Book>
     <Book Series="Birds of Prey: Manhunt" Number="1" Volume="1996" Year="1996">
-      <Id>9ab557f2-3f59-415e-b212-4176cc1e43d7</Id>
+      <Database Name="cv" Series="6634" Issue="47372" />
     </Book>
     <Book Series="Birds of Prey: Manhunt" Number="2" Volume="1996" Year="1996">
-      <Id>11ee9088-64a9-4f78-9450-465292c22a84</Id>
+      <Database Name="cv" Series="6634" Issue="47373" />
     </Book>
     <Book Series="Birds of Prey: Manhunt" Number="3" Volume="1996" Year="1996">
-      <Id>bebfc1c2-1678-4f58-95e8-ab083be4e11b</Id>
+      <Database Name="cv" Series="6634" Issue="47374" />
     </Book>
     <Book Series="Birds of Prey: Manhunt" Number="4" Volume="1996" Year="1996">
-      <Id>6f86ca0e-50c6-42b8-975a-ad4632d12d38</Id>
+      <Database Name="cv" Series="6634" Issue="47375" />
     </Book>
     <Book Series="Birds of Prey: Revolution" Number="1" Volume="1997" Year="1997">
-      <Id>669f808e-97ef-4d9f-866a-1f0368571dcc</Id>
+      <Database Name="cv" Series="18993" Issue="112855" />
     </Book>
     <Book Series="Birds of Prey: Wolves" Number="1" Volume="1997" Year="1997">
-      <Id>3308a1e1-cada-4240-aca7-ebf15d5978be</Id>
+      <Database Name="cv" Series="18995" Issue="112865" />
     </Book>
     <Book Series="Birds of Prey: Black Canary/Batgirl" Number="1" Volume="1998" Year="1998">
-      <Id>7fe5eb62-6cde-4cb8-bce4-c56578b38e4d</Id>
+      <Database Name="cv" Series="18996" Issue="112866" />
     </Book>
     <Book Series="Birds of Prey: The Ravens" Number="1" Volume="1998" Year="1998">
-      <Id>97df0a5d-23a0-45a5-85a6-f50e8d6bc239</Id>
+      <Database Name="cv" Series="18994" Issue="112863" />
     </Book>
     <Book Series="Birds of Prey" Number="1" Volume="1999" Year="1999">
-      <Id>dde35d8d-2f52-40fb-ad14-fe644ec64481</Id>
+      <Database Name="cv" Series="6498" Issue="46507" />
     </Book>
     <Book Series="Birds of Prey" Number="2" Volume="1999" Year="1999">
-      <Id>cabce9c0-8361-4ac3-98b6-1043165f4725</Id>
+      <Database Name="cv" Series="6498" Issue="46508" />
     </Book>
     <Book Series="Birds of Prey" Number="3" Volume="1999" Year="1999">
-      <Id>87f3c885-5a00-4a18-849d-1506abbeee26</Id>
+      <Database Name="cv" Series="6498" Issue="46509" />
     </Book>
     <Book Series="Birds of Prey" Number="4" Volume="1999" Year="1999">
-      <Id>9339779b-02a8-4217-87e3-258970733f8f</Id>
+      <Database Name="cv" Series="6498" Issue="46510" />
     </Book>
     <Book Series="Birds of Prey" Number="5" Volume="1999" Year="1999">
-      <Id>e637265f-75ad-4985-8fef-d76911b567b9</Id>
+      <Database Name="cv" Series="6498" Issue="46511" />
     </Book>
     <Book Series="Birds of Prey" Number="6" Volume="1999" Year="1999">
-      <Id>d7abcb14-b226-48a4-8300-9d362b197a78</Id>
+      <Database Name="cv" Series="6498" Issue="46512" />
     </Book>
     <Book Series="Birds of Prey" Number="7" Volume="1999" Year="1999">
-      <Id>a315bc29-77d0-4208-a3bc-2e47ed4de888</Id>
+      <Database Name="cv" Series="6498" Issue="46513" />
     </Book>
     <Book Series="Birds of Prey" Number="8" Volume="1999" Year="1999">
-      <Id>cf38bd0d-f70e-4bc8-97ef-a416f406b530</Id>
+      <Database Name="cv" Series="6498" Issue="46514" />
     </Book>
     <Book Series="Birds of Prey" Number="9" Volume="1999" Year="1999">
-      <Id>4b1a814d-6602-45ec-944d-a2933cd6bc9b</Id>
+      <Database Name="cv" Series="6498" Issue="46515" />
     </Book>
     <Book Series="Birds of Prey" Number="10" Volume="1999" Year="1999">
-      <Id>4d358b66-7bb7-48db-ac46-65f71a340c56</Id>
+      <Database Name="cv" Series="6498" Issue="46516" />
     </Book>
     <Book Series="Birds of Prey" Number="11" Volume="1999" Year="1999">
-      <Id>71a4d5ea-1cc2-48e2-bfb4-5bdeeb7819b9</Id>
+      <Database Name="cv" Series="6498" Issue="46517" />
     </Book>
     <Book Series="Birds of Prey" Number="12" Volume="1999" Year="1999">
-      <Id>8d8fa03f-c2eb-4de6-93f8-406e9f191c61</Id>
+      <Database Name="cv" Series="6498" Issue="112361" />
     </Book>
     <Book Series="Birds of Prey" Number="13" Volume="1999" Year="2000">
-      <Id>738f6603-1656-45f6-af28-75951791cf1f</Id>
+      <Database Name="cv" Series="6498" Issue="46518" />
     </Book>
     <Book Series="Birds of Prey" Number="14" Volume="1999" Year="2000">
-      <Id>c376e156-57ca-4574-ac2d-1b32f484883d</Id>
+      <Database Name="cv" Series="6498" Issue="46519" />
     </Book>
     <Book Series="Birds of Prey" Number="15" Volume="1999" Year="2000">
-      <Id>705ed358-205c-4dc2-bc82-ef1ec4fd799a</Id>
+      <Database Name="cv" Series="6498" Issue="46520" />
     </Book>
     <Book Series="Birds of Prey" Number="16" Volume="1999" Year="2000">
-      <Id>e01540b1-3a84-425c-9c88-0366e9d2d516</Id>
+      <Database Name="cv" Series="6498" Issue="46521" />
     </Book>
     <Book Series="Birds of Prey" Number="17" Volume="1999" Year="2000">
-      <Id>a3c4dcb3-bada-42ac-9118-fa798808ba89</Id>
+      <Database Name="cv" Series="6498" Issue="46522" />
     </Book>
     <Book Series="Birds of Prey" Number="18" Volume="1999" Year="2000">
-      <Id>52e37660-ab53-48b4-a98b-b61e8243d1e6</Id>
+      <Database Name="cv" Series="6498" Issue="46523" />
     </Book>
     <Book Series="Birds of Prey" Number="19" Volume="1999" Year="2000">
-      <Id>f87ea291-2da1-458c-ab38-c910b0df339f</Id>
+      <Database Name="cv" Series="6498" Issue="46524" />
     </Book>
     <Book Series="Nightwing" Number="45" Volume="1996" Year="2000">
-      <Id>7b23f5b2-5eb4-43a9-85bd-d32ad4ea7d0b</Id>
+      <Database Name="cv" Series="5755" Issue="46380" />
     </Book>
     <Book Series="Birds of Prey" Number="20" Volume="1999" Year="2000">
-      <Id>2ad9b095-cc0f-4cfd-85ab-353808d0ebf7</Id>
+      <Database Name="cv" Series="6498" Issue="46525" />
     </Book>
     <Book Series="Nightwing" Number="46" Volume="1996" Year="2000">
-      <Id>ecba30fb-e6e2-4963-8f16-9601e1bf30d8</Id>
+      <Database Name="cv" Series="5755" Issue="46395" />
     </Book>
     <Book Series="Birds of Prey" Number="21" Volume="1999" Year="2000">
-      <Id>c9ca76d5-8407-45ce-b938-94646f8f18bd</Id>
+      <Database Name="cv" Series="6498" Issue="46526" />
     </Book>
     <Book Series="Birds of Prey" Number="22" Volume="1999" Year="2000">
-      <Id>e350e306-764d-487b-9dd8-7bc185e58d6e</Id>
+      <Database Name="cv" Series="6498" Issue="46527" />
     </Book>
     <Book Series="Birds of Prey" Number="23" Volume="1999" Year="2000">
-      <Id>ec4222d7-7b26-491a-b55a-31883987fd56</Id>
+      <Database Name="cv" Series="6498" Issue="46528" />
     </Book>
     <Book Series="Birds of Prey" Number="24" Volume="1999" Year="2000">
-      <Id>79650258-3401-48c4-a233-fc6dd938fdc2</Id>
+      <Database Name="cv" Series="6498" Issue="46529" />
     </Book>
     <Book Series="Birds of Prey" Number="25" Volume="1999" Year="2001">
-      <Id>c22a3902-4b1d-4bd9-bfed-265c6fc7bcaa</Id>
+      <Database Name="cv" Series="6498" Issue="46530" />
     </Book>
     <Book Series="Birds of Prey" Number="26" Volume="1999" Year="2001">
-      <Id>1e92c9ea-4663-450f-a440-4023dc850258</Id>
+      <Database Name="cv" Series="6498" Issue="73279" />
     </Book>
     <Book Series="Birds of Prey" Number="27" Volume="1999" Year="2001">
-      <Id>c64b0199-3ea5-4946-9cea-8ea655e0a3ef</Id>
+      <Database Name="cv" Series="6498" Issue="73280" />
     </Book>
     <Book Series="Birds of Prey" Number="28" Volume="1999" Year="2001">
-      <Id>270eac4e-e72d-43c1-b9a4-f0f79bb34a1b</Id>
+      <Database Name="cv" Series="6498" Issue="73281" />
     </Book>
     <Book Series="Birds of Prey" Number="29" Volume="1999" Year="2001">
-      <Id>7a3cfb12-34ba-46fe-96e7-7c54d45942cf</Id>
+      <Database Name="cv" Series="6498" Issue="73282" />
     </Book>
     <Book Series="Birds of Prey" Number="30" Volume="1999" Year="2001">
-      <Id>e4c9f7eb-088d-40af-bc67-f1233a7efef5</Id>
+      <Database Name="cv" Series="6498" Issue="73283" />
     </Book>
     <Book Series="Birds of Prey" Number="31" Volume="1999" Year="2001">
-      <Id>68f6c1b3-b553-40ec-8857-cf13ed12f665</Id>
+      <Database Name="cv" Series="6498" Issue="73284" />
     </Book>
     <Book Series="Birds of Prey" Number="32" Volume="1999" Year="2001">
-      <Id>e7e61fb4-554c-4ad9-8442-243dde97d7d8</Id>
+      <Database Name="cv" Series="6498" Issue="112362" />
     </Book>
     <Book Series="Birds of Prey" Number="33" Volume="1999" Year="2001">
-      <Id>aac21029-ba2c-4060-922f-a61a4ae8d3ed</Id>
+      <Database Name="cv" Series="6498" Issue="112363" />
     </Book>
     <Book Series="Birds of Prey" Number="34" Volume="1999" Year="2001">
-      <Id>59ee4cfd-c83b-44ff-8a5f-8aa54b0d8d7c</Id>
+      <Database Name="cv" Series="6498" Issue="112387" />
     </Book>
     <Book Series="Birds of Prey" Number="35" Volume="1999" Year="2001">
-      <Id>9b45cbf2-e5f2-42e6-9002-69f83b44f09b</Id>
+      <Database Name="cv" Series="6498" Issue="112388" />
     </Book>
     <Book Series="Birds of Prey" Number="36" Volume="1999" Year="2001">
-      <Id>e83948bc-2253-444f-9977-4f5e2bce1815</Id>
+      <Database Name="cv" Series="6498" Issue="80280" />
     </Book>
     <Book Series="Birds of Prey" Number="37" Volume="1999" Year="2002">
-      <Id>06e9e872-0016-45b2-8f5d-513928113580</Id>
+      <Database Name="cv" Series="6498" Issue="80281" />
     </Book>
     <Book Series="Birds of Prey" Number="38" Volume="1999" Year="2002">
-      <Id>452014e6-67b1-4a95-bf08-2c3e6fdb8e42</Id>
+      <Database Name="cv" Series="6498" Issue="80282" />
     </Book>
     <Book Series="Birds of Prey" Number="39" Volume="1999" Year="2002">
-      <Id>c19046aa-9d02-4672-9d7a-fe5b33bd9270</Id>
+      <Database Name="cv" Series="6498" Issue="80283" />
     </Book>
     <Book Series="Birds of Prey" Number="40" Volume="1999" Year="2002">
-      <Id>282d93fe-40ff-42e8-89c0-0fed4c4cd8f3</Id>
+      <Database Name="cv" Series="6498" Issue="80284" />
     </Book>
     <Book Series="Birds of Prey" Number="41" Volume="1999" Year="2002">
-      <Id>c3c53be9-1a55-4e4d-981b-8b17c8767912</Id>
+      <Database Name="cv" Series="6498" Issue="80285" />
     </Book>
     <Book Series="Birds of Prey" Number="42" Volume="1999" Year="2002">
-      <Id>f99a64f5-a0c5-41c2-aa13-22b7e7c79b0c</Id>
+      <Database Name="cv" Series="6498" Issue="80286" />
     </Book>
     <Book Series="Birds of Prey" Number="43" Volume="1999" Year="2002">
-      <Id>3c0f7c26-3612-4bd3-81e9-d54125653b1f</Id>
+      <Database Name="cv" Series="6498" Issue="112389" />
     </Book>
     <Book Series="Birds of Prey" Number="44" Volume="1999" Year="2002">
-      <Id>869d829f-46c3-4c60-bb86-00f13d94dda8</Id>
+      <Database Name="cv" Series="6498" Issue="112390" />
     </Book>
     <Book Series="Birds of Prey" Number="45" Volume="1999" Year="2002">
-      <Id>ea6ea2b9-7caf-41a2-909d-c933a90b2245</Id>
+      <Database Name="cv" Series="6498" Issue="112391" />
     </Book>
     <Book Series="Birds of Prey" Number="46" Volume="1999" Year="2002">
-      <Id>e21631f6-0607-4b3f-98a2-06041ddbcf81</Id>
+      <Database Name="cv" Series="6498" Issue="112955" />
     </Book>
     <Book Series="Birds of Prey" Number="47" Volume="1999" Year="2002">
-      <Id>32a866d1-4ce7-4a7e-9365-dff4d656bd72</Id>
+      <Database Name="cv" Series="6498" Issue="112957" />
     </Book>
     <Book Series="Birds of Prey" Number="48" Volume="1999" Year="2002">
-      <Id>90d71093-71a2-4051-b023-92259e285cb7</Id>
+      <Database Name="cv" Series="6498" Issue="112961" />
     </Book>
     <Book Series="Birds of Prey" Number="49" Volume="1999" Year="2003">
-      <Id>e9800bcc-4028-4d8a-a8f0-f18724e1a559</Id>
+      <Database Name="cv" Series="6498" Issue="112963" />
     </Book>
     <Book Series="Birds of Prey" Number="50" Volume="1999" Year="2003">
-      <Id>46d8cd4e-20a7-4e36-ba1b-0c65bd123825</Id>
+      <Database Name="cv" Series="6498" Issue="112964" />
     </Book>
     <Book Series="Birds of Prey" Number="51" Volume="1999" Year="2003">
-      <Id>c8aad475-3e07-43e0-befe-e4818c45d956</Id>
+      <Database Name="cv" Series="6498" Issue="112970" />
     </Book>
     <Book Series="Birds of Prey" Number="52" Volume="1999" Year="2003">
-      <Id>01f4a813-653c-434f-a60b-bdfe5d421c0e</Id>
+      <Database Name="cv" Series="6498" Issue="112972" />
     </Book>
     <Book Series="Birds of Prey" Number="53" Volume="1999" Year="2003">
-      <Id>79367732-992e-455d-97da-7161ceb0ed66</Id>
+      <Database Name="cv" Series="6498" Issue="112974" />
     </Book>
     <Book Series="Birds of Prey" Number="54" Volume="1999" Year="2003">
-      <Id>9e1c52a3-61e3-4ed6-9916-ee4b8cf1f4dc</Id>
+      <Database Name="cv" Series="6498" Issue="112976" />
     </Book>
     <Book Series="Birds of Prey" Number="55" Volume="1999" Year="2003">
-      <Id>102841e1-ad01-4340-8faa-c89fc669fed6</Id>
+      <Database Name="cv" Series="6498" Issue="112978" />
     </Book>
     <Book Series="Birds of Prey" Number="56" Volume="1999" Year="2003">
-      <Id>7a12a1ac-9a7a-4a95-93cd-26627e88a007</Id>
+      <Database Name="cv" Series="6498" Issue="112981" />
     </Book>
     <Book Series="Birds of Prey" Number="57" Volume="1999" Year="2003">
-      <Id>9a3f6a2c-c02e-490b-81c7-b0ee23e3a202</Id>
+      <Database Name="cv" Series="6498" Issue="112982" />
     </Book>
     <Book Series="Birds of Prey" Number="58" Volume="1999" Year="2003">
-      <Id>f86e139d-4328-48ac-8a19-b3759baf0171</Id>
+      <Database Name="cv" Series="6498" Issue="112983" />
     </Book>
     <Book Series="Birds of Prey" Number="59" Volume="1999" Year="2003">
-      <Id>b0be405f-dbf3-4698-a9ad-82287608a471</Id>
+      <Database Name="cv" Series="6498" Issue="113096" />
     </Book>
     <Book Series="Birds of Prey" Number="60" Volume="1999" Year="2003">
-      <Id>2066ae0a-547f-4dc6-9017-772181f198cf</Id>
+      <Database Name="cv" Series="6498" Issue="113341" />
     </Book>
     <Book Series="Birds of Prey" Number="61" Volume="1999" Year="2004">
-      <Id>aac0dc3b-bf39-4350-9fb2-600a8d4bd549</Id>
+      <Database Name="cv" Series="6498" Issue="113342" />
     </Book>
     <Book Series="Birds of Prey" Number="62" Volume="1999" Year="2004">
-      <Id>7add3164-a25a-4c85-add4-72105bc6eda0</Id>
+      <Database Name="cv" Series="6498" Issue="113345" />
     </Book>
     <Book Series="Birds of Prey" Number="63" Volume="1999" Year="2004">
-      <Id>dc9295f9-cf22-46ae-89b1-6fc2fccbfd02</Id>
+      <Database Name="cv" Series="6498" Issue="113343" />
     </Book>
     <Book Series="Birds of Prey" Number="64" Volume="1999" Year="2004">
-      <Id>69ab567d-fcd1-4e4a-84c6-f10cd3c15934</Id>
+      <Database Name="cv" Series="6498" Issue="113344" />
     </Book>
     <Book Series="Birds of Prey" Number="65" Volume="1999" Year="2004">
-      <Id>add6bd95-5af2-422d-b9ed-86da8d6c38ac</Id>
+      <Database Name="cv" Series="6498" Issue="113346" />
     </Book>
     <Book Series="Birds of Prey" Number="66" Volume="1999" Year="2004">
-      <Id>0f5ba06f-118a-4343-9ffa-13ad83dfc289</Id>
+      <Database Name="cv" Series="6498" Issue="113347" />
     </Book>
     <Book Series="Birds of Prey" Number="67" Volume="1999" Year="2004">
-      <Id>bb221aa8-77ba-47af-a263-7c77937f66b5</Id>
+      <Database Name="cv" Series="6498" Issue="113348" />
     </Book>
     <Book Series="Birds of Prey" Number="68" Volume="1999" Year="2004">
-      <Id>b7963af4-2031-4981-8f83-5841b79cc0b7</Id>
+      <Database Name="cv" Series="6498" Issue="113349" />
     </Book>
     <Book Series="Birds of Prey" Number="69" Volume="1999" Year="2004">
-      <Id>165bec73-62f9-44ad-a7df-ac4edffabd83</Id>
+      <Database Name="cv" Series="6498" Issue="113350" />
     </Book>
     <Book Series="Birds of Prey" Number="70" Volume="1999" Year="2004">
-      <Id>4bde5ec2-bd5b-498e-8462-4e354620c904</Id>
+      <Database Name="cv" Series="6498" Issue="113318" />
     </Book>
     <Book Series="Birds of Prey" Number="71" Volume="1999" Year="2004">
-      <Id>1ba4b690-cb2b-41df-bd83-f65b5c33d1d5</Id>
+      <Database Name="cv" Series="6498" Issue="113319" />
     </Book>
     <Book Series="Birds of Prey" Number="72" Volume="1999" Year="2004">
-      <Id>aa35c5a2-4e1e-4708-a0e4-0ffec0efe0c7</Id>
+      <Database Name="cv" Series="6498" Issue="93547" />
     </Book>
     <Book Series="Birds of Prey" Number="73" Volume="1999" Year="2004">
-      <Id>1f5eabba-2717-4bec-9f63-1754f2798280</Id>
+      <Database Name="cv" Series="6498" Issue="93548" />
     </Book>
     <Book Series="Birds of Prey" Number="74" Volume="1999" Year="2004">
-      <Id>c335b228-a391-47dd-9cc9-5a58951b48f0</Id>
+      <Database Name="cv" Series="6498" Issue="93549" />
     </Book>
     <Book Series="Birds of Prey" Number="75" Volume="1999" Year="2004">
-      <Id>2735470f-3511-40e2-8c80-985c97942357</Id>
+      <Database Name="cv" Series="6498" Issue="96815" />
     </Book>
     <Book Series="Birds of Prey" Number="76" Volume="1999" Year="2005">
-      <Id>f0e72fae-13c1-45f0-a225-c47f368ebed4</Id>
+      <Database Name="cv" Series="6498" Issue="97340" />
     </Book>
     <Book Series="Birds of Prey" Number="77" Volume="1999" Year="2005">
-      <Id>7dad2905-5067-4620-bfd9-1cf4042701f4</Id>
+      <Database Name="cv" Series="6498" Issue="97775" />
     </Book>
     <Book Series="Birds of Prey" Number="78" Volume="1999" Year="2005">
-      <Id>0d5ad968-fc8b-4ed4-aa1b-4ab3bfa583e8</Id>
+      <Database Name="cv" Series="6498" Issue="99605" />
     </Book>
     <Book Series="Birds of Prey" Number="79" Volume="1999" Year="2005">
-      <Id>1d2c53a5-38c2-4727-83cf-1671d6f95893</Id>
+      <Database Name="cv" Series="6498" Issue="99749" />
     </Book>
     <Book Series="Birds of Prey" Number="80" Volume="1999" Year="2005">
-      <Id>4251955d-af20-48c5-92da-894df39cbbbb</Id>
+      <Database Name="cv" Series="6498" Issue="100915" />
     </Book>
     <Book Series="Birds of Prey" Number="81" Volume="1999" Year="2005">
-      <Id>e9af1163-1348-45b5-b1f2-c7a87d9f5881</Id>
+      <Database Name="cv" Series="6498" Issue="100916" />
     </Book>
     <Book Series="Birds of Prey" Number="82" Volume="1999" Year="2005">
-      <Id>ce411ded-61ef-47c6-857b-fd6eec5bf517</Id>
+      <Database Name="cv" Series="6498" Issue="113369" />
     </Book>
     <Book Series="Birds of Prey" Number="83" Volume="1999" Year="2005">
-      <Id>04387f0e-f35a-4be9-aebf-f0320fe3366c</Id>
+      <Database Name="cv" Series="6498" Issue="113370" />
     </Book>
     <Book Series="Birds of Prey" Number="84" Volume="1999" Year="2005">
-      <Id>1648fcca-826a-48ad-8177-33850158c75e</Id>
+      <Database Name="cv" Series="6498" Issue="113520" />
     </Book>
     <Book Series="Birds of Prey" Number="85" Volume="1999" Year="2005">
-      <Id>3cfa8b53-14f9-4b1b-9b5c-1ebd7aff94fa</Id>
+      <Database Name="cv" Series="6498" Issue="113521" />
     </Book>
     <Book Series="Birds of Prey" Number="86" Volume="1999" Year="2005">
-      <Id>03afff69-ca79-42da-a465-b0b28dc654fc</Id>
+      <Database Name="cv" Series="6498" Issue="113522" />
     </Book>
     <Book Series="Birds of Prey" Number="87" Volume="1999" Year="2005">
-      <Id>8dd4c44b-b530-4d9d-a3dd-d609ddb777b1</Id>
+      <Database Name="cv" Series="6498" Issue="107876" />
     </Book>
     <Book Series="Birds of Prey" Number="88" Volume="1999" Year="2006">
-      <Id>58477ac0-0d4b-4b30-8979-baa87c79cabb</Id>
+      <Database Name="cv" Series="6498" Issue="113523" />
     </Book>
     <Book Series="Birds of Prey" Number="89" Volume="1999" Year="2006">
-      <Id>71f30c55-9954-4683-872f-b3f3182e192f</Id>
+      <Database Name="cv" Series="6498" Issue="113524" />
     </Book>
     <Book Series="Birds of Prey" Number="90" Volume="1999" Year="2006">
-      <Id>e7391c77-c660-4e1f-b27d-4a7cdb0162b6</Id>
+      <Database Name="cv" Series="6498" Issue="113578" />
     </Book>
     <Book Series="Birds of Prey" Number="91" Volume="1999" Year="2006">
-      <Id>6093335b-836e-4e96-a855-3458105e3018</Id>
+      <Database Name="cv" Series="6498" Issue="113932" />
     </Book>
     <Book Series="Birds of Prey" Number="92" Volume="1999" Year="2006">
-      <Id>c62f457d-b8d3-4213-a2b4-a3a8f34362ff</Id>
+      <Database Name="cv" Series="6498" Issue="113933" />
     </Book>
     <Book Series="Birds of Prey" Number="93" Volume="1999" Year="2006">
-      <Id>c3762c6a-402a-4f35-abc5-6c5f535fc625</Id>
+      <Database Name="cv" Series="6498" Issue="113937" />
     </Book>
     <Book Series="Birds of Prey" Number="94" Volume="1999" Year="2006">
-      <Id>da7266ce-1d96-4a47-82d7-722ac1428a7a</Id>
+      <Database Name="cv" Series="6498" Issue="113938" />
     </Book>
     <Book Series="Birds of Prey" Number="95" Volume="1999" Year="2006">
-      <Id>e6f3a637-b670-420f-abb1-93740c2766f1</Id>
+      <Database Name="cv" Series="6498" Issue="114000" />
     </Book>
     <Book Series="Birds of Prey" Number="96" Volume="1999" Year="2006">
-      <Id>67a5df7b-0903-4443-a404-d144f170013d</Id>
+      <Database Name="cv" Series="6498" Issue="114001" />
     </Book>
     <Book Series="Birds of Prey" Number="97" Volume="1999" Year="2006">
-      <Id>424c5dc4-5996-4b35-81be-7ba99ab77f5e</Id>
+      <Database Name="cv" Series="6498" Issue="114002" />
     </Book>
     <Book Series="Birds of Prey" Number="98" Volume="1999" Year="2006">
-      <Id>3b09bd7e-c42d-4953-8bba-aaf272955069</Id>
+      <Database Name="cv" Series="6498" Issue="114003" />
     </Book>
     <Book Series="Birds of Prey" Number="99" Volume="1999" Year="2006">
-      <Id>7204cd62-ee6f-4057-b452-effd404d5358</Id>
+      <Database Name="cv" Series="6498" Issue="114004" />
     </Book>
     <Book Series="Birds of Prey" Number="100" Volume="1999" Year="2007">
-      <Id>de114cf1-53d0-46f7-9e92-864e4f5fe4fc</Id>
+      <Database Name="cv" Series="6498" Issue="106840" />
     </Book>
     <Book Series="Birds of Prey" Number="101" Volume="1999" Year="2007">
-      <Id>78da2b14-a04f-448f-afc4-e5b2fe36c722</Id>
+      <Database Name="cv" Series="6498" Issue="106841" />
     </Book>
     <Book Series="Birds of Prey" Number="102" Volume="1999" Year="2007">
-      <Id>85706e5a-6cc5-4025-ade1-74da01b19a81</Id>
+      <Database Name="cv" Series="6498" Issue="107394" />
     </Book>
     <Book Series="Birds of Prey" Number="103" Volume="1999" Year="2007">
-      <Id>23d24d22-ca7a-4215-b335-df832d1ea1c5</Id>
+      <Database Name="cv" Series="6498" Issue="107825" />
     </Book>
     <Book Series="Birds of Prey" Number="104" Volume="1999" Year="2007">
-      <Id>3ecd1bf4-1ec1-4987-be75-6999bc3f2edf</Id>
+      <Database Name="cv" Series="6498" Issue="114157" />
     </Book>
     <Book Series="Birds of Prey" Number="105" Volume="1999" Year="2007">
-      <Id>91b12404-b568-4dfe-8b2d-1cea6619aac2</Id>
+      <Database Name="cv" Series="6498" Issue="110905" />
     </Book>
     <Book Series="Birds of Prey" Number="106" Volume="1999" Year="2007">
-      <Id>0e6caff8-37d4-4a0e-848b-619aff68e31a</Id>
+      <Database Name="cv" Series="6498" Issue="110906" />
     </Book>
     <Book Series="Birds of Prey" Number="107" Volume="1999" Year="2007">
-      <Id>9d9a9725-39b3-4111-aa10-c561cd3e787b</Id>
+      <Database Name="cv" Series="6498" Issue="110275" />
     </Book>
     <Book Series="Birds of Prey" Number="108" Volume="1999" Year="2007">
-      <Id>68c4c0b4-c623-4935-a482-5a87ac19ce4f</Id>
+      <Database Name="cv" Series="6498" Issue="112312" />
     </Book>
     <Book Series="Birds of Prey" Number="109" Volume="1999" Year="2007">
-      <Id>43ac52d7-2835-47d8-9e5b-f90ba50d6fc0</Id>
+      <Database Name="cv" Series="6498" Issue="114158" />
     </Book>
     <Book Series="Birds of Prey" Number="110" Volume="1999" Year="2007">
-      <Id>3b8e24bb-c8ae-45f9-b589-c2c2798f1cf0</Id>
+      <Database Name="cv" Series="6498" Issue="114763" />
     </Book>
     <Book Series="Birds of Prey" Number="111" Volume="1999" Year="2007">
-      <Id>68bfe98c-4a3c-438f-a696-2f29f2a856c3</Id>
+      <Database Name="cv" Series="6498" Issue="115635" />
     </Book>
     <Book Series="Birds of Prey" Number="112" Volume="1999" Year="2008">
-      <Id>4d961dbc-7081-440c-8450-2778e3337900</Id>
+      <Database Name="cv" Series="6498" Issue="118194" />
     </Book>
     <Book Series="Birds of Prey" Number="113" Volume="1999" Year="2008">
-      <Id>0c7873f7-84c0-4251-bd50-ef1abf08311f</Id>
+      <Database Name="cv" Series="6498" Issue="120914" />
     </Book>
     <Book Series="Birds of Prey" Number="114" Volume="1999" Year="2008">
-      <Id>57a7f8b5-5323-4e69-b16e-3c0ec9c7c375</Id>
+      <Database Name="cv" Series="6498" Issue="121735" />
     </Book>
     <Book Series="Birds of Prey" Number="115" Volume="1999" Year="2008">
-      <Id>9c8c437d-1486-4917-9a74-8968e1a074a3</Id>
+      <Database Name="cv" Series="6498" Issue="128707" />
     </Book>
     <Book Series="Birds of Prey" Number="116" Volume="1999" Year="2008">
-      <Id>1d911263-1b83-4009-aa4b-d6b277b4c67f</Id>
+      <Database Name="cv" Series="6498" Issue="128710" />
     </Book>
     <Book Series="Birds of Prey" Number="117" Volume="1999" Year="2008">
-      <Id>a6318d7c-579f-4c90-8524-e66812aa8115</Id>
+      <Database Name="cv" Series="6498" Issue="128711" />
     </Book>
     <Book Series="Birds of Prey" Number="118" Volume="1999" Year="2008">
-      <Id>4fb49303-3f05-429b-b52d-c43d4bec8fea</Id>
+      <Database Name="cv" Series="6498" Issue="130967" />
     </Book>
     <Book Series="Birds of Prey" Number="119" Volume="1999" Year="2008">
-      <Id>b9304775-68e4-4157-a893-f5c3d97f9ecf</Id>
+      <Database Name="cv" Series="6498" Issue="131779" />
     </Book>
     <Book Series="Birds of Prey" Number="120" Volume="1999" Year="2008">
-      <Id>b26034ee-19c6-4cac-997b-7b26bbb4a87c</Id>
+      <Database Name="cv" Series="6498" Issue="133755" />
     </Book>
     <Book Series="Birds of Prey" Number="121" Volume="1999" Year="2008">
-      <Id>bccac6ba-9395-4dc3-8335-72c2d25fb389</Id>
+      <Database Name="cv" Series="6498" Issue="136055" />
     </Book>
     <Book Series="Birds of Prey" Number="122" Volume="1999" Year="2008">
-      <Id>04e45c59-ee70-4740-b43b-65ee0ac1c8de</Id>
+      <Database Name="cv" Series="6498" Issue="139016" />
     </Book>
     <Book Series="Birds of Prey" Number="123" Volume="1999" Year="2008">
-      <Id>d81f7f34-d50b-4269-9d98-9c83ecb3fe14</Id>
+      <Database Name="cv" Series="6498" Issue="140889" />
     </Book>
     <Book Series="Birds of Prey" Number="124" Volume="1999" Year="2009">
-      <Id>b5d4d345-9c0c-4bf7-a9d0-3db633e441fb</Id>
+      <Database Name="cv" Series="6498" Issue="143277" />
     </Book>
     <Book Series="Birds of Prey" Number="125" Volume="1999" Year="2009">
-      <Id>f60f8964-571d-4ba7-8a47-133fdcf08e0b</Id>
+      <Database Name="cv" Series="6498" Issue="146896" />
     </Book>
     <Book Series="Birds of Prey" Number="126" Volume="1999" Year="2009">
-      <Id>36b94d64-1208-4c47-8a81-0600b2690f55</Id>
+      <Database Name="cv" Series="6498" Issue="150509" />
     </Book>
     <Book Series="Birds of Prey" Number="127" Volume="1999" Year="2009">
-      <Id>740f4d47-9b2f-4e49-9cb1-1a0deeeb6e82</Id>
+      <Database Name="cv" Series="6498" Issue="152229" />
     </Book>
     <Book Series="Oracle: The Cure" Number="1" Volume="2009" Year="2009">
-      <Id>ad701315-542f-450e-836b-3cb2baaca0dc</Id>
+      <Database Name="cv" Series="26058" Issue="154027" />
     </Book>
     <Book Series="Oracle: The Cure" Number="2" Volume="2009" Year="2009">
-      <Id>fdcb023b-74fa-49bb-a355-08491d37f0e8</Id>
+      <Database Name="cv" Series="26058" Issue="155508" />
     </Book>
     <Book Series="Oracle: The Cure" Number="3" Volume="2009" Year="2009">
-      <Id>7d7479d5-4613-44d7-aee2-5b09d8e8c060</Id>
+      <Database Name="cv" Series="26058" Issue="157302" />
     </Book>
     <Book Series="Birds of Prey" Number="1" Volume="2010" Year="2010">
-      <Id>73ad27d3-5461-4cec-98a4-60a7893d6d9a</Id>
+      <Database Name="cv" Series="33087" Issue="213468" />
     </Book>
     <Book Series="Birds of Prey" Number="2" Volume="2010" Year="2010">
-      <Id>028f3c73-d7ec-41d6-9f07-2cdf7c393dd7</Id>
+      <Database Name="cv" Series="33087" Issue="219574" />
     </Book>
     <Book Series="Birds of Prey" Number="3" Volume="2010" Year="2010">
-      <Id>5589a7f3-e588-42da-9461-cb150d3fbf51</Id>
+      <Database Name="cv" Series="33087" Issue="224745" />
     </Book>
     <Book Series="Birds of Prey" Number="4" Volume="2010" Year="2010">
-      <Id>3ecf5c47-1a38-4e48-825e-b3cb551c5a4b</Id>
+      <Database Name="cv" Series="33087" Issue="228897" />
     </Book>
     <Book Series="Birds of Prey" Number="5" Volume="2010" Year="2010">
-      <Id>d4b72d53-4b42-4ade-a6f0-6396211032c9</Id>
+      <Database Name="cv" Series="33087" Issue="234625" />
     </Book>
     <Book Series="Birds of Prey" Number="6" Volume="2010" Year="2011">
-      <Id>6d014a27-a309-4a82-98aa-d5c1976875d4</Id>
+      <Database Name="cv" Series="33087" Issue="241937" />
     </Book>
     <Book Series="Birds of Prey" Number="7" Volume="2010" Year="2011">
-      <Id>5318df32-df34-4f71-99af-1ef759a7ed5c</Id>
+      <Database Name="cv" Series="33087" Issue="249175" />
     </Book>
     <Book Series="Birds of Prey" Number="8" Volume="2010" Year="2011">
-      <Id>26172a92-8104-42f6-8e97-855295fa7649</Id>
+      <Database Name="cv" Series="33087" Issue="255899" />
     </Book>
     <Book Series="Birds of Prey" Number="9" Volume="2010" Year="2011">
-      <Id>66352c64-cbd9-4857-b3cc-e6cf4f7cc2c5</Id>
+      <Database Name="cv" Series="33087" Issue="261126" />
     </Book>
     <Book Series="Birds of Prey" Number="10" Volume="2010" Year="2011">
-      <Id>5ef43974-88f2-4378-bac2-86eef9ed417f</Id>
+      <Database Name="cv" Series="33087" Issue="265496" />
     </Book>
     <Book Series="Birds of Prey" Number="11" Volume="2010" Year="2011">
-      <Id>e4215ac2-5e25-4209-8e95-48280892bbd6</Id>
+      <Database Name="cv" Series="33087" Issue="268213" />
     </Book>
     <Book Series="Birds of Prey" Number="12" Volume="2010" Year="2011">
-      <Id>144c4fda-b6cf-4799-9280-9b2280d7b864</Id>
+      <Database Name="cv" Series="33087" Issue="269825" />
     </Book>
     <Book Series="Birds of Prey" Number="13" Volume="2010" Year="2011">
-      <Id>bb750a66-bda5-42e3-b5c5-1913fa3fdf79</Id>
+      <Database Name="cv" Series="33087" Issue="273086" />
     </Book>
     <Book Series="Birds of Prey" Number="14" Volume="2010" Year="2011">
-      <Id>c34b69dd-a55b-4fa7-a6e1-18c92a9ce3f8</Id>
+      <Database Name="cv" Series="33087" Issue="278596" />
     </Book>
     <Book Series="Birds of Prey" Number="15" Volume="2010" Year="2011">
-      <Id>624f6767-f567-4145-8986-43197849c314</Id>
+      <Database Name="cv" Series="33087" Issue="285197" />
     </Book>
   </Books>
   <Matchers />

--- a/DC/Characters/unsorted/Birds of Prey/Birds of Prey 002 (New52_Rebirth).cbl
+++ b/DC/Characters/unsorted/Birds of Prey/Birds of Prey 002 (New52_Rebirth).cbl
@@ -1,219 +1,220 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Birds of Prey 2 (New52/Rebirth)</Name>
+  <Name>Birds of Prey 002 (New52_Rebirth)</Name>
+  <NumIssues>71</NumIssues>
   <Books>
     <Book Series="Birds of Prey" Number="1" Volume="2011" Year="2011">
-      <Id>7692160e-4888-4b51-8b84-f2dc41fe9a25</Id>
+      <Database Name="cv" Series="42806" Issue="293260" />
     </Book>
     <Book Series="Birds of Prey" Number="2" Volume="2011" Year="2011">
-      <Id>0206b2ef-3792-4dcf-a12b-b162e98a102c</Id>
+      <Database Name="cv" Series="42806" Issue="297221" />
     </Book>
     <Book Series="Birds of Prey" Number="3" Volume="2011" Year="2012">
-      <Id>88c0ad33-b73b-4183-82d8-16688e8a1857</Id>
+      <Database Name="cv" Series="42806" Issue="302529" />
     </Book>
     <Book Series="Birds of Prey" Number="4" Volume="2011" Year="2012">
-      <Id>588f2dd8-22e8-456e-8f35-acba61d35fcc</Id>
+      <Database Name="cv" Series="42806" Issue="307456" />
     </Book>
     <Book Series="Birds of Prey" Number="5" Volume="2011" Year="2012">
-      <Id>9033dfd9-8860-486b-b278-d0b774714597</Id>
+      <Database Name="cv" Series="42806" Issue="311663" />
     </Book>
     <Book Series="Birds of Prey" Number="6" Volume="2011" Year="2012">
-      <Id>bab2d534-853b-4a8c-945f-efebd8dbc096</Id>
+      <Database Name="cv" Series="42806" Issue="315711" />
     </Book>
     <Book Series="Birds of Prey" Number="7" Volume="2011" Year="2012">
-      <Id>6ff6ef9c-11a5-415a-af61-b2a46f4a9d44</Id>
+      <Database Name="cv" Series="42806" Issue="322740" />
     </Book>
     <Book Series="Birds of Prey" Number="8" Volume="2011" Year="2012">
-      <Id>995b395e-8c08-449e-94d1-979959cc2b08</Id>
+      <Database Name="cv" Series="42806" Issue="331844" />
     </Book>
     <Book Series="Birds of Prey" Number="9" Volume="2011" Year="2012">
-      <Id>1c6611eb-dc6e-4cd3-ab55-76d4bd406181</Id>
+      <Database Name="cv" Series="42806" Issue="335896" />
     </Book>
     <Book Series="Birds of Prey" Number="10" Volume="2011" Year="2012">
-      <Id>803c45fa-220b-42b6-8b6d-0b82841080ae</Id>
+      <Database Name="cv" Series="42806" Issue="341638" />
     </Book>
     <Book Series="Birds of Prey" Number="11" Volume="2011" Year="2012">
-      <Id>be30d390-89cf-4072-a8b1-7c76e9e66aed</Id>
+      <Database Name="cv" Series="42806" Issue="346224" />
     </Book>
     <Book Series="Birds of Prey" Number="12" Volume="2011" Year="2012">
-      <Id>eac173cf-8cdf-4cd7-9011-197f48522de6</Id>
+      <Database Name="cv" Series="42806" Issue="350902" />
     </Book>
     <Book Series="Birds of Prey" Number="0" Volume="2011" Year="2012">
-      <Id>f9b8d0d1-0212-42aa-a3c8-12fe7d335196</Id>
+      <Database Name="cv" Series="42806" Issue="357622" />
     </Book>
     <Book Series="Batgirl Annual" Number="1" Volume="2012" Year="2012">
-      <Id>d93a697f-429d-4b07-87b5-fb0b11b144e6</Id>
+      <Database Name="cv" Series="53505" Issue="364092" />
     </Book>
     <Book Series="Birds of Prey" Number="13" Volume="2011" Year="2012">
-      <Id>d144f1e5-88e9-433d-a436-2eb611c78861</Id>
+      <Database Name="cv" Series="42806" Issue="362282" />
     </Book>
     <Book Series="Birds of Prey" Number="14" Volume="2011" Year="2013">
-      <Id>85ece657-8f89-457c-9cec-79b8c5603d30</Id>
+      <Database Name="cv" Series="42806" Issue="369030" />
     </Book>
     <Book Series="Birds of Prey" Number="15" Volume="2011" Year="2013">
-      <Id>2a6d2a4a-b64f-4234-ba17-feae071c8e24</Id>
+      <Database Name="cv" Series="42806" Issue="373259" />
     </Book>
     <Book Series="Birds of Prey" Number="16" Volume="2011" Year="2013">
-      <Id>184f9876-335b-43b8-a6ad-15d8ad891373</Id>
+      <Database Name="cv" Series="42806" Issue="381524" />
     </Book>
     <Book Series="Birds of Prey" Number="17" Volume="2011" Year="2013">
-      <Id>33bd1d64-4d16-4d60-a7fb-e679d07e628a</Id>
+      <Database Name="cv" Series="42806" Issue="387211" />
     </Book>
     <Book Series="Birds of Prey" Number="18" Volume="2011" Year="2013">
-      <Id>db452413-b7f7-441b-8694-1cf79d772219</Id>
+      <Database Name="cv" Series="42806" Issue="394648" />
     </Book>
     <Book Series="Birds of Prey" Number="19" Volume="2011" Year="2013">
-      <Id>3e9b957b-b7ed-488c-8115-820bd3e52463</Id>
+      <Database Name="cv" Series="42806" Issue="397491" />
     </Book>
     <Book Series="Birds of Prey" Number="20" Volume="2011" Year="2013">
-      <Id>d4537145-6201-452b-a7c5-9f504cdc416e</Id>
+      <Database Name="cv" Series="42806" Issue="402241" />
     </Book>
     <Book Series="Birds of Prey" Number="21" Volume="2011" Year="2013">
-      <Id>12ec0705-8f75-43f9-b3bb-5ee34ec19ab8</Id>
+      <Database Name="cv" Series="42806" Issue="411787" />
     </Book>
     <Book Series="Birds of Prey" Number="22" Volume="2011" Year="2013">
-      <Id>9b7cda88-0284-4e26-bf59-3ec1d335f45b</Id>
+      <Database Name="cv" Series="42806" Issue="417793" />
     </Book>
     <Book Series="Birds of Prey" Number="23" Volume="2011" Year="2013">
-      <Id>03165305-0daf-4683-a348-0f72a0f6e19e</Id>
+      <Database Name="cv" Series="42806" Issue="422440" />
     </Book>
     <Book Series="Birds of Prey" Number="24" Volume="2011" Year="2013">
-      <Id>c9a89ce3-1b71-419b-9215-e2277b3f663e</Id>
+      <Database Name="cv" Series="42806" Issue="428829" />
     </Book>
     <Book Series="Birds of Prey" Number="25" Volume="2011" Year="2014">
-      <Id>17194e42-a45a-4a96-a4c1-1405a3228ed9</Id>
+      <Database Name="cv" Series="42806" Issue="433793" />
     </Book>
     <Book Series="Birds of Prey" Number="26" Volume="2011" Year="2014">
-      <Id>4a0cc5e0-eac0-47a4-bb5e-11468d9cfbdc</Id>
+      <Database Name="cv" Series="42806" Issue="437423" />
     </Book>
     <Book Series="Birds of Prey" Number="27" Volume="2011" Year="2014">
-      <Id>22e760c8-9054-459b-bf73-9133c52d7a83</Id>
+      <Database Name="cv" Series="42806" Issue="442878" />
     </Book>
     <Book Series="Birds of Prey" Number="28" Volume="2011" Year="2014">
-      <Id>b79c32f3-41b4-41c5-b28c-8cbca9e5bdde</Id>
+      <Database Name="cv" Series="42806" Issue="445770" />
     </Book>
     <Book Series="Birds of Prey" Number="29" Volume="2011" Year="2014">
-      <Id>dc5f3e4c-7b7a-4a4c-8c51-63f9b72c2a40</Id>
+      <Database Name="cv" Series="42806" Issue="447950" />
     </Book>
     <Book Series="Birds of Prey" Number="30" Volume="2011" Year="2014">
-      <Id>ab2d2fd5-6159-4c5c-98a4-a0e76532788c</Id>
+      <Database Name="cv" Series="42806" Issue="450510" />
     </Book>
     <Book Series="Birds of Prey" Number="31" Volume="2011" Year="2014">
-      <Id>736874f6-1c33-49c5-867f-ccbb57785e6b</Id>
+      <Database Name="cv" Series="42806" Issue="453358" />
     </Book>
     <Book Series="Birds of Prey" Number="32" Volume="2011" Year="2014">
-      <Id>e35aab2b-11c3-419c-9444-a48e78b8c513</Id>
+      <Database Name="cv" Series="42806" Issue="455972" />
     </Book>
     <Book Series="Birds of Prey" Number="33" Volume="2011" Year="2014">
-      <Id>ebac43c0-57a9-4555-bf75-1a82d4969182</Id>
+      <Database Name="cv" Series="42806" Issue="459116" />
     </Book>
     <Book Series="Birds of Prey" Number="34" Volume="2011" Year="2014">
-      <Id>847343d5-6b2b-402a-8265-f120c526ac2c</Id>
+      <Database Name="cv" Series="42806" Issue="462202" />
     </Book>
     <Book Series="Black Canary" Number="1" Volume="2015" Year="2015">
-      <Id>6ca570c7-d043-4a29-a7a5-10ce21ef2717</Id>
+      <Database Name="cv" Series="82655" Issue="492158" />
     </Book>
     <Book Series="Black Canary" Number="2" Volume="2015" Year="2015">
-      <Id>61ca2766-453a-492f-9524-ce384b1276d2</Id>
+      <Database Name="cv" Series="82655" Issue="495243" />
     </Book>
     <Book Series="Black Canary" Number="3" Volume="2015" Year="2015">
-      <Id>d3bd34e5-837c-41b7-94fb-6dcfff11fca0</Id>
+      <Database Name="cv" Series="82655" Issue="497909" />
     </Book>
     <Book Series="Black Canary" Number="4" Volume="2015" Year="2015">
-      <Id>72daa878-e5a1-44d8-a4e0-43404e20cd1f</Id>
+      <Database Name="cv" Series="82655" Issue="500266" />
     </Book>
     <Book Series="Black Canary" Number="5" Volume="2015" Year="2015">
-      <Id>37124f15-708a-48fd-894c-5ee0de9cebda</Id>
+      <Database Name="cv" Series="82655" Issue="503526" />
     </Book>
     <Book Series="Black Canary" Number="6" Volume="2015" Year="2016">
-      <Id>bd10ae1e-8d12-4c1f-a052-c201b762d34b</Id>
+      <Database Name="cv" Series="82655" Issue="509420" />
     </Book>
     <Book Series="Black Canary" Number="7" Volume="2015" Year="2016">
-      <Id>c008d360-38a6-45e4-b4c2-cb3280f628ba</Id>
+      <Database Name="cv" Series="82655" Issue="512392" />
     </Book>
     <Book Series="Black Canary" Number="8" Volume="2015" Year="2016">
-      <Id>471e952c-f86a-41e4-8d48-121b78b80f0e</Id>
+      <Database Name="cv" Series="82655" Issue="514400" />
     </Book>
     <Book Series="Black Canary" Number="9" Volume="2015" Year="2016">
-      <Id>d4ddfb27-62b9-44cb-bd48-2e60ecc09fcf</Id>
+      <Database Name="cv" Series="82655" Issue="520169" />
     </Book>
     <Book Series="Black Canary" Number="10" Volume="2015" Year="2016">
-      <Id>ea335019-31c8-4ff1-9096-c2b5f219f638</Id>
+      <Database Name="cv" Series="82655" Issue="524995" />
     </Book>
     <Book Series="Black Canary" Number="11" Volume="2015" Year="2016">
-      <Id>5f859066-6443-4c9b-824d-f7bbbfeae0d1</Id>
+      <Database Name="cv" Series="82655" Issue="527106" />
     </Book>
     <Book Series="Black Canary" Number="12" Volume="2015" Year="2016">
-      <Id>09b7ab8b-080f-4c8f-9987-c4761d4273a1</Id>
+      <Database Name="cv" Series="82655" Issue="534257" />
     </Book>
-    <Book Series="Batgirl and the Birds of Prey: Rebirth" Number="1" Volume="2016" Year="2016">
-      <Id>4d4319a0-82ee-480a-b37d-cb9ae27f4ec2</Id>
+    <Book Series="Batgirl &amp; the Birds of Prey: Rebirth" Number="1" Volume="2016" Year="2016">
+      <Database Name="cv" Series="92351" Issue="540045" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="1" Volume="2016" Year="2016">
-      <Id>aa35299a-9fee-4ab0-9328-0aaca222681f</Id>
+      <Database Name="cv" Series="93179" Issue="544954" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="2" Volume="2016" Year="2016">
-      <Id>b4d7d669-9a36-4858-a6fa-4d6e580a5524</Id>
+      <Database Name="cv" Series="93179" Issue="549483" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="3" Volume="2016" Year="2016">
-      <Id>dcedf4f8-7357-4956-a5bf-9551c13e1b02</Id>
+      <Database Name="cv" Series="93179" Issue="552967" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="4" Volume="2016" Year="2017">
-      <Id>f8b8cb5c-30da-4588-9bfa-e93288a5547c</Id>
+      <Database Name="cv" Series="93179" Issue="557330" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="5" Volume="2016" Year="2017">
-      <Id>addce30a-f01d-437d-927e-9525cf7ab83e</Id>
+      <Database Name="cv" Series="93179" Issue="566670" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="6" Volume="2016" Year="2017">
-      <Id>ace25f88-dd49-402e-a56e-ca00c55ea067</Id>
+      <Database Name="cv" Series="93179" Issue="575827" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="7" Volume="2016" Year="2017">
-      <Id>69fd2336-905b-44e5-a6bd-2a7b1aceaf95</Id>
+      <Database Name="cv" Series="93179" Issue="580711" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="8" Volume="2016" Year="2017">
-      <Id>c84bba86-cb04-455c-9e90-91de4910ba4a</Id>
+      <Database Name="cv" Series="93179" Issue="585054" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="9" Volume="2016" Year="2017">
-      <Id>c94489bf-02f6-4dfd-8a27-ab2957663d7b</Id>
+      <Database Name="cv" Series="93179" Issue="591718" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="10" Volume="2016" Year="2017">
-      <Id>d6e648c3-d7fe-42be-a4ad-25b0f62fd6d4</Id>
+      <Database Name="cv" Series="93179" Issue="594927" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="11" Volume="2016" Year="2017">
-      <Id>18a0d5a2-bd2d-48e0-8b8e-992d1532adfc</Id>
+      <Database Name="cv" Series="93179" Issue="601755" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="12" Volume="2016" Year="2017">
-      <Id>c11b5691-712a-46ce-8749-2beab724cc23</Id>
+      <Database Name="cv" Series="93179" Issue="608170" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="13" Volume="2016" Year="2017">
-      <Id>9e940ad2-ff5a-466f-8dde-d05f9d70d9a7</Id>
+      <Database Name="cv" Series="93179" Issue="613732" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="14" Volume="2016" Year="2017">
-      <Id>d671f6b7-8271-445e-aad9-eaa6a5a49aad</Id>
+      <Database Name="cv" Series="93179" Issue="621579" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="15" Volume="2016" Year="2017">
-      <Id>62bd4563-4a51-471c-be4e-763a785c359c</Id>
+      <Database Name="cv" Series="93179" Issue="628542" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="16" Volume="2016" Year="2018">
-      <Id>46ab6e1a-cb53-48c6-be9c-06e1793fb460</Id>
+      <Database Name="cv" Series="93179" Issue="636334" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="17" Volume="2016" Year="2018">
-      <Id>3563ed5d-b10b-46fc-b9a4-83b27a946f41</Id>
+      <Database Name="cv" Series="93179" Issue="646151" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="18" Volume="2016" Year="2018">
-      <Id>0a8d729b-72a5-4169-b117-4fe126d890c2</Id>
+      <Database Name="cv" Series="93179" Issue="652591" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="19" Volume="2016" Year="2018">
-      <Id>69a4e359-4241-4765-b1cb-720918387867</Id>
+      <Database Name="cv" Series="93179" Issue="659973" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="20" Volume="2016" Year="2018">
-      <Id>512ecad0-8681-4ad4-8411-0f74f53b34c7</Id>
+      <Database Name="cv" Series="93179" Issue="662707" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="21" Volume="2016" Year="2018">
-      <Id>2159a898-7137-4bb0-8dd5-36231e69d6cb</Id>
+      <Database Name="cv" Series="93179" Issue="665873" />
     </Book>
     <Book Series="Batgirl and the Birds of Prey" Number="22" Volume="2016" Year="2018">
-      <Id>23ca719d-54b3-4c4d-8d43-817d10f6a0e2</Id>
+      <Database Name="cv" Series="93179" Issue="669422" />
     </Book>
   </Books>
   <Matchers />

--- a/DC/Characters/unsorted/Birds of Prey/Birds of Prey 002 (New52_Rebirth).cbl
+++ b/DC/Characters/unsorted/Birds of Prey/Birds of Prey 002 (New52_Rebirth).cbl
@@ -2,217 +2,217 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Birds of Prey 2 (New52/Rebirth)</Name>
   <Books>
-    <Book Series="Birds of Prey" Number="1" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Birds of Prey" Number="1" Volume="2011" Year="2011">
       <Id>7692160e-4888-4b51-8b84-f2dc41fe9a25</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="2" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Birds of Prey" Number="2" Volume="2011" Year="2011">
       <Id>0206b2ef-3792-4dcf-a12b-b162e98a102c</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="3" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Birds of Prey" Number="3" Volume="2011" Year="2012">
       <Id>88c0ad33-b73b-4183-82d8-16688e8a1857</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="4" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Birds of Prey" Number="4" Volume="2011" Year="2012">
       <Id>588f2dd8-22e8-456e-8f35-acba61d35fcc</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="5" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Birds of Prey" Number="5" Volume="2011" Year="2012">
       <Id>9033dfd9-8860-486b-b278-d0b774714597</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="6" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Birds of Prey" Number="6" Volume="2011" Year="2012">
       <Id>bab2d534-853b-4a8c-945f-efebd8dbc096</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="7" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Birds of Prey" Number="7" Volume="2011" Year="2012">
       <Id>6ff6ef9c-11a5-415a-af61-b2a46f4a9d44</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="8" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Birds of Prey" Number="8" Volume="2011" Year="2012">
       <Id>995b395e-8c08-449e-94d1-979959cc2b08</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="9" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Birds of Prey" Number="9" Volume="2011" Year="2012">
       <Id>1c6611eb-dc6e-4cd3-ab55-76d4bd406181</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="10" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Birds of Prey" Number="10" Volume="2011" Year="2012">
       <Id>803c45fa-220b-42b6-8b6d-0b82841080ae</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="11" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Birds of Prey" Number="11" Volume="2011" Year="2012">
       <Id>be30d390-89cf-4072-a8b1-7c76e9e66aed</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="12" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Birds of Prey" Number="12" Volume="2011" Year="2012">
       <Id>eac173cf-8cdf-4cd7-9011-197f48522de6</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="0" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Birds of Prey" Number="0" Volume="2011" Year="2012">
       <Id>f9b8d0d1-0212-42aa-a3c8-12fe7d335196</Id>
     </Book>
-    <Book Series="Batgirl Annual" Number="1" Volume="2012" Year="2012" Format="Annual">
+    <Book Series="Batgirl Annual" Number="1" Volume="2012" Year="2012">
       <Id>d93a697f-429d-4b07-87b5-fb0b11b144e6</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="13" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Birds of Prey" Number="13" Volume="2011" Year="2012">
       <Id>d144f1e5-88e9-433d-a436-2eb611c78861</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="14" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Birds of Prey" Number="14" Volume="2011" Year="2013">
       <Id>85ece657-8f89-457c-9cec-79b8c5603d30</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="15" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Birds of Prey" Number="15" Volume="2011" Year="2013">
       <Id>2a6d2a4a-b64f-4234-ba17-feae071c8e24</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="16" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Birds of Prey" Number="16" Volume="2011" Year="2013">
       <Id>184f9876-335b-43b8-a6ad-15d8ad891373</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="17" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Birds of Prey" Number="17" Volume="2011" Year="2013">
       <Id>33bd1d64-4d16-4d60-a7fb-e679d07e628a</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="18" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Birds of Prey" Number="18" Volume="2011" Year="2013">
       <Id>db452413-b7f7-441b-8694-1cf79d772219</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="19" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Birds of Prey" Number="19" Volume="2011" Year="2013">
       <Id>3e9b957b-b7ed-488c-8115-820bd3e52463</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="20" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Birds of Prey" Number="20" Volume="2011" Year="2013">
       <Id>d4537145-6201-452b-a7c5-9f504cdc416e</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="21" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Birds of Prey" Number="21" Volume="2011" Year="2013">
       <Id>12ec0705-8f75-43f9-b3bb-5ee34ec19ab8</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="22" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Birds of Prey" Number="22" Volume="2011" Year="2013">
       <Id>9b7cda88-0284-4e26-bf59-3ec1d335f45b</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="23" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Birds of Prey" Number="23" Volume="2011" Year="2013">
       <Id>03165305-0daf-4683-a348-0f72a0f6e19e</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="24" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Birds of Prey" Number="24" Volume="2011" Year="2013">
       <Id>c9a89ce3-1b71-419b-9215-e2277b3f663e</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="25" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Birds of Prey" Number="25" Volume="2011" Year="2014">
       <Id>17194e42-a45a-4a96-a4c1-1405a3228ed9</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="26" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Birds of Prey" Number="26" Volume="2011" Year="2014">
       <Id>4a0cc5e0-eac0-47a4-bb5e-11468d9cfbdc</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="27" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Birds of Prey" Number="27" Volume="2011" Year="2014">
       <Id>22e760c8-9054-459b-bf73-9133c52d7a83</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="28" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Birds of Prey" Number="28" Volume="2011" Year="2014">
       <Id>b79c32f3-41b4-41c5-b28c-8cbca9e5bdde</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="29" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Birds of Prey" Number="29" Volume="2011" Year="2014">
       <Id>dc5f3e4c-7b7a-4a4c-8c51-63f9b72c2a40</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="30" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Birds of Prey" Number="30" Volume="2011" Year="2014">
       <Id>ab2d2fd5-6159-4c5c-98a4-a0e76532788c</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="31" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Birds of Prey" Number="31" Volume="2011" Year="2014">
       <Id>736874f6-1c33-49c5-867f-ccbb57785e6b</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="32" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Birds of Prey" Number="32" Volume="2011" Year="2014">
       <Id>e35aab2b-11c3-419c-9444-a48e78b8c513</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="33" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Birds of Prey" Number="33" Volume="2011" Year="2014">
       <Id>ebac43c0-57a9-4555-bf75-1a82d4969182</Id>
     </Book>
-    <Book Series="Birds of Prey" Number="34" Volume="2011" Year="2014" Format="Main Series">
+    <Book Series="Birds of Prey" Number="34" Volume="2011" Year="2014">
       <Id>847343d5-6b2b-402a-8265-f120c526ac2c</Id>
     </Book>
-    <Book Series="Black Canary" Number="1" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Black Canary" Number="1" Volume="2015" Year="2015">
       <Id>6ca570c7-d043-4a29-a7a5-10ce21ef2717</Id>
     </Book>
-    <Book Series="Black Canary" Number="2" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Black Canary" Number="2" Volume="2015" Year="2015">
       <Id>61ca2766-453a-492f-9524-ce384b1276d2</Id>
     </Book>
-    <Book Series="Black Canary" Number="3" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Black Canary" Number="3" Volume="2015" Year="2015">
       <Id>d3bd34e5-837c-41b7-94fb-6dcfff11fca0</Id>
     </Book>
-    <Book Series="Black Canary" Number="4" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Black Canary" Number="4" Volume="2015" Year="2015">
       <Id>72daa878-e5a1-44d8-a4e0-43404e20cd1f</Id>
     </Book>
-    <Book Series="Black Canary" Number="5" Volume="2015" Year="2015" Format="Main Series">
+    <Book Series="Black Canary" Number="5" Volume="2015" Year="2015">
       <Id>37124f15-708a-48fd-894c-5ee0de9cebda</Id>
     </Book>
-    <Book Series="Black Canary" Number="6" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Black Canary" Number="6" Volume="2015" Year="2016">
       <Id>bd10ae1e-8d12-4c1f-a052-c201b762d34b</Id>
     </Book>
-    <Book Series="Black Canary" Number="7" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Black Canary" Number="7" Volume="2015" Year="2016">
       <Id>c008d360-38a6-45e4-b4c2-cb3280f628ba</Id>
     </Book>
-    <Book Series="Black Canary" Number="8" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Black Canary" Number="8" Volume="2015" Year="2016">
       <Id>471e952c-f86a-41e4-8d48-121b78b80f0e</Id>
     </Book>
-    <Book Series="Black Canary" Number="9" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Black Canary" Number="9" Volume="2015" Year="2016">
       <Id>d4ddfb27-62b9-44cb-bd48-2e60ecc09fcf</Id>
     </Book>
-    <Book Series="Black Canary" Number="10" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Black Canary" Number="10" Volume="2015" Year="2016">
       <Id>ea335019-31c8-4ff1-9096-c2b5f219f638</Id>
     </Book>
-    <Book Series="Black Canary" Number="11" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Black Canary" Number="11" Volume="2015" Year="2016">
       <Id>5f859066-6443-4c9b-824d-f7bbbfeae0d1</Id>
     </Book>
-    <Book Series="Black Canary" Number="12" Volume="2015" Year="2016" Format="Main Series">
+    <Book Series="Black Canary" Number="12" Volume="2015" Year="2016">
       <Id>09b7ab8b-080f-4c8f-9987-c4761d4273a1</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey: Rebirth" Number="1" Volume="2016" Year="2016" Format="One-Shot">
+    <Book Series="Batgirl and the Birds of Prey: Rebirth" Number="1" Volume="2016" Year="2016">
       <Id>4d4319a0-82ee-480a-b37d-cb9ae27f4ec2</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="1" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="1" Volume="2016" Year="2016">
       <Id>aa35299a-9fee-4ab0-9328-0aaca222681f</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="2" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="2" Volume="2016" Year="2016">
       <Id>b4d7d669-9a36-4858-a6fa-4d6e580a5524</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="3" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="3" Volume="2016" Year="2016">
       <Id>dcedf4f8-7357-4956-a5bf-9551c13e1b02</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="4" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="4" Volume="2016" Year="2017">
       <Id>f8b8cb5c-30da-4588-9bfa-e93288a5547c</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="5" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="5" Volume="2016" Year="2017">
       <Id>addce30a-f01d-437d-927e-9525cf7ab83e</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="6" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="6" Volume="2016" Year="2017">
       <Id>ace25f88-dd49-402e-a56e-ca00c55ea067</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="7" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="7" Volume="2016" Year="2017">
       <Id>69fd2336-905b-44e5-a6bd-2a7b1aceaf95</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="8" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="8" Volume="2016" Year="2017">
       <Id>c84bba86-cb04-455c-9e90-91de4910ba4a</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="9" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="9" Volume="2016" Year="2017">
       <Id>c94489bf-02f6-4dfd-8a27-ab2957663d7b</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="10" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="10" Volume="2016" Year="2017">
       <Id>d6e648c3-d7fe-42be-a4ad-25b0f62fd6d4</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="11" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="11" Volume="2016" Year="2017">
       <Id>18a0d5a2-bd2d-48e0-8b8e-992d1532adfc</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="12" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="12" Volume="2016" Year="2017">
       <Id>c11b5691-712a-46ce-8749-2beab724cc23</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="13" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="13" Volume="2016" Year="2017">
       <Id>9e940ad2-ff5a-466f-8dde-d05f9d70d9a7</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="14" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="14" Volume="2016" Year="2017">
       <Id>d671f6b7-8271-445e-aad9-eaa6a5a49aad</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="15" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="15" Volume="2016" Year="2017">
       <Id>62bd4563-4a51-471c-be4e-763a785c359c</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="16" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="16" Volume="2016" Year="2018">
       <Id>46ab6e1a-cb53-48c6-be9c-06e1793fb460</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="17" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="17" Volume="2016" Year="2018">
       <Id>3563ed5d-b10b-46fc-b9a4-83b27a946f41</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="18" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="18" Volume="2016" Year="2018">
       <Id>0a8d729b-72a5-4169-b117-4fe126d890c2</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="19" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="19" Volume="2016" Year="2018">
       <Id>69a4e359-4241-4765-b1cb-720918387867</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="20" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="20" Volume="2016" Year="2018">
       <Id>512ecad0-8681-4ad4-8411-0f74f53b34c7</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="21" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="21" Volume="2016" Year="2018">
       <Id>2159a898-7137-4bb0-8dd5-36231e69d6cb</Id>
     </Book>
-    <Book Series="Batgirl and the Birds of Prey" Number="22" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Batgirl and the Birds of Prey" Number="22" Volume="2016" Year="2018">
       <Id>23ca719d-54b3-4c4d-8d43-817d10f6a0e2</Id>
     </Book>
   </Books>

--- a/DC/Characters/unsorted/Black Lightning/Black Lightning.cbl
+++ b/DC/Characters/unsorted/Black Lightning/Black Lightning.cbl
@@ -2,43 +2,43 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Black Lightning</Name>
   <Books>
-    <Book Series="Black Lightning: Year One" Number="1" Volume="2009" Year="2009" Format="TPB">
+    <Book Series="Black Lightning: Year One" Number="1" Volume="2009" Year="2009">
       <Id>41ab4b46-7f71-4e4a-9580-efa3813b98ad</Id>
     </Book>
-    <Book Series="Black Lightning" Number="1" Volume="2016" Year="2016" Format="TPB">
+    <Book Series="Black Lightning" Number="1" Volume="2016" Year="2016">
       <Id>53abfdbd-02d3-4fc0-81c8-93d0103bd782</Id>
     </Book>
-    <Book Series="Black Lightning" Number="2" Volume="2016" Year="2018" Format="TPB">
+    <Book Series="Black Lightning" Number="2" Volume="2016" Year="2018">
       <Id>86e21e9a-1b44-4a57-95a8-08c16005e581</Id>
     </Book>
-    <Book Series="Batman and the Outsiders" Number="1" Volume="1983" Year="1983" Format="Main Series">
+    <Book Series="Batman and the Outsiders" Number="1" Volume="1983" Year="1983">
       <Id>4ef9b6f1-cffa-4c9e-bd01-399aeba8b212</Id>
     </Book>
-    <Book Series="Batman and the Outsiders" Number="2" Volume="1983" Year="1983" Format="Main Series">
+    <Book Series="Batman and the Outsiders" Number="2" Volume="1983" Year="1983">
       <Id>6f5d830a-3ba1-486e-8ab6-0fe3061ab0f4</Id>
     </Book>
-    <Book Series="Black Lightning: Brick City Blues" Number="1" Volume="2019" Year="2019" Format="TPB">
+    <Book Series="Black Lightning: Brick City Blues" Number="1" Volume="2019" Year="2019">
       <Id>42c0ed49-f65f-4f71-830f-bf46bde09be2</Id>
     </Book>
-    <Book Series="DC Universe Presents: Black Lightning and Blue Devil" Number="1" Volume="2014" Year="2014" Format="TPB">
+    <Book Series="DC Universe Presents: Black Lightning and Blue Devil" Number="1" Volume="2014" Year="2014">
       <Id>3b17fb03-d64a-4133-9c13-2df97495b314</Id>
     </Book>
-    <Book Series="Black Lightning: Cold Dead Hands" Number="1" Volume="2017" Year="2018" Format="Limited Series">
+    <Book Series="Black Lightning: Cold Dead Hands" Number="1" Volume="2017" Year="2018">
       <Id>64ce23ed-52b4-4db9-ad2c-e1845d933319</Id>
     </Book>
-    <Book Series="Black Lightning: Cold Dead Hands" Number="2" Volume="2017" Year="2018" Format="Limited Series">
+    <Book Series="Black Lightning: Cold Dead Hands" Number="2" Volume="2017" Year="2018">
       <Id>270abd43-20fb-4c05-9fb4-c907d3121584</Id>
     </Book>
-    <Book Series="Black Lightning: Cold Dead Hands" Number="3" Volume="2017" Year="2018" Format="Limited Series">
+    <Book Series="Black Lightning: Cold Dead Hands" Number="3" Volume="2017" Year="2018">
       <Id>ff1c967c-ae3d-471c-b56e-8483260a93e4</Id>
     </Book>
-    <Book Series="Black Lightning: Cold Dead Hands" Number="4" Volume="2017" Year="2018" Format="Limited Series">
+    <Book Series="Black Lightning: Cold Dead Hands" Number="4" Volume="2017" Year="2018">
       <Id>6db2e027-b5e9-4eeb-b60a-f305e0c18a4e</Id>
     </Book>
-    <Book Series="Black Lightning: Cold Dead Hands" Number="5" Volume="2017" Year="2018" Format="Limited Series">
+    <Book Series="Black Lightning: Cold Dead Hands" Number="5" Volume="2017" Year="2018">
       <Id>5821e9e4-6958-403d-98a6-db90d657074b</Id>
     </Book>
-    <Book Series="Black Lightning: Cold Dead Hands" Number="6" Volume="2017" Year="2018" Format="Limited Series">
+    <Book Series="Black Lightning: Cold Dead Hands" Number="6" Volume="2017" Year="2018">
       <Id>b3ff7e3d-6c5e-46a2-8062-94e53b23bf63</Id>
     </Book>
   </Books>

--- a/DC/Characters/unsorted/Black Lightning/Black Lightning.cbl
+++ b/DC/Characters/unsorted/Black Lightning/Black Lightning.cbl
@@ -1,45 +1,55 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Black Lightning</Name>
+  <NumIssues>16</NumIssues>
   <Books>
     <Book Series="Black Lightning: Year One" Number="1" Volume="2009" Year="2009">
-      <Id>41ab4b46-7f71-4e4a-9580-efa3813b98ad</Id>
+      <Database Name="cv" Series="25413" Issue="149995" />
     </Book>
     <Book Series="Black Lightning" Number="1" Volume="2016" Year="2016">
-      <Id>53abfdbd-02d3-4fc0-81c8-93d0103bd782</Id>
+      <Database Name="cv" Series="89349" Issue="523220" />
     </Book>
     <Book Series="Black Lightning" Number="2" Volume="2016" Year="2018">
-      <Id>86e21e9a-1b44-4a57-95a8-08c16005e581</Id>
+      <Database Name="cv" Series="89349" Issue="656676" />
     </Book>
     <Book Series="Batman and the Outsiders" Number="1" Volume="1983" Year="1983">
-      <Id>4ef9b6f1-cffa-4c9e-bd01-399aeba8b212</Id>
+      <Database Name="cv" Series="3194" Issue="23330" />
     </Book>
     <Book Series="Batman and the Outsiders" Number="2" Volume="1983" Year="1983">
-      <Id>6f5d830a-3ba1-486e-8ab6-0fe3061ab0f4</Id>
+      <Database Name="cv" Series="3194" Issue="23411" />
     </Book>
     <Book Series="Black Lightning: Brick City Blues" Number="1" Volume="2019" Year="2019">
-      <Id>42c0ed49-f65f-4f71-830f-bf46bde09be2</Id>
+      <Database Name="cv" Series="117198" Issue="701283" />
     </Book>
-    <Book Series="DC Universe Presents: Black Lightning and Blue Devil" Number="1" Volume="2014" Year="2014">
-      <Id>3b17fb03-d64a-4133-9c13-2df97495b314</Id>
+    <Book Series="DC Universe Presents" Number="13" Volume="2011" Year="2012">
+      <Database Name="cv" Series="42885" Issue="362164" />
+    </Book>
+    <Book Series="DC Universe Presents" Number="14" Volume="2011" Year="2013">
+      <Database Name="cv" Series="42885" Issue="369037" />
+    </Book>
+    <Book Series="DC Universe Presents" Number="15" Volume="2011" Year="2013">
+      <Database Name="cv" Series="42885" Issue="373270" />
+    </Book>
+    <Book Series="DC Universe Presents" Number="16" Volume="2011" Year="2013">
+      <Database Name="cv" Series="42885" Issue="381531" />
     </Book>
     <Book Series="Black Lightning: Cold Dead Hands" Number="1" Volume="2017" Year="2018">
-      <Id>64ce23ed-52b4-4db9-ad2c-e1845d933319</Id>
+      <Database Name="cv" Series="105740" Issue="634507" />
     </Book>
     <Book Series="Black Lightning: Cold Dead Hands" Number="2" Volume="2017" Year="2018">
-      <Id>270abd43-20fb-4c05-9fb4-c907d3121584</Id>
+      <Database Name="cv" Series="105740" Issue="644470" />
     </Book>
     <Book Series="Black Lightning: Cold Dead Hands" Number="3" Volume="2017" Year="2018">
-      <Id>ff1c967c-ae3d-471c-b56e-8483260a93e4</Id>
+      <Database Name="cv" Series="105740" Issue="650889" />
     </Book>
     <Book Series="Black Lightning: Cold Dead Hands" Number="4" Volume="2017" Year="2018">
-      <Id>6db2e027-b5e9-4eeb-b60a-f305e0c18a4e</Id>
+      <Database Name="cv" Series="105740" Issue="658691" />
     </Book>
     <Book Series="Black Lightning: Cold Dead Hands" Number="5" Volume="2017" Year="2018">
-      <Id>5821e9e4-6958-403d-98a6-db90d657074b</Id>
+      <Database Name="cv" Series="105740" Issue="662058" />
     </Book>
     <Book Series="Black Lightning: Cold Dead Hands" Number="6" Volume="2017" Year="2018">
-      <Id>b3ff7e3d-6c5e-46a2-8062-94e53b23bf63</Id>
+      <Database Name="cv" Series="105740" Issue="664881" />
     </Book>
   </Books>
   <Matchers />

--- a/DC/Characters/unsorted/Blue Beetle/Blue Beetle 001 - Pre-Crisis.cbl
+++ b/DC/Characters/unsorted/Blue Beetle/Blue Beetle 001 - Pre-Crisis.cbl
@@ -2,43 +2,43 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Blue Beetle 1 - Pre-Crisis</Name>
   <Books>
-    <Book Series="Blue Beetle" Number="1" Volume="1964" Year="1964" Format="TPB">
+    <Book Series="Blue Beetle" Number="1" Volume="1964" Year="1964">
       <Id>b9a5c690-6e99-4108-a906-68e471a797bf</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="50" Volume="1965" Year="1965" Format="Limited Series">
+    <Book Series="Blue Beetle" Number="50" Volume="1965" Year="1965">
       <Id>70f09643-8ba6-4b8a-bbeb-b15b56bd20f1</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="51" Volume="1965" Year="1965" Format="Limited Series">
+    <Book Series="Blue Beetle" Number="51" Volume="1965" Year="1965">
       <Id>fcfc90e5-585f-4d18-abb6-9ea5b42da6f8</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="52" Volume="1965" Year="1965" Format="Limited Series">
+    <Book Series="Blue Beetle" Number="52" Volume="1965" Year="1965">
       <Id>c95d1f8d-3d28-4299-bf09-73f59cc80080</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="53" Volume="1965" Year="1965" Format="Limited Series">
+    <Book Series="Blue Beetle" Number="53" Volume="1965" Year="1965">
       <Id>14af0aa5-0c4d-4443-9556-b292a3f2e88c</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="54" Volume="1965" Year="1966" Format="Limited Series">
+    <Book Series="Blue Beetle" Number="54" Volume="1965" Year="1966">
       <Id>798f797c-4223-442f-84f6-90eff93e87fd</Id>
     </Book>
-    <Book Series="Secret Origins" Number="2" Volume="1986" Year="1986" Format="Main Series">
+    <Book Series="Secret Origins" Number="2" Volume="1986" Year="1986">
       <Id>c668efef-30e7-4673-a213-11173cc948ca</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="1" Volume="1967" Year="1967" Format="Limited Series">
+    <Book Series="Blue Beetle" Number="1" Volume="1967" Year="1967">
       <Id>f6d6a96c-2fd2-4d32-84b2-2b1122bf7971</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="2" Volume="1967" Year="1967" Format="Limited Series">
+    <Book Series="Blue Beetle" Number="2" Volume="1967" Year="1967">
       <Id>021f3cea-581c-4d1d-8397-a5fd3811db6d</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="3" Volume="1967" Year="1967" Format="Limited Series">
+    <Book Series="Blue Beetle" Number="3" Volume="1967" Year="1967">
       <Id>979351a9-712b-4641-a4a8-c81f7f4c91fd</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="4" Volume="1967" Year="1967" Format="Limited Series">
+    <Book Series="Blue Beetle" Number="4" Volume="1967" Year="1967">
       <Id>37ebf3ef-2433-4e7e-8331-cbe413e5cde6</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="5" Volume="1967" Year="1968" Format="Limited Series">
+    <Book Series="Blue Beetle" Number="5" Volume="1967" Year="1968">
       <Id>8a8f1112-132b-45d8-9bc1-0eef30e7a3c5</Id>
     </Book>
-    <Book Series="Crisis on Infinite Earths" Number="1" Volume="2000" Year="2000" Format="TPB">
+    <Book Series="Crisis on Infinite Earths" Number="1" Volume="2000" Year="2000">
       <Id>c0549fd7-dda8-4277-9966-04f15f0317e1</Id>
     </Book>
   </Books>

--- a/DC/Characters/unsorted/Blue Beetle/Blue Beetle 001 - Pre-Crisis.cbl
+++ b/DC/Characters/unsorted/Blue Beetle/Blue Beetle 001 - Pre-Crisis.cbl
@@ -1,45 +1,91 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Blue Beetle 1 - Pre-Crisis</Name>
+  <Name>Blue Beetle 001 - Pre-Crisis</Name>
+  <NumIssues>28</NumIssues>
   <Books>
     <Book Series="Blue Beetle" Number="1" Volume="1964" Year="1964">
-      <Id>b9a5c690-6e99-4108-a906-68e471a797bf</Id>
+      <Database Name="cv" Series="2170" Issue="7125" />
+    </Book>
+    <Book Series="Blue Beetle" Number="2" Volume="1964" Year="1964">
+      <Database Name="cv" Series="2170" Issue="7271" />
+    </Book>
+    <Book Series="Blue Beetle" Number="3" Volume="1964" Year="1964">
+      <Database Name="cv" Series="2170" Issue="7391" />
+    </Book>
+    <Book Series="Blue Beetle" Number="4" Volume="1964" Year="1965">
+      <Database Name="cv" Series="2170" Issue="7520" />
+    </Book>
+    <Book Series="Blue Beetle" Number="5" Volume="1964" Year="1965">
+      <Database Name="cv" Series="2170" Issue="7634" />
     </Book>
     <Book Series="Blue Beetle" Number="50" Volume="1965" Year="1965">
-      <Id>70f09643-8ba6-4b8a-bbeb-b15b56bd20f1</Id>
+      <Database Name="cv" Series="2219" Issue="7861" />
     </Book>
     <Book Series="Blue Beetle" Number="51" Volume="1965" Year="1965">
-      <Id>fcfc90e5-585f-4d18-abb6-9ea5b42da6f8</Id>
+      <Database Name="cv" Series="2219" Issue="7925" />
     </Book>
     <Book Series="Blue Beetle" Number="52" Volume="1965" Year="1965">
-      <Id>c95d1f8d-3d28-4299-bf09-73f59cc80080</Id>
+      <Database Name="cv" Series="2219" Issue="8063" />
     </Book>
     <Book Series="Blue Beetle" Number="53" Volume="1965" Year="1965">
-      <Id>14af0aa5-0c4d-4443-9556-b292a3f2e88c</Id>
+      <Database Name="cv" Series="2219" Issue="8191" />
     </Book>
     <Book Series="Blue Beetle" Number="54" Volume="1965" Year="1966">
-      <Id>798f797c-4223-442f-84f6-90eff93e87fd</Id>
+      <Database Name="cv" Series="2219" Issue="8332" />
     </Book>
     <Book Series="Secret Origins" Number="2" Volume="1986" Year="1986">
-      <Id>c668efef-30e7-4673-a213-11173cc948ca</Id>
+      <Database Name="cv" Series="3616" Issue="26760" />
     </Book>
     <Book Series="Blue Beetle" Number="1" Volume="1967" Year="1967">
-      <Id>f6d6a96c-2fd2-4d32-84b2-2b1122bf7971</Id>
+      <Database Name="cv" Series="2330" Issue="9383" />
     </Book>
     <Book Series="Blue Beetle" Number="2" Volume="1967" Year="1967">
-      <Id>021f3cea-581c-4d1d-8397-a5fd3811db6d</Id>
+      <Database Name="cv" Series="2330" Issue="9513" />
     </Book>
     <Book Series="Blue Beetle" Number="3" Volume="1967" Year="1967">
-      <Id>979351a9-712b-4641-a4a8-c81f7f4c91fd</Id>
+      <Database Name="cv" Series="2330" Issue="9640" />
     </Book>
     <Book Series="Blue Beetle" Number="4" Volume="1967" Year="1967">
-      <Id>37ebf3ef-2433-4e7e-8331-cbe413e5cde6</Id>
+      <Database Name="cv" Series="2330" Issue="9778" />
     </Book>
     <Book Series="Blue Beetle" Number="5" Volume="1967" Year="1968">
-      <Id>8a8f1112-132b-45d8-9bc1-0eef30e7a3c5</Id>
+      <Database Name="cv" Series="2330" Issue="122956" />
     </Book>
-    <Book Series="Crisis on Infinite Earths" Number="1" Volume="2000" Year="2000">
-      <Id>c0549fd7-dda8-4277-9966-04f15f0317e1</Id>
+    <Book Series="Crisis on Infinite Earths" Number="1" Volume="1985" Year="1985">
+      <Database Name="cv" Series="3441" Issue="25335" />
+    </Book>
+    <Book Series="Crisis on Infinite Earths" Number="2" Volume="1985" Year="1985">
+      <Database Name="cv" Series="3441" Issue="25441" />
+    </Book>
+    <Book Series="Crisis on Infinite Earths" Number="3" Volume="1985" Year="1985">
+      <Database Name="cv" Series="3441" Issue="25532" />
+    </Book>
+    <Book Series="Crisis on Infinite Earths" Number="4" Volume="1985" Year="1985">
+      <Database Name="cv" Series="3441" Issue="25638" />
+    </Book>
+    <Book Series="Crisis on Infinite Earths" Number="5" Volume="1985" Year="1985">
+      <Database Name="cv" Series="3441" Issue="25734" />
+    </Book>
+    <Book Series="Crisis on Infinite Earths" Number="6" Volume="1985" Year="1985">
+      <Database Name="cv" Series="3441" Issue="25834" />
+    </Book>
+    <Book Series="Crisis on Infinite Earths" Number="7" Volume="1985" Year="1985">
+      <Database Name="cv" Series="3441" Issue="25926" />
+    </Book>
+    <Book Series="Crisis on Infinite Earths" Number="8" Volume="1985" Year="1985">
+      <Database Name="cv" Series="3441" Issue="26031" />
+    </Book>
+    <Book Series="Crisis on Infinite Earths" Number="9" Volume="1985" Year="1985">
+      <Database Name="cv" Series="3441" Issue="26138" />
+    </Book>
+    <Book Series="Crisis on Infinite Earths" Number="10" Volume="1985" Year="1986">
+      <Database Name="cv" Series="3441" Issue="26347" />
+    </Book>
+    <Book Series="Crisis on Infinite Earths" Number="11" Volume="1985" Year="1986">
+      <Database Name="cv" Series="3441" Issue="26452" />
+    </Book>
+    <Book Series="Crisis on Infinite Earths" Number="12" Volume="1985" Year="1986">
+      <Database Name="cv" Series="3441" Issue="26556" />
     </Book>
   </Books>
   <Matchers />

--- a/DC/Characters/unsorted/Blue Beetle/Blue Beetle 002 - Post Crisis.cbl
+++ b/DC/Characters/unsorted/Blue Beetle/Blue Beetle 002 - Post Crisis.cbl
@@ -1,252 +1,271 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Blue Beetle 2 - Post Crisis</Name>
+  <Name>Blue Beetle 002 - Post Crisis</Name>
+  <NumIssues>88</NumIssues>
   <Books>
     <Book Series="Blue Beetle" Number="1" Volume="1986" Year="1986">
-      <Id>9e349e17-6462-4a17-bdb0-3b0630e80e7e</Id>
+      <Database Name="cv" Series="3595" Issue="26835" />
     </Book>
     <Book Series="Blue Beetle" Number="2" Volume="1986" Year="1986">
-      <Id>04feaba6-0e84-435e-b7d3-931eb02c18f7</Id>
+      <Database Name="cv" Series="3595" Issue="26937" />
     </Book>
     <Book Series="Blue Beetle" Number="3" Volume="1986" Year="1986">
-      <Id>46c4ef89-5201-4c64-b0d0-42d885b38051</Id>
+      <Database Name="cv" Series="3595" Issue="27035" />
     </Book>
     <Book Series="Blue Beetle" Number="4" Volume="1986" Year="1986">
-      <Id>61b8afbb-645f-4383-be5d-90fb4a67e6c1</Id>
+      <Database Name="cv" Series="3595" Issue="27132" />
     </Book>
     <Book Series="Blue Beetle" Number="5" Volume="1986" Year="1986">
-      <Id>d550f390-5dcd-493d-927f-cb7402209ffd</Id>
+      <Database Name="cv" Series="3595" Issue="27223" />
     </Book>
     <Book Series="Blue Beetle" Number="6" Volume="1986" Year="1986">
-      <Id>9f2e0e60-10a1-4456-abf6-f77582e7575b</Id>
+      <Database Name="cv" Series="3595" Issue="27329" />
     </Book>
     <Book Series="Blue Beetle" Number="7" Volume="1986" Year="1986">
-      <Id>4c1cfdc7-13f0-4663-8fdf-d094a0a40823</Id>
+      <Database Name="cv" Series="3595" Issue="27434" />
     </Book>
     <Book Series="Blue Beetle" Number="8" Volume="1986" Year="1987">
-      <Id>686df0bf-47ff-4312-b93e-86cab94df87c</Id>
+      <Database Name="cv" Series="3595" Issue="27627" />
     </Book>
     <Book Series="Blue Beetle" Number="9" Volume="1986" Year="1987">
-      <Id>d0c8ad97-0745-46c5-8b0f-bfa359c79f89</Id>
+      <Database Name="cv" Series="3595" Issue="27734" />
     </Book>
     <Book Series="Blue Beetle" Number="10" Volume="1986" Year="1987">
-      <Id>13bf47e2-72d4-4da1-bec0-751099a65fd3</Id>
+      <Database Name="cv" Series="3595" Issue="27843" />
     </Book>
     <Book Series="Blue Beetle" Number="11" Volume="1986" Year="1987">
-      <Id>d9ddb600-4319-4019-9fa7-80879c037d57</Id>
+      <Database Name="cv" Series="3595" Issue="27952" />
     </Book>
     <Book Series="Blue Beetle" Number="12" Volume="1986" Year="1987">
-      <Id>1cdddb00-a2e8-4c11-bd07-20e37d93958a</Id>
+      <Database Name="cv" Series="3595" Issue="28067" />
     </Book>
     <Book Series="Blue Beetle" Number="13" Volume="1986" Year="1987">
-      <Id>e71ec09e-4fed-47ad-81d4-f24772d803af</Id>
+      <Database Name="cv" Series="3595" Issue="28166" />
     </Book>
     <Book Series="Blue Beetle" Number="14" Volume="1986" Year="1987">
-      <Id>8ef28fc0-acee-4fbf-9fb8-2a36c1c8a93f</Id>
+      <Database Name="cv" Series="3595" Issue="28278" />
     </Book>
     <Book Series="Blue Beetle" Number="15" Volume="1986" Year="1987">
-      <Id>df0c91f0-0358-485c-bc8f-1cc91ed6cb32</Id>
+      <Database Name="cv" Series="3595" Issue="28401" />
     </Book>
-    <Book Series="Justice League International" Number="1" Volume="1988" Year="2009">
-      <Id>084472c7-bfac-4e72-8f8b-a645ab4ca8cf</Id>
+    <Book Series="Justice League" Number="1" Volume="1987" Year="1987">
+      <Database Name="cv" Series="3796" Issue="105729" />
     </Book>
     <Book Series="Blue Beetle" Number="16" Volume="1986" Year="1987">
-      <Id>46c19433-c35b-4bfb-8705-532533bf6f93</Id>
+      <Database Name="cv" Series="3595" Issue="28508" />
     </Book>
     <Book Series="Blue Beetle" Number="17" Volume="1986" Year="1987">
-      <Id>ac90d9f3-7b05-486e-9bbd-7ef35dcf78a0</Id>
+      <Database Name="cv" Series="3595" Issue="28625" />
     </Book>
     <Book Series="Blue Beetle" Number="18" Volume="1986" Year="1987">
-      <Id>8f26c74d-e053-4a52-8e2d-fe3c0982f2d2</Id>
+      <Database Name="cv" Series="3595" Issue="28742" />
     </Book>
     <Book Series="Blue Beetle" Number="19" Volume="1986" Year="1987">
-      <Id>094ea602-ec3a-4669-92f6-21b736eeebe5</Id>
+      <Database Name="cv" Series="3595" Issue="28863" />
     </Book>
     <Book Series="Blue Beetle" Number="20" Volume="1986" Year="1988">
-      <Id>371cabc9-dfdd-4182-9d11-cd0e63e3d4e3</Id>
+      <Database Name="cv" Series="3595" Issue="29081" />
     </Book>
     <Book Series="Blue Beetle" Number="21" Volume="1986" Year="1988">
-      <Id>3b3672c0-f7b1-4a30-97d2-2329a57f5add</Id>
+      <Database Name="cv" Series="3595" Issue="29200" />
     </Book>
     <Book Series="Blue Beetle" Number="22" Volume="1986" Year="1988">
-      <Id>f9d06034-7a2c-41bc-ae68-fbef4dec0780</Id>
+      <Database Name="cv" Series="3595" Issue="29312" />
     </Book>
     <Book Series="Blue Beetle" Number="23" Volume="1986" Year="1988">
-      <Id>dfe1b138-12fb-4c88-96cb-bfc4a7fd3223</Id>
+      <Database Name="cv" Series="3595" Issue="29428" />
     </Book>
     <Book Series="Blue Beetle" Number="24" Volume="1986" Year="1988">
-      <Id>331213b1-1203-434d-a9a5-02a5796ac270</Id>
+      <Database Name="cv" Series="3595" Issue="29531" />
     </Book>
-    <Book Series="Justice League International" Number="2" Volume="1988" Year="2009">
-      <Id>318ee8dd-a125-4717-abdf-0d257de73b5c</Id>
+    <Book Series="Justice League International" Number="2" Volume="1987" Year="1987">
+      <Database Name="cv" Series="3796" Issue="28244" />
     </Book>
-    <Book Series="Justice League International" Number="3" Volume="1988" Year="2009">
-      <Id>30f42965-18ec-4096-ae1f-8475db67bbb7</Id>
+    <Book Series="Justice League International" Number="3" Volume="1987" Year="1987">
+      <Database Name="cv" Series="3796" Issue="28362" />
     </Book>
-    <Book Series="Justice League International" Number="4" Volume="1988" Year="2010">
-      <Id>c37e5bc3-dfaf-48f6-b78a-65f3be305e44</Id>
+    <Book Series="Justice League International" Number="4" Volume="1987" Year="1987">
+      <Database Name="cv" Series="3796" Issue="28476" />
     </Book>
-    <Book Series="Justice League International" Number="5" Volume="1988" Year="2011">
-      <Id>7eada596-7cca-4ae4-8c10-693f356308d3</Id>
+    <Book Series="Justice League International" Number="5" Volume="1987" Year="1987">
+      <Database Name="cv" Series="3796" Issue="28587" />
     </Book>
-    <Book Series="Justice League International" Number="6" Volume="1988" Year="2011">
-      <Id>26d247d7-2efc-48af-9bdc-742cc2866956</Id>
+    <Book Series="Justice League International" Number="6" Volume="1987" Year="1987">
+      <Database Name="cv" Series="3796" Issue="28709" />
     </Book>
     <Book Series="Formerly Known as the Justice League" Number="1" Volume="2003" Year="2003">
-      <Id>5139b613-d20b-4395-9d93-924ea6b7169c</Id>
+      <Database Name="cv" Series="10767" Issue="91418" />
     </Book>
     <Book Series="Formerly Known as the Justice League" Number="2" Volume="2003" Year="2003">
-      <Id>1567463d-aa91-4813-ba56-ed00e22da2c3</Id>
+      <Database Name="cv" Series="10767" Issue="91419" />
     </Book>
     <Book Series="Formerly Known as the Justice League" Number="3" Volume="2003" Year="2003">
-      <Id>5b98d479-839d-4ce0-8402-d0366b6c6906</Id>
+      <Database Name="cv" Series="10767" Issue="91420" />
     </Book>
     <Book Series="Formerly Known as the Justice League" Number="4" Volume="2003" Year="2003">
-      <Id>f61e34ce-a490-47a6-a37c-caad5cbc8fc8</Id>
+      <Database Name="cv" Series="10767" Issue="91421" />
     </Book>
     <Book Series="Formerly Known as the Justice League" Number="5" Volume="2003" Year="2004">
-      <Id>0b71259e-0117-4e49-a4a8-e1f505d0e16d</Id>
+      <Database Name="cv" Series="10767" Issue="91422" />
     </Book>
     <Book Series="Formerly Known as the Justice League" Number="6" Volume="2003" Year="2004">
-      <Id>0cd9fa38-6223-4cb6-a1a9-ceed16199cda</Id>
+      <Database Name="cv" Series="10767" Issue="91423" />
     </Book>
-    <Book Series="Infinite Crisis" Number="1" Volume="2006" Year="2006">
-      <Id>33d910d7-9baa-4fd8-af52-b79ef30e6844</Id>
+    <Book Series="Infinite Crisis" Number="1" Volume="2005" Year="2005">
+      <Database Name="cv" Series="17983" Issue="105305" />
+    </Book>
+    <Book Series="Infinite Crisis" Number="2" Volume="2005" Year="2006">
+      <Database Name="cv" Series="17983" Issue="107877" />
+    </Book>
+    <Book Series="Infinite Crisis" Number="3" Volume="2005" Year="2006">
+      <Database Name="cv" Series="17983" Issue="107881" />
+    </Book>
+    <Book Series="Infinite Crisis" Number="4" Volume="2005" Year="2006">
+      <Database Name="cv" Series="17983" Issue="105306" />
+    </Book>
+    <Book Series="Infinite Crisis" Number="5" Volume="2005" Year="2006">
+      <Database Name="cv" Series="17983" Issue="122050" />
+    </Book>
+    <Book Series="Infinite Crisis" Number="6" Volume="2005" Year="2006">
+      <Database Name="cv" Series="17983" Issue="122054" />
+    </Book>
+    <Book Series="Infinite Crisis" Number="7" Volume="2005" Year="2006">
+      <Database Name="cv" Series="17983" Issue="121466" />
     </Book>
     <Book Series="Blue Beetle" Number="1" Volume="2006" Year="2006">
-      <Id>93332632-7655-4ab0-a3bb-f9d2c0a3b183</Id>
+      <Database Name="cv" Series="18443" Issue="111271" />
     </Book>
     <Book Series="Blue Beetle" Number="2" Volume="2006" Year="2006">
-      <Id>93e7a7a3-4294-40c4-8576-8ea152c83257</Id>
+      <Database Name="cv" Series="18443" Issue="112201" />
     </Book>
     <Book Series="Blue Beetle" Number="3" Volume="2006" Year="2006">
-      <Id>6ac07ab4-4a30-41c4-be6d-25c25371261e</Id>
+      <Database Name="cv" Series="18443" Issue="112204" />
     </Book>
     <Book Series="Blue Beetle" Number="4" Volume="2006" Year="2006">
-      <Id>99a3eee3-2043-4c79-a354-f4cd65a00c81</Id>
+      <Database Name="cv" Series="18443" Issue="112205" />
     </Book>
     <Book Series="Blue Beetle" Number="5" Volume="2006" Year="2006">
-      <Id>ac694450-50fc-4a17-bc10-e7bda7f57015</Id>
+      <Database Name="cv" Series="18443" Issue="112206" />
     </Book>
     <Book Series="Blue Beetle" Number="6" Volume="2006" Year="2006">
-      <Id>97170320-2c65-49af-98b6-381059f855e8</Id>
+      <Database Name="cv" Series="18443" Issue="108238" />
     </Book>
     <Book Series="Blue Beetle" Number="7" Volume="2006" Year="2006">
-      <Id>d52f5f6f-ecfa-4c15-a3fa-60a1a2b5bc98</Id>
+      <Database Name="cv" Series="18443" Issue="112211" />
     </Book>
     <Book Series="Blue Beetle" Number="8" Volume="2006" Year="2006">
-      <Id>bee1f9c6-83eb-421a-b938-37de8c5b059b</Id>
+      <Database Name="cv" Series="18443" Issue="112225" />
     </Book>
     <Book Series="Blue Beetle" Number="9" Volume="2006" Year="2007">
-      <Id>b4ebe4b2-bb33-4215-ac5b-bafa2f5e750b</Id>
+      <Database Name="cv" Series="18443" Issue="112663" />
     </Book>
     <Book Series="Blue Beetle" Number="10" Volume="2006" Year="2007">
-      <Id>8afb6e28-9e8b-46be-960e-d282b27efccb</Id>
+      <Database Name="cv" Series="18443" Issue="112226" />
     </Book>
     <Book Series="Blue Beetle" Number="11" Volume="2006" Year="2007">
-      <Id>f6c21b7c-8a2a-4ef1-9438-abff1f90a4bd</Id>
+      <Database Name="cv" Series="18443" Issue="112227" />
     </Book>
     <Book Series="Blue Beetle" Number="12" Volume="2006" Year="2007">
-      <Id>06c4dfcf-fb99-4aae-948a-90509dd8d1e7</Id>
+      <Database Name="cv" Series="18443" Issue="112228" />
     </Book>
     <Book Series="Blue Beetle" Number="13" Volume="2006" Year="2007">
-      <Id>203f1dc8-3f0b-4123-b552-c48bdfebb38b</Id>
+      <Database Name="cv" Series="18443" Issue="112668" />
     </Book>
     <Book Series="Blue Beetle" Number="14" Volume="2006" Year="2007">
-      <Id>657f7d30-614f-4aab-b990-a52f7e209e28</Id>
+      <Database Name="cv" Series="18443" Issue="112666" />
     </Book>
     <Book Series="Blue Beetle" Number="15" Volume="2006" Year="2007">
-      <Id>4a90c8b1-4549-48b2-94a9-ff1edf2c32ec</Id>
+      <Database Name="cv" Series="18443" Issue="112229" />
     </Book>
     <Book Series="Blue Beetle" Number="16" Volume="2006" Year="2007">
-      <Id>bfb12e9e-73dc-406f-90e7-3221d8c276a1</Id>
+      <Database Name="cv" Series="18443" Issue="112230" />
     </Book>
     <Book Series="Blue Beetle" Number="17" Volume="2006" Year="2007">
-      <Id>4fc2cf55-b252-42d2-8be4-ece1ef289cfb</Id>
+      <Database Name="cv" Series="18443" Issue="112142" />
     </Book>
     <Book Series="Blue Beetle" Number="18" Volume="2006" Year="2007">
-      <Id>71ec6d7f-67f7-4796-9edf-2b7b9860d9d2</Id>
+      <Database Name="cv" Series="18443" Issue="114370" />
     </Book>
     <Book Series="Blue Beetle" Number="19" Volume="2006" Year="2007">
-      <Id>0304cb5c-4788-4bc0-80e9-b776a81873be</Id>
+      <Database Name="cv" Series="18443" Issue="115089" />
     </Book>
     <Book Series="Blue Beetle" Number="20" Volume="2006" Year="2007">
-      <Id>b00f39c4-e466-4ee9-b6f1-8bfcfdd68e4d</Id>
+      <Database Name="cv" Series="18443" Issue="120427" />
     </Book>
     <Book Series="Blue Beetle" Number="21" Volume="2006" Year="2008">
-      <Id>9f9fcbba-bc92-45e4-85cf-cb17d450bfc0</Id>
+      <Database Name="cv" Series="18443" Issue="120254" />
     </Book>
     <Book Series="Blue Beetle" Number="22" Volume="2006" Year="2008">
-      <Id>e19afce7-1f8b-467a-ac8e-4db9bc3d27c4</Id>
+      <Database Name="cv" Series="18443" Issue="121487" />
     </Book>
     <Book Series="Blue Beetle" Number="23" Volume="2006" Year="2008">
-      <Id>d2d20729-9ab4-4313-ad51-dc8f4664db53</Id>
+      <Database Name="cv" Series="18443" Issue="126244" />
     </Book>
     <Book Series="Blue Beetle" Number="24" Volume="2006" Year="2008">
-      <Id>bb0047cf-0319-45ac-b641-9e452aad1ff5</Id>
+      <Database Name="cv" Series="18443" Issue="125749" />
     </Book>
     <Book Series="Blue Beetle" Number="25" Volume="2006" Year="2008">
-      <Id>fe55cca3-6401-4651-a90c-c63c88bf1150</Id>
+      <Database Name="cv" Series="18443" Issue="125995" />
     </Book>
     <Book Series="Blue Beetle" Number="26" Volume="2006" Year="2008">
-      <Id>5ae43c16-5882-4644-aa47-eec3295effa4</Id>
+      <Database Name="cv" Series="18443" Issue="129106" />
     </Book>
     <Book Series="Blue Beetle" Number="27" Volume="2006" Year="2008">
-      <Id>62527823-8431-4590-9c0e-cdd6b653524d</Id>
+      <Database Name="cv" Series="18443" Issue="133109" />
     </Book>
     <Book Series="Blue Beetle" Number="28" Volume="2006" Year="2008">
-      <Id>bfa37dd9-4d76-46b7-bdb8-bb34fda6ccf3</Id>
+      <Database Name="cv" Series="18443" Issue="133136" />
     </Book>
     <Book Series="Blue Beetle" Number="29" Volume="2006" Year="2008">
-      <Id>dabe14c0-4607-409d-88a0-37a7976e36a4</Id>
+      <Database Name="cv" Series="18443" Issue="134988" />
     </Book>
     <Book Series="Blue Beetle" Number="30" Volume="2006" Year="2008">
-      <Id>6bfa7553-8b0d-46e1-94d0-2eac6b3ea33d</Id>
+      <Database Name="cv" Series="18443" Issue="138677" />
     </Book>
     <Book Series="Blue Beetle" Number="31" Volume="2006" Year="2008">
-      <Id>cb7eb34b-e7c5-4d10-b6fa-478904e9c48f</Id>
+      <Database Name="cv" Series="18443" Issue="139412" />
     </Book>
     <Book Series="Blue Beetle" Number="32" Volume="2006" Year="2008">
-      <Id>e0ea8038-4d8e-400e-8831-5fefe2f15cca</Id>
+      <Database Name="cv" Series="18443" Issue="141461" />
     </Book>
     <Book Series="Blue Beetle" Number="33" Volume="2006" Year="2009">
-      <Id>86975a2a-dc82-496b-b72c-fc9086e1ccd7</Id>
+      <Database Name="cv" Series="18443" Issue="143504" />
     </Book>
     <Book Series="Blue Beetle" Number="34" Volume="2006" Year="2009">
-      <Id>4fd3b12a-1c51-4a89-87f3-0a7067bdacc2</Id>
+      <Database Name="cv" Series="18443" Issue="149766" />
     </Book>
     <Book Series="Blue Beetle" Number="35" Volume="2006" Year="2009">
-      <Id>4e97adcd-0398-4b7e-a2a4-6b33ea175708</Id>
+      <Database Name="cv" Series="18443" Issue="151373" />
     </Book>
     <Book Series="Blue Beetle" Number="36" Volume="2006" Year="2009">
-      <Id>d1d5fb64-b9fc-429d-bd4a-96c597a8727a</Id>
+      <Database Name="cv" Series="18443" Issue="152823" />
     </Book>
     <Book Series="Booster Gold" Number="21" Volume="2007" Year="2009">
-      <Id>acbe4b40-c0b6-49da-8ba6-5df783198bb5</Id>
+      <Database Name="cv" Series="19025" Issue="159848" />
     </Book>
     <Book Series="Booster Gold" Number="22" Volume="2007" Year="2009">
-      <Id>82abd577-525a-4aea-95f0-7585997ec225</Id>
+      <Database Name="cv" Series="19025" Issue="163283" />
     </Book>
     <Book Series="Booster Gold" Number="23" Volume="2007" Year="2009">
-      <Id>af57ba89-d3e7-4c03-8b2d-f7e90475794f</Id>
+      <Database Name="cv" Series="19025" Issue="166826" />
     </Book>
     <Book Series="Booster Gold" Number="24" Volume="2007" Year="2009">
-      <Id>cbef1537-7f38-481a-96a9-89ee7a3a3447</Id>
+      <Database Name="cv" Series="19025" Issue="170391" />
     </Book>
     <Book Series="Booster Gold" Number="25" Volume="2007" Year="2009">
-      <Id>6b9e899c-b8b2-4950-b462-c8d6aec3a63b</Id>
+      <Database Name="cv" Series="19025" Issue="176019" />
     </Book>
     <Book Series="Booster Gold" Number="26" Volume="2007" Year="2010">
-      <Id>1af4c5a9-cb47-4d27-8c54-3498dd0a7102</Id>
+      <Database Name="cv" Series="19025" Issue="182940" />
     </Book>
     <Book Series="Booster Gold" Number="27" Volume="2007" Year="2010">
-      <Id>a0276d22-f15b-4aea-8c37-e87c8e7551f4</Id>
+      <Database Name="cv" Series="19025" Issue="186736" />
     </Book>
     <Book Series="Booster Gold" Number="28" Volume="2007" Year="2010">
-      <Id>9e7cd434-1379-499c-979b-c2d393b36cd3</Id>
+      <Database Name="cv" Series="19025" Issue="192765" />
     </Book>
     <Book Series="Booster Gold" Number="29" Volume="2007" Year="2010">
-      <Id>ebbe8a08-47b9-422d-b1d4-ffc52172c264</Id>
+      <Database Name="cv" Series="19025" Issue="196777" />
     </Book>
   </Books>
   <Matchers />

--- a/DC/Characters/unsorted/Blue Beetle/Blue Beetle 002 - Post Crisis.cbl
+++ b/DC/Characters/unsorted/Blue Beetle/Blue Beetle 002 - Post Crisis.cbl
@@ -2,250 +2,250 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Blue Beetle 2 - Post Crisis</Name>
   <Books>
-    <Book Series="Blue Beetle" Number="1" Volume="1986" Year="1986" Format="Main Series">
+    <Book Series="Blue Beetle" Number="1" Volume="1986" Year="1986">
       <Id>9e349e17-6462-4a17-bdb0-3b0630e80e7e</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="2" Volume="1986" Year="1986" Format="Main Series">
+    <Book Series="Blue Beetle" Number="2" Volume="1986" Year="1986">
       <Id>04feaba6-0e84-435e-b7d3-931eb02c18f7</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="3" Volume="1986" Year="1986" Format="Main Series">
+    <Book Series="Blue Beetle" Number="3" Volume="1986" Year="1986">
       <Id>46c4ef89-5201-4c64-b0d0-42d885b38051</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="4" Volume="1986" Year="1986" Format="Main Series">
+    <Book Series="Blue Beetle" Number="4" Volume="1986" Year="1986">
       <Id>61b8afbb-645f-4383-be5d-90fb4a67e6c1</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="5" Volume="1986" Year="1986" Format="Main Series">
+    <Book Series="Blue Beetle" Number="5" Volume="1986" Year="1986">
       <Id>d550f390-5dcd-493d-927f-cb7402209ffd</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="6" Volume="1986" Year="1986" Format="Main Series">
+    <Book Series="Blue Beetle" Number="6" Volume="1986" Year="1986">
       <Id>9f2e0e60-10a1-4456-abf6-f77582e7575b</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="7" Volume="1986" Year="1986" Format="Main Series">
+    <Book Series="Blue Beetle" Number="7" Volume="1986" Year="1986">
       <Id>4c1cfdc7-13f0-4663-8fdf-d094a0a40823</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="8" Volume="1986" Year="1987" Format="Main Series">
+    <Book Series="Blue Beetle" Number="8" Volume="1986" Year="1987">
       <Id>686df0bf-47ff-4312-b93e-86cab94df87c</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="9" Volume="1986" Year="1987" Format="Main Series">
+    <Book Series="Blue Beetle" Number="9" Volume="1986" Year="1987">
       <Id>d0c8ad97-0745-46c5-8b0f-bfa359c79f89</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="10" Volume="1986" Year="1987" Format="Main Series">
+    <Book Series="Blue Beetle" Number="10" Volume="1986" Year="1987">
       <Id>13bf47e2-72d4-4da1-bec0-751099a65fd3</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="11" Volume="1986" Year="1987" Format="Main Series">
+    <Book Series="Blue Beetle" Number="11" Volume="1986" Year="1987">
       <Id>d9ddb600-4319-4019-9fa7-80879c037d57</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="12" Volume="1986" Year="1987" Format="Main Series">
+    <Book Series="Blue Beetle" Number="12" Volume="1986" Year="1987">
       <Id>1cdddb00-a2e8-4c11-bd07-20e37d93958a</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="13" Volume="1986" Year="1987" Format="Main Series">
+    <Book Series="Blue Beetle" Number="13" Volume="1986" Year="1987">
       <Id>e71ec09e-4fed-47ad-81d4-f24772d803af</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="14" Volume="1986" Year="1987" Format="Main Series">
+    <Book Series="Blue Beetle" Number="14" Volume="1986" Year="1987">
       <Id>8ef28fc0-acee-4fbf-9fb8-2a36c1c8a93f</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="15" Volume="1986" Year="1987" Format="Main Series">
+    <Book Series="Blue Beetle" Number="15" Volume="1986" Year="1987">
       <Id>df0c91f0-0358-485c-bc8f-1cc91ed6cb32</Id>
     </Book>
-    <Book Series="Justice League International" Number="1" Volume="1988" Year="2009" Format="TPB">
+    <Book Series="Justice League International" Number="1" Volume="1988" Year="2009">
       <Id>084472c7-bfac-4e72-8f8b-a645ab4ca8cf</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="16" Volume="1986" Year="1987" Format="Main Series">
+    <Book Series="Blue Beetle" Number="16" Volume="1986" Year="1987">
       <Id>46c19433-c35b-4bfb-8705-532533bf6f93</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="17" Volume="1986" Year="1987" Format="Main Series">
+    <Book Series="Blue Beetle" Number="17" Volume="1986" Year="1987">
       <Id>ac90d9f3-7b05-486e-9bbd-7ef35dcf78a0</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="18" Volume="1986" Year="1987" Format="Main Series">
+    <Book Series="Blue Beetle" Number="18" Volume="1986" Year="1987">
       <Id>8f26c74d-e053-4a52-8e2d-fe3c0982f2d2</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="19" Volume="1986" Year="1987" Format="Main Series">
+    <Book Series="Blue Beetle" Number="19" Volume="1986" Year="1987">
       <Id>094ea602-ec3a-4669-92f6-21b736eeebe5</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="20" Volume="1986" Year="1988" Format="Main Series">
+    <Book Series="Blue Beetle" Number="20" Volume="1986" Year="1988">
       <Id>371cabc9-dfdd-4182-9d11-cd0e63e3d4e3</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="21" Volume="1986" Year="1988" Format="Main Series">
+    <Book Series="Blue Beetle" Number="21" Volume="1986" Year="1988">
       <Id>3b3672c0-f7b1-4a30-97d2-2329a57f5add</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="22" Volume="1986" Year="1988" Format="Main Series">
+    <Book Series="Blue Beetle" Number="22" Volume="1986" Year="1988">
       <Id>f9d06034-7a2c-41bc-ae68-fbef4dec0780</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="23" Volume="1986" Year="1988" Format="Main Series">
+    <Book Series="Blue Beetle" Number="23" Volume="1986" Year="1988">
       <Id>dfe1b138-12fb-4c88-96cb-bfc4a7fd3223</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="24" Volume="1986" Year="1988" Format="Main Series">
+    <Book Series="Blue Beetle" Number="24" Volume="1986" Year="1988">
       <Id>331213b1-1203-434d-a9a5-02a5796ac270</Id>
     </Book>
-    <Book Series="Justice League International" Number="2" Volume="1988" Year="2009" Format="TPB">
+    <Book Series="Justice League International" Number="2" Volume="1988" Year="2009">
       <Id>318ee8dd-a125-4717-abdf-0d257de73b5c</Id>
     </Book>
-    <Book Series="Justice League International" Number="3" Volume="1988" Year="2009" Format="TPB">
+    <Book Series="Justice League International" Number="3" Volume="1988" Year="2009">
       <Id>30f42965-18ec-4096-ae1f-8475db67bbb7</Id>
     </Book>
-    <Book Series="Justice League International" Number="4" Volume="1988" Year="2010" Format="TPB">
+    <Book Series="Justice League International" Number="4" Volume="1988" Year="2010">
       <Id>c37e5bc3-dfaf-48f6-b78a-65f3be305e44</Id>
     </Book>
-    <Book Series="Justice League International" Number="5" Volume="1988" Year="2011" Format="TPB">
+    <Book Series="Justice League International" Number="5" Volume="1988" Year="2011">
       <Id>7eada596-7cca-4ae4-8c10-693f356308d3</Id>
     </Book>
-    <Book Series="Justice League International" Number="6" Volume="1988" Year="2011" Format="TPB">
+    <Book Series="Justice League International" Number="6" Volume="1988" Year="2011">
       <Id>26d247d7-2efc-48af-9bdc-742cc2866956</Id>
     </Book>
-    <Book Series="Formerly Known as the Justice League" Number="1" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Formerly Known as the Justice League" Number="1" Volume="2003" Year="2003">
       <Id>5139b613-d20b-4395-9d93-924ea6b7169c</Id>
     </Book>
-    <Book Series="Formerly Known as the Justice League" Number="2" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Formerly Known as the Justice League" Number="2" Volume="2003" Year="2003">
       <Id>1567463d-aa91-4813-ba56-ed00e22da2c3</Id>
     </Book>
-    <Book Series="Formerly Known as the Justice League" Number="3" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Formerly Known as the Justice League" Number="3" Volume="2003" Year="2003">
       <Id>5b98d479-839d-4ce0-8402-d0366b6c6906</Id>
     </Book>
-    <Book Series="Formerly Known as the Justice League" Number="4" Volume="2003" Year="2003" Format="Limited Series">
+    <Book Series="Formerly Known as the Justice League" Number="4" Volume="2003" Year="2003">
       <Id>f61e34ce-a490-47a6-a37c-caad5cbc8fc8</Id>
     </Book>
-    <Book Series="Formerly Known as the Justice League" Number="5" Volume="2003" Year="2004" Format="Limited Series">
+    <Book Series="Formerly Known as the Justice League" Number="5" Volume="2003" Year="2004">
       <Id>0b71259e-0117-4e49-a4a8-e1f505d0e16d</Id>
     </Book>
-    <Book Series="Formerly Known as the Justice League" Number="6" Volume="2003" Year="2004" Format="Limited Series">
+    <Book Series="Formerly Known as the Justice League" Number="6" Volume="2003" Year="2004">
       <Id>0cd9fa38-6223-4cb6-a1a9-ceed16199cda</Id>
     </Book>
-    <Book Series="Infinite Crisis" Number="1" Volume="2006" Year="2006" Format="TPB">
+    <Book Series="Infinite Crisis" Number="1" Volume="2006" Year="2006">
       <Id>33d910d7-9baa-4fd8-af52-b79ef30e6844</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="1" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="Blue Beetle" Number="1" Volume="2006" Year="2006">
       <Id>93332632-7655-4ab0-a3bb-f9d2c0a3b183</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="2" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="Blue Beetle" Number="2" Volume="2006" Year="2006">
       <Id>93e7a7a3-4294-40c4-8576-8ea152c83257</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="3" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="Blue Beetle" Number="3" Volume="2006" Year="2006">
       <Id>6ac07ab4-4a30-41c4-be6d-25c25371261e</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="4" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="Blue Beetle" Number="4" Volume="2006" Year="2006">
       <Id>99a3eee3-2043-4c79-a354-f4cd65a00c81</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="5" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="Blue Beetle" Number="5" Volume="2006" Year="2006">
       <Id>ac694450-50fc-4a17-bc10-e7bda7f57015</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="6" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="Blue Beetle" Number="6" Volume="2006" Year="2006">
       <Id>97170320-2c65-49af-98b6-381059f855e8</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="7" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="Blue Beetle" Number="7" Volume="2006" Year="2006">
       <Id>d52f5f6f-ecfa-4c15-a3fa-60a1a2b5bc98</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="8" Volume="2006" Year="2006" Format="Main Series">
+    <Book Series="Blue Beetle" Number="8" Volume="2006" Year="2006">
       <Id>bee1f9c6-83eb-421a-b938-37de8c5b059b</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="9" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Blue Beetle" Number="9" Volume="2006" Year="2007">
       <Id>b4ebe4b2-bb33-4215-ac5b-bafa2f5e750b</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="10" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Blue Beetle" Number="10" Volume="2006" Year="2007">
       <Id>8afb6e28-9e8b-46be-960e-d282b27efccb</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="11" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Blue Beetle" Number="11" Volume="2006" Year="2007">
       <Id>f6c21b7c-8a2a-4ef1-9438-abff1f90a4bd</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="12" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Blue Beetle" Number="12" Volume="2006" Year="2007">
       <Id>06c4dfcf-fb99-4aae-948a-90509dd8d1e7</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="13" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Blue Beetle" Number="13" Volume="2006" Year="2007">
       <Id>203f1dc8-3f0b-4123-b552-c48bdfebb38b</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="14" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Blue Beetle" Number="14" Volume="2006" Year="2007">
       <Id>657f7d30-614f-4aab-b990-a52f7e209e28</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="15" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Blue Beetle" Number="15" Volume="2006" Year="2007">
       <Id>4a90c8b1-4549-48b2-94a9-ff1edf2c32ec</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="16" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Blue Beetle" Number="16" Volume="2006" Year="2007">
       <Id>bfb12e9e-73dc-406f-90e7-3221d8c276a1</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="17" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Blue Beetle" Number="17" Volume="2006" Year="2007">
       <Id>4fc2cf55-b252-42d2-8be4-ece1ef289cfb</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="18" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Blue Beetle" Number="18" Volume="2006" Year="2007">
       <Id>71ec6d7f-67f7-4796-9edf-2b7b9860d9d2</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="19" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Blue Beetle" Number="19" Volume="2006" Year="2007">
       <Id>0304cb5c-4788-4bc0-80e9-b776a81873be</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="20" Volume="2006" Year="2007" Format="Main Series">
+    <Book Series="Blue Beetle" Number="20" Volume="2006" Year="2007">
       <Id>b00f39c4-e466-4ee9-b6f1-8bfcfdd68e4d</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="21" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Blue Beetle" Number="21" Volume="2006" Year="2008">
       <Id>9f9fcbba-bc92-45e4-85cf-cb17d450bfc0</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="22" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Blue Beetle" Number="22" Volume="2006" Year="2008">
       <Id>e19afce7-1f8b-467a-ac8e-4db9bc3d27c4</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="23" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Blue Beetle" Number="23" Volume="2006" Year="2008">
       <Id>d2d20729-9ab4-4313-ad51-dc8f4664db53</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="24" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Blue Beetle" Number="24" Volume="2006" Year="2008">
       <Id>bb0047cf-0319-45ac-b641-9e452aad1ff5</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="25" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Blue Beetle" Number="25" Volume="2006" Year="2008">
       <Id>fe55cca3-6401-4651-a90c-c63c88bf1150</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="26" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Blue Beetle" Number="26" Volume="2006" Year="2008">
       <Id>5ae43c16-5882-4644-aa47-eec3295effa4</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="27" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Blue Beetle" Number="27" Volume="2006" Year="2008">
       <Id>62527823-8431-4590-9c0e-cdd6b653524d</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="28" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Blue Beetle" Number="28" Volume="2006" Year="2008">
       <Id>bfa37dd9-4d76-46b7-bdb8-bb34fda6ccf3</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="29" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Blue Beetle" Number="29" Volume="2006" Year="2008">
       <Id>dabe14c0-4607-409d-88a0-37a7976e36a4</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="30" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Blue Beetle" Number="30" Volume="2006" Year="2008">
       <Id>6bfa7553-8b0d-46e1-94d0-2eac6b3ea33d</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="31" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Blue Beetle" Number="31" Volume="2006" Year="2008">
       <Id>cb7eb34b-e7c5-4d10-b6fa-478904e9c48f</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="32" Volume="2006" Year="2008" Format="Main Series">
+    <Book Series="Blue Beetle" Number="32" Volume="2006" Year="2008">
       <Id>e0ea8038-4d8e-400e-8831-5fefe2f15cca</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="33" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Blue Beetle" Number="33" Volume="2006" Year="2009">
       <Id>86975a2a-dc82-496b-b72c-fc9086e1ccd7</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="34" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Blue Beetle" Number="34" Volume="2006" Year="2009">
       <Id>4fd3b12a-1c51-4a89-87f3-0a7067bdacc2</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="35" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Blue Beetle" Number="35" Volume="2006" Year="2009">
       <Id>4e97adcd-0398-4b7e-a2a4-6b33ea175708</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="36" Volume="2006" Year="2009" Format="Main Series">
+    <Book Series="Blue Beetle" Number="36" Volume="2006" Year="2009">
       <Id>d1d5fb64-b9fc-429d-bd4a-96c597a8727a</Id>
     </Book>
-    <Book Series="Booster Gold" Number="21" Volume="2007" Year="2009" Format="Main Series">
+    <Book Series="Booster Gold" Number="21" Volume="2007" Year="2009">
       <Id>acbe4b40-c0b6-49da-8ba6-5df783198bb5</Id>
     </Book>
-    <Book Series="Booster Gold" Number="22" Volume="2007" Year="2009" Format="Main Series">
+    <Book Series="Booster Gold" Number="22" Volume="2007" Year="2009">
       <Id>82abd577-525a-4aea-95f0-7585997ec225</Id>
     </Book>
-    <Book Series="Booster Gold" Number="23" Volume="2007" Year="2009" Format="Main Series">
+    <Book Series="Booster Gold" Number="23" Volume="2007" Year="2009">
       <Id>af57ba89-d3e7-4c03-8b2d-f7e90475794f</Id>
     </Book>
-    <Book Series="Booster Gold" Number="24" Volume="2007" Year="2009" Format="Main Series">
+    <Book Series="Booster Gold" Number="24" Volume="2007" Year="2009">
       <Id>cbef1537-7f38-481a-96a9-89ee7a3a3447</Id>
     </Book>
-    <Book Series="Booster Gold" Number="25" Volume="2007" Year="2009" Format="Main Series">
+    <Book Series="Booster Gold" Number="25" Volume="2007" Year="2009">
       <Id>6b9e899c-b8b2-4950-b462-c8d6aec3a63b</Id>
     </Book>
-    <Book Series="Booster Gold" Number="26" Volume="2007" Year="2010" Format="Main Series">
+    <Book Series="Booster Gold" Number="26" Volume="2007" Year="2010">
       <Id>1af4c5a9-cb47-4d27-8c54-3498dd0a7102</Id>
     </Book>
-    <Book Series="Booster Gold" Number="27" Volume="2007" Year="2010" Format="Main Series">
+    <Book Series="Booster Gold" Number="27" Volume="2007" Year="2010">
       <Id>a0276d22-f15b-4aea-8c37-e87c8e7551f4</Id>
     </Book>
-    <Book Series="Booster Gold" Number="28" Volume="2007" Year="2010" Format="Main Series">
+    <Book Series="Booster Gold" Number="28" Volume="2007" Year="2010">
       <Id>9e7cd434-1379-499c-979b-c2d393b36cd3</Id>
     </Book>
-    <Book Series="Booster Gold" Number="29" Volume="2007" Year="2010" Format="Main Series">
+    <Book Series="Booster Gold" Number="29" Volume="2007" Year="2010">
       <Id>ebbe8a08-47b9-422d-b1d4-ffc52172c264</Id>
     </Book>
   </Books>

--- a/DC/Characters/unsorted/Blue Beetle/Blue Beetle 003 - New52_Rebirth.cbl
+++ b/DC/Characters/unsorted/Blue Beetle/Blue Beetle 003 - New52_Rebirth.cbl
@@ -2,118 +2,118 @@
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Blue Beetle 3 - New52/Rebirth</Name>
   <Books>
-    <Book Series="Blue Beetle" Number="0" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Blue Beetle" Number="0" Volume="2011" Year="2012">
       <Id>dc3e7473-be26-425c-bc9b-ec4e7e546c5b</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="1" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Blue Beetle" Number="1" Volume="2011" Year="2011">
       <Id>e7b78590-bc6f-4a9d-a683-0df96d0468c9</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="2" Volume="2011" Year="2011" Format="Main Series">
+    <Book Series="Blue Beetle" Number="2" Volume="2011" Year="2011">
       <Id>73c990c4-2b18-4ae2-8359-045dae499d07</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="3" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Blue Beetle" Number="3" Volume="2011" Year="2012">
       <Id>6d3831f7-6fc1-4451-8e78-8a4cb27f177b</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="4" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Blue Beetle" Number="4" Volume="2011" Year="2012">
       <Id>55144623-5a22-40f3-b87f-4ba75c8f6f04</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="5" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Blue Beetle" Number="5" Volume="2011" Year="2012">
       <Id>767ef392-d90f-4f23-ac9b-aa9b1dc95513</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="6" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Blue Beetle" Number="6" Volume="2011" Year="2012">
       <Id>4bf4e672-706b-4c26-8bab-e2bfcbfca4fa</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="7" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Blue Beetle" Number="7" Volume="2011" Year="2012">
       <Id>ec911a74-fe09-4229-bb9f-11eb4a719cd4</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="8" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Blue Beetle" Number="8" Volume="2011" Year="2012">
       <Id>b678992d-0c25-4c6b-9410-eebdd9a5efe1</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="9" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Blue Beetle" Number="9" Volume="2011" Year="2012">
       <Id>3dc0a65a-940c-4499-9924-73efe0f2a056</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="10" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Blue Beetle" Number="10" Volume="2011" Year="2012">
       <Id>345adc3b-375d-4d10-812f-317cfd0af8ec</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="11" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Blue Beetle" Number="11" Volume="2011" Year="2012">
       <Id>c1a3d695-a03a-4a41-bb3e-072a26c569a9</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="12" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Blue Beetle" Number="12" Volume="2011" Year="2012">
       <Id>7f181d82-54bd-432d-9b60-bdb93eeddf82</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="13" Volume="2011" Year="2012" Format="Main Series">
+    <Book Series="Blue Beetle" Number="13" Volume="2011" Year="2012">
       <Id>127cb775-64fc-4469-9457-93cfb50e1389</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="14" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Blue Beetle" Number="14" Volume="2011" Year="2013">
       <Id>ce8da59f-b2f5-44e3-9478-b386805c1e1f</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="15" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Blue Beetle" Number="15" Volume="2011" Year="2013">
       <Id>2f3142b1-c7b9-4d3c-9d9e-3e04c3a61d3d</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="16" Volume="2011" Year="2013" Format="Main Series">
+    <Book Series="Blue Beetle" Number="16" Volume="2011" Year="2013">
       <Id>0c6b1453-be1b-4f0c-a2e1-a4dd308f7ada</Id>
     </Book>
-    <Book Series="Convergence Blue Beetle" Number="1" Volume="2015" Year="2015" Format="Crossover">
+    <Book Series="Convergence Blue Beetle" Number="1" Volume="2015" Year="2015">
       <Id>057226c6-3e3d-422e-8e36-5cf684973704</Id>
     </Book>
-    <Book Series="Convergence Blue Beetle" Number="2" Volume="2015" Year="2015" Format="Crossover">
+    <Book Series="Convergence Blue Beetle" Number="2" Volume="2015" Year="2015">
       <Id>5294ef74-de40-4e14-a5d8-1594142d79aa</Id>
     </Book>
-    <Book Series="Blue Beetle: Rebirth" Number="1" Volume="2016" Year="2016" Format="One-Shot">
+    <Book Series="Blue Beetle: Rebirth" Number="1" Volume="2016" Year="2016">
       <Id>0e8b73c1-d332-434d-badf-a11d67b38d72</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="1" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Blue Beetle" Number="1" Volume="2016" Year="2016">
       <Id>79b0327e-2bd0-44ff-988f-b078761b9f6d</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="2" Volume="2016" Year="2016" Format="Main Series">
+    <Book Series="Blue Beetle" Number="2" Volume="2016" Year="2016">
       <Id>f7270727-2e47-481c-9ef2-bf95f70ac9c6</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="3" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Blue Beetle" Number="3" Volume="2016" Year="2017">
       <Id>bd954b79-f2a0-48ca-aaa9-3505aa688a00</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="4" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Blue Beetle" Number="4" Volume="2016" Year="2017">
       <Id>ffdffdab-892b-4ab0-b816-e6b7edb5081c</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="5" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Blue Beetle" Number="5" Volume="2016" Year="2017">
       <Id>bfb632d4-8a38-433d-926f-57169bc662d3</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="6" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Blue Beetle" Number="6" Volume="2016" Year="2017">
       <Id>b197823c-9440-40e9-bb79-bdaf516784ab</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="7" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Blue Beetle" Number="7" Volume="2016" Year="2017">
       <Id>ddcc30e3-69aa-4317-9309-8aa03d2047b2</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="8" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Blue Beetle" Number="8" Volume="2016" Year="2017">
       <Id>d564b806-2b7a-48ac-89a2-c6300c2d478d</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="9" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Blue Beetle" Number="9" Volume="2016" Year="2017">
       <Id>f00ae04e-6417-43d6-a1d0-760621032c0d</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="10" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Blue Beetle" Number="10" Volume="2016" Year="2017">
       <Id>c72684db-ac36-4c37-88f5-ebfcc0258f16</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="11" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Blue Beetle" Number="11" Volume="2016" Year="2017">
       <Id>ca1b4132-062f-4f21-bf37-a3a290fedef9</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="12" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Blue Beetle" Number="12" Volume="2016" Year="2017">
       <Id>0154ba06-6330-4303-b310-df43f336f4cb</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="13" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Blue Beetle" Number="13" Volume="2016" Year="2017">
       <Id>b33f3a66-9556-40bd-b8bd-a9a09e2904ff</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="14" Volume="2016" Year="2017" Format="Main Series">
+    <Book Series="Blue Beetle" Number="14" Volume="2016" Year="2017">
       <Id>e44f2164-674b-4cab-82f4-6cfae0387d1f</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="15" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Blue Beetle" Number="15" Volume="2016" Year="2018">
       <Id>f4db6e51-4751-4fa0-a82b-f3c883e36446</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="16" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Blue Beetle" Number="16" Volume="2016" Year="2018">
       <Id>2daab30b-d2f0-441e-901f-1db86723fccc</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="17" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Blue Beetle" Number="17" Volume="2016" Year="2018">
       <Id>b30a5890-f8d4-4a08-b37f-5202bd0e76c2</Id>
     </Book>
-    <Book Series="Blue Beetle" Number="18" Volume="2016" Year="2018" Format="Main Series">
+    <Book Series="Blue Beetle" Number="18" Volume="2016" Year="2018">
       <Id>857afe24-80fa-45c1-8db7-0001bbed2d85</Id>
     </Book>
   </Books>

--- a/DC/Characters/unsorted/Blue Beetle/Blue Beetle 003 - New52_Rebirth.cbl
+++ b/DC/Characters/unsorted/Blue Beetle/Blue Beetle 003 - New52_Rebirth.cbl
@@ -1,120 +1,121 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>Blue Beetle 3 - New52/Rebirth</Name>
+  <Name>Blue Beetle 003 - New52_Rebirth</Name>
+  <NumIssues>38</NumIssues>
   <Books>
     <Book Series="Blue Beetle" Number="0" Volume="2011" Year="2012">
-      <Id>dc3e7473-be26-425c-bc9b-ec4e7e546c5b</Id>
+      <Database Name="cv" Series="42970" Issue="357630" />
     </Book>
     <Book Series="Blue Beetle" Number="1" Volume="2011" Year="2011">
-      <Id>e7b78590-bc6f-4a9d-a683-0df96d0468c9</Id>
+      <Database Name="cv" Series="42970" Issue="293401" />
     </Book>
     <Book Series="Blue Beetle" Number="2" Volume="2011" Year="2011">
-      <Id>73c990c4-2b18-4ae2-8359-045dae499d07</Id>
+      <Database Name="cv" Series="42970" Issue="297226" />
     </Book>
     <Book Series="Blue Beetle" Number="3" Volume="2011" Year="2012">
-      <Id>6d3831f7-6fc1-4451-8e78-8a4cb27f177b</Id>
+      <Database Name="cv" Series="42970" Issue="302533" />
     </Book>
     <Book Series="Blue Beetle" Number="4" Volume="2011" Year="2012">
-      <Id>55144623-5a22-40f3-b87f-4ba75c8f6f04</Id>
+      <Database Name="cv" Series="42970" Issue="307447" />
     </Book>
     <Book Series="Blue Beetle" Number="5" Volume="2011" Year="2012">
-      <Id>767ef392-d90f-4f23-ac9b-aa9b1dc95513</Id>
+      <Database Name="cv" Series="42970" Issue="311666" />
     </Book>
     <Book Series="Blue Beetle" Number="6" Volume="2011" Year="2012">
-      <Id>4bf4e672-706b-4c26-8bab-e2bfcbfca4fa</Id>
+      <Database Name="cv" Series="42970" Issue="315714" />
     </Book>
     <Book Series="Blue Beetle" Number="7" Volume="2011" Year="2012">
-      <Id>ec911a74-fe09-4229-bb9f-11eb4a719cd4</Id>
+      <Database Name="cv" Series="42970" Issue="322749" />
     </Book>
     <Book Series="Blue Beetle" Number="8" Volume="2011" Year="2012">
-      <Id>b678992d-0c25-4c6b-9410-eebdd9a5efe1</Id>
+      <Database Name="cv" Series="42970" Issue="331849" />
     </Book>
     <Book Series="Blue Beetle" Number="9" Volume="2011" Year="2012">
-      <Id>3dc0a65a-940c-4499-9924-73efe0f2a056</Id>
+      <Database Name="cv" Series="42970" Issue="335903" />
     </Book>
     <Book Series="Blue Beetle" Number="10" Volume="2011" Year="2012">
-      <Id>345adc3b-375d-4d10-812f-317cfd0af8ec</Id>
+      <Database Name="cv" Series="42970" Issue="341645" />
     </Book>
     <Book Series="Blue Beetle" Number="11" Volume="2011" Year="2012">
-      <Id>c1a3d695-a03a-4a41-bb3e-072a26c569a9</Id>
+      <Database Name="cv" Series="42970" Issue="346232" />
     </Book>
     <Book Series="Blue Beetle" Number="12" Volume="2011" Year="2012">
-      <Id>7f181d82-54bd-432d-9b60-bdb93eeddf82</Id>
+      <Database Name="cv" Series="42970" Issue="350906" />
     </Book>
     <Book Series="Blue Beetle" Number="13" Volume="2011" Year="2012">
-      <Id>127cb775-64fc-4469-9457-93cfb50e1389</Id>
+      <Database Name="cv" Series="42970" Issue="362254" />
     </Book>
     <Book Series="Blue Beetle" Number="14" Volume="2011" Year="2013">
-      <Id>ce8da59f-b2f5-44e3-9478-b386805c1e1f</Id>
+      <Database Name="cv" Series="42970" Issue="369040" />
     </Book>
     <Book Series="Blue Beetle" Number="15" Volume="2011" Year="2013">
-      <Id>2f3142b1-c7b9-4d3c-9d9e-3e04c3a61d3d</Id>
+      <Database Name="cv" Series="42970" Issue="373268" />
     </Book>
     <Book Series="Blue Beetle" Number="16" Volume="2011" Year="2013">
-      <Id>0c6b1453-be1b-4f0c-a2e1-a4dd308f7ada</Id>
+      <Database Name="cv" Series="42970" Issue="381389" />
     </Book>
     <Book Series="Convergence Blue Beetle" Number="1" Volume="2015" Year="2015">
-      <Id>057226c6-3e3d-422e-8e36-5cf684973704</Id>
+      <Database Name="cv" Series="81586" Issue="487165" />
     </Book>
     <Book Series="Convergence Blue Beetle" Number="2" Volume="2015" Year="2015">
-      <Id>5294ef74-de40-4e14-a5d8-1594142d79aa</Id>
+      <Database Name="cv" Series="81586" Issue="489842" />
     </Book>
     <Book Series="Blue Beetle: Rebirth" Number="1" Volume="2016" Year="2016">
-      <Id>0e8b73c1-d332-434d-badf-a11d67b38d72</Id>
+      <Database Name="cv" Series="93372" Issue="546027" />
     </Book>
     <Book Series="Blue Beetle" Number="1" Volume="2016" Year="2016">
-      <Id>79b0327e-2bd0-44ff-988f-b078761b9f6d</Id>
+      <Database Name="cv" Series="94410" Issue="551267" />
     </Book>
     <Book Series="Blue Beetle" Number="2" Volume="2016" Year="2016">
-      <Id>f7270727-2e47-481c-9ef2-bf95f70ac9c6</Id>
+      <Database Name="cv" Series="94410" Issue="555484" />
     </Book>
     <Book Series="Blue Beetle" Number="3" Volume="2016" Year="2017">
-      <Id>bd954b79-f2a0-48ca-aaa9-3505aa688a00</Id>
+      <Database Name="cv" Series="94410" Issue="558930" />
     </Book>
     <Book Series="Blue Beetle" Number="4" Volume="2016" Year="2017">
-      <Id>ffdffdab-892b-4ab0-b816-e6b7edb5081c</Id>
+      <Database Name="cv" Series="94410" Issue="571628" />
     </Book>
     <Book Series="Blue Beetle" Number="5" Volume="2016" Year="2017">
-      <Id>bfb632d4-8a38-433d-926f-57169bc662d3</Id>
+      <Database Name="cv" Series="94410" Issue="578422" />
     </Book>
     <Book Series="Blue Beetle" Number="6" Volume="2016" Year="2017">
-      <Id>b197823c-9440-40e9-bb79-bdaf516784ab</Id>
+      <Database Name="cv" Series="94410" Issue="582491" />
     </Book>
     <Book Series="Blue Beetle" Number="7" Volume="2016" Year="2017">
-      <Id>ddcc30e3-69aa-4317-9309-8aa03d2047b2</Id>
+      <Database Name="cv" Series="94410" Issue="588533" />
     </Book>
     <Book Series="Blue Beetle" Number="8" Volume="2016" Year="2017">
-      <Id>d564b806-2b7a-48ac-89a2-c6300c2d478d</Id>
+      <Database Name="cv" Series="94410" Issue="593223" />
     </Book>
     <Book Series="Blue Beetle" Number="9" Volume="2016" Year="2017">
-      <Id>f00ae04e-6417-43d6-a1d0-760621032c0d</Id>
+      <Database Name="cv" Series="94410" Issue="597161" />
     </Book>
     <Book Series="Blue Beetle" Number="10" Volume="2016" Year="2017">
-      <Id>c72684db-ac36-4c37-88f5-ebfcc0258f16</Id>
+      <Database Name="cv" Series="94410" Issue="605054" />
     </Book>
     <Book Series="Blue Beetle" Number="11" Volume="2016" Year="2017">
-      <Id>ca1b4132-062f-4f21-bf37-a3a290fedef9</Id>
+      <Database Name="cv" Series="94410" Issue="610458" />
     </Book>
     <Book Series="Blue Beetle" Number="12" Volume="2016" Year="2017">
-      <Id>0154ba06-6330-4303-b310-df43f336f4cb</Id>
+      <Database Name="cv" Series="94410" Issue="616139" />
     </Book>
     <Book Series="Blue Beetle" Number="13" Volume="2016" Year="2017">
-      <Id>b33f3a66-9556-40bd-b8bd-a9a09e2904ff</Id>
+      <Database Name="cv" Series="94410" Issue="625273" />
     </Book>
     <Book Series="Blue Beetle" Number="14" Volume="2016" Year="2017">
-      <Id>e44f2164-674b-4cab-82f4-6cfae0387d1f</Id>
+      <Database Name="cv" Series="94410" Issue="632458" />
     </Book>
     <Book Series="Blue Beetle" Number="15" Volume="2016" Year="2018">
-      <Id>f4db6e51-4751-4fa0-a82b-f3c883e36446</Id>
+      <Database Name="cv" Series="94410" Issue="641373" />
     </Book>
     <Book Series="Blue Beetle" Number="16" Volume="2016" Year="2018">
-      <Id>2daab30b-d2f0-441e-901f-1db86723fccc</Id>
+      <Database Name="cv" Series="94410" Issue="649695" />
     </Book>
     <Book Series="Blue Beetle" Number="17" Volume="2016" Year="2018">
-      <Id>b30a5890-f8d4-4a08-b37f-5202bd0e76c2</Id>
+      <Database Name="cv" Series="94410" Issue="655468" />
     </Book>
     <Book Series="Blue Beetle" Number="18" Volume="2016" Year="2018">
-      <Id>857afe24-80fa-45c1-8db7-0001bbed2d85</Id>
+      <Database Name="cv" Series="94410" Issue="661110" />
     </Book>
   </Books>
   <Matchers />


### PR DESCRIPTION
- Have ignored the Batman folder.  Not short of Batman lists, so focussing effort elsewhere!
- The two TPBs at the start of Batgirl don't seem to exist.  Maybe they are custom compilations?  Have substituted what I think are appropriate omnibus collections.
- Completed the end of the trailing Batman Beyond series and added the two next series linked on ComicVine
- Could not find a TPB for the named Black Lightning / Blue Devil collection, but there are 4 issues titled that in the DC Presents series
- Expanded pre-crisis Blue Beetle v1 + TPBs for crisis events