### PR TITLE
Enhanced Death of Wolverine Reading List (CBH)

### DIFF
--- a/Marvel/Events/CBH/[Marvel] [2014-2015] Death of Wolverine (CBH).cbl
+++ b/Marvel/Events/CBH/[Marvel] [2014-2015] Death of Wolverine (CBH).cbl
@@ -1,174 +1,174 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-<Name>[2014-2015] Death of Wolverine (CBH)</Name>
+<Name>[Marvel] [2014-2015] Death of Wolverine (CBH)</Name>
 <NumIssues>56</NumIssues>
 <Books>
-<Book Series="Wolverine" Number="1" Volume="2013" Year="2013">
+<Book Series="Wolverine" Number="1" Volume="0" Year="2013">
 <Database Name="cv" Series="58822" Issue="392213" />
 </Book>
-<Book Series="Wolverine" Number="2" Volume="2013" Year="2013">
+<Book Series="Wolverine" Number="2" Volume="0" Year="2013">
 <Database Name="cv" Series="58822" Issue="396437" />
 </Book>
-<Book Series="Wolverine" Number="3" Volume="2013" Year="2013">
+<Book Series="Wolverine" Number="3" Volume="0" Year="2013">
 <Database Name="cv" Series="58822" Issue="401214" />
 </Book>
-<Book Series="Wolverine" Number="4" Volume="2013" Year="2013">
+<Book Series="Wolverine" Number="4" Volume="0" Year="2013">
 <Database Name="cv" Series="58822" Issue="410326" />
 </Book>
-<Book Series="Wolverine" Number="5" Volume="2013" Year="2013">
+<Book Series="Wolverine" Number="5" Volume="0" Year="2013">
 <Database Name="cv" Series="58822" Issue="413670" />
 </Book>
-<Book Series="Wolverine" Number="6" Volume="2013" Year="2013">
+<Book Series="Wolverine" Number="6" Volume="0" Year="2013">
 <Database Name="cv" Series="58822" Issue="416948" />
 </Book>
-<Book Series="Wolverine" Number="7" Volume="2013" Year="2013">
+<Book Series="Wolverine" Number="7" Volume="0" Year="2013">
 <Database Name="cv" Series="58822" Issue="418826" />
 </Book>
-<Book Series="Wolverine" Number="8" Volume="2013" Year="2013">
+<Book Series="Wolverine" Number="8" Volume="0" Year="2013">
 <Database Name="cv" Series="58822" Issue="421700" />
 </Book>
-<Book Series="Wolverine" Number="9" Volume="2013" Year="2013">
+<Book Series="Wolverine" Number="9" Volume="0" Year="2013">
 <Database Name="cv" Series="58822" Issue="425035" />
 </Book>
-<Book Series="Wolverine" Number="10" Volume="2013" Year="2013">
+<Book Series="Wolverine" Number="10" Volume="0" Year="2013">
 <Database Name="cv" Series="58822" Issue="428303" />
 </Book>
-<Book Series="Wolverine" Number="11" Volume="2013" Year="2014">
+<Book Series="Wolverine" Number="11" Volume="0" Year="2014">
 <Database Name="cv" Series="58822" Issue="433179" />
 </Book>
-<Book Series="Wolverine" Number="12" Volume="2013" Year="2014">
+<Book Series="Wolverine" Number="12" Volume="0" Year="2014">
 <Database Name="cv" Series="58822" Issue="436209" />
 </Book>
-<Book Series="Wolverine" Number="13" Volume="2013" Year="2014">
+<Book Series="Wolverine" Number="13" Volume="0" Year="2014">
 <Database Name="cv" Series="58822" Issue="441421" />
 </Book>
-<Book Series="Death of Wolverine" Number="1" Volume="2015" Year="2014">
+<Book Series="Death of Wolverine" Number="1" Volume="0" Year="2014">
 <Database Name="cv" Series="76710" Issue="463886" />
 </Book>
-<Book Series="Death of Wolverine" Number="2" Volume="2015" Year="2014">
+<Book Series="Death of Wolverine" Number="2" Volume="0" Year="2014">
 <Database Name="cv" Series="76710" Issue="464978" />
 </Book>
-<Book Series="Death of Wolverine" Number="3" Volume="2015" Year="2014">
+<Book Series="Death of Wolverine" Number="3" Volume="0" Year="2014">
 <Database Name="cv" Series="76710" Issue="467034" />
 </Book>
-<Book Series="Death of Wolverine" Number="4" Volume="2015" Year="2014">
+<Book Series="Death of Wolverine" Number="4" Volume="0" Year="2014">
 <Database Name="cv" Series="76710" Issue="468075" />
 </Book>
