### PR TITLE
WildStorm Rising (LOCG)

### DIFF
--- a/DC/Events/LoCG/[1995] WildStorm Rising (DC Comics) (LoCG).cbl
+++ b/DC/Events/LoCG/[1995] WildStorm Rising (DC Comics) (LoCG).cbl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-<Name>[LOCG] [1995] WildStorm Rising</Name>
+<Name>[1995] WildStorm Rising (DC Comics)(LoCG)</Name>
 <NumIssues>9</NumIssues>
 <Books>
 <Book Series="Team 7 - Objective: Hell" Number="1" Volume="1995" Year="1995">


### PR DESCRIPTION
Stormwatch and WildC.A.T.S teams end up at odds but have to stop fighting long enough to stop Helspont and Defile from collecting all the keys to unlock the Daemonite ship (buried on Earth for centuries) which could destroy Earth.

https://leagueofcomicgeeks.com/comics/event/14475/wildstorm-rising