### PR TITLE
Updated Death of Wolverine Event + Battle of the Atom Event

### DIFF
--- a/[2014-2015] Death of Wolverine (CBH).cbl
+++ b/[2014-2015] Death of Wolverine (CBH).cbl
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Name>[2014-2015] Death of Wolverine (CBH)</Name>
+<NumIssues>56</NumIssues>
+<Books>
+<Book Series="Wolverine" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="58822" Issue="392213" />
+</Book>
+<Book Series="Wolverine" Number="2" Volume="2013" Year="2013">
+<Database Name="cv" Series="58822" Issue="396437" />
+</Book>
+<Book Series="Wolverine" Number="3" Volume="2013" Year="2013">
+<Database Name="cv" Series="58822" Issue="401214" />
+</Book>
+<Book Series="Wolverine" Number="4" Volume="2013" Year="2013">
+<Database Name="cv" Series="58822" Issue="410326" />
+</Book>
+<Book Series="Wolverine" Number="5" Volume="2013" Year="2013">
+<Database Name="cv" Series="58822" Issue="413670" />
+</Book>
+<Book Series="Wolverine" Number="6" Volume="2013" Year="2013">
+<Database Name="cv" Series="58822" Issue="416948" />
+</Book>
+<Book Series="Wolverine" Number="7" Volume="2013" Year="2013">
+<Database Name="cv" Series="58822" Issue="418826" />
+</Book>
+<Book Series="Wolverine" Number="8" Volume="2013" Year="2013">
+<Database Name="cv" Series="58822" Issue="421700" />
+</Book>
+<Book Series="Wolverine" Number="9" Volume="2013" Year="2013">
+<Database Name="cv" Series="58822" Issue="425035" />
+</Book>
+<Book Series="Wolverine" Number="10" Volume="2013" Year="2013">
+<Database Name="cv" Series="58822" Issue="428303" />
+</Book>
+<Book Series="Wolverine" Number="11" Volume="2013" Year="2014">
+<Database Name="cv" Series="58822" Issue="433179" />
+</Book>
+<Book Series="Wolverine" Number="12" Volume="2013" Year="2014">
+<Database Name="cv" Series="58822" Issue="436209" />
+</Book>
+<Book Series="Wolverine" Number="13" Volume="2013" Year="2014">
+<Database Name="cv" Series="58822" Issue="441421" />
+</Book>
+<Book Series="Death of Wolverine" Number="1" Volume="2015" Year="2014">
+<Database Name="cv" Series="76710" Issue="463886" />
+</Book>
+<Book Series="Death of Wolverine" Number="2" Volume="2015" Year="2014">
+<Database Name="cv" Series="76710" Issue="464978" />
+</Book>
+<Book Series="Death of Wolverine" Number="3" Volume="2015" Year="2014">
+<Database Name="cv" Series="76710" Issue="467034" />
+</Book>
+<Book Series="Death of Wolverine" Number="4" Volume="2015" Year="2014">
+<Database Name="cv" Series="76710" Issue="468075" />
+</Book>
+<Book Series="Death of Wolverine: Life After Logan" Number="1" Volume="2014" Year="2015">
+<Database Name="cv" Series="77939" Issue="469491" />
+</Book>
+<Book Series="Death of Wolverine: Deadpool &#38; Captain America" Number="1" Volume="2014" Year="2014">
+<Database Name="cv" Series="77807" Issue="468903" />
+</Book>
+<Book Series="Storm" Number="4" Volume="2014" Year="2014">
+<Database Name="cv" Series="75874" Issue="468088" />
+</Book>
+<Book Series="Storm" Number="5" Volume="2014" Year="2015">
+<Database Name="cv" Series="75874" Issue="470435" />
+</Book>
+<Book Series="Nightcrawler" Number="7" Volume="2014" Year="2014">
+<Database Name="cv" Series="72934" Issue="467653" />
+</Book>
+<Book Series="Wolverine &#38; the X-Men" Number="10" Volume="2014" Year="2014">
+<Database Name="cv" Series="72113" Issue="468092" />
+</Book>
+<Book Series="Wolverine &#38; the X-Men" Number="11" Volume="2014" Year="2014">
+<Database Name="cv" Series="72113" Issue="468916" />
+</Book>
+<Book Series="Death of Wolverine: The Weapon X Program" Number="1" Volume="2015" Year="2015">
+<Database Name="cv" Series="77940" Issue="469492" />
+</Book>
+<Book Series="Death of Wolverine: The Weapon X Program" Number="2" Volume="2015" Year="2015">
+<Database Name="cv" Series="77940" Issue="470425" />
+</Book>
+<Book Series="Death of Wolverine: The Weapon X Program" Number="3" Volume="2015" Year="2015">
+<Database Name="cv" Series="77940" Issue="471963" />
+</Book>
+<Book Series="Death of Wolverine: The Weapon X Program" Number="4" Volume="2015" Year="2015">
+<Database Name="cv" Series="77940" Issue="473645" />
+</Book>
+<Book Series="Death of Wolverine: The Weapon X Program" Number="5" Volume="2015" Year="2015">
+<Database Name="cv" Series="77940" Issue="475454" />
+</Book>
+<Book Series="Death of Wolverine: The Logan Legacy" Number="1" Volume="2015" Year="2014">
+<Database Name="cv" Series="77576" Issue="468076" />
+</Book>
+<Book Series="Death of Wolverine: The Logan Legacy" Number="2" Volume="2015" Year="2014">
+<Database Name="cv" Series="77576" Issue="468462" />
+</Book>
+<Book Series="Death of Wolverine: The Logan Legacy" Number="3" Volume="2015" Year="2014">
+<Database Name="cv" Series="77576" Issue="468904" />
+</Book>
+<Book Series="Death of Wolverine: The Logan Legacy" Number="4" Volume="2015" Year="2015">
+<Database Name="cv" Series="77576" Issue="469831" />
+</Book>
+<Book Series="Death of Wolverine: The Logan Legacy" Number="5" Volume="2015" Year="2015">
+<Database Name="cv" Series="77576" Issue="471315" />
+</Book>
+<Book Series="Death of Wolverine: The Logan Legacy" Number="6" Volume="2015" Year="2015">
+<Database Name="cv" Series="77576" Issue="472905" />
+</Book>
+<Book Series="Death of Wolverine: The Logan Legacy" Number="7" Volume="2015" Year="2015">
+<Database Name="cv" Series="77576" Issue="474627" />
+</Book>
+<Book Series="Wolverines" Number="1" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="475465" />
+</Book>
+<Book Series="Wolverines" Number="2" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="475947" />
+</Book>
+<Book Series="Wolverines" Number="3" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="476797" />
+</Book>
+<Book Series="Wolverines" Number="4" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="477859" />
+</Book>
+<Book Series="Wolverines" Number="5" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="478618" />
+</Book>
+<Book Series="Wolverines" Number="6" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="479266" />
+</Book>
+<Book Series="Wolverines" Number="7" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="479986" />
+</Book>
+<Book Series="Wolverines" Number="8" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="480686" />
+</Book>
+<Book Series="Wolverines" Number="9" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="481616" />
+</Book>
+<Book Series="Wolverines" Number="10" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="482169" />
+</Book>
+<Book Series="Wolverines" Number="11" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="482696" />
+</Book>
+<Book Series="Wolverines" Number="12" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="483362" />
+</Book>
+<Book Series="Wolverines" Number="13" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="484910" />
+</Book>
+<Book Series="Wolverines" Number="14" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="486159" />
+</Book>
+<Book Series="Wolverines" Number="15" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="486731" />
+</Book>
+<Book Series="Wolverines" Number="16" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="487221" />
+</Book>
+<Book Series="Wolverines" Number="17" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="487849" />
+</Book>
+<Book Series="Wolverines" Number="18" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="488664" />
+</Book>
+<Book Series="Wolverines" Number="19" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="489331" />
+</Book>
+<Book Series="Wolverines" Number="20" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="490896" />
+</Book>
+</Books>
+<Matchers />
+</ReadingList>