-<Book Series="Death of Wolverine: Life After Logan" Number="1" Volume="2014" Year="2015">
+<Book Series="Death of Wolverine: Life After Logan" Number="1" Volume="0" Year="2015">
 <Database Name="cv" Series="77939" Issue="469491" />
 </Book>
-<Book Series="Death of Wolverine: Deadpool &#38; Captain America" Number="1" Volume="2014" Year="2014">
+<Book Series="Death of Wolverine: Deadpool &#38; Captain America" Number="1" Volume="0" Year="2014">
 <Database Name="cv" Series="77807" Issue="468903" />
 </Book>
-<Book Series="Storm" Number="4" Volume="2014" Year="2014">
+<Book Series="Storm" Number="4" Volume="0" Year="2014">
 <Database Name="cv" Series="75874" Issue="468088" />
 </Book>
-<Book Series="Storm" Number="5" Volume="2014" Year="2015">
+<Book Series="Storm" Number="5" Volume="0" Year="2015">
 <Database Name="cv" Series="75874" Issue="470435" />
 </Book>
-<Book Series="Nightcrawler" Number="7" Volume="2014" Year="2014">
+<Book Series="Nightcrawler" Number="7" Volume="0" Year="2014">
 <Database Name="cv" Series="72934" Issue="467653" />
 </Book>
-<Book Series="Wolverine &#38; the X-Men" Number="10" Volume="2014" Year="2014">
+<Book Series="Wolverine &#38; the X-Men" Number="10" Volume="0" Year="2014">
 <Database Name="cv" Series="72113" Issue="468092" />
 </Book>
-<Book Series="Wolverine &#38; the X-Men" Number="11" Volume="2014" Year="2014">
+<Book Series="Wolverine &#38; the X-Men" Number="11" Volume="0" Year="2014">
 <Database Name="cv" Series="72113" Issue="468916" />
 </Book>
-<Book Series="Death of Wolverine: The Weapon X Program" Number="1" Volume="2015" Year="2015">
+<Book Series="Death of Wolverine: The Weapon X Program" Number="1" Volume="0" Year="2015">
 <Database Name="cv" Series="77940" Issue="469492" />
 </Book>
-<Book Series="Death of Wolverine: The Weapon X Program" Number="2" Volume="2015" Year="2015">
+<Book Series="Death of Wolverine: The Weapon X Program" Number="2" Volume="0" Year="2015">
 <Database Name="cv" Series="77940" Issue="470425" />
 </Book>
-<Book Series="Death of Wolverine: The Weapon X Program" Number="3" Volume="2015" Year="2015">
+<Book Series="Death of Wolverine: The Weapon X Program" Number="3" Volume="0" Year="2015">
 <Database Name="cv" Series="77940" Issue="471963" />
 </Book>
-<Book Series="Death of Wolverine: The Weapon X Program" Number="4" Volume="2015" Year="2015">
+<Book Series="Death of Wolverine: The Weapon X Program" Number="4" Volume="0" Year="2015">
 <Database Name="cv" Series="77940" Issue="473645" />
 </Book>
-<Book Series="Death of Wolverine: The Weapon X Program" Number="5" Volume="2015" Year="2015">
+<Book Series="Death of Wolverine: The Weapon X Program" Number="5" Volume="0" Year="2015">
 <Database Name="cv" Series="77940" Issue="475454" />
 </Book>
-<Book Series="Death of Wolverine: The Logan Legacy" Number="1" Volume="2015" Year="2014">
+<Book Series="Death of Wolverine: The Logan Legacy" Number="1" Volume="0" Year="2014">
 <Database Name="cv" Series="77576" Issue="468076" />
 </Book>
-<Book Series="Death of Wolverine: The Logan Legacy" Number="2" Volume="2015" Year="2014">
+<Book Series="Death of Wolverine: The Logan Legacy" Number="2" Volume="0" Year="2014">
 <Database Name="cv" Series="77576" Issue="468462" />
 </Book>
-<Book Series="Death of Wolverine: The Logan Legacy" Number="3" Volume="2015" Year="2014">
+<Book Series="Death of Wolverine: The Logan Legacy" Number="3" Volume="0" Year="2014">
 <Database Name="cv" Series="77576" Issue="468904" />
 </Book>
-<Book Series="Death of Wolverine: The Logan Legacy" Number="4" Volume="2015" Year="2015">
+<Book Series="Death of Wolverine: The Logan Legacy" Number="4" Volume="0" Year="2015">
 <Database Name="cv" Series="77576" Issue="469831" />
 </Book>
-<Book Series="Death of Wolverine: The Logan Legacy" Number="5" Volume="2015" Year="2015">
+<Book Series="Death of Wolverine: The Logan Legacy" Number="5" Volume="0" Year="2015">
 <Database Name="cv" Series="77576" Issue="471315" />
 </Book>
