### PR TITLE
Added Ghostbusters IDW complete run

### DIFF
--- a/IDW/Characters/Ghostbusters/Ghostbusters IDW Run.cbl
+++ b/IDW/Characters/Ghostbusters/Ghostbusters IDW Run.cbl
@@ -1,0 +1,344 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Name>Ghostbusters IDW Run</Name>
+<NumIssues>112</NumIssues>
+<Books>
+<Book Series="Ghostbusters: The Other Side" Number="1" Volume="2009" Year="2008">
+<Database Name="cv" Series="23419" Issue="140462" />
+</Book>
+<Book Series="Ghostbusters: The Other Side" Number="2" Volume="2009" Year="2008">
+<Database Name="cv" Series="23419" Issue="142301" />
+</Book>
+<Book Series="Ghostbusters: The Other Side" Number="3" Volume="2009" Year="2008">
+<Database Name="cv" Series="23419" Issue="146908" />
+</Book>
+<Book Series="Ghostbusters: The Other Side" Number="4" Volume="2009" Year="2009">
+<Database Name="cv" Series="23419" Issue="150069" />
+</Book>
+<Book Series="Ghostbusters: Displaced Aggression" Number="1" Volume="2010" Year="2009">
+<Database Name="cv" Series="28566" Issue="176006" />
+</Book>
+<Book Series="Ghostbusters: Displaced Aggression" Number="2" Volume="2010" Year="2009">
+<Database Name="cv" Series="28566" Issue="176002" />
+</Book>
+<Book Series="Ghostbusters: Displaced Aggression" Number="3" Volume="2010" Year="2009">
+<Database Name="cv" Series="28566" Issue="186150" />
+</Book>
+<Book Series="Ghostbusters: Displaced Aggression" Number="4" Volume="2010" Year="2009">
+<Database Name="cv" Series="28566" Issue="188305" />
+</Book>
+<Book Series="Ghostbusters: Past, Present, and Future" Number="1" Volume="2009" Year="2009">
+<Database Name="cv" Series="34473" Issue="224973" />
+</Book>
+<Book Series="Ghostbusters: Tainted Love" Number="1" Volume="2010" Year="2010">
+<Database Name="cv" Series="31694" Issue="199167" />
+</Book>
+<Book Series="Ghostbusters: Con-volution" Number="1" Volume="2010" Year="2010">
+<Database Name="cv" Series="33943" Issue="221136" />
+</Book>
+<Book Series="Ghostbusters: What In Samhain Just Happened?!" Number="1" Volume="2010" Year="2010">
+<Database Name="cv" Series="36251" Issue="239341" />
+</Book>
+<Book Series="Ghostbusters: Infestation" Number="1" Volume="2011" Year="2011">
+<Database Name="cv" Series="39312" Issue="265589" />
+</Book>
+<Book Series="Ghostbusters: Infestation" Number="2" Volume="2011" Year="2011">
+<Database Name="cv" Series="39312" Issue="266583" />
+</Book>
+<Book Series="Ghostbusters" Number="1" Volume="2011" Year="2011">
+<Database Name="cv" Series="43066" Issue="293892" />
+</Book>
+<Book Series="Ghostbusters" Number="2" Volume="2011" Year="2011">
+<Database Name="cv" Series="43066" Issue="298510" />
+</Book>
+<Book Series="Ghostbusters" Number="3" Volume="2011" Year="2011">
+<Database Name="cv" Series="43066" Issue="302742" />
+</Book>
+<Book Series="Ghostbusters" Number="4" Volume="2011" Year="2011">
+<Database Name="cv" Series="43066" Issue="307708" />
+</Book>
+<Book Series="Ghostbusters" Number="5" Volume="2011" Year="2012">
+<Database Name="cv" Series="43066" Issue="311743" />
+</Book>
+<Book Series="Ghostbusters" Number="6" Volume="2011" Year="2012">
+<Database Name="cv" Series="43066" Issue="315825" />
+</Book>
+<Book Series="Ghostbusters" Number="7" Volume="2011" Year="2012">
+<Database Name="cv" Series="43066" Issue="323153" />
+</Book>
+<Book Series="Ghostbusters" Number="8" Volume="2011" Year="2012">
+<Database Name="cv" Series="43066" Issue="332590" />
+</Book>
+<Book Series="Ghostbusters" Number="9" Volume="2011" Year="2012">
+<Database Name="cv" Series="43066" Issue="337567" />
+</Book>
+<Book Series="Ghostbusters" Number="10" Volume="2011" Year="2012">
+<Database Name="cv" Series="43066" Issue="341896" />
+</Book>
+<Book Series="Ghostbusters" Number="11" Volume="2011" Year="2012">
+<Database Name="cv" Series="43066" Issue="347335" />
+</Book>
+<Book Series="Ghostbusters" Number="12" Volume="2011" Year="2012">
+<Database Name="cv" Series="43066" Issue="354067" />
+</Book>
+<Book Series="Ghostbusters" Number="13" Volume="2011" Year="2012">
+<Database Name="cv" Series="43066" Issue="357662" />
+</Book>
+<Book Series="Ghostbusters" Number="14" Volume="2011" Year="2012">
+<Database Name="cv" Series="43066" Issue="364138" />
+</Book>
+<Book Series="Ghostbusters" Number="15" Volume="2011" Year="2012">
+<Database Name="cv" Series="43066" Issue="370357" />
+</Book>
+<Book Series="Ghostbusters" Number="16" Volume="2011" Year="2012">
+<Database Name="cv" Series="43066" Issue="372419" />
+</Book>
+<Book Series="Ghostbusters: Times Scare! Mini Comic" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="52658" Issue="359965" />
+</Book>
+<Book Series="Ghostbusters" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="57184" Issue="386152" />
+</Book>
+<Book Series="Ghostbusters" Number="2" Volume="2013" Year="2013">
+<Database Name="cv" Series="57184" Issue="392387" />
+</Book>
+<Book Series="Ghostbusters" Number="3" Volume="2013" Year="2013">
+<Database Name="cv" Series="57184" Issue="397577" />
+</Book>
+<Book Series="Ghostbusters" Number="4" Volume="2013" Year="2013">
+<Database Name="cv" Series="57184" Issue="404735" />
+</Book>
+<Book Series="Ghostbusters" Number="5" Volume="2013" Year="2013">
+<Database Name="cv" Series="57184" Issue="413687" />
+</Book>
+<Book Series="Ghostbusters" Number="6" Volume="2013" Year="2013">
+<Database Name="cv" Series="57184" Issue="418836" />
+</Book>
+<Book Series="Ghostbusters" Number="7" Volume="2013" Year="2013">
+<Database Name="cv" Series="57184" Issue="425958" />
+</Book>
+<Book Series="Ghostbusters" Number="8" Volume="2013" Year="2013">
+<Database Name="cv" Series="57184" Issue="428316" />
+</Book>
+<Book Series="Ghostbusters" Number="9" Volume="2013" Year="2013">
+<Database Name="cv" Series="57184" Issue="432356" />
+</Book>
+<Book Series="Ghostbusters" Number="10" Volume="2013" Year="2013">
+<Database Name="cv" Series="57184" Issue="435084" />
+</Book>
+<Book Series="Ghostbusters" Number="11" Volume="2013" Year="2013">
+<Database Name="cv" Series="57184" Issue="437521" />
+</Book>
+<Book Series="Ghostbusters" Number="12" Volume="2013" Year="2014">
+<Database Name="cv" Series="57184" Issue="444000" />
+</Book>
+<Book Series="Ghostbusters" Number="13" Volume="2013" Year="2014">
+<Database Name="cv" Series="57184" Issue="446504" />
+</Book>
+<Book Series="Ghostbusters" Number="14" Volume="2013" Year="2014">
+<Database Name="cv" Series="57184" Issue="448994" />
+</Book>
+<Book Series="Ghostbusters" Number="15" Volume="2013" Year="2014">
+<Database Name="cv" Series="57184" Issue="451787" />
+</Book>
+<Book Series="Ghostbusters" Number="16" Volume="2013" Year="2014">
+<Database Name="cv" Series="57184" Issue="454118" />
+</Book>
+<Book Series="Ghostbusters" Number="17" Volume="2013" Year="2014">
+<Database Name="cv" Series="57184" Issue="457665" />
+</Book>
+<Book Series="Ghostbusters" Number="18" Volume="2013" Year="2014">
+<Database Name="cv" Series="57184" Issue="460983" />
+</Book>
+<Book Series="Ghostbusters" Number="19" Volume="2013" Year="2014">
+<Database Name="cv" Series="57184" Issue="463499" />
+</Book>
+<Book Series="Ghostbusters" Number="20" Volume="2013" Year="2014">
+<Database Name="cv" Series="57184" Issue="466348" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles/Ghostbusters" Number="1" Volume="2015" Year="2014">
+<Database Name="cv" Series="77699" Issue="468489" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles/Ghostbusters" Number="2" Volume="2015" Year="2014">
+<Database Name="cv" Series="77699" Issue="471347" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles/Ghostbusters" Number="3" Volume="2015" Year="2014">
+<Database Name="cv" Series="77699" Issue="474650" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles/Ghostbusters" Number="4" Volume="2015" Year="2015">
+<Database Name="cv" Series="77699" Issue="477886" />
+</Book>
+<Book Series="Ghostbusters: Get Real" Number="1" Volume="2015" Year="2015">
+<Database Name="cv" Series="82687" Issue="492239" />
+</Book>
+<Book Series="Ghostbusters: Get Real" Number="2" Volume="2015" Year="2015">
+<Database Name="cv" Series="82687" Issue="496405" />
+</Book>
+<Book Series="Ghostbusters: Get Real" Number="3" Volume="2015" Year="2015">
+<Database Name="cv" Series="82687" Issue="498412" />
+</Book>
+<Book Series="Ghostbusters: Get Real" Number="4" Volume="2015" Year="2015">
+<Database Name="cv" Series="82687" Issue="501627" />
+</Book>
+<Book Series="Ghostbusters Annual 2015" Number="1" Volume="2015" Year="2015">
+<Database Name="cv" Series="86231" Issue="506675" />
+</Book>
+<Book Series="Ghostbusters: International" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="87614" Issue="512445" />
+</Book>
+<Book Series="Ghostbusters: International" Number="2" Volume="2016" Year="2016">
+<Database Name="cv" Series="87614" Issue="516834" />
+</Book>
+<Book Series="Ghostbusters: International" Number="3" Volume="2016" Year="2016">
+<Database Name="cv" Series="87614" Issue="522194" />
+</Book>
+<Book Series="Ghostbusters: International" Number="4" Volume="2016" Year="2016">
+<Database Name="cv" Series="87614" Issue="527025" />
+</Book>
+<Book Series="Ghostbusters: International" Number="5" Volume="2016" Year="2016">
+<Database Name="cv" Series="87614" Issue="531763" />
+</Book>
+<Book Series="Ghostbusters: International" Number="6" Volume="2016" Year="2016">
+<Database Name="cv" Series="87614" Issue="537851" />
+</Book>
+<Book Series="Ghostbusters: International" Number="7" Volume="2016" Year="2016">
+<Database Name="cv" Series="87614" Issue="540814" />
+</Book>
+<Book Series="Ghostbusters: International" Number="8" Volume="2016" Year="2016">
+<Database Name="cv" Series="87614" Issue="545971" />
+</Book>
+<Book Series="Ghostbusters: International" Number="9" Volume="2016" Year="2016">
+<Database Name="cv" Series="87614" Issue="552080" />
+</Book>
+<Book Series="Ghostbusters: International" Number="10" Volume="2016" Year="2016">
+<Database Name="cv" Series="87614" Issue="553793" />
+</Book>
+<Book Series="Ghostbusters: International" Number="11" Volume="2016" Year="2016">
+<Database Name="cv" Series="87614" Issue="562391" />
+</Book>
+<Book Series="Ghostbusters Deviations" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="88813" Issue="519156" />
+</Book>
+<Book Series="Ghostbusters Annual 2017" Number="1" Volume="2017" Year="2017">
+<Database Name="cv" Series="98029" Issue="576551" />
+</Book>
+<Book Series="Ghostbusters 101" Number="1" Volume="2017" Year="2017">
+<Database Name="cv" Series="100059" Issue="588456" />
+</Book>
+<Book Series="Ghostbusters 101" Number="2" Volume="2017" Year="2017">
+<Database Name="cv" Series="100059" Issue="594028" />
+</Book>
+<Book Series="Ghostbusters 101" Number="3" Volume="2017" Year="2017">
+<Database Name="cv" Series="100059" Issue="596806" />
+</Book>
+<Book Series="Ghostbusters 101" Number="4" Volume="2017" Year="2017">
+<Database Name="cv" Series="100059" Issue="604917" />
+</Book>
+<Book Series="Ghostbusters 101" Number="5" Volume="2017" Year="2017">
+<Database Name="cv" Series="100059" Issue="610507" />
+</Book>
+<Book Series="Ghostbusters 101" Number="6" Volume="2017" Year="2017">
+<Database Name="cv" Series="100059" Issue="617489" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles/Ghostbusters 2" Number="1" Volume="2018" Year="2017">
+<Database Name="cv" Series="105719" Issue="634222" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles/Ghostbusters 2" Number="2" Volume="2018" Year="2017">
+<Database Name="cv" Series="105719" Issue="635899" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles/Ghostbusters 2" Number="3" Volume="2018" Year="2017">
+<Database Name="cv" Series="105719" Issue="637565" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles/Ghostbusters 2" Number="4" Volume="2018" Year="2017">
+<Database Name="cv" Series="105719" Issue="640428" />
+</Book>
+<Book Series="Teenage Mutant Ninja Turtles/Ghostbusters 2" Number="5" Volume="2018" Year="2017">
+<Database Name="cv" Series="105719" Issue="643102" />
+</Book>
+<Book Series="Ghostbusters Annual 2018" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="109056" Issue="661798" />
+</Book>
+<Book Series="Ghostbusters: Crossing Over" Number="1" Volume="2019" Year="2018">
+<Database Name="cv" Series="109172" Issue="662591" />
+</Book>
+<Book Series="Ghostbusters: Crossing Over" Number="2" Volume="2019" Year="2018">
+<Database Name="cv" Series="109172" Issue="666662" />
+</Book>
+<Book Series="Ghostbusters: Crossing Over" Number="3" Volume="2019" Year="2018">
+<Database Name="cv" Series="109172" Issue="672189" />
+</Book>
+<Book Series="Ghostbusters: Crossing Over" Number="4" Volume="2019" Year="2018">
+<Database Name="cv" Series="109172" Issue="675831" />
+</Book>
+<Book Series="Ghostbusters: Crossing Over" Number="5" Volume="2019" Year="2018">
+<Database Name="cv" Series="109172" Issue="678370" />
+</Book>
+<Book Series="Ghostbusters: Crossing Over" Number="6" Volume="2019" Year="2018">
+<Database Name="cv" Series="109172" Issue="683665" />
+</Book>
+<Book Series="Ghostbusters: Crossing Over" Number="7" Volume="2019" Year="2018">
+<Database Name="cv" Series="109172" Issue="688926" />
+</Book>
+<Book Series="Ghostbusters: Crossing Over" Number="8" Volume="2019" Year="2018">
+<Database Name="cv" Series="109172" Issue="691853" />
+</Book>
+<Book Series="Ghostbusters: Answer the Call" Number="1" Volume="2018" Year="2017">
+<Database Name="cv" Series="105525" Issue="632536" />
+</Book>
+<Book Series="Ghostbusters: Answer the Call" Number="2" Volume="2018" Year="2017">
+<Database Name="cv" Series="105525" Issue="650596" />
+</Book>
+<Book Series="Ghostbusters: Answer the Call" Number="3" Volume="2018" Year="2017">
+<Database Name="cv" Series="105525" Issue="658751" />
+</Book>
+<Book Series="Ghostbusters: Answer the Call" Number="4" Volume="2018" Year="2018">
+<Database Name="cv" Series="105525" Issue="663441" />
+</Book>
+<Book Series="Ghostbusters: Answer the Call" Number="5" Volume="2018" Year="2018">
+<Database Name="cv" Series="105525" Issue="669400" />
+</Book>
+<Book Series="Ghostbusters 20/20" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="116476" Issue="697368" />
+</Book>
+<Book Series="Ghostbusters 35th Anniversary: Ghostbusters: One-Shot" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="118106" Issue="705365" />
+</Book>
+<Book Series="Ghostbusters 35th Anniversary: The Real Ghostbusters: One-Shot" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="118205" Issue="705683" />
+</Book>
+<Book Series="Answer the Call Ghostbusters 35th Anniversary: One-Shot" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="118368" Issue="706221" />
+</Book>
+<Book Series="Ghostbusters 35th Anniversary: Extreme: One-Shot" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="118481" Issue="706837" />
+</Book>
+<Book Series="Transformers/Ghostbusters" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="119841" Issue="712244" />
+</Book>
+<Book Series="Transformers/Ghostbusters" Number="2" Volume="2019" Year="2019">
+<Database Name="cv" Series="119841" Issue="713737" />
+</Book>
+<Book Series="Transformers/Ghostbusters" Number="3" Volume="2019" Year="2019">
+<Database Name="cv" Series="119841" Issue="715043" />
+</Book>
+<Book Series="Transformers/Ghostbusters" Number="4" Volume="2019" Year="2019">
+<Database Name="cv" Series="119841" Issue="717834" />
+</Book>
+<Book Series="Transformers/Ghostbusters" Number="5" Volume="2019" Year="2019">
+<Database Name="cv" Series="119841" Issue="721096" />
+</Book>
+<Book Series="Ghostbusters: Year One" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="124398" Issue="734335" />
+</Book>
+<Book Series="Ghostbusters: Year One" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="124398" Issue="739463" />
+</Book>
+<Book Series="Ghostbusters: Year One" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="124398" Issue="743197" />
+</Book>
+<Book Series="Ghostbusters: Year One" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="124398" Issue="772711" />
+</Book>
+</Books>
+<Matchers />
+</ReadingList>


### PR DESCRIPTION
Added a publication order (while there's time hopping the story seems to make most sense this way) list for IDW's now complete Ghostbusters run as the license moved to DHC.