### PR TITLE
Zombie Tales issues by publication

### DIFF
--- a/Boom/Zombie Tales Publication Order.cbl
+++ b/Boom/Zombie Tales Publication Order.cbl
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Name>Zombie Tales Publication Order</Name>
+<NumIssues>17</NumIssues>
+<Books>
+<Book Series="Zombie Tales: Death Valley" Number="1" Volume="2005" Year="2005">
+<Database Name="cv" Series="40992" Issue="276441" />
+</Book>
+<Book Series="Zombie Tales: Death Valley" Number="2" Volume="2005" Year="2005">
+<Database Name="cv" Series="40992" Issue="276614" />
+</Book>
+<Book Series="Zombie Tales: Oblivion" Number="1" Volume="2005" Year="2005">
+<Database Name="cv" Series="40991" Issue="276440" />
+</Book>
+<Book Series="Zombie Tales" Number="1" Volume="2005" Year="2005">
+<Database Name="cv" Series="19357" Issue="116111" />
+</Book>
+<Book Series="Zombie Tales: The Dead" Number="1" Volume="2006" Year="2006">
+<Database Name="cv" Series="40990" Issue="276439" />
+</Book>
+<Book Series="Zombie Tales: The Series" Number="1" Volume="2008" Year="2008">
+<Database Name="cv" Series="23619" Issue="141593" />
+</Book>
+<Book Series="Zombie Tales: The Series" Number="2" Volume="2008" Year="2008">
+<Database Name="cv" Series="23619" Issue="141594" />
+</Book>
+<Book Series="Zombie Tales: The Series" Number="3" Volume="2008" Year="2008">
+<Database Name="cv" Series="23619" Issue="141596" />
+</Book>
+<Book Series="Zombie Tales: The Series" Number="4" Volume="2008" Year="2008">
+<Database Name="cv" Series="23619" Issue="141595" />
+</Book>
+<Book Series="Zombie Tales: The Series" Number="5" Volume="2008" Year="2008">
+<Database Name="cv" Series="23619" Issue="141597" />
+</Book>
+<Book Series="Zombie Tales: The Series" Number="6" Volume="2008" Year="2008">
+<Database Name="cv" Series="23619" Issue="141598" />
+</Book>
+<Book Series="Zombie Tales: The Series" Number="7" Volume="2008" Year="2008">
+<Database Name="cv" Series="23619" Issue="143342" />
+</Book>
+<Book Series="Zombie Tales: The Series" Number="8" Volume="2008" Year="2008">
+<Database Name="cv" Series="23619" Issue="146952" />
+</Book>
+<Book Series="Zombie Tales: The Series" Number="9" Volume="2008" Year="2008">
+<Database Name="cv" Series="23619" Issue="150205" />
+</Book>
+<Book Series="Zombie Tales: The Series" Number="10" Volume="2008" Year="2009">
+<Database Name="cv" Series="23619" Issue="153388" />
+</Book>
+<Book Series="Zombie Tales: The Series" Number="11" Volume="2008" Year="2009">
+<Database Name="cv" Series="23619" Issue="157373" />
+</Book>
+<Book Series="Zombie Tales: The Series" Number="12" Volume="2008" Year="2009">
+<Database Name="cv" Series="23619" Issue="153709" />
+</Book>
+</Books>
+<Matchers />
+</ReadingList>


### PR DESCRIPTION
An early Boom! zombie anthology, no chronological order needed due to anthology nature but series are all named in ways that aren't clear and CV has two dates missing causing incorrect ordering for people going it their own. But no more!