-<Book Series="Death of Wolverine: The Logan Legacy" Number="6" Volume="2015" Year="2015">
+<Book Series="Death of Wolverine: The Logan Legacy" Number="6" Volume="0" Year="2015">
 <Database Name="cv" Series="77576" Issue="472905" />
 </Book>
-<Book Series="Death of Wolverine: The Logan Legacy" Number="7" Volume="2015" Year="2015">
+<Book Series="Death of Wolverine: The Logan Legacy" Number="7" Volume="0" Year="2015">
 <Database Name="cv" Series="77576" Issue="474627" />
 </Book>
-<Book Series="Wolverines" Number="1" Volume="2015" Year="2015">
+<Book Series="Wolverines" Number="1" Volume="0" Year="2015">
 <Database Name="cv" Series="79270" Issue="475465" />
 </Book>
-<Book Series="Wolverines" Number="2" Volume="2015" Year="2015">
+<Book Series="Wolverines" Number="2" Volume="0" Year="2015">
 <Database Name="cv" Series="79270" Issue="475947" />
 </Book>
-<Book Series="Wolverines" Number="3" Volume="2015" Year="2015">
+<Book Series="Wolverines" Number="3" Volume="0" Year="2015">
 <Database Name="cv" Series="79270" Issue="476797" />
 </Book>
-<Book Series="Wolverines" Number="4" Volume="2015" Year="2015">
+<Book Series="Wolverines" Number="4" Volume="0" Year="2015">
 <Database Name="cv" Series="79270" Issue="477859" />
 </Book>
-<Book Series="Wolverines" Number="5" Volume="2015" Year="2015">
+<Book Series="Wolverines" Number="5" Volume="0" Year="2015">
 <Database Name="cv" Series="79270" Issue="478618" />
 </Book>
-<Book Series="Wolverines" Number="6" Volume="2015" Year="2015">
+<Book Series="Wolverines" Number="6" Volume="0" Year="2015">
 <Database Name="cv" Series="79270" Issue="479266" />
 </Book>
-<Book Series="Wolverines" Number="7" Volume="2015" Year="2015">
+<Book Series="Wolverines" Number="7" Volume="0" Year="2015">
 <Database Name="cv" Series="79270" Issue="479986" />
 </Book>
-<Book Series="Wolverines" Number="8" Volume="2015" Year="2015">
+<Book Series="Wolverines" Number="8" Volume="0" Year="2015">
 <Database Name="cv" Series="79270" Issue="480686" />
 </Book>
-<Book Series="Wolverines" Number="9" Volume="2015" Year="2015">
+<Book Series="Wolverines" Number="9" Volume="0" Year="2015">
 <Database Name="cv" Series="79270" Issue="481616" />
 </Book>
-<Book Series="Wolverines" Number="10" Volume="2015" Year="2015">
+<Book Series="Wolverines" Number="10" Volume="0" Year="2015">
 <Database Name="cv" Series="79270" Issue="482169" />
 </Book>
-<Book Series="Wolverines" Number="11" Volume="2015" Year="2015">
+<Book Series="Wolverines" Number="11" Volume="0" Year="2015">
 <Database Name="cv" Series="79270" Issue="482696" />
 </Book>
-<Book Series="Wolverines" Number="12" Volume="2015" Year="2015">
+<Book Series="Wolverines" Number="12" Volume="0" Year="2015">
 <Database Name="cv" Series="79270" Issue="483362" />
 </Book>
-<Book Series="Wolverines" Number="13" Volume="2015" Year="2015">
+<Book Series="Wolverines" Number="13" Volume="0" Year="2015">
 <Database Name="cv" Series="79270" Issue="484910" />
 </Book>
-<Book Series="Wolverines" Number="14" Volume="2015" Year="2015">
+<Book Series="Wolverines" Number="14" Volume="0" Year="2015">
 <Database Name="cv" Series="79270" Issue="486159" />
 </Book>
-<Book Series="Wolverines" Number="15" Volume="2015" Year="2015">
+<Book Series="Wolverines" Number="15" Volume="0" Year="2015">
 <Database Name="cv" Series="79270" Issue="486731" />
 </Book>
-<Book Series="Wolverines" Number="16" Volume="2015" Year="2015">
+<Book Series="Wolverines" Number="16" Volume="0" Year="2015">
 <Database Name="cv" Series="79270" Issue="487221" />
 </Book>
-<Book Series="Wolverines" Number="17" Volume="2015" Year="2015">
+<Book Series="Wolverines" Number="17" Volume="0" Year="2015">
 <Database Name="cv" Series="79270" Issue="487849" />
 </Book>
-<Book Series="Wolverines" Number="18" Volume="2015" Year="2015">
+<Book Series="Wolverines" Number="18" Volume="0" Year="2015">
 <Database Name="cv" Series="79270" Issue="488664" />
 </Book>