--- a/[Marvel] (2013) Battle of The Atom (Official).cbl
+++ b/[Marvel] (2013) Battle of The Atom (Official).cbl
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Name>[Marvel] (2013) Battle of The Atom (Official)</Name>
+<NumIssues>18</NumIssues>
+<Books>
+<Book Series="X-Men: Schism" Number="1" Volume="2011" Year="2011">
+<Database Name="cv" Series="41281" Issue="278744" />
+</Book>
+<Book Series="Avengers Vs. X-Men" Number="11" Volume="2012" Year="2012">
+<Database Name="cv" Series="47331" Issue="356764" />
+</Book>
+<Book Series="All-New X-Men" Number="1" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="367691" />
+</Book>
+<Book Series="All-New X-Men" Number="4" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="373215" />
+</Book>
+<Book Series="Uncanny X-Men" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="386141" />
+</Book>
+<Book Series="X-Men: Battle of the Atom" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="67028" Issue="424543" />
+</Book>
+<Book Series="All-New X-Men" Number="16" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="424528" />
+</Book>
+<Book Series="X-Men" Number="5" Volume="2013" Year="2013">
+<Database Name="cv" Series="62383" Issue="425036" />
+</Book>
+<Book Series="Uncanny X-Men" Number="12" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="425944" />
+</Book>
+<Book Series="Wolverine &#38; the X-Men" Number="36" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="426886" />
+</Book>
+<Book Series="All-New X-Men" Number="17" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="427682" />
+</Book>
+<Book Series="X-Men" Number="6" Volume="2013" Year="2013">
+<Database Name="cv" Series="62383" Issue="428304" />
+</Book>
+<Book Series="Uncanny X-Men" Number="13" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="428867" />
+</Book>
+<Book Series="Wolverine &#38; the X-Men" Number="37" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="430768" />
+</Book>
+<Book Series="X-Men: Battle of the Atom" Number="2" Volume="2013" Year="2013">
+<Database Name="cv" Series="67028" Issue="431449" />
+</Book>
+<Book Series="All-New X-Men" Number="28" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="456017" />
+</Book>
+<Book Series="Uncanny X-Men" Number="14" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="433852" />
+</Book>
+<Book Series="Wolverine &#38; the X-Men" Number="38" Volume="2011" Year="2014">
+<Database Name="cv" Series="43539" Issue="435069" />
+</Book>
+</Books>
+<Matchers />
+</ReadingList>


### PR DESCRIPTION
Battle of The Atom - 2013 X-Men Event Reading Order Directly from Marvel - https://www.marvel.com/comics/guides/136/xmen_battle_of_the_atom_complete_event

Death of Wolverine - More comprehensive list of the 2014-2015 Death of Wolverine including the 2014 "Wolverine" ongoing that serves as the catalyst of Wolverine's new-found vulnerability, as well as the 2015 "Wolverines" series that serves as the epilogue to the event.