-<Book Series="Wolverines" Number="19" Volume="2015" Year="2015">
+<Book Series="Wolverines" Number="19" Volume="0" Year="2015">
 <Database Name="cv" Series="79270" Issue="489331" />
 </Book>
-<Book Series="Wolverines" Number="20" Volume="2015" Year="2015">
+<Book Series="Wolverines" Number="20" Volume="0" Year="2015">
 <Database Name="cv" Series="79270" Issue="490896" />
 </Book>
 </Books>

--- a/Marvel/Events/CBH/[Marvel] [2014-2015] Death of Wolverine (CBH).cbl
+++ b/Marvel/Events/CBH/[Marvel] [2014-2015] Death of Wolverine (CBH).cbl
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Name>[2014-2015] Death of Wolverine (CBH)</Name>
+<NumIssues>56</NumIssues>
+<Books>
+<Book Series="Wolverine" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="58822" Issue="392213" />
+</Book>
+<Book Series="Wolverine" Number="2" Volume="2013" Year="2013">
+<Database Name="cv" Series="58822" Issue="396437" />
+</Book>
+<Book Series="Wolverine" Number="3" Volume="2013" Year="2013">
+<Database Name="cv" Series="58822" Issue="401214" />
+</Book>
+<Book Series="Wolverine" Number="4" Volume="2013" Year="2013">
+<Database Name="cv" Series="58822" Issue="410326" />
+</Book>
+<Book Series="Wolverine" Number="5" Volume="2013" Year="2013">
+<Database Name="cv" Series="58822" Issue="413670" />
+</Book>
+<Book Series="Wolverine" Number="6" Volume="2013" Year="2013">
+<Database Name="cv" Series="58822" Issue="416948" />
+</Book>
+<Book Series="Wolverine" Number="7" Volume="2013" Year="2013">
+<Database Name="cv" Series="58822" Issue="418826" />
+</Book>
+<Book Series="Wolverine" Number="8" Volume="2013" Year="2013">
+<Database Name="cv" Series="58822" Issue="421700" />
+</Book>
+<Book Series="Wolverine" Number="9" Volume="2013" Year="2013">
+<Database Name="cv" Series="58822" Issue="425035" />
+</Book>
+<Book Series="Wolverine" Number="10" Volume="2013" Year="2013">
+<Database Name="cv" Series="58822" Issue="428303" />
+</Book>
+<Book Series="Wolverine" Number="11" Volume="2013" Year="2014">
+<Database Name="cv" Series="58822" Issue="433179" />
+</Book>
+<Book Series="Wolverine" Number="12" Volume="2013" Year="2014">
+<Database Name="cv" Series="58822" Issue="436209" />
+</Book>
+<Book Series="Wolverine" Number="13" Volume="2013" Year="2014">
+<Database Name="cv" Series="58822" Issue="441421" />
+</Book>
+<Book Series="Death of Wolverine" Number="1" Volume="2015" Year="2014">
+<Database Name="cv" Series="76710" Issue="463886" />
+</Book>
+<Book Series="Death of Wolverine" Number="2" Volume="2015" Year="2014">
+<Database Name="cv" Series="76710" Issue="464978" />
+</Book>
+<Book Series="Death of Wolverine" Number="3" Volume="2015" Year="2014">
+<Database Name="cv" Series="76710" Issue="467034" />
+</Book>
+<Book Series="Death of Wolverine" Number="4" Volume="2015" Year="2014">
+<Database Name="cv" Series="76710" Issue="468075" />
+</Book>
+<Book Series="Death of Wolverine: Life After Logan" Number="1" Volume="2014" Year="2015">
+<Database Name="cv" Series="77939" Issue="469491" />
+</Book>
+<Book Series="Death of Wolverine: Deadpool &#38; Captain America" Number="1" Volume="2014" Year="2014">
+<Database Name="cv" Series="77807" Issue="468903" />
+</Book>
+<Book Series="Storm" Number="4" Volume="2014" Year="2014">
+<Database Name="cv" Series="75874" Issue="468088" />
+</Book>
+<Book Series="Storm" Number="5" Volume="2014" Year="2015">
+<Database Name="cv" Series="75874" Issue="470435" />
+</Book>
+<Book Series="Nightcrawler" Number="7" Volume="2014" Year="2014">
+<Database Name="cv" Series="72934" Issue="467653" />
+</Book>
+<Book Series="Wolverine &#38; the X-Men" Number="10" Volume="2014" Year="2014">
+<Database Name="cv" Series="72113" Issue="468092" />
+</Book>
+<Book Series="Wolverine &#38; the X-Men" Number="11" Volume="2014" Year="2014">
+<Database Name="cv" Series="72113" Issue="468916" />
+</Book>
+<Book Series="Death of Wolverine: The Weapon X Program" Number="1" Volume="2015" Year="2015">
+<Database Name="cv" Series="77940" Issue="469492" />
+</Book>
+<Book Series="Death of Wolverine: The Weapon X Program" Number="2" Volume="2015" Year="2015">
+<Database Name="cv" Series="77940" Issue="470425" />
+</Book>
+<Book Series="Death of Wolverine: The Weapon X Program" Number="3" Volume="2015" Year="2015">
+<Database Name="cv" Series="77940" Issue="471963" />
+</Book>
+<Book Series="Death of Wolverine: The Weapon X Program" Number="4" Volume="2015" Year="2015">
+<Database Name="cv" Series="77940" Issue="473645" />
+</Book>
+<Book Series="Death of Wolverine: The Weapon X Program" Number="5" Volume="2015" Year="2015">
+<Database Name="cv" Series="77940" Issue="475454" />
+</Book>
+<Book Series="Death of Wolverine: The Logan Legacy" Number="1" Volume="2015" Year="2014">
+<Database Name="cv" Series="77576" Issue="468076" />
+</Book>
+<Book Series="Death of Wolverine: The Logan Legacy" Number="2" Volume="2015" Year="2014">
+<Database Name="cv" Series="77576" Issue="468462" />
+</Book>
+<Book Series="Death of Wolverine: The Logan Legacy" Number="3" Volume="2015" Year="2014">
+<Database Name="cv" Series="77576" Issue="468904" />
+</Book>
+<Book Series="Death of Wolverine: The Logan Legacy" Number="4" Volume="2015" Year="2015">
+<Database Name="cv" Series="77576" Issue="469831" />
+</Book>
+<Book Series="Death of Wolverine: The Logan Legacy" Number="5" Volume="2015" Year="2015">
+<Database Name="cv" Series="77576" Issue="471315" />
+</Book>
+<Book Series="Death of Wolverine: The Logan Legacy" Number="6" Volume="2015" Year="2015">
+<Database Name="cv" Series="77576" Issue="472905" />
+</Book>
+<Book Series="Death of Wolverine: The Logan Legacy" Number="7" Volume="2015" Year="2015">
+<Database Name="cv" Series="77576" Issue="474627" />
+</Book>
+<Book Series="Wolverines" Number="1" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="475465" />
+</Book>
+<Book Series="Wolverines" Number="2" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="475947" />
+</Book>
+<Book Series="Wolverines" Number="3" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="476797" />
+</Book>
+<Book Series="Wolverines" Number="4" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="477859" />
+</Book>
+<Book Series="Wolverines" Number="5" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="478618" />
+</Book>
+<Book Series="Wolverines" Number="6" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="479266" />
+</Book>
+<Book Series="Wolverines" Number="7" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="479986" />
+</Book>
+<Book Series="Wolverines" Number="8" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="480686" />
+</Book>
+<Book Series="Wolverines" Number="9" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="481616" />
+</Book>
+<Book Series="Wolverines" Number="10" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="482169" />
+</Book>
+<Book Series="Wolverines" Number="11" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="482696" />
+</Book>
+<Book Series="Wolverines" Number="12" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="483362" />
+</Book>
+<Book Series="Wolverines" Number="13" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="484910" />
+</Book>
+<Book Series="Wolverines" Number="14" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="486159" />
+</Book>
+<Book Series="Wolverines" Number="15" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="486731" />
+</Book>
+<Book Series="Wolverines" Number="16" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="487221" />
+</Book>
+<Book Series="Wolverines" Number="17" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="487849" />
+</Book>
+<Book Series="Wolverines" Number="18" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="488664" />
+</Book>
+<Book Series="Wolverines" Number="19" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="489331" />
+</Book>
+<Book Series="Wolverines" Number="20" Volume="2015" Year="2015">
+<Database Name="cv" Series="79270" Issue="490896" />
+</Book>
+</Books>
+<Matchers />
+</ReadingList>

--- a/Marvel/Events/CBH/[Marvel] [2014-2015] Death of Wolverine (CBH).cbl
+++ b/Marvel/Events/CBH/[Marvel] [2014-2015] Death of Wolverine (CBH).cbl
@@ -3,172 +3,172 @@
 <Name>[Marvel] [2014-2015] Death of Wolverine (CBH)</Name>
 <NumIssues>56</NumIssues>
 <Books>
-<Book Series="Wolverine" Number="1" Volume="0" Year="2013">
+<Book Series="Wolverine" Number="1" Volume="2013" Year="2013">
 <Database Name="cv" Series="58822" Issue="392213" />
 </Book>
-<Book Series="Wolverine" Number="2" Volume="0" Year="2013">
+<Book Series="Wolverine" Number="2" Volume="2013" Year="2013">
 <Database Name="cv" Series="58822" Issue="396437" />
 </Book>
-<Book Series="Wolverine" Number="3" Volume="0" Year="2013">
+<Book Series="Wolverine" Number="3" Volume="2013" Year="2013">
 <Database Name="cv" Series="58822" Issue="401214" />
 </Book>
-<Book Series="Wolverine" Number="4" Volume="0" Year="2013">
+<Book Series="Wolverine" Number="4" Volume="2013" Year="2013">
 <Database Name="cv" Series="58822" Issue="410326" />
 </Book>
-<Book Series="Wolverine" Number="5" Volume="0" Year="2013">
+<Book Series="Wolverine" Number="5" Volume="2013" Year="2013">
 <Database Name="cv" Series="58822" Issue="413670" />
 </Book>
-<Book Series="Wolverine" Number="6" Volume="0" Year="2013">
+<Book Series="Wolverine" Number="6" Volume="2013" Year="2013">
 <Database Name="cv" Series="58822" Issue="416948" />
 </Book>
-<Book Series="Wolverine" Number="7" Volume="0" Year="2013">
+<Book Series="Wolverine" Number="7" Volume="2013" Year="2013">
 <Database Name="cv" Series="58822" Issue="418826" />
 </Book>
-<Book Series="Wolverine" Number="8" Volume="0" Year="2013">
+<Book Series="Wolverine" Number="8" Volume="2013" Year="2013">
 <Database Name="cv" Series="58822" Issue="421700" />
 </Book>
-<Book Series="Wolverine" Number="9" Volume="0" Year="2013">
+<Book Series="Wolverine" Number="9" Volume="2013" Year="2013">
 <Database Name="cv" Series="58822" Issue="425035" />
 </Book>
-<Book Series="Wolverine" Number="10" Volume="0" Year="2013">
+<Book Series="Wolverine" Number="10" Volume="2013" Year="2013">
 <Database Name="cv" Series="58822" Issue="428303" />
 </Book>
-<Book Series="Wolverine" Number="11" Volume="0" Year="2014">
+<Book Series="Wolverine" Number="11" Volume="2013" Year="2014">
 <Database Name="cv" Series="58822" Issue="433179" />
 </Book>
-<Book Series="Wolverine" Number="12" Volume="0" Year="2014">
+<Book Series="Wolverine" Number="12" Volume="2013" Year="2014">
 <Database Name="cv" Series="58822" Issue="436209" />
 </Book>
-<Book Series="Wolverine" Number="13" Volume="0" Year="2014">
+<Book Series="Wolverine" Number="13" Volume="2013" Year="2014">
 <Database Name="cv" Series="58822" Issue="441421" />
 </Book>
-<Book Series="Death of Wolverine" Number="1" Volume="0" Year="2014">
+<Book Series="Death of Wolverine" Number="1" Volume="2014" Year="2014">
 <Database Name="cv" Series="76710" Issue="463886" />
 </Book>
-<Book Series="Death of Wolverine" Number="2" Volume="0" Year="2014">
+<Book Series="Death of Wolverine" Number="2" Volume="2014" Year="2014">
 <Database Name="cv" Series="76710" Issue="464978" />
 </Book>
-<Book Series="Death of Wolverine" Number="3" Volume="0" Year="2014">
+<Book Series="Death of Wolverine" Number="3" Volume="2014" Year="2014">
 <Database Name="cv" Series="76710" Issue="467034" />
 </Book>
-<Book Series="Death of Wolverine" Number="4" Volume="0" Year="2014">
+<Book Series="Death of Wolverine" Number="4" Volume="2014" Year="2014">
 <Database Name="cv" Series="76710" Issue="468075" />
 </Book>
-<Book Series="Death of Wolverine: Life After Logan" Number="1" Volume="0" Year="2015">
+<Book Series="Death of Wolverine: Life After Logan" Number="1" Volume="2014" Year="2015">
 <Database Name="cv" Series="77939" Issue="469491" />
 </Book>
-<Book Series="Death of Wolverine: Deadpool &#38; Captain America" Number="1" Volume="0" Year="2014">
+<Book Series="Death of Wolverine: Deadpool &#38; Captain America" Number="1" Volume="2014" Year="2014">
 <Database Name="cv" Series="77807" Issue="468903" />
 </Book>
-<Book Series="Storm" Number="4" Volume="0" Year="2014">
+<Book Series="Storm" Number="4" Volume="2014" Year="2014">
 <Database Name="cv" Series="75874" Issue="468088" />
 </Book>
-<Book Series="Storm" Number="5" Volume="0" Year="2015">
+<Book Series="Storm" Number="5" Volume="2014" Year="2015">
 <Database Name="cv" Series="75874" Issue="470435" />
 </Book>
-<Book Series="Nightcrawler" Number="7" Volume="0" Year="2014">
+<Book Series="Nightcrawler" Number="7" Volume="2014" Year="2014">
 <Database Name="cv" Series="72934" Issue="467653" />
 </Book>
-<Book Series="Wolverine &#38; the X-Men" Number="10" Volume="0" Year="2014">
+<Book Series="Wolverine &#38; the X-Men" Number="10" Volume="2014" Year="2014">
 <Database Name="cv" Series="72113" Issue="468092" />
 </Book>
-<Book Series="Wolverine &#38; the X-Men" Number="11" Volume="0" Year="2014">
+<Book Series="Wolverine &#38; the X-Men" Number="11" Volume="2014" Year="2014">
 <Database Name="cv" Series="72113" Issue="468916" />
 </Book>
-<Book Series="Death of Wolverine: The Weapon X Program" Number="1" Volume="0" Year="2015">
+<Book Series="Death of Wolverine: The Weapon X Program" Number="1" Volume="2014" Year="2015">
 <Database Name="cv" Series="77940" Issue="469492" />
 </Book>
-<Book Series="Death of Wolverine: The Weapon X Program" Number="2" Volume="0" Year="2015">
+<Book Series="Death of Wolverine: The Weapon X Program" Number="2" Volume="2014" Year="2015">
 <Database Name="cv" Series="77940" Issue="470425" />
 </Book>
-<Book Series="Death of Wolverine: The Weapon X Program" Number="3" Volume="0" Year="2015">
+<Book Series="Death of Wolverine: The Weapon X Program" Number="3" Volume="2014" Year="2015">
 <Database Name="cv" Series="77940" Issue="471963" />
 </Book>
-<Book Series="Death of Wolverine: The Weapon X Program" Number="4" Volume="0" Year="2015">
+<Book Series="Death of Wolverine: The Weapon X Program" Number="4" Volume="2014" Year="2015">
 <Database Name="cv" Series="77940" Issue="473645" />
 </Book>
-<Book Series="Death of Wolverine: The Weapon X Program" Number="5" Volume="0" Year="2015">
+<Book Series="Death of Wolverine: The Weapon X Program" Number="5" Volume="2014" Year="2015">
 <Database Name="cv" Series="77940" Issue="475454" />
 </Book>
-<Book Series="Death of Wolverine: The Logan Legacy" Number="1" Volume="0" Year="2014">
+<Book Series="Death of Wolverine: The Logan Legacy" Number="1" Volume="2014" Year="2014">
 <Database Name="cv" Series="77576" Issue="468076" />
 </Book>
-<Book Series="Death of Wolverine: The Logan Legacy" Number="2" Volume="0" Year="2014">
+<Book Series="Death of Wolverine: The Logan Legacy" Number="2" Volume="2014" Year="2014">
 <Database Name="cv" Series="77576" Issue="468462" />
 </Book>
-<Book Series="Death of Wolverine: The Logan Legacy" Number="3" Volume="0" Year="2014">
+<Book Series="Death of Wolverine: The Logan Legacy" Number="3" Volume="2014" Year="2014">
 <Database Name="cv" Series="77576" Issue="468904" />
 </Book>
-<Book Series="Death of Wolverine: The Logan Legacy" Number="4" Volume="0" Year="2015">
+<Book Series="Death of Wolverine: The Logan Legacy" Number="4" Volume="2014" Year="2015">
 <Database Name="cv" Series="77576" Issue="469831" />
 </Book>
-<Book Series="Death of Wolverine: The Logan Legacy" Number="5" Volume="0" Year="2015">
+<Book Series="Death of Wolverine: The Logan Legacy" Number="5" Volume="2014" Year="2015">
 <Database Name="cv" Series="77576" Issue="471315" />
 </Book>
-<Book Series="Death of Wolverine: The Logan Legacy" Number="6" Volume="0" Year="2015">
+<Book Series="Death of Wolverine: The Logan Legacy" Number="6" Volume="2014" Year="2015">
 <Database Name="cv" Series="77576" Issue="472905" />
 </Book>
-<Book Series="Death of Wolverine: The Logan Legacy" Number="7" Volume="0" Year="2015">
+<Book Series="Death of Wolverine: The Logan Legacy" Number="7" Volume="2014" Year="2015">
 <Database Name="cv" Series="77576" Issue="474627" />
 </Book>
-<Book Series="Wolverines" Number="1" Volume="0" Year="2015">
+<Book Series="Wolverines" Number="1" Volume="2015" Year="2015">
 <Database Name="cv" Series="79270" Issue="475465" />
 </Book>
-<Book Series="Wolverines" Number="2" Volume="0" Year="2015">
+<Book Series="Wolverines" Number="2" Volume="2015" Year="2015">
 <Database Name="cv" Series="79270" Issue="475947" />
 </Book>
-<Book Series="Wolverines" Number="3" Volume="0" Year="2015">
+<Book Series="Wolverines" Number="3" Volume="2015" Year="2015">
 <Database Name="cv" Series="79270" Issue="476797" />
 </Book>
-<Book Series="Wolverines" Number="4" Volume="0" Year="2015">
+<Book Series="Wolverines" Number="4" Volume="2015" Year="2015">
 <Database Name="cv" Series="79270" Issue="477859" />
 </Book>
-<Book Series="Wolverines" Number="5" Volume="0" Year="2015">
+<Book Series="Wolverines" Number="5" Volume="2015" Year="2015">
 <Database Name="cv" Series="79270" Issue="478618" />
 </Book>
-<Book Series="Wolverines" Number="6" Volume="0" Year="2015">
+<Book Series="Wolverines" Number="6" Volume="2015" Year="2015">
 <Database Name="cv" Series="79270" Issue="479266" />
 </Book>
-<Book Series="Wolverines" Number="7" Volume="0" Year="2015">
+<Book Series="Wolverines" Number="7" Volume="2015" Year="2015">
 <Database Name="cv" Series="79270" Issue="479986" />
 </Book>
-<Book Series="Wolverines" Number="8" Volume="0" Year="2015">
+<Book Series="Wolverines" Number="8" Volume="2015" Year="2015">
 <Database Name="cv" Series="79270" Issue="480686" />
 </Book>
-<Book Series="Wolverines" Number="9" Volume="0" Year="2015">
+<Book Series="Wolverines" Number="9" Volume="2015" Year="2015">
 <Database Name="cv" Series="79270" Issue="481616" />
 </Book>
-<Book Series="Wolverines" Number="10" Volume="0" Year="2015">
+<Book Series="Wolverines" Number="10" Volume="2015" Year="2015">
 <Database Name="cv" Series="79270" Issue="482169" />
 </Book>
-<Book Series="Wolverines" Number="11" Volume="0" Year="2015">
+<Book Series="Wolverines" Number="11" Volume="2015" Year="2015">
 <Database Name="cv" Series="79270" Issue="482696" />
 </Book>
-<Book Series="Wolverines" Number="12" Volume="0" Year="2015">
+<Book Series="Wolverines" Number="12" Volume="2015" Year="2015">
 <Database Name="cv" Series="79270" Issue="483362" />
 </Book>
-<Book Series="Wolverines" Number="13" Volume="0" Year="2015">
+<Book Series="Wolverines" Number="13" Volume="2015" Year="2015">
 <Database Name="cv" Series="79270" Issue="484910" />
 </Book>
-<Book Series="Wolverines" Number="14" Volume="0" Year="2015">
+<Book Series="Wolverines" Number="14" Volume="2015" Year="2015">
 <Database Name="cv" Series="79270" Issue="486159" />
 </Book>
-<Book Series="Wolverines" Number="15" Volume="0" Year="2015">
+<Book Series="Wolverines" Number="15" Volume="2015" Year="2015">
 <Database Name="cv" Series="79270" Issue="486731" />
 </Book>
-<Book Series="Wolverines" Number="16" Volume="0" Year="2015">
+<Book Series="Wolverines" Number="16" Volume="2015" Year="2015">
 <Database Name="cv" Series="79270" Issue="487221" />
 </Book>
-<Book Series="Wolverines" Number="17" Volume="0" Year="2015">
+<Book Series="Wolverines" Number="17" Volume="2015" Year="2015">
 <Database Name="cv" Series="79270" Issue="487849" />
 </Book>
-<Book Series="Wolverines" Number="18" Volume="0" Year="2015">
+<Book Series="Wolverines" Number="18" Volume="2015" Year="2015">
 <Database Name="cv" Series="79270" Issue="488664" />
 </Book>
-<Book Series="Wolverines" Number="19" Volume="0" Year="2015">
+<Book Series="Wolverines" Number="19" Volume="2015" Year="2015">
 <Database Name="cv" Series="79270" Issue="489331" />
 </Book>
-<Book Series="Wolverines" Number="20" Volume="0" Year="2015">
+<Book Series="Wolverines" Number="20" Volume="2015" Year="2015">
 <Database Name="cv" Series="79270" Issue="490896" />
 </Book>
 </Books>


### PR DESCRIPTION
Enhanced .cbl of this pre-existing event including: 2014 Wolverine ongoing, which is the catalyst of the entire event, and the 2015 "Wolverines" series which serves as the epilogue to the event. 
https://www.comicbookherald.com/the-complete-marvel-reading-order-guide/death-of-wolverine-reading-order/