### PR TITLE
Update Energon list to current released issues. Correct Avengers v X men CBRO event. Added X-Men and X-Men Krakoa era CBRO lists

### DIFF
--- a/Image/Master Reading Order/Energon Universe/[Image] [2023-Present] Energon Universe (CBH).cbl
+++ b/Image/Master Reading Order/Energon Universe/[Image] [2023-Present] Energon Universe (CBH).cbl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 <Name>[Image] [2023-Present] Energon Universe (CBH)</Name>
-<NumIssues>80</NumIssues>
+<NumIssues>99</NumIssues>
 <Books>
 <Book Series="Void Rivals" Number="1" Volume="2023" Year="2023">
 <Database Name="cv" Series="151301" Issue="994693" />
@@ -242,6 +242,63 @@
 </Book>
 <Book Series="Void Rivals" Number="23" Volume="2023" Year="2025">
 <Database Name="cv" Series="151301" Issue="1135132" />
+</Book>
+<Book Series="Transformers" Number="25" Volume="2023" Year="2025">
+<Database Name="cv" Series="153968" Issue="1137186" />
+</Book>
+<Book Series="G.I. Joe" Number="12" Volume="2024" Year="2025">
+<Database Name="cv" Series="161047" Issue="1138307" />
+</Book>
+<Book Series="Transformers" Number="26" Volume="2023" Year="2025">
+<Database Name="cv" Series="153968" Issue="1143321" />
+</Book>
+<Book Series="Void Rivals" Number="24" Volume="2023" Year="2025">
+<Database Name="cv" Series="151301" Issue="1142030" />
+</Book>
+<Book Series="Transformers" Number="27" Volume="2023" Year="2025">
+<Database Name="cv" Series="153968" Issue="1147725" />
+</Book>
+<Book Series="G.I. Joe" Number="13" Volume="2024" Year="2025">
+<Database Name="cv" Series="161047" Issue="1141999" />
+</Book>
+<Book Series="Void Rivals" Number="25" Volume="2023" Year="2025">
+<Database Name="cv" Series="151301" Issue="1149876" />
+</Book>
+<Book Series="Transformers" Number="28" Volume="2023" Year="2026">
+<Database Name="cv" Series="153968" Issue="1152806" />
+</Book>
+<Book Series="G.I. Joe" Number="14" Volume="2024" Year="2025">
+<Database Name="cv" Series="161047" Issue="1144231" />
+</Book>
+<Book Series="Void Rivals" Number="26" Volume="2023" Year="2026">
+<Database Name="cv" Series="151301" Issue="1154129" />
+</Book>
+<Book Series="Transformers" Number="29" Volume="2023" Year="2026">
+<Database Name="cv" Series="153968" Issue="1155901" />
+</Book>
+<Book Series="G.I. Joe" Number="15" Volume="2024" Year="2025">
+<Database Name="cv" Series="161047" Issue="1146764" />
+</Book>
+<Book Series="G.I. Joe" Number="16" Volume="2024" Year="2025">
+<Database Name="cv" Series="161047" Issue="1148728" />
+</Book>
+<Book Series="Void Rivals" Number="27" Volume="2023" Year="2026">
+<Database Name="cv" Series="151301" Issue="1156987" />
+</Book>
+<Book Series="Transformers" Number="30" Volume="2023" Year="2026">
+<Database Name="cv" Series="153968" Issue="1159227" />
+</Book>
+<Book Series="G.I. Joe" Number="17" Volume="2024" Year="2026">
+<Database Name="cv" Series="161047" Issue="1152785" />
+</Book>
+<Book Series="G.I. Joe" Number="18" Volume="2024" Year="2026">
+<Database Name="cv" Series="161047" Issue="1154096" />
+</Book>
+<Book Series="Void Rivals" Number="28" Volume="2023" Year="2026">
+<Database Name="cv" Series="151301" Issue="1160338" />
+</Book>
+<Book Series="G.I. Joe" Number="19" Volume="2024" Year="2026">
+<Database Name="cv" Series="161047" Issue="1156288" />
 </Book>
 </Books>
 <Matchers />

--- a/Marvel/Events/CBRO/2011-2012 - Part 10/[Marvel] Avengers vs. X-Men (WEB-CBRO).cbl
+++ b/Marvel/Events/CBRO/2011-2012 - Part 10/[Marvel] Avengers vs. X-Men (WEB-CBRO).cbl
@@ -42,8 +42,8 @@
 <Book Series="AVX: VS" Number="1" Volume="2012" Year="2012">
 <Database Name="cv" Series="48342" Issue="333447" />
 </Book>
-<Book Series="Uncanny X-Men" Number="11" Volume="2013" Year="2013">
-<Database Name="cv" Series="57181" Issue="423684" />
+<Book Series="Uncanny X-Men" Number="11" Volume="2011" Year="2012">
+<Database Name="cv" Series="43785" Issue="333449" />
 </Book>
 <Book Series="Avengers Vs. X-Men" Number="3" Volume="2012" Year="2012">
 <Database Name="cv" Series="47331" Issue="334169" />
@@ -90,8 +90,8 @@
 <Book Series="AVX: VS" Number="2" Volume="2012" Year="2012">
 <Database Name="cv" Series="48342" Issue="335954" />
 </Book>
-<Book Series="Uncanny X-Men" Number="12" Volume="2013" Year="2013">
-<Database Name="cv" Series="57181" Issue="425944" />
+<Book Series="Uncanny X-Men" Number="12" Volume="2011" Year="2012">
+<Database Name="cv" Series="43785" Issue="336047" />
 </Book>
 <Book Series="Wolverine &amp; the X-Men" Number="11" Volume="2011" Year="2012">
 <Database Name="cv" Series="43539" Issue="337499" />
@@ -99,8 +99,8 @@
 <Book Series="Avengers Vs. X-Men" Number="5" Volume="2012" Year="2012">
 <Database Name="cv" Series="47331" Issue="338525" />
 </Book>
-<Book Series="Uncanny X-Men" Number="13" Volume="2013" Year="2013">
-<Database Name="cv" Series="57181" Issue="428867" />
+<Book Series="Uncanny X-Men" Number="13" Volume="2011" Year="2012">
+<Database Name="cv" Series="43785" Issue="338486" />
 </Book>
 <Book Series="AVX: VS" Number="3" Volume="2012" Year="2012">
 <Database Name="cv" Series="48342" Issue="340399" />
@@ -114,8 +114,8 @@
 <Book Series="Avengers Academy" Number="33" Volume="2010" Year="2012">
 <Database Name="cv" Series="33633" Issue="346269" />
 </Book>
-<Book Series="Uncanny X-Men" Number="14" Volume="2013" Year="2014">
-<Database Name="cv" Series="57181" Issue="433852" />
+<Book Series="Uncanny X-Men" Number="14" Volume="2011" Year="2012">
+<Database Name="cv" Series="43785" Issue="341738" />
 </Book>
 <Book Series="Avengers Vs. X-Men" Number="6" Volume="2012" Year="2012">
 <Database Name="cv" Series="47331" Issue="341749" />
@@ -129,14 +129,14 @@
 <Book Series="Avengers" Number="28" Volume="2010" Year="2012">
 <Database Name="cv" Series="33227" Issue="347231" />
 </Book>
-<Book Series="Uncanny X-Men" Number="15" Volume="2013" Year="2014">
-<Database Name="cv" Series="57181" Issue="436208" />
+<Book Series="Uncanny X-Men" Number="15" Volume="2011" Year="2012">
+<Database Name="cv" Series="43785" Issue="344115" />
 </Book>
-<Book Series="Uncanny X-Men" Number="16" Volume="2013" Year="2014">
-<Database Name="cv" Series="57181" Issue="442179" />
+<Book Series="Uncanny X-Men" Number="16" Volume="2011" Year="2012">
+<Database Name="cv" Series="43785" Issue="346273" />
 </Book>
-<Book Series="Uncanny X-Men" Number="17" Volume="2013" Year="2014">
-<Database Name="cv" Series="57181" Issue="445823" />
+<Book Series="Uncanny X-Men" Number="17" Volume="2011" Year="2012">
+<Database Name="cv" Series="43785" Issue="352641" />
 </Book>
 <Book Series="Avengers" Number="29" Volume="2010" Year="2012">
 <Database Name="cv" Series="33227" Issue="351071" />
@@ -189,14 +189,14 @@
 <Book Series="Avengers Vs. X-Men" Number="11" Volume="2012" Year="2012">
 <Database Name="cv" Series="47331" Issue="356764" />
 </Book>
-<Book Series="Uncanny X-Men" Number="18" Volume="2013" Year="2014">
-<Database Name="cv" Series="57181" Issue="446998" />
+<Book Series="Uncanny X-Men" Number="18" Volume="2011" Year="2012">
+<Database Name="cv" Series="43785" Issue="356777" />
 </Book>
 <Book Series="Avengers Vs. X-Men" Number="12" Volume="2012" Year="2012">
 <Database Name="cv" Series="47331" Issue="359916" />
 </Book>
-<Book Series="Uncanny X-Men" Number="19" Volume="2013" Year="2014">
-<Database Name="cv" Series="57181" Issue="448006" />
+<Book Series="Uncanny X-Men" Number="19" Volume="2011" Year="2012">
+<Database Name="cv" Series="43785" Issue="360032" />
 </Book>
 <Book Series="AVX: VS" Number="6" Volume="2012" Year="2012">
 <Database Name="cv" Series="48342" Issue="360037" />
@@ -210,8 +210,8 @@
 <Book Series="Wolverine &amp; the X-Men" Number="18" Volume="2011" Year="2012">
 <Database Name="cv" Series="43539" Issue="360916" />
 </Book>
-<Book Series="Uncanny X-Men" Number="20" Volume="2013" Year="2014">
-<Database Name="cv" Series="57181" Issue="450557" />
+<Book Series="Uncanny X-Men" Number="20" Volume="2011" Year="2012">
+<Database Name="cv" Series="43785" Issue="362220" />
 </Book>
 <Book Series="A-Babies vs. X-Babies" Number="1" Volume="2012" Year="2012">
 <Database Name="cv" Series="53122" Issue="362255" />

--- a/Marvel/Teams/X-Men/WEB-CBRO/[Marvel] X-Men Krakoa Era no events (WEB-CBRO).cbl
+++ b/Marvel/Teams/X-Men/WEB-CBRO/[Marvel] X-Men Krakoa Era no events (WEB-CBRO).cbl
@@ -1,0 +1,1643 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Name>[Marvel] X-Men Krakoa Era no events (WEB-CBRO)</Name>
+<NumIssues>545</NumIssues>
+<Books>
+<Book Series="House of X" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="120309" Issue="714236" />
+</Book>
+<Book Series="Powers of X" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="120407" Issue="714669" />
+</Book>
+<Book Series="House of X" Number="2" Volume="2019" Year="2019">
+<Database Name="cv" Series="120309" Issue="715306" />
+</Book>
+<Book Series="Powers of X" Number="2" Volume="2019" Year="2019">
+<Database Name="cv" Series="120407" Issue="716371" />
+</Book>
+<Book Series="House of X" Number="3" Volume="2019" Year="2019">
+<Database Name="cv" Series="120309" Issue="717519" />
+</Book>
+<Book Series="Powers of X" Number="3" Volume="2019" Year="2019">
+<Database Name="cv" Series="120407" Issue="716968" />
+</Book>
+<Book Series="House of X" Number="4" Volume="2019" Year="2019">
+<Database Name="cv" Series="120309" Issue="718128" />
+</Book>
+<Book Series="Powers of X" Number="4" Volume="2019" Year="2019">
+<Database Name="cv" Series="120407" Issue="718763" />
+</Book>
+<Book Series="House of X" Number="5" Volume="2019" Year="2019">
+<Database Name="cv" Series="120309" Issue="719439" />
+</Book>
+<Book Series="Powers of X" Number="5" Volume="2019" Year="2019">
+<Database Name="cv" Series="120407" Issue="720169" />
+</Book>
+<Book Series="House of X" Number="6" Volume="2019" Year="2019">
+<Database Name="cv" Series="120309" Issue="721154" />
+</Book>
+<Book Series="Powers of X" Number="6" Volume="2019" Year="2019">
+<Database Name="cv" Series="120407" Issue="721789" />
+</Book>
+<Book Series="X-Men" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="122077" Issue="723121" />
+</Book>
+<Book Series="New Mutants" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="726210" />
+</Book>
+<Book Series="New Mutants" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="728977" />
+</Book>
+<Book Series="New Mutants" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="730341" />
+</Book>
+<Book Series="New Mutants" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="731522" />
+</Book>
+<Book Series="New Mutants" Number="6" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="735526" />
+</Book>
+<Book Series="Marauders" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="122218" Issue="723862" />
+</Book>
+<Book Series="Excalibur" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="122488" Issue="725247" />
+</Book>
+<Book Series="Excalibur" Number="2" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="728420" />
+</Book>
+<Book Series="Excalibur" Number="3" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="729679" />
+</Book>
+<Book Series="X-Men/Fantastic Four" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="124822" Issue="736501" />
+</Book>
+<Book Series="X-Men/Fantastic Four" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="124822" Issue="738624" />
+</Book>
+<Book Series="X-Men/Fantastic Four" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="124822" Issue="743454" />
+</Book>
+<Book Series="X-Men/Fantastic Four" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="124822" Issue="781439" />
+</Book>
+<Book Series="X-Force" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="726217" />
+</Book>
+<Book Series="Fallen Angels" Number="1" Volume="2019" Year="2020">
+<Database Name="cv" Series="122814" Issue="727257" />
+</Book>
+<Book Series="Fallen Angels" Number="2" Volume="2019" Year="2020">
+<Database Name="cv" Series="122814" Issue="728972" />
+</Book>
+<Book Series="Fallen Angels" Number="3" Volume="2019" Year="2020">
+<Database Name="cv" Series="122814" Issue="730333" />
+</Book>
+<Book Series="Fallen Angels" Number="4" Volume="2019" Year="2020">
+<Database Name="cv" Series="122814" Issue="731511" />
+</Book>
+<Book Series="Marauders" Number="2" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="728426" />
+</Book>
+<Book Series="Marauders" Number="3" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="729682" />
+</Book>
+<Book Series="X-Men" Number="2" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="727273" />
+</Book>
+<Book Series="X-Men" Number="3" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="729692" />
+</Book>
+<Book Series="New Mutants" Number="5" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="732887" />
+</Book>
+<Book Series="New Mutants" Number="7" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="737761" />
+</Book>
+<Book Series="New Mutants" Number="8" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="738614" />
+</Book>
+<Book Series="New Mutants" Number="9" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="740822" />
+</Book>
+<Book Series="New Mutants" Number="10" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="767932" />
+</Book>
+<Book Series="New Mutants" Number="11" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="781436" />
+</Book>
+<Book Series="X-Force" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="728984" />
+</Book>
+<Book Series="X-Force" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="730351" />
+</Book>
+<Book Series="X-Men" Number="4" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="731983" />
+</Book>
+<Book Series="X-Force" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="731530" />
+</Book>
+<Book Series="X-Force" Number="5" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="732895" />
+</Book>
+<Book Series="X-Force" Number="6" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="735534" />
+</Book>
+<Book Series="Fallen Angels" Number="5" Volume="2019" Year="2020">
+<Database Name="cv" Series="122814" Issue="732878" />
+</Book>
+<Book Series="Fallen Angels" Number="6" Volume="2019" Year="2020">
+<Database Name="cv" Series="122814" Issue="735522" />
+</Book>
+<Book Series="Excalibur" Number="4" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="731510" />
+</Book>
+<Book Series="Excalibur" Number="5" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="732877" />
+</Book>
+<Book Series="Excalibur" Number="6" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="734640" />
+</Book>
+<Book Series="X-Men" Number="5" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="735535" />
+</Book>
+<Book Series="Giant-Size X-Men: Jean Grey and Emma Frost" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="125302" Issue="738612" />
+</Book>
+<Book Series="X-Men" Number="6" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="737173" />
+</Book>
+<Book Series="Hellions" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="126015" Issue="743440" />
+</Book>
+<Book Series="Hellions" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="126015" Issue="781434" />
+</Book>
+<Book Series="Hellions" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="126015" Issue="796298" />
+</Book>
+<Book Series="Hellions" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="126015" Issue="799949" />
+</Book>
+<Book Series="Marauders" Number="4" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="731519" />
+</Book>
+<Book Series="Marauders" Number="5" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="731974" />
+</Book>
+<Book Series="Marauders" Number="6" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="734643" />
+</Book>
+<Book Series="Marauders" Number="7" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="736492" />
+</Book>
+<Book Series="Marauders" Number="8" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="737758" />
+</Book>
+<Book Series="Cable" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="125678" Issue="740814" />
+</Book>
+<Book Series="X-Men" Number="8" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="740832" />
+</Book>
+<Book Series="X-Men" Number="9" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="743453" />
+</Book>
+<Book Series="X-Force" Number="7" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="737172" />
+</Book>
+<Book Series="X-Force" Number="8" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="738622" />
+</Book>
+<Book Series="Excalibur" Number="7" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="737156" />
+</Book>
+<Book Series="Excalibur" Number="8" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="739558" />
+</Book>
+<Book Series="X-Force" Number="9" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="742380" />
+</Book>
+<Book Series="X-Force" Number="10" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="775013" />
+</Book>
+<Book Series="X-Factor" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="129097" Issue="784416" />
+</Book>
+<Book Series="Wolverine" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="125121" Issue="737765" />
+</Book>
+<Book Series="Wolverine" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="125121" Issue="743452" />
+</Book>
+<Book Series="Wolverine" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="125121" Issue="781438" />
+</Book>
+<Book Series="Cable" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="125678" Issue="784406" />
+</Book>
+<Book Series="Cable" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="125678" Issue="794931" />
+</Book>
+<Book Series="Cable" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="125678" Issue="797240" />
+</Book>
+<Book Series="Marauders" Number="9" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="739561" />
+</Book>
+<Book Series="Marauders" Number="10" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="763574" />
+</Book>
+<Book Series="Marauders" Number="11" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="791927" />
+</Book>
+<Book Series="Marauders" Number="12" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="797983" />
+</Book>
+<Book Series="Giant-Size X-Men: Nightcrawler" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="126014" Issue="743439" />
+</Book>
+<Book Series="New Mutants" Number="12" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="797246" />
+</Book>
+<Book Series="Marvel&apos;s Voices: Indigenous Voices" Number="1" Volume="2020" Year="2021">
+<Database Name="cv" Series="132129" Issue="819121" />
+</Book>
+<Book Series="Children of the Atom" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="134388" Issue="836298" />
+</Book>
+<Book Series="Children of the Atom" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="134388" Issue="842957" />
+</Book>
+<Book Series="X-Men" Number="7" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="738623" />
+</Book>
+<Book Series="Giant-Size X-Men: Fantomex" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="129245" Issue="787352" />
+</Book>
+<Book Series="Giant-Size X-Men: Storm" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="130395" Issue="799948" />
+</Book>
+<Book Series="Wolverine" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="125121" Issue="794942" />
+</Book>
+<Book Series="Wolverine" Number="5" Volume="2020" Year="2020">
+<Database Name="cv" Series="125121" Issue="797248" />
+</Book>
+<Book Series="X-Factor" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="129097" Issue="796302" />
+</Book>
+<Book Series="X-Factor" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="129097" Issue="797986" />
+</Book>
+<Book Series="X-Force" Number="11" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="791931" />
+</Book>
+<Book Series="X-Force" Number="12" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="797987" />
+</Book>
+<Book Series="X-Force" Number="15" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="821504" />
+</Book>
+<Book Series="X-Force" Number="16" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="825509" />
+</Book>
+<Book Series="Excalibur" Number="9" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="742368" />
+</Book>
+<Book Series="Excalibur" Number="10" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="767930" />
+</Book>
+<Book Series="Excalibur" Number="11" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="794936" />
+</Book>
+<Book Series="Excalibur" Number="12" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="799947" />
+</Book>
+<Book Series="X-Men" Number="12" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="799956" />
+</Book>
+<Book Series="S.W.O.R.D." Number="1" Volume="2020" Year="2021">
+<Database Name="cv" Series="132511" Issue="820748" />
+</Book>
+<Book Series="Excalibur" Number="16" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="822348" />
+</Book>
+<Book Series="Hellions" Number="7" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="820023" />
+</Book>
+<Book Series="Hellions" Number="8" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="824026" />
+</Book>
+<Book Series="X-Factor" Number="5" Volume="2020" Year="2021">
+<Database Name="cv" Series="129097" Issue="820030" />
+</Book>
+<Book Series="Cable" Number="7" Volume="2020" Year="2021">
+<Database Name="cv" Series="125678" Issue="825505" />
+</Book>
+<Book Series="Cable" Number="8" Volume="2020" Year="2021">
+<Database Name="cv" Series="125678" Issue="828850" />
+</Book>
+<Book Series="X-Men" Number="16" Volume="2019" Year="2021">
+<Database Name="cv" Series="122077" Issue="823351" />
+</Book>
+<Book Series="Marauders" Number="16" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="820747" />
+</Book>
+<Book Series="New Mutants" Number="14" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="821499" />
+</Book>
+<Book Series="X-Factor" Number="6" Volume="2020" Year="2021">
+<Database Name="cv" Series="129097" Issue="824036" />
+</Book>
+<Book Series="New Mutants" Number="15" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="826560" />
+</Book>
+<Book Series="X-Men" Number="17" Volume="2019" Year="2021">
+<Database Name="cv" Series="122077" Issue="826566" />
+</Book>
+<Book Series="Giant-Size X-Men: Magneto" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="128617" Issue="779007" />
+</Book>
+<Book Series="Marauders" Number="17" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="824452" />
+</Book>
+<Book Series="Wolverine" Number="8" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="823350" />
+</Book>
+<Book Series="Cable" Number="9" Volume="2020" Year="2021">
+<Database Name="cv" Series="125678" Issue="839790" />
+</Book>
+<Book Series="Wolverine" Number="9" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="826565" />
+</Book>
+<Book Series="Wolverine" Number="10" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="830035" />
+</Book>
+<Book Series="Wolverine" Number="11" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="842971" />
+</Book>
+<Book Series="Wolverine" Number="12" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="851314" />
+</Book>
+<Book Series="Juggernaut" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="130568" Issue="803645" />
+</Book>
+<Book Series="Juggernaut" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="130568" Issue="813284" />
+</Book>
+<Book Series="Juggernaut" Number="3" Volume="2020" Year="2021">
+<Database Name="cv" Series="130568" Issue="819120" />
+</Book>
+<Book Series="Juggernaut" Number="4" Volume="2020" Year="2021">
+<Database Name="cv" Series="130568" Issue="820745" />
+</Book>
+<Book Series="Juggernaut" Number="5" Volume="2020" Year="2021">
+<Database Name="cv" Series="130568" Issue="824028" />
+</Book>
+<Book Series="X-Force" Number="17" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="828200" />
+</Book>
+<Book Series="X-Force" Number="18" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="838891" />
+</Book>
+<Book Series="X-Force" Number="19" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="844977" />
+</Book>
+<Book Series="Children of the Atom" Number="3" Volume="2021" Year="2021">
+<Database Name="cv" Series="134388" Issue="848848" />
+</Book>
+<Book Series="New Mutants" Number="16" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="830031" />
+</Book>
+<Book Series="New Mutants" Number="17" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="846089" />
+</Book>
+<Book Series="X-Men" Number="18" Volume="2019" Year="2021">
+<Database Name="cv" Series="122077" Issue="830036" />
+</Book>
+<Book Series="X-Men" Number="19" Volume="2019" Year="2021">
+<Database Name="cv" Series="122077" Issue="840961" />
+</Book>
+<Book Series="New Mutants" Number="18" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="855632" />
+</Book>
+<Book Series="Excalibur" Number="17" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="826556" />
+</Book>
+<Book Series="Excalibur" Number="18" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="828191" />
+</Book>
+<Book Series="Excalibur" Number="19" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="839793" />
+</Book>
+<Book Series="Excalibur" Number="20" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="842202" />
+</Book>
+<Book Series="X-Men" Number="20" Volume="2019" Year="2021">
+<Database Name="cv" Series="122077" Issue="855634" />
+</Book>
+<Book Series="Hellions" Number="9" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="827522" />
+</Book>
+<Book Series="Hellions" Number="10" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="832862" />
+</Book>
+<Book Series="Hellions" Number="11" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="847510" />
+</Book>
+<Book Series="Cable" Number="10" Volume="2020" Year="2021">
+<Database Name="cv" Series="125678" Issue="846084" />
+</Book>
+<Book Series="Cable" Number="11" Volume="2020" Year="2021">
+<Database Name="cv" Series="125678" Issue="866577" />
+</Book>
+<Book Series="Cable" Number="12" Volume="2020" Year="2021">
+<Database Name="cv" Series="125678" Issue="874521" />
+</Book>
+<Book Series="S.W.O.R.D." Number="5" Volume="2020" Year="2021">
+<Database Name="cv" Series="132511" Issue="844973" />
+</Book>
+<Book Series="X-Factor" Number="7" Volume="2020" Year="2021">
+<Database Name="cv" Series="129097" Issue="827532" />
+</Book>
+<Book Series="X-Factor" Number="8" Volume="2020" Year="2021">
+<Database Name="cv" Series="129097" Issue="836308" />
+</Book>
+<Book Series="X-Factor" Number="9" Volume="2020" Year="2021">
+<Database Name="cv" Series="129097" Issue="848859" />
+</Book>
+<Book Series="X-Corp" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="136025" Issue="848858" />
+</Book>
+<Book Series="Marauders" Number="18" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="828860" />
+</Book>
+<Book Series="Marauders" Number="19" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="842206" />
+</Book>
+<Book Series="Children of the Atom" Number="4" Volume="2021" Year="2021">
+<Database Name="cv" Series="134388" Issue="858871" />
+</Book>
+<Book Series="Children of the Atom" Number="5" Volume="2021" Year="2021">
+<Database Name="cv" Series="134388" Issue="868608" />
+</Book>
+<Book Series="Way of X" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="135583" Issue="844975" />
+</Book>
+<Book Series="Way of X" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="135583" Issue="851313" />
+</Book>
+<Book Series="Marauders" Number="20" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="847514" />
+</Book>
+<Book Series="Marauders" Number="22" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="872876" />
+</Book>
+<Book Series="S.W.O.R.D." Number="7" Volume="2020" Year="2021">
+<Database Name="cv" Series="132511" Issue="874522" />
+</Book>
+<Book Series="Cable: Reloaded" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="138527" Issue="882047" />
+</Book>
+<Book Series="X-Men" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="137402" Issue="868602" />
+</Book>
+<Book Series="New Mutants" Number="20" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="872877" />
+</Book>
+<Book Series="New Mutants" Number="21" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="882897" />
+</Book>
+<Book Series="New Mutants" Number="22" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="888638" />
+</Book>
+<Book Series="New Mutants" Number="23" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="896124" />
+</Book>
+<Book Series="X-Men: The Trial of Magneto" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="138343" Issue="880915" />
+</Book>
+<Book Series="Marauders" Number="23" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="880901" />
+</Book>
+<Book Series="Wolverine" Number="14" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="874523" />
+</Book>
+<Book Series="Wolverine" Number="15" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="882049" />
+</Book>
+<Book Series="Wolverine" Number="16" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="886940" />
+</Book>
+<Book Series="X-Men: The Trial of Magneto" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="138343" Issue="884830" />
+</Book>
+<Book Series="X-Men: The Trial of Magneto" Number="3" Volume="2021" Year="2021">
+<Database Name="cv" Series="138343" Issue="890603" />
+</Book>
+<Book Series="X-Men: The Trial of Magneto" Number="4" Volume="2021" Year="2022">
+<Database Name="cv" Series="138343" Issue="896094" />
+</Book>
+<Book Series="Inferno" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="139289" Issue="886937" />
+</Book>
+<Book Series="Hellions" Number="13" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="868599" />
+</Book>
+<Book Series="Hellions" Number="14" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="877059" />
+</Book>
+<Book Series="Hellions" Number="15" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="882896" />
+</Book>
+<Book Series="Hellions" Number="16" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="888637" />
+</Book>
+<Book Series="S.W.O.R.D." Number="8" Volume="2020" Year="2021">
+<Database Name="cv" Series="132511" Issue="886939" />
+</Book>
+<Book Series="Hellions" Number="17" Volume="2020" Year="2022">
+<Database Name="cv" Series="126015" Issue="893934" />
+</Book>
+<Book Series="Hellions" Number="18" Volume="2020" Year="2022">
+<Database Name="cv" Series="126015" Issue="897328" />
+</Book>
+<Book Series="X-Men: The Trial of Magneto" Number="5" Volume="2021" Year="2022">
+<Database Name="cv" Series="138343" Issue="899168" />
+</Book>
+<Book Series="New Mutants" Number="24" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="906634" />
+</Book>
+<Book Series="X-Men" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="137402" Issue="877060" />
+</Book>
+<Book Series="Excalibur" Number="22" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="871563" />
+</Book>
+<Book Series="Excalibur" Number="23" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="884068" />
+</Book>
+<Book Series="Excalibur" Number="24" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="888636" />
+</Book>
+<Book Series="Excalibur" Number="25" Volume="2019" Year="2022">
+<Database Name="cv" Series="122488" Issue="893974" />
+</Book>
+<Book Series="Excalibur" Number="26" Volume="2019" Year="2022">
+<Database Name="cv" Series="122488" Issue="898357" />
+</Book>
+<Book Series="Way of X" Number="4" Volume="2021" Year="2021">
+<Database Name="cv" Series="135583" Issue="871569" />
+</Book>
+<Book Series="Way of X" Number="5" Volume="2021" Year="2021">
+<Database Name="cv" Series="135583" Issue="880912" />
+</Book>
+<Book Series="X-Men: The Onslaught Revelation" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="139124" Issue="885606" />
+</Book>
+<Book Series="Marauders" Number="24" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="884828" />
+</Book>
+<Book Series="Marauders" Number="25" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="891563" />
+</Book>
+<Book Series="X-Men" Number="3" Volume="2021" Year="2021">
+<Database Name="cv" Series="137402" Issue="885604" />
+</Book>
+<Book Series="X-Corp" Number="3" Volume="2021" Year="2021">
+<Database Name="cv" Series="136025" Issue="871578" />
+</Book>
+<Book Series="X-Corp" Number="4" Volume="2021" Year="2021">
+<Database Name="cv" Series="136025" Issue="880913" />
+</Book>
+<Book Series="X-Corp" Number="5" Volume="2021" Year="2021">
+<Database Name="cv" Series="136025" Issue="885603" />
+</Book>
+<Book Series="S.W.O.R.D." Number="9" Volume="2020" Year="2021">
+<Database Name="cv" Series="132511" Issue="891564" />
+</Book>
+<Book Series="S.W.O.R.D." Number="10" Volume="2020" Year="2022">
+<Database Name="cv" Series="132511" Issue="894139" />
+</Book>
+<Book Series="S.W.O.R.D." Number="11" Volume="2020" Year="2022">
+<Database Name="cv" Series="132511" Issue="899166" />
+</Book>
+<Book Series="X-Men" Number="4" Volume="2021" Year="2021">
+<Database Name="cv" Series="137402" Issue="889466" />
+</Book>
+<Book Series="X-Men" Number="5" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="895353" />
+</Book>
+<Book Series="Marauders" Number="26" Volume="2019" Year="2022">
+<Database Name="cv" Series="122218" Issue="896131" />
+</Book>
+<Book Series="X-Men" Number="6" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="901350" />
+</Book>
+<Book Series="X-Men" Number="7" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="904779" />
+</Book>
+<Book Series="X-Men" Number="8" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="907432" />
+</Book>
+<Book Series="Devil&apos;s Reign: X-Men" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="141328" Issue="903910" />
+</Book>
+<Book Series="Devil&apos;s Reign: X-Men" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="141328" Issue="909677" />
+</Book>
+<Book Series="Devil&apos;s Reign: X-Men" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="141328" Issue="912248" />
+</Book>
+<Book Series="X-Force" Number="21" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="868600" />
+</Book>
+<Book Series="X-Force" Number="22" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="878792" />
+</Book>
+<Book Series="Wolverine" Number="17" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="891565" />
+</Book>
+<Book Series="Wolverine" Number="18" Volume="2020" Year="2022">
+<Database Name="cv" Series="125121" Issue="895337" />
+</Book>
+<Book Series="X-Force" Number="23" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="884069" />
+</Book>
+<Book Series="X-Force" Number="24" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="889465" />
+</Book>
+<Book Series="Inferno" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="139289" Issue="891562" />
+</Book>
+<Book Series="X-Force" Number="25" Volume="2020" Year="2022">
+<Database Name="cv" Series="122668" Issue="894133" />
+</Book>
+<Book Series="X-Force" Number="26" Volume="2020" Year="2022">
+<Database Name="cv" Series="122668" Issue="898353" />
+</Book>
+<Book Series="Wolverine" Number="19" Volume="2020" Year="2022">
+<Database Name="cv" Series="125121" Issue="899167" />
+</Book>
+<Book Series="Inferno" Number="3" Volume="2021" Year="2022">
+<Database Name="cv" Series="139289" Issue="897331" />
+</Book>
+<Book Series="Inferno" Number="4" Volume="2021" Year="2022">
+<Database Name="cv" Series="139289" Issue="901345" />
+</Book>
+<Book Series="Marauders" Number="27" Volume="2019" Year="2022">
+<Database Name="cv" Series="122218" Issue="902690" />
+</Book>
+<Book Series="X-Men" Number="9" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="909674" />
+</Book>
+<Book Series="X-Force Annual" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="142143" Issue="914651" />
+</Book>
+<Book Series="X Lives of Wolverine" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="141332" Issue="903920" />
+</Book>
+<Book Series="X Deaths of Wolverine" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="141460" Issue="904769" />
+</Book>
+<Book Series="X Lives of Wolverine" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="141332" Issue="905751" />
+</Book>
+<Book Series="X Deaths of Wolverine" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="141460" Issue="906636" />
+</Book>
+<Book Series="X Lives of Wolverine" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="141332" Issue="907433" />
+</Book>
+<Book Series="X Deaths of Wolverine" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="141460" Issue="908676" />
+</Book>
+<Book Series="X Lives of Wolverine" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="141332" Issue="910624" />
+</Book>
+<Book Series="X Deaths of Wolverine" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="141460" Issue="910625" />
+</Book>
+<Book Series="X Lives of Wolverine" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="141332" Issue="911227" />
+</Book>
+<Book Series="X Deaths of Wolverine" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="141460" Issue="912246" />
+</Book>
+<Book Series="X-Force" Number="27" Volume="2020" Year="2022">
+<Database Name="cv" Series="122668" Issue="914648" />
+</Book>
+<Book Series="X-Force" Number="28" Volume="2020" Year="2022">
+<Database Name="cv" Series="122668" Issue="924786" />
+</Book>
+<Book Series="X-Force" Number="29" Volume="2020" Year="2022">
+<Database Name="cv" Series="122668" Issue="933078" />
+</Book>
+<Book Series="Wolverine" Number="20" Volume="2020" Year="2022">
+<Database Name="cv" Series="125121" Issue="918155" />
+</Book>
+<Book Series="Wolverine" Number="21" Volume="2020" Year="2022">
+<Database Name="cv" Series="125121" Issue="924801" />
+</Book>
+<Book Series="Wolverine" Number="22" Volume="2020" Year="2022">
+<Database Name="cv" Series="125121" Issue="930974" />
+</Book>
+<Book Series="Wolverine" Number="23" Volume="2020" Year="2022">
+<Database Name="cv" Series="125121" Issue="935753" />
+</Book>
+<Book Series="X-Men Unlimited: X-Men Green" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="144596" Issue="942888" />
+</Book>
+<Book Series="X-Men Unlimited: X-Men Green" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="144596" Issue="948120" />
+</Book>
+<Book Series="Sabretooth" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="141524" Issue="905793" />
+</Book>
+<Book Series="Sabretooth" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="141524" Issue="910621" />
+</Book>
+<Book Series="Sabretooth" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="141524" Issue="919308" />
+</Book>
+<Book Series="Sabretooth" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="141524" Issue="933081" />
+</Book>
+<Book Series="Sabretooth" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="141524" Issue="934984" />
+</Book>
+<Book Series="Sabretooth and the Exiles" Number="1" Volume="2022" Year="2023">
+<Database Name="cv" Series="145971" Issue="954280" />
+</Book>
+<Book Series="Sabretooth and the Exiles" Number="2" Volume="2022" Year="2023">
+<Database Name="cv" Series="145971" Issue="960981" />
+</Book>
+<Book Series="Sabretooth and the Exiles" Number="3" Volume="2022" Year="2023">
+<Database Name="cv" Series="145971" Issue="966425" />
+</Book>
+<Book Series="Sabretooth and the Exiles" Number="4" Volume="2022" Year="2023">
+<Database Name="cv" Series="145971" Issue="973028" />
+</Book>
+<Book Series="Sabretooth and the Exiles" Number="5" Volume="2022" Year="2023">
+<Database Name="cv" Series="145971" Issue="979429" />
+</Book>
+<Book Series="Immortal X-Men" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="142053" Issue="913161" />
+</Book>
+<Book Series="Immortal X-Men" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="142053" Issue="924799" />
+</Book>
+<Book Series="Immortal X-Men" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="142053" Issue="931630" />
+</Book>
+<Book Series="Legion of X" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="143115" Issue="926170" />
+</Book>
+<Book Series="Legion of X" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="143115" Issue="929646" />
+</Book>
+<Book Series="X-Men: Red" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="142134" Issue="914549" />
+</Book>
+<Book Series="X-Men: Red" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="142134" Issue="924793" />
+</Book>
+<Book Series="X-Men: Red" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="142134" Issue="930978" />
+</Book>
+<Book Series="Legion of X" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="143115" Issue="934980" />
+</Book>
+<Book Series="Legion of X" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="143115" Issue="940229" />
+</Book>
+<Book Series="Legion of X" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="143115" Issue="948111" />
+</Book>
+<Book Series="Knights of X" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="142576" Issue="919304" />
+</Book>
+<Book Series="Knights of X" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="142576" Issue="928438" />
+</Book>
+<Book Series="Knights of X" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="142576" Issue="931632" />
+</Book>
+<Book Series="Knights of X" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="142576" Issue="937731" />
+</Book>
+<Book Series="Knights of X" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="142576" Issue="944673" />
+</Book>
+<Book Series="The Secret X-Men" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="141588" Issue="906626" />
+</Book>
+<Book Series="Marauders Annual" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="141459" Issue="904768" />
+</Book>
+<Book Series="Marauders" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="142135" Issue="914550" />
+</Book>
+<Book Series="Marauders" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="142135" Issue="921063" />
+</Book>
+<Book Series="Marauders" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="142135" Issue="929645" />
+</Book>
+<Book Series="Marauders" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="142135" Issue="935761" />
+</Book>
+<Book Series="X-Men" Number="10" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="916414" />
+</Book>
+<Book Series="X-Men" Number="11" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="922402" />
+</Book>
+<Book Series="X-Men" Number="12" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="931633" />
+</Book>
+<Book Series="Free Comic Book Day 2022: Avengers/X-Men" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="142841" Issue="922405" />
+</Book>
+<Book Series="X-Men: Hellfire Gala" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="153656" Issue="1016342" />
+</Book>
+<Book Series="X-Men: Red" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="142134" Issue="933084" />
+</Book>
+<Book Series="Marauders" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="142135" Issue="943897" />
+</Book>
+<Book Series="X-Force" Number="30" Volume="2020" Year="2022">
+<Database Name="cv" Series="122668" Issue="942706" />
+</Book>
+<Book Series="Immortal X-Men" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="142053" Issue="935751" />
+</Book>
+<Book Series="Eternals" Number="10" Volume="2021" Year="2022">
+<Database Name="cv" Series="133080" Issue="910626" />
+</Book>
+<Book Series="Eternals" Number="11" Volume="2021" Year="2022">
+<Database Name="cv" Series="133080" Issue="916411" />
+</Book>
+<Book Series="Eternals" Number="12" Volume="2021" Year="2022">
+<Database Name="cv" Series="133080" Issue="924798" />
+</Book>
+<Book Series="A.X.E.: Eve of Judgment" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="144026" Issue="935759" />
+</Book>
+<Book Series="Immortal X-Men" Number="8" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="955124" />
+</Book>
+<Book Series="Marauders" Number="7" Volume="2022" Year="2022">
+<Database Name="cv" Series="142135" Issue="949640" />
+</Book>
+<Book Series="Marauders" Number="8" Volume="2022" Year="2023">
+<Database Name="cv" Series="142135" Issue="953976" />
+</Book>
+<Book Series="Marauders" Number="9" Volume="2022" Year="2023">
+<Database Name="cv" Series="142135" Issue="958985" />
+</Book>
+<Book Series="Marauders" Number="10" Volume="2022" Year="2023">
+<Database Name="cv" Series="142135" Issue="962851" />
+</Book>
+<Book Series="Marauders" Number="11" Volume="2022" Year="2023">
+<Database Name="cv" Series="142135" Issue="971896" />
+</Book>
+<Book Series="Marauders" Number="12" Volume="2022" Year="2023">
+<Database Name="cv" Series="142135" Issue="978483" />
+</Book>
+<Book Series="New Mutants" Number="25" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="924785" />
+</Book>
+<Book Series="New Mutants" Number="26" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="931631" />
+</Book>
+<Book Series="New Mutants" Number="27" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="935764" />
+</Book>
+<Book Series="New Mutants" Number="28" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="942712" />
+</Book>
+<Book Series="New Mutants" Number="29" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="946211" />
+</Book>
+<Book Series="New Mutants" Number="30" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="948113" />
+</Book>
+<Book Series="New Mutants" Number="31" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="952303" />
+</Book>
+<Book Series="New Mutants" Number="32" Volume="2020" Year="2023">
+<Database Name="cv" Series="122666" Issue="958986" />
+</Book>
+<Book Series="New Mutants" Number="33" Volume="2020" Year="2023">
+<Database Name="cv" Series="122666" Issue="961943" />
+</Book>
+<Book Series="New Mutants: Lethal Legion" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="148780" Issue="975693" />
+</Book>
+<Book Series="New Mutants: Lethal Legion" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="148780" Issue="984327" />
+</Book>
+<Book Series="New Mutants: Lethal Legion" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="148780" Issue="991069" />
+</Book>
+<Book Series="New Mutants: Lethal Legion" Number="4" Volume="2023" Year="2023">
+<Database Name="cv" Series="148780" Issue="996024" />
+</Book>
+<Book Series="New Mutants: Lethal Legion" Number="5" Volume="2023" Year="2023">
+<Database Name="cv" Series="148780" Issue="1002001" />
+</Book>
+<Book Series="X-Men Annual" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="146988" Issue="960987" />
+</Book>
+<Book Series="X-Men" Number="15" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="949129" />
+</Book>
+<Book Series="X-Men" Number="16" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="951447" />
+</Book>
+<Book Series="X-Men" Number="17" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="956846" />
+</Book>
+<Book Series="X-Terminators" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="145163" Issue="948121" />
+</Book>
+<Book Series="X-Terminators" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="145163" Issue="952307" />
+</Book>
+<Book Series="X-Terminators" Number="3" Volume="2022" Year="2023">
+<Database Name="cv" Series="145163" Issue="958044" />
+</Book>
+<Book Series="X-Terminators" Number="4" Volume="2022" Year="2023">
+<Database Name="cv" Series="145163" Issue="961964" />
+</Book>
+<Book Series="X-Terminators" Number="5" Volume="2022" Year="2023">
+<Database Name="cv" Series="145163" Issue="966432" />
+</Book>
+<Book Series="Dark Web" Number="1" Volume="2022" Year="2023">
+<Database Name="cv" Series="146735" Issue="959000" />
+</Book>
+<Book Series="Dark Web: X-Men" Number="1" Volume="2022" Year="2023">
+<Database Name="cv" Series="146875" Issue="960026" />
+</Book>
+<Book Series="Dark Web: X-Men" Number="2" Volume="2022" Year="2023">
+<Database Name="cv" Series="146875" Issue="961948" />
+</Book>
+<Book Series="Dark Web: X-Men" Number="3" Volume="2022" Year="2023">
+<Database Name="cv" Series="146875" Issue="964964" />
+</Book>
+<Book Series="Dark Web: Finale" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="147905" Issue="967787" />
+</Book>
+<Book Series="X-Men" Number="18" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="963985" />
+</Book>
+<Book Series="Captain Marvel" Number="43" Volume="2019" Year="2023">
+<Database Name="cv" Series="116365" Issue="953019" />
+</Book>
+<Book Series="Captain Marvel" Number="44" Volume="2019" Year="2023">
+<Database Name="cv" Series="116365" Issue="958979" />
+</Book>
+<Book Series="Captain Marvel" Number="45" Volume="2019" Year="2023">
+<Database Name="cv" Series="116365" Issue="962850" />
+</Book>
+<Book Series="Captain Marvel" Number="46" Volume="2019" Year="2023">
+<Database Name="cv" Series="116365" Issue="971895" />
+</Book>
+<Book Series="Captain Marvel" Number="47" Volume="2019" Year="2023">
+<Database Name="cv" Series="116365" Issue="976907" />
+</Book>
+<Book Series="Captain Marvel" Number="48" Volume="2019" Year="2023">
+<Database Name="cv" Series="116365" Issue="982355" />
+</Book>
+<Book Series="Captain Marvel" Number="49" Volume="2019" Year="2023">
+<Database Name="cv" Series="116365" Issue="987103" />
+</Book>
+<Book Series="X-Men" Number="19" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="971885" />
+</Book>
+<Book Series="X-Men" Number="20" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="975695" />
+</Book>
+<Book Series="X-Men" Number="21" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="982356" />
+</Book>
+<Book Series="X-Men: Red" Number="8" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="953033" />
+</Book>
+<Book Series="X-Men: Red" Number="9" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="958991" />
+</Book>
+<Book Series="X-Men: Red" Number="10" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="962849" />
+</Book>
+<Book Series="Legion of X" Number="7" Volume="2022" Year="2023">
+<Database Name="cv" Series="143115" Issue="953977" />
+</Book>
+<Book Series="Legion of X" Number="8" Volume="2022" Year="2023">
+<Database Name="cv" Series="143115" Issue="960023" />
+</Book>
+<Book Series="Legion of X" Number="9" Volume="2022" Year="2023">
+<Database Name="cv" Series="143115" Issue="963981" />
+</Book>
+<Book Series="Legion of X" Number="10" Volume="2022" Year="2023">
+<Database Name="cv" Series="143115" Issue="967794" />
+</Book>
+<Book Series="Immortal X-Men" Number="9" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="958983" />
+</Book>
+<Book Series="Immortal X-Men" Number="10" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="964967" />
+</Book>
+<Book Series="Immortal X-Men" Number="11" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="987132" />
+</Book>
+<Book Series="X-Men: Before the Fall - Sons of X" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="150028" Issue="987192" />
+</Book>
+<Book Series="X-Men: Red" Number="11" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="988124" />
+</Book>
+<Book Series="X-Men: Red" Number="12" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="994356" />
+</Book>
+<Book Series="Wolverine" Number="26" Volume="2020" Year="2022">
+<Database Name="cv" Series="125121" Issue="952302" />
+</Book>
+<Book Series="Wolverine" Number="27" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="953983" />
+</Book>
+<Book Series="Wolverine" Number="28" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="960986" />
+</Book>
+<Book Series="X-Force" Number="34" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="956778" />
+</Book>
+<Book Series="X-Force" Number="35" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="958990" />
+</Book>
+<Book Series="X-Force" Number="36" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="962844" />
+</Book>
+<Book Series="X-Force" Number="37" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="967790" />
+</Book>
+<Book Series="X-Force" Number="38" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="974096" />
+</Book>
+<Book Series="Wolverine" Number="29" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="963982" />
+</Book>
+<Book Series="Wolverine" Number="30" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="971883" />
+</Book>
+<Book Series="Wolverine" Number="31" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="976904" />
+</Book>
+<Book Series="Wolverine" Number="32" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="981473" />
+</Book>
+<Book Series="X-Force" Number="39" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="984323" />
+</Book>
+<Book Series="Wolverine" Number="33" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="988123" />
+</Book>
+<Book Series="Wolverine" Number="34" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="994359" />
+</Book>
+<Book Series="X-Force" Number="40" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="989670" />
+</Book>
+<Book Series="X-Force" Number="41" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="996027" />
+</Book>
+<Book Series="X-Force" Number="42" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="1000244" />
+</Book>
+<Book Series="Wolverine" Number="35" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="1003593" />
+</Book>
+<Book Series="Deadpool" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="953021" />
+</Book>
+<Book Series="Deadpool" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="960024" />
+</Book>
+<Book Series="Deadpool" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="964961" />
+</Book>
+<Book Series="Deadpool" Number="4" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="973019" />
+</Book>
+<Book Series="Deadpool" Number="5" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="979419" />
+</Book>
+<Book Series="Deadpool" Number="6" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="985710" />
+</Book>
+<Book Series="Deadpool" Number="7" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="992312" />
+</Book>
+<Book Series="Deadpool" Number="8" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="997389" />
+</Book>
+<Book Series="Deadpool" Number="9" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="1003576" />
+</Book>
+<Book Series="Deadpool" Number="10" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="1010046" />
+</Book>
+<Book Series="Rogue &amp; Gambit" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="148664" Issue="974106" />
+</Book>
+<Book Series="Rogue &amp; Gambit" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="148664" Issue="981478" />
+</Book>
+<Book Series="Rogue &amp; Gambit" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="148664" Issue="988125" />
+</Book>
+<Book Series="Rogue &amp; Gambit" Number="4" Volume="2023" Year="2023">
+<Database Name="cv" Series="148664" Issue="994364" />
+</Book>
+<Book Series="Rogue &amp; Gambit" Number="5" Volume="2023" Year="2023">
+<Database Name="cv" Series="148664" Issue="1000237" />
+</Book>
+<Book Series="X-Men" Number="22" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="989671" />
+</Book>
+<Book Series="X-Men: Before the Fall – Mutant First Strike" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="151052" Issue="993583" />
+</Book>
+<Book Series="Bishop: War College" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="148091" Issue="969391" />
+</Book>
+<Book Series="Bishop: War College" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="148091" Issue="976901" />
+</Book>
+<Book Series="Bishop: War College" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="148091" Issue="984330" />
+</Book>
+<Book Series="Bishop: War College" Number="4" Volume="2023" Year="2023">
+<Database Name="cv" Series="148091" Issue="991063" />
+</Book>
+<Book Series="Bishop: War College" Number="5" Volume="2023" Year="2023">
+<Database Name="cv" Series="148091" Issue="993226" />
+</Book>
+<Book Series="Marvel&apos;s Voices: Pride" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="151966" Issue="999054" />
+</Book>
+<Book Series="Betsy Braddock: Captain Britain" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="148474" Issue="973000" />
+</Book>
+<Book Series="Betsy Braddock: Captain Britain" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="148474" Issue="979432" />
+</Book>
+<Book Series="Betsy Braddock: Captain Britain" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="148474" Issue="985715" />
+</Book>
+<Book Series="Betsy Braddock: Captain Britain" Number="4" Volume="2023" Year="2023">
+<Database Name="cv" Series="148474" Issue="992288" />
+</Book>
+<Book Series="Betsy Braddock: Captain Britain" Number="5" Volume="2023" Year="2023">
+<Database Name="cv" Series="148474" Issue="996014" />
+</Book>
+<Book Series="X-Men" Number="23" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="993241" />
+</Book>
+<Book Series="Fallen Friend: The Death of Ms. Marvel" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="152123" Issue="1000229" />
+</Book>
+<Book Series="X-Men: Before the Fall - Sinister Four" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="151912" Issue="998591" />
+</Book>
+<Book Series="Immortal X-Men" Number="12" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="993232" />
+</Book>
+<Book Series="X-Men: Before The Fall - Heralds of Apocalypse" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="151708" Issue="997400" />
+</Book>
+<Book Series="X-Men: Red" Number="13" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="1001998" />
+</Book>
+<Book Series="Immortal X-Men" Number="13" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="1000231" />
+</Book>
+<Book Series="X-Men" Number="24" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="999414" />
+</Book>
+<Book Series="X-Men: Hellfire Gala" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="152567" Issue="1003871" />
+</Book>
+<Book Series="Free Comic Book Day 2023: Avengers/X-Men" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="150031" Issue="987190" />
+</Book>
+<Book Series="X-Force" Number="43" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="1010057" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="8" Volume="2022" Year="2023">
+<Database Name="cv" Series="146873" Issue="1003582" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="9" Volume="2022" Year="2023">
+<Database Name="cv" Series="146873" Issue="1010048" />
+</Book>
+<Book Series="Marvel&apos;s Voices: X-Men" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153035" Issue="1009043" />
+</Book>
+<Book Series="X-Men: Red" Number="14" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="1008944" />
+</Book>
+<Book Series="X-Men: Red" Number="15" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="1013504" />
+</Book>
+<Book Series="Realm of X" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153121" Issue="1010053" />
+</Book>
+<Book Series="Realm of X" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="153121" Issue="1018027" />
+</Book>
+<Book Series="Ghost Rider / Wolverine: Weapons of Vengeance – Alpha" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="152897" Issue="1006447" />
+</Book>
+<Book Series="Ghost Rider" Number="17" Volume="2022" Year="2023">
+<Database Name="cv" Series="141707" Issue="1008949" />
+</Book>
+<Book Series="Wolverine" Number="36" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="1010949" />
+</Book>
+<Book Series="Ghost Rider/Wolverine: Weapons of Vengeance Omega" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153361" Issue="1012328" />
+</Book>
+<Book Series="X-Men" Number="25" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="1004347" />
+</Book>
+<Book Series="Uncanny Avengers" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153018" Issue="1008929" />
+</Book>
+<Book Series="Uncanny Avengers" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="153018" Issue="1014896" />
+</Book>
+<Book Series="Children of the Vault" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="152893" Issue="1006445" />
+</Book>
+<Book Series="Children of the Vault" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="152893" Issue="1013492" />
+</Book>
+<Book Series="Children of the Vault" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="152893" Issue="1025150" />
+</Book>
+<Book Series="Children of the Vault" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="152893" Issue="1029679" />
+</Book>
+<Book Series="Giant-Size X-Men" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="158070" Issue="1054379" />
+</Book>
+<Book Series="X-Men" Number="26" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="1011788" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="10" Volume="2022" Year="2023">
+<Database Name="cv" Series="146873" Issue="1018021" />
+</Book>
+<Book Series="Ms. Marvel: The New Mutant" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153238" Issue="1010944" />
+</Book>
+<Book Series="Ms. Marvel: The New Mutant" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="153238" Issue="1018026" />
+</Book>
+<Book Series="Ms. Marvel: The New Mutant" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="153238" Issue="1026552" />
+</Book>
+<Book Series="Ms. Marvel: The New Mutant" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="153238" Issue="1031695" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="11" Volume="2022" Year="2023">
+<Database Name="cv" Series="146873" Issue="1025158" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="12" Volume="2022" Year="2024">
+<Database Name="cv" Series="146873" Issue="1030786" />
+</Book>
+<Book Series="Alpha Flight" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153020" Issue="1008998" />
+</Book>
+<Book Series="Alpha Flight" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="153020" Issue="1014904" />
+</Book>
+<Book Series="Alpha Flight" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="153020" Issue="1026542" />
+</Book>
+<Book Series="Alpha Flight" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="153020" Issue="1029674" />
+</Book>
+<Book Series="Alpha Flight" Number="5" Volume="2023" Year="2024">
+<Database Name="cv" Series="153020" Issue="1033198" />
+</Book>
+<Book Series="Dark X-Men" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153023" Issue="1008999" />
+</Book>
+<Book Series="Dark X-Men" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="153023" Issue="1014902" />
+</Book>
+<Book Series="Dark X-Men" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="153023" Issue="1026546" />
+</Book>
+<Book Series="Wolverine" Number="37" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="1014897" />
+</Book>
+<Book Series="Wolverine" Number="38" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="1024060" />
+</Book>
+<Book Series="Wolverine" Number="39" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1030799" />
+</Book>
+<Book Series="X-Force" Number="44" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="1013503" />
+</Book>
+<Book Series="X-Force" Number="45" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="1020543" />
+</Book>
+<Book Series="X-Force" Number="46" Volume="2020" Year="2024">
+<Database Name="cv" Series="122668" Issue="1028638" />
+</Book>
+<Book Series="Wolverine" Number="40" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1035971" />
+</Book>
+<Book Series="X-Men" Number="27" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="1020544" />
+</Book>
+<Book Series="X-Men" Number="28" Volume="2021" Year="2024">
+<Database Name="cv" Series="137402" Issue="1027605" />
+</Book>
+<Book Series="X-Men" Number="29" Volume="2021" Year="2024">
+<Database Name="cv" Series="137402" Issue="1033214" />
+</Book>
+<Book Series="X-Men: Red" Number="16" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="1024061" />
+</Book>
+<Book Series="X-Men: Red" Number="17" Volume="2022" Year="2024">
+<Database Name="cv" Series="142134" Issue="1028639" />
+</Book>
+<Book Series="X-Men: Red" Number="18" Volume="2022" Year="2024">
+<Database Name="cv" Series="142134" Issue="1034349" />
+</Book>
+<Book Series="X-Force" Number="47" Volume="2020" Year="2024">
+<Database Name="cv" Series="122668" Issue="1038291" />
+</Book>
+<Book Series="X-Force" Number="48" Volume="2020" Year="2024">
+<Database Name="cv" Series="122668" Issue="1042220" />
+</Book>
+<Book Series="X-Force" Number="49" Volume="2020" Year="2024">
+<Database Name="cv" Series="122668" Issue="1045769" />
+</Book>
+<Book Series="X-Force" Number="50" Volume="2020" Year="2024">
+<Database Name="cv" Series="122668" Issue="1049286" />
+</Book>
+<Book Series="Wolverine" Number="41" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1039590" />
+</Book>
+<Book Series="Wolverine" Number="42" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1042837" />
+</Book>
+<Book Series="Wolverine" Number="43" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1044787" />
+</Book>
+<Book Series="Wolverine" Number="44" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1046277" />
+</Book>
+<Book Series="Wolverine" Number="45" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1047957" />
+</Book>
+<Book Series="Wolverine" Number="46" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1049285" />
+</Book>
+<Book Series="Wolverine" Number="47" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1051133" />
+</Book>
+<Book Series="Wolverine" Number="48" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1052947" />
+</Book>
+<Book Series="Wolverine" Number="49" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1054385" />
+</Book>
+<Book Series="Wolverine" Number="50" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1057018" />
+</Book>
+<Book Series="Astonishing Iceman" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="152649" Issue="1004321" />
+</Book>
+<Book Series="Astonishing Iceman" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="152649" Issue="1013489" />
+</Book>
+<Book Series="Uncanny Spider-Man" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153606" Issue="1014911" />
+</Book>
+<Book Series="Uncanny Spider-Man" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="153606" Issue="1026559" />
+</Book>
+<Book Series="Uncanny Spider-Man" Number="3" Volume="2023" Year="2024">
+<Database Name="cv" Series="153606" Issue="1028637" />
+</Book>
+<Book Series="Dark X-Men" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="153023" Issue="1029681" />
+</Book>
+<Book Series="Dark X-Men" Number="5" Volume="2023" Year="2024">
+<Database Name="cv" Series="153023" Issue="1034337" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="13" Volume="2022" Year="2024">
+<Database Name="cv" Series="146873" Issue="1033204" />
+</Book>
+<Book Series="Astonishing Iceman" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="152649" Issue="1025148" />
+</Book>
+<Book Series="Astonishing Iceman" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="152649" Issue="1029675" />
+</Book>
+<Book Series="Astonishing Iceman" Number="5" Volume="2023" Year="2024">
+<Database Name="cv" Series="152649" Issue="1035955" />
+</Book>
+<Book Series="Uncanny Spider-Man" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="153606" Issue="1030798" />
+</Book>
+<Book Series="X-Men Blue: Origins" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="154998" Issue="1032224" />
+</Book>
+<Book Series="Uncanny Spider-Man" Number="5" Volume="2023" Year="2024">
+<Database Name="cv" Series="153606" Issue="1035970" />
+</Book>
+<Book Series="Uncanny Avengers" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="153018" Issue="1026557" />
+</Book>
+<Book Series="Uncanny Avengers" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="153018" Issue="1029696" />
+</Book>
+<Book Series="Uncanny Avengers" Number="5" Volume="2023" Year="2024">
+<Database Name="cv" Series="153018" Issue="1035969" />
+</Book>
+<Book Series="Realm of X" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="153121" Issue="1026554" />
+</Book>
+<Book Series="Realm of X" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="153121" Issue="1031697" />
+</Book>
+<Book Series="Immortal X-Men" Number="14" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="1006441" />
+</Book>
+<Book Series="Immortal X-Men" Number="15" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="1011780" />
+</Book>
+<Book Series="Immortal X-Men" Number="16" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="1020537" />
+</Book>
+<Book Series="Jean Grey" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153119" Issue="1010049" />
+</Book>
+<Book Series="Jean Grey" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="153119" Issue="1018022" />
+</Book>
+<Book Series="Jean Grey" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="153119" Issue="1026549" />
+</Book>
+<Book Series="Jean Grey" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="153119" Issue="1029686" />
+</Book>
+<Book Series="Immortal X-Men" Number="17" Volume="2022" Year="2024">
+<Database Name="cv" Series="142053" Issue="1030784" />
+</Book>
+<Book Series="Immortal X-Men" Number="18" Volume="2022" Year="2024">
+<Database Name="cv" Series="142053" Issue="1038387" />
+</Book>
+<Book Series="Resurrection of Magneto" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="156369" Issue="1042231" />
+</Book>
+<Book Series="Resurrection of Magneto" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="156369" Issue="1046272" />
+</Book>
+<Book Series="Resurrection of Magneto" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="156369" Issue="1048669" />
+</Book>
+<Book Series="Ms. Marvel: Mutant Menace" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="157125" Issue="1047085" />
+</Book>
+<Book Series="Ms. Marvel: Mutant Menace" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="157125" Issue="1051125" />
+</Book>
+<Book Series="Ms. Marvel: Mutant Menace" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="157125" Issue="1055028" />
+</Book>
+<Book Series="Ms. Marvel: Mutant Menace" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="157125" Issue="1058725" />
+</Book>
+<Book Series="X-Men" Number="30" Volume="2021" Year="2024">
+<Database Name="cv" Series="137402" Issue="1040949" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="14" Volume="2022" Year="2024">
+<Database Name="cv" Series="146873" Issue="1040941" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="15" Volume="2022" Year="2024">
+<Database Name="cv" Series="146873" Issue="1046268" />
+</Book>
+<Book Series="Avengers" Number="12" Volume="2023" Year="2024">
+<Database Name="cv" Series="150431" Issue="1050565" />
+</Book>
+<Book Series="Avengers" Number="13" Volume="2023" Year="2024">
+<Database Name="cv" Series="150431" Issue="1052926" />
+</Book>
+<Book Series="Fall of the House of X" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="155874" Issue="1038990" />
+</Book>
+<Book Series="X-Men" Number="31" Volume="2021" Year="2024">
+<Database Name="cv" Series="137402" Issue="1043844" />
+</Book>
+<Book Series="Fall of the House of X" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="155874" Issue="1044779" />
+</Book>
+<Book Series="X-Men" Number="32" Volume="2021" Year="2024">
+<Database Name="cv" Series="137402" Issue="1047095" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="16" Volume="2022" Year="2024">
+<Database Name="cv" Series="146873" Issue="1048667" />
+</Book>
+<Book Series="Resurrection of Magneto" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="156369" Issue="1051126" />
+</Book>
+<Book Series="Fall of the House of X" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="155874" Issue="1047947" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="17" Volume="2022" Year="2024">
+<Database Name="cv" Series="146873" Issue="1051124" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="18" Volume="2022" Year="2024">
+<Database Name="cv" Series="146873" Issue="1053541" />
+</Book>
+<Book Series="X-Men" Number="33" Volume="2021" Year="2024">
+<Database Name="cv" Series="137402" Issue="1050579" />
+</Book>
+<Book Series="Cable" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="156139" Issue="1040936" />
+</Book>
+<Book Series="Cable" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="156139" Issue="1046263" />
+</Book>
+<Book Series="Cable" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="156139" Issue="1049270" />
+</Book>
+<Book Series="Cable" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="156139" Issue="1053536" />
+</Book>
+<Book Series="X-Men Forever" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="157312" Issue="1048680" />
+</Book>
+<Book Series="Rise of the Powers of X" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="155968" Issue="1039582" />
+</Book>
+<Book Series="Rise of the Powers of X" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="155968" Issue="1045770" />
+</Book>
+<Book Series="Dead X-Men" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="156494" Issue="1042825" />
+</Book>
+<Book Series="Dead X-Men" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="156494" Issue="1046265" />
+</Book>
+<Book Series="Dead X-Men" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="156494" Issue="1047946" />
+</Book>
+<Book Series="Dead X-Men" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="156494" Issue="1051493" />
+</Book>
+<Book Series="Rise of the Powers of X" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="155968" Issue="1049278" />
+</Book>
+<Book Series="Rise of the Powers of X" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="155968" Issue="1052938" />
+</Book>
+<Book Series="X-Men Forever" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="157312" Issue="1052948" />
+</Book>
+<Book Series="Fall of the House of X" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="155874" Issue="1051494" />
+</Book>
+<Book Series="X-Men" Number="34" Volume="2021" Year="2024">
+<Database Name="cv" Series="137402" Issue="1053547" />
+</Book>
+<Book Series="X-Men Forever" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="157312" Issue="1054386" />
+</Book>
+<Book Series="X-Men Forever" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="157312" Issue="1055038" />
+</Book>
+<Book Series="Fall of the House of X" Number="5" Volume="2024" Year="2024">
+<Database Name="cv" Series="155874" Issue="1056203" />
+</Book>
+<Book Series="Rise of the Powers of X" Number="5" Volume="2024" Year="2024">
+<Database Name="cv" Series="155968" Issue="1057008" />
+</Book>
+<Book Series="X-Men" Number="35" Volume="2021" Year="2024">
+<Database Name="cv" Series="137402" Issue="1058720" />
+</Book>
+</Books>
+<Matchers />
+</ReadingList>

--- a/Marvel/Teams/X-Men/WEB-CBRO/[Marvel] X-Men Krakoa Era with events (WEB-CBRO).cbl
+++ b/Marvel/Teams/X-Men/WEB-CBRO/[Marvel] X-Men Krakoa Era with events (WEB-CBRO).cbl
@@ -1,0 +1,2195 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Name>[Marvel] X-Men Krakoa Era with events (WEB-CBRO)</Name>
+<NumIssues>729</NumIssues>
+<Books>
+<Book Series="House of X" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="120309" Issue="714236" />
+</Book>
+<Book Series="Powers of X" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="120407" Issue="714669" />
+</Book>
+<Book Series="House of X" Number="2" Volume="2019" Year="2019">
+<Database Name="cv" Series="120309" Issue="715306" />
+</Book>
+<Book Series="Powers of X" Number="2" Volume="2019" Year="2019">
+<Database Name="cv" Series="120407" Issue="716371" />
+</Book>
+<Book Series="House of X" Number="3" Volume="2019" Year="2019">
+<Database Name="cv" Series="120309" Issue="717519" />
+</Book>
+<Book Series="Powers of X" Number="3" Volume="2019" Year="2019">
+<Database Name="cv" Series="120407" Issue="716968" />
+</Book>
+<Book Series="House of X" Number="4" Volume="2019" Year="2019">
+<Database Name="cv" Series="120309" Issue="718128" />
+</Book>
+<Book Series="Powers of X" Number="4" Volume="2019" Year="2019">
+<Database Name="cv" Series="120407" Issue="718763" />
+</Book>
+<Book Series="House of X" Number="5" Volume="2019" Year="2019">
+<Database Name="cv" Series="120309" Issue="719439" />
+</Book>
+<Book Series="Powers of X" Number="5" Volume="2019" Year="2019">
+<Database Name="cv" Series="120407" Issue="720169" />
+</Book>
+<Book Series="House of X" Number="6" Volume="2019" Year="2019">
+<Database Name="cv" Series="120309" Issue="721154" />
+</Book>
+<Book Series="Powers of X" Number="6" Volume="2019" Year="2019">
+<Database Name="cv" Series="120407" Issue="721789" />
+</Book>
+<Book Series="X-Men" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="122077" Issue="723121" />
+</Book>
+<Book Series="New Mutants" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="726210" />
+</Book>
+<Book Series="New Mutants" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="728977" />
+</Book>
+<Book Series="New Mutants" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="730341" />
+</Book>
+<Book Series="New Mutants" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="731522" />
+</Book>
+<Book Series="New Mutants" Number="6" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="735526" />
+</Book>
+<Book Series="Marauders" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="122218" Issue="723862" />
+</Book>
+<Book Series="Excalibur" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="122488" Issue="725247" />
+</Book>
+<Book Series="Excalibur" Number="2" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="728420" />
+</Book>
+<Book Series="Excalibur" Number="3" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="729679" />
+</Book>
+<Book Series="X-Men/Fantastic Four" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="124822" Issue="736501" />
+</Book>
+<Book Series="X-Men/Fantastic Four" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="124822" Issue="738624" />
+</Book>
+<Book Series="X-Men/Fantastic Four" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="124822" Issue="743454" />
+</Book>
+<Book Series="X-Men/Fantastic Four" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="124822" Issue="781439" />
+</Book>
+<Book Series="X-Force" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="726217" />
+</Book>
+<Book Series="Fallen Angels" Number="1" Volume="2019" Year="2020">
+<Database Name="cv" Series="122814" Issue="727257" />
+</Book>
+<Book Series="Fallen Angels" Number="2" Volume="2019" Year="2020">
+<Database Name="cv" Series="122814" Issue="728972" />
+</Book>
+<Book Series="Fallen Angels" Number="3" Volume="2019" Year="2020">
+<Database Name="cv" Series="122814" Issue="730333" />
+</Book>
+<Book Series="Fallen Angels" Number="4" Volume="2019" Year="2020">
+<Database Name="cv" Series="122814" Issue="731511" />
+</Book>
+<Book Series="Marauders" Number="2" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="728426" />
+</Book>
+<Book Series="Marauders" Number="3" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="729682" />
+</Book>
+<Book Series="X-Men" Number="2" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="727273" />
+</Book>
+<Book Series="X-Men" Number="3" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="729692" />
+</Book>
+<Book Series="New Mutants" Number="5" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="732887" />
+</Book>
+<Book Series="New Mutants" Number="7" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="737761" />
+</Book>
+<Book Series="New Mutants" Number="8" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="738614" />
+</Book>
+<Book Series="New Mutants" Number="9" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="740822" />
+</Book>
+<Book Series="New Mutants" Number="10" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="767932" />
+</Book>
+<Book Series="New Mutants" Number="11" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="781436" />
+</Book>
+<Book Series="X-Force" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="728984" />
+</Book>
+<Book Series="X-Force" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="730351" />
+</Book>
+<Book Series="X-Men" Number="4" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="731983" />
+</Book>
+<Book Series="X-Force" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="731530" />
+</Book>
+<Book Series="X-Force" Number="5" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="732895" />
+</Book>
+<Book Series="X-Force" Number="6" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="735534" />
+</Book>
+<Book Series="Fallen Angels" Number="5" Volume="2019" Year="2020">
+<Database Name="cv" Series="122814" Issue="732878" />
+</Book>
+<Book Series="Fallen Angels" Number="6" Volume="2019" Year="2020">
+<Database Name="cv" Series="122814" Issue="735522" />
+</Book>
+<Book Series="Excalibur" Number="4" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="731510" />
+</Book>
+<Book Series="Excalibur" Number="5" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="732877" />
+</Book>
+<Book Series="Excalibur" Number="6" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="734640" />
+</Book>
+<Book Series="X-Men" Number="5" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="735535" />
+</Book>
+<Book Series="Giant-Size X-Men: Jean Grey and Emma Frost" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="125302" Issue="738612" />
+</Book>
+<Book Series="X-Men" Number="6" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="737173" />
+</Book>
+<Book Series="Hellions" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="126015" Issue="743440" />
+</Book>
+<Book Series="Hellions" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="126015" Issue="781434" />
+</Book>
+<Book Series="Hellions" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="126015" Issue="796298" />
+</Book>
+<Book Series="Hellions" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="126015" Issue="799949" />
+</Book>
+<Book Series="Marauders" Number="4" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="731519" />
+</Book>
+<Book Series="Marauders" Number="5" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="731974" />
+</Book>
+<Book Series="Marauders" Number="6" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="734643" />
+</Book>
+<Book Series="Marauders" Number="7" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="736492" />
+</Book>
+<Book Series="Marauders" Number="8" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="737758" />
+</Book>
+<Book Series="Cable" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="125678" Issue="740814" />
+</Book>
+<Book Series="X-Men" Number="8" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="740832" />
+</Book>
+<Book Series="X-Men" Number="9" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="743453" />
+</Book>
+<Book Series="X-Force" Number="7" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="737172" />
+</Book>
+<Book Series="X-Force" Number="8" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="738622" />
+</Book>
+<Book Series="Excalibur" Number="7" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="737156" />
+</Book>
+<Book Series="Excalibur" Number="8" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="739558" />
+</Book>
+<Book Series="X-Force" Number="9" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="742380" />
+</Book>
+<Book Series="X-Force" Number="10" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="775013" />
+</Book>
+<Book Series="X-Factor" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="129097" Issue="784416" />
+</Book>
+<Book Series="Wolverine" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="125121" Issue="737765" />
+</Book>
+<Book Series="Wolverine" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="125121" Issue="743452" />
+</Book>
+<Book Series="Wolverine" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="125121" Issue="781438" />
+</Book>
+<Book Series="Cable" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="125678" Issue="784406" />
+</Book>
+<Book Series="Cable" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="125678" Issue="794931" />
+</Book>
+<Book Series="Cable" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="125678" Issue="797240" />
+</Book>
+<Book Series="Marauders" Number="9" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="739561" />
+</Book>
+<Book Series="Marauders" Number="10" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="763574" />
+</Book>
+<Book Series="Marauders" Number="11" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="791927" />
+</Book>
+<Book Series="Marauders" Number="12" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="797983" />
+</Book>
+<Book Series="Giant-Size X-Men: Nightcrawler" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="126014" Issue="743439" />
+</Book>
+<Book Series="New Mutants" Number="12" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="797246" />
+</Book>
+<Book Series="Marvel&apos;s Voices: Indigenous Voices" Number="1" Volume="2020" Year="2021">
+<Database Name="cv" Series="132129" Issue="819121" />
+</Book>
+<Book Series="Children of the Atom" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="134388" Issue="836298" />
+</Book>
+<Book Series="Children of the Atom" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="134388" Issue="842957" />
+</Book>
+<Book Series="X-Men" Number="7" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="738623" />
+</Book>
+<Book Series="Empyre: Avengers" Number="0" Volume="2020" Year="2020">
+<Database Name="cv" Series="128103" Issue="769751" />
+</Book>
+<Book Series="Empyre: Fantastic Four" Number="0" Volume="2020" Year="2020">
+<Database Name="cv" Series="128447" Issue="775009" />
+</Book>
+<Book Series="Lords of Empyre: Emperor Hulkling" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="128881" Issue="781435" />
+</Book>
+<Book Series="Empyre" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="128616" Issue="779005" />
+</Book>
+<Book Series="Empyre" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="128616" Issue="781431" />
+</Book>
+<Book Series="Fantastic Four" Number="21" Volume="2018" Year="2020">
+<Database Name="cv" Series="112685" Issue="779006" />
+</Book>
+<Book Series="Fantastic Four" Number="22" Volume="2018" Year="2020">
+<Database Name="cv" Series="112685" Issue="787351" />
+</Book>
+<Book Series="Lords of Empyre: Swordsman" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="129649" Issue="794937" />
+</Book>
+<Book Series="Lords of Empyre: Celestial Messiah" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="129246" Issue="787354" />
+</Book>
+<Book Series="Captain Marvel" Number="18" Volume="2019" Year="2020">
+<Database Name="cv" Series="116365" Issue="784407" />
+</Book>
+<Book Series="Captain Marvel" Number="19" Volume="2019" Year="2020">
+<Database Name="cv" Series="116365" Issue="791921" />
+</Book>
+<Book Series="Captain Marvel" Number="20" Volume="2019" Year="2020">
+<Database Name="cv" Series="116365" Issue="794933" />
+</Book>
+<Book Series="Empyre" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="128616" Issue="784408" />
+</Book>
+<Book Series="X-Men" Number="10" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="784126" />
+</Book>
+<Book Series="Empyre: Savage Avengers" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="129095" Issue="784410" />
+</Book>
+<Book Series="Empyre: Avengers" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="128103" Issue="781432" />
+</Book>
+<Book Series="Empyre: Captain America" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="129094" Issue="784409" />
+</Book>
+<Book Series="Empyre: X-Men" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="128880" Issue="781433" />
+</Book>
+<Book Series="Empyre: X-Men" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="128880" Issue="787350" />
+</Book>
+<Book Series="Empyre: X-Men" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="128880" Issue="791925" />
+</Book>
+<Book Series="Empyre: X-Men" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="128880" Issue="794935" />
+</Book>
+<Book Series="Empyre: Captain America" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="129094" Issue="791924" />
+</Book>
+<Book Series="Empyre" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="128616" Issue="787348" />
+</Book>
+<Book Series="Empyre" Number="5" Volume="2020" Year="2020">
+<Database Name="cv" Series="128616" Issue="791922" />
+</Book>
+<Book Series="Empyre: Captain America" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="129094" Issue="796296" />
+</Book>
+<Book Series="Empyre: Avengers" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="128103" Issue="791923" />
+</Book>
+<Book Series="Empyre: Avengers" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="128103" Issue="796295" />
+</Book>
+<Book Series="Empyre" Number="6" Volume="2020" Year="2020">
+<Database Name="cv" Series="128616" Issue="797241" />
+</Book>
+<Book Series="Fantastic Four" Number="23" Volume="2018" Year="2020">
+<Database Name="cv" Series="112685" Issue="797242" />
+</Book>
+<Book Series="X-Men" Number="11" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="796303" />
+</Book>
+<Book Series="Captain Marvel" Number="21" Volume="2019" Year="2020">
+<Database Name="cv" Series="116365" Issue="797979" />
+</Book>
+<Book Series="Guardians of the Galaxy" Number="6" Volume="2020" Year="2020">
+<Database Name="cv" Series="124447" Issue="797243" />
+</Book>
+<Book Series="Guardians of the Galaxy" Number="7" Volume="2020" Year="2020">
+<Database Name="cv" Series="124447" Issue="813282" />
+</Book>
+<Book Series="Guardians of the Galaxy" Number="8" Volume="2020" Year="2021">
+<Database Name="cv" Series="124447" Issue="816467" />
+</Book>
+<Book Series="Empyre: Aftermath Avengers" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="130186" Issue="797980" />
+</Book>
+<Book Series="Empyre: Fallout Fantastic Four" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="130187" Issue="797981" />
+</Book>
+<Book Series="Immortal She-Hulk" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="130567" Issue="803644" />
+</Book>
+<Book Series="Web of Venom: Empyre's End" Number="1" Volume="2020" Year="2021">
+<Database Name="cv" Series="131733" Issue="816471" />
+</Book>
+<Book Series="Giant-Size X-Men: Fantomex" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="129245" Issue="787352" />
+</Book>
+<Book Series="Giant-Size X-Men: Storm" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="130395" Issue="799948" />
+</Book>
+<Book Series="Wolverine" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="125121" Issue="794942" />
+</Book>
+<Book Series="Wolverine" Number="5" Volume="2020" Year="2020">
+<Database Name="cv" Series="125121" Issue="797248" />
+</Book>
+<Book Series="X-Factor" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="129097" Issue="796302" />
+</Book>
+<Book Series="X-Factor" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="129097" Issue="797986" />
+</Book>
+<Book Series="X-Force" Number="11" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="791931" />
+</Book>
+<Book Series="X-Force" Number="12" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="797987" />
+</Book>
+<Book Series="X-Force" Number="15" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="821504" />
+</Book>
+<Book Series="X-Force" Number="16" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="825509" />
+</Book>
+<Book Series="Excalibur" Number="9" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="742368" />
+</Book>
+<Book Series="Excalibur" Number="10" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="767930" />
+</Book>
+<Book Series="Excalibur" Number="11" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="794936" />
+</Book>
+<Book Series="Excalibur" Number="12" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="799947" />
+</Book>
+<Book Series="X-Men" Number="12" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="799956" />
+</Book>
+<Book Series="X of Swords: Creation" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="130569" Issue="803652" />
+</Book>
+<Book Series="X-Factor" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="129097" Issue="805100" />
+</Book>
+<Book Series="Wolverine" Number="6" Volume="2020" Year="2020">
+<Database Name="cv" Series="125121" Issue="807579" />
+</Book>
+<Book Series="X-Force" Number="13" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="807580" />
+</Book>
+<Book Series="Marauders" Number="13" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="807571" />
+</Book>
+<Book Series="Hellions" Number="5" Volume="2020" Year="2020">
+<Database Name="cv" Series="126015" Issue="810727" />
+</Book>
+<Book Series="New Mutants" Number="13" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="810730" />
+</Book>
+<Book Series="Cable" Number="5" Volume="2020" Year="2020">
+<Database Name="cv" Series="125678" Issue="810724" />
+</Book>
+<Book Series="Excalibur" Number="13" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="813279" />
+</Book>
+<Book Series="X-Men" Number="13" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="813291" />
+</Book>
+<Book Series="X of Swords: Stasis" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="131525" Issue="814483" />
+</Book>
+<Book Series="X-Men" Number="14" Volume="2019" Year="2021">
+<Database Name="cv" Series="122077" Issue="816456" />
+</Book>
+<Book Series="Marauders" Number="14" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="816455" />
+</Book>
+<Book Series="Marauders" Number="15" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="817705" />
+</Book>
+<Book Series="Excalibur" Number="14" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="817704" />
+</Book>
+<Book Series="Wolverine" Number="7" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="817706" />
+</Book>
+<Book Series="X-Force" Number="14" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="819097" />
+</Book>
+<Book Series="Hellions" Number="6" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="819096" />
+</Book>
+<Book Series="Cable" Number="6" Volume="2020" Year="2021">
+<Database Name="cv" Series="125678" Issue="819095" />
+</Book>
+<Book Series="X-Men" Number="15" Volume="2019" Year="2021">
+<Database Name="cv" Series="122077" Issue="819479" />
+</Book>
+<Book Series="Excalibur" Number="15" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="819478" />
+</Book>
+<Book Series="X of Swords: Destruction" Number="1" Volume="2020" Year="2021">
+<Database Name="cv" Series="132228" Issue="819480" />
+</Book>
+<Book Series="S.W.O.R.D." Number="1" Volume="2020" Year="2021">
+<Database Name="cv" Series="132511" Issue="820748" />
+</Book>
+<Book Series="Symbiote Spider-Man: King In Black" Number="1" Volume="2020" Year="2021">
+<Database Name="cv" Series="132130" Issue="819124" />
+</Book>
+<Book Series="Symbiote Spider-Man: King In Black" Number="2" Volume="2020" Year="2021">
+<Database Name="cv" Series="132130" Issue="821501" />
+</Book>
+<Book Series="Symbiote Spider-Man: King In Black" Number="3" Volume="2020" Year="2021">
+<Database Name="cv" Series="132130" Issue="824033" />
+</Book>
+<Book Series="Symbiote Spider-Man: King In Black" Number="4" Volume="2020" Year="2021">
+<Database Name="cv" Series="132130" Issue="830032" />
+</Book>
+<Book Series="Symbiote Spider-Man: King In Black" Number="5" Volume="2020" Year="2021">
+<Database Name="cv" Series="132130" Issue="840958" />
+</Book>
+<Book Series="King In Black: Namor" Number="1" Volume="2020" Year="2021">
+<Database Name="cv" Series="132510" Issue="820746" />
+</Book>
+<Book Series="King In Black: Namor" Number="2" Volume="2020" Year="2021">
+<Database Name="cv" Series="132510" Issue="823346" />
+</Book>
+<Book Series="King In Black: Namor" Number="3" Volume="2020" Year="2021">
+<Database Name="cv" Series="132510" Issue="826558" />
+</Book>
+<Book Series="King In Black: Namor" Number="4" Volume="2020" Year="2021">
+<Database Name="cv" Series="132510" Issue="830026" />
+</Book>
+<Book Series="Atlantis Attacks" Number="5" Volume="2020" Year="2021">
+<Database Name="cv" Series="124446" Issue="820017" />
+</Book>
+<Book Series="King In Black: Wiccan and Hulking" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="134223" Issue="832867" />
+</Book>
+<Book Series="King In Black" Number="1" Volume="2020" Year="2021">
+<Database Name="cv" Series="132376" Issue="820024" />
+</Book>
+<Book Series="The Union" Number="1" Volume="2020" Year="2021">
+<Database Name="cv" Series="132378" Issue="820029" />
+</Book>
+<Book Series="The Union" Number="2" Volume="2020" Year="2021">
+<Database Name="cv" Series="132378" Issue="824454" />
+</Book>
+<Book Series="Black Cat" Number="1" Volume="2020" Year="2021">
+<Database Name="cv" Series="132631" Issue="821491" />
+</Book>
+<Book Series="Spider-Woman" Number="7" Volume="2020" Year="2021">
+<Database Name="cv" Series="125812" Issue="822352" />
+</Book>
+<Book Series="Spider-Woman" Number="8" Volume="2020" Year="2021">
+<Database Name="cv" Series="125812" Issue="824032" />
+</Book>
+<Book Series="Guardians of the Galaxy" Number="10" Volume="2020" Year="2021">
+<Database Name="cv" Series="124447" Issue="824025" />
+</Book>
+<Book Series="King In Black: Ghost Rider" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="135003" Issue="840954" />
+</Book>
+<Book Series="King In Black: Black Knight" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="133609" Issue="827524" />
+</Book>
+<Book Series="King In Black: Black Panther" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="133724" Issue="828193" />
+</Book>
+<Book Series="Venom" Number="31" Volume="2018" Year="2021">
+<Database Name="cv" Series="110770" Issue="820751" />
+</Book>
+<Book Series="King In Black" Number="2" Volume="2020" Year="2021">
+<Database Name="cv" Series="132376" Issue="822349" />
+</Book>
+<Book Series="Venom" Number="32" Volume="2018" Year="2021">
+<Database Name="cv" Series="110770" Issue="824035" />
+</Book>
+<Book Series="King In Black: Iron Man/Doom" Number="1" Volume="2020" Year="2021">
+<Database Name="cv" Series="132913" Issue="823345" />
+</Book>
+<Book Series="King In Black: Return of the Valkyries" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="133081" Issue="824029" />
+</Book>
+<Book Series="King In Black: Planet of the Symbiotes" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="133196" Issue="824450" />
+</Book>
+<Book Series="King In Black: Planet of the Symbiotes" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="133196" Issue="828858" />
+</Book>
+<Book Series="King In Black: Thunderbolts" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="133197" Issue="824451" />
+</Book>
+<Book Series="King In Black: Thunderbolts" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="133197" Issue="828194" />
+</Book>
+<Book Series="King In Black: Thunderbolts" Number="3" Volume="2021" Year="2021">
+<Database Name="cv" Series="133197" Issue="832866" />
+</Book>
+<Book Series="King in Black: Gwenom vs. Carnage" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="133195" Issue="824449" />
+</Book>
+<Book Series="King in Black: Gwenom vs. Carnage" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="133195" Issue="827525" />
+</Book>
+<Book Series="King in Black: Gwenom vs. Carnage" Number="3" Volume="2021" Year="2021">
+<Database Name="cv" Series="133195" Issue="832864" />
+</Book>
+<Book Series="King In Black: Immortal Hulk" Number="1" Volume="2020" Year="2021">
+<Database Name="cv" Series="132632" Issue="821497" />
+</Book>
+<Book Series="S.W.O.R.D." Number="2" Volume="2020" Year="2021">
+<Database Name="cv" Series="132511" Issue="824453" />
+</Book>
+<Book Series="S.W.O.R.D." Number="3" Volume="2020" Year="2021">
+<Database Name="cv" Series="132511" Issue="828197" />
+</Book>
+<Book Series="King In Black" Number="3" Volume="2020" Year="2021">
+<Database Name="cv" Series="132376" Issue="825507" />
+</Book>
+<Book Series="Daredevil" Number="26" Volume="2019" Year="2021">
+<Database Name="cv" Series="116964" Issue="826554" />
+</Book>
+<Book Series="Daredevil" Number="27" Volume="2019" Year="2021">
+<Database Name="cv" Series="116964" Issue="828189" />
+</Book>
+<Book Series="Deadpool" Number="10" Volume="2019" Year="2021">
+<Database Name="cv" Series="122987" Issue="826555" />
+</Book>
+<Book Series="King In Black: Marauders" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="133610" Issue="827526" />
+</Book>
+<Book Series="Savage Avengers" Number="17" Volume="2019" Year="2021">
+<Database Name="cv" Series="118663" Issue="826561" />
+</Book>
+<Book Series="Savage Avengers" Number="18" Volume="2019" Year="2021">
+<Database Name="cv" Series="118663" Issue="828863" />
+</Book>
+<Book Series="Savage Avengers" Number="19" Volume="2019" Year="2021">
+<Database Name="cv" Series="118663" Issue="839798" />
+</Book>
+<Book Series="Miles Morales: Spider-Man" Number="23" Volume="2019" Year="2021">
+<Database Name="cv" Series="115897" Issue="828862" />
+</Book>
+<Book Series="King In Black: Return of the Valkyries" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="133081" Issue="827527" />
+</Book>
+<Book Series="King In Black: Return of the Valkyries" Number="3" Volume="2021" Year="2021">
+<Database Name="cv" Series="133081" Issue="830027" />
+</Book>
+<Book Series="King In Black: Return of the Valkyries" Number="4" Volume="2021" Year="2021">
+<Database Name="cv" Series="133081" Issue="840956" />
+</Book>
+<Book Series="Black Cat" Number="2" Volume="2020" Year="2021">
+<Database Name="cv" Series="132631" Issue="825504" />
+</Book>
+<Book Series="Black Cat" Number="3" Volume="2020" Year="2021">
+<Database Name="cv" Series="132631" Issue="830022" />
+</Book>
+<Book Series="Venom" Number="33" Volume="2018" Year="2021">
+<Database Name="cv" Series="110770" Issue="827531" />
+</Book>
+<Book Series="King In Black" Number="4" Volume="2020" Year="2021">
+<Database Name="cv" Series="132376" Issue="828857" />
+</Book>
+<Book Series="Fantastic Four" Number="29" Volume="2018" Year="2021">
+<Database Name="cv" Series="112685" Issue="828192" />
+</Book>
+<Book Series="King In Black: Captain America" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="134221" Issue="832863" />
+</Book>
+<Book Series="King In Black: Scream" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="134781" Issue="839795" />
+</Book>
+<Book Series="King In Black: Spider-Man" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="134620" Issue="838866" />
+</Book>
+<Book Series="S.W.O.R.D." Number="4" Volume="2020" Year="2021">
+<Database Name="cv" Series="132511" Issue="838885" />
+</Book>
+<Book Series="Fantastic Four" Number="30" Volume="2018" Year="2021">
+<Database Name="cv" Series="112685" Issue="842960" />
+</Book>
+<Book Series="Venom" Number="34" Volume="2018" Year="2021">
+<Database Name="cv" Series="110770" Issue="842208" />
+</Book>
+<Book Series="Avengers" Number="45" Volume="2018" Year="2021">
+<Database Name="cv" Series="110496" Issue="844966" />
+</Book>
+<Book Series="King In Black" Number="5" Volume="2020" Year="2021">
+<Database Name="cv" Series="132376" Issue="842204" />
+</Book>
+<Book Series="King In Black: Namor" Number="5" Volume="2020" Year="2021">
+<Database Name="cv" Series="132510" Issue="842964" />
+</Book>
+<Book Series="King In Black: Planet of the Symbiotes" Number="3" Volume="2021" Year="2021">
+<Database Name="cv" Series="133196" Issue="842205" />
+</Book>
+<Book Series="Venom" Number="35" Volume="2018" Year="2021">
+<Database Name="cv" Series="110770" Issue="861680" />
+</Book>
+<Book Series="Excalibur" Number="16" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="822348" />
+</Book>
+<Book Series="Hellions" Number="7" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="820023" />
+</Book>
+<Book Series="Hellions" Number="8" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="824026" />
+</Book>
+<Book Series="X-Factor" Number="5" Volume="2020" Year="2021">
+<Database Name="cv" Series="129097" Issue="820030" />
+</Book>
+<Book Series="Cable" Number="7" Volume="2020" Year="2021">
+<Database Name="cv" Series="125678" Issue="825505" />
+</Book>
+<Book Series="Cable" Number="8" Volume="2020" Year="2021">
+<Database Name="cv" Series="125678" Issue="828850" />
+</Book>
+<Book Series="X-Men" Number="16" Volume="2019" Year="2021">
+<Database Name="cv" Series="122077" Issue="823351" />
+</Book>
+<Book Series="Marauders" Number="16" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="820747" />
+</Book>
+<Book Series="New Mutants" Number="14" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="821499" />
+</Book>
+<Book Series="X-Factor" Number="6" Volume="2020" Year="2021">
+<Database Name="cv" Series="129097" Issue="824036" />
+</Book>
+<Book Series="New Mutants" Number="15" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="826560" />
+</Book>
+<Book Series="X-Men" Number="17" Volume="2019" Year="2021">
+<Database Name="cv" Series="122077" Issue="826566" />
+</Book>
+<Book Series="Giant-Size X-Men: Magneto" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="128617" Issue="779007" />
+</Book>
+<Book Series="Marauders" Number="17" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="824452" />
+</Book>
+<Book Series="Wolverine" Number="8" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="823350" />
+</Book>
+<Book Series="Cable" Number="9" Volume="2020" Year="2021">
+<Database Name="cv" Series="125678" Issue="839790" />
+</Book>
+<Book Series="Wolverine" Number="9" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="826565" />
+</Book>
+<Book Series="Wolverine" Number="10" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="830035" />
+</Book>
+<Book Series="Wolverine" Number="11" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="842971" />
+</Book>
+<Book Series="Wolverine" Number="12" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="851314" />
+</Book>
+<Book Series="Juggernaut" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="130568" Issue="803645" />
+</Book>
+<Book Series="Juggernaut" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="130568" Issue="813284" />
+</Book>
+<Book Series="Juggernaut" Number="3" Volume="2020" Year="2021">
+<Database Name="cv" Series="130568" Issue="819120" />
+</Book>
+<Book Series="Juggernaut" Number="4" Volume="2020" Year="2021">
+<Database Name="cv" Series="130568" Issue="820745" />
+</Book>
+<Book Series="Juggernaut" Number="5" Volume="2020" Year="2021">
+<Database Name="cv" Series="130568" Issue="824028" />
+</Book>
+<Book Series="X-Force" Number="17" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="828200" />
+</Book>
+<Book Series="X-Force" Number="18" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="838891" />
+</Book>
+<Book Series="X-Force" Number="19" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="844977" />
+</Book>
+<Book Series="Children of the Atom" Number="3" Volume="2021" Year="2021">
+<Database Name="cv" Series="134388" Issue="848848" />
+</Book>
+<Book Series="New Mutants" Number="16" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="830031" />
+</Book>
+<Book Series="New Mutants" Number="17" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="846089" />
+</Book>
+<Book Series="X-Men" Number="18" Volume="2019" Year="2021">
+<Database Name="cv" Series="122077" Issue="830036" />
+</Book>
+<Book Series="X-Men" Number="19" Volume="2019" Year="2021">
+<Database Name="cv" Series="122077" Issue="840961" />
+</Book>
+<Book Series="New Mutants" Number="18" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="855632" />
+</Book>
+<Book Series="Excalibur" Number="17" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="826556" />
+</Book>
+<Book Series="Excalibur" Number="18" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="828191" />
+</Book>
+<Book Series="Excalibur" Number="19" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="839793" />
+</Book>
+<Book Series="Excalibur" Number="20" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="842202" />
+</Book>
+<Book Series="X-Men" Number="20" Volume="2019" Year="2021">
+<Database Name="cv" Series="122077" Issue="855634" />
+</Book>
+<Book Series="Hellions" Number="9" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="827522" />
+</Book>
+<Book Series="Hellions" Number="10" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="832862" />
+</Book>
+<Book Series="Hellions" Number="11" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="847510" />
+</Book>
+<Book Series="Cable" Number="10" Volume="2020" Year="2021">
+<Database Name="cv" Series="125678" Issue="846084" />
+</Book>
+<Book Series="Cable" Number="11" Volume="2020" Year="2021">
+<Database Name="cv" Series="125678" Issue="866577" />
+</Book>
+<Book Series="Cable" Number="12" Volume="2020" Year="2021">
+<Database Name="cv" Series="125678" Issue="874521" />
+</Book>
+<Book Series="S.W.O.R.D." Number="5" Volume="2020" Year="2021">
+<Database Name="cv" Series="132511" Issue="844973" />
+</Book>
+<Book Series="X-Factor" Number="7" Volume="2020" Year="2021">
+<Database Name="cv" Series="129097" Issue="827532" />
+</Book>
+<Book Series="X-Factor" Number="8" Volume="2020" Year="2021">
+<Database Name="cv" Series="129097" Issue="836308" />
+</Book>
+<Book Series="X-Factor" Number="9" Volume="2020" Year="2021">
+<Database Name="cv" Series="129097" Issue="848859" />
+</Book>
+<Book Series="X-Corp" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="136025" Issue="848858" />
+</Book>
+<Book Series="Marauders" Number="18" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="828860" />
+</Book>
+<Book Series="Marauders" Number="19" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="842206" />
+</Book>
+<Book Series="Children of the Atom" Number="4" Volume="2021" Year="2021">
+<Database Name="cv" Series="134388" Issue="858871" />
+</Book>
+<Book Series="Children of the Atom" Number="5" Volume="2021" Year="2021">
+<Database Name="cv" Series="134388" Issue="868608" />
+</Book>
+<Book Series="Way of X" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="135583" Issue="844975" />
+</Book>
+<Book Series="Way of X" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="135583" Issue="851313" />
+</Book>
+<Book Series="Marauders" Number="20" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="847514" />
+</Book>
+<Book Series="Marauders" Number="21" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="857597" />
+</Book>
+<Book Series="X-Force" Number="20" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="857598" />
+</Book>
+<Book Series="Hellions" Number="12" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="857596" />
+</Book>
+<Book Series="Excalibur" Number="21" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="858872" />
+</Book>
+<Book Series="X-Men" Number="21" Volume="2019" Year="2021">
+<Database Name="cv" Series="122077" Issue="858873" />
+</Book>
+<Book Series="Planet-Size X-Men" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="136937" Issue="861642" />
+</Book>
+<Book Series="New Mutants" Number="19" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="861639" />
+</Book>
+<Book Series="Children of the Atom" Number="6" Volume="2021" Year="2021">
+<Database Name="cv" Series="134388" Issue="878791" />
+</Book>
+<Book Series="X-Corp" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="136025" Issue="861644" />
+</Book>
+<Book Series="Wolverine" Number="13" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="863865" />
+</Book>
+<Book Series="S.W.O.R.D." Number="6" Volume="2020" Year="2021">
+<Database Name="cv" Series="132511" Issue="863852" />
+</Book>
+<Book Series="Way of X" Number="3" Volume="2021" Year="2021">
+<Database Name="cv" Series="135583" Issue="863854" />
+</Book>
+<Book Series="X-Factor" Number="10" Volume="2020" Year="2021">
+<Database Name="cv" Series="129097" Issue="866581" />
+</Book>
+<Book Series="Marauders" Number="22" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="872876" />
+</Book>
+<Book Series="S.W.O.R.D." Number="7" Volume="2020" Year="2021">
+<Database Name="cv" Series="132511" Issue="874522" />
+</Book>
+<Book Series="Cable: Reloaded" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="138527" Issue="882047" />
+</Book>
+<Book Series="X-Men" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="137402" Issue="868602" />
+</Book>
+<Book Series="New Mutants" Number="20" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="872877" />
+</Book>
+<Book Series="New Mutants" Number="21" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="882897" />
+</Book>
+<Book Series="New Mutants" Number="22" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="888638" />
+</Book>
+<Book Series="New Mutants" Number="23" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="896124" />
+</Book>
+<Book Series="X-Men: The Trial of Magneto" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="138343" Issue="880915" />
+</Book>
+<Book Series="Marauders" Number="23" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="880901" />
+</Book>
+<Book Series="Wolverine" Number="14" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="874523" />
+</Book>
+<Book Series="Wolverine" Number="15" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="882049" />
+</Book>
+<Book Series="Wolverine" Number="16" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="886940" />
+</Book>
+<Book Series="X-Men: The Trial of Magneto" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="138343" Issue="884830" />
+</Book>
+<Book Series="X-Men: The Trial of Magneto" Number="3" Volume="2021" Year="2021">
+<Database Name="cv" Series="138343" Issue="890603" />
+</Book>
+<Book Series="X-Men: The Trial of Magneto" Number="4" Volume="2021" Year="2022">
+<Database Name="cv" Series="138343" Issue="896094" />
+</Book>
+<Book Series="Inferno" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="139289" Issue="886937" />
+</Book>
+<Book Series="Hellions" Number="13" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="868599" />
+</Book>
+<Book Series="Hellions" Number="14" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="877059" />
+</Book>
+<Book Series="Hellions" Number="15" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="882896" />
+</Book>
+<Book Series="Hellions" Number="16" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="888637" />
+</Book>
+<Book Series="S.W.O.R.D." Number="8" Volume="2020" Year="2021">
+<Database Name="cv" Series="132511" Issue="886939" />
+</Book>
+<Book Series="Hellions" Number="17" Volume="2020" Year="2022">
+<Database Name="cv" Series="126015" Issue="893934" />
+</Book>
+<Book Series="Hellions" Number="18" Volume="2020" Year="2022">
+<Database Name="cv" Series="126015" Issue="897328" />
+</Book>
+<Book Series="X-Men: The Trial of Magneto" Number="5" Volume="2021" Year="2022">
+<Database Name="cv" Series="138343" Issue="899168" />
+</Book>
+<Book Series="New Mutants" Number="24" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="906634" />
+</Book>
+<Book Series="X-Men" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="137402" Issue="877060" />
+</Book>
+<Book Series="Excalibur" Number="22" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="871563" />
+</Book>
+<Book Series="Excalibur" Number="23" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="884068" />
+</Book>
+<Book Series="Excalibur" Number="24" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="888636" />
+</Book>
+<Book Series="Excalibur" Number="25" Volume="2019" Year="2022">
+<Database Name="cv" Series="122488" Issue="893974" />
+</Book>
+<Book Series="Excalibur" Number="26" Volume="2019" Year="2022">
+<Database Name="cv" Series="122488" Issue="898357" />
+</Book>
+<Book Series="Way of X" Number="4" Volume="2021" Year="2021">
+<Database Name="cv" Series="135583" Issue="871569" />
+</Book>
+<Book Series="Way of X" Number="5" Volume="2021" Year="2021">
+<Database Name="cv" Series="135583" Issue="880912" />
+</Book>
+<Book Series="X-Men: The Onslaught Revelation" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="139124" Issue="885606" />
+</Book>
+<Book Series="Marauders" Number="24" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="884828" />
+</Book>
+<Book Series="Marauders" Number="25" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="891563" />
+</Book>
+<Book Series="X-Men" Number="3" Volume="2021" Year="2021">
+<Database Name="cv" Series="137402" Issue="885604" />
+</Book>
+<Book Series="X-Corp" Number="3" Volume="2021" Year="2021">
+<Database Name="cv" Series="136025" Issue="871578" />
+</Book>
+<Book Series="X-Corp" Number="4" Volume="2021" Year="2021">
+<Database Name="cv" Series="136025" Issue="880913" />
+</Book>
+<Book Series="X-Corp" Number="5" Volume="2021" Year="2021">
+<Database Name="cv" Series="136025" Issue="885603" />
+</Book>
+<Book Series="S.W.O.R.D." Number="9" Volume="2020" Year="2021">
+<Database Name="cv" Series="132511" Issue="891564" />
+</Book>
+<Book Series="S.W.O.R.D." Number="10" Volume="2020" Year="2022">
+<Database Name="cv" Series="132511" Issue="894139" />
+</Book>
+<Book Series="S.W.O.R.D." Number="11" Volume="2020" Year="2022">
+<Database Name="cv" Series="132511" Issue="899166" />
+</Book>
+<Book Series="X-Men" Number="4" Volume="2021" Year="2021">
+<Database Name="cv" Series="137402" Issue="889466" />
+</Book>
+<Book Series="X-Men" Number="5" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="895353" />
+</Book>
+<Book Series="Marauders" Number="26" Volume="2019" Year="2022">
+<Database Name="cv" Series="122218" Issue="896131" />
+</Book>
+<Book Series="X-Men" Number="6" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="901350" />
+</Book>
+<Book Series="X-Men" Number="7" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="904779" />
+</Book>
+<Book Series="X-Men" Number="8" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="907432" />
+</Book>
+<Book Series="Devil&apos;s Reign: X-Men" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="141328" Issue="903910" />
+</Book>
+<Book Series="Devil&apos;s Reign: X-Men" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="141328" Issue="909677" />
+</Book>
+<Book Series="Devil&apos;s Reign: X-Men" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="141328" Issue="912248" />
+</Book>
+<Book Series="X-Force" Number="21" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="868600" />
+</Book>
+<Book Series="X-Force" Number="22" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="878792" />
+</Book>
+<Book Series="Wolverine" Number="17" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="891565" />
+</Book>
+<Book Series="Wolverine" Number="18" Volume="2020" Year="2022">
+<Database Name="cv" Series="125121" Issue="895337" />
+</Book>
+<Book Series="X-Force" Number="23" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="884069" />
+</Book>
+<Book Series="X-Force" Number="24" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="889465" />
+</Book>
+<Book Series="Inferno" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="139289" Issue="891562" />
+</Book>
+<Book Series="X-Force" Number="25" Volume="2020" Year="2022">
+<Database Name="cv" Series="122668" Issue="894133" />
+</Book>
+<Book Series="X-Force" Number="26" Volume="2020" Year="2022">
+<Database Name="cv" Series="122668" Issue="898353" />
+</Book>
+<Book Series="Wolverine" Number="19" Volume="2020" Year="2022">
+<Database Name="cv" Series="125121" Issue="899167" />
+</Book>
+<Book Series="Inferno" Number="3" Volume="2021" Year="2022">
+<Database Name="cv" Series="139289" Issue="897331" />
+</Book>
+<Book Series="Inferno" Number="4" Volume="2021" Year="2022">
+<Database Name="cv" Series="139289" Issue="901345" />
+</Book>
+<Book Series="Marauders" Number="27" Volume="2019" Year="2022">
+<Database Name="cv" Series="122218" Issue="902690" />
+</Book>
+<Book Series="X-Men" Number="9" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="909674" />
+</Book>
+<Book Series="X-Force Annual" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="142143" Issue="914651" />
+</Book>
+<Book Series="X Lives of Wolverine" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="141332" Issue="903920" />
+</Book>
+<Book Series="X Deaths of Wolverine" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="141460" Issue="904769" />
+</Book>
+<Book Series="X Lives of Wolverine" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="141332" Issue="905751" />
+</Book>
+<Book Series="X Deaths of Wolverine" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="141460" Issue="906636" />
+</Book>
+<Book Series="X Lives of Wolverine" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="141332" Issue="907433" />
+</Book>
+<Book Series="X Deaths of Wolverine" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="141460" Issue="908676" />
+</Book>
+<Book Series="X Lives of Wolverine" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="141332" Issue="910624" />
+</Book>
+<Book Series="X Deaths of Wolverine" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="141460" Issue="910625" />
+</Book>
+<Book Series="X Lives of Wolverine" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="141332" Issue="911227" />
+</Book>
+<Book Series="X Deaths of Wolverine" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="141460" Issue="912246" />
+</Book>
+<Book Series="X-Force" Number="27" Volume="2020" Year="2022">
+<Database Name="cv" Series="122668" Issue="914648" />
+</Book>
+<Book Series="X-Force" Number="28" Volume="2020" Year="2022">
+<Database Name="cv" Series="122668" Issue="924786" />
+</Book>
+<Book Series="X-Force" Number="29" Volume="2020" Year="2022">
+<Database Name="cv" Series="122668" Issue="933078" />
+</Book>
+<Book Series="Wolverine" Number="20" Volume="2020" Year="2022">
+<Database Name="cv" Series="125121" Issue="918155" />
+</Book>
+<Book Series="Wolverine" Number="21" Volume="2020" Year="2022">
+<Database Name="cv" Series="125121" Issue="924801" />
+</Book>
+<Book Series="Wolverine" Number="22" Volume="2020" Year="2022">
+<Database Name="cv" Series="125121" Issue="930974" />
+</Book>
+<Book Series="Wolverine" Number="23" Volume="2020" Year="2022">
+<Database Name="cv" Series="125121" Issue="935753" />
+</Book>
+<Book Series="X-Men Unlimited: X-Men Green" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="144596" Issue="942888" />
+</Book>
+<Book Series="X-Men Unlimited: X-Men Green" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="144596" Issue="948120" />
+</Book>
+<Book Series="Sabretooth" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="141524" Issue="905793" />
+</Book>
+<Book Series="Sabretooth" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="141524" Issue="910621" />
+</Book>
+<Book Series="Sabretooth" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="141524" Issue="919308" />
+</Book>
+<Book Series="Sabretooth" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="141524" Issue="933081" />
+</Book>
+<Book Series="Sabretooth" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="141524" Issue="934984" />
+</Book>
+<Book Series="Sabretooth and the Exiles" Number="1" Volume="2022" Year="2023">
+<Database Name="cv" Series="145971" Issue="954280" />
+</Book>
+<Book Series="Sabretooth and the Exiles" Number="2" Volume="2022" Year="2023">
+<Database Name="cv" Series="145971" Issue="960981" />
+</Book>
+<Book Series="Sabretooth and the Exiles" Number="3" Volume="2022" Year="2023">
+<Database Name="cv" Series="145971" Issue="966425" />
+</Book>
+<Book Series="Sabretooth and the Exiles" Number="4" Volume="2022" Year="2023">
+<Database Name="cv" Series="145971" Issue="973028" />
+</Book>
+<Book Series="Sabretooth and the Exiles" Number="5" Volume="2022" Year="2023">
+<Database Name="cv" Series="145971" Issue="979429" />
+</Book>
+<Book Series="Immortal X-Men" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="142053" Issue="913161" />
+</Book>
+<Book Series="Immortal X-Men" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="142053" Issue="924799" />
+</Book>
+<Book Series="Immortal X-Men" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="142053" Issue="931630" />
+</Book>
+<Book Series="Legion of X" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="143115" Issue="926170" />
+</Book>
+<Book Series="Legion of X" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="143115" Issue="929646" />
+</Book>
+<Book Series="X-Men: Red" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="142134" Issue="914549" />
+</Book>
+<Book Series="X-Men: Red" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="142134" Issue="924793" />
+</Book>
+<Book Series="X-Men: Red" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="142134" Issue="930978" />
+</Book>
+<Book Series="Legion of X" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="143115" Issue="934980" />
+</Book>
+<Book Series="Legion of X" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="143115" Issue="940229" />
+</Book>
+<Book Series="Legion of X" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="143115" Issue="948111" />
+</Book>
+<Book Series="Knights of X" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="142576" Issue="919304" />
+</Book>
+<Book Series="Knights of X" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="142576" Issue="928438" />
+</Book>
+<Book Series="Knights of X" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="142576" Issue="931632" />
+</Book>
+<Book Series="Knights of X" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="142576" Issue="937731" />
+</Book>
+<Book Series="Knights of X" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="142576" Issue="944673" />
+</Book>
+<Book Series="The Secret X-Men" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="141588" Issue="906626" />
+</Book>
+<Book Series="Marauders Annual" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="141459" Issue="904768" />
+</Book>
+<Book Series="Marauders" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="142135" Issue="914550" />
+</Book>
+<Book Series="Marauders" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="142135" Issue="921063" />
+</Book>
+<Book Series="Marauders" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="142135" Issue="929645" />
+</Book>
+<Book Series="Marauders" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="142135" Issue="935761" />
+</Book>
+<Book Series="X-Men" Number="10" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="916414" />
+</Book>
+<Book Series="X-Men" Number="11" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="922402" />
+</Book>
+<Book Series="X-Men" Number="12" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="931633" />
+</Book>
+<Book Series="Free Comic Book Day 2022: Avengers/X-Men" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="142841" Issue="922405" />
+</Book>
+<Book Series="X-Men: Hellfire Gala" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="153656" Issue="1016342" />
+</Book>
+<Book Series="X-Men: Red" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="142134" Issue="933084" />
+</Book>
+<Book Series="Marauders" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="142135" Issue="943897" />
+</Book>
+<Book Series="X-Force" Number="30" Volume="2020" Year="2022">
+<Database Name="cv" Series="122668" Issue="942706" />
+</Book>
+<Book Series="Immortal X-Men" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="142053" Issue="935751" />
+</Book>
+<Book Series="Eternals" Number="10" Volume="2021" Year="2022">
+<Database Name="cv" Series="133080" Issue="910626" />
+</Book>
+<Book Series="Eternals" Number="11" Volume="2021" Year="2022">
+<Database Name="cv" Series="133080" Issue="916411" />
+</Book>
+<Book Series="Eternals" Number="12" Volume="2021" Year="2022">
+<Database Name="cv" Series="133080" Issue="924798" />
+</Book>
+<Book Series="A.X.E.: Eve of Judgment" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="144026" Issue="935759" />
+</Book>
+<Book Series="A.X.E.: Judgment Day" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="144123" Issue="937937" />
+</Book>
+<Book Series="X-Men: Red" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="142134" Issue="940222" />
+</Book>
+<Book Series="Immortal X-Men" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="142053" Issue="940226" />
+</Book>
+<Book Series="A.X.E.: Judgment Day" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="144123" Issue="941552" />
+</Book>
+<Book Series="A.X.E.: Death to the Mutants" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="144577" Issue="942722" />
+</Book>
+<Book Series="X-Men" Number="13" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="942704" />
+</Book>
+<Book Series="A.X.E.: Judgment Day" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="144123" Issue="943804" />
+</Book>
+<Book Series="A.X.E.: Death to the Mutants" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="144577" Issue="946198" />
+</Book>
+<Book Series="X-Men" Number="14" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="944674" />
+</Book>
+<Book Series="Wolverine" Number="24" Volume="2020" Year="2022">
+<Database Name="cv" Series="125121" Issue="946208" />
+</Book>
+<Book Series="Wolverine" Number="25" Volume="2020" Year="2022">
+<Database Name="cv" Series="125121" Issue="950794" />
+</Book>
+<Book Series="X-Force" Number="31" Volume="2020" Year="2022">
+<Database Name="cv" Series="122668" Issue="944669" />
+</Book>
+<Book Series="X-Force" Number="32" Volume="2020" Year="2022">
+<Database Name="cv" Series="122668" Issue="950383" />
+</Book>
+<Book Series="X-Force" Number="33" Volume="2020" Year="2022">
+<Database Name="cv" Series="122668" Issue="951451" />
+</Book>
+<Book Series="Immortal X-Men" Number="6" Volume="2022" Year="2022">
+<Database Name="cv" Series="142053" Issue="946148" />
+</Book>
+<Book Series="X-Men: Red" Number="6" Volume="2022" Year="2022">
+<Database Name="cv" Series="142134" Issue="946725" />
+</Book>
+<Book Series="A.X.E.: Iron Fist" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="145487" Issue="950486" />
+</Book>
+<Book Series="Avengers" Number="60" Volume="2018" Year="2022">
+<Database Name="cv" Series="110496" Issue="948104" />
+</Book>
+<Book Series="Fantastic Four" Number="47" Volume="2018" Year="2022">
+<Database Name="cv" Series="112685" Issue="948107" />
+</Book>
+<Book Series="Fantastic Four" Number="48" Volume="2018" Year="2022">
+<Database Name="cv" Series="112685" Issue="950375" />
+</Book>
+<Book Series="The Amazing Spider-Man" Number="10" Volume="2022" Year="2022">
+<Database Name="cv" Series="142577" Issue="949133" />
+</Book>
+<Book Series="Captain Marvel" Number="42" Volume="2019" Year="2022">
+<Database Name="cv" Series="116365" Issue="950790" />
+</Book>
+<Book Series="A.X.E.: Judgment Day" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="144123" Issue="946709" />
+</Book>
+<Book Series="X-Men: Red" Number="7" Volume="2022" Year="2022">
+<Database Name="cv" Series="142134" Issue="949645" />
+</Book>
+<Book Series="Legion of X" Number="6" Volume="2022" Year="2022">
+<Database Name="cv" Series="143115" Issue="950373" />
+</Book>
+<Book Series="Marauders" Number="6" Volume="2022" Year="2022">
+<Database Name="cv" Series="142135" Issue="946133" />
+</Book>
+<Book Series="A.X.E.: Judgment Day" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="144123" Issue="948102" />
+</Book>
+<Book Series="Immortal X-Men" Number="7" Volume="2022" Year="2022">
+<Database Name="cv" Series="142053" Issue="950483" />
+</Book>
+<Book Series="A.X.E.: Death to the Mutants" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="144577" Issue="950484" />
+</Book>
+<Book Series="A.X.E.: Starfox" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="145362" Issue="949633" />
+</Book>
+<Book Series="A.X.E.: Avengers" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="145299" Issue="949158" />
+</Book>
+<Book Series="A.X.E.: X-Men" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="145363" Issue="949634" />
+</Book>
+<Book Series="A.X.E.: Eternals" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="145486" Issue="950485" />
+</Book>
+<Book Series="A.X.E.: Judgment Day" Number="6" Volume="2022" Year="2022">
+<Database Name="cv" Series="144123" Issue="952304" />
+</Book>
+<Book Series="A.X.E.: Judgment Day Omega" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="145974" Issue="954292" />
+</Book>
+<Book Series="Immortal X-Men" Number="8" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="955124" />
+</Book>
+<Book Series="Marauders" Number="7" Volume="2022" Year="2022">
+<Database Name="cv" Series="142135" Issue="949640" />
+</Book>
+<Book Series="Marauders" Number="8" Volume="2022" Year="2023">
+<Database Name="cv" Series="142135" Issue="953976" />
+</Book>
+<Book Series="Marauders" Number="9" Volume="2022" Year="2023">
+<Database Name="cv" Series="142135" Issue="958985" />
+</Book>
+<Book Series="Marauders" Number="10" Volume="2022" Year="2023">
+<Database Name="cv" Series="142135" Issue="962851" />
+</Book>
+<Book Series="Marauders" Number="11" Volume="2022" Year="2023">
+<Database Name="cv" Series="142135" Issue="971896" />
+</Book>
+<Book Series="Marauders" Number="12" Volume="2022" Year="2023">
+<Database Name="cv" Series="142135" Issue="978483" />
+</Book>
+<Book Series="New Mutants" Number="25" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="924785" />
+</Book>
+<Book Series="New Mutants" Number="26" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="931631" />
+</Book>
+<Book Series="New Mutants" Number="27" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="935764" />
+</Book>
+<Book Series="New Mutants" Number="28" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="942712" />
+</Book>
+<Book Series="New Mutants" Number="29" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="946211" />
+</Book>
+<Book Series="New Mutants" Number="30" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="948113" />
+</Book>
+<Book Series="New Mutants" Number="31" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="952303" />
+</Book>
+<Book Series="New Mutants" Number="32" Volume="2020" Year="2023">
+<Database Name="cv" Series="122666" Issue="958986" />
+</Book>
+<Book Series="New Mutants" Number="33" Volume="2020" Year="2023">
+<Database Name="cv" Series="122666" Issue="961943" />
+</Book>
+<Book Series="New Mutants: Lethal Legion" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="148780" Issue="975693" />
+</Book>
+<Book Series="New Mutants: Lethal Legion" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="148780" Issue="984327" />
+</Book>
+<Book Series="New Mutants: Lethal Legion" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="148780" Issue="991069" />
+</Book>
+<Book Series="New Mutants: Lethal Legion" Number="4" Volume="2023" Year="2023">
+<Database Name="cv" Series="148780" Issue="996024" />
+</Book>
+<Book Series="New Mutants: Lethal Legion" Number="5" Volume="2023" Year="2023">
+<Database Name="cv" Series="148780" Issue="1002001" />
+</Book>
+<Book Series="X-Men Annual" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="146988" Issue="960987" />
+</Book>
+<Book Series="X-Men" Number="15" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="949129" />
+</Book>
+<Book Series="X-Men" Number="16" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="951447" />
+</Book>
+<Book Series="X-Men" Number="17" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="956846" />
+</Book>
+<Book Series="X-Terminators" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="145163" Issue="948121" />
+</Book>
+<Book Series="X-Terminators" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="145163" Issue="952307" />
+</Book>
+<Book Series="X-Terminators" Number="3" Volume="2022" Year="2023">
+<Database Name="cv" Series="145163" Issue="958044" />
+</Book>
+<Book Series="X-Terminators" Number="4" Volume="2022" Year="2023">
+<Database Name="cv" Series="145163" Issue="961964" />
+</Book>
+<Book Series="X-Terminators" Number="5" Volume="2022" Year="2023">
+<Database Name="cv" Series="145163" Issue="966432" />
+</Book>
+<Book Series="Dark Web" Number="1" Volume="2022" Year="2023">
+<Database Name="cv" Series="146735" Issue="959000" />
+</Book>
+<Book Series="Dark Web: X-Men" Number="1" Volume="2022" Year="2023">
+<Database Name="cv" Series="146875" Issue="960026" />
+</Book>
+<Book Series="Dark Web: X-Men" Number="2" Volume="2022" Year="2023">
+<Database Name="cv" Series="146875" Issue="961948" />
+</Book>
+<Book Series="Dark Web: X-Men" Number="3" Volume="2022" Year="2023">
+<Database Name="cv" Series="146875" Issue="964964" />
+</Book>
+<Book Series="Dark Web: Finale" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="147905" Issue="967787" />
+</Book>
+<Book Series="X-Men" Number="18" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="963985" />
+</Book>
+<Book Series="Captain Marvel" Number="43" Volume="2019" Year="2023">
+<Database Name="cv" Series="116365" Issue="953019" />
+</Book>
+<Book Series="Captain Marvel" Number="44" Volume="2019" Year="2023">
+<Database Name="cv" Series="116365" Issue="958979" />
+</Book>
+<Book Series="Captain Marvel" Number="45" Volume="2019" Year="2023">
+<Database Name="cv" Series="116365" Issue="962850" />
+</Book>
+<Book Series="Captain Marvel" Number="46" Volume="2019" Year="2023">
+<Database Name="cv" Series="116365" Issue="971895" />
+</Book>
+<Book Series="Captain Marvel" Number="47" Volume="2019" Year="2023">
+<Database Name="cv" Series="116365" Issue="976907" />
+</Book>
+<Book Series="Captain Marvel" Number="48" Volume="2019" Year="2023">
+<Database Name="cv" Series="116365" Issue="982355" />
+</Book>
+<Book Series="Captain Marvel" Number="49" Volume="2019" Year="2023">
+<Database Name="cv" Series="116365" Issue="987103" />
+</Book>
+<Book Series="X-Men" Number="19" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="971885" />
+</Book>
+<Book Series="X-Men" Number="20" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="975695" />
+</Book>
+<Book Series="X-Men" Number="21" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="982356" />
+</Book>
+<Book Series="X-Men: Red" Number="8" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="953033" />
+</Book>
+<Book Series="X-Men: Red" Number="9" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="958991" />
+</Book>
+<Book Series="X-Men: Red" Number="10" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="962849" />
+</Book>
+<Book Series="Legion of X" Number="7" Volume="2022" Year="2023">
+<Database Name="cv" Series="143115" Issue="953977" />
+</Book>
+<Book Series="Legion of X" Number="8" Volume="2022" Year="2023">
+<Database Name="cv" Series="143115" Issue="960023" />
+</Book>
+<Book Series="Legion of X" Number="9" Volume="2022" Year="2023">
+<Database Name="cv" Series="143115" Issue="963981" />
+</Book>
+<Book Series="Legion of X" Number="10" Volume="2022" Year="2023">
+<Database Name="cv" Series="143115" Issue="967794" />
+</Book>
+<Book Series="Immortal X-Men" Number="9" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="958983" />
+</Book>
+<Book Series="Immortal X-Men" Number="10" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="964967" />
+</Book>
+<Book Series="Sins of Sinister" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153615" Issue="1014917" />
+</Book>
+<Book Series="Storm &#38; The Brotherhood of Mutants" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="148090" Issue="969390" />
+</Book>
+<Book Series="Nightcrawlers" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="148297" Issue="971894" />
+</Book>
+<Book Series="Immoral X-Men" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="148475" Issue="973001" />
+</Book>
+<Book Series="Nightcrawlers" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="148297" Issue="975699" />
+</Book>
+<Book Series="Immoral X-Men" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="148475" Issue="976915" />
+</Book>
+<Book Series="Storm &#38; The Brotherhood of Mutants" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="148090" Issue="978480" />
+</Book>
+<Book Series="Immoral X-Men" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="148475" Issue="981484" />
+</Book>
+<Book Series="Storm &#38; The Brotherhood of Mutants" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="148090" Issue="982353" />
+</Book>
+<Book Series="Nightcrawlers" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="148297" Issue="984326" />
+</Book>
+<Book Series="Sins of Sinister: Dominion" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="149776" Issue="985704" />
+</Book>
+<Book Series="Immortal X-Men" Number="11" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="987132" />
+</Book>
+<Book Series="X-Men: Before the Fall - Sons of X" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="150028" Issue="987192" />
+</Book>
+<Book Series="X-Men: Red" Number="11" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="988124" />
+</Book>
+<Book Series="X-Men: Red" Number="12" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="994356" />
+</Book>
+<Book Series="Wolverine" Number="26" Volume="2020" Year="2022">
+<Database Name="cv" Series="125121" Issue="952302" />
+</Book>
+<Book Series="Wolverine" Number="27" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="953983" />
+</Book>
+<Book Series="Wolverine" Number="28" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="960986" />
+</Book>
+<Book Series="X-Force" Number="34" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="956778" />
+</Book>
+<Book Series="X-Force" Number="35" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="958990" />
+</Book>
+<Book Series="X-Force" Number="36" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="962844" />
+</Book>
+<Book Series="X-Force" Number="37" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="967790" />
+</Book>
+<Book Series="X-Force" Number="38" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="974096" />
+</Book>
+<Book Series="Wolverine" Number="29" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="963982" />
+</Book>
+<Book Series="Wolverine" Number="30" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="971883" />
+</Book>
+<Book Series="Wolverine" Number="31" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="976904" />
+</Book>
+<Book Series="Wolverine" Number="32" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="981473" />
+</Book>
+<Book Series="X-Force" Number="39" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="984323" />
+</Book>
+<Book Series="Wolverine" Number="33" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="988123" />
+</Book>
+<Book Series="Wolverine" Number="34" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="994359" />
+</Book>
+<Book Series="X-Force" Number="40" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="989670" />
+</Book>
+<Book Series="X-Force" Number="41" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="996027" />
+</Book>
+<Book Series="X-Force" Number="42" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="1000244" />
+</Book>
+<Book Series="Wolverine" Number="35" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="1003593" />
+</Book>
+<Book Series="Deadpool" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="953021" />
+</Book>
+<Book Series="Deadpool" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="960024" />
+</Book>
+<Book Series="Deadpool" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="964961" />
+</Book>
+<Book Series="Deadpool" Number="4" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="973019" />
+</Book>
+<Book Series="Deadpool" Number="5" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="979419" />
+</Book>
+<Book Series="Deadpool" Number="6" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="985710" />
+</Book>
+<Book Series="Deadpool" Number="7" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="992312" />
+</Book>
+<Book Series="Deadpool" Number="8" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="997389" />
+</Book>
+<Book Series="Deadpool" Number="9" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="1003576" />
+</Book>
+<Book Series="Deadpool" Number="10" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="1010046" />
+</Book>
+<Book Series="Rogue &amp; Gambit" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="148664" Issue="974106" />
+</Book>
+<Book Series="Rogue &amp; Gambit" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="148664" Issue="981478" />
+</Book>
+<Book Series="Rogue &amp; Gambit" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="148664" Issue="988125" />
+</Book>
+<Book Series="Rogue &amp; Gambit" Number="4" Volume="2023" Year="2023">
+<Database Name="cv" Series="148664" Issue="994364" />
+</Book>
+<Book Series="Rogue &amp; Gambit" Number="5" Volume="2023" Year="2023">
+<Database Name="cv" Series="148664" Issue="1000237" />
+</Book>
+<Book Series="X-Men" Number="22" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="989671" />
+</Book>
+<Book Series="X-Men: Before the Fall – Mutant First Strike" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="151052" Issue="993583" />
+</Book>
+<Book Series="Bishop: War College" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="148091" Issue="969391" />
+</Book>
+<Book Series="Bishop: War College" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="148091" Issue="976901" />
+</Book>
+<Book Series="Bishop: War College" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="148091" Issue="984330" />
+</Book>
+<Book Series="Bishop: War College" Number="4" Volume="2023" Year="2023">
+<Database Name="cv" Series="148091" Issue="991063" />
+</Book>
+<Book Series="Bishop: War College" Number="5" Volume="2023" Year="2023">
+<Database Name="cv" Series="148091" Issue="993226" />
+</Book>
+<Book Series="Marvel&apos;s Voices: Pride" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="151966" Issue="999054" />
+</Book>
+<Book Series="Betsy Braddock: Captain Britain" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="148474" Issue="973000" />
+</Book>
+<Book Series="Betsy Braddock: Captain Britain" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="148474" Issue="979432" />
+</Book>
+<Book Series="Betsy Braddock: Captain Britain" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="148474" Issue="985715" />
+</Book>
+<Book Series="Betsy Braddock: Captain Britain" Number="4" Volume="2023" Year="2023">
+<Database Name="cv" Series="148474" Issue="992288" />
+</Book>
+<Book Series="Betsy Braddock: Captain Britain" Number="5" Volume="2023" Year="2023">
+<Database Name="cv" Series="148474" Issue="996014" />
+</Book>
+<Book Series="X-Men" Number="23" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="993241" />
+</Book>
+<Book Series="Fallen Friend: The Death of Ms. Marvel" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="152123" Issue="1000229" />
+</Book>
+<Book Series="X-Men: Before the Fall - Sinister Four" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="151912" Issue="998591" />
+</Book>
+<Book Series="Immortal X-Men" Number="12" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="993232" />
+</Book>
+<Book Series="X-Men: Before The Fall - Heralds of Apocalypse" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="151708" Issue="997400" />
+</Book>
+<Book Series="X-Men: Red" Number="13" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="1001998" />
+</Book>
+<Book Series="Immortal X-Men" Number="13" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="1000231" />
+</Book>
+<Book Series="X-Men" Number="24" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="999414" />
+</Book>
+<Book Series="X-Men: Hellfire Gala" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="152567" Issue="1003871" />
+</Book>
+<Book Series="Free Comic Book Day 2023: Avengers/X-Men" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="150031" Issue="987190" />
+</Book>
+<Book Series="X-Force" Number="43" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="1010057" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="8" Volume="2022" Year="2023">
+<Database Name="cv" Series="146873" Issue="1003582" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="9" Volume="2022" Year="2023">
+<Database Name="cv" Series="146873" Issue="1010048" />
+</Book>
+<Book Series="Marvel&apos;s Voices: X-Men" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153035" Issue="1009043" />
+</Book>
+<Book Series="X-Men: Red" Number="14" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="1008944" />
+</Book>
+<Book Series="X-Men: Red" Number="15" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="1013504" />
+</Book>
+<Book Series="Realm of X" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153121" Issue="1010053" />
+</Book>
+<Book Series="Realm of X" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="153121" Issue="1018027" />
+</Book>
+<Book Series="Ghost Rider / Wolverine: Weapons of Vengeance – Alpha" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="152897" Issue="1006447" />
+</Book>
+<Book Series="Ghost Rider" Number="17" Volume="2022" Year="2023">
+<Database Name="cv" Series="141707" Issue="1008949" />
+</Book>
+<Book Series="Wolverine" Number="36" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="1010949" />
+</Book>
+<Book Series="Ghost Rider/Wolverine: Weapons of Vengeance Omega" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153361" Issue="1012328" />
+</Book>
+<Book Series="X-Men" Number="25" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="1004347" />
+</Book>
+<Book Series="Uncanny Avengers" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153018" Issue="1008929" />
+</Book>
+<Book Series="Uncanny Avengers" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="153018" Issue="1014896" />
+</Book>
+<Book Series="Children of the Vault" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="152893" Issue="1006445" />
+</Book>
+<Book Series="Children of the Vault" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="152893" Issue="1013492" />
+</Book>
+<Book Series="Children of the Vault" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="152893" Issue="1025150" />
+</Book>
+<Book Series="Children of the Vault" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="152893" Issue="1029679" />
+</Book>
+<Book Series="Giant-Size X-Men" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="158070" Issue="1054379" />
+</Book>
+<Book Series="X-Men" Number="26" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="1011788" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="10" Volume="2022" Year="2023">
+<Database Name="cv" Series="146873" Issue="1018021" />
+</Book>
+<Book Series="Ms. Marvel: The New Mutant" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153238" Issue="1010944" />
+</Book>
+<Book Series="Ms. Marvel: The New Mutant" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="153238" Issue="1018026" />
+</Book>
+<Book Series="Ms. Marvel: The New Mutant" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="153238" Issue="1026552" />
+</Book>
+<Book Series="Ms. Marvel: The New Mutant" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="153238" Issue="1031695" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="11" Volume="2022" Year="2023">
+<Database Name="cv" Series="146873" Issue="1025158" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="12" Volume="2022" Year="2024">
+<Database Name="cv" Series="146873" Issue="1030786" />
+</Book>
+<Book Series="Alpha Flight" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153020" Issue="1008998" />
+</Book>
+<Book Series="Alpha Flight" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="153020" Issue="1014904" />
+</Book>
+<Book Series="Alpha Flight" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="153020" Issue="1026542" />
+</Book>
+<Book Series="Alpha Flight" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="153020" Issue="1029674" />
+</Book>
+<Book Series="Alpha Flight" Number="5" Volume="2023" Year="2024">
+<Database Name="cv" Series="153020" Issue="1033198" />
+</Book>
+<Book Series="Dark X-Men" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153023" Issue="1008999" />
+</Book>
+<Book Series="Dark X-Men" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="153023" Issue="1014902" />
+</Book>
+<Book Series="Dark X-Men" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="153023" Issue="1026546" />
+</Book>
+<Book Series="Wolverine" Number="37" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="1014897" />
+</Book>
+<Book Series="Wolverine" Number="38" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="1024060" />
+</Book>
+<Book Series="Wolverine" Number="39" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1030799" />
+</Book>
+<Book Series="X-Force" Number="44" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="1013503" />
+</Book>
+<Book Series="X-Force" Number="45" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="1020543" />
+</Book>
+<Book Series="X-Force" Number="46" Volume="2020" Year="2024">
+<Database Name="cv" Series="122668" Issue="1028638" />
+</Book>
+<Book Series="Wolverine" Number="40" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1035971" />
+</Book>
+<Book Series="X-Men" Number="27" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="1020544" />
+</Book>
+<Book Series="X-Men" Number="28" Volume="2021" Year="2024">
+<Database Name="cv" Series="137402" Issue="1027605" />
+</Book>
+<Book Series="X-Men" Number="29" Volume="2021" Year="2024">
+<Database Name="cv" Series="137402" Issue="1033214" />
+</Book>
+<Book Series="X-Men: Red" Number="16" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="1024061" />
+</Book>
+<Book Series="X-Men: Red" Number="17" Volume="2022" Year="2024">
+<Database Name="cv" Series="142134" Issue="1028639" />
+</Book>
+<Book Series="X-Men: Red" Number="18" Volume="2022" Year="2024">
+<Database Name="cv" Series="142134" Issue="1034349" />
+</Book>
+<Book Series="X-Force" Number="47" Volume="2020" Year="2024">
+<Database Name="cv" Series="122668" Issue="1038291" />
+</Book>
+<Book Series="X-Force" Number="48" Volume="2020" Year="2024">
+<Database Name="cv" Series="122668" Issue="1042220" />
+</Book>
+<Book Series="X-Force" Number="49" Volume="2020" Year="2024">
+<Database Name="cv" Series="122668" Issue="1045769" />
+</Book>
+<Book Series="X-Force" Number="50" Volume="2020" Year="2024">
+<Database Name="cv" Series="122668" Issue="1049286" />
+</Book>
+<Book Series="Wolverine" Number="41" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1039590" />
+</Book>
+<Book Series="Wolverine" Number="42" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1042837" />
+</Book>
+<Book Series="Wolverine" Number="43" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1044787" />
+</Book>
+<Book Series="Wolverine" Number="44" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1046277" />
+</Book>
+<Book Series="Wolverine" Number="45" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1047957" />
+</Book>
+<Book Series="Wolverine" Number="46" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1049285" />
+</Book>
+<Book Series="Wolverine" Number="47" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1051133" />
+</Book>
+<Book Series="Wolverine" Number="48" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1052947" />
+</Book>
+<Book Series="Wolverine" Number="49" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1054385" />
+</Book>
+<Book Series="Wolverine" Number="50" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1057018" />
+</Book>
+<Book Series="Astonishing Iceman" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="152649" Issue="1004321" />
+</Book>
+<Book Series="Astonishing Iceman" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="152649" Issue="1013489" />
+</Book>
+<Book Series="Uncanny Spider-Man" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153606" Issue="1014911" />
+</Book>
+<Book Series="Uncanny Spider-Man" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="153606" Issue="1026559" />
+</Book>
+<Book Series="Uncanny Spider-Man" Number="3" Volume="2023" Year="2024">
+<Database Name="cv" Series="153606" Issue="1028637" />
+</Book>
+<Book Series="Dark X-Men" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="153023" Issue="1029681" />
+</Book>
+<Book Series="Dark X-Men" Number="5" Volume="2023" Year="2024">
+<Database Name="cv" Series="153023" Issue="1034337" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="13" Volume="2022" Year="2024">
+<Database Name="cv" Series="146873" Issue="1033204" />
+</Book>
+<Book Series="Astonishing Iceman" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="152649" Issue="1025148" />
+</Book>
+<Book Series="Astonishing Iceman" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="152649" Issue="1029675" />
+</Book>
+<Book Series="Astonishing Iceman" Number="5" Volume="2023" Year="2024">
+<Database Name="cv" Series="152649" Issue="1035955" />
+</Book>
+<Book Series="Uncanny Spider-Man" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="153606" Issue="1030798" />
+</Book>
+<Book Series="X-Men Blue: Origins" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="154998" Issue="1032224" />
+</Book>
+<Book Series="Uncanny Spider-Man" Number="5" Volume="2023" Year="2024">
+<Database Name="cv" Series="153606" Issue="1035970" />
+</Book>
+<Book Series="Uncanny Avengers" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="153018" Issue="1026557" />
+</Book>
+<Book Series="Uncanny Avengers" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="153018" Issue="1029696" />
+</Book>
+<Book Series="Uncanny Avengers" Number="5" Volume="2023" Year="2024">
+<Database Name="cv" Series="153018" Issue="1035969" />
+</Book>
+<Book Series="Realm of X" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="153121" Issue="1026554" />
+</Book>
+<Book Series="Realm of X" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="153121" Issue="1031697" />
+</Book>
+<Book Series="Immortal X-Men" Number="14" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="1006441" />
+</Book>
+<Book Series="Immortal X-Men" Number="15" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="1011780" />
+</Book>
+<Book Series="Immortal X-Men" Number="16" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="1020537" />
+</Book>
+<Book Series="Jean Grey" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153119" Issue="1010049" />
+</Book>
+<Book Series="Jean Grey" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="153119" Issue="1018022" />
+</Book>
+<Book Series="Jean Grey" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="153119" Issue="1026549" />
+</Book>
+<Book Series="Jean Grey" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="153119" Issue="1029686" />
+</Book>
+<Book Series="Immortal X-Men" Number="17" Volume="2022" Year="2024">
+<Database Name="cv" Series="142053" Issue="1030784" />
+</Book>
+<Book Series="Immortal X-Men" Number="18" Volume="2022" Year="2024">
+<Database Name="cv" Series="142053" Issue="1038387" />
+</Book>
+<Book Series="Resurrection of Magneto" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="156369" Issue="1042231" />
+</Book>
+<Book Series="Resurrection of Magneto" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="156369" Issue="1046272" />
+</Book>
+<Book Series="Resurrection of Magneto" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="156369" Issue="1048669" />
+</Book>
+<Book Series="Ms. Marvel: Mutant Menace" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="157125" Issue="1047085" />
+</Book>
+<Book Series="Ms. Marvel: Mutant Menace" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="157125" Issue="1051125" />
+</Book>
+<Book Series="Ms. Marvel: Mutant Menace" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="157125" Issue="1055028" />
+</Book>
+<Book Series="Ms. Marvel: Mutant Menace" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="157125" Issue="1058725" />
+</Book>
+<Book Series="X-Men" Number="30" Volume="2021" Year="2024">
+<Database Name="cv" Series="137402" Issue="1040949" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="14" Volume="2022" Year="2024">
+<Database Name="cv" Series="146873" Issue="1040941" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="15" Volume="2022" Year="2024">
+<Database Name="cv" Series="146873" Issue="1046268" />
+</Book>
+<Book Series="Avengers" Number="12" Volume="2023" Year="2024">
+<Database Name="cv" Series="150431" Issue="1050565" />
+</Book>
+<Book Series="Avengers" Number="13" Volume="2023" Year="2024">
+<Database Name="cv" Series="150431" Issue="1052926" />
+</Book>
+<Book Series="Fall of the House of X" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="155874" Issue="1038990" />
+</Book>
+<Book Series="X-Men" Number="31" Volume="2021" Year="2024">
+<Database Name="cv" Series="137402" Issue="1043844" />
+</Book>
+<Book Series="Fall of the House of X" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="155874" Issue="1044779" />
+</Book>
+<Book Series="X-Men" Number="32" Volume="2021" Year="2024">
+<Database Name="cv" Series="137402" Issue="1047095" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="16" Volume="2022" Year="2024">
+<Database Name="cv" Series="146873" Issue="1048667" />
+</Book>
+<Book Series="Resurrection of Magneto" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="156369" Issue="1051126" />
+</Book>
+<Book Series="Fall of the House of X" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="155874" Issue="1047947" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="17" Volume="2022" Year="2024">
+<Database Name="cv" Series="146873" Issue="1051124" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="18" Volume="2022" Year="2024">
+<Database Name="cv" Series="146873" Issue="1053541" />
+</Book>
+<Book Series="X-Men" Number="33" Volume="2021" Year="2024">
+<Database Name="cv" Series="137402" Issue="1050579" />
+</Book>
+<Book Series="Cable" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="156139" Issue="1040936" />
+</Book>
+<Book Series="Cable" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="156139" Issue="1046263" />
+</Book>
+<Book Series="Cable" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="156139" Issue="1049270" />
+</Book>
+<Book Series="Cable" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="156139" Issue="1053536" />
+</Book>
+<Book Series="X-Men Forever" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="157312" Issue="1048680" />
+</Book>
+<Book Series="Rise of the Powers of X" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="155968" Issue="1039582" />
+</Book>
+<Book Series="Rise of the Powers of X" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="155968" Issue="1045770" />
+</Book>
+<Book Series="Dead X-Men" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="156494" Issue="1042825" />
+</Book>
+<Book Series="Dead X-Men" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="156494" Issue="1046265" />
+</Book>
+<Book Series="Dead X-Men" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="156494" Issue="1047946" />
+</Book>
+<Book Series="Dead X-Men" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="156494" Issue="1051493" />
+</Book>
+<Book Series="Rise of the Powers of X" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="155968" Issue="1049278" />
+</Book>
+<Book Series="Rise of the Powers of X" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="155968" Issue="1052938" />
+</Book>
+<Book Series="X-Men Forever" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="157312" Issue="1052948" />
+</Book>
+<Book Series="Fall of the House of X" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="155874" Issue="1051494" />
+</Book>
+<Book Series="X-Men" Number="34" Volume="2021" Year="2024">
+<Database Name="cv" Series="137402" Issue="1053547" />
+</Book>
+<Book Series="X-Men Forever" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="157312" Issue="1054386" />
+</Book>
+<Book Series="X-Men Forever" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="157312" Issue="1055038" />
+</Book>
+<Book Series="Fall of the House of X" Number="5" Volume="2024" Year="2024">
+<Database Name="cv" Series="155874" Issue="1056203" />
+</Book>
+<Book Series="Rise of the Powers of X" Number="5" Volume="2024" Year="2024">
+<Database Name="cv" Series="155968" Issue="1057008" />
+</Book>
+<Book Series="X-Men" Number="35" Volume="2021" Year="2024">
+<Database Name="cv" Series="137402" Issue="1058720" />
+</Book>
+</Books>
+<Matchers />
+</ReadingList>

--- a/Marvel/Teams/X-Men/WEB-CBRO/[Marvel] X-Men no events (WEB-CBRO).cbl
+++ b/Marvel/Teams/X-Men/WEB-CBRO/[Marvel] X-Men no events (WEB-CBRO).cbl
@@ -1,0 +1,3470 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Name>[Marvel] X-Men no events (WEB-CBRO)</Name>
+<NumIssues>1154</NumIssues>
+<Books>
+<Book Series="The X-Men" Number="1" Volume="1963" Year="1963">
+<Database Name="cv" Series="2133" Issue="6694" />
+</Book>
+<Book Series="The X-Men" Number="3" Volume="1963" Year="1964">
+<Database Name="cv" Series="2133" Issue="6946" />
+</Book>
+<Book Series="The X-Men" Number="4" Volume="1963" Year="1964">
+<Database Name="cv" Series="2133" Issue="7032" />
+</Book>
+<Book Series="X-Men: Season One" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="46608" Issue="321744" />
+</Book>
+<Book Series="The X-Men" Number="10" Volume="1963" Year="1965">
+<Database Name="cv" Series="2133" Issue="7674" />
+</Book>
+<Book Series="The X-Men" Number="12" Volume="1963" Year="1965">
+<Database Name="cv" Series="2133" Issue="7900" />
+</Book>
+<Book Series="The X-Men" Number="13" Volume="1963" Year="1965">
+<Database Name="cv" Series="2133" Issue="8037" />
+</Book>
+<Book Series="The X-Men" Number="14" Volume="1963" Year="1965">
+<Database Name="cv" Series="2133" Issue="8170" />
+</Book>
+<Book Series="The X-Men" Number="15" Volume="1963" Year="1965">
+<Database Name="cv" Series="2133" Issue="8238" />
+</Book>
+<Book Series="The X-Men" Number="16" Volume="1963" Year="1966">
+<Database Name="cv" Series="2133" Issue="8315" />
+</Book>
+<Book Series="X-Men: First Class" Number="1" Volume="2006" Year="2006">
+<Database Name="cv" Series="18550" Issue="109251" />
+</Book>
+<Book Series="X-Men: First Class" Number="2" Volume="2006" Year="2006">
+<Database Name="cv" Series="18550" Issue="109284" />
+</Book>
+<Book Series="X-Men: First Class" Number="3" Volume="2006" Year="2007">
+<Database Name="cv" Series="18550" Issue="109285" />
+</Book>
+<Book Series="X-Men: First Class" Number="4" Volume="2006" Year="2007">
+<Database Name="cv" Series="18550" Issue="109286" />
+</Book>
+<Book Series="X-Men: First Class" Number="5" Volume="2006" Year="2007">
+<Database Name="cv" Series="18550" Issue="109287" />
+</Book>
+<Book Series="X-Men: First Class" Number="6" Volume="2006" Year="2007">
+<Database Name="cv" Series="18550" Issue="109214" />
+</Book>
+<Book Series="X-Men: First Class" Number="7" Volume="2006" Year="2007">
+<Database Name="cv" Series="18550" Issue="109288" />
+</Book>
+<Book Series="X-Men: First Class" Number="8" Volume="2006" Year="2007">
+<Database Name="cv" Series="18550" Issue="109290" />
+</Book>
+<Book Series="X-Men First Class Special" Number="1" Volume="2007" Year="2007">
+<Database Name="cv" Series="18585" Issue="109606" />
+</Book>
+<Book Series="X-Men: First Class" Number="1" Volume="2007" Year="2007">
+<Database Name="cv" Series="18941" Issue="121890" />
+</Book>
+<Book Series="X-Men: First Class" Number="2" Volume="2007" Year="2007">
+<Database Name="cv" Series="18941" Issue="112057" />
+</Book>
+<Book Series="X-Men: First Class" Number="3" Volume="2007" Year="2007">
+<Database Name="cv" Series="18941" Issue="113837" />
+</Book>
+<Book Series="X-Men: First Class" Number="4" Volume="2007" Year="2007">
+<Database Name="cv" Series="18941" Issue="115033" />
+</Book>
+<Book Series="X-Men: First Class" Number="5" Volume="2007" Year="2007">
+<Database Name="cv" Series="18941" Issue="121891" />
+</Book>
+<Book Series="X-Men: First Class" Number="6" Volume="2007" Year="2008">
+<Database Name="cv" Series="18941" Issue="118647" />
+</Book>
+<Book Series="X-Men: First Class" Number="7" Volume="2007" Year="2008">
+<Database Name="cv" Series="18941" Issue="121859" />
+</Book>
+<Book Series="X-Men: First Class" Number="8" Volume="2007" Year="2008">
+<Database Name="cv" Series="18941" Issue="126173" />
+</Book>
+<Book Series="X-Men: First Class" Number="9" Volume="2007" Year="2008">
+<Database Name="cv" Series="18941" Issue="126174" />
+</Book>
+<Book Series="X-Men: First Class" Number="10" Volume="2007" Year="2008">
+<Database Name="cv" Series="18941" Issue="126209" />
+</Book>
+<Book Series="X-Men: First Class" Number="11" Volume="2007" Year="2008">
+<Database Name="cv" Series="18941" Issue="129089" />
+</Book>
+<Book Series="X-Men: First Class" Number="12" Volume="2007" Year="2008">
+<Database Name="cv" Series="18941" Issue="131240" />
+</Book>
+<Book Series="X-Men: First Class" Number="13" Volume="2007" Year="2008">
+<Database Name="cv" Series="18941" Issue="132041" />
+</Book>
+<Book Series="X-Men: First Class" Number="14" Volume="2007" Year="2008">
+<Database Name="cv" Series="18941" Issue="134993" />
+</Book>
+<Book Series="X-Men: First Class" Number="15" Volume="2007" Year="2008">
+<Database Name="cv" Series="18941" Issue="138036" />
+</Book>
+<Book Series="X-Men: First Class" Number="16" Volume="2007" Year="2008">
+<Database Name="cv" Series="18941" Issue="138995" />
+</Book>
+<Book Series="X-Men: First Class Giant-Sized Special" Number="1" Volume="2008" Year="2008">
+<Database Name="cv" Series="23733" Issue="142059" />
+</Book>
+<Book Series="The X-Men" Number="28" Volume="1963" Year="1967">
+<Database Name="cv" Series="2133" Issue="9098" />
+</Book>
+<Book Series="The X-Men" Number="29" Volume="1963" Year="1967">
+<Database Name="cv" Series="2133" Issue="9162" />
+</Book>
+<Book Series="The X-Men" Number="32" Volume="1963" Year="1967">
+<Database Name="cv" Series="2133" Issue="9364" />
+</Book>
+<Book Series="The X-Men" Number="33" Volume="1963" Year="1967">
+<Database Name="cv" Series="2133" Issue="9434" />
+</Book>
+<Book Series="The X-Men" Number="41" Volume="1963" Year="1968">
+<Database Name="cv" Series="2133" Issue="9945" />
+</Book>
+<Book Series="The X-Men" Number="42" Volume="1963" Year="1968">
+<Database Name="cv" Series="2133" Issue="105594" />
+</Book>
+<Book Series="The X-Men" Number="43" Volume="1963" Year="1968">
+<Database Name="cv" Series="2133" Issue="114499" />
+</Book>
+<Book Series="The X-Men" Number="46" Volume="1963" Year="1968">
+<Database Name="cv" Series="2133" Issue="123671" />
+</Book>
+<Book Series="The X-Men" Number="49" Volume="1963" Year="1968">
+<Database Name="cv" Series="2133" Issue="123674" />
+</Book>
+<Book Series="The X-Men" Number="50" Volume="1963" Year="1968">
+<Database Name="cv" Series="2133" Issue="114340" />
+</Book>
+<Book Series="Emma Frost" Number="1" Volume="2003" Year="2003">
+<Database Name="cv" Series="18014" Issue="105439" />
+</Book>
+<Book Series="Emma Frost" Number="2" Volume="2003" Year="2003">
+<Database Name="cv" Series="18014" Issue="107660" />
+</Book>
+<Book Series="Emma Frost" Number="3" Volume="2003" Year="2003">
+<Database Name="cv" Series="18014" Issue="107661" />
+</Book>
+<Book Series="Emma Frost" Number="4" Volume="2003" Year="2003">
+<Database Name="cv" Series="18014" Issue="107662" />
+</Book>
+<Book Series="Emma Frost" Number="5" Volume="2003" Year="2004">
+<Database Name="cv" Series="18014" Issue="107663" />
+</Book>
+<Book Series="Emma Frost" Number="6" Volume="2003" Year="2004">
+<Database Name="cv" Series="18014" Issue="107664" />
+</Book>
+<Book Series="The X-Men" Number="54" Volume="1963" Year="1969">
+<Database Name="cv" Series="2133" Issue="10107" />
+</Book>
+<Book Series="The X-Men" Number="55" Volume="1963" Year="1969">
+<Database Name="cv" Series="2133" Issue="10163" />
+</Book>
+<Book Series="The X-Men" Number="56" Volume="1963" Year="1969">
+<Database Name="cv" Series="2133" Issue="10215" />
+</Book>
+<Book Series="The X-Men" Number="57" Volume="1963" Year="1969">
+<Database Name="cv" Series="2133" Issue="10270" />
+</Book>
+<Book Series="The X-Men" Number="58" Volume="1963" Year="1969">
+<Database Name="cv" Series="2133" Issue="10317" />
+</Book>
+<Book Series="The X-Men" Number="60" Volume="1963" Year="1969">
+<Database Name="cv" Series="2133" Issue="10417" />
+</Book>
+<Book Series="The X-Men" Number="61" Volume="1963" Year="1969">
+<Database Name="cv" Series="2133" Issue="10475" />
+</Book>
+<Book Series="The X-Men" Number="62" Volume="1963" Year="1969">
+<Database Name="cv" Series="2133" Issue="10526" />
+</Book>
+<Book Series="The X-Men" Number="63" Volume="1963" Year="1969">
+<Database Name="cv" Series="2133" Issue="10580" />
+</Book>
+<Book Series="The X-Men" Number="64" Volume="1963" Year="1970">
+<Database Name="cv" Series="2133" Issue="10635" />
+</Book>
+<Book Series="The X-Men" Number="65" Volume="1963" Year="1970">
+<Database Name="cv" Series="2133" Issue="10676" />
+</Book>
+<Book Series="The X-Men" Number="66" Volume="1963" Year="1970">
+<Database Name="cv" Series="2133" Issue="10724" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="1" Volume="1999" Year="1999">
+<Database Name="cv" Series="9202" Issue="124309" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="2" Volume="1999" Year="2000">
+<Database Name="cv" Series="9202" Issue="70469" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="3" Volume="1999" Year="2000">
+<Database Name="cv" Series="9202" Issue="70470" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="4" Volume="1999" Year="2000">
+<Database Name="cv" Series="9202" Issue="70471" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="5" Volume="1999" Year="2000">
+<Database Name="cv" Series="9202" Issue="70472" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="6" Volume="1999" Year="2000">
+<Database Name="cv" Series="9202" Issue="70473" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="7" Volume="1999" Year="2000">
+<Database Name="cv" Series="9202" Issue="70474" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="8" Volume="1999" Year="2000">
+<Database Name="cv" Series="9202" Issue="70475" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="9" Volume="1999" Year="2000">
+<Database Name="cv" Series="9202" Issue="70476" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="10" Volume="1999" Year="2000">
+<Database Name="cv" Series="9202" Issue="70477" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="11" Volume="1999" Year="2000">
+<Database Name="cv" Series="9202" Issue="70478" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="12" Volume="1999" Year="2000">
+<Database Name="cv" Series="9202" Issue="124311" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="13" Volume="1999" Year="2000">
+<Database Name="cv" Series="9202" Issue="124313" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="14" Volume="1999" Year="2001">
+<Database Name="cv" Series="9202" Issue="124315" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="15" Volume="1999" Year="2001">
+<Database Name="cv" Series="9202" Issue="120844" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="16" Volume="1999" Year="2001">
+<Database Name="cv" Series="9202" Issue="124316" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="17" Volume="1999" Year="2001">
+<Database Name="cv" Series="9202" Issue="124317" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="18" Volume="1999" Year="2001">
+<Database Name="cv" Series="9202" Issue="124320" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="19" Volume="1999" Year="2001">
+<Database Name="cv" Series="9202" Issue="124326" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="20" Volume="1999" Year="2001">
+<Database Name="cv" Series="9202" Issue="124321" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="21" Volume="1999" Year="2001">
+<Database Name="cv" Series="9202" Issue="124319" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="22" Volume="1999" Year="2001">
+<Database Name="cv" Series="9202" Issue="70489" />
+</Book>
+<Book Series="Emma Frost" Number="7" Volume="2003" Year="2004">
+<Database Name="cv" Series="18014" Issue="107668" />
+</Book>
+<Book Series="Emma Frost" Number="8" Volume="2003" Year="2004">
+<Database Name="cv" Series="18014" Issue="107671" />
+</Book>
+<Book Series="Emma Frost" Number="9" Volume="2003" Year="2004">
+<Database Name="cv" Series="18014" Issue="107667" />
+</Book>
+<Book Series="Emma Frost" Number="10" Volume="2003" Year="2004">
+<Database Name="cv" Series="18014" Issue="107674" />
+</Book>
+<Book Series="Emma Frost" Number="11" Volume="2003" Year="2004">
+<Database Name="cv" Series="18014" Issue="107673" />
+</Book>
+<Book Series="Emma Frost" Number="12" Volume="2003" Year="2004">
+<Database Name="cv" Series="18014" Issue="107670" />
+</Book>
+<Book Series="Emma Frost" Number="13" Volume="2003" Year="2004">
+<Database Name="cv" Series="18014" Issue="107676" />
+</Book>
+<Book Series="Emma Frost" Number="14" Volume="2003" Year="2004">
+<Database Name="cv" Series="18014" Issue="107665" />
+</Book>
+<Book Series="Emma Frost" Number="15" Volume="2003" Year="2004">
+<Database Name="cv" Series="18014" Issue="107669" />
+</Book>
+<Book Series="Emma Frost" Number="16" Volume="2003" Year="2004">
+<Database Name="cv" Series="18014" Issue="107672" />
+</Book>
+<Book Series="Emma Frost" Number="17" Volume="2003" Year="2005">
+<Database Name="cv" Series="18014" Issue="107666" />
+</Book>
+<Book Series="Emma Frost" Number="18" Volume="2003" Year="2005">
+<Database Name="cv" Series="18014" Issue="107675" />
+</Book>
+<Book Series="X-Men: First Class Finals" Number="1" Volume="2009" Year="2009">
+<Database Name="cv" Series="25669" Issue="151276" />
+</Book>
+<Book Series="X-Men: First Class Finals" Number="2" Volume="2009" Year="2009">
+<Database Name="cv" Series="25669" Issue="153877" />
+</Book>
+<Book Series="X-Men: First Class Finals" Number="3" Volume="2009" Year="2009">
+<Database Name="cv" Series="25669" Issue="154464" />
+</Book>
+<Book Series="X-Men: First Class Finals" Number="4" Volume="2009" Year="2009">
+<Database Name="cv" Series="25669" Issue="156642" />
+</Book>
+<Book Series="Giant-Size X-Men" Number="1" Volume="1975" Year="1975">
+<Database Name="cv" Series="2763" Issue="14890" />
+</Book>
+<Book Series="The X-Men" Number="94" Volume="1963" Year="1975">
+<Database Name="cv" Series="2133" Issue="15508" />
+</Book>
+<Book Series="The X-Men" Number="95" Volume="1963" Year="1975">
+<Database Name="cv" Series="2133" Issue="15711" />
+</Book>
+<Book Series="The X-Men" Number="96" Volume="1963" Year="1975">
+<Database Name="cv" Series="2133" Issue="15889" />
+</Book>
+<Book Series="The X-Men" Number="97" Volume="1963" Year="1976">
+<Database Name="cv" Series="2133" Issue="16100" />
+</Book>
+<Book Series="Uncanny X-Men: First Class Giant-Size Special" Number="1" Volume="2009" Year="2009">
+<Database Name="cv" Series="26666" Issue="159793" />
+</Book>
+<Book Series="The X-Men" Number="98" Volume="1963" Year="1976">
+<Database Name="cv" Series="2133" Issue="16278" />
+</Book>
+<Book Series="The X-Men" Number="99" Volume="1963" Year="1976">
+<Database Name="cv" Series="2133" Issue="16440" />
+</Book>
+<Book Series="The X-Men" Number="100" Volume="1963" Year="1976">
+<Database Name="cv" Series="2133" Issue="16618" />
+</Book>
+<Book Series="The X-Men" Number="101" Volume="1963" Year="1976">
+<Database Name="cv" Series="2133" Issue="16800" />
+</Book>
+<Book Series="The X-Men" Number="102" Volume="1963" Year="1976">
+<Database Name="cv" Series="2133" Issue="16981" />
+</Book>
+<Book Series="The X-Men" Number="103" Volume="1963" Year="1977">
+<Database Name="cv" Series="2133" Issue="17209" />
+</Book>
+<Book Series="The X-Men" Number="104" Volume="1963" Year="1977">
+<Database Name="cv" Series="2133" Issue="17371" />
+</Book>
+<Book Series="The X-Men" Number="105" Volume="1963" Year="1977">
+<Database Name="cv" Series="2133" Issue="17526" />
+</Book>
+<Book Series="The X-Men" Number="106" Volume="1963" Year="1977">
+<Database Name="cv" Series="2133" Issue="17708" />
+</Book>
+<Book Series="The X-Men" Number="107" Volume="1963" Year="1977">
+<Database Name="cv" Series="2133" Issue="17894" />
+</Book>
+<Book Series="The X-Men" Number="108" Volume="1963" Year="1977">
+<Database Name="cv" Series="2133" Issue="18064" />
+</Book>
+<Book Series="The X-Men" Number="109" Volume="1963" Year="1978">
+<Database Name="cv" Series="2133" Issue="18267" />
+</Book>
+<Book Series="Uncanny X-Men: First Class" Number="1" Volume="2009" Year="2009">
+<Database Name="cv" Series="27037" Issue="163641" />
+</Book>
+<Book Series="Uncanny X-Men: First Class" Number="2" Volume="2009" Year="2009">
+<Database Name="cv" Series="27037" Issue="166810" />
+</Book>
+<Book Series="Uncanny X-Men: First Class" Number="3" Volume="2009" Year="2009">
+<Database Name="cv" Series="27037" Issue="171556" />
+</Book>
+<Book Series="Uncanny X-Men: First Class" Number="4" Volume="2009" Year="2009">
+<Database Name="cv" Series="27037" Issue="176137" />
+</Book>
+<Book Series="Uncanny X-Men: First Class" Number="5" Volume="2009" Year="2010">
+<Database Name="cv" Series="27037" Issue="182998" />
+</Book>
+<Book Series="Uncanny X-Men: First Class" Number="6" Volume="2009" Year="2010">
+<Database Name="cv" Series="27037" Issue="186932" />
+</Book>
+<Book Series="Uncanny X-Men: First Class" Number="7" Volume="2009" Year="2010">
+<Database Name="cv" Series="27037" Issue="192764" />
+</Book>
+<Book Series="Uncanny X-Men: First Class" Number="8" Volume="2009" Year="2010">
+<Database Name="cv" Series="27037" Issue="196856" />
+</Book>
+<Book Series="The X-Men" Number="110" Volume="1963" Year="1978">
+<Database Name="cv" Series="2133" Issue="18435" />
+</Book>
+<Book Series="The X-Men" Number="111" Volume="1963" Year="1978">
+<Database Name="cv" Series="2133" Issue="18598" />
+</Book>
+<Book Series="The X-Men" Number="112" Volume="1963" Year="1978">
+<Database Name="cv" Series="2133" Issue="18757" />
+</Book>
+<Book Series="The X-Men" Number="113" Volume="1963" Year="1978">
+<Database Name="cv" Series="2133" Issue="18837" />
+</Book>
+<Book Series="The X-Men" Number="114" Volume="1963" Year="1978">
+<Database Name="cv" Series="2133" Issue="18916" />
+</Book>
+<Book Series="The X-Men" Number="115" Volume="1963" Year="1978">
+<Database Name="cv" Series="2133" Issue="18985" />
+</Book>
+<Book Series="The X-Men" Number="116" Volume="1963" Year="1978">
+<Database Name="cv" Series="2133" Issue="19060" />
+</Book>
+<Book Series="The X-Men" Number="117" Volume="1963" Year="1979">
+<Database Name="cv" Series="2133" Issue="19210" />
+</Book>
+<Book Series="The X-Men" Number="118" Volume="1963" Year="1979">
+<Database Name="cv" Series="2133" Issue="19317" />
+</Book>
+<Book Series="The X-Men" Number="119" Volume="1963" Year="1979">
+<Database Name="cv" Series="2133" Issue="19386" />
+</Book>
+<Book Series="The X-Men" Number="120" Volume="1963" Year="1979">
+<Database Name="cv" Series="2133" Issue="19455" />
+</Book>
+<Book Series="The X-Men" Number="121" Volume="1963" Year="1979">
+<Database Name="cv" Series="2133" Issue="19525" />
+</Book>
+<Book Series="The X-Men" Number="122" Volume="1963" Year="1979">
+<Database Name="cv" Series="2133" Issue="19592" />
+</Book>
+<Book Series="The X-Men" Number="123" Volume="1963" Year="1979">
+<Database Name="cv" Series="2133" Issue="123628" />
+</Book>
+<Book Series="The X-Men" Number="124" Volume="1963" Year="1979">
+<Database Name="cv" Series="2133" Issue="19726" />
+</Book>
+<Book Series="The X-Men" Number="125" Volume="1963" Year="1979">
+<Database Name="cv" Series="2133" Issue="19794" />
+</Book>
+<Book Series="The X-Men" Number="126" Volume="1963" Year="1979">
+<Database Name="cv" Series="2133" Issue="19865" />
+</Book>
+<Book Series="The X-Men" Number="127" Volume="1963" Year="1979">
+<Database Name="cv" Series="2133" Issue="19934" />
+</Book>
+<Book Series="The X-Men" Number="128" Volume="1963" Year="1979">
+<Database Name="cv" Series="2133" Issue="20006" />
+</Book>
+<Book Series="The X-Men" Number="129" Volume="1963" Year="1980">
+<Database Name="cv" Series="2133" Issue="20114" />
+</Book>
+<Book Series="The X-Men" Number="130" Volume="1963" Year="1980">
+<Database Name="cv" Series="2133" Issue="20186" />
+</Book>
+<Book Series="The X-Men" Number="131" Volume="1963" Year="1980">
+<Database Name="cv" Series="2133" Issue="20258" />
+</Book>
+<Book Series="The X-Men" Number="132" Volume="1963" Year="1980">
+<Database Name="cv" Series="2133" Issue="20333" />
+</Book>
+<Book Series="The X-Men" Number="133" Volume="1963" Year="1980">
+<Database Name="cv" Series="2133" Issue="20403" />
+</Book>
+<Book Series="The X-Men" Number="134" Volume="1963" Year="1980">
+<Database Name="cv" Series="2133" Issue="20477" />
+</Book>
+<Book Series="The X-Men" Number="135" Volume="1963" Year="1980">
+<Database Name="cv" Series="2133" Issue="20546" />
+</Book>
+<Book Series="The X-Men" Number="136" Volume="1963" Year="1980">
+<Database Name="cv" Series="2133" Issue="20613" />
+</Book>
+<Book Series="The X-Men" Number="137" Volume="1963" Year="1980">
+<Database Name="cv" Series="2133" Issue="20681" />
+</Book>
+<Book Series="The X-Men" Number="138" Volume="1963" Year="1980">
+<Database Name="cv" Series="2133" Issue="20751" />
+</Book>
+<Book Series="The X-Men" Number="139" Volume="1963" Year="1980">
+<Database Name="cv" Series="2133" Issue="20812" />
+</Book>
+<Book Series="The X-Men" Number="140" Volume="1963" Year="1980">
+<Database Name="cv" Series="2133" Issue="20884" />
+</Book>
+<Book Series="The X-Men" Number="141" Volume="1963" Year="1981">
+<Database Name="cv" Series="2133" Issue="20988" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="142" Volume="1981" Year="1981">
+<Database Name="cv" Series="3092" Issue="21057" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="143" Volume="1981" Year="1981">
+<Database Name="cv" Series="3092" Issue="21127" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="144" Volume="1981" Year="1981">
+<Database Name="cv" Series="3092" Issue="107059" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="145" Volume="1981" Year="1981">
+<Database Name="cv" Series="3092" Issue="21258" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="146" Volume="1981" Year="1981">
+<Database Name="cv" Series="3092" Issue="21320" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="147" Volume="1981" Year="1981">
+<Database Name="cv" Series="3092" Issue="21392" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="148" Volume="1981" Year="1981">
+<Database Name="cv" Series="3092" Issue="21461" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="149" Volume="1981" Year="1981">
+<Database Name="cv" Series="3092" Issue="21531" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="150" Volume="1981" Year="1981">
+<Database Name="cv" Series="3092" Issue="21614" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="151" Volume="1981" Year="1981">
+<Database Name="cv" Series="3092" Issue="21679" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="152" Volume="1981" Year="1981">
+<Database Name="cv" Series="3092" Issue="21752" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="153" Volume="1981" Year="1982">
+<Database Name="cv" Series="3092" Issue="21875" />
+</Book>
+<Book Series="Weapon X: First Class" Number="1" Volume="2009" Year="2009">
+<Database Name="cv" Series="23783" Issue="142205" />
+</Book>
+<Book Series="Weapon X: First Class" Number="2" Volume="2009" Year="2009">
+<Database Name="cv" Series="23783" Issue="145367" />
+</Book>
+<Book Series="Weapon X: First Class" Number="3" Volume="2009" Year="2009">
+<Database Name="cv" Series="23783" Issue="150583" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="154" Volume="1981" Year="1982">
+<Database Name="cv" Series="3092" Issue="21952" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="155" Volume="1981" Year="1982">
+<Database Name="cv" Series="3092" Issue="22027" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="156" Volume="1981" Year="1982">
+<Database Name="cv" Series="3092" Issue="22100" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="157" Volume="1981" Year="1982">
+<Database Name="cv" Series="3092" Issue="22179" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="158" Volume="1981" Year="1982">
+<Database Name="cv" Series="3092" Issue="22248" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="159" Volume="1981" Year="1982">
+<Database Name="cv" Series="3092" Issue="22318" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="160" Volume="1981" Year="1982">
+<Database Name="cv" Series="3092" Issue="22393" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="161" Volume="1981" Year="1982">
+<Database Name="cv" Series="3092" Issue="22462" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="162" Volume="1981" Year="1982">
+<Database Name="cv" Series="3092" Issue="22537" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="163" Volume="1981" Year="1982">
+<Database Name="cv" Series="3092" Issue="22611" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="164" Volume="1981" Year="1982">
+<Database Name="cv" Series="3092" Issue="22687" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="165" Volume="1981" Year="1983">
+<Database Name="cv" Series="3092" Issue="22808" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="166" Volume="1981" Year="1983">
+<Database Name="cv" Series="3092" Issue="22882" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="167" Volume="1981" Year="1983">
+<Database Name="cv" Series="3092" Issue="22969" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="168" Volume="1981" Year="1983">
+<Database Name="cv" Series="3092" Issue="23051" />
+</Book>
+<Book Series="Marvel Graphic Novel" Number="5" Volume="1982" Year="1982">
+<Database Name="cv" Series="3144" Issue="21795" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="169" Volume="1981" Year="1983">
+<Database Name="cv" Series="3092" Issue="23139" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="170" Volume="1981" Year="1983">
+<Database Name="cv" Series="3092" Issue="23219" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="171" Volume="1981" Year="1983">
+<Database Name="cv" Series="3092" Issue="23307" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="172" Volume="1981" Year="1983">
+<Database Name="cv" Series="3092" Issue="23387" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="173" Volume="1981" Year="1983">
+<Database Name="cv" Series="3092" Issue="23469" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="174" Volume="1981" Year="1983">
+<Database Name="cv" Series="3092" Issue="23556" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="175" Volume="1981" Year="1983">
+<Database Name="cv" Series="3092" Issue="23648" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="176" Volume="1981" Year="1983">
+<Database Name="cv" Series="3092" Issue="23743" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="177" Volume="1981" Year="1984">
+<Database Name="cv" Series="3092" Issue="23894" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="178" Volume="1981" Year="1984">
+<Database Name="cv" Series="3092" Issue="23994" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="179" Volume="1981" Year="1984">
+<Database Name="cv" Series="3092" Issue="24112" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="180" Volume="1981" Year="1984">
+<Database Name="cv" Series="3092" Issue="24216" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="181" Volume="1981" Year="1984">
+<Database Name="cv" Series="3092" Issue="24322" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="182" Volume="1981" Year="1984">
+<Database Name="cv" Series="3092" Issue="24419" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="183" Volume="1981" Year="1984">
+<Database Name="cv" Series="3092" Issue="24518" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="184" Volume="1981" Year="1984">
+<Database Name="cv" Series="3092" Issue="24620" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="185" Volume="1981" Year="1984">
+<Database Name="cv" Series="3092" Issue="24708" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="186" Volume="1981" Year="1984">
+<Database Name="cv" Series="3092" Issue="24808" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="187" Volume="1981" Year="1984">
+<Database Name="cv" Series="3092" Issue="24907" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="188" Volume="1981" Year="1984">
+<Database Name="cv" Series="3092" Issue="25014" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="189" Volume="1981" Year="1985">
+<Database Name="cv" Series="3092" Issue="25178" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="190" Volume="1981" Year="1985">
+<Database Name="cv" Series="3092" Issue="25279" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="191" Volume="1981" Year="1985">
+<Database Name="cv" Series="3092" Issue="25301" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="192" Volume="1981" Year="1985">
+<Database Name="cv" Series="3092" Issue="25406" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="193" Volume="1981" Year="1985">
+<Database Name="cv" Series="3092" Issue="25500" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="194" Volume="1981" Year="1985">
+<Database Name="cv" Series="3092" Issue="25602" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="195" Volume="1981" Year="1985">
+<Database Name="cv" Series="3092" Issue="25701" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="196" Volume="1981" Year="1985">
+<Database Name="cv" Series="3092" Issue="25801" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="197" Volume="1981" Year="1985">
+<Database Name="cv" Series="3092" Issue="25896" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="198" Volume="1981" Year="1985">
+<Database Name="cv" Series="3092" Issue="25999" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="199" Volume="1981" Year="1985">
+<Database Name="cv" Series="3092" Issue="26105" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="200" Volume="1981" Year="1985">
+<Database Name="cv" Series="3092" Issue="26210" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="201" Volume="1981" Year="1986">
+<Database Name="cv" Series="3092" Issue="26413" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="202" Volume="1981" Year="1986">
+<Database Name="cv" Series="3092" Issue="26519" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="203" Volume="1981" Year="1986">
+<Database Name="cv" Series="3092" Issue="26613" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="204" Volume="1981" Year="1986">
+<Database Name="cv" Series="3092" Issue="26710" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="205" Volume="1981" Year="1986">
+<Database Name="cv" Series="3092" Issue="26804" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="206" Volume="1981" Year="1986">
+<Database Name="cv" Series="3092" Issue="26902" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="207" Volume="1981" Year="1986">
+<Database Name="cv" Series="3092" Issue="26997" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="208" Volume="1981" Year="1986">
+<Database Name="cv" Series="3092" Issue="27093" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="209" Volume="1981" Year="1986">
+<Database Name="cv" Series="3092" Issue="27189" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="214" Volume="1981" Year="1987">
+<Database Name="cv" Series="3092" Issue="27803" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="215" Volume="1981" Year="1987">
+<Database Name="cv" Series="3092" Issue="27912" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="216" Volume="1981" Year="1987">
+<Database Name="cv" Series="3092" Issue="28023" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="217" Volume="1981" Year="1987">
+<Database Name="cv" Series="3092" Issue="28124" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="218" Volume="1981" Year="1987">
+<Database Name="cv" Series="3092" Issue="28234" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="219" Volume="1981" Year="1987">
+<Database Name="cv" Series="3092" Issue="28351" />
+</Book>
+<Book Series="The X-Men vs. The Avengers" Number="1" Volume="1987" Year="1987">
+<Database Name="cv" Series="3867" Issue="28027" />
+</Book>
+<Book Series="The X-Men vs. The Avengers" Number="2" Volume="1987" Year="1987">
+<Database Name="cv" Series="3867" Issue="28128" />
+</Book>
+<Book Series="The X-Men vs. The Avengers" Number="3" Volume="1987" Year="1987">
+<Database Name="cv" Series="3867" Issue="28238" />
+</Book>
+<Book Series="The X-Men vs. The Avengers" Number="4" Volume="1987" Year="1987">
+<Database Name="cv" Series="3867" Issue="28355" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="228" Volume="1981" Year="1988">
+<Database Name="cv" Series="3092" Issue="29494" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="229" Volume="1981" Year="1988">
+<Database Name="cv" Series="3092" Issue="29603" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="230" Volume="1981" Year="1988">
+<Database Name="cv" Series="3092" Issue="29719" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="231" Volume="1981" Year="1988">
+<Database Name="cv" Series="3092" Issue="29838" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="232" Volume="1981" Year="1988">
+<Database Name="cv" Series="3092" Issue="29954" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="233" Volume="1981" Year="1988">
+<Database Name="cv" Series="3092" Issue="30070" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="234" Volume="1981" Year="1988">
+<Database Name="cv" Series="3092" Issue="30103" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="235" Volume="1981" Year="1988">
+<Database Name="cv" Series="3092" Issue="30194" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="236" Volume="1981" Year="1988">
+<Database Name="cv" Series="3092" Issue="30232" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="237" Volume="1981" Year="1988">
+<Database Name="cv" Series="3092" Issue="30326" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="238" Volume="1981" Year="1988">
+<Database Name="cv" Series="3092" Issue="30360" />
+</Book>
+<Book Series="Excalibur" Number="1" Volume="1988" Year="1988">
+<Database Name="cv" Series="4052" Issue="30178" />
+</Book>
+<Book Series="Excalibur" Number="2" Volume="1988" Year="1988">
+<Database Name="cv" Series="4052" Issue="30308" />
+</Book>
+<Book Series="Excalibur" Number="3" Volume="1988" Year="1988">
+<Database Name="cv" Series="4052" Issue="30429" />
+</Book>
+<Book Series="Excalibur" Number="4" Volume="1988" Year="1989">
+<Database Name="cv" Series="4052" Issue="30779" />
+</Book>
+<Book Series="Excalibur" Number="5" Volume="1988" Year="1989">
+<Database Name="cv" Series="4052" Issue="113568" />
+</Book>
+<Book Series="Excalibur" Number="8" Volume="1988" Year="1989">
+<Database Name="cv" Series="4052" Issue="66340" />
+</Book>
+<Book Series="Excalibur" Number="9" Volume="1988" Year="1989">
+<Database Name="cv" Series="4052" Issue="31323" />
+</Book>
+<Book Series="Excalibur" Number="10" Volume="1988" Year="1989">
+<Database Name="cv" Series="4052" Issue="66341" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="244" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="31230" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="245" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="31340" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="246" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="31451" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="247" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="31554" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="248" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="31670" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="249" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="31781" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="250" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="31807" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="251" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="31885" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="252" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="31935" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="253" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="31944" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="254" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="32017" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="255" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="32074" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="256" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="32081" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="257" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="32337" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="258" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="32436" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="259" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="32535" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="260" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="32647" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="261" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="32741" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="262" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="32861" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="263" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="32982" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="264" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="33015" />
+</Book>
+<Book Series="Excalibur" Number="20" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="66344" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="265" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="33099" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="266" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="33137" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="267" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="106308" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="268" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="33256" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="269" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="33334" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="273" Volume="1981" Year="1991">
+<Database Name="cv" Series="3092" Issue="33893" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="274" Volume="1981" Year="1991">
+<Database Name="cv" Series="3092" Issue="34007" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="275" Volume="1981" Year="1991">
+<Database Name="cv" Series="3092" Issue="34111" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="276" Volume="1981" Year="1991">
+<Database Name="cv" Series="3092" Issue="34214" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="277" Volume="1981" Year="1991">
+<Database Name="cv" Series="3092" Issue="34313" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="278" Volume="1981" Year="1991">
+<Database Name="cv" Series="3092" Issue="34430" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="279" Volume="1981" Year="1991">
+<Database Name="cv" Series="3092" Issue="34545" />
+</Book>
+<Book Series="Excalibur" Number="11" Volume="1988" Year="1989">
+<Database Name="cv" Series="4052" Issue="66342" />
+</Book>
+<Book Series="Excalibur" Number="12" Volume="1988" Year="1989">
+<Database Name="cv" Series="4052" Issue="31651" />
+</Book>
+<Book Series="Excalibur" Number="13" Volume="1988" Year="1989">
+<Database Name="cv" Series="4052" Issue="31761" />
+</Book>
+<Book Series="Excalibur" Number="14" Volume="1988" Year="1989">
+<Database Name="cv" Series="4052" Issue="31866" />
+</Book>
+<Book Series="Excalibur" Number="15" Volume="1988" Year="1989">
+<Database Name="cv" Series="4052" Issue="31921" />
+</Book>
+<Book Series="Excalibur" Number="16" Volume="1988" Year="1989">
+<Database Name="cv" Series="4052" Issue="31996" />
+</Book>
+<Book Series="Excalibur" Number="17" Volume="1988" Year="1989">
+<Database Name="cv" Series="4052" Issue="32058" />
+</Book>
+<Book Series="Excalibur" Number="18" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="66343" />
+</Book>
+<Book Series="Excalibur" Number="19" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="32417" />
+</Book>
+<Book Series="Excalibur" Number="21" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="66345" />
+</Book>
+<Book Series="Excalibur" Number="22" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="32836" />
+</Book>
+<Book Series="Excalibur" Number="23" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="66346" />
+</Book>
+<Book Series="Excalibur" Number="24" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="32962" />
+</Book>
+<Book Series="Excalibur" Number="25" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="66347" />
+</Book>
+<Book Series="Excalibur" Number="26" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="66348" />
+</Book>
+<Book Series="Excalibur" Number="27" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="33076" />
+</Book>
+<Book Series="Excalibur" Number="28" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="66349" />
+</Book>
+<Book Series="Excalibur" Number="29" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="66350" />
+</Book>
+<Book Series="Excalibur" Number="30" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="113569" />
+</Book>
+<Book Series="Excalibur" Number="31" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="66351" />
+</Book>
+<Book Series="Excalibur" Number="32" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="120771" />
+</Book>
+<Book Series="Excalibur" Number="33" Volume="1988" Year="1991">
+<Database Name="cv" Series="4052" Issue="120772" />
+</Book>
+<Book Series="Excalibur" Number="34" Volume="1988" Year="1991">
+<Database Name="cv" Series="4052" Issue="120773" />
+</Book>
+<Book Series="Excalibur" Number="35" Volume="1988" Year="1991">
+<Database Name="cv" Series="4052" Issue="66352" />
+</Book>
+<Book Series="Excalibur" Number="36" Volume="1988" Year="1991">
+<Database Name="cv" Series="4052" Issue="66353" />
+</Book>
+<Book Series="Excalibur" Number="37" Volume="1988" Year="1991">
+<Database Name="cv" Series="4052" Issue="34196" />
+</Book>
+<Book Series="Excalibur" Number="38" Volume="1988" Year="1991">
+<Database Name="cv" Series="4052" Issue="34295" />
+</Book>
+<Book Series="Excalibur" Number="39" Volume="1988" Year="1991">
+<Database Name="cv" Series="4052" Issue="34410" />
+</Book>
+<Book Series="Excalibur" Number="40" Volume="1988" Year="1991">
+<Database Name="cv" Series="4052" Issue="66354" />
+</Book>
+<Book Series="Excalibur" Number="41" Volume="1988" Year="1991">
+<Database Name="cv" Series="4052" Issue="66355" />
+</Book>
+<Book Series="Excalibur" Number="42" Volume="1988" Year="1991">
+<Database Name="cv" Series="4052" Issue="34760" />
+</Book>
+<Book Series="X-Men" Number="1" Volume="1991" Year="1991">
+<Database Name="cv" Series="4605" Issue="34784" />
+</Book>
+<Book Series="X-Men" Number="2" Volume="1991" Year="1991">
+<Database Name="cv" Series="4605" Issue="34900" />
+</Book>
+<Book Series="X-Men" Number="3" Volume="1991" Year="1991">
+<Database Name="cv" Series="4605" Issue="35019" />
+</Book>
+<Book Series="Excalibur" Number="43" Volume="1988" Year="1991">
+<Database Name="cv" Series="4052" Issue="34877" />
+</Book>
+<Book Series="Excalibur" Number="44" Volume="1988" Year="1991">
+<Database Name="cv" Series="4052" Issue="34931" />
+</Book>
+<Book Series="Excalibur" Number="45" Volume="1988" Year="1991">
+<Database Name="cv" Series="4052" Issue="120774" />
+</Book>
+<Book Series="Excalibur" Number="46" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="35257" />
+</Book>
+<Book Series="Excalibur" Number="47" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="35364" />
+</Book>
+<Book Series="Excalibur" Number="48" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="35469" />
+</Book>
+<Book Series="Excalibur" Number="49" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="35573" />
+</Book>
+<Book Series="Excalibur" Number="50" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="35676" />
+</Book>
+<Book Series="Excalibur" Number="51" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="118524" />
+</Book>
+<Book Series="Excalibur" Number="52" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="35904" />
+</Book>
+<Book Series="Excalibur" Number="53" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="36022" />
+</Book>
+<Book Series="Excalibur" Number="54" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="36149" />
+</Book>
+<Book Series="Excalibur" Number="55" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="36272" />
+</Book>
+<Book Series="Excalibur" Number="56" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="36397" />
+</Book>
+<Book Series="Excalibur" Number="57" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="36447" />
+</Book>
+<Book Series="Excalibur" Number="58" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="36512" />
+</Book>
+<Book Series="Excalibur" Number="59" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="36557" />
+</Book>
+<Book Series="Excalibur" Number="60" Volume="1988" Year="1993">
+<Database Name="cv" Series="4052" Issue="66356" />
+</Book>
+<Book Series="Excalibur" Number="61" Volume="1988" Year="1993">
+<Database Name="cv" Series="4052" Issue="36754" />
+</Book>
+<Book Series="Excalibur" Number="62" Volume="1988" Year="1993">
+<Database Name="cv" Series="4052" Issue="36859" />
+</Book>
+<Book Series="Excalibur" Number="63" Volume="1988" Year="1993">
+<Database Name="cv" Series="4052" Issue="36970" />
+</Book>
+<Book Series="Excalibur" Number="64" Volume="1988" Year="1993">
+<Database Name="cv" Series="4052" Issue="37089" />
+</Book>
+<Book Series="Excalibur" Number="65" Volume="1988" Year="1993">
+<Database Name="cv" Series="4052" Issue="37225" />
+</Book>
+<Book Series="Excalibur" Number="66" Volume="1988" Year="1993">
+<Database Name="cv" Series="4052" Issue="37360" />
+</Book>
+<Book Series="Excalibur" Number="67" Volume="1988" Year="1993">
+<Database Name="cv" Series="4052" Issue="37514" />
+</Book>
+<Book Series="Excalibur" Number="68" Volume="1988" Year="1993">
+<Database Name="cv" Series="4052" Issue="66357" />
+</Book>
+<Book Series="Excalibur" Number="69" Volume="1988" Year="1993">
+<Database Name="cv" Series="4052" Issue="66358" />
+</Book>
+<Book Series="Excalibur" Number="70" Volume="1988" Year="1993">
+<Database Name="cv" Series="4052" Issue="66359" />
+</Book>
+<Book Series="X-Men" Number="24" Volume="1991" Year="1993">
+<Database Name="cv" Series="4605" Issue="37813" />
+</Book>
+<Book Series="Excalibur" Number="72" Volume="1988" Year="1993">
+<Database Name="cv" Series="4052" Issue="66361" />
+</Book>
+<Book Series="Excalibur" Number="73" Volume="1988" Year="1994">
+<Database Name="cv" Series="4052" Issue="66362" />
+</Book>
+<Book Series="Excalibur" Number="74" Volume="1988" Year="1994">
+<Database Name="cv" Series="4052" Issue="66363" />
+</Book>
+<Book Series="Excalibur" Number="75" Volume="1988" Year="1994">
+<Database Name="cv" Series="4052" Issue="66364" />
+</Book>
+<Book Series="Excalibur" Number="76" Volume="1988" Year="1994">
+<Database Name="cv" Series="4052" Issue="66365" />
+</Book>
+<Book Series="Excalibur" Number="77" Volume="1988" Year="1994">
+<Database Name="cv" Series="4052" Issue="66366" />
+</Book>
+<Book Series="Excalibur" Number="78" Volume="1988" Year="1994">
+<Database Name="cv" Series="4052" Issue="66367" />
+</Book>
+<Book Series="Excalibur" Number="79" Volume="1988" Year="1994">
+<Database Name="cv" Series="4052" Issue="66368" />
+</Book>
+<Book Series="Excalibur" Number="80" Volume="1988" Year="1994">
+<Database Name="cv" Series="4052" Issue="66369" />
+</Book>
+<Book Series="Excalibur" Number="81" Volume="1988" Year="1994">
+<Database Name="cv" Series="4052" Issue="66370" />
+</Book>
+<Book Series="The Adventures of Cyclops and Phoenix" Number="1" Volume="1994" Year="1994">
+<Database Name="cv" Series="5272" Issue="39115" />
+</Book>
+<Book Series="The Adventures of Cyclops and Phoenix" Number="2" Volume="1994" Year="1994">
+<Database Name="cv" Series="5272" Issue="39265" />
+</Book>
+<Book Series="The Adventures of Cyclops and Phoenix" Number="3" Volume="1994" Year="1994">
+<Database Name="cv" Series="5272" Issue="39408" />
+</Book>
+<Book Series="The Adventures of Cyclops and Phoenix" Number="4" Volume="1994" Year="1994">
+<Database Name="cv" Series="5272" Issue="39551" />
+</Book>
+<Book Series="Excalibur" Number="83" Volume="1988" Year="1994">
+<Database Name="cv" Series="4052" Issue="39934" />
+</Book>
+<Book Series="Excalibur" Number="84" Volume="1988" Year="1994">
+<Database Name="cv" Series="4052" Issue="40076" />
+</Book>
+<Book Series="Excalibur" Number="85" Volume="1988" Year="1995">
+<Database Name="cv" Series="4052" Issue="40317" />
+</Book>
+<Book Series="Excalibur" Number="86" Volume="1988" Year="1995">
+<Database Name="cv" Series="4052" Issue="66372" />
+</Book>
+<Book Series="Excalibur" Number="87" Volume="1988" Year="1995">
+<Database Name="cv" Series="4052" Issue="66373" />
+</Book>
+<Book Series="Excalibur" Number="88" Volume="1988" Year="1995">
+<Database Name="cv" Series="4052" Issue="66374" />
+</Book>
+<Book Series="Excalibur" Number="89" Volume="1988" Year="1995">
+<Database Name="cv" Series="4052" Issue="41383" />
+</Book>
+<Book Series="Excalibur" Number="90" Volume="1988" Year="1995">
+<Database Name="cv" Series="4052" Issue="66376" />
+</Book>
+<Book Series="Excalibur" Number="91" Volume="1988" Year="1995">
+<Database Name="cv" Series="4052" Issue="41641" />
+</Book>
+<Book Series="Excalibur" Number="92" Volume="1988" Year="1995">
+<Database Name="cv" Series="4052" Issue="66377" />
+</Book>
+<Book Series="Excalibur" Number="93" Volume="1988" Year="1996">
+<Database Name="cv" Series="4052" Issue="66378" />
+</Book>
+<Book Series="Excalibur" Number="94" Volume="1988" Year="1996">
+<Database Name="cv" Series="4052" Issue="66379" />
+</Book>
+<Book Series="Excalibur" Number="95" Volume="1988" Year="1996">
+<Database Name="cv" Series="4052" Issue="42205" />
+</Book>
+<Book Series="Excalibur" Number="96" Volume="1988" Year="1996">
+<Database Name="cv" Series="4052" Issue="42302" />
+</Book>
+<Book Series="Excalibur" Number="97" Volume="1988" Year="1996">
+<Database Name="cv" Series="4052" Issue="66380" />
+</Book>
+<Book Series="Excalibur" Number="98" Volume="1988" Year="1996">
+<Database Name="cv" Series="4052" Issue="66381" />
+</Book>
+<Book Series="Excalibur" Number="99" Volume="1988" Year="1996">
+<Database Name="cv" Series="4052" Issue="66382" />
+</Book>
+<Book Series="Excalibur" Number="100" Volume="1988" Year="1996">
+<Database Name="cv" Series="4052" Issue="66383" />
+</Book>
+<Book Series="Excalibur" Number="101" Volume="1988" Year="1996">
+<Database Name="cv" Series="4052" Issue="66384" />
+</Book>
+<Book Series="Excalibur" Number="102" Volume="1988" Year="1996">
+<Database Name="cv" Series="4052" Issue="66385" />
+</Book>
+<Book Series="Excalibur" Number="103" Volume="1988" Year="1996">
+<Database Name="cv" Series="4052" Issue="66386" />
+</Book>
+<Book Series="Excalibur" Number="104" Volume="1988" Year="1996">
+<Database Name="cv" Series="4052" Issue="66387" />
+</Book>
+<Book Series="Excalibur" Number="105" Volume="1988" Year="1997">
+<Database Name="cv" Series="4052" Issue="66388" />
+</Book>
+<Book Series="Excalibur" Number="106" Volume="1988" Year="1997">
+<Database Name="cv" Series="4052" Issue="66389" />
+</Book>
+<Book Series="Excalibur" Number="107" Volume="1988" Year="1997">
+<Database Name="cv" Series="4052" Issue="43481" />
+</Book>
+<Book Series="Excalibur" Number="108" Volume="1988" Year="1997">
+<Database Name="cv" Series="4052" Issue="43577" />
+</Book>
+<Book Series="Excalibur" Number="109" Volume="1988" Year="1997">
+<Database Name="cv" Series="4052" Issue="66391" />
+</Book>
+<Book Series="Excalibur" Number="110" Volume="1988" Year="1997">
+<Database Name="cv" Series="4052" Issue="66392" />
+</Book>
+<Book Series="Excalibur" Number="111" Volume="1988" Year="1997">
+<Database Name="cv" Series="4052" Issue="66393" />
+</Book>
+<Book Series="Excalibur" Number="112" Volume="1988" Year="1997">
+<Database Name="cv" Series="4052" Issue="66394" />
+</Book>
+<Book Series="Excalibur" Number="113" Volume="1988" Year="1997">
+<Database Name="cv" Series="4052" Issue="66395" />
+</Book>
+<Book Series="Excalibur" Number="114" Volume="1988" Year="1997">
+<Database Name="cv" Series="4052" Issue="66396" />
+</Book>
+<Book Series="Excalibur" Number="115" Volume="1988" Year="1997">
+<Database Name="cv" Series="4052" Issue="66397" />
+</Book>
+<Book Series="Excalibur" Number="116" Volume="1988" Year="1998">
+<Database Name="cv" Series="4052" Issue="66398" />
+</Book>
+<Book Series="Excalibur" Number="117" Volume="1988" Year="1998">
+<Database Name="cv" Series="4052" Issue="66399" />
+</Book>
+<Book Series="Excalibur" Number="118" Volume="1988" Year="1998">
+<Database Name="cv" Series="4052" Issue="66400" />
+</Book>
+<Book Series="Excalibur" Number="119" Volume="1988" Year="1998">
+<Database Name="cv" Series="4052" Issue="66401" />
+</Book>
+<Book Series="Excalibur" Number="120" Volume="1988" Year="1998">
+<Database Name="cv" Series="4052" Issue="66402" />
+</Book>
+<Book Series="Excalibur" Number="121" Volume="1988" Year="1998">
+<Database Name="cv" Series="4052" Issue="66403" />
+</Book>
+<Book Series="Excalibur" Number="122" Volume="1988" Year="1998">
+<Database Name="cv" Series="4052" Issue="66404" />
+</Book>
+<Book Series="Excalibur" Number="123" Volume="1988" Year="1998">
+<Database Name="cv" Series="4052" Issue="66405" />
+</Book>
+<Book Series="Excalibur" Number="124" Volume="1988" Year="1998">
+<Database Name="cv" Series="4052" Issue="66406" />
+</Book>
+<Book Series="Excalibur" Number="125" Volume="1988" Year="1998">
+<Database Name="cv" Series="4052" Issue="66407" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="365" Volume="1981" Year="1999">
+<Database Name="cv" Series="3092" Issue="45681" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="366" Volume="1981" Year="1999">
+<Database Name="cv" Series="3092" Issue="45736" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="367" Volume="1981" Year="1999">
+<Database Name="cv" Series="3092" Issue="45785" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="368" Volume="1981" Year="1999">
+<Database Name="cv" Series="3092" Issue="45834" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="369" Volume="1981" Year="1999">
+<Database Name="cv" Series="3092" Issue="45878" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="370" Volume="1981" Year="1999">
+<Database Name="cv" Series="3092" Issue="65136" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="371" Volume="1981" Year="1999">
+<Database Name="cv" Series="3092" Issue="65137" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="372" Volume="1981" Year="1999">
+<Database Name="cv" Series="3092" Issue="65138" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="373" Volume="1981" Year="1999">
+<Database Name="cv" Series="3092" Issue="150001" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="374" Volume="1981" Year="1999">
+<Database Name="cv" Series="3092" Issue="65139" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="375" Volume="1981" Year="1999">
+<Database Name="cv" Series="3092" Issue="65140" />
+</Book>
+<Book Series="Mutant X" Number="1" Volume="1998" Year="1998">
+<Database Name="cv" Series="6217" Issue="45399" />
+</Book>
+<Book Series="Mutant X" Number="2" Volume="1998" Year="1998">
+<Database Name="cv" Series="6217" Issue="45470" />
+</Book>
+<Book Series="Mutant X" Number="3" Volume="1998" Year="1998">
+<Database Name="cv" Series="6217" Issue="45530" />
+</Book>
+<Book Series="Mutant X" Number="4" Volume="1998" Year="1999">
+<Database Name="cv" Series="6217" Issue="45621" />
+</Book>
+<Book Series="Mutant X" Number="5" Volume="1998" Year="1999">
+<Database Name="cv" Series="6217" Issue="45683" />
+</Book>
+<Book Series="Mutant X" Number="6" Volume="1998" Year="1999">
+<Database Name="cv" Series="6217" Issue="45737" />
+</Book>
+<Book Series="Mutant X" Number="7" Volume="1998" Year="1999">
+<Database Name="cv" Series="6217" Issue="45787" />
+</Book>
+<Book Series="Mutant X" Number="8" Volume="1998" Year="1999">
+<Database Name="cv" Series="6217" Issue="45835" />
+</Book>
+<Book Series="Mutant X" Number="9" Volume="1998" Year="1999">
+<Database Name="cv" Series="6217" Issue="45880" />
+</Book>
+<Book Series="Mutant X" Number="10" Volume="1998" Year="1999">
+<Database Name="cv" Series="6217" Issue="45923" />
+</Book>
+<Book Series="Mutant X" Number="11" Volume="1998" Year="1999">
+<Database Name="cv" Series="6217" Issue="45958" />
+</Book>
+<Book Series="Mutant X" Number="12" Volume="1998" Year="1999">
+<Database Name="cv" Series="6217" Issue="46005" />
+</Book>
+<Book Series="Mutant X" Number="13" Volume="1998" Year="1999">
+<Database Name="cv" Series="6217" Issue="46049" />
+</Book>
+<Book Series="Mutant X" Number="14" Volume="1998" Year="1999">
+<Database Name="cv" Series="6217" Issue="46093" />
+</Book>
+<Book Series="Mutant X" Number="15" Volume="1998" Year="1999">
+<Database Name="cv" Series="6217" Issue="46175" />
+</Book>
+<Book Series="Mutant X" Number="16" Volume="1998" Year="2000">
+<Database Name="cv" Series="6217" Issue="46235" />
+</Book>
+<Book Series="Mutant X" Number="17" Volume="1998" Year="2000">
+<Database Name="cv" Series="6217" Issue="46282" />
+</Book>
+<Book Series="Mutant X" Number="18" Volume="1998" Year="2000">
+<Database Name="cv" Series="6217" Issue="46337" />
+</Book>
+<Book Series="Mutant X" Number="19" Volume="1998" Year="2000">
+<Database Name="cv" Series="6217" Issue="46357" />
+</Book>
+<Book Series="Mutant X" Number="20" Volume="1998" Year="2000">
+<Database Name="cv" Series="6217" Issue="46377" />
+</Book>
+<Book Series="Mutant X" Number="21" Volume="1998" Year="2000">
+<Database Name="cv" Series="6217" Issue="46394" />
+</Book>
+<Book Series="Mutant X" Number="22" Volume="1998" Year="2000">
+<Database Name="cv" Series="6217" Issue="46410" />
+</Book>
+<Book Series="Mutant X" Number="23" Volume="1998" Year="2000">
+<Database Name="cv" Series="6217" Issue="46425" />
+</Book>
+<Book Series="Mutant X" Number="24" Volume="1998" Year="2000">
+<Database Name="cv" Series="6217" Issue="46433" />
+</Book>
+<Book Series="Mutant X" Number="25" Volume="1998" Year="2000">
+<Database Name="cv" Series="6217" Issue="46442" />
+</Book>
+<Book Series="Mutant X" Number="26" Volume="1998" Year="2000">
+<Database Name="cv" Series="6217" Issue="49443" />
+</Book>
+<Book Series="Mutant X" Number="27" Volume="1998" Year="2001">
+<Database Name="cv" Series="6217" Issue="49444" />
+</Book>
+<Book Series="Mutant X" Number="28" Volume="1998" Year="2001">
+<Database Name="cv" Series="6217" Issue="49445" />
+</Book>
+<Book Series="Mutant X" Number="29" Volume="1998" Year="2001">
+<Database Name="cv" Series="6217" Issue="49446" />
+</Book>
+<Book Series="Mutant X" Number="30" Volume="1998" Year="2001">
+<Database Name="cv" Series="6217" Issue="49447" />
+</Book>
+<Book Series="Mutant X" Number="31" Volume="1998" Year="2001">
+<Database Name="cv" Series="6217" Issue="49448" />
+</Book>
+<Book Series="Mutant X" Number="32" Volume="1998" Year="2001">
+<Database Name="cv" Series="6217" Issue="49449" />
+</Book>
+<Book Series="X-Men: Magik" Number="1" Volume="2000" Year="2000">
+<Database Name="cv" Series="11667" Issue="103140" />
+</Book>
+<Book Series="X-Men: Magik" Number="2" Volume="2000" Year="2001">
+<Database Name="cv" Series="11667" Issue="103141" />
+</Book>
+<Book Series="X-Men: Magik" Number="3" Volume="2000" Year="2001">
+<Database Name="cv" Series="11667" Issue="103142" />
+</Book>
+<Book Series="X-Men: Magik" Number="4" Volume="2000" Year="2001">
+<Database Name="cv" Series="11667" Issue="103143" />
+</Book>
+<Book Series="New X-Men" Number="114" Volume="2001" Year="2001">
+<Database Name="cv" Series="9121" Issue="66992" />
+</Book>
+<Book Series="New X-Men" Number="115" Volume="2001" Year="2001">
+<Database Name="cv" Series="9121" Issue="66993" />
+</Book>
+<Book Series="New X-Men" Number="116" Volume="2001" Year="2001">
+<Database Name="cv" Series="9121" Issue="66994" />
+</Book>
+<Book Series="New X-Men" Number="117" Volume="2001" Year="2001">
+<Database Name="cv" Series="9121" Issue="66995" />
+</Book>
+<Book Series="New X-Men" Number="118" Volume="2001" Year="2001">
+<Database Name="cv" Series="9121" Issue="78322" />
+</Book>
+<Book Series="New X-Men" Number="119" Volume="2001" Year="2001">
+<Database Name="cv" Series="9121" Issue="78323" />
+</Book>
+<Book Series="New X-Men" Number="120" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="78324" />
+</Book>
+<Book Series="New X-Men" Number="121" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="78325" />
+</Book>
+<Book Series="New X-Men" Number="122" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="78326" />
+</Book>
+<Book Series="New X-Men" Number="123" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="78327" />
+</Book>
+<Book Series="New X-Men" Number="124" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="78328" />
+</Book>
+<Book Series="New X-Men" Number="125" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="78329" />
+</Book>
+<Book Series="New X-Men" Number="126" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="78330" />
+</Book>
+<Book Series="New X-Men" Number="127" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="78331" />
+</Book>
+<Book Series="New X-Men" Number="128" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="80585" />
+</Book>
+<Book Series="New X-Men" Number="129" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="106089" />
+</Book>
+<Book Series="New X-Men" Number="130" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="106112" />
+</Book>
+<Book Series="New X-Men" Number="131" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="106161" />
+</Book>
+<Book Series="New X-Men" Number="132" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="106564" />
+</Book>
+<Book Series="New X-Men" Number="133" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="106301" />
+</Book>
+<Book Series="New X-Men" Number="134" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="106499" />
+</Book>
+<Book Series="New X-Men" Number="135" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="112536" />
+</Book>
+<Book Series="New X-Men" Number="136" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="114332" />
+</Book>
+<Book Series="New X-Men" Number="137" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="114333" />
+</Book>
+<Book Series="New X-Men" Number="138" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="114334" />
+</Book>
+<Book Series="New X-Men" Number="139" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="114335" />
+</Book>
+<Book Series="New X-Men" Number="140" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="114336" />
+</Book>
+<Book Series="New X-Men" Number="141" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="114456" />
+</Book>
+<Book Series="New X-Men" Number="142" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="114457" />
+</Book>
+<Book Series="New X-Men" Number="143" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="114449" />
+</Book>
+<Book Series="New X-Men" Number="144" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="114450" />
+</Book>
+<Book Series="New X-Men" Number="145" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="114453" />
+</Book>
+<Book Series="New X-Men" Number="146" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="114451" />
+</Book>
+<Book Series="New X-Men" Number="147" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="114452" />
+</Book>
+<Book Series="New X-Men" Number="148" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="114454" />
+</Book>
+<Book Series="New X-Men" Number="149" Volume="2001" Year="2004">
+<Database Name="cv" Series="9121" Issue="114458" />
+</Book>
+<Book Series="New X-Men" Number="150" Volume="2001" Year="2004">
+<Database Name="cv" Series="9121" Issue="114459" />
+</Book>
+<Book Series="New X-Men" Number="151" Volume="2001" Year="2004">
+<Database Name="cv" Series="9121" Issue="106245" />
+</Book>
+<Book Series="New X-Men" Number="152" Volume="2001" Year="2004">
+<Database Name="cv" Series="9121" Issue="106246" />
+</Book>
+<Book Series="New X-Men" Number="153" Volume="2001" Year="2004">
+<Database Name="cv" Series="9121" Issue="106247" />
+</Book>
+<Book Series="New X-Men" Number="154" Volume="2001" Year="2004">
+<Database Name="cv" Series="9121" Issue="106248" />
+</Book>
+<Book Series="Exiles" Number="1" Volume="2001" Year="2001">
+<Database Name="cv" Series="6983" Issue="49450" />
+</Book>
+<Book Series="Exiles" Number="2" Volume="2001" Year="2001">
+<Database Name="cv" Series="6983" Issue="50744" />
+</Book>
+<Book Series="Exiles" Number="3" Volume="2001" Year="2001">
+<Database Name="cv" Series="6983" Issue="50745" />
+</Book>
+<Book Series="Exiles" Number="4" Volume="2001" Year="2001">
+<Database Name="cv" Series="6983" Issue="50746" />
+</Book>
+<Book Series="Exiles" Number="5" Volume="2001" Year="2001">
+<Database Name="cv" Series="6983" Issue="50747" />
+</Book>
+<Book Series="Exiles" Number="6" Volume="2001" Year="2002">
+<Database Name="cv" Series="6983" Issue="50748" />
+</Book>
+<Book Series="Exiles" Number="7" Volume="2001" Year="2002">
+<Database Name="cv" Series="6983" Issue="105360" />
+</Book>
+<Book Series="Exiles" Number="8" Volume="2001" Year="2002">
+<Database Name="cv" Series="6983" Issue="105361" />
+</Book>
+<Book Series="Exiles" Number="9" Volume="2001" Year="2002">
+<Database Name="cv" Series="6983" Issue="105362" />
+</Book>
+<Book Series="Exiles" Number="10" Volume="2001" Year="2002">
+<Database Name="cv" Series="6983" Issue="74606" />
+</Book>
+<Book Series="Exiles" Number="11" Volume="2001" Year="2002">
+<Database Name="cv" Series="6983" Issue="105363" />
+</Book>
+<Book Series="Exiles" Number="12" Volume="2001" Year="2002">
+<Database Name="cv" Series="6983" Issue="105364" />
+</Book>
+<Book Series="Exiles" Number="13" Volume="2001" Year="2002">
+<Database Name="cv" Series="6983" Issue="105365" />
+</Book>
+<Book Series="Exiles" Number="14" Volume="2001" Year="2002">
+<Database Name="cv" Series="6983" Issue="105366" />
+</Book>
+<Book Series="Exiles" Number="15" Volume="2001" Year="2002">
+<Database Name="cv" Series="6983" Issue="105367" />
+</Book>
+<Book Series="Exiles" Number="16" Volume="2001" Year="2002">
+<Database Name="cv" Series="6983" Issue="105369" />
+</Book>
+<Book Series="Exiles" Number="17" Volume="2001" Year="2002">
+<Database Name="cv" Series="6983" Issue="105368" />
+</Book>
+<Book Series="Exiles" Number="18" Volume="2001" Year="2002">
+<Database Name="cv" Series="6983" Issue="105370" />
+</Book>
+<Book Series="Exiles" Number="19" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="105371" />
+</Book>
+<Book Series="Exiles" Number="20" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="105372" />
+</Book>
+<Book Series="Exiles" Number="21" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92774" />
+</Book>
+<Book Series="Exiles" Number="22" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92775" />
+</Book>
+<Book Series="Exiles" Number="23" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92776" />
+</Book>
+<Book Series="Exiles" Number="24" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92777" />
+</Book>
+<Book Series="Exiles" Number="25" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92778" />
+</Book>
+<Book Series="Exiles" Number="26" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92779" />
+</Book>
+<Book Series="Exiles" Number="27" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92780" />
+</Book>
+<Book Series="Exiles" Number="28" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92781" />
+</Book>
+<Book Series="Exiles" Number="29" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92782" />
+</Book>
+<Book Series="Exiles" Number="30" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92783" />
+</Book>
+<Book Series="Exiles" Number="31" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92784" />
+</Book>
+<Book Series="Exiles" Number="32" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92785" />
+</Book>
+<Book Series="Exiles" Number="33" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92786" />
+</Book>
+<Book Series="Exiles" Number="34" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92787" />
+</Book>
+<Book Series="Exiles" Number="35" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92788" />
+</Book>
+<Book Series="Exiles" Number="36" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92789" />
+</Book>
+<Book Series="Exiles" Number="37" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="92790" />
+</Book>
+<Book Series="Exiles" Number="38" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="92791" />
+</Book>
+<Book Series="Exiles" Number="39" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="92792" />
+</Book>
+<Book Series="Exiles" Number="40" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="92793" />
+</Book>
+<Book Series="Exiles" Number="41" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="92794" />
+</Book>
+<Book Series="Exiles" Number="42" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="92795" />
+</Book>
+<Book Series="Exiles" Number="43" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="92796" />
+</Book>
+<Book Series="Exiles" Number="44" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="92797" />
+</Book>
+<Book Series="Exiles" Number="45" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="92798" />
+</Book>
+<Book Series="Exiles" Number="46" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="92799" />
+</Book>
+<Book Series="Exiles" Number="47" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="92800" />
+</Book>
+<Book Series="Exiles" Number="48" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="92801" />
+</Book>
+<Book Series="Exiles" Number="49" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="99106" />
+</Book>
+<Book Series="Exiles" Number="50" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="99107" />
+</Book>
+<Book Series="Exiles" Number="51" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="99108" />
+</Book>
+<Book Series="Exiles" Number="52" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="99109" />
+</Book>
+<Book Series="Exiles" Number="53" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="99110" />
+</Book>
+<Book Series="Exiles" Number="54" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="99111" />
+</Book>
+<Book Series="Exiles" Number="55" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="99112" />
+</Book>
+<Book Series="Exiles" Number="56" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="99113" />
+</Book>
+<Book Series="Exiles" Number="57" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="99114" />
+</Book>
+<Book Series="Exiles" Number="58" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="101047" />
+</Book>
+<Book Series="Exiles" Number="59" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="101048" />
+</Book>
+<Book Series="Exiles" Number="60" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="101049" />
+</Book>
+<Book Series="Exiles" Number="61" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="101050" />
+</Book>
+<Book Series="Exiles" Number="62" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="101051" />
+</Book>
+<Book Series="Exiles" Number="63" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="105423" />
+</Book>
+<Book Series="Exiles" Number="64" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="105424" />
+</Book>
+<Book Series="Exiles" Number="65" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="105425" />
+</Book>
+<Book Series="Exiles" Number="66" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="105794" />
+</Book>
+<Book Series="Exiles" Number="67" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="105795" />
+</Book>
+<Book Series="Exiles" Number="68" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="105796" />
+</Book>
+<Book Series="NYX" Number="1" Volume="2003" Year="2003">
+<Database Name="cv" Series="17987" Issue="105318" />
+</Book>
+<Book Series="NYX" Number="2" Volume="2003" Year="2004">
+<Database Name="cv" Series="17987" Issue="105410" />
+</Book>
+<Book Series="NYX" Number="3" Volume="2003" Year="2004">
+<Database Name="cv" Series="17987" Issue="105411" />
+</Book>
+<Book Series="NYX" Number="4" Volume="2003" Year="2004">
+<Database Name="cv" Series="17987" Issue="105412" />
+</Book>
+<Book Series="NYX" Number="5" Volume="2003" Year="2004">
+<Database Name="cv" Series="17987" Issue="105413" />
+</Book>
+<Book Series="NYX" Number="6" Volume="2003" Year="2005">
+<Database Name="cv" Series="17987" Issue="107239" />
+</Book>
+<Book Series="NYX" Number="7" Volume="2003" Year="2005">
+<Database Name="cv" Series="17987" Issue="107240" />
+</Book>
+<Book Series="District X" Number="1" Volume="2004" Year="2004">
+<Database Name="cv" Series="19327" Issue="116029" />
+</Book>
+<Book Series="District X" Number="2" Volume="2004" Year="2004">
+<Database Name="cv" Series="19327" Issue="116067" />
+</Book>
+<Book Series="District X" Number="3" Volume="2004" Year="2004">
+<Database Name="cv" Series="19327" Issue="116069" />
+</Book>
+<Book Series="District X" Number="4" Volume="2004" Year="2004">
+<Database Name="cv" Series="19327" Issue="116070" />
+</Book>
+<Book Series="District X" Number="5" Volume="2004" Year="2004">
+<Database Name="cv" Series="19327" Issue="116071" />
+</Book>
+<Book Series="District X" Number="6" Volume="2004" Year="2004">
+<Database Name="cv" Series="19327" Issue="116072" />
+</Book>
+<Book Series="District X" Number="7" Volume="2004" Year="2005">
+<Database Name="cv" Series="19327" Issue="118019" />
+</Book>
+<Book Series="District X" Number="8" Volume="2004" Year="2005">
+<Database Name="cv" Series="19327" Issue="120737" />
+</Book>
+<Book Series="District X" Number="9" Volume="2004" Year="2005">
+<Database Name="cv" Series="19327" Issue="120738" />
+</Book>
+<Book Series="District X" Number="10" Volume="2004" Year="2005">
+<Database Name="cv" Series="19327" Issue="120739" />
+</Book>
+<Book Series="District X" Number="11" Volume="2004" Year="2005">
+<Database Name="cv" Series="19327" Issue="120740" />
+</Book>
+<Book Series="District X" Number="12" Volume="2004" Year="2005">
+<Database Name="cv" Series="19327" Issue="120741" />
+</Book>
+<Book Series="District X" Number="13" Volume="2004" Year="2005">
+<Database Name="cv" Series="19327" Issue="126234" />
+</Book>
+<Book Series="District X" Number="14" Volume="2004" Year="2005">
+<Database Name="cv" Series="19327" Issue="126233" />
+</Book>
+<Book Series="Astonishing X-Men" Number="1" Volume="2004" Year="2004">
+<Database Name="cv" Series="10746" Issue="90580" />
+</Book>
+<Book Series="Astonishing X-Men" Number="2" Volume="2004" Year="2004">
+<Database Name="cv" Series="10746" Issue="90581" />
+</Book>
+<Book Series="Astonishing X-Men" Number="3" Volume="2004" Year="2004">
+<Database Name="cv" Series="10746" Issue="90583" />
+</Book>
+<Book Series="Astonishing X-Men" Number="4" Volume="2004" Year="2004">
+<Database Name="cv" Series="10746" Issue="93543" />
+</Book>
+<Book Series="Astonishing X-Men" Number="5" Volume="2004" Year="2004">
+<Database Name="cv" Series="10746" Issue="93544" />
+</Book>
+<Book Series="Astonishing X-Men" Number="6" Volume="2004" Year="2004">
+<Database Name="cv" Series="10746" Issue="99750" />
+</Book>
+<Book Series="X-Men: Colossus Bloodline" Number="1" Volume="2005" Year="2005">
+<Database Name="cv" Series="18699" Issue="110540" />
+</Book>
+<Book Series="X-Men: Colossus Bloodline" Number="2" Volume="2005" Year="2005">
+<Database Name="cv" Series="18699" Issue="110638" />
+</Book>
+<Book Series="X-Men: Colossus Bloodline" Number="3" Volume="2005" Year="2006">
+<Database Name="cv" Series="18699" Issue="110818" />
+</Book>
+<Book Series="X-Men: Colossus Bloodline" Number="4" Volume="2005" Year="2006">
+<Database Name="cv" Series="18699" Issue="110819" />
+</Book>
+<Book Series="X-Men: Colossus Bloodline" Number="5" Volume="2005" Year="2006">
+<Database Name="cv" Series="18699" Issue="110820" />
+</Book>
+<Book Series="Astonishing X-Men" Number="7" Volume="2004" Year="2005">
+<Database Name="cv" Series="10746" Issue="99751" />
+</Book>
+<Book Series="Astonishing X-Men" Number="8" Volume="2004" Year="2005">
+<Database Name="cv" Series="10746" Issue="99752" />
+</Book>
+<Book Series="Astonishing X-Men" Number="9" Volume="2004" Year="2005">
+<Database Name="cv" Series="10746" Issue="106131" />
+</Book>
+<Book Series="Astonishing X-Men" Number="10" Volume="2004" Year="2005">
+<Database Name="cv" Series="10746" Issue="106670" />
+</Book>
+<Book Series="Astonishing X-Men" Number="11" Volume="2004" Year="2005">
+<Database Name="cv" Series="10746" Issue="106671" />
+</Book>
+<Book Series="Astonishing X-Men" Number="12" Volume="2004" Year="2005">
+<Database Name="cv" Series="10746" Issue="106676" />
+</Book>
+<Book Series="Exiles" Number="74" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="105985" />
+</Book>
+<Book Series="Exiles" Number="75" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="106000" />
+</Book>
+<Book Series="Exiles" Number="76" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="106001" />
+</Book>
+<Book Series="Exiles" Number="77" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="106002" />
+</Book>
+<Book Series="Exiles" Number="78" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="106003" />
+</Book>
+<Book Series="Exiles" Number="79" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="106030" />
+</Book>
+<Book Series="Exiles" Number="80" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="106031" />
+</Book>
+<Book Series="Exiles" Number="81" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="106032" />
+</Book>
+<Book Series="Exiles" Number="82" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="106033" />
+</Book>
+<Book Series="Exiles" Number="83" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="106035" />
+</Book>
+<Book Series="Exiles" Number="84" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="106037" />
+</Book>
+<Book Series="Exiles" Number="85" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="106038" />
+</Book>
+<Book Series="Exiles" Number="86" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="106039" />
+</Book>
+<Book Series="Exiles" Number="87" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="106383" />
+</Book>
+<Book Series="Exiles" Number="88" Volume="2001" Year="2007">
+<Database Name="cv" Series="6983" Issue="106384" />
+</Book>
+<Book Series="X-Men" Number="188" Volume="2004" Year="2006">
+<Database Name="cv" Series="10731" Issue="108778" />
+</Book>
+<Book Series="X-Men" Number="189" Volume="2004" Year="2006">
+<Database Name="cv" Series="10731" Issue="107955" />
+</Book>
+<Book Series="X-Men" Number="190" Volume="2004" Year="2006">
+<Database Name="cv" Series="10731" Issue="107956" />
+</Book>
+<Book Series="X-Men" Number="191" Volume="2004" Year="2006">
+<Database Name="cv" Series="10731" Issue="107957" />
+</Book>
+<Book Series="X-Men" Number="192" Volume="2004" Year="2006">
+<Database Name="cv" Series="10731" Issue="107946" />
+</Book>
+<Book Series="X-Men" Number="193" Volume="2004" Year="2007">
+<Database Name="cv" Series="10731" Issue="107947" />
+</Book>
+<Book Series="Exiles" Number="89" Volume="2001" Year="2007">
+<Database Name="cv" Series="6983" Issue="106385" />
+</Book>
+<Book Series="Exiles" Number="90" Volume="2001" Year="2007">
+<Database Name="cv" Series="6983" Issue="106560" />
+</Book>
+<Book Series="Exiles" Number="91" Volume="2001" Year="2007">
+<Database Name="cv" Series="6983" Issue="106487" />
+</Book>
+<Book Series="Exiles" Number="92" Volume="2001" Year="2007">
+<Database Name="cv" Series="6983" Issue="107224" />
+</Book>
+<Book Series="Exiles" Number="93" Volume="2001" Year="2007">
+<Database Name="cv" Series="6983" Issue="108790" />
+</Book>
+<Book Series="Exiles" Number="94" Volume="2001" Year="2007">
+<Database Name="cv" Series="6983" Issue="109702" />
+</Book>
+<Book Series="Exiles" Number="95" Volume="2001" Year="2007">
+<Database Name="cv" Series="6983" Issue="110439" />
+</Book>
+<Book Series="Exiles" Number="96" Volume="2001" Year="2007">
+<Database Name="cv" Series="6983" Issue="111596" />
+</Book>
+<Book Series="Exiles" Number="97" Volume="2001" Year="2007">
+<Database Name="cv" Series="6983" Issue="113430" />
+</Book>
+<Book Series="Exiles" Number="98" Volume="2001" Year="2007">
+<Database Name="cv" Series="6983" Issue="114222" />
+</Book>
+<Book Series="Exiles" Number="99" Volume="2001" Year="2007">
+<Database Name="cv" Series="6983" Issue="116028" />
+</Book>
+<Book Series="Exiles" Number="100" Volume="2001" Year="2008">
+<Database Name="cv" Series="6983" Issue="120279" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="475" Volume="1981" Year="2006">
+<Database Name="cv" Series="3092" Issue="107938" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="476" Volume="1981" Year="2006">
+<Database Name="cv" Series="3092" Issue="107939" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="477" Volume="1981" Year="2006">
+<Database Name="cv" Series="3092" Issue="107940" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="478" Volume="1981" Year="2006">
+<Database Name="cv" Series="3092" Issue="107941" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="479" Volume="1981" Year="2006">
+<Database Name="cv" Series="3092" Issue="107942" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="480" Volume="1981" Year="2007">
+<Database Name="cv" Series="3092" Issue="109939" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="481" Volume="1981" Year="2007">
+<Database Name="cv" Series="3092" Issue="107943" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="482" Volume="1981" Year="2007">
+<Database Name="cv" Series="3092" Issue="106278" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="483" Volume="1981" Year="2007">
+<Database Name="cv" Series="3092" Issue="106366" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="484" Volume="1981" Year="2007">
+<Database Name="cv" Series="3092" Issue="106795" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="485" Volume="1981" Year="2007">
+<Database Name="cv" Series="3092" Issue="108365" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="486" Volume="1981" Year="2007">
+<Database Name="cv" Series="3092" Issue="109610" />
+</Book>
+<Book Series="Astonishing X-Men" Number="13" Volume="2004" Year="2006">
+<Database Name="cv" Series="10746" Issue="106677" />
+</Book>
+<Book Series="Astonishing X-Men" Number="14" Volume="2004" Year="2006">
+<Database Name="cv" Series="10746" Issue="106678" />
+</Book>
+<Book Series="Astonishing X-Men" Number="15" Volume="2004" Year="2006">
+<Database Name="cv" Series="10746" Issue="106750" />
+</Book>
+<Book Series="Astonishing X-Men" Number="16" Volume="2004" Year="2006">
+<Database Name="cv" Series="10746" Issue="106751" />
+</Book>
+<Book Series="Astonishing X-Men" Number="17" Volume="2004" Year="2006">
+<Database Name="cv" Series="10746" Issue="106752" />
+</Book>
+<Book Series="Astonishing X-Men" Number="18" Volume="2004" Year="2006">
+<Database Name="cv" Series="10746" Issue="106130" />
+</Book>
+<Book Series="Astonishing X-Men" Number="19" Volume="2004" Year="2007">
+<Database Name="cv" Series="10746" Issue="106105" />
+</Book>
+<Book Series="Astonishing X-Men" Number="20" Volume="2004" Year="2007">
+<Database Name="cv" Series="10746" Issue="106469" />
+</Book>
+<Book Series="Astonishing X-Men" Number="21" Volume="2004" Year="2007">
+<Database Name="cv" Series="10746" Issue="108923" />
+</Book>
+<Book Series="Astonishing X-Men" Number="22" Volume="2004" Year="2007">
+<Database Name="cv" Series="10746" Issue="113737" />
+</Book>
+<Book Series="Astonishing X-Men" Number="23" Volume="2004" Year="2008">
+<Database Name="cv" Series="10746" Issue="116965" />
+</Book>
+<Book Series="Astonishing X-Men" Number="24" Volume="2004" Year="2008">
+<Database Name="cv" Series="10746" Issue="121887" />
+</Book>
+<Book Series="Giant-Size Astonishing X-Men" Number="1" Volume="2008" Year="2008">
+<Database Name="cv" Series="21710" Issue="130969" />
+</Book>
+<Book Series="Young X-Men" Number="1" Volume="2008" Year="2008">
+<Database Name="cv" Series="21082" Issue="126423" />
+</Book>
+<Book Series="Young X-Men" Number="2" Volume="2008" Year="2008">
+<Database Name="cv" Series="21082" Issue="129704" />
+</Book>
+<Book Series="Young X-Men" Number="3" Volume="2008" Year="2008">
+<Database Name="cv" Series="21082" Issue="131325" />
+</Book>
+<Book Series="Young X-Men" Number="4" Volume="2008" Year="2008">
+<Database Name="cv" Series="21082" Issue="133021" />
+</Book>
+<Book Series="Young X-Men" Number="5" Volume="2008" Year="2008">
+<Database Name="cv" Series="21082" Issue="136066" />
+</Book>
+<Book Series="X-Men: Worlds Apart" Number="1" Volume="2008" Year="2008">
+<Database Name="cv" Series="23443" Issue="140555" />
+</Book>
+<Book Series="X-Men: Worlds Apart" Number="2" Volume="2008" Year="2009">
+<Database Name="cv" Series="23443" Issue="142743" />
+</Book>
+<Book Series="X-Men: Worlds Apart" Number="3" Volume="2008" Year="2009">
+<Database Name="cv" Series="23443" Issue="149297" />
+</Book>
+<Book Series="X-Men: Worlds Apart" Number="4" Volume="2008" Year="2009">
+<Database Name="cv" Series="23443" Issue="150654" />
+</Book>
+<Book Series="NYX: No Way Home" Number="1" Volume="2008" Year="2008">
+<Database Name="cv" Series="22497" Issue="135071" />
+</Book>
+<Book Series="NYX: No Way Home" Number="2" Volume="2008" Year="2008">
+<Database Name="cv" Series="22497" Issue="138256" />
+</Book>
+<Book Series="NYX: No Way Home" Number="3" Volume="2008" Year="2008">
+<Database Name="cv" Series="22497" Issue="140473" />
+</Book>
+<Book Series="NYX: No Way Home" Number="4" Volume="2008" Year="2009">
+<Database Name="cv" Series="22497" Issue="144573" />
+</Book>
+<Book Series="NYX: No Way Home" Number="5" Volume="2008" Year="2009">
+<Database Name="cv" Series="22497" Issue="149786" />
+</Book>
+<Book Series="NYX: No Way Home" Number="6" Volume="2008" Year="2009">
+<Database Name="cv" Series="22497" Issue="152418" />
+</Book>
+<Book Series="Young X-Men" Number="6" Volume="2008" Year="2008">
+<Database Name="cv" Series="21082" Issue="139001" />
+</Book>
+<Book Series="Young X-Men" Number="7" Volume="2008" Year="2008">
+<Database Name="cv" Series="21082" Issue="140445" />
+</Book>
+<Book Series="Young X-Men" Number="8" Volume="2008" Year="2009">
+<Database Name="cv" Series="21082" Issue="142546" />
+</Book>
+<Book Series="Young X-Men" Number="9" Volume="2008" Year="2009">
+<Database Name="cv" Series="21082" Issue="149466" />
+</Book>
+<Book Series="Young X-Men" Number="10" Volume="2008" Year="2009">
+<Database Name="cv" Series="21082" Issue="150703" />
+</Book>
+<Book Series="Young X-Men" Number="11" Volume="2008" Year="2009">
+<Database Name="cv" Series="21082" Issue="152247" />
+</Book>
+<Book Series="Young X-Men" Number="12" Volume="2008" Year="2009">
+<Database Name="cv" Series="21082" Issue="153682" />
+</Book>
+<Book Series="X-Men: To Serve and Protect" Number="1" Volume="2011" Year="2011">
+<Database Name="cv" Series="36470" Issue="240745" />
+</Book>
+<Book Series="X-Men: To Serve and Protect" Number="2" Volume="2011" Year="2011">
+<Database Name="cv" Series="36470" Issue="252756" />
+</Book>
+<Book Series="X-Men: To Serve and Protect" Number="3" Volume="2011" Year="2011">
+<Database Name="cv" Series="36470" Issue="259133" />
+</Book>
+<Book Series="X-Men: To Serve and Protect" Number="4" Volume="2011" Year="2011">
+<Database Name="cv" Series="36470" Issue="263750" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="5" Volume="2011" Year="2012">
+<Database Name="cv" Series="43539" Issue="315083" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="6" Volume="2011" Year="2012">
+<Database Name="cv" Series="43539" Issue="316711" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="7" Volume="2011" Year="2012">
+<Database Name="cv" Series="43539" Issue="321295" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="8" Volume="2011" Year="2012">
+<Database Name="cv" Series="43539" Issue="326863" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="17" Volume="2011" Year="2012">
+<Database Name="cv" Series="43539" Issue="358926" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="19" Volume="2011" Year="2012">
+<Database Name="cv" Series="43539" Issue="364133" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="20" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="367699" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="21" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="369058" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="22" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="373313" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="23" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="378900" />
+</Book>
+<Book Series="Uncanny Avengers" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="52880" Issue="360884" />
+</Book>
+<Book Series="Uncanny Avengers" Number="2" Volume="2012" Year="2013">
+<Database Name="cv" Series="52880" Issue="370249" />
+</Book>
+<Book Series="Uncanny Avengers" Number="3" Volume="2012" Year="2013">
+<Database Name="cv" Series="52880" Issue="381419" />
+</Book>
+<Book Series="Uncanny Avengers" Number="4" Volume="2012" Year="2013">
+<Database Name="cv" Series="52880" Issue="388564" />
+</Book>
+<Book Series="All-New X-Men" Number="1" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="367691" />
+</Book>
+<Book Series="All-New X-Men" Number="2" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="370245" />
+</Book>
+<Book Series="All-New X-Men" Number="3" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="371105" />
+</Book>
+<Book Series="All-New X-Men" Number="4" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="373215" />
+</Book>
+<Book Series="All-New X-Men" Number="5" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="376661" />
+</Book>
+<Book Series="All-New X-Men" Number="6" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="380348" />
+</Book>
+<Book Series="All-New X-Men" Number="7" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="384952" />
+</Book>
+<Book Series="All-New X-Men" Number="8" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="390443" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="24" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="381421" />
+</Book>
+<Book Series="Uncanny Avengers" Number="5" Volume="2012" Year="2013">
+<Database Name="cv" Series="52880" Issue="395258" />
+</Book>
+<Book Series="Uncanny X-Men" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="386141" />
+</Book>
+<Book Series="Uncanny X-Men" Number="2" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="388566" />
+</Book>
+<Book Series="Uncanny X-Men" Number="3" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="392362" />
+</Book>
+<Book Series="All-New X-Men" Number="9" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="394700" />
+</Book>
+<Book Series="All-New X-Men" Number="10" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="395700" />
+</Book>
+<Book Series="All-New X-Men" Number="11" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="400145" />
+</Book>
+<Book Series="Uncanny X-Men" Number="4" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="396436" />
+</Book>
+<Book Series="All-New X-Men" Number="12" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="408989" />
+</Book>
+<Book Series="All-New X-Men" Number="13" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="413652" />
+</Book>
+<Book Series="All-New X-Men" Number="14" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="417830" />
+</Book>
+<Book Series="Uncanny X-Men" Number="5" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="398994" />
+</Book>
+<Book Series="Uncanny X-Men" Number="6" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="404705" />
+</Book>
+<Book Series="Uncanny X-Men" Number="7" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="413669" />
+</Book>
+<Book Series="Uncanny X-Men" Number="8" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="416917" />
+</Book>
+<Book Series="Uncanny X-Men" Number="9" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="419973" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="25" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="386142" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="26" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="392363" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="27" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="395260" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="28" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="398995" />
+</Book>
+<Book Series="Uncanny Avengers" Number="6" Volume="2012" Year="2013">
+<Database Name="cv" Series="52880" Issue="396435" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="27AU" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="397554" />
+</Book>
+<Book Series="Uncanny Avengers" Number="8AU" Volume="2012" Year="2013">
+<Database Name="cv" Series="52880" Issue="404704" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="29" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="402293" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="30" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="406982" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="31" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="410327" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="32" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="413671" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="33" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="418978" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="34" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="421701" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="35" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="423685" />
+</Book>
+<Book Series="All-New X-Men" Number="15" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="420633" />
+</Book>
+<Book Series="Uncanny X-Men" Number="10" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="421699" />
+</Book>
+<Book Series="Uncanny X-Men" Number="11" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="423684" />
+</Book>
+<Book Series="Uncanny Avengers" Number="7" Volume="2012" Year="2013">
+<Database Name="cv" Series="52880" Issue="398993" />
+</Book>
+<Book Series="Uncanny Avengers" Number="8" Volume="2012" Year="2013">
+<Database Name="cv" Series="52880" Issue="401212" />
+</Book>
+<Book Series="Uncanny Avengers" Number="9" Volume="2012" Year="2013">
+<Database Name="cv" Series="52880" Issue="411836" />
+</Book>
+<Book Series="Uncanny Avengers" Number="10" Volume="2012" Year="2013">
+<Database Name="cv" Series="52880" Issue="418825" />
+</Book>
+<Book Series="Uncanny Avengers" Number="11" Volume="2012" Year="2013">
+<Database Name="cv" Series="52880" Issue="423683" />
+</Book>
+<Book Series="Uncanny Avengers" Number="12" Volume="2012" Year="2013">
+<Database Name="cv" Series="52880" Issue="426885" />
+</Book>
+<Book Series="Uncanny Avengers" Number="13" Volume="2012" Year="2013">
+<Database Name="cv" Series="52880" Issue="430766" />
+</Book>
+<Book Series="Uncanny Avengers" Number="14" Volume="2012" Year="2014">
+<Database Name="cv" Series="52880" Issue="435067" />
+</Book>
+<Book Series="Uncanny Avengers" Number="15" Volume="2012" Year="2014">
+<Database Name="cv" Series="52880" Issue="437499" />
+</Book>
+<Book Series="Uncanny Avengers" Number="16" Volume="2012" Year="2014">
+<Database Name="cv" Series="52880" Issue="443990" />
+</Book>
+<Book Series="Uncanny Avengers" Number="17" Volume="2012" Year="2014">
+<Database Name="cv" Series="52880" Issue="446492" />
+</Book>
+<Book Series="Uncanny Avengers" Number="18" Volume="2012" Year="2014">
+<Database Name="cv" Series="52880" Issue="448981" />
+</Book>
+<Book Series="Uncanny Avengers" Number="19" Volume="2012" Year="2014">
+<Database Name="cv" Series="52880" Issue="451093" />
+</Book>
+<Book Series="Uncanny Avengers" Number="20" Volume="2012" Year="2014">
+<Database Name="cv" Series="52880" Issue="454109" />
+</Book>
+<Book Series="Uncanny Avengers" Number="21" Volume="2012" Year="2014">
+<Database Name="cv" Series="52880" Issue="457652" />
+</Book>
+<Book Series="Uncanny Avengers" Number="22" Volume="2012" Year="2014">
+<Database Name="cv" Series="52880" Issue="460973" />
+</Book>
+<Book Series="Uncanny X-Men" Number="14" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="433852" />
+</Book>
+<Book Series="All-New X-Men" Number="18" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="433167" />
+</Book>
+<Book Series="All-New X-Men" Number="19" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="435047" />
+</Book>
+<Book Series="All-New X-Men" Number="20" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="437482" />
+</Book>
+<Book Series="All-New X-Men" Number="21" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="442161" />
+</Book>
+<Book Series="Uncanny X-Men" Number="15" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="436208" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="38" Volume="2011" Year="2014">
+<Database Name="cv" Series="43539" Issue="435069" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="39" Volume="2011" Year="2014">
+<Database Name="cv" Series="43539" Issue="436210" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="40" Volume="2011" Year="2014">
+<Database Name="cv" Series="43539" Issue="442929" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="41" Volume="2011" Year="2014">
+<Database Name="cv" Series="43539" Issue="445187" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="42" Volume="2011" Year="2014">
+<Database Name="cv" Series="43539" Issue="446494" />
+</Book>
+<Book Series="Uncanny X-Men" Number="16" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="442179" />
+</Book>
+<Book Series="Uncanny X-Men" Number="17" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="445823" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="1" Volume="2014" Year="2014">
+<Database Name="cv" Series="72113" Issue="446927" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="2" Volume="2014" Year="2014">
+<Database Name="cv" Series="72113" Issue="448008" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="3" Volume="2014" Year="2014">
+<Database Name="cv" Series="72113" Issue="450561" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="4" Volume="2014" Year="2014">
+<Database Name="cv" Series="72113" Issue="453423" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="5" Volume="2014" Year="2014">
+<Database Name="cv" Series="72113" Issue="456559" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="6" Volume="2014" Year="2014">
+<Database Name="cv" Series="72113" Issue="460319" />
+</Book>
+<Book Series="All-New X-Men" Number="25" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="450068" />
+</Book>
+<Book Series="All-New X-Men" Number="26" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="451763" />
+</Book>
+<Book Series="All-New X-Men" Number="27" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="452845" />
+</Book>
+<Book Series="All-New X-Men" Number="28" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="456017" />
+</Book>
+<Book Series="All-New X-Men" Number="29" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="459161" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="7" Volume="2014" Year="2014">
+<Database Name="cv" Series="72113" Issue="462262" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="8" Volume="2014" Year="2014">
+<Database Name="cv" Series="72113" Issue="463491" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="9" Volume="2014" Year="2014">
+<Database Name="cv" Series="72113" Issue="465854" />
+</Book>
+<Book Series="Uncanny X-Men" Number="19" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="448006" />
+</Book>
+<Book Series="Uncanny X-Men" Number="20" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="450557" />
+</Book>
+<Book Series="Uncanny X-Men" Number="21" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="453422" />
+</Book>
+<Book Series="Uncanny X-Men" Number="22" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="456558" />
+</Book>
+<Book Series="Uncanny X-Men" Number="23" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="459685" />
+</Book>
+<Book Series="All-New X-Men" Number="30" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="462241" />
+</Book>
+<Book Series="Uncanny X-Men" Number="24" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="460974" />
+</Book>
+<Book Series="Uncanny X-Men" Number="25" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="463998" />
+</Book>
+<Book Series="All-New X-Men" Number="31" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="463476" />
+</Book>
+<Book Series="Uncanny X-Men" Number="26" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="465853" />
+</Book>
+<Book Series="Uncanny X-Men" Number="27" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="468091" />
+</Book>
+<Book Series="Uncanny X-Men" Number="28" Volume="2013" Year="2015">
+<Database Name="cv" Series="57181" Issue="470436" />
+</Book>
+<Book Series="Uncanny X-Men" Number="29" Volume="2013" Year="2015">
+<Database Name="cv" Series="57181" Issue="474637" />
+</Book>
+<Book Series="Uncanny X-Men" Number="30" Volume="2013" Year="2015">
+<Database Name="cv" Series="57181" Issue="477858" />
+</Book>
+<Book Series="Uncanny X-Men" Number="31" Volume="2013" Year="2015">
+<Database Name="cv" Series="57181" Issue="479985" />
+</Book>
+<Book Series="All-New X-Men" Number="32" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="465836" />
+</Book>
+<Book Series="All-New X-Men" Number="33" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="468900" />
+</Book>
+<Book Series="All-New X-Men" Number="34" Volume="2012" Year="2015">
+<Database Name="cv" Series="53919" Issue="473638" />
+</Book>
+<Book Series="All-New X-Men" Number="35" Volume="2012" Year="2015">
+<Database Name="cv" Series="53919" Issue="476778" />
+</Book>
+<Book Series="All-New X-Men" Number="36" Volume="2012" Year="2015">
+<Database Name="cv" Series="53919" Issue="479253" />
+</Book>
+<Book Series="Uncanny Avengers" Number="23" Volume="2012" Year="2014">
+<Database Name="cv" Series="52880" Issue="463489" />
+</Book>
+<Book Series="Uncanny Avengers" Number="24" Volume="2012" Year="2014">
+<Database Name="cv" Series="52880" Issue="465852" />
+</Book>
+<Book Series="Uncanny Avengers" Number="25" Volume="2012" Year="2014">
+<Database Name="cv" Series="52880" Issue="467043" />
+</Book>
+<Book Series="All-New X-Men" Number="37" Volume="2012" Year="2015">
+<Database Name="cv" Series="53919" Issue="482149" />
+</Book>
+<Book Series="All-New X-Men" Number="38" Volume="2012" Year="2015">
+<Database Name="cv" Series="53919" Issue="480667" />
+</Book>
+<Book Series="All-New X-Men" Number="39" Volume="2012" Year="2015">
+<Database Name="cv" Series="53919" Issue="482678" />
+</Book>
+<Book Series="All-New X-Men" Number="40" Volume="2012" Year="2015">
+<Database Name="cv" Series="53919" Issue="486715" />
+</Book>
+<Book Series="All-New X-Men" Number="41" Volume="2012" Year="2015">
+<Database Name="cv" Series="53919" Issue="490874" />
+</Book>
+<Book Series="Uncanny X-Men" Number="32" Volume="2013" Year="2015">
+<Database Name="cv" Series="57181" Issue="483361" />
+</Book>
+<Book Series="Uncanny X-Men" Number="33" Volume="2013" Year="2015">
+<Database Name="cv" Series="57181" Issue="486158" />
+</Book>
+<Book Series="Uncanny X-Men" Number="34" Volume="2013" Year="2015">
+<Database Name="cv" Series="57181" Issue="489330" />
+</Book>
+<Book Series="Uncanny X-Men" Number="35" Volume="2013" Year="2015">
+<Database Name="cv" Series="57181" Issue="495810" />
+</Book>
+<Book Series="Spider-Man &amp; the X-Men" Number="1" Volume="2014" Year="2015">
+<Database Name="cv" Series="78717" Issue="472911" />
+</Book>
+<Book Series="Spider-Man &amp; the X-Men" Number="2" Volume="2014" Year="2015">
+<Database Name="cv" Series="78717" Issue="477855" />
+</Book>
+<Book Series="Spider-Man &amp; the X-Men" Number="3" Volume="2014" Year="2015">
+<Database Name="cv" Series="78717" Issue="480681" />
+</Book>
+<Book Series="Spider-Man &amp; the X-Men" Number="4" Volume="2014" Year="2015">
+<Database Name="cv" Series="78717" Issue="482165" />
+</Book>
+<Book Series="Spider-Man &amp; the X-Men" Number="5" Volume="2014" Year="2015">
+<Database Name="cv" Series="78717" Issue="486153" />
+</Book>
+<Book Series="Spider-Man &amp; the X-Men" Number="6" Volume="2014" Year="2015">
+<Database Name="cv" Series="78717" Issue="487217" />
+</Book>
+<Book Series="Uncanny X-Men" Number="600" Volume="2013" Year="2016">
+<Database Name="cv" Series="57181" Issue="504952" />
+</Book>
+<Book Series="Death of X" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="94620" Issue="552158" />
+</Book>
+<Book Series="Death of X" Number="2" Volume="2016" Year="2016">
+<Database Name="cv" Series="94620" Issue="553955" />
+</Book>
+<Book Series="Death of X" Number="3" Volume="2016" Year="2017">
+<Database Name="cv" Series="94620" Issue="556471" />
+</Book>
+<Book Series="Death of X" Number="4" Volume="2016" Year="2017">
+<Database Name="cv" Series="94620" Issue="558962" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="1" Volume="2015" Year="2016">
+<Database Name="cv" Series="85756" Issue="504937" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="2" Volume="2015" Year="2016">
+<Database Name="cv" Series="85756" Issue="506168" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="3" Volume="2015" Year="2016">
+<Database Name="cv" Series="85756" Issue="507180" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="4" Volume="2015" Year="2016">
+<Database Name="cv" Series="85756" Issue="508890" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="5" Volume="2015" Year="2016">
+<Database Name="cv" Series="85756" Issue="510940" />
+</Book>
+<Book Series="All-New X-Men" Number="1" Volume="2015" Year="2016">
+<Database Name="cv" Series="86334" Issue="507175" />
+</Book>
+<Book Series="All-New X-Men" Number="2" Volume="2015" Year="2016">
+<Database Name="cv" Series="86334" Issue="508422" />
+</Book>
+<Book Series="All-New X-Men" Number="3" Volume="2015" Year="2016">
+<Database Name="cv" Series="86334" Issue="510935" />
+</Book>
+<Book Series="X-Men: Worst X-Man Ever" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="87194" Issue="510513" />
+</Book>
+<Book Series="X-Men: Worst X-Man Ever" Number="2" Volume="2016" Year="2016">
+<Database Name="cv" Series="87194" Issue="511087" />
+</Book>
+<Book Series="X-Men: Worst X-Man Ever" Number="3" Volume="2016" Year="2016">
+<Database Name="cv" Series="87194" Issue="511738" />
+</Book>
+<Book Series="X-Men: Worst X-Man Ever" Number="4" Volume="2016" Year="2016">
+<Database Name="cv" Series="87194" Issue="512645" />
+</Book>
+<Book Series="X-Men: Worst X-Man Ever" Number="5" Volume="2016" Year="2016">
+<Database Name="cv" Series="87194" Issue="513820" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="6" Volume="2015" Year="2016">
+<Database Name="cv" Series="85756" Issue="512423" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="7" Volume="2015" Year="2016">
+<Database Name="cv" Series="85756" Issue="516083" />
+</Book>
+<Book Series="Uncanny X-Men" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="87190" Issue="510510" />
+</Book>
+<Book Series="Uncanny X-Men" Number="2" Volume="2016" Year="2016">
+<Database Name="cv" Series="87190" Issue="511529" />
+</Book>
+<Book Series="Uncanny X-Men" Number="3" Volume="2016" Year="2016">
+<Database Name="cv" Series="87190" Issue="513660" />
+</Book>
+<Book Series="Uncanny X-Men" Number="4" Volume="2016" Year="2016">
+<Database Name="cv" Series="87190" Issue="517837" />
+</Book>
+<Book Series="Uncanny X-Men" Number="5" Volume="2016" Year="2016">
+<Database Name="cv" Series="87190" Issue="521347" />
+</Book>
+<Book Series="All-New X-Men" Number="4" Volume="2015" Year="2016">
+<Database Name="cv" Series="86334" Issue="514431" />
+</Book>
+<Book Series="All-New X-Men" Number="5" Volume="2015" Year="2016">
+<Database Name="cv" Series="86334" Issue="516946" />
+</Book>
+<Book Series="All-New X-Men" Number="6" Volume="2015" Year="2016">
+<Database Name="cv" Series="86334" Issue="520195" />
+</Book>
+<Book Series="All-New X-Men" Number="7" Volume="2015" Year="2016">
+<Database Name="cv" Series="86334" Issue="522423" />
+</Book>
+<Book Series="All-New X-Men" Number="8" Volume="2015" Year="2016">
+<Database Name="cv" Series="86334" Issue="525018" />
+</Book>
+<Book Series="X-Men &apos;92" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="89284" Issue="522437" />
+</Book>
+<Book Series="X-Men &apos;92" Number="2" Volume="2016" Year="2016">
+<Database Name="cv" Series="89284" Issue="525044" />
+</Book>
+<Book Series="X-Men &apos;92" Number="3" Volume="2016" Year="2016">
+<Database Name="cv" Series="89284" Issue="528526" />
+</Book>
+<Book Series="X-Men &apos;92" Number="4" Volume="2016" Year="2016">
+<Database Name="cv" Series="89284" Issue="533043" />
+</Book>
+<Book Series="X-Men &apos;92" Number="5" Volume="2016" Year="2016">
+<Database Name="cv" Series="89284" Issue="541229" />
+</Book>
+<Book Series="X-Men &apos;92" Number="6" Volume="2016" Year="2016">
+<Database Name="cv" Series="89284" Issue="547298" />
+</Book>
+<Book Series="X-Men &apos;92" Number="7" Volume="2016" Year="2016">
+<Database Name="cv" Series="89284" Issue="551327" />
+</Book>
+<Book Series="X-Men &apos;92" Number="8" Volume="2016" Year="2016">
+<Database Name="cv" Series="89284" Issue="553973" />
+</Book>
+<Book Series="X-Men &apos;92" Number="9" Volume="2016" Year="2017">
+<Database Name="cv" Series="89284" Issue="558980" />
+</Book>
+<Book Series="X-Men &apos;92" Number="10" Volume="2016" Year="2017">
+<Database Name="cv" Series="89284" Issue="571694" />
+</Book>
+<Book Series="Uncanny X-Men" Number="11" Volume="2016" Year="2016">
+<Database Name="cv" Series="87190" Issue="542634" />
+</Book>
+<Book Series="Uncanny X-Men" Number="12" Volume="2016" Year="2016">
+<Database Name="cv" Series="87190" Issue="548588" />
+</Book>
+<Book Series="Uncanny X-Men" Number="13" Volume="2016" Year="2016">
+<Database Name="cv" Series="87190" Issue="550370" />
+</Book>
+<Book Series="Uncanny X-Men" Number="14" Volume="2016" Year="2016">
+<Database Name="cv" Series="87190" Issue="552174" />
+</Book>
+<Book Series="Uncanny X-Men" Number="15" Volume="2016" Year="2017">
+<Database Name="cv" Series="87190" Issue="557381" />
+</Book>
+<Book Series="All-New X-Men Annual" Number="1" Volume="2016" Year="2017">
+<Database Name="cv" Series="95807" Issue="558952" />
+</Book>
+<Book Series="All-New X-Men" Number="12" Volume="2015" Year="2016">
+<Database Name="cv" Series="86334" Issue="543744" />
+</Book>
+<Book Series="All-New X-Men" Number="13" Volume="2015" Year="2016">
+<Database Name="cv" Series="86334" Issue="549510" />
+</Book>
+<Book Series="All-New X-Men" Number="14" Volume="2015" Year="2016">
+<Database Name="cv" Series="86334" Issue="553944" />
+</Book>
+<Book Series="All-New X-Men" Number="15" Volume="2015" Year="2017">
+<Database Name="cv" Series="86334" Issue="557353" />
+</Book>
+<Book Series="All-New X-Men" Number="16" Volume="2015" Year="2017">
+<Database Name="cv" Series="86334" Issue="566702" />
+</Book>
+<Book Series="Extraordinary X-Men Annual" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="94271" Issue="550357" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="13" Volume="2015" Year="2016">
+<Database Name="cv" Series="85756" Issue="546057" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="14" Volume="2015" Year="2016">
+<Database Name="cv" Series="85756" Issue="551305" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="15" Volume="2015" Year="2016">
+<Database Name="cv" Series="85756" Issue="555521" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="16" Volume="2015" Year="2017">
+<Database Name="cv" Series="85756" Issue="562593" />
+</Book>
+<Book Series="Civil War II: X-Men" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="91275" Issue="535351" />
+</Book>
+<Book Series="Civil War II: X-Men" Number="2" Volume="2016" Year="2016">
+<Database Name="cv" Series="91275" Issue="538504" />
+</Book>
+<Book Series="Civil War II: X-Men" Number="3" Volume="2016" Year="2016">
+<Database Name="cv" Series="91275" Issue="544984" />
+</Book>
+<Book Series="Civil War II: X-Men" Number="4" Volume="2016" Year="2016">
+<Database Name="cv" Series="91275" Issue="550353" />
+</Book>
+<Book Series="Uncanny X-Men Annual" Number="1" Volume="2016" Year="2017">
+<Database Name="cv" Series="95754" Issue="558428" />
+</Book>
+<Book Series="Uncanny X-Men" Number="19" Volume="2016" Year="2017">
+<Database Name="cv" Series="87190" Issue="587422" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="20" Volume="2015" Year="2017">
+<Database Name="cv" Series="85756" Issue="588563" />
+</Book>
+<Book Series="All-New X-Men" Number="19" Volume="2015" Year="2017">
+<Database Name="cv" Series="86334" Issue="589821" />
+</Book>
+<Book Series="X-Men Prime" Number="1" Volume="2017" Year="2017">
+<Database Name="cv" Series="100395" Issue="589842" />
+</Book>
+<Book Series="X-Men: Blue" Number="1" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="591772" />
+</Book>
+<Book Series="X-Men: Blue" Number="2" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="593277" />
+</Book>
+<Book Series="X-Men: Blue" Number="3" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="594979" />
+</Book>
+<Book Series="X-Men: Blue" Number="4" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="597208" />
+</Book>
+<Book Series="X-Men: Blue" Number="5" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="601813" />
+</Book>
+<Book Series="X-Men: Blue" Number="6" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="605139" />
+</Book>
+<Book Series="X-Men: Gold" Number="1" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="590811" />
+</Book>
+<Book Series="X-Men: Gold" Number="2" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="593278" />
+</Book>
+<Book Series="X-Men: Gold" Number="3" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="594129" />
+</Book>
+<Book Series="X-Men: Gold" Number="4" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="595708" />
+</Book>
+<Book Series="X-Men: Gold" Number="5" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="599881" />
+</Book>
+<Book Series="X-Men: Gold" Number="6" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="603149" />
+</Book>
+<Book Series="Generation X" Number="1" Volume="2017" Year="2017">
+<Database Name="cv" Series="101478" Issue="595688" />
+</Book>
+<Book Series="Generation X" Number="2" Volume="2017" Year="2017">
+<Database Name="cv" Series="101478" Issue="598374" />
+</Book>
+<Book Series="Generation X" Number="3" Volume="2017" Year="2017">
+<Database Name="cv" Series="101478" Issue="601793" />
+</Book>
+<Book Series="Generation X" Number="4" Volume="2017" Year="2017">
+<Database Name="cv" Series="101478" Issue="608245" />
+</Book>
+<Book Series="X-Men: Gold" Number="7" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="606647" />
+</Book>
+<Book Series="X-Men: Gold" Number="8" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="609368" />
+</Book>
+<Book Series="X-Men: Blue" Number="7" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="608266" />
+</Book>
+<Book Series="X-Men: Blue" Number="8" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="610543" />
+</Book>
+<Book Series="X-Men: Blue" Number="9" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="615039" />
+</Book>
+<Book Series="X-Men: Blue" Number="10" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="617858" />
+</Book>
+<Book Series="X-Men: Blue" Number="11" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="621686" />
+</Book>
+<Book Series="X-Men: Blue" Number="12" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="625333" />
+</Book>
+<Book Series="X-Men: Gold" Number="9" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="612056" />
+</Book>
+<Book Series="X-Men: Gold" Number="10" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="616206" />
+</Book>
+<Book Series="X-Men: Gold" Number="11" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="619646" />
+</Book>
+<Book Series="X-Men: Gold" Number="12" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="622961" />
+</Book>
+<Book Series="Astonishing X-Men" Number="1" Volume="2017" Year="2017">
+<Database Name="cv" Series="102882" Issue="609338" />
+</Book>
+<Book Series="Astonishing X-Men" Number="2" Volume="2017" Year="2017">
+<Database Name="cv" Series="102882" Issue="615015" />
+</Book>
+<Book Series="Astonishing X-Men" Number="3" Volume="2017" Year="2017">
+<Database Name="cv" Series="102882" Issue="619616" />
+</Book>
+<Book Series="Astonishing X-Men" Number="4" Volume="2017" Year="2017">
+<Database Name="cv" Series="102882" Issue="626275" />
+</Book>
+<Book Series="Astonishing X-Men" Number="5" Volume="2017" Year="2018">
+<Database Name="cv" Series="102882" Issue="634524" />
+</Book>
+<Book Series="Astonishing X-Men" Number="6" Volume="2017" Year="2018">
+<Database Name="cv" Series="102882" Issue="644496" />
+</Book>
+<Book Series="Generation X" Number="5" Volume="2017" Year="2017">
+<Database Name="cv" Series="101478" Issue="615020" />
+</Book>
+<Book Series="Generation X" Number="6" Volume="2017" Year="2017">
+<Database Name="cv" Series="101478" Issue="619622" />
+</Book>
+<Book Series="Generation X" Number="7" Volume="2017" Year="2017">
+<Database Name="cv" Series="101478" Issue="630521" />
+</Book>
+<Book Series="Generation X" Number="8" Volume="2017" Year="2018">
+<Database Name="cv" Series="101478" Issue="636373" />
+</Book>
+<Book Series="Generation X" Number="9" Volume="2017" Year="2018">
+<Database Name="cv" Series="101478" Issue="641404" />
+</Book>
+<Book Series="X-Men: Gold" Number="13" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="626306" />
+</Book>
+<Book Series="X-Men: Blue" Number="13" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="628601" />
+</Book>
+<Book Series="X-Men: Gold" Number="14" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="630540" />
+</Book>
+<Book Series="X-Men: Blue" Number="14" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="632512" />
+</Book>
+<Book Series="X-Men: Gold" Number="15" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="636392" />
+</Book>
+<Book Series="X-Men: Blue" Number="15" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="638615" />
+</Book>
+<Book Series="X-Men: Gold" Number="16" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="641422" />
+</Book>
+<Book Series="X-Men: Gold" Number="17" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="644521" />
+</Book>
+<Book Series="X-Men: Gold" Number="18" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="647963" />
+</Book>
+<Book Series="X-Men: Gold" Number="19" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="650929" />
+</Book>
+<Book Series="X-Men: Gold" Number="20" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="654065" />
+</Book>
+<Book Series="X-Men: Blue" Number="16" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="643049" />
+</Book>
+<Book Series="X-Men: Blue" Number="17" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="646207" />
+</Book>
+<Book Series="X-Men: Blue" Number="18" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="649753" />
+</Book>
+<Book Series="X-Men: Blue" Number="19" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="652646" />
+</Book>
+<Book Series="X-Men: Blue" Number="20" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="655516" />
+</Book>
+<Book Series="Generation X" Number="85" Volume="2017" Year="2018">
+<Database Name="cv" Series="101478" Issue="647941" />
+</Book>
+<Book Series="Generation X" Number="86" Volume="2017" Year="2018">
+<Database Name="cv" Series="101478" Issue="654054" />
+</Book>
+<Book Series="Generation X" Number="87" Volume="2017" Year="2018">
+<Database Name="cv" Series="101478" Issue="660662" />
+</Book>
+<Book Series="X-Men: Gold" Number="21" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="658737" />
+</Book>
+<Book Series="X-Men: Gold" Number="22" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="660674" />
+</Book>
+<Book Series="X-Men: Gold Annual" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="107672" Issue="652647" />
+</Book>
+<Book Series="X-Men Blue Annual" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="108127" Issue="655517" />
+</Book>
+<Book Series="X-Men: Blue" Number="21" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="660028" />
+</Book>
+<Book Series="Venom" Number="162" Volume="2016" Year="2018">
+<Database Name="cv" Series="95845" Issue="660673" />
+</Book>
+<Book Series="X-Men: Blue" Number="22" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="661168" />
+</Book>
+<Book Series="Venom" Number="163" Volume="2016" Year="2018">
+<Database Name="cv" Series="95845" Issue="662102" />
+</Book>
+<Book Series="X-Men: Gold" Number="23" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="662103" />
+</Book>
+<Book Series="X-Men: Gold" Number="24" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="663595" />
+</Book>
+<Book Series="X-Men: Gold" Number="25" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="664931" />
+</Book>
+<Book Series="X-Men: Blue" Number="23" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="662757" />
+</Book>
+<Book Series="X-Men: Blue" Number="24" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="664317" />
+</Book>
+<Book Series="X-Men: Blue" Number="25" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="665929" />
+</Book>
+<Book Series="X-Men: Blue" Number="26" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="667666" />
+</Book>
+<Book Series="X-Men: Blue" Number="27" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="669466" />
+</Book>
+<Book Series="X-Men: Blue" Number="28" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="671344" />
+</Book>
+<Book Series="Astonishing X-Men" Number="7" Volume="2017" Year="2018">
+<Database Name="cv" Series="102882" Issue="650910" />
+</Book>
+<Book Series="Astonishing X-Men" Number="8" Volume="2017" Year="2018">
+<Database Name="cv" Series="102882" Issue="660652" />
+</Book>
+<Book Series="Astonishing X-Men" Number="9" Volume="2017" Year="2018">
+<Database Name="cv" Series="102882" Issue="662736" />
+</Book>
+<Book Series="Astonishing X-Men" Number="10" Volume="2017" Year="2018">
+<Database Name="cv" Series="102882" Issue="664906" />
+</Book>
+<Book Series="Astonishing X-Men" Number="11" Volume="2017" Year="2018">
+<Database Name="cv" Series="102882" Issue="668769" />
+</Book>
+<Book Series="Astonishing X-Men" Number="12" Volume="2017" Year="2018">
+<Database Name="cv" Series="102882" Issue="672275" />
+</Book>
+<Book Series="X-Men: Red" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="108548" Issue="658738" />
+</Book>
+<Book Series="X-Men: Red" Number="2" Volume="2018" Year="2018">
+<Database Name="cv" Series="108548" Issue="662104" />
+</Book>
+<Book Series="X-Men: Red" Number="3" Volume="2018" Year="2018">
+<Database Name="cv" Series="108548" Issue="665930" />
+</Book>
+<Book Series="X-Men: Red" Number="4" Volume="2018" Year="2018">
+<Database Name="cv" Series="108548" Issue="670128" />
+</Book>
+<Book Series="X-Men: Red" Number="5" Volume="2018" Year="2018">
+<Database Name="cv" Series="108548" Issue="672297" />
+</Book>
+<Book Series="X-Men: The Wedding Special" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="110945" Issue="670129" />
+</Book>
+<Book Series="X-Men: Gold" Number="26" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="666820" />
+</Book>
+<Book Series="X-Men: Gold" Number="27" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="668791" />
+</Book>
+<Book Series="X-Men: Gold" Number="28" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="670766" />
+</Book>
+<Book Series="X-Men: Gold" Number="29" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="672296" />
+</Book>
+<Book Series="X-Men: Gold" Number="30" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="674147" />
+</Book>
+<Book Series="X-Men: Gold" Number="31" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="675995" />
+</Book>
+<Book Series="X-Men: Gold" Number="32" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="677305" />
+</Book>
+<Book Series="X-Men: Red" Number="6" Volume="2018" Year="2018">
+<Database Name="cv" Series="108548" Issue="677306" />
+</Book>
+<Book Series="X-Men: Red" Number="7" Volume="2018" Year="2018">
+<Database Name="cv" Series="108548" Issue="680744" />
+</Book>
+<Book Series="X-Men: Red" Number="8" Volume="2018" Year="2018">
+<Database Name="cv" Series="108548" Issue="686403" />
+</Book>
+<Book Series="X-Men: Red" Number="9" Volume="2018" Year="2018">
+<Database Name="cv" Series="108548" Issue="689884" />
+</Book>
+<Book Series="X-Men: Red" Number="10" Volume="2018" Year="2019">
+<Database Name="cv" Series="108548" Issue="691400" />
+</Book>
+<Book Series="X-Men: Red" Number="11" Volume="2018" Year="2019">
+<Database Name="cv" Series="108548" Issue="694937" />
+</Book>
+<Book Series="X-Men: Gold" Number="33" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="678545" />
+</Book>
+<Book Series="X-Men: Gold" Number="34" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="680743" />
+</Book>
+<Book Series="X-Men: Gold" Number="35" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="683845" />
+</Book>
+<Book Series="X-Men: Gold" Number="36" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="685869" />
+</Book>
+<Book Series="X-Men: Blue" Number="29" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="673041" />
+</Book>
+<Book Series="X-Men: Blue" Number="30" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="675161" />
+</Book>
+<Book Series="X-Men: Blue" Number="31" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="676718" />
+</Book>
+<Book Series="X-Men: Blue" Number="32" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="677987" />
+</Book>
+<Book Series="X-Men: Blue" Number="33" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="679423" />
+</Book>
+<Book Series="X-Men: Blue" Number="34" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="682670" />
+</Book>
+<Book Series="X-Men: Blue" Number="35" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="684931" />
+</Book>
+<Book Series="X-Men: Blue" Number="36" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="686402" />
+</Book>
+<Book Series="Extermination" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="112807" Issue="679992" />
+</Book>
+<Book Series="Extermination" Number="2" Volume="2018" Year="2018">
+<Database Name="cv" Series="112807" Issue="682654" />
+</Book>
+<Book Series="Extermination" Number="3" Volume="2018" Year="2018">
+<Database Name="cv" Series="112807" Issue="686380" />
+</Book>
+<Book Series="Extermination" Number="4" Volume="2018" Year="2018">
+<Database Name="cv" Series="112807" Issue="690809" />
+</Book>
+<Book Series="Extermination" Number="5" Volume="2018" Year="2019">
+<Database Name="cv" Series="112807" Issue="695634" />
+</Book>
+<Book Series="X-Men: The Exterminated" Number="1" Volume="2018" Year="2019">
+<Database Name="cv" Series="115775" Issue="694156" />
+</Book>
+<Book Series="Astonishing X-Men" Number="13" Volume="2017" Year="2018">
+<Database Name="cv" Series="102882" Issue="675968" />
+</Book>
+<Book Series="Astonishing X-Men" Number="14" Volume="2017" Year="2018">
+<Database Name="cv" Series="102882" Issue="678524" />
+</Book>
+<Book Series="Astonishing X-Men" Number="15" Volume="2017" Year="2018">
+<Database Name="cv" Series="102882" Issue="683819" />
+</Book>
+<Book Series="Astonishing X-Men" Number="16" Volume="2017" Year="2018">
+<Database Name="cv" Series="102882" Issue="689038" />
+</Book>
+<Book Series="Astonishing X-Men" Number="17" Volume="2017" Year="2019">
+<Database Name="cv" Series="102882" Issue="692540" />
+</Book>
+<Book Series="Exiles" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="109764" Issue="665914" />
+</Book>
+<Book Series="Exiles" Number="2" Volume="2018" Year="2018">
+<Database Name="cv" Series="109764" Issue="667640" />
+</Book>
+<Book Series="Exiles" Number="3" Volume="2018" Year="2018">
+<Database Name="cv" Series="109764" Issue="669449" />
+</Book>
+<Book Series="Exiles" Number="4" Volume="2018" Year="2018">
+<Database Name="cv" Series="109764" Issue="673018" />
+</Book>
+<Book Series="Exiles" Number="5" Volume="2018" Year="2018">
+<Database Name="cv" Series="109764" Issue="676699" />
+</Book>
+<Book Series="Exiles" Number="6" Volume="2018" Year="2018">
+<Database Name="cv" Series="109764" Issue="679411" />
+</Book>
+<Book Series="Exiles" Number="7" Volume="2018" Year="2018">
+<Database Name="cv" Series="109764" Issue="682653" />
+</Book>
+<Book Series="Exiles" Number="8" Volume="2018" Year="2018">
+<Database Name="cv" Series="109764" Issue="684904" />
+</Book>
+<Book Series="Exiles" Number="9" Volume="2018" Year="2018">
+<Database Name="cv" Series="109764" Issue="688315" />
+</Book>
+<Book Series="Exiles" Number="10" Volume="2018" Year="2019">
+<Database Name="cv" Series="109764" Issue="692067" />
+</Book>
+<Book Series="Exiles" Number="11" Volume="2018" Year="2019">
+<Database Name="cv" Series="109764" Issue="695633" />
+</Book>
+<Book Series="Exiles" Number="12" Volume="2018" Year="2019">
+<Database Name="cv" Series="109764" Issue="699398" />
+</Book>
+<Book Series="Merry X-Men Holiday Special" Number="1" Volume="2018" Year="2019">
+<Database Name="cv" Series="115752" Issue="694139" />
+</Book>
+<Book Series="X-Men: Black - Magneto" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="114104" Issue="687031" />
+</Book>
+<Book Series="X-Men: Black - Mojo" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="114278" Issue="688333" />
+</Book>
+<Book Series="X-Men: Black - Mystique" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="114428" Issue="689064" />
+</Book>
+<Book Series="X-Men: Black - Juggernaut" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="114744" Issue="689883" />
+</Book>
+<Book Series="X-Men: Black - Emma Frost" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="114923" Issue="690825" />
+</Book>
+<Book Series="Uncanny X-Men: Winter&apos;s End" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="117610" Issue="703069" />
+</Book>
+<Book Series="Uncanny X-Men" Number="1" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="692088" />
+</Book>
+<Book Series="Uncanny X-Men" Number="2" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="692562" />
+</Book>
+<Book Series="Uncanny X-Men" Number="3" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="693475" />
+</Book>
+<Book Series="Uncanny X-Men" Number="4" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="694151" />
+</Book>
+<Book Series="Uncanny X-Men" Number="5" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="694932" />
+</Book>
+<Book Series="Uncanny X-Men" Number="6" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="695668" />
+</Book>
+<Book Series="Uncanny X-Men" Number="7" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="695923" />
+</Book>
+<Book Series="Uncanny X-Men" Number="8" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="696371" />
+</Book>
+<Book Series="Uncanny X-Men" Number="9" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="696961" />
+</Book>
+<Book Series="Uncanny X-Men" Number="10" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="697647" />
+</Book>
+<Book Series="Uncanny X-Men Annual" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="116708" Issue="698618" />
+</Book>
+<Book Series="Uncanny X-Men" Number="11" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="700153" />
+</Book>
+<Book Series="Uncanny X-Men" Number="12" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="701327" />
+</Book>
+<Book Series="Uncanny X-Men" Number="13" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="702477" />
+</Book>
+<Book Series="Uncanny X-Men" Number="14" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="703956" />
+</Book>
+<Book Series="Uncanny X-Men" Number="15" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="705488" />
+</Book>
+<Book Series="War of the Realms: Uncanny X-Men" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="118545" Issue="706976" />
+</Book>
+<Book Series="War of the Realms: Uncanny X-Men" Number="2" Volume="2019" Year="2019">
+<Database Name="cv" Series="118545" Issue="709739" />
+</Book>
+<Book Series="War of the Realms: Uncanny X-Men" Number="3" Volume="2019" Year="2019">
+<Database Name="cv" Series="118545" Issue="712560" />
+</Book>
+<Book Series="Uncanny X-Men" Number="16" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="706426" />
+</Book>
+<Book Series="Uncanny X-Men" Number="17" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="707533" />
+</Book>
+<Book Series="Uncanny X-Men" Number="18" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="709217" />
+</Book>
+<Book Series="Uncanny X-Men" Number="19" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="710699" />
+</Book>
+<Book Series="Uncanny X-Men" Number="20" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="711963" />
+</Book>
+<Book Series="Uncanny X-Men" Number="21" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="713087" />
+</Book>
+<Book Series="Uncanny X-Men" Number="22" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="713870" />
+</Book>
+<Book Series="X-Men &apos;97" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="157399" Issue="1049287" />
+</Book>
+<Book Series="X-Men &apos;97" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="157399" Issue="1051134" />
+</Book>
+<Book Series="X-Men &apos;97" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="157399" Issue="1056219" />
+</Book>
+<Book Series="X-Men &apos;97" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="157399" Issue="1060867" />
+</Book>
+<Book Series="X-Men: The Wedding Special" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="158299" Issue="1057019" />
+</Book>
+<Book Series="Free Comic Book Day 2024: Blood Hunt/X-Men" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="158042" Issue="1054292" />
+</Book>
+<Book Series="X-Men: Blood Hunt - Psylocke" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="158700" Issue="1061882" />
+</Book>
+<Book Series="X-Men: Blood Hunt - Jubilee" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="158460" Issue="1059274" />
+</Book>
+<Book Series="X-Men: Blood Hunt - Laura Kinney the Wolverine" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="158869" Issue="1063238" />
+</Book>
+<Book Series="X-Men: Blood Hunt - Magik" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="158599" Issue="1060868" />
+</Book>
+<Book Series="Weapon X-Men" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="157128" Issue="1047094" />
+</Book>
+<Book Series="Weapon X-Men" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="157128" Issue="1051132" />
+</Book>
+<Book Series="Weapon X-Men" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="157128" Issue="1053546" />
+</Book>
+<Book Series="Weapon X-Men" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="157128" Issue="1055034" />
+</Book>
+<Book Series="X-Men: Xavier&apos;s Secret" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="162064" Issue="1091221" />
+</Book>
+<Book Series="X-Men" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="158814" Issue="1062857" />
+</Book>
+<Book Series="X-Men" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="158814" Issue="1066713" />
+</Book>
+<Book Series="Uncanny X-Men" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="159189" Issue="1066308" />
+</Book>
+<Book Series="Uncanny X-Men" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="159189" Issue="1069421" />
+</Book>
+<Book Series="X-Men" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="158814" Issue="1067992" />
+</Book>
+<Book Series="Exceptional X-Men" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="159604" Issue="1068649" />
+</Book>
+<Book Series="X-Men" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="158814" Issue="1070144" />
+</Book>
+<Book Series="X-Men" Number="5" Volume="2024" Year="2024">
+<Database Name="cv" Series="158814" Issue="1072226" />
+</Book>
+<Book Series="X-Men" Number="6" Volume="2024" Year="2024">
+<Database Name="cv" Series="158814" Issue="1074687" />
+</Book>
+<Book Series="X-Men" Number="7" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1076643" />
+</Book>
+<Book Series="Uncanny X-Men" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="159189" Issue="1071609" />
+</Book>
+<Book Series="Uncanny X-Men" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="159189" Issue="1073893" />
+</Book>
+<Book Series="Uncanny X-Men" Number="5" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1077648" />
+</Book>
+<Book Series="Uncanny X-Men" Number="6" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1079283" />
+</Book>
+<Book Series="X-Men" Number="8" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1080305" />
+</Book>
+<Book Series="Uncanny X-Men" Number="7" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1081560" />
+</Book>
+<Book Series="X-Men" Number="9" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1086231" />
+</Book>
+<Book Series="Uncanny X-Men" Number="8" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1089482" />
+</Book>
+<Book Series="X-Men" Number="10" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1093030" />
+</Book>
+<Book Series="Exceptional X-Men" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="159604" Issue="1073267" />
+</Book>
+<Book Series="Exceptional X-Men" Number="3" Volume="2024" Year="2025">
+<Database Name="cv" Series="159604" Issue="1078493" />
+</Book>
+<Book Series="Exceptional X-Men" Number="4" Volume="2024" Year="2025">
+<Database Name="cv" Series="159604" Issue="1086201" />
+</Book>
+<Book Series="Exceptional X-Men" Number="5" Volume="2024" Year="2025">
+<Database Name="cv" Series="159604" Issue="1090268" />
+</Book>
+<Book Series="X-Men: Demons and Death" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="165183" Issue="1116931" />
+</Book>
+<Book Series="X-Men: Tooth and Claw" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="166463" Issue="1128977" />
+</Book>
+<Book Series="X-Men: The Undertow" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="167336" Issue="1136145" />
+</Book>
+<Book Series="Uncanny X-Men" Number="9" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1091217" />
+</Book>
+<Book Series="Uncanny X-Men" Number="10" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1096477" />
+</Book>
+<Book Series="Weapon X-Men" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="162486" Issue="1096472" />
+</Book>
+<Book Series="Weapon X-Men" Number="2" Volume="2025" Year="2025">
+<Database Name="cv" Series="162486" Issue="1100296" />
+</Book>
+<Book Series="Weapon X-Men" Number="3" Volume="2025" Year="2025">
+<Database Name="cv" Series="162486" Issue="1107196" />
+</Book>
+<Book Series="Weapon X-Men" Number="4" Volume="2025" Year="2025">
+<Database Name="cv" Series="162486" Issue="1111728" />
+</Book>
+<Book Series="Exceptional X-Men" Number="6" Volume="2024" Year="2025">
+<Database Name="cv" Series="159604" Issue="1096437" />
+</Book>
+<Book Series="X-Men" Number="11" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1095610" />
+</Book>
+<Book Series="X-Men" Number="12" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1097018" />
+</Book>
+<Book Series="Uncanny X-Men" Number="11" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1097716" />
+</Book>
+<Book Series="NYX" Number="9" Volume="2024" Year="2025">
+<Database Name="cv" Series="159012" Issue="1097725" />
+</Book>
+<Book Series="Storm" Number="6" Volume="2024" Year="2025">
+<Database Name="cv" Series="160203" Issue="1097718" />
+</Book>
+<Book Series="X-Men" Number="13" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1098352" />
+</Book>
+<Book Series="X-Factor" Number="8" Volume="2024" Year="2025">
+<Database Name="cv" Series="159244" Issue="1098351" />
+</Book>
+<Book Series="Exceptional X-Men" Number="7" Volume="2024" Year="2025">
+<Database Name="cv" Series="159604" Issue="1099489" />
+</Book>
+<Book Series="X-Force" Number="9" Volume="2024" Year="2025">
+<Database Name="cv" Series="159110" Issue="1099550" />
+</Book>
+<Book Series="X-Manhunt Omega" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="163011" Issue="1100298" />
+</Book>
+<Book Series="Exceptional X-Men" Number="8" Volume="2024" Year="2025">
+<Database Name="cv" Series="159604" Issue="1104102" />
+</Book>
+<Book Series="Exceptional X-Men" Number="9" Volume="2024" Year="2025">
+<Database Name="cv" Series="159604" Issue="1111717" />
+</Book>
+<Book Series="Exceptional X-Men" Number="10" Volume="2024" Year="2025">
+<Database Name="cv" Series="159604" Issue="1115799" />
+</Book>
+<Book Series="Uncanny X-Men" Number="12" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1100295" />
+</Book>
+<Book Series="Uncanny X-Men" Number="13" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1102469" />
+</Book>
+<Book Series="Uncanny X-Men" Number="14" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1109664" />
+</Book>
+<Book Series="Uncanny X-Men" Number="15" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1112969" />
+</Book>
+<Book Series="Uncanny X-Men" Number="16" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1116826" />
+</Book>
+<Book Series="Free Comic Book Day 2025: Fantastic Four/Giant-Size X-Men" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="164375" Issue="1110584" />
+</Book>
+<Book Series="Giant-Size X-Men" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="164643" Issue="1112955" />
+</Book>
+<Book Series="Giant-Size Dark Phoenix Saga" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="165019" Issue="1115808" />
+</Book>
+<Book Series="Giant-Size Age of Apocalypse" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="165159" Issue="1116812" />
+</Book>
+<Book Series="Giant-Size House of M" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="165534" Issue="1120404" />
+</Book>
+<Book Series="Giant-Size X-Men" Number="2" Volume="2025" Year="2025">
+<Database Name="cv" Series="164643" Issue="1125789" />
+</Book>
+<Book Series="X-Men" Number="14" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1101451" />
+</Book>
+<Book Series="X-Men" Number="15" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1106071" />
+</Book>
+<Book Series="X-Men" Number="16" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1108868" />
+</Book>
+<Book Series="X-Men" Number="17" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1114025" />
+</Book>
+<Book Series="X-Men" Number="18" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1116316" />
+</Book>
+<Book Series="Godzilla vs. X-Men" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="164322" Issue="1109650" />
+</Book>
+<Book Series="Exceptional X-Men" Number="11" Volume="2024" Year="2025">
+<Database Name="cv" Series="159604" Issue="1120403" />
+</Book>
+<Book Series="Exceptional X-Men" Number="12" Volume="2024" Year="2025">
+<Database Name="cv" Series="159604" Issue="1127201" />
+</Book>
+<Book Series="Exceptional X-Men" Number="13" Volume="2024" Year="2025">
+<Database Name="cv" Series="159604" Issue="1131765" />
+</Book>
+<Book Series="X-Men" Number="19" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1117444" />
+</Book>
+<Book Series="Uncanny X-Men" Number="17" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1119106" />
+</Book>
+<Book Series="Uncanny X-Men" Number="18" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1121733" />
+</Book>
+<Book Series="Uncanny X-Men" Number="19" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1124679" />
+</Book>
+<Book Series="Uncanny X-Men" Number="20" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1130279" />
+</Book>
+<Book Series="Uncanny X-Men" Number="21" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1133853" />
+</Book>
+<Book Series="X-Men: Hellfire Vigil" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="165235" Issue="1117445" />
+</Book>
+<Book Series="X-Men" Number="20" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1125801" />
+</Book>
+<Book Series="X-Men" Number="21" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1128976" />
+</Book>
+<Book Series="X-Men" Number="22" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1134954" />
+</Book>
+</Books>
+<Matchers />
+</ReadingList>

--- a/Marvel/Teams/X-Men/WEB-CBRO/[Marvel] X-Men with events (WEB-CBRO).cbl
+++ b/Marvel/Teams/X-Men/WEB-CBRO/[Marvel] X-Men with events (WEB-CBRO).cbl
@@ -1,0 +1,7433 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Name>[Marvel] X-Men with events (WEB-CBRO)</Name>
+<NumIssues>2475</NumIssues>
+<Books>
+<Book Series="The X-Men" Number="1" Volume="1963" Year="1963">
+<Database Name="cv" Series="2133" Issue="6694" />
+</Book>
+<Book Series="The X-Men" Number="3" Volume="1963" Year="1964">
+<Database Name="cv" Series="2133" Issue="6946" />
+</Book>
+<Book Series="The X-Men" Number="4" Volume="1963" Year="1964">
+<Database Name="cv" Series="2133" Issue="7032" />
+</Book>
+<Book Series="X-Men: Season One" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="46608" Issue="321744" />
+</Book>
+<Book Series="The X-Men" Number="10" Volume="1963" Year="1965">
+<Database Name="cv" Series="2133" Issue="7674" />
+</Book>
+<Book Series="The X-Men" Number="12" Volume="1963" Year="1965">
+<Database Name="cv" Series="2133" Issue="7900" />
+</Book>
+<Book Series="The X-Men" Number="13" Volume="1963" Year="1965">
+<Database Name="cv" Series="2133" Issue="8037" />
+</Book>
+<Book Series="The X-Men" Number="14" Volume="1963" Year="1965">
+<Database Name="cv" Series="2133" Issue="8170" />
+</Book>
+<Book Series="The X-Men" Number="15" Volume="1963" Year="1965">
+<Database Name="cv" Series="2133" Issue="8238" />
+</Book>
+<Book Series="The X-Men" Number="16" Volume="1963" Year="1966">
+<Database Name="cv" Series="2133" Issue="8315" />
+</Book>
+<Book Series="X-Men: First Class" Number="1" Volume="2006" Year="2006">
+<Database Name="cv" Series="18550" Issue="109251" />
+</Book>
+<Book Series="X-Men: First Class" Number="2" Volume="2006" Year="2006">
+<Database Name="cv" Series="18550" Issue="109284" />
+</Book>
+<Book Series="X-Men: First Class" Number="3" Volume="2006" Year="2007">
+<Database Name="cv" Series="18550" Issue="109285" />
+</Book>
+<Book Series="X-Men: First Class" Number="4" Volume="2006" Year="2007">
+<Database Name="cv" Series="18550" Issue="109286" />
+</Book>
+<Book Series="X-Men: First Class" Number="5" Volume="2006" Year="2007">
+<Database Name="cv" Series="18550" Issue="109287" />
+</Book>
+<Book Series="X-Men: First Class" Number="6" Volume="2006" Year="2007">
+<Database Name="cv" Series="18550" Issue="109214" />
+</Book>
+<Book Series="X-Men: First Class" Number="7" Volume="2006" Year="2007">
+<Database Name="cv" Series="18550" Issue="109288" />
+</Book>
+<Book Series="X-Men: First Class" Number="8" Volume="2006" Year="2007">
+<Database Name="cv" Series="18550" Issue="109290" />
+</Book>
+<Book Series="X-Men First Class Special" Number="1" Volume="2007" Year="2007">
+<Database Name="cv" Series="18585" Issue="109606" />
+</Book>
+<Book Series="X-Men: First Class" Number="1" Volume="2007" Year="2007">
+<Database Name="cv" Series="18941" Issue="121890" />
+</Book>
+<Book Series="X-Men: First Class" Number="2" Volume="2007" Year="2007">
+<Database Name="cv" Series="18941" Issue="112057" />
+</Book>
+<Book Series="X-Men: First Class" Number="3" Volume="2007" Year="2007">
+<Database Name="cv" Series="18941" Issue="113837" />
+</Book>
+<Book Series="X-Men: First Class" Number="4" Volume="2007" Year="2007">
+<Database Name="cv" Series="18941" Issue="115033" />
+</Book>
+<Book Series="X-Men: First Class" Number="5" Volume="2007" Year="2007">
+<Database Name="cv" Series="18941" Issue="121891" />
+</Book>
+<Book Series="X-Men: First Class" Number="6" Volume="2007" Year="2008">
+<Database Name="cv" Series="18941" Issue="118647" />
+</Book>
+<Book Series="X-Men: First Class" Number="7" Volume="2007" Year="2008">
+<Database Name="cv" Series="18941" Issue="121859" />
+</Book>
+<Book Series="X-Men: First Class" Number="8" Volume="2007" Year="2008">
+<Database Name="cv" Series="18941" Issue="126173" />
+</Book>
+<Book Series="X-Men: First Class" Number="9" Volume="2007" Year="2008">
+<Database Name="cv" Series="18941" Issue="126174" />
+</Book>
+<Book Series="X-Men: First Class" Number="10" Volume="2007" Year="2008">
+<Database Name="cv" Series="18941" Issue="126209" />
+</Book>
+<Book Series="X-Men: First Class" Number="11" Volume="2007" Year="2008">
+<Database Name="cv" Series="18941" Issue="129089" />
+</Book>
+<Book Series="X-Men: First Class" Number="12" Volume="2007" Year="2008">
+<Database Name="cv" Series="18941" Issue="131240" />
+</Book>
+<Book Series="X-Men: First Class" Number="13" Volume="2007" Year="2008">
+<Database Name="cv" Series="18941" Issue="132041" />
+</Book>
+<Book Series="X-Men: First Class" Number="14" Volume="2007" Year="2008">
+<Database Name="cv" Series="18941" Issue="134993" />
+</Book>
+<Book Series="X-Men: First Class" Number="15" Volume="2007" Year="2008">
+<Database Name="cv" Series="18941" Issue="138036" />
+</Book>
+<Book Series="X-Men: First Class" Number="16" Volume="2007" Year="2008">
+<Database Name="cv" Series="18941" Issue="138995" />
+</Book>
+<Book Series="X-Men: First Class Giant-Sized Special" Number="1" Volume="2008" Year="2008">
+<Database Name="cv" Series="23733" Issue="142059" />
+</Book>
+<Book Series="The X-Men" Number="28" Volume="1963" Year="1967">
+<Database Name="cv" Series="2133" Issue="9098" />
+</Book>
+<Book Series="The X-Men" Number="29" Volume="1963" Year="1967">
+<Database Name="cv" Series="2133" Issue="9162" />
+</Book>
+<Book Series="The X-Men" Number="32" Volume="1963" Year="1967">
+<Database Name="cv" Series="2133" Issue="9364" />
+</Book>
+<Book Series="The X-Men" Number="33" Volume="1963" Year="1967">
+<Database Name="cv" Series="2133" Issue="9434" />
+</Book>
+<Book Series="The X-Men" Number="41" Volume="1963" Year="1968">
+<Database Name="cv" Series="2133" Issue="9945" />
+</Book>
+<Book Series="The X-Men" Number="42" Volume="1963" Year="1968">
+<Database Name="cv" Series="2133" Issue="105594" />
+</Book>
+<Book Series="The X-Men" Number="43" Volume="1963" Year="1968">
+<Database Name="cv" Series="2133" Issue="114499" />
+</Book>
+<Book Series="The X-Men" Number="46" Volume="1963" Year="1968">
+<Database Name="cv" Series="2133" Issue="123671" />
+</Book>
+<Book Series="The X-Men" Number="49" Volume="1963" Year="1968">
+<Database Name="cv" Series="2133" Issue="123674" />
+</Book>
+<Book Series="The X-Men" Number="50" Volume="1963" Year="1968">
+<Database Name="cv" Series="2133" Issue="114340" />
+</Book>
+<Book Series="Emma Frost" Number="1" Volume="2003" Year="2003">
+<Database Name="cv" Series="18014" Issue="105439" />
+</Book>
+<Book Series="Emma Frost" Number="2" Volume="2003" Year="2003">
+<Database Name="cv" Series="18014" Issue="107660" />
+</Book>
+<Book Series="Emma Frost" Number="3" Volume="2003" Year="2003">
+<Database Name="cv" Series="18014" Issue="107661" />
+</Book>
+<Book Series="Emma Frost" Number="4" Volume="2003" Year="2003">
+<Database Name="cv" Series="18014" Issue="107662" />
+</Book>
+<Book Series="Emma Frost" Number="5" Volume="2003" Year="2004">
+<Database Name="cv" Series="18014" Issue="107663" />
+</Book>
+<Book Series="Emma Frost" Number="6" Volume="2003" Year="2004">
+<Database Name="cv" Series="18014" Issue="107664" />
+</Book>
+<Book Series="The X-Men" Number="54" Volume="1963" Year="1969">
+<Database Name="cv" Series="2133" Issue="10107" />
+</Book>
+<Book Series="The X-Men" Number="55" Volume="1963" Year="1969">
+<Database Name="cv" Series="2133" Issue="10163" />
+</Book>
+<Book Series="The X-Men" Number="56" Volume="1963" Year="1969">
+<Database Name="cv" Series="2133" Issue="10215" />
+</Book>
+<Book Series="The X-Men" Number="57" Volume="1963" Year="1969">
+<Database Name="cv" Series="2133" Issue="10270" />
+</Book>
+<Book Series="The X-Men" Number="58" Volume="1963" Year="1969">
+<Database Name="cv" Series="2133" Issue="10317" />
+</Book>
+<Book Series="The X-Men" Number="60" Volume="1963" Year="1969">
+<Database Name="cv" Series="2133" Issue="10417" />
+</Book>
+<Book Series="The X-Men" Number="61" Volume="1963" Year="1969">
+<Database Name="cv" Series="2133" Issue="10475" />
+</Book>
+<Book Series="The X-Men" Number="62" Volume="1963" Year="1969">
+<Database Name="cv" Series="2133" Issue="10526" />
+</Book>
+<Book Series="The X-Men" Number="63" Volume="1963" Year="1969">
+<Database Name="cv" Series="2133" Issue="10580" />
+</Book>
+<Book Series="The X-Men" Number="64" Volume="1963" Year="1970">
+<Database Name="cv" Series="2133" Issue="10635" />
+</Book>
+<Book Series="The X-Men" Number="65" Volume="1963" Year="1970">
+<Database Name="cv" Series="2133" Issue="10676" />
+</Book>
+<Book Series="The X-Men" Number="66" Volume="1963" Year="1970">
+<Database Name="cv" Series="2133" Issue="10724" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="1" Volume="1999" Year="1999">
+<Database Name="cv" Series="9202" Issue="124309" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="2" Volume="1999" Year="2000">
+<Database Name="cv" Series="9202" Issue="70469" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="3" Volume="1999" Year="2000">
+<Database Name="cv" Series="9202" Issue="70470" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="4" Volume="1999" Year="2000">
+<Database Name="cv" Series="9202" Issue="70471" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="5" Volume="1999" Year="2000">
+<Database Name="cv" Series="9202" Issue="70472" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="6" Volume="1999" Year="2000">
+<Database Name="cv" Series="9202" Issue="70473" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="7" Volume="1999" Year="2000">
+<Database Name="cv" Series="9202" Issue="70474" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="8" Volume="1999" Year="2000">
+<Database Name="cv" Series="9202" Issue="70475" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="9" Volume="1999" Year="2000">
+<Database Name="cv" Series="9202" Issue="70476" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="10" Volume="1999" Year="2000">
+<Database Name="cv" Series="9202" Issue="70477" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="11" Volume="1999" Year="2000">
+<Database Name="cv" Series="9202" Issue="70478" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="12" Volume="1999" Year="2000">
+<Database Name="cv" Series="9202" Issue="124311" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="13" Volume="1999" Year="2000">
+<Database Name="cv" Series="9202" Issue="124313" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="14" Volume="1999" Year="2001">
+<Database Name="cv" Series="9202" Issue="124315" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="15" Volume="1999" Year="2001">
+<Database Name="cv" Series="9202" Issue="120844" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="16" Volume="1999" Year="2001">
+<Database Name="cv" Series="9202" Issue="124316" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="17" Volume="1999" Year="2001">
+<Database Name="cv" Series="9202" Issue="124317" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="18" Volume="1999" Year="2001">
+<Database Name="cv" Series="9202" Issue="124320" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="19" Volume="1999" Year="2001">
+<Database Name="cv" Series="9202" Issue="124326" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="20" Volume="1999" Year="2001">
+<Database Name="cv" Series="9202" Issue="124321" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="21" Volume="1999" Year="2001">
+<Database Name="cv" Series="9202" Issue="124319" />
+</Book>
+<Book Series="X-Men: The Hidden Years" Number="22" Volume="1999" Year="2001">
+<Database Name="cv" Series="9202" Issue="70489" />
+</Book>
+<Book Series="Emma Frost" Number="7" Volume="2003" Year="2004">
+<Database Name="cv" Series="18014" Issue="107668" />
+</Book>
+<Book Series="Emma Frost" Number="8" Volume="2003" Year="2004">
+<Database Name="cv" Series="18014" Issue="107671" />
+</Book>
+<Book Series="Emma Frost" Number="9" Volume="2003" Year="2004">
+<Database Name="cv" Series="18014" Issue="107667" />
+</Book>
+<Book Series="Emma Frost" Number="10" Volume="2003" Year="2004">
+<Database Name="cv" Series="18014" Issue="107674" />
+</Book>
+<Book Series="Emma Frost" Number="11" Volume="2003" Year="2004">
+<Database Name="cv" Series="18014" Issue="107673" />
+</Book>
+<Book Series="Emma Frost" Number="12" Volume="2003" Year="2004">
+<Database Name="cv" Series="18014" Issue="107670" />
+</Book>
+<Book Series="Emma Frost" Number="13" Volume="2003" Year="2004">
+<Database Name="cv" Series="18014" Issue="107676" />
+</Book>
+<Book Series="Emma Frost" Number="14" Volume="2003" Year="2004">
+<Database Name="cv" Series="18014" Issue="107665" />
+</Book>
+<Book Series="Emma Frost" Number="15" Volume="2003" Year="2004">
+<Database Name="cv" Series="18014" Issue="107669" />
+</Book>
+<Book Series="Emma Frost" Number="16" Volume="2003" Year="2004">
+<Database Name="cv" Series="18014" Issue="107672" />
+</Book>
+<Book Series="Emma Frost" Number="17" Volume="2003" Year="2005">
+<Database Name="cv" Series="18014" Issue="107666" />
+</Book>
+<Book Series="Emma Frost" Number="18" Volume="2003" Year="2005">
+<Database Name="cv" Series="18014" Issue="107675" />
+</Book>
+<Book Series="X-Men: First Class Finals" Number="1" Volume="2009" Year="2009">
+<Database Name="cv" Series="25669" Issue="151276" />
+</Book>
+<Book Series="X-Men: First Class Finals" Number="2" Volume="2009" Year="2009">
+<Database Name="cv" Series="25669" Issue="153877" />
+</Book>
+<Book Series="X-Men: First Class Finals" Number="3" Volume="2009" Year="2009">
+<Database Name="cv" Series="25669" Issue="154464" />
+</Book>
+<Book Series="X-Men: First Class Finals" Number="4" Volume="2009" Year="2009">
+<Database Name="cv" Series="25669" Issue="156642" />
+</Book>
+<Book Series="Giant-Size X-Men" Number="1" Volume="1975" Year="1975">
+<Database Name="cv" Series="2763" Issue="14890" />
+</Book>
+<Book Series="The X-Men" Number="94" Volume="1963" Year="1975">
+<Database Name="cv" Series="2133" Issue="15508" />
+</Book>
+<Book Series="The X-Men" Number="95" Volume="1963" Year="1975">
+<Database Name="cv" Series="2133" Issue="15711" />
+</Book>
+<Book Series="The X-Men" Number="96" Volume="1963" Year="1975">
+<Database Name="cv" Series="2133" Issue="15889" />
+</Book>
+<Book Series="The X-Men" Number="97" Volume="1963" Year="1976">
+<Database Name="cv" Series="2133" Issue="16100" />
+</Book>
+<Book Series="Uncanny X-Men: First Class Giant-Size Special" Number="1" Volume="2009" Year="2009">
+<Database Name="cv" Series="26666" Issue="159793" />
+</Book>
+<Book Series="The X-Men" Number="98" Volume="1963" Year="1976">
+<Database Name="cv" Series="2133" Issue="16278" />
+</Book>
+<Book Series="The X-Men" Number="99" Volume="1963" Year="1976">
+<Database Name="cv" Series="2133" Issue="16440" />
+</Book>
+<Book Series="The X-Men" Number="100" Volume="1963" Year="1976">
+<Database Name="cv" Series="2133" Issue="16618" />
+</Book>
+<Book Series="The X-Men" Number="101" Volume="1963" Year="1976">
+<Database Name="cv" Series="2133" Issue="16800" />
+</Book>
+<Book Series="The X-Men" Number="102" Volume="1963" Year="1976">
+<Database Name="cv" Series="2133" Issue="16981" />
+</Book>
+<Book Series="The X-Men" Number="103" Volume="1963" Year="1977">
+<Database Name="cv" Series="2133" Issue="17209" />
+</Book>
+<Book Series="The X-Men" Number="104" Volume="1963" Year="1977">
+<Database Name="cv" Series="2133" Issue="17371" />
+</Book>
+<Book Series="The X-Men" Number="105" Volume="1963" Year="1977">
+<Database Name="cv" Series="2133" Issue="17526" />
+</Book>
+<Book Series="The X-Men" Number="106" Volume="1963" Year="1977">
+<Database Name="cv" Series="2133" Issue="17708" />
+</Book>
+<Book Series="The X-Men" Number="107" Volume="1963" Year="1977">
+<Database Name="cv" Series="2133" Issue="17894" />
+</Book>
+<Book Series="The X-Men" Number="108" Volume="1963" Year="1977">
+<Database Name="cv" Series="2133" Issue="18064" />
+</Book>
+<Book Series="The X-Men" Number="109" Volume="1963" Year="1978">
+<Database Name="cv" Series="2133" Issue="18267" />
+</Book>
+<Book Series="Uncanny X-Men: First Class" Number="1" Volume="2009" Year="2009">
+<Database Name="cv" Series="27037" Issue="163641" />
+</Book>
+<Book Series="Uncanny X-Men: First Class" Number="2" Volume="2009" Year="2009">
+<Database Name="cv" Series="27037" Issue="166810" />
+</Book>
+<Book Series="Uncanny X-Men: First Class" Number="3" Volume="2009" Year="2009">
+<Database Name="cv" Series="27037" Issue="171556" />
+</Book>
+<Book Series="Uncanny X-Men: First Class" Number="4" Volume="2009" Year="2009">
+<Database Name="cv" Series="27037" Issue="176137" />
+</Book>
+<Book Series="Uncanny X-Men: First Class" Number="5" Volume="2009" Year="2010">
+<Database Name="cv" Series="27037" Issue="182998" />
+</Book>
+<Book Series="Uncanny X-Men: First Class" Number="6" Volume="2009" Year="2010">
+<Database Name="cv" Series="27037" Issue="186932" />
+</Book>
+<Book Series="Uncanny X-Men: First Class" Number="7" Volume="2009" Year="2010">
+<Database Name="cv" Series="27037" Issue="192764" />
+</Book>
+<Book Series="Uncanny X-Men: First Class" Number="8" Volume="2009" Year="2010">
+<Database Name="cv" Series="27037" Issue="196856" />
+</Book>
+<Book Series="The X-Men" Number="110" Volume="1963" Year="1978">
+<Database Name="cv" Series="2133" Issue="18435" />
+</Book>
+<Book Series="The X-Men" Number="111" Volume="1963" Year="1978">
+<Database Name="cv" Series="2133" Issue="18598" />
+</Book>
+<Book Series="The X-Men" Number="112" Volume="1963" Year="1978">
+<Database Name="cv" Series="2133" Issue="18757" />
+</Book>
+<Book Series="The X-Men" Number="113" Volume="1963" Year="1978">
+<Database Name="cv" Series="2133" Issue="18837" />
+</Book>
+<Book Series="The X-Men" Number="114" Volume="1963" Year="1978">
+<Database Name="cv" Series="2133" Issue="18916" />
+</Book>
+<Book Series="The X-Men" Number="115" Volume="1963" Year="1978">
+<Database Name="cv" Series="2133" Issue="18985" />
+</Book>
+<Book Series="The X-Men" Number="116" Volume="1963" Year="1978">
+<Database Name="cv" Series="2133" Issue="19060" />
+</Book>
+<Book Series="The X-Men" Number="117" Volume="1963" Year="1979">
+<Database Name="cv" Series="2133" Issue="19210" />
+</Book>
+<Book Series="The X-Men" Number="118" Volume="1963" Year="1979">
+<Database Name="cv" Series="2133" Issue="19317" />
+</Book>
+<Book Series="The X-Men" Number="119" Volume="1963" Year="1979">
+<Database Name="cv" Series="2133" Issue="19386" />
+</Book>
+<Book Series="The X-Men" Number="120" Volume="1963" Year="1979">
+<Database Name="cv" Series="2133" Issue="19455" />
+</Book>
+<Book Series="The X-Men" Number="121" Volume="1963" Year="1979">
+<Database Name="cv" Series="2133" Issue="19525" />
+</Book>
+<Book Series="The X-Men" Number="122" Volume="1963" Year="1979">
+<Database Name="cv" Series="2133" Issue="19592" />
+</Book>
+<Book Series="The X-Men" Number="123" Volume="1963" Year="1979">
+<Database Name="cv" Series="2133" Issue="123628" />
+</Book>
+<Book Series="The X-Men" Number="124" Volume="1963" Year="1979">
+<Database Name="cv" Series="2133" Issue="19726" />
+</Book>
+<Book Series="The X-Men" Number="125" Volume="1963" Year="1979">
+<Database Name="cv" Series="2133" Issue="19794" />
+</Book>
+<Book Series="The X-Men" Number="126" Volume="1963" Year="1979">
+<Database Name="cv" Series="2133" Issue="19865" />
+</Book>
+<Book Series="The X-Men" Number="127" Volume="1963" Year="1979">
+<Database Name="cv" Series="2133" Issue="19934" />
+</Book>
+<Book Series="The X-Men" Number="128" Volume="1963" Year="1979">
+<Database Name="cv" Series="2133" Issue="20006" />
+</Book>
+<Book Series="The X-Men" Number="129" Volume="1963" Year="1980">
+<Database Name="cv" Series="2133" Issue="20114" />
+</Book>
+<Book Series="The X-Men" Number="130" Volume="1963" Year="1980">
+<Database Name="cv" Series="2133" Issue="20186" />
+</Book>
+<Book Series="The X-Men" Number="131" Volume="1963" Year="1980">
+<Database Name="cv" Series="2133" Issue="20258" />
+</Book>
+<Book Series="The X-Men" Number="132" Volume="1963" Year="1980">
+<Database Name="cv" Series="2133" Issue="20333" />
+</Book>
+<Book Series="The X-Men" Number="133" Volume="1963" Year="1980">
+<Database Name="cv" Series="2133" Issue="20403" />
+</Book>
+<Book Series="The X-Men" Number="134" Volume="1963" Year="1980">
+<Database Name="cv" Series="2133" Issue="20477" />
+</Book>
+<Book Series="The X-Men" Number="135" Volume="1963" Year="1980">
+<Database Name="cv" Series="2133" Issue="20546" />
+</Book>
+<Book Series="The X-Men" Number="136" Volume="1963" Year="1980">
+<Database Name="cv" Series="2133" Issue="20613" />
+</Book>
+<Book Series="The X-Men" Number="137" Volume="1963" Year="1980">
+<Database Name="cv" Series="2133" Issue="20681" />
+</Book>
+<Book Series="The X-Men" Number="138" Volume="1963" Year="1980">
+<Database Name="cv" Series="2133" Issue="20751" />
+</Book>
+<Book Series="The X-Men" Number="139" Volume="1963" Year="1980">
+<Database Name="cv" Series="2133" Issue="20812" />
+</Book>
+<Book Series="The X-Men" Number="140" Volume="1963" Year="1980">
+<Database Name="cv" Series="2133" Issue="20884" />
+</Book>
+<Book Series="The X-Men" Number="141" Volume="1963" Year="1981">
+<Database Name="cv" Series="2133" Issue="20988" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="142" Volume="1981" Year="1981">
+<Database Name="cv" Series="3092" Issue="21057" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="143" Volume="1981" Year="1981">
+<Database Name="cv" Series="3092" Issue="21127" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="144" Volume="1981" Year="1981">
+<Database Name="cv" Series="3092" Issue="107059" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="145" Volume="1981" Year="1981">
+<Database Name="cv" Series="3092" Issue="21258" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="146" Volume="1981" Year="1981">
+<Database Name="cv" Series="3092" Issue="21320" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="147" Volume="1981" Year="1981">
+<Database Name="cv" Series="3092" Issue="21392" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="148" Volume="1981" Year="1981">
+<Database Name="cv" Series="3092" Issue="21461" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="149" Volume="1981" Year="1981">
+<Database Name="cv" Series="3092" Issue="21531" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="150" Volume="1981" Year="1981">
+<Database Name="cv" Series="3092" Issue="21614" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="151" Volume="1981" Year="1981">
+<Database Name="cv" Series="3092" Issue="21679" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="152" Volume="1981" Year="1981">
+<Database Name="cv" Series="3092" Issue="21752" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="153" Volume="1981" Year="1982">
+<Database Name="cv" Series="3092" Issue="21875" />
+</Book>
+<Book Series="Weapon X: First Class" Number="1" Volume="2009" Year="2009">
+<Database Name="cv" Series="23783" Issue="142205" />
+</Book>
+<Book Series="Weapon X: First Class" Number="2" Volume="2009" Year="2009">
+<Database Name="cv" Series="23783" Issue="145367" />
+</Book>
+<Book Series="Weapon X: First Class" Number="3" Volume="2009" Year="2009">
+<Database Name="cv" Series="23783" Issue="150583" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="154" Volume="1981" Year="1982">
+<Database Name="cv" Series="3092" Issue="21952" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="155" Volume="1981" Year="1982">
+<Database Name="cv" Series="3092" Issue="22027" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="156" Volume="1981" Year="1982">
+<Database Name="cv" Series="3092" Issue="22100" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="157" Volume="1981" Year="1982">
+<Database Name="cv" Series="3092" Issue="22179" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="158" Volume="1981" Year="1982">
+<Database Name="cv" Series="3092" Issue="22248" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="159" Volume="1981" Year="1982">
+<Database Name="cv" Series="3092" Issue="22318" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="160" Volume="1981" Year="1982">
+<Database Name="cv" Series="3092" Issue="22393" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="161" Volume="1981" Year="1982">
+<Database Name="cv" Series="3092" Issue="22462" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="162" Volume="1981" Year="1982">
+<Database Name="cv" Series="3092" Issue="22537" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="163" Volume="1981" Year="1982">
+<Database Name="cv" Series="3092" Issue="22611" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="164" Volume="1981" Year="1982">
+<Database Name="cv" Series="3092" Issue="22687" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="165" Volume="1981" Year="1983">
+<Database Name="cv" Series="3092" Issue="22808" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="166" Volume="1981" Year="1983">
+<Database Name="cv" Series="3092" Issue="22882" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="167" Volume="1981" Year="1983">
+<Database Name="cv" Series="3092" Issue="22969" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="168" Volume="1981" Year="1983">
+<Database Name="cv" Series="3092" Issue="23051" />
+</Book>
+<Book Series="Marvel Graphic Novel" Number="5" Volume="1982" Year="1982">
+<Database Name="cv" Series="3144" Issue="21795" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="169" Volume="1981" Year="1983">
+<Database Name="cv" Series="3092" Issue="23139" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="170" Volume="1981" Year="1983">
+<Database Name="cv" Series="3092" Issue="23219" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="171" Volume="1981" Year="1983">
+<Database Name="cv" Series="3092" Issue="23307" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="172" Volume="1981" Year="1983">
+<Database Name="cv" Series="3092" Issue="23387" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="173" Volume="1981" Year="1983">
+<Database Name="cv" Series="3092" Issue="23469" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="174" Volume="1981" Year="1983">
+<Database Name="cv" Series="3092" Issue="23556" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="175" Volume="1981" Year="1983">
+<Database Name="cv" Series="3092" Issue="23648" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="176" Volume="1981" Year="1983">
+<Database Name="cv" Series="3092" Issue="23743" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="177" Volume="1981" Year="1984">
+<Database Name="cv" Series="3092" Issue="23894" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="178" Volume="1981" Year="1984">
+<Database Name="cv" Series="3092" Issue="23994" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="179" Volume="1981" Year="1984">
+<Database Name="cv" Series="3092" Issue="24112" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="180" Volume="1981" Year="1984">
+<Database Name="cv" Series="3092" Issue="24216" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="181" Volume="1981" Year="1984">
+<Database Name="cv" Series="3092" Issue="24322" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="182" Volume="1981" Year="1984">
+<Database Name="cv" Series="3092" Issue="24419" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="183" Volume="1981" Year="1984">
+<Database Name="cv" Series="3092" Issue="24518" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="184" Volume="1981" Year="1984">
+<Database Name="cv" Series="3092" Issue="24620" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="185" Volume="1981" Year="1984">
+<Database Name="cv" Series="3092" Issue="24708" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="186" Volume="1981" Year="1984">
+<Database Name="cv" Series="3092" Issue="24808" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="187" Volume="1981" Year="1984">
+<Database Name="cv" Series="3092" Issue="24907" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="188" Volume="1981" Year="1984">
+<Database Name="cv" Series="3092" Issue="25014" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="189" Volume="1981" Year="1985">
+<Database Name="cv" Series="3092" Issue="25178" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="190" Volume="1981" Year="1985">
+<Database Name="cv" Series="3092" Issue="25279" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="191" Volume="1981" Year="1985">
+<Database Name="cv" Series="3092" Issue="25301" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="192" Volume="1981" Year="1985">
+<Database Name="cv" Series="3092" Issue="25406" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="193" Volume="1981" Year="1985">
+<Database Name="cv" Series="3092" Issue="25500" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="194" Volume="1981" Year="1985">
+<Database Name="cv" Series="3092" Issue="25602" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="195" Volume="1981" Year="1985">
+<Database Name="cv" Series="3092" Issue="25701" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="196" Volume="1981" Year="1985">
+<Database Name="cv" Series="3092" Issue="25801" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="197" Volume="1981" Year="1985">
+<Database Name="cv" Series="3092" Issue="25896" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="198" Volume="1981" Year="1985">
+<Database Name="cv" Series="3092" Issue="25999" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="199" Volume="1981" Year="1985">
+<Database Name="cv" Series="3092" Issue="26105" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="200" Volume="1981" Year="1985">
+<Database Name="cv" Series="3092" Issue="26210" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="201" Volume="1981" Year="1986">
+<Database Name="cv" Series="3092" Issue="26413" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="202" Volume="1981" Year="1986">
+<Database Name="cv" Series="3092" Issue="26519" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="203" Volume="1981" Year="1986">
+<Database Name="cv" Series="3092" Issue="26613" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="204" Volume="1981" Year="1986">
+<Database Name="cv" Series="3092" Issue="26710" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="205" Volume="1981" Year="1986">
+<Database Name="cv" Series="3092" Issue="26804" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="206" Volume="1981" Year="1986">
+<Database Name="cv" Series="3092" Issue="26902" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="207" Volume="1981" Year="1986">
+<Database Name="cv" Series="3092" Issue="26997" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="208" Volume="1981" Year="1986">
+<Database Name="cv" Series="3092" Issue="27093" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="209" Volume="1981" Year="1986">
+<Database Name="cv" Series="3092" Issue="27189" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="210" Volume="1981" Year="1986">
+<Database Name="cv" Series="3092" Issue="107057" />
+</Book>
+<Book Series="X-Factor" Number="9" Volume="1986" Year="1986">
+<Database Name="cv" Series="3657" Issue="27290" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="211" Volume="1981" Year="1986">
+<Database Name="cv" Series="3092" Issue="27396" />
+</Book>
+<Book Series="X-Factor" Number="10" Volume="1986" Year="1986">
+<Database Name="cv" Series="3657" Issue="27399" />
+</Book>
+<Book Series="The New Mutants" Number="46" Volume="1983" Year="1986">
+<Database Name="cv" Series="3234" Issue="27523" />
+</Book>
+<Book Series="Thor" Number="373" Volume="1966" Year="1986">
+<Database Name="cv" Series="2294" Issue="27395" />
+</Book>
+<Book Series="Power Pack" Number="27" Volume="1984" Year="1986">
+<Database Name="cv" Series="3358" Issue="27494" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="212" Volume="1981" Year="1986">
+<Database Name="cv" Series="3092" Issue="27501" />
+</Book>
+<Book Series="Thor" Number="374" Volume="1966" Year="1986">
+<Database Name="cv" Series="2294" Issue="27500" />
+</Book>
+<Book Series="X-Factor" Number="11" Volume="1986" Year="1986">
+<Database Name="cv" Series="3657" Issue="27504" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="213" Volume="1981" Year="1987">
+<Database Name="cv" Series="3092" Issue="27691" />
+</Book>
+<Book Series="Daredevil" Number="238" Volume="1964" Year="1987">
+<Database Name="cv" Series="2190" Issue="27676" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="214" Volume="1981" Year="1987">
+<Database Name="cv" Series="3092" Issue="27803" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="215" Volume="1981" Year="1987">
+<Database Name="cv" Series="3092" Issue="27912" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="216" Volume="1981" Year="1987">
+<Database Name="cv" Series="3092" Issue="28023" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="217" Volume="1981" Year="1987">
+<Database Name="cv" Series="3092" Issue="28124" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="218" Volume="1981" Year="1987">
+<Database Name="cv" Series="3092" Issue="28234" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="219" Volume="1981" Year="1987">
+<Database Name="cv" Series="3092" Issue="28351" />
+</Book>
+<Book Series="The X-Men vs. The Avengers" Number="1" Volume="1987" Year="1987">
+<Database Name="cv" Series="3867" Issue="28027" />
+</Book>
+<Book Series="The X-Men vs. The Avengers" Number="2" Volume="1987" Year="1987">
+<Database Name="cv" Series="3867" Issue="28128" />
+</Book>
+<Book Series="The X-Men vs. The Avengers" Number="3" Volume="1987" Year="1987">
+<Database Name="cv" Series="3867" Issue="28238" />
+</Book>
+<Book Series="The X-Men vs. The Avengers" Number="4" Volume="1987" Year="1987">
+<Database Name="cv" Series="3867" Issue="28355" />
+</Book>
+<Book Series="X-Factor" Number="18" Volume="1986" Year="1987">
+<Database Name="cv" Series="3657" Issue="28354" />
+</Book>
+<Book Series="X-Factor" Number="19" Volume="1986" Year="1987">
+<Database Name="cv" Series="3657" Issue="28473" />
+</Book>
+<Book Series="X-Factor" Number="20" Volume="1986" Year="1987">
+<Database Name="cv" Series="3657" Issue="28582" />
+</Book>
+<Book Series="X-Factor" Number="21" Volume="1986" Year="1987">
+<Database Name="cv" Series="3657" Issue="28703" />
+</Book>
+<Book Series="X-Factor" Number="22" Volume="1986" Year="1987">
+<Database Name="cv" Series="3657" Issue="28821" />
+</Book>
+<Book Series="X-Factor" Number="23" Volume="1986" Year="1987">
+<Database Name="cv" Series="3657" Issue="28938" />
+</Book>
+<Book Series="X-Factor" Number="24" Volume="1986" Year="1988">
+<Database Name="cv" Series="3657" Issue="29161" />
+</Book>
+<Book Series="X-Factor" Number="25" Volume="1986" Year="1988">
+<Database Name="cv" Series="3657" Issue="29276" />
+</Book>
+<Book Series="Power Pack" Number="35" Volume="1984" Year="1988">
+<Database Name="cv" Series="3358" Issue="29264" />
+</Book>
+<Book Series="Daredevil" Number="252" Volume="1964" Year="1988">
+<Database Name="cv" Series="2190" Issue="29370" />
+</Book>
+<Book Series="Captain America" Number="339" Volume="1968" Year="1988">
+<Database Name="cv" Series="2400" Issue="29368" />
+</Book>
+<Book Series="X-Factor" Number="26" Volume="1986" Year="1988">
+<Database Name="cv" Series="3657" Issue="29387" />
+</Book>
+<Book Series="Fantastic Four" Number="312" Volume="1961" Year="1988">
+<Database Name="cv" Series="2045" Issue="29371" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="220" Volume="1981" Year="1987">
+<Database Name="cv" Series="3092" Issue="28470" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="221" Volume="1981" Year="1987">
+<Database Name="cv" Series="3092" Issue="28577" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="222" Volume="1981" Year="1987">
+<Database Name="cv" Series="3092" Issue="28700" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="223" Volume="1981" Year="1987">
+<Database Name="cv" Series="3092" Issue="28817" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="224" Volume="1981" Year="1987">
+<Database Name="cv" Series="3092" Issue="28935" />
+</Book>
+<Book Series="The Incredible Hulk" Number="340" Volume="1968" Year="1988">
+<Database Name="cv" Series="2406" Issue="29262" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="225" Volume="1981" Year="1988">
+<Database Name="cv" Series="3092" Issue="29158" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="226" Volume="1981" Year="1988">
+<Database Name="cv" Series="3092" Issue="29273" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="227" Volume="1981" Year="1988">
+<Database Name="cv" Series="3092" Issue="29383" />
+</Book>
+<Book Series="The New Mutants" Number="55" Volume="1983" Year="1987">
+<Database Name="cv" Series="3234" Issue="28603" />
+</Book>
+<Book Series="The New Mutants" Number="56" Volume="1983" Year="1987">
+<Database Name="cv" Series="3234" Issue="28724" />
+</Book>
+<Book Series="The New Mutants" Number="57" Volume="1983" Year="1987">
+<Database Name="cv" Series="3234" Issue="28842" />
+</Book>
+<Book Series="The New Mutants" Number="58" Volume="1983" Year="1987">
+<Database Name="cv" Series="3234" Issue="28954" />
+</Book>
+<Book Series="The New Mutants" Number="59" Volume="1983" Year="1988">
+<Database Name="cv" Series="3234" Issue="29179" />
+</Book>
+<Book Series="The New Mutants" Number="60" Volume="1983" Year="1988">
+<Database Name="cv" Series="3234" Issue="29296" />
+</Book>
+<Book Series="The New Mutants" Number="61" Volume="1983" Year="1988">
+<Database Name="cv" Series="3234" Issue="29405" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="228" Volume="1981" Year="1988">
+<Database Name="cv" Series="3092" Issue="29494" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="229" Volume="1981" Year="1988">
+<Database Name="cv" Series="3092" Issue="29603" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="230" Volume="1981" Year="1988">
+<Database Name="cv" Series="3092" Issue="29719" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="231" Volume="1981" Year="1988">
+<Database Name="cv" Series="3092" Issue="29838" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="232" Volume="1981" Year="1988">
+<Database Name="cv" Series="3092" Issue="29954" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="233" Volume="1981" Year="1988">
+<Database Name="cv" Series="3092" Issue="30070" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="234" Volume="1981" Year="1988">
+<Database Name="cv" Series="3092" Issue="30103" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="235" Volume="1981" Year="1988">
+<Database Name="cv" Series="3092" Issue="30194" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="236" Volume="1981" Year="1988">
+<Database Name="cv" Series="3092" Issue="30232" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="237" Volume="1981" Year="1988">
+<Database Name="cv" Series="3092" Issue="30326" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="238" Volume="1981" Year="1988">
+<Database Name="cv" Series="3092" Issue="30360" />
+</Book>
+<Book Series="Excalibur" Number="1" Volume="1988" Year="1988">
+<Database Name="cv" Series="4052" Issue="30178" />
+</Book>
+<Book Series="Excalibur" Number="2" Volume="1988" Year="1988">
+<Database Name="cv" Series="4052" Issue="30308" />
+</Book>
+<Book Series="Excalibur" Number="3" Volume="1988" Year="1988">
+<Database Name="cv" Series="4052" Issue="30429" />
+</Book>
+<Book Series="Excalibur" Number="4" Volume="1988" Year="1989">
+<Database Name="cv" Series="4052" Issue="30779" />
+</Book>
+<Book Series="Excalibur" Number="5" Volume="1988" Year="1989">
+<Database Name="cv" Series="4052" Issue="113568" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="239" Volume="1981" Year="1988">
+<Database Name="cv" Series="3092" Issue="30448" />
+</Book>
+<Book Series="X-Terminators" Number="1" Volume="1988" Year="1988">
+<Database Name="cv" Series="4082" Issue="30213" />
+</Book>
+<Book Series="X-Terminators" Number="2" Volume="1988" Year="1988">
+<Database Name="cv" Series="4082" Issue="30342" />
+</Book>
+<Book Series="X-Terminators" Number="3" Volume="1988" Year="1988">
+<Database Name="cv" Series="4082" Issue="30460" />
+</Book>
+<Book Series="X-Factor" Number="36" Volume="1986" Year="1989">
+<Database Name="cv" Series="3657" Issue="30800" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="240" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="30797" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="241" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="30905" />
+</Book>
+<Book Series="Fantastic Four" Number="322" Volume="1961" Year="1989">
+<Database Name="cv" Series="2045" Issue="30780" />
+</Book>
+<Book Series="The Avengers" Number="298" Volume="1963" Year="1988">
+<Database Name="cv" Series="2128" Issue="30424" />
+</Book>
+<Book Series="The Amazing Spider-Man" Number="311" Volume="1963" Year="1989">
+<Database Name="cv" Series="2127" Issue="30773" />
+</Book>
+<Book Series="The Spectacular Spider-Man" Number="146" Volume="1976" Year="1989">
+<Database Name="cv" Series="2870" Issue="30792" />
+</Book>
+<Book Series="Web of Spider-Man" Number="47" Volume="1985" Year="1989">
+<Database Name="cv" Series="3519" Issue="30906" />
+</Book>
+<Book Series="The Amazing Spider-Man" Number="312" Volume="1963" Year="1989">
+<Database Name="cv" Series="2127" Issue="30883" />
+</Book>
+<Book Series="The Spectacular Spider-Man" Number="147" Volume="1976" Year="1989">
+<Database Name="cv" Series="2870" Issue="30901" />
+</Book>
+<Book Series="Web of Spider-Man" Number="48" Volume="1985" Year="1989">
+<Database Name="cv" Series="3519" Issue="31007" />
+</Book>
+<Book Series="Daredevil" Number="262" Volume="1964" Year="1989">
+<Database Name="cv" Series="2190" Issue="30778" />
+</Book>
+<Book Series="Power Pack" Number="42" Volume="1984" Year="1988">
+<Database Name="cv" Series="3358" Issue="30435" />
+</Book>
+<Book Series="Power Pack" Number="43" Volume="1984" Year="1989">
+<Database Name="cv" Series="3358" Issue="30785" />
+</Book>
+<Book Series="The Amazing Spider-Man" Number="313" Volume="1963" Year="1989">
+<Database Name="cv" Series="2127" Issue="113269" />
+</Book>
+<Book Series="The Avengers" Number="299" Volume="1963" Year="1989">
+<Database Name="cv" Series="2128" Issue="30774" />
+</Book>
+<Book Series="The Avengers" Number="300" Volume="1963" Year="1989">
+<Database Name="cv" Series="2128" Issue="30884" />
+</Book>
+<Book Series="Daredevil" Number="263" Volume="1964" Year="1989">
+<Database Name="cv" Series="2190" Issue="30887" />
+</Book>
+<Book Series="The New Mutants" Number="71" Volume="1983" Year="1989">
+<Database Name="cv" Series="3234" Issue="30824" />
+</Book>
+<Book Series="X-Terminators" Number="4" Volume="1988" Year="1989">
+<Database Name="cv" Series="4082" Issue="30811" />
+</Book>
+<Book Series="The New Mutants" Number="72" Volume="1983" Year="1989">
+<Database Name="cv" Series="3234" Issue="30929" />
+</Book>
+<Book Series="The New Mutants" Number="73" Volume="1983" Year="1989">
+<Database Name="cv" Series="3234" Issue="31027" />
+</Book>
+<Book Series="Fantastic Four" Number="323" Volume="1961" Year="1989">
+<Database Name="cv" Series="2045" Issue="30889" />
+</Book>
+<Book Series="Daredevil" Number="265" Volume="1964" Year="1989">
+<Database Name="cv" Series="2190" Issue="31098" />
+</Book>
+<Book Series="X-Factor" Number="37" Volume="1986" Year="1989">
+<Database Name="cv" Series="3657" Issue="30908" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="242" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="31006" />
+</Book>
+<Book Series="X-Factor" Number="38" Volume="1986" Year="1989">
+<Database Name="cv" Series="3657" Issue="31009" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="243" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="31117" />
+</Book>
+<Book Series="X-Factor" Number="39" Volume="1986" Year="1989">
+<Database Name="cv" Series="3657" Issue="31120" />
+</Book>
+<Book Series="Excalibur" Number="6" Volume="1988" Year="1989">
+<Database Name="cv" Series="4052" Issue="30989" />
+</Book>
+<Book Series="Excalibur" Number="7" Volume="1988" Year="1989">
+<Database Name="cv" Series="4052" Issue="31100" />
+</Book>
+<Book Series="The Mutant Misadventures of Cloak and Dagger" Number="4" Volume="1988" Year="1989">
+<Database Name="cv" Series="4060" Issue="95262" />
+</Book>
+<Book Series="The Spectacular Spider-Man" Number="148" Volume="1976" Year="1989">
+<Database Name="cv" Series="2870" Issue="31001" />
+</Book>
+<Book Series="Power Pack" Number="44" Volume="1984" Year="1989">
+<Database Name="cv" Series="3358" Issue="30994" />
+</Book>
+<Book Series="Damage Control" Number="4" Volume="1989" Year="1989">
+<Database Name="cv" Series="4349" Issue="31537" />
+</Book>
+<Book Series="Excalibur" Number="8" Volume="1988" Year="1989">
+<Database Name="cv" Series="4052" Issue="66340" />
+</Book>
+<Book Series="Excalibur" Number="9" Volume="1988" Year="1989">
+<Database Name="cv" Series="4052" Issue="31323" />
+</Book>
+<Book Series="Excalibur" Number="10" Volume="1988" Year="1989">
+<Database Name="cv" Series="4052" Issue="66341" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="244" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="31230" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="245" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="31340" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="246" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="31451" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="247" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="31554" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="248" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="31670" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="249" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="31781" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="250" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="31807" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="251" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="31885" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="252" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="31935" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="253" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="31944" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="254" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="32017" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="255" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="32074" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="256" Volume="1981" Year="1989">
+<Database Name="cv" Series="3092" Issue="32081" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="257" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="32337" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="258" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="32436" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="259" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="32535" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="260" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="32647" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="261" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="32741" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="262" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="32861" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="263" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="32982" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="264" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="33015" />
+</Book>
+<Book Series="Excalibur" Number="20" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="66344" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="265" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="33099" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="266" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="33137" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="267" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="106308" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="268" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="33256" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="269" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="33334" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="270" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="33443" />
+</Book>
+<Book Series="The New Mutants" Number="95" Volume="1983" Year="1990">
+<Database Name="cv" Series="3234" Issue="33468" />
+</Book>
+<Book Series="X-Factor" Number="60" Volume="1986" Year="1990">
+<Database Name="cv" Series="3657" Issue="33446" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="271" Volume="1981" Year="1990">
+<Database Name="cv" Series="3092" Issue="33551" />
+</Book>
+<Book Series="The New Mutants" Number="96" Volume="1983" Year="1990">
+<Database Name="cv" Series="3234" Issue="106559" />
+</Book>
+<Book Series="X-Factor" Number="61" Volume="1986" Year="1990">
+<Database Name="cv" Series="3657" Issue="33554" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="272" Volume="1981" Year="1991">
+<Database Name="cv" Series="3092" Issue="33793" />
+</Book>
+<Book Series="The New Mutants" Number="97" Volume="1983" Year="1991">
+<Database Name="cv" Series="3234" Issue="33816" />
+</Book>
+<Book Series="X-Factor" Number="62" Volume="1986" Year="1991">
+<Database Name="cv" Series="3657" Issue="33807" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="273" Volume="1981" Year="1991">
+<Database Name="cv" Series="3092" Issue="33893" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="274" Volume="1981" Year="1991">
+<Database Name="cv" Series="3092" Issue="34007" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="275" Volume="1981" Year="1991">
+<Database Name="cv" Series="3092" Issue="34111" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="276" Volume="1981" Year="1991">
+<Database Name="cv" Series="3092" Issue="34214" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="277" Volume="1981" Year="1991">
+<Database Name="cv" Series="3092" Issue="34313" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="278" Volume="1981" Year="1991">
+<Database Name="cv" Series="3092" Issue="34430" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="279" Volume="1981" Year="1991">
+<Database Name="cv" Series="3092" Issue="34545" />
+</Book>
+<Book Series="Excalibur" Number="11" Volume="1988" Year="1989">
+<Database Name="cv" Series="4052" Issue="66342" />
+</Book>
+<Book Series="Excalibur" Number="12" Volume="1988" Year="1989">
+<Database Name="cv" Series="4052" Issue="31651" />
+</Book>
+<Book Series="Excalibur" Number="13" Volume="1988" Year="1989">
+<Database Name="cv" Series="4052" Issue="31761" />
+</Book>
+<Book Series="Excalibur" Number="14" Volume="1988" Year="1989">
+<Database Name="cv" Series="4052" Issue="31866" />
+</Book>
+<Book Series="Excalibur" Number="15" Volume="1988" Year="1989">
+<Database Name="cv" Series="4052" Issue="31921" />
+</Book>
+<Book Series="Excalibur" Number="16" Volume="1988" Year="1989">
+<Database Name="cv" Series="4052" Issue="31996" />
+</Book>
+<Book Series="Excalibur" Number="17" Volume="1988" Year="1989">
+<Database Name="cv" Series="4052" Issue="32058" />
+</Book>
+<Book Series="Excalibur" Number="18" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="66343" />
+</Book>
+<Book Series="Excalibur" Number="19" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="32417" />
+</Book>
+<Book Series="Excalibur" Number="21" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="66345" />
+</Book>
+<Book Series="Excalibur" Number="22" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="32836" />
+</Book>
+<Book Series="Excalibur" Number="23" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="66346" />
+</Book>
+<Book Series="Excalibur" Number="24" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="32962" />
+</Book>
+<Book Series="Excalibur" Number="25" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="66347" />
+</Book>
+<Book Series="Excalibur" Number="26" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="66348" />
+</Book>
+<Book Series="Excalibur" Number="27" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="33076" />
+</Book>
+<Book Series="Excalibur" Number="28" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="66349" />
+</Book>
+<Book Series="Excalibur" Number="29" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="66350" />
+</Book>
+<Book Series="Excalibur" Number="30" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="113569" />
+</Book>
+<Book Series="Excalibur" Number="31" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="66351" />
+</Book>
+<Book Series="Excalibur" Number="32" Volume="1988" Year="1990">
+<Database Name="cv" Series="4052" Issue="120771" />
+</Book>
+<Book Series="Excalibur" Number="33" Volume="1988" Year="1991">
+<Database Name="cv" Series="4052" Issue="120772" />
+</Book>
+<Book Series="Excalibur" Number="34" Volume="1988" Year="1991">
+<Database Name="cv" Series="4052" Issue="120773" />
+</Book>
+<Book Series="Excalibur" Number="35" Volume="1988" Year="1991">
+<Database Name="cv" Series="4052" Issue="66352" />
+</Book>
+<Book Series="Excalibur" Number="36" Volume="1988" Year="1991">
+<Database Name="cv" Series="4052" Issue="66353" />
+</Book>
+<Book Series="Excalibur" Number="37" Volume="1988" Year="1991">
+<Database Name="cv" Series="4052" Issue="34196" />
+</Book>
+<Book Series="Excalibur" Number="38" Volume="1988" Year="1991">
+<Database Name="cv" Series="4052" Issue="34295" />
+</Book>
+<Book Series="Excalibur" Number="39" Volume="1988" Year="1991">
+<Database Name="cv" Series="4052" Issue="34410" />
+</Book>
+<Book Series="Excalibur" Number="40" Volume="1988" Year="1991">
+<Database Name="cv" Series="4052" Issue="66354" />
+</Book>
+<Book Series="Excalibur" Number="41" Volume="1988" Year="1991">
+<Database Name="cv" Series="4052" Issue="66355" />
+</Book>
+<Book Series="Excalibur" Number="42" Volume="1988" Year="1991">
+<Database Name="cv" Series="4052" Issue="34760" />
+</Book>
+<Book Series="X-Men" Number="1" Volume="1991" Year="1991">
+<Database Name="cv" Series="4605" Issue="34784" />
+</Book>
+<Book Series="X-Men" Number="2" Volume="1991" Year="1991">
+<Database Name="cv" Series="4605" Issue="34900" />
+</Book>
+<Book Series="X-Men" Number="3" Volume="1991" Year="1991">
+<Database Name="cv" Series="4605" Issue="35019" />
+</Book>
+<Book Series="Excalibur" Number="43" Volume="1988" Year="1991">
+<Database Name="cv" Series="4052" Issue="34877" />
+</Book>
+<Book Series="Excalibur" Number="44" Volume="1988" Year="1991">
+<Database Name="cv" Series="4052" Issue="34931" />
+</Book>
+<Book Series="Excalibur" Number="45" Volume="1988" Year="1991">
+<Database Name="cv" Series="4052" Issue="120774" />
+</Book>
+<Book Series="Excalibur" Number="46" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="35257" />
+</Book>
+<Book Series="Excalibur" Number="47" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="35364" />
+</Book>
+<Book Series="Excalibur" Number="48" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="35469" />
+</Book>
+<Book Series="Excalibur" Number="49" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="35573" />
+</Book>
+<Book Series="Excalibur" Number="50" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="35676" />
+</Book>
+<Book Series="Excalibur" Number="51" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="118524" />
+</Book>
+<Book Series="Excalibur" Number="52" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="35904" />
+</Book>
+<Book Series="Excalibur" Number="53" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="36022" />
+</Book>
+<Book Series="Excalibur" Number="54" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="36149" />
+</Book>
+<Book Series="Excalibur" Number="55" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="36272" />
+</Book>
+<Book Series="Excalibur" Number="56" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="36397" />
+</Book>
+<Book Series="Excalibur" Number="57" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="36447" />
+</Book>
+<Book Series="Excalibur" Number="58" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="36512" />
+</Book>
+<Book Series="Excalibur" Number="59" Volume="1988" Year="1992">
+<Database Name="cv" Series="4052" Issue="36557" />
+</Book>
+<Book Series="Excalibur" Number="60" Volume="1988" Year="1993">
+<Database Name="cv" Series="4052" Issue="66356" />
+</Book>
+<Book Series="Excalibur" Number="61" Volume="1988" Year="1993">
+<Database Name="cv" Series="4052" Issue="36754" />
+</Book>
+<Book Series="Excalibur" Number="62" Volume="1988" Year="1993">
+<Database Name="cv" Series="4052" Issue="36859" />
+</Book>
+<Book Series="Excalibur" Number="63" Volume="1988" Year="1993">
+<Database Name="cv" Series="4052" Issue="36970" />
+</Book>
+<Book Series="Excalibur" Number="64" Volume="1988" Year="1993">
+<Database Name="cv" Series="4052" Issue="37089" />
+</Book>
+<Book Series="Excalibur" Number="65" Volume="1988" Year="1993">
+<Database Name="cv" Series="4052" Issue="37225" />
+</Book>
+<Book Series="Excalibur" Number="66" Volume="1988" Year="1993">
+<Database Name="cv" Series="4052" Issue="37360" />
+</Book>
+<Book Series="Excalibur" Number="67" Volume="1988" Year="1993">
+<Database Name="cv" Series="4052" Issue="37514" />
+</Book>
+<Book Series="Excalibur" Number="68" Volume="1988" Year="1993">
+<Database Name="cv" Series="4052" Issue="66357" />
+</Book>
+<Book Series="Excalibur" Number="69" Volume="1988" Year="1993">
+<Database Name="cv" Series="4052" Issue="66358" />
+</Book>
+<Book Series="Excalibur" Number="70" Volume="1988" Year="1993">
+<Database Name="cv" Series="4052" Issue="66359" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="294" Volume="1981" Year="1992">
+<Database Name="cv" Series="3092" Issue="107063" />
+</Book>
+<Book Series="X-Factor" Number="84" Volume="1986" Year="1992">
+<Database Name="cv" Series="3657" Issue="107134" />
+</Book>
+<Book Series="X-Men" Number="14" Volume="1991" Year="1992">
+<Database Name="cv" Series="4605" Issue="106566" />
+</Book>
+<Book Series="X-Force" Number="16" Volume="1991" Year="1992">
+<Database Name="cv" Series="4604" Issue="107129" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="295" Volume="1981" Year="1992">
+<Database Name="cv" Series="3092" Issue="107067" />
+</Book>
+<Book Series="X-Factor" Number="85" Volume="1986" Year="1992">
+<Database Name="cv" Series="3657" Issue="107135" />
+</Book>
+<Book Series="X-Men" Number="15" Volume="1991" Year="1992">
+<Database Name="cv" Series="4605" Issue="106567" />
+</Book>
+<Book Series="X-Force" Number="17" Volume="1991" Year="1992">
+<Database Name="cv" Series="4604" Issue="107130" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="296" Volume="1981" Year="1993">
+<Database Name="cv" Series="3092" Issue="107087" />
+</Book>
+<Book Series="X-Factor" Number="86" Volume="1986" Year="1993">
+<Database Name="cv" Series="3657" Issue="107136" />
+</Book>
+<Book Series="X-Men" Number="16" Volume="1991" Year="1993">
+<Database Name="cv" Series="4605" Issue="106568" />
+</Book>
+<Book Series="X-Force" Number="18" Volume="1991" Year="1993">
+<Database Name="cv" Series="4604" Issue="107133" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="297" Volume="1981" Year="1993">
+<Database Name="cv" Series="3092" Issue="107105" />
+</Book>
+<Book Series="X-Men" Number="24" Volume="1991" Year="1993">
+<Database Name="cv" Series="4605" Issue="37813" />
+</Book>
+<Book Series="X-Factor" Number="92" Volume="1986" Year="1993">
+<Database Name="cv" Series="3657" Issue="37532" />
+</Book>
+<Book Series="X-Force" Number="25" Volume="1991" Year="1993">
+<Database Name="cv" Series="4604" Issue="64502" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="304" Volume="1981" Year="1993">
+<Database Name="cv" Series="3092" Issue="37831" />
+</Book>
+<Book Series="X-Men" Number="25" Volume="1991" Year="1993">
+<Database Name="cv" Series="4605" Issue="65726" />
+</Book>
+<Book Series="Wolverine" Number="75" Volume="1988" Year="1993">
+<Database Name="cv" Series="4250" Issue="38134" />
+</Book>
+<Book Series="Excalibur" Number="71" Volume="1988" Year="1993">
+<Database Name="cv" Series="4052" Issue="66360" />
+</Book>
+<Book Series="Excalibur" Number="72" Volume="1988" Year="1993">
+<Database Name="cv" Series="4052" Issue="66361" />
+</Book>
+<Book Series="Excalibur" Number="73" Volume="1988" Year="1994">
+<Database Name="cv" Series="4052" Issue="66362" />
+</Book>
+<Book Series="Excalibur" Number="74" Volume="1988" Year="1994">
+<Database Name="cv" Series="4052" Issue="66363" />
+</Book>
+<Book Series="Excalibur" Number="75" Volume="1988" Year="1994">
+<Database Name="cv" Series="4052" Issue="66364" />
+</Book>
+<Book Series="Excalibur" Number="76" Volume="1988" Year="1994">
+<Database Name="cv" Series="4052" Issue="66365" />
+</Book>
+<Book Series="Excalibur" Number="77" Volume="1988" Year="1994">
+<Database Name="cv" Series="4052" Issue="66366" />
+</Book>
+<Book Series="Excalibur" Number="78" Volume="1988" Year="1994">
+<Database Name="cv" Series="4052" Issue="66367" />
+</Book>
+<Book Series="Excalibur" Number="79" Volume="1988" Year="1994">
+<Database Name="cv" Series="4052" Issue="66368" />
+</Book>
+<Book Series="Excalibur" Number="80" Volume="1988" Year="1994">
+<Database Name="cv" Series="4052" Issue="66369" />
+</Book>
+<Book Series="Excalibur" Number="81" Volume="1988" Year="1994">
+<Database Name="cv" Series="4052" Issue="66370" />
+</Book>
+<Book Series="The Adventures of Cyclops and Phoenix" Number="1" Volume="1994" Year="1994">
+<Database Name="cv" Series="5272" Issue="39115" />
+</Book>
+<Book Series="The Adventures of Cyclops and Phoenix" Number="2" Volume="1994" Year="1994">
+<Database Name="cv" Series="5272" Issue="39265" />
+</Book>
+<Book Series="The Adventures of Cyclops and Phoenix" Number="3" Volume="1994" Year="1994">
+<Database Name="cv" Series="5272" Issue="39408" />
+</Book>
+<Book Series="The Adventures of Cyclops and Phoenix" Number="4" Volume="1994" Year="1994">
+<Database Name="cv" Series="5272" Issue="39551" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="316" Volume="1981" Year="1994">
+<Database Name="cv" Series="3092" Issue="39680" />
+</Book>
+<Book Series="X-Men" Number="36" Volume="1991" Year="1994">
+<Database Name="cv" Series="4605" Issue="65737" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="317" Volume="1981" Year="1994">
+<Database Name="cv" Series="3092" Issue="39830" />
+</Book>
+<Book Series="X-Men" Number="37" Volume="1991" Year="1994">
+<Database Name="cv" Series="4605" Issue="65738" />
+</Book>
+<Book Series="X-Factor" Number="106" Volume="1986" Year="1994">
+<Database Name="cv" Series="3657" Issue="65687" />
+</Book>
+<Book Series="X-Force" Number="38" Volume="1991" Year="1994">
+<Database Name="cv" Series="4604" Issue="64512" />
+</Book>
+<Book Series="Excalibur" Number="82" Volume="1988" Year="1994">
+<Database Name="cv" Series="4052" Issue="39791" />
+</Book>
+<Book Series="Wolverine" Number="85" Volume="1988" Year="1994">
+<Database Name="cv" Series="4250" Issue="39683" />
+</Book>
+<Book Series="Cable" Number="16" Volume="1993" Year="1994">
+<Database Name="cv" Series="4993" Issue="39824" />
+</Book>
+<Book Series="Excalibur" Number="83" Volume="1988" Year="1994">
+<Database Name="cv" Series="4052" Issue="39934" />
+</Book>
+<Book Series="Excalibur" Number="84" Volume="1988" Year="1994">
+<Database Name="cv" Series="4052" Issue="40076" />
+</Book>
+<Book Series="Excalibur" Number="85" Volume="1988" Year="1995">
+<Database Name="cv" Series="4052" Issue="40317" />
+</Book>
+<Book Series="Excalibur" Number="86" Volume="1988" Year="1995">
+<Database Name="cv" Series="4052" Issue="66372" />
+</Book>
+<Book Series="X-Men" Number="38" Volume="1991" Year="1994">
+<Database Name="cv" Series="4605" Issue="65739" />
+</Book>
+<Book Series="X-Factor" Number="108" Volume="1986" Year="1994">
+<Database Name="cv" Series="3657" Issue="65689" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="319" Volume="1981" Year="1994">
+<Database Name="cv" Series="3092" Issue="40115" />
+</Book>
+<Book Series="X-Men" Number="39" Volume="1991" Year="1994">
+<Database Name="cv" Series="4605" Issue="65740" />
+</Book>
+<Book Series="X-Factor" Number="109" Volume="1986" Year="1994">
+<Database Name="cv" Series="3657" Issue="65690" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="320" Volume="1981" Year="1995">
+<Database Name="cv" Series="3092" Issue="40358" />
+</Book>
+<Book Series="X-Men" Number="40" Volume="1991" Year="1995">
+<Database Name="cv" Series="4605" Issue="65741" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="321" Volume="1981" Year="1995">
+<Database Name="cv" Series="3092" Issue="40487" />
+</Book>
+<Book Series="X-Men" Number="41" Volume="1991" Year="1995">
+<Database Name="cv" Series="4605" Issue="65742" />
+</Book>
+<Book Series="Cable" Number="20" Volume="1993" Year="1995">
+<Database Name="cv" Series="4993" Issue="40492" />
+</Book>
+<Book Series="X-Men: Age of Apocalypse" Number="1" Volume="2005" Year="2005">
+<Database Name="cv" Series="11501" Issue="101450" />
+</Book>
+<Book Series="X-Men Chronicles" Number="1" Volume="1995" Year="1995">
+<Database Name="cv" Series="18037" Issue="105613" />
+</Book>
+<Book Series="X-Man '96" Number="1" Volume="1996" Year="1996">
+<Database Name="cv" Series="18050" Issue="105728" />
+</Book>
+<Book Series="Tales from the Age of Apocalypse" Number="2" Volume="1996" Year="1997">
+<Database Name="cv" Series="18054" Issue="105741" />
+</Book>
+<Book Series="Tales from the Age of Apocalypse" Number="1" Volume="1996" Year="1996">
+<Database Name="cv" Series="18054" Issue="105734" />
+</Book>
+<Book Series="X-Men Chronicles" Number="2" Volume="1995" Year="1995">
+<Database Name="cv" Series="18037" Issue="105648" />
+</Book>
+<Book Series="X-Man" Number="-1" Volume="1995" Year="1997">
+<Database Name="cv" Series="5567" Issue="43887" />
+</Book>
+<Book Series="Blink" Number="1" Volume="2001" Year="2001">
+<Database Name="cv" Series="6985" Issue="49461" />
+</Book>
+<Book Series="Blink" Number="2" Volume="2001" Year="2001">
+<Database Name="cv" Series="6985" Issue="49462" />
+</Book>
+<Book Series="Blink" Number="3" Volume="2001" Year="2001">
+<Database Name="cv" Series="6985" Issue="49463" />
+</Book>
+<Book Series="Blink" Number="4" Volume="2001" Year="2001">
+<Database Name="cv" Series="6985" Issue="49464" />
+</Book>
+<Book Series="X-Men Alpha" Number="1" Volume="1995" Year="1995">
+<Database Name="cv" Series="18051" Issue="105731" />
+</Book>
+<Book Series="Astonishing X-Men" Number="1" Volume="1995" Year="1995">
+<Database Name="cv" Series="5536" Issue="40582" />
+</Book>
+<Book Series="X-Calibre" Number="1" Volume="1995" Year="1995">
+<Database Name="cv" Series="5566" Issue="40600" />
+</Book>
+<Book Series="Gambit &#38; The X-Ternals" Number="1" Volume="1995" Year="1995">
+<Database Name="cv" Series="5546" Issue="40588" />
+</Book>
+<Book Series="Generation Next" Number="1" Volume="1995" Year="1995">
+<Database Name="cv" Series="5547" Issue="40589" />
+</Book>
+<Book Series="Weapon X" Number="1" Volume="1995" Year="1995">
+<Database Name="cv" Series="5564" Issue="40598" />
+</Book>
+<Book Series="Amazing X-Men" Number="1" Volume="1995" Year="1995">
+<Database Name="cv" Series="5535" Issue="40581" />
+</Book>
+<Book Series="Factor X" Number="1" Volume="1995" Year="1995">
+<Database Name="cv" Series="5543" Issue="40587" />
+</Book>
+<Book Series="X-Man" Number="1" Volume="1995" Year="1995">
+<Database Name="cv" Series="5567" Issue="40601" />
+</Book>
+<Book Series="Amazing X-Men" Number="2" Volume="1995" Year="1995">
+<Database Name="cv" Series="5535" Issue="105543" />
+</Book>
+<Book Series="Factor X" Number="2" Volume="1995" Year="1995">
+<Database Name="cv" Series="5543" Issue="40726" />
+</Book>
+<Book Series="Weapon X" Number="2" Volume="1995" Year="1995">
+<Database Name="cv" Series="5564" Issue="40733" />
+</Book>
+<Book Series="Gambit &#38; The X-Ternals" Number="2" Volume="1995" Year="1995">
+<Database Name="cv" Series="5546" Issue="40728" />
+</Book>
+<Book Series="X-Calibre" Number="2" Volume="1995" Year="1995">
+<Database Name="cv" Series="5566" Issue="40735" />
+</Book>
+<Book Series="Generation Next" Number="2" Volume="1995" Year="1995">
+<Database Name="cv" Series="5547" Issue="40729" />
+</Book>
+<Book Series="Astonishing X-Men" Number="2" Volume="1995" Year="1995">
+<Database Name="cv" Series="5536" Issue="40720" />
+</Book>
+<Book Series="X-Man" Number="2" Volume="1995" Year="1995">
+<Database Name="cv" Series="5567" Issue="40736" />
+</Book>
+<Book Series="Age of Apocalypse: The Chosen" Number="1" Volume="1995" Year="1995">
+<Database Name="cv" Series="18065" Issue="105758" />
+</Book>
+<Book Series="Factor X" Number="3" Volume="1995" Year="1995">
+<Database Name="cv" Series="5543" Issue="40850" />
+</Book>
+<Book Series="Astonishing X-Men" Number="3" Volume="1995" Year="1995">
+<Database Name="cv" Series="5536" Issue="40845" />
+</Book>
+<Book Series="Amazing X-Men" Number="3" Volume="1995" Year="1995">
+<Database Name="cv" Series="5535" Issue="40844" />
+</Book>
+<Book Series="X-Calibre" Number="3" Volume="1995" Year="1995">
+<Database Name="cv" Series="5566" Issue="40861" />
+</Book>
+<Book Series="Gambit &#38; The X-Ternals" Number="3" Volume="1995" Year="1995">
+<Database Name="cv" Series="5546" Issue="40852" />
+</Book>
+<Book Series="Generation Next" Number="3" Volume="1995" Year="1995">
+<Database Name="cv" Series="5547" Issue="40853" />
+</Book>
+<Book Series="X-Man" Number="3" Volume="1995" Year="1995">
+<Database Name="cv" Series="5567" Issue="40862" />
+</Book>
+<Book Series="Weapon X" Number="3" Volume="1995" Year="1995">
+<Database Name="cv" Series="5564" Issue="40859" />
+</Book>
+<Book Series="X-Universe" Number="1" Volume="1995" Year="1995">
+<Database Name="cv" Series="5572" Issue="40864" />
+</Book>
+<Book Series="X-Calibre" Number="4" Volume="1995" Year="1995">
+<Database Name="cv" Series="5566" Issue="40984" />
+</Book>
+<Book Series="Generation Next" Number="4" Volume="1995" Year="1995">
+<Database Name="cv" Series="5547" Issue="40977" />
+</Book>
+<Book Series="Astonishing X-Men" Number="4" Volume="1995" Year="1995">
+<Database Name="cv" Series="5536" Issue="40968" />
+</Book>
+<Book Series="X-Man" Number="4" Volume="1995" Year="1995">
+<Database Name="cv" Series="5567" Issue="40985" />
+</Book>
+<Book Series="Factor X" Number="4" Volume="1995" Year="1995">
+<Database Name="cv" Series="5543" Issue="40973" />
+</Book>
+<Book Series="Weapon X" Number="4" Volume="1995" Year="1995">
+<Database Name="cv" Series="5564" Issue="40982" />
+</Book>
+<Book Series="X-Universe" Number="2" Volume="1995" Year="1995">
+<Database Name="cv" Series="5572" Issue="40988" />
+</Book>
+<Book Series="Gambit &#38; The X-Ternals" Number="4" Volume="1995" Year="1995">
+<Database Name="cv" Series="5546" Issue="40976" />
+</Book>
+<Book Series="Amazing X-Men" Number="4" Volume="1995" Year="1995">
+<Database Name="cv" Series="5535" Issue="40967" />
+</Book>
+<Book Series="X-Men Omega" Number="1" Volume="1995" Year="1995">
+<Database Name="cv" Series="18093" Issue="105975" />
+</Book>
+<Book Series="Excalibur" Number="87" Volume="1988" Year="1995">
+<Database Name="cv" Series="4052" Issue="66373" />
+</Book>
+<Book Series="Excalibur" Number="88" Volume="1988" Year="1995">
+<Database Name="cv" Series="4052" Issue="66374" />
+</Book>
+<Book Series="Excalibur" Number="89" Volume="1988" Year="1995">
+<Database Name="cv" Series="4052" Issue="41383" />
+</Book>
+<Book Series="Excalibur" Number="90" Volume="1988" Year="1995">
+<Database Name="cv" Series="4052" Issue="66376" />
+</Book>
+<Book Series="Excalibur" Number="91" Volume="1988" Year="1995">
+<Database Name="cv" Series="4052" Issue="41641" />
+</Book>
+<Book Series="Excalibur" Number="92" Volume="1988" Year="1995">
+<Database Name="cv" Series="4052" Issue="66377" />
+</Book>
+<Book Series="Excalibur" Number="93" Volume="1988" Year="1996">
+<Database Name="cv" Series="4052" Issue="66378" />
+</Book>
+<Book Series="Excalibur" Number="94" Volume="1988" Year="1996">
+<Database Name="cv" Series="4052" Issue="66379" />
+</Book>
+<Book Series="Excalibur" Number="95" Volume="1988" Year="1996">
+<Database Name="cv" Series="4052" Issue="42205" />
+</Book>
+<Book Series="Excalibur" Number="96" Volume="1988" Year="1996">
+<Database Name="cv" Series="4052" Issue="42302" />
+</Book>
+<Book Series="Excalibur" Number="97" Volume="1988" Year="1996">
+<Database Name="cv" Series="4052" Issue="66380" />
+</Book>
+<Book Series="Excalibur" Number="98" Volume="1988" Year="1996">
+<Database Name="cv" Series="4052" Issue="66381" />
+</Book>
+<Book Series="Excalibur" Number="99" Volume="1988" Year="1996">
+<Database Name="cv" Series="4052" Issue="66382" />
+</Book>
+<Book Series="Excalibur" Number="100" Volume="1988" Year="1996">
+<Database Name="cv" Series="4052" Issue="66383" />
+</Book>
+<Book Series="Excalibur" Number="101" Volume="1988" Year="1996">
+<Database Name="cv" Series="4052" Issue="66384" />
+</Book>
+<Book Series="Excalibur" Number="102" Volume="1988" Year="1996">
+<Database Name="cv" Series="4052" Issue="66385" />
+</Book>
+<Book Series="Excalibur" Number="103" Volume="1988" Year="1996">
+<Database Name="cv" Series="4052" Issue="66386" />
+</Book>
+<Book Series="Excalibur" Number="104" Volume="1988" Year="1996">
+<Database Name="cv" Series="4052" Issue="66387" />
+</Book>
+<Book Series="Excalibur" Number="105" Volume="1988" Year="1997">
+<Database Name="cv" Series="4052" Issue="66388" />
+</Book>
+<Book Series="Excalibur" Number="106" Volume="1988" Year="1997">
+<Database Name="cv" Series="4052" Issue="66389" />
+</Book>
+<Book Series="Excalibur" Number="107" Volume="1988" Year="1997">
+<Database Name="cv" Series="4052" Issue="43481" />
+</Book>
+<Book Series="Excalibur" Number="108" Volume="1988" Year="1997">
+<Database Name="cv" Series="4052" Issue="43577" />
+</Book>
+<Book Series="Excalibur" Number="109" Volume="1988" Year="1997">
+<Database Name="cv" Series="4052" Issue="66391" />
+</Book>
+<Book Series="Excalibur" Number="110" Volume="1988" Year="1997">
+<Database Name="cv" Series="4052" Issue="66392" />
+</Book>
+<Book Series="Excalibur" Number="111" Volume="1988" Year="1997">
+<Database Name="cv" Series="4052" Issue="66393" />
+</Book>
+<Book Series="Excalibur" Number="112" Volume="1988" Year="1997">
+<Database Name="cv" Series="4052" Issue="66394" />
+</Book>
+<Book Series="Excalibur" Number="113" Volume="1988" Year="1997">
+<Database Name="cv" Series="4052" Issue="66395" />
+</Book>
+<Book Series="Excalibur" Number="114" Volume="1988" Year="1997">
+<Database Name="cv" Series="4052" Issue="66396" />
+</Book>
+<Book Series="Excalibur" Number="115" Volume="1988" Year="1997">
+<Database Name="cv" Series="4052" Issue="66397" />
+</Book>
+<Book Series="Excalibur" Number="116" Volume="1988" Year="1998">
+<Database Name="cv" Series="4052" Issue="66398" />
+</Book>
+<Book Series="Excalibur" Number="117" Volume="1988" Year="1998">
+<Database Name="cv" Series="4052" Issue="66399" />
+</Book>
+<Book Series="Excalibur" Number="118" Volume="1988" Year="1998">
+<Database Name="cv" Series="4052" Issue="66400" />
+</Book>
+<Book Series="Excalibur" Number="119" Volume="1988" Year="1998">
+<Database Name="cv" Series="4052" Issue="66401" />
+</Book>
+<Book Series="Excalibur" Number="120" Volume="1988" Year="1998">
+<Database Name="cv" Series="4052" Issue="66402" />
+</Book>
+<Book Series="Excalibur" Number="121" Volume="1988" Year="1998">
+<Database Name="cv" Series="4052" Issue="66403" />
+</Book>
+<Book Series="Excalibur" Number="122" Volume="1988" Year="1998">
+<Database Name="cv" Series="4052" Issue="66404" />
+</Book>
+<Book Series="Excalibur" Number="123" Volume="1988" Year="1998">
+<Database Name="cv" Series="4052" Issue="66405" />
+</Book>
+<Book Series="Excalibur" Number="124" Volume="1988" Year="1998">
+<Database Name="cv" Series="4052" Issue="66406" />
+</Book>
+<Book Series="Excalibur" Number="125" Volume="1988" Year="1998">
+<Database Name="cv" Series="4052" Issue="66407" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="365" Volume="1981" Year="1999">
+<Database Name="cv" Series="3092" Issue="45681" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="366" Volume="1981" Year="1999">
+<Database Name="cv" Series="3092" Issue="45736" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="367" Volume="1981" Year="1999">
+<Database Name="cv" Series="3092" Issue="45785" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="368" Volume="1981" Year="1999">
+<Database Name="cv" Series="3092" Issue="45834" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="369" Volume="1981" Year="1999">
+<Database Name="cv" Series="3092" Issue="45878" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="370" Volume="1981" Year="1999">
+<Database Name="cv" Series="3092" Issue="65136" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="371" Volume="1981" Year="1999">
+<Database Name="cv" Series="3092" Issue="65137" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="372" Volume="1981" Year="1999">
+<Database Name="cv" Series="3092" Issue="65138" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="373" Volume="1981" Year="1999">
+<Database Name="cv" Series="3092" Issue="150001" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="374" Volume="1981" Year="1999">
+<Database Name="cv" Series="3092" Issue="65139" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="375" Volume="1981" Year="1999">
+<Database Name="cv" Series="3092" Issue="65140" />
+</Book>
+<Book Series="Mutant X" Number="1" Volume="1998" Year="1998">
+<Database Name="cv" Series="6217" Issue="45399" />
+</Book>
+<Book Series="Mutant X" Number="2" Volume="1998" Year="1998">
+<Database Name="cv" Series="6217" Issue="45470" />
+</Book>
+<Book Series="Mutant X" Number="3" Volume="1998" Year="1998">
+<Database Name="cv" Series="6217" Issue="45530" />
+</Book>
+<Book Series="Mutant X" Number="4" Volume="1998" Year="1999">
+<Database Name="cv" Series="6217" Issue="45621" />
+</Book>
+<Book Series="Mutant X" Number="5" Volume="1998" Year="1999">
+<Database Name="cv" Series="6217" Issue="45683" />
+</Book>
+<Book Series="Mutant X" Number="6" Volume="1998" Year="1999">
+<Database Name="cv" Series="6217" Issue="45737" />
+</Book>
+<Book Series="Mutant X" Number="7" Volume="1998" Year="1999">
+<Database Name="cv" Series="6217" Issue="45787" />
+</Book>
+<Book Series="Mutant X" Number="8" Volume="1998" Year="1999">
+<Database Name="cv" Series="6217" Issue="45835" />
+</Book>
+<Book Series="Mutant X" Number="9" Volume="1998" Year="1999">
+<Database Name="cv" Series="6217" Issue="45880" />
+</Book>
+<Book Series="Mutant X" Number="10" Volume="1998" Year="1999">
+<Database Name="cv" Series="6217" Issue="45923" />
+</Book>
+<Book Series="Mutant X" Number="11" Volume="1998" Year="1999">
+<Database Name="cv" Series="6217" Issue="45958" />
+</Book>
+<Book Series="Mutant X" Number="12" Volume="1998" Year="1999">
+<Database Name="cv" Series="6217" Issue="46005" />
+</Book>
+<Book Series="Mutant X" Number="13" Volume="1998" Year="1999">
+<Database Name="cv" Series="6217" Issue="46049" />
+</Book>
+<Book Series="Mutant X" Number="14" Volume="1998" Year="1999">
+<Database Name="cv" Series="6217" Issue="46093" />
+</Book>
+<Book Series="Mutant X" Number="15" Volume="1998" Year="1999">
+<Database Name="cv" Series="6217" Issue="46175" />
+</Book>
+<Book Series="Mutant X" Number="16" Volume="1998" Year="2000">
+<Database Name="cv" Series="6217" Issue="46235" />
+</Book>
+<Book Series="Mutant X" Number="17" Volume="1998" Year="2000">
+<Database Name="cv" Series="6217" Issue="46282" />
+</Book>
+<Book Series="Mutant X" Number="18" Volume="1998" Year="2000">
+<Database Name="cv" Series="6217" Issue="46337" />
+</Book>
+<Book Series="Mutant X" Number="19" Volume="1998" Year="2000">
+<Database Name="cv" Series="6217" Issue="46357" />
+</Book>
+<Book Series="Mutant X" Number="20" Volume="1998" Year="2000">
+<Database Name="cv" Series="6217" Issue="46377" />
+</Book>
+<Book Series="Mutant X" Number="21" Volume="1998" Year="2000">
+<Database Name="cv" Series="6217" Issue="46394" />
+</Book>
+<Book Series="Mutant X" Number="22" Volume="1998" Year="2000">
+<Database Name="cv" Series="6217" Issue="46410" />
+</Book>
+<Book Series="Mutant X" Number="23" Volume="1998" Year="2000">
+<Database Name="cv" Series="6217" Issue="46425" />
+</Book>
+<Book Series="Mutant X" Number="24" Volume="1998" Year="2000">
+<Database Name="cv" Series="6217" Issue="46433" />
+</Book>
+<Book Series="Mutant X" Number="25" Volume="1998" Year="2000">
+<Database Name="cv" Series="6217" Issue="46442" />
+</Book>
+<Book Series="Mutant X" Number="26" Volume="1998" Year="2000">
+<Database Name="cv" Series="6217" Issue="49443" />
+</Book>
+<Book Series="Mutant X" Number="27" Volume="1998" Year="2001">
+<Database Name="cv" Series="6217" Issue="49444" />
+</Book>
+<Book Series="Mutant X" Number="28" Volume="1998" Year="2001">
+<Database Name="cv" Series="6217" Issue="49445" />
+</Book>
+<Book Series="Mutant X" Number="29" Volume="1998" Year="2001">
+<Database Name="cv" Series="6217" Issue="49446" />
+</Book>
+<Book Series="Mutant X" Number="30" Volume="1998" Year="2001">
+<Database Name="cv" Series="6217" Issue="49447" />
+</Book>
+<Book Series="Mutant X" Number="31" Volume="1998" Year="2001">
+<Database Name="cv" Series="6217" Issue="49448" />
+</Book>
+<Book Series="Mutant X" Number="32" Volume="1998" Year="2001">
+<Database Name="cv" Series="6217" Issue="49449" />
+</Book>
+<Book Series="X-Men: Magik" Number="1" Volume="2000" Year="2000">
+<Database Name="cv" Series="11667" Issue="103140" />
+</Book>
+<Book Series="X-Men: Magik" Number="2" Volume="2000" Year="2001">
+<Database Name="cv" Series="11667" Issue="103141" />
+</Book>
+<Book Series="X-Men: Magik" Number="3" Volume="2000" Year="2001">
+<Database Name="cv" Series="11667" Issue="103142" />
+</Book>
+<Book Series="X-Men: Magik" Number="4" Volume="2000" Year="2001">
+<Database Name="cv" Series="11667" Issue="103143" />
+</Book>
+<Book Series="New X-Men" Number="114" Volume="2001" Year="2001">
+<Database Name="cv" Series="9121" Issue="66992" />
+</Book>
+<Book Series="New X-Men" Number="115" Volume="2001" Year="2001">
+<Database Name="cv" Series="9121" Issue="66993" />
+</Book>
+<Book Series="New X-Men" Number="116" Volume="2001" Year="2001">
+<Database Name="cv" Series="9121" Issue="66994" />
+</Book>
+<Book Series="New X-Men" Number="117" Volume="2001" Year="2001">
+<Database Name="cv" Series="9121" Issue="66995" />
+</Book>
+<Book Series="New X-Men" Number="118" Volume="2001" Year="2001">
+<Database Name="cv" Series="9121" Issue="78322" />
+</Book>
+<Book Series="New X-Men" Number="119" Volume="2001" Year="2001">
+<Database Name="cv" Series="9121" Issue="78323" />
+</Book>
+<Book Series="New X-Men" Number="120" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="78324" />
+</Book>
+<Book Series="New X-Men" Number="121" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="78325" />
+</Book>
+<Book Series="New X-Men" Number="122" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="78326" />
+</Book>
+<Book Series="New X-Men" Number="123" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="78327" />
+</Book>
+<Book Series="New X-Men" Number="124" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="78328" />
+</Book>
+<Book Series="New X-Men" Number="125" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="78329" />
+</Book>
+<Book Series="New X-Men" Number="126" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="78330" />
+</Book>
+<Book Series="New X-Men" Number="127" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="78331" />
+</Book>
+<Book Series="New X-Men" Number="128" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="80585" />
+</Book>
+<Book Series="New X-Men" Number="129" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="106089" />
+</Book>
+<Book Series="New X-Men" Number="130" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="106112" />
+</Book>
+<Book Series="New X-Men" Number="131" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="106161" />
+</Book>
+<Book Series="New X-Men" Number="132" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="106564" />
+</Book>
+<Book Series="New X-Men" Number="133" Volume="2001" Year="2002">
+<Database Name="cv" Series="9121" Issue="106301" />
+</Book>
+<Book Series="New X-Men" Number="134" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="106499" />
+</Book>
+<Book Series="New X-Men" Number="135" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="112536" />
+</Book>
+<Book Series="New X-Men" Number="136" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="114332" />
+</Book>
+<Book Series="New X-Men" Number="137" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="114333" />
+</Book>
+<Book Series="New X-Men" Number="138" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="114334" />
+</Book>
+<Book Series="New X-Men" Number="139" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="114335" />
+</Book>
+<Book Series="New X-Men" Number="140" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="114336" />
+</Book>
+<Book Series="New X-Men" Number="141" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="114456" />
+</Book>
+<Book Series="New X-Men" Number="142" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="114457" />
+</Book>
+<Book Series="New X-Men" Number="143" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="114449" />
+</Book>
+<Book Series="New X-Men" Number="144" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="114450" />
+</Book>
+<Book Series="New X-Men" Number="145" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="114453" />
+</Book>
+<Book Series="New X-Men" Number="146" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="114451" />
+</Book>
+<Book Series="New X-Men" Number="147" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="114452" />
+</Book>
+<Book Series="New X-Men" Number="148" Volume="2001" Year="2003">
+<Database Name="cv" Series="9121" Issue="114454" />
+</Book>
+<Book Series="New X-Men" Number="149" Volume="2001" Year="2004">
+<Database Name="cv" Series="9121" Issue="114458" />
+</Book>
+<Book Series="New X-Men" Number="150" Volume="2001" Year="2004">
+<Database Name="cv" Series="9121" Issue="114459" />
+</Book>
+<Book Series="New X-Men" Number="151" Volume="2001" Year="2004">
+<Database Name="cv" Series="9121" Issue="106245" />
+</Book>
+<Book Series="New X-Men" Number="152" Volume="2001" Year="2004">
+<Database Name="cv" Series="9121" Issue="106246" />
+</Book>
+<Book Series="New X-Men" Number="153" Volume="2001" Year="2004">
+<Database Name="cv" Series="9121" Issue="106247" />
+</Book>
+<Book Series="New X-Men" Number="154" Volume="2001" Year="2004">
+<Database Name="cv" Series="9121" Issue="106248" />
+</Book>
+<Book Series="Exiles" Number="1" Volume="2001" Year="2001">
+<Database Name="cv" Series="6983" Issue="49450" />
+</Book>
+<Book Series="Exiles" Number="2" Volume="2001" Year="2001">
+<Database Name="cv" Series="6983" Issue="50744" />
+</Book>
+<Book Series="Exiles" Number="3" Volume="2001" Year="2001">
+<Database Name="cv" Series="6983" Issue="50745" />
+</Book>
+<Book Series="Exiles" Number="4" Volume="2001" Year="2001">
+<Database Name="cv" Series="6983" Issue="50746" />
+</Book>
+<Book Series="Exiles" Number="5" Volume="2001" Year="2001">
+<Database Name="cv" Series="6983" Issue="50747" />
+</Book>
+<Book Series="Exiles" Number="6" Volume="2001" Year="2002">
+<Database Name="cv" Series="6983" Issue="50748" />
+</Book>
+<Book Series="Exiles" Number="7" Volume="2001" Year="2002">
+<Database Name="cv" Series="6983" Issue="105360" />
+</Book>
+<Book Series="Exiles" Number="8" Volume="2001" Year="2002">
+<Database Name="cv" Series="6983" Issue="105361" />
+</Book>
+<Book Series="Exiles" Number="9" Volume="2001" Year="2002">
+<Database Name="cv" Series="6983" Issue="105362" />
+</Book>
+<Book Series="Exiles" Number="10" Volume="2001" Year="2002">
+<Database Name="cv" Series="6983" Issue="74606" />
+</Book>
+<Book Series="Exiles" Number="11" Volume="2001" Year="2002">
+<Database Name="cv" Series="6983" Issue="105363" />
+</Book>
+<Book Series="Exiles" Number="12" Volume="2001" Year="2002">
+<Database Name="cv" Series="6983" Issue="105364" />
+</Book>
+<Book Series="Exiles" Number="13" Volume="2001" Year="2002">
+<Database Name="cv" Series="6983" Issue="105365" />
+</Book>
+<Book Series="Exiles" Number="14" Volume="2001" Year="2002">
+<Database Name="cv" Series="6983" Issue="105366" />
+</Book>
+<Book Series="Exiles" Number="15" Volume="2001" Year="2002">
+<Database Name="cv" Series="6983" Issue="105367" />
+</Book>
+<Book Series="Exiles" Number="16" Volume="2001" Year="2002">
+<Database Name="cv" Series="6983" Issue="105369" />
+</Book>
+<Book Series="Exiles" Number="17" Volume="2001" Year="2002">
+<Database Name="cv" Series="6983" Issue="105368" />
+</Book>
+<Book Series="Exiles" Number="18" Volume="2001" Year="2002">
+<Database Name="cv" Series="6983" Issue="105370" />
+</Book>
+<Book Series="Exiles" Number="19" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="105371" />
+</Book>
+<Book Series="Exiles" Number="20" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="105372" />
+</Book>
+<Book Series="Exiles" Number="21" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92774" />
+</Book>
+<Book Series="Exiles" Number="22" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92775" />
+</Book>
+<Book Series="Exiles" Number="23" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92776" />
+</Book>
+<Book Series="Exiles" Number="24" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92777" />
+</Book>
+<Book Series="Exiles" Number="25" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92778" />
+</Book>
+<Book Series="Exiles" Number="26" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92779" />
+</Book>
+<Book Series="Exiles" Number="27" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92780" />
+</Book>
+<Book Series="Exiles" Number="28" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92781" />
+</Book>
+<Book Series="Exiles" Number="29" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92782" />
+</Book>
+<Book Series="Exiles" Number="30" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92783" />
+</Book>
+<Book Series="Exiles" Number="31" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92784" />
+</Book>
+<Book Series="Exiles" Number="32" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92785" />
+</Book>
+<Book Series="Exiles" Number="33" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92786" />
+</Book>
+<Book Series="Exiles" Number="34" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92787" />
+</Book>
+<Book Series="Exiles" Number="35" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92788" />
+</Book>
+<Book Series="Exiles" Number="36" Volume="2001" Year="2003">
+<Database Name="cv" Series="6983" Issue="92789" />
+</Book>
+<Book Series="Exiles" Number="37" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="92790" />
+</Book>
+<Book Series="Exiles" Number="38" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="92791" />
+</Book>
+<Book Series="Exiles" Number="39" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="92792" />
+</Book>
+<Book Series="Exiles" Number="40" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="92793" />
+</Book>
+<Book Series="Exiles" Number="41" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="92794" />
+</Book>
+<Book Series="Exiles" Number="42" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="92795" />
+</Book>
+<Book Series="Exiles" Number="43" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="92796" />
+</Book>
+<Book Series="Exiles" Number="44" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="92797" />
+</Book>
+<Book Series="Exiles" Number="45" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="92798" />
+</Book>
+<Book Series="Exiles" Number="46" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="92799" />
+</Book>
+<Book Series="Exiles" Number="47" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="92800" />
+</Book>
+<Book Series="Exiles" Number="48" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="92801" />
+</Book>
+<Book Series="Exiles" Number="49" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="99106" />
+</Book>
+<Book Series="Exiles" Number="50" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="99107" />
+</Book>
+<Book Series="Exiles" Number="51" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="99108" />
+</Book>
+<Book Series="Exiles" Number="52" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="99109" />
+</Book>
+<Book Series="Exiles" Number="53" Volume="2001" Year="2004">
+<Database Name="cv" Series="6983" Issue="99110" />
+</Book>
+<Book Series="Exiles" Number="54" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="99111" />
+</Book>
+<Book Series="Exiles" Number="55" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="99112" />
+</Book>
+<Book Series="Exiles" Number="56" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="99113" />
+</Book>
+<Book Series="Exiles" Number="57" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="99114" />
+</Book>
+<Book Series="Exiles" Number="58" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="101047" />
+</Book>
+<Book Series="Exiles" Number="59" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="101048" />
+</Book>
+<Book Series="Exiles" Number="60" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="101049" />
+</Book>
+<Book Series="Exiles" Number="61" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="101050" />
+</Book>
+<Book Series="Exiles" Number="62" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="101051" />
+</Book>
+<Book Series="Exiles" Number="63" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="105423" />
+</Book>
+<Book Series="Exiles" Number="64" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="105424" />
+</Book>
+<Book Series="Exiles" Number="65" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="105425" />
+</Book>
+<Book Series="Exiles" Number="66" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="105794" />
+</Book>
+<Book Series="Exiles" Number="67" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="105795" />
+</Book>
+<Book Series="Exiles" Number="68" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="105796" />
+</Book>
+<Book Series="NYX" Number="1" Volume="2003" Year="2003">
+<Database Name="cv" Series="17987" Issue="105318" />
+</Book>
+<Book Series="NYX" Number="2" Volume="2003" Year="2004">
+<Database Name="cv" Series="17987" Issue="105410" />
+</Book>
+<Book Series="NYX" Number="3" Volume="2003" Year="2004">
+<Database Name="cv" Series="17987" Issue="105411" />
+</Book>
+<Book Series="NYX" Number="4" Volume="2003" Year="2004">
+<Database Name="cv" Series="17987" Issue="105412" />
+</Book>
+<Book Series="NYX" Number="5" Volume="2003" Year="2004">
+<Database Name="cv" Series="17987" Issue="105413" />
+</Book>
+<Book Series="NYX" Number="6" Volume="2003" Year="2005">
+<Database Name="cv" Series="17987" Issue="107239" />
+</Book>
+<Book Series="NYX" Number="7" Volume="2003" Year="2005">
+<Database Name="cv" Series="17987" Issue="107240" />
+</Book>
+<Book Series="District X" Number="1" Volume="2004" Year="2004">
+<Database Name="cv" Series="19327" Issue="116029" />
+</Book>
+<Book Series="District X" Number="2" Volume="2004" Year="2004">
+<Database Name="cv" Series="19327" Issue="116067" />
+</Book>
+<Book Series="District X" Number="3" Volume="2004" Year="2004">
+<Database Name="cv" Series="19327" Issue="116069" />
+</Book>
+<Book Series="District X" Number="4" Volume="2004" Year="2004">
+<Database Name="cv" Series="19327" Issue="116070" />
+</Book>
+<Book Series="District X" Number="5" Volume="2004" Year="2004">
+<Database Name="cv" Series="19327" Issue="116071" />
+</Book>
+<Book Series="District X" Number="6" Volume="2004" Year="2004">
+<Database Name="cv" Series="19327" Issue="116072" />
+</Book>
+<Book Series="District X" Number="7" Volume="2004" Year="2005">
+<Database Name="cv" Series="19327" Issue="118019" />
+</Book>
+<Book Series="District X" Number="8" Volume="2004" Year="2005">
+<Database Name="cv" Series="19327" Issue="120737" />
+</Book>
+<Book Series="District X" Number="9" Volume="2004" Year="2005">
+<Database Name="cv" Series="19327" Issue="120738" />
+</Book>
+<Book Series="District X" Number="10" Volume="2004" Year="2005">
+<Database Name="cv" Series="19327" Issue="120739" />
+</Book>
+<Book Series="District X" Number="11" Volume="2004" Year="2005">
+<Database Name="cv" Series="19327" Issue="120740" />
+</Book>
+<Book Series="District X" Number="12" Volume="2004" Year="2005">
+<Database Name="cv" Series="19327" Issue="120741" />
+</Book>
+<Book Series="District X" Number="13" Volume="2004" Year="2005">
+<Database Name="cv" Series="19327" Issue="126234" />
+</Book>
+<Book Series="District X" Number="14" Volume="2004" Year="2005">
+<Database Name="cv" Series="19327" Issue="126233" />
+</Book>
+<Book Series="Astonishing X-Men" Number="1" Volume="2004" Year="2004">
+<Database Name="cv" Series="10746" Issue="90580" />
+</Book>
+<Book Series="Astonishing X-Men" Number="2" Volume="2004" Year="2004">
+<Database Name="cv" Series="10746" Issue="90581" />
+</Book>
+<Book Series="Astonishing X-Men" Number="3" Volume="2004" Year="2004">
+<Database Name="cv" Series="10746" Issue="90583" />
+</Book>
+<Book Series="Astonishing X-Men" Number="4" Volume="2004" Year="2004">
+<Database Name="cv" Series="10746" Issue="93543" />
+</Book>
+<Book Series="Astonishing X-Men" Number="5" Volume="2004" Year="2004">
+<Database Name="cv" Series="10746" Issue="93544" />
+</Book>
+<Book Series="Astonishing X-Men" Number="6" Volume="2004" Year="2004">
+<Database Name="cv" Series="10746" Issue="99750" />
+</Book>
+<Book Series="X-Men: Colossus Bloodline" Number="1" Volume="2005" Year="2005">
+<Database Name="cv" Series="18699" Issue="110540" />
+</Book>
+<Book Series="X-Men: Colossus Bloodline" Number="2" Volume="2005" Year="2005">
+<Database Name="cv" Series="18699" Issue="110638" />
+</Book>
+<Book Series="X-Men: Colossus Bloodline" Number="3" Volume="2005" Year="2006">
+<Database Name="cv" Series="18699" Issue="110818" />
+</Book>
+<Book Series="X-Men: Colossus Bloodline" Number="4" Volume="2005" Year="2006">
+<Database Name="cv" Series="18699" Issue="110819" />
+</Book>
+<Book Series="X-Men: Colossus Bloodline" Number="5" Volume="2005" Year="2006">
+<Database Name="cv" Series="18699" Issue="110820" />
+</Book>
+<Book Series="Astonishing X-Men" Number="7" Volume="2004" Year="2005">
+<Database Name="cv" Series="10746" Issue="99751" />
+</Book>
+<Book Series="Astonishing X-Men" Number="8" Volume="2004" Year="2005">
+<Database Name="cv" Series="10746" Issue="99752" />
+</Book>
+<Book Series="Astonishing X-Men" Number="9" Volume="2004" Year="2005">
+<Database Name="cv" Series="10746" Issue="106131" />
+</Book>
+<Book Series="Astonishing X-Men" Number="10" Volume="2004" Year="2005">
+<Database Name="cv" Series="10746" Issue="106670" />
+</Book>
+<Book Series="Astonishing X-Men" Number="11" Volume="2004" Year="2005">
+<Database Name="cv" Series="10746" Issue="106671" />
+</Book>
+<Book Series="Astonishing X-Men" Number="12" Volume="2004" Year="2005">
+<Database Name="cv" Series="10746" Issue="106676" />
+</Book>
+<Book Series="Excalibur" Number="13" Volume="2004" Year="2005">
+<Database Name="cv" Series="11292" Issue="120015" />
+</Book>
+<Book Series="Excalibur" Number="14" Volume="2004" Year="2005">
+<Database Name="cv" Series="11292" Issue="117978" />
+</Book>
+<Book Series="House of M" Number="1" Volume="2005" Year="2005">
+<Database Name="cv" Series="12049" Issue="104861" />
+</Book>
+<Book Series="House of M" Number="2" Volume="2005" Year="2005">
+<Database Name="cv" Series="12049" Issue="104862" />
+</Book>
+<Book Series="House of M: Civil War" Number="1" Volume="2008" Year="2008">
+<Database Name="cv" Series="22973" Issue="138414" />
+</Book>
+<Book Series="House of M: Civil War" Number="2" Volume="2008" Year="2008">
+<Database Name="cv" Series="22973" Issue="139693" />
+</Book>
+<Book Series="House of M: Civil War" Number="3" Volume="2008" Year="2009">
+<Database Name="cv" Series="22973" Issue="141552" />
+</Book>
+<Book Series="House of M: Civil War" Number="4" Volume="2008" Year="2009">
+<Database Name="cv" Series="22973" Issue="145605" />
+</Book>
+<Book Series="House of M: Civil War" Number="5" Volume="2008" Year="2009">
+<Database Name="cv" Series="22973" Issue="150049" />
+</Book>
+<Book Series="House of M: Masters of Evil" Number="1" Volume="2009" Year="2009">
+<Database Name="cv" Series="27286" Issue="166276" />
+</Book>
+<Book Series="House of M: Masters of Evil" Number="2" Volume="2009" Year="2009">
+<Database Name="cv" Series="27286" Issue="169225" />
+</Book>
+<Book Series="House of M: Masters of Evil" Number="3" Volume="2009" Year="2009">
+<Database Name="cv" Series="27286" Issue="175230" />
+</Book>
+<Book Series="House of M: Masters of Evil" Number="4" Volume="2009" Year="2010">
+<Database Name="cv" Series="27286" Issue="181091" />
+</Book>
+<Book Series="House of M: Avengers" Number="1" Volume="2008" Year="2008">
+<Database Name="cv" Series="19668" Issue="118013" />
+</Book>
+<Book Series="House of M: Avengers" Number="2" Volume="2008" Year="2008">
+<Database Name="cv" Series="19668" Issue="119712" />
+</Book>
+<Book Series="House of M: Avengers" Number="3" Volume="2008" Year="2008">
+<Database Name="cv" Series="19668" Issue="120627" />
+</Book>
+<Book Series="House of M: Avengers" Number="4" Volume="2008" Year="2008">
+<Database Name="cv" Series="19668" Issue="122065" />
+</Book>
+<Book Series="House of M: Avengers" Number="5" Volume="2008" Year="2008">
+<Database Name="cv" Series="19668" Issue="124224" />
+</Book>
+<Book Series="Incredible Hulk" Number="83" Volume="2000" Year="2005">
+<Database Name="cv" Series="6558" Issue="117046" />
+</Book>
+<Book Series="The Pulse: House of M Special" Number="1" Volume="2005" Year="2005">
+<Database Name="cv" Series="22711" Issue="136173" />
+</Book>
+<Book Series="Fantastic Four: House of M" Number="1" Volume="2005" Year="2005">
+<Database Name="cv" Series="11892" Issue="104054" />
+</Book>
+<Book Series="Fantastic Four: House of M" Number="2" Volume="2005" Year="2005">
+<Database Name="cv" Series="11892" Issue="104055" />
+</Book>
+<Book Series="Fantastic Four: House of M" Number="3" Volume="2005" Year="2005">
+<Database Name="cv" Series="11892" Issue="104056" />
+</Book>
+<Book Series="Spider-Man: House of M" Number="1" Volume="2005" Year="2005">
+<Database Name="cv" Series="19465" Issue="116494" />
+</Book>
+<Book Series="Spider-Man: House of M" Number="2" Volume="2005" Year="2005">
+<Database Name="cv" Series="19465" Issue="116546" />
+</Book>
+<Book Series="Spider-Man: House of M" Number="3" Volume="2005" Year="2005">
+<Database Name="cv" Series="19465" Issue="116547" />
+</Book>
+<Book Series="Spider-Man: House of M" Number="4" Volume="2005" Year="2005">
+<Database Name="cv" Series="19465" Issue="116549" />
+</Book>
+<Book Series="Spider-Man: House of M" Number="5" Volume="2005" Year="2005">
+<Database Name="cv" Series="19465" Issue="116548" />
+</Book>
+<Book Series="Incredible Hulk" Number="84" Volume="2000" Year="2005">
+<Database Name="cv" Series="6558" Issue="117044" />
+</Book>
+<Book Series="Incredible Hulk" Number="85" Volume="2000" Year="2005">
+<Database Name="cv" Series="6558" Issue="117041" />
+</Book>
+<Book Series="Incredible Hulk" Number="86" Volume="2000" Year="2005">
+<Database Name="cv" Series="6558" Issue="117039" />
+</Book>
+<Book Series="Iron Man: House of M" Number="1" Volume="2005" Year="2005">
+<Database Name="cv" Series="19689" Issue="118072" />
+</Book>
+<Book Series="Iron Man: House of M" Number="2" Volume="2005" Year="2005">
+<Database Name="cv" Series="19689" Issue="131931" />
+</Book>
+<Book Series="Iron Man: House of M" Number="3" Volume="2005" Year="2005">
+<Database Name="cv" Series="19689" Issue="136164" />
+</Book>
+<Book Series="Mutopia X" Number="1" Volume="2005" Year="2005">
+<Database Name="cv" Series="22712" Issue="136174" />
+</Book>
+<Book Series="Mutopia X" Number="2" Volume="2005" Year="2005">
+<Database Name="cv" Series="22712" Issue="136175" />
+</Book>
+<Book Series="Mutopia X" Number="3" Volume="2005" Year="2005">
+<Database Name="cv" Series="22712" Issue="136176" />
+</Book>
+<Book Series="New Thunderbolts" Number="11" Volume="2005" Year="2005">
+<Database Name="cv" Series="11298" Issue="99223" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="462" Volume="1981" Year="2005">
+<Database Name="cv" Series="3092" Issue="106584" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="463" Volume="1981" Year="2005">
+<Database Name="cv" Series="3092" Issue="106585" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="464" Volume="1981" Year="2005">
+<Database Name="cv" Series="3092" Issue="106586" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="465" Volume="1981" Year="2005">
+<Database Name="cv" Series="3092" Issue="106587" />
+</Book>
+<Book Series="House of M" Number="3" Volume="2005" Year="2005">
+<Database Name="cv" Series="12049" Issue="104863" />
+</Book>
+<Book Series="New X-Men" Number="16" Volume="2004" Year="2005">
+<Database Name="cv" Series="18078" Issue="106293" />
+</Book>
+<Book Series="New X-Men" Number="17" Volume="2004" Year="2005">
+<Database Name="cv" Series="18078" Issue="106294" />
+</Book>
+<Book Series="New X-Men" Number="18" Volume="2004" Year="2005">
+<Database Name="cv" Series="18078" Issue="106295" />
+</Book>
+<Book Series="New X-Men" Number="19" Volume="2004" Year="2005">
+<Database Name="cv" Series="18078" Issue="106296" />
+</Book>
+<Book Series="Wolverine" Number="33" Volume="2003" Year="2005">
+<Database Name="cv" Series="10809" Issue="114511" />
+</Book>
+<Book Series="Wolverine" Number="34" Volume="2003" Year="2005">
+<Database Name="cv" Series="10809" Issue="114517" />
+</Book>
+<Book Series="Wolverine" Number="35" Volume="2003" Year="2005">
+<Database Name="cv" Series="10809" Issue="114518" />
+</Book>
+<Book Series="House of M" Number="4" Volume="2005" Year="2005">
+<Database Name="cv" Series="12049" Issue="104864" />
+</Book>
+<Book Series="House of M" Number="5" Volume="2005" Year="2005">
+<Database Name="cv" Series="12049" Issue="104865" />
+</Book>
+<Book Series="The Pulse" Number="10" Volume="2004" Year="2005">
+<Database Name="cv" Series="11310" Issue="105810" />
+</Book>
+<Book Series="Captain America" Number="10" Volume="2004" Year="2005">
+<Database Name="cv" Series="11499" Issue="115271" />
+</Book>
+<Book Series="Black Panther" Number="7" Volume="2005" Year="2005">
+<Database Name="cv" Series="11502" Issue="126178" />
+</Book>
+<Book Series="Exiles" Number="69" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="105979" />
+</Book>
+<Book Series="Exiles" Number="70" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="105980" />
+</Book>
+<Book Series="Exiles" Number="71" Volume="2001" Year="2005">
+<Database Name="cv" Series="6983" Issue="105981" />
+</Book>
+<Book Series="Cable &#38; Deadpool" Number="17" Volume="2004" Year="2005">
+<Database Name="cv" Series="18070" Issue="106394" />
+</Book>
+<Book Series="House of M" Number="6" Volume="2005" Year="2005">
+<Database Name="cv" Series="12049" Issue="104866" />
+</Book>
+<Book Series="House of M" Number="7" Volume="2005" Year="2005">
+<Database Name="cv" Series="12049" Issue="104867" />
+</Book>
+<Book Series="Mutopia X" Number="4" Volume="2005" Year="2005">
+<Database Name="cv" Series="22712" Issue="136177" />
+</Book>
+<Book Series="House of M" Number="8" Volume="2005" Year="2005">
+<Database Name="cv" Series="12049" Issue="104868" />
+</Book>
+<Book Series="Giant-Size Ms. Marvel" Number="1" Volume="2006" Year="2006">
+<Database Name="cv" Series="22510" Issue="135114" />
+</Book>
+<Book Series="Decimation: House of M - The Day After" Number="1" Volume="2006" Year="2006">
+<Database Name="cv" Series="18132" Issue="106215" />
+</Book>
+<Book Series="Mutopia X" Number="5" Volume="2005" Year="2006">
+<Database Name="cv" Series="22712" Issue="136178" />
+</Book>
+<Book Series="X-Men: The 198 Files" Number="1" Volume="2006" Year="2006">
+<Database Name="cv" Series="18136" Issue="106250" />
+</Book>
+<Book Series="Sentinel Squad O*N*E" Number="1" Volume="2006" Year="2006">
+<Database Name="cv" Series="23276" Issue="139879" />
+</Book>
+<Book Series="Sentinel Squad O*N*E" Number="2" Volume="2006" Year="2006">
+<Database Name="cv" Series="23276" Issue="139882" />
+</Book>
+<Book Series="Sentinel Squad O*N*E" Number="3" Volume="2006" Year="2006">
+<Database Name="cv" Series="23276" Issue="139884" />
+</Book>
+<Book Series="Sentinel Squad O*N*E" Number="4" Volume="2006" Year="2006">
+<Database Name="cv" Series="23276" Issue="139887" />
+</Book>
+<Book Series="Sentinel Squad O*N*E" Number="5" Volume="2006" Year="2006">
+<Database Name="cv" Series="23276" Issue="139889" />
+</Book>
+<Book Series="New Excalibur" Number="1" Volume="2006" Year="2006">
+<Database Name="cv" Series="18019" Issue="106157" />
+</Book>
+<Book Series="New Excalibur" Number="2" Volume="2006" Year="2006">
+<Database Name="cv" Series="18019" Issue="106158" />
+</Book>
+<Book Series="New Excalibur" Number="3" Volume="2006" Year="2006">
+<Database Name="cv" Series="18019" Issue="106167" />
+</Book>
+<Book Series="X-Men" Number="177" Volume="2004" Year="2006">
+<Database Name="cv" Series="10731" Issue="106207" />
+</Book>
+<Book Series="X-Men" Number="178" Volume="2004" Year="2006">
+<Database Name="cv" Series="10731" Issue="106208" />
+</Book>
+<Book Series="X-Men" Number="179" Volume="2004" Year="2006">
+<Database Name="cv" Series="10731" Issue="106209" />
+</Book>
+<Book Series="New X-Men" Number="20" Volume="2004" Year="2006">
+<Database Name="cv" Series="18078" Issue="106297" />
+</Book>
+<Book Series="New X-Men" Number="21" Volume="2004" Year="2006">
+<Database Name="cv" Series="18078" Issue="105973" />
+</Book>
+<Book Series="New X-Men" Number="22" Volume="2004" Year="2006">
+<Database Name="cv" Series="18078" Issue="105984" />
+</Book>
+<Book Series="New X-Men" Number="23" Volume="2004" Year="2006">
+<Database Name="cv" Series="18078" Issue="105955" />
+</Book>
+<Book Series="Generation M" Number="1" Volume="2006" Year="2006">
+<Database Name="cv" Series="18145" Issue="106303" />
+</Book>
+<Book Series="Generation M" Number="2" Volume="2006" Year="2006">
+<Database Name="cv" Series="18145" Issue="106334" />
+</Book>
+<Book Series="Generation M" Number="3" Volume="2006" Year="2006">
+<Database Name="cv" Series="18145" Issue="106335" />
+</Book>
+<Book Series="Generation M" Number="4" Volume="2006" Year="2006">
+<Database Name="cv" Series="18145" Issue="106336" />
+</Book>
+<Book Series="Generation M" Number="5" Volume="2006" Year="2006">
+<Database Name="cv" Series="18145" Issue="106337" />
+</Book>
+<Book Series="Son of M" Number="1" Volume="2006" Year="2006">
+<Database Name="cv" Series="18160" Issue="106360" />
+</Book>
+<Book Series="Son of M" Number="2" Volume="2006" Year="2006">
+<Database Name="cv" Series="18160" Issue="106370" />
+</Book>
+<Book Series="Son of M" Number="3" Volume="2006" Year="2006">
+<Database Name="cv" Series="18160" Issue="106405" />
+</Book>
+<Book Series="Son of M" Number="4" Volume="2006" Year="2006">
+<Database Name="cv" Series="18160" Issue="106406" />
+</Book>
+<Book Series="Son of M" Number="5" Volume="2006" Year="2006">
+<Database Name="cv" Series="18160" Issue="106422" />
+</Book>
+<Book Series="Son of M" Number="6" Volume="2006" Year="2006">
+<Database Name="cv" Series="18160" Issue="106423" />
+</Book>
+<Book Series="X-Men: The 198" Number="1" Volume="2006" Year="2006">
+<Database Name="cv" Series="18129" Issue="106206" />
+</Book>
+<Book Series="X-Men: The 198" Number="2" Volume="2006" Year="2006">
+<Database Name="cv" Series="18129" Issue="106241" />
+</Book>
+<Book Series="X-Men: The 198" Number="3" Volume="2006" Year="2006">
+<Database Name="cv" Series="18129" Issue="106242" />
+</Book>
+<Book Series="X-Men: The 198" Number="4" Volume="2006" Year="2006">
+<Database Name="cv" Series="18129" Issue="106267" />
+</Book>
+<Book Series="X-Men: The 198" Number="5" Volume="2006" Year="2006">
+<Database Name="cv" Series="18129" Issue="106268" />
+</Book>
+<Book Series="X-Men: Deadly Genesis" Number="1" Volume="2006" Year="2006">
+<Database Name="cv" Series="18091" Issue="120892" />
+</Book>
+<Book Series="X-Men: Deadly Genesis" Number="2" Volume="2006" Year="2006">
+<Database Name="cv" Series="18091" Issue="120882" />
+</Book>
+<Book Series="X-Men: Deadly Genesis" Number="3" Volume="2006" Year="2006">
+<Database Name="cv" Series="18091" Issue="120891" />
+</Book>
+<Book Series="X-Men: Deadly Genesis" Number="4" Volume="2006" Year="2006">
+<Database Name="cv" Series="18091" Issue="105971" />
+</Book>
+<Book Series="X-Men: Deadly Genesis" Number="5" Volume="2006" Year="2006">
+<Database Name="cv" Series="18091" Issue="106024" />
+</Book>
+<Book Series="X-Men: Deadly Genesis" Number="6" Volume="2006" Year="2006">
+<Database Name="cv" Series="18091" Issue="106197" />
+</Book>
+<Book Series="Wolverine" Number="36" Volume="2003" Year="2006">
+<Database Name="cv" Series="10809" Issue="114519" />
+</Book>
+<Book Series="Wolverine" Number="37" Volume="2003" Year="2006">
+<Database Name="cv" Series="10809" Issue="114390" />
+</Book>
+<Book Series="Wolverine" Number="38" Volume="2003" Year="2006">
+<Database Name="cv" Series="10809" Issue="112980" />
+</Book>
+<Book Series="Wolverine" Number="39" Volume="2003" Year="2006">
+<Database Name="cv" Series="10809" Issue="113029" />
+</Book>
+<Book Series="Wolverine" Number="40" Volume="2003" Year="2006">
+<Database Name="cv" Series="10809" Issue="113030" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="466" Volume="1981" Year="2006">
+<Database Name="cv" Series="3092" Issue="106081" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="467" Volume="1981" Year="2006">
+<Database Name="cv" Series="3092" Issue="106082" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="468" Volume="1981" Year="2006">
+<Database Name="cv" Series="3092" Issue="106083" />
+</Book>
+<Book Series="X-Factor" Number="1" Volume="2006" Year="2006">
+<Database Name="cv" Series="18109" Issue="106090" />
+</Book>
+<Book Series="X-Factor" Number="2" Volume="2006" Year="2006">
+<Database Name="cv" Series="18109" Issue="106091" />
+</Book>
+<Book Series="X-Factor" Number="3" Volume="2006" Year="2006">
+<Database Name="cv" Series="18109" Issue="106092" />
+</Book>
+<Book Series="X-Factor" Number="4" Volume="2006" Year="2006">
+<Database Name="cv" Series="18109" Issue="106093" />
+</Book>
+<Book Series="X-Men Unlimited" Number="13" Volume="2004" Year="2006">
+<Database Name="cv" Series="10745" Issue="113641" />
+</Book>
+<Book Series="Exiles" Number="74" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="105985" />
+</Book>
+<Book Series="Exiles" Number="75" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="106000" />
+</Book>
+<Book Series="Exiles" Number="76" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="106001" />
+</Book>
+<Book Series="Exiles" Number="77" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="106002" />
+</Book>
+<Book Series="Exiles" Number="78" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="106003" />
+</Book>
+<Book Series="Exiles" Number="79" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="106030" />
+</Book>
+<Book Series="Exiles" Number="80" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="106031" />
+</Book>
+<Book Series="Exiles" Number="81" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="106032" />
+</Book>
+<Book Series="Exiles" Number="82" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="106033" />
+</Book>
+<Book Series="Exiles" Number="83" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="106035" />
+</Book>
+<Book Series="Exiles" Number="84" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="106037" />
+</Book>
+<Book Series="Exiles" Number="85" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="106038" />
+</Book>
+<Book Series="Exiles" Number="86" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="106039" />
+</Book>
+<Book Series="Exiles" Number="87" Volume="2001" Year="2006">
+<Database Name="cv" Series="6983" Issue="106383" />
+</Book>
+<Book Series="Exiles" Number="88" Volume="2001" Year="2007">
+<Database Name="cv" Series="6983" Issue="106384" />
+</Book>
+<Book Series="X-Men" Number="188" Volume="2004" Year="2006">
+<Database Name="cv" Series="10731" Issue="108778" />
+</Book>
+<Book Series="X-Men" Number="189" Volume="2004" Year="2006">
+<Database Name="cv" Series="10731" Issue="107955" />
+</Book>
+<Book Series="X-Men" Number="190" Volume="2004" Year="2006">
+<Database Name="cv" Series="10731" Issue="107956" />
+</Book>
+<Book Series="X-Men" Number="191" Volume="2004" Year="2006">
+<Database Name="cv" Series="10731" Issue="107957" />
+</Book>
+<Book Series="X-Men" Number="192" Volume="2004" Year="2006">
+<Database Name="cv" Series="10731" Issue="107946" />
+</Book>
+<Book Series="X-Men" Number="193" Volume="2004" Year="2007">
+<Database Name="cv" Series="10731" Issue="107947" />
+</Book>
+<Book Series="Exiles" Number="89" Volume="2001" Year="2007">
+<Database Name="cv" Series="6983" Issue="106385" />
+</Book>
+<Book Series="Exiles" Number="90" Volume="2001" Year="2007">
+<Database Name="cv" Series="6983" Issue="106560" />
+</Book>
+<Book Series="Exiles" Number="91" Volume="2001" Year="2007">
+<Database Name="cv" Series="6983" Issue="106487" />
+</Book>
+<Book Series="Exiles" Number="92" Volume="2001" Year="2007">
+<Database Name="cv" Series="6983" Issue="107224" />
+</Book>
+<Book Series="Exiles" Number="93" Volume="2001" Year="2007">
+<Database Name="cv" Series="6983" Issue="108790" />
+</Book>
+<Book Series="Exiles" Number="94" Volume="2001" Year="2007">
+<Database Name="cv" Series="6983" Issue="109702" />
+</Book>
+<Book Series="Exiles" Number="95" Volume="2001" Year="2007">
+<Database Name="cv" Series="6983" Issue="110439" />
+</Book>
+<Book Series="Exiles" Number="96" Volume="2001" Year="2007">
+<Database Name="cv" Series="6983" Issue="111596" />
+</Book>
+<Book Series="Exiles" Number="97" Volume="2001" Year="2007">
+<Database Name="cv" Series="6983" Issue="113430" />
+</Book>
+<Book Series="Exiles" Number="98" Volume="2001" Year="2007">
+<Database Name="cv" Series="6983" Issue="114222" />
+</Book>
+<Book Series="Exiles" Number="99" Volume="2001" Year="2007">
+<Database Name="cv" Series="6983" Issue="116028" />
+</Book>
+<Book Series="Exiles" Number="100" Volume="2001" Year="2008">
+<Database Name="cv" Series="6983" Issue="120279" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="475" Volume="1981" Year="2006">
+<Database Name="cv" Series="3092" Issue="107938" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="476" Volume="1981" Year="2006">
+<Database Name="cv" Series="3092" Issue="107939" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="477" Volume="1981" Year="2006">
+<Database Name="cv" Series="3092" Issue="107940" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="478" Volume="1981" Year="2006">
+<Database Name="cv" Series="3092" Issue="107941" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="479" Volume="1981" Year="2006">
+<Database Name="cv" Series="3092" Issue="107942" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="480" Volume="1981" Year="2007">
+<Database Name="cv" Series="3092" Issue="109939" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="481" Volume="1981" Year="2007">
+<Database Name="cv" Series="3092" Issue="107943" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="482" Volume="1981" Year="2007">
+<Database Name="cv" Series="3092" Issue="106278" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="483" Volume="1981" Year="2007">
+<Database Name="cv" Series="3092" Issue="106366" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="484" Volume="1981" Year="2007">
+<Database Name="cv" Series="3092" Issue="106795" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="485" Volume="1981" Year="2007">
+<Database Name="cv" Series="3092" Issue="108365" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="486" Volume="1981" Year="2007">
+<Database Name="cv" Series="3092" Issue="109610" />
+</Book>
+<Book Series="Astonishing X-Men" Number="13" Volume="2004" Year="2006">
+<Database Name="cv" Series="10746" Issue="106677" />
+</Book>
+<Book Series="Astonishing X-Men" Number="14" Volume="2004" Year="2006">
+<Database Name="cv" Series="10746" Issue="106678" />
+</Book>
+<Book Series="Astonishing X-Men" Number="15" Volume="2004" Year="2006">
+<Database Name="cv" Series="10746" Issue="106750" />
+</Book>
+<Book Series="Astonishing X-Men" Number="16" Volume="2004" Year="2006">
+<Database Name="cv" Series="10746" Issue="106751" />
+</Book>
+<Book Series="Astonishing X-Men" Number="17" Volume="2004" Year="2006">
+<Database Name="cv" Series="10746" Issue="106752" />
+</Book>
+<Book Series="Astonishing X-Men" Number="18" Volume="2004" Year="2006">
+<Database Name="cv" Series="10746" Issue="106130" />
+</Book>
+<Book Series="Astonishing X-Men" Number="19" Volume="2004" Year="2007">
+<Database Name="cv" Series="10746" Issue="106105" />
+</Book>
+<Book Series="Astonishing X-Men" Number="20" Volume="2004" Year="2007">
+<Database Name="cv" Series="10746" Issue="106469" />
+</Book>
+<Book Series="Astonishing X-Men" Number="21" Volume="2004" Year="2007">
+<Database Name="cv" Series="10746" Issue="108923" />
+</Book>
+<Book Series="Astonishing X-Men" Number="22" Volume="2004" Year="2007">
+<Database Name="cv" Series="10746" Issue="113737" />
+</Book>
+<Book Series="Astonishing X-Men" Number="23" Volume="2004" Year="2008">
+<Database Name="cv" Series="10746" Issue="116965" />
+</Book>
+<Book Series="Astonishing X-Men" Number="24" Volume="2004" Year="2008">
+<Database Name="cv" Series="10746" Issue="121887" />
+</Book>
+<Book Series="Giant-Size Astonishing X-Men" Number="1" Volume="2008" Year="2008">
+<Database Name="cv" Series="21710" Issue="130969" />
+</Book>
+<Book Series="X-Men: Messiah Complex" Number="1" Volume="2007" Year="2007">
+<Database Name="cv" Series="19419" Issue="116360" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="492" Volume="1981" Year="2008">
+<Database Name="cv" Series="3092" Issue="116949" />
+</Book>
+<Book Series="X-Factor" Number="25" Volume="2006" Year="2008">
+<Database Name="cv" Series="18109" Issue="117825" />
+</Book>
+<Book Series="New X-Men" Number="44" Volume="2004" Year="2008">
+<Database Name="cv" Series="18078" Issue="118081" />
+</Book>
+<Book Series="X-Men" Number="205" Volume="2004" Year="2008">
+<Database Name="cv" Series="10731" Issue="118499" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="493" Volume="1981" Year="2008">
+<Database Name="cv" Series="3092" Issue="119231" />
+</Book>
+<Book Series="X-Factor" Number="26" Volume="2006" Year="2008">
+<Database Name="cv" Series="18109" Issue="119874" />
+</Book>
+<Book Series="New X-Men" Number="45" Volume="2004" Year="2008">
+<Database Name="cv" Series="18078" Issue="120242" />
+</Book>
+<Book Series="X-Men" Number="206" Volume="2004" Year="2008">
+<Database Name="cv" Series="10731" Issue="120558" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="494" Volume="1981" Year="2008">
+<Database Name="cv" Series="3092" Issue="120868" />
+</Book>
+<Book Series="X-Factor" Number="27" Volume="2006" Year="2008">
+<Database Name="cv" Series="18109" Issue="121100" />
+</Book>
+<Book Series="New X-Men" Number="46" Volume="2004" Year="2008">
+<Database Name="cv" Series="18078" Issue="121611" />
+</Book>
+<Book Series="X-Men" Number="207" Volume="2004" Year="2008">
+<Database Name="cv" Series="10731" Issue="121878" />
+</Book>
+<Book Series="Young X-Men" Number="1" Volume="2008" Year="2008">
+<Database Name="cv" Series="21082" Issue="126423" />
+</Book>
+<Book Series="Young X-Men" Number="2" Volume="2008" Year="2008">
+<Database Name="cv" Series="21082" Issue="129704" />
+</Book>
+<Book Series="Young X-Men" Number="3" Volume="2008" Year="2008">
+<Database Name="cv" Series="21082" Issue="131325" />
+</Book>
+<Book Series="Young X-Men" Number="4" Volume="2008" Year="2008">
+<Database Name="cv" Series="21082" Issue="133021" />
+</Book>
+<Book Series="Young X-Men" Number="5" Volume="2008" Year="2008">
+<Database Name="cv" Series="21082" Issue="136066" />
+</Book>
+<Book Series="X-Men: Worlds Apart" Number="1" Volume="2008" Year="2008">
+<Database Name="cv" Series="23443" Issue="140555" />
+</Book>
+<Book Series="X-Men: Worlds Apart" Number="2" Volume="2008" Year="2009">
+<Database Name="cv" Series="23443" Issue="142743" />
+</Book>
+<Book Series="X-Men: Worlds Apart" Number="3" Volume="2008" Year="2009">
+<Database Name="cv" Series="23443" Issue="149297" />
+</Book>
+<Book Series="X-Men: Worlds Apart" Number="4" Volume="2008" Year="2009">
+<Database Name="cv" Series="23443" Issue="150654" />
+</Book>
+<Book Series="NYX: No Way Home" Number="1" Volume="2008" Year="2008">
+<Database Name="cv" Series="22497" Issue="135071" />
+</Book>
+<Book Series="NYX: No Way Home" Number="2" Volume="2008" Year="2008">
+<Database Name="cv" Series="22497" Issue="138256" />
+</Book>
+<Book Series="NYX: No Way Home" Number="3" Volume="2008" Year="2008">
+<Database Name="cv" Series="22497" Issue="140473" />
+</Book>
+<Book Series="NYX: No Way Home" Number="4" Volume="2008" Year="2009">
+<Database Name="cv" Series="22497" Issue="144573" />
+</Book>
+<Book Series="NYX: No Way Home" Number="5" Volume="2008" Year="2009">
+<Database Name="cv" Series="22497" Issue="149786" />
+</Book>
+<Book Series="NYX: No Way Home" Number="6" Volume="2008" Year="2009">
+<Database Name="cv" Series="22497" Issue="152418" />
+</Book>
+<Book Series="Young X-Men" Number="6" Volume="2008" Year="2008">
+<Database Name="cv" Series="21082" Issue="139001" />
+</Book>
+<Book Series="Young X-Men" Number="7" Volume="2008" Year="2008">
+<Database Name="cv" Series="21082" Issue="140445" />
+</Book>
+<Book Series="Young X-Men" Number="8" Volume="2008" Year="2009">
+<Database Name="cv" Series="21082" Issue="142546" />
+</Book>
+<Book Series="Young X-Men" Number="9" Volume="2008" Year="2009">
+<Database Name="cv" Series="21082" Issue="149466" />
+</Book>
+<Book Series="Young X-Men" Number="10" Volume="2008" Year="2009">
+<Database Name="cv" Series="21082" Issue="150703" />
+</Book>
+<Book Series="Young X-Men" Number="11" Volume="2008" Year="2009">
+<Database Name="cv" Series="21082" Issue="152247" />
+</Book>
+<Book Series="Young X-Men" Number="12" Volume="2008" Year="2009">
+<Database Name="cv" Series="21082" Issue="153682" />
+</Book>
+<Book Series="Dark X-Men: The Confession" Number="1" Volume="2009" Year="2009">
+<Database Name="cv" Series="28085" Issue="172433" />
+</Book>
+<Book Series="Dark Avengers/Uncanny X-Men: Utopia" Number="1" Volume="2009" Year="2009">
+<Database Name="cv" Series="26888" Issue="161518" />
+</Book>
+<Book Series="X-Men: Legacy" Number="226" Volume="2008" Year="2009">
+<Database Name="cv" Series="20691" Issue="163253" />
+</Book>
+<Book Series="X-Men: Legacy" Number="227" Volume="2008" Year="2009">
+<Database Name="cv" Series="20691" Issue="167374" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="513" Volume="1981" Year="2009">
+<Database Name="cv" Series="3092" Issue="162522" />
+</Book>
+<Book Series="Dark X-Men: The Beginning" Number="1" Volume="2009" Year="2009">
+<Database Name="cv" Series="27004" Issue="163261" />
+</Book>
+<Book Series="Dark Avengers" Number="7" Volume="2009" Year="2009">
+<Database Name="cv" Series="25512" Issue="164008" />
+</Book>
+<Book Series="Dark X-Men: The Beginning" Number="2" Volume="2009" Year="2009">
+<Database Name="cv" Series="27004" Issue="165447" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="514" Volume="1981" Year="2009">
+<Database Name="cv" Series="3092" Issue="166794" />
+</Book>
+<Book Series="Dark Avengers" Number="8" Volume="2009" Year="2009">
+<Database Name="cv" Series="25512" Issue="168320" />
+</Book>
+<Book Series="Dark X-Men: The Beginning" Number="3" Volume="2009" Year="2009">
+<Database Name="cv" Series="27004" Issue="168299" />
+</Book>
+<Book Series="Dark Avengers/Uncanny X-Men: Exodus" Number="1" Volume="2009" Year="2009">
+<Database Name="cv" Series="27804" Issue="170312" />
+</Book>
+<Book Series="Dark Reign: The List - X-Men" Number="1" Volume="2009" Year="2009">
+<Database Name="cv" Series="28084" Issue="172431" />
+</Book>
+<Book Series="Deadpool" Number="15" Volume="2008" Year="2009">
+<Database Name="cv" Series="22955" Issue="169211" />
+</Book>
+<Book Series="Deadpool" Number="16" Volume="2008" Year="2009">
+<Database Name="cv" Series="22955" Issue="175163" />
+</Book>
+<Book Series="Deadpool" Number="17" Volume="2008" Year="2010">
+<Database Name="cv" Series="22955" Issue="182578" />
+</Book>
+<Book Series="Deadpool" Number="18" Volume="2008" Year="2010">
+<Database Name="cv" Series="22955" Issue="186800" />
+</Book>
+<Book Series="X-Men: Legacy Annual" Number="1" Volume="2009" Year="2009">
+<Database Name="cv" Series="27952" Issue="171387" />
+</Book>
+<Book Series="X-Men: Legacy" Number="228" Volume="2008" Year="2009">
+<Database Name="cv" Series="20691" Issue="176851" />
+</Book>
+<Book Series="X-Men: Legacy" Number="229" Volume="2008" Year="2010">
+<Database Name="cv" Series="20691" Issue="183795" />
+</Book>
+<Book Series="X-Men: Legacy" Number="230" Volume="2008" Year="2010">
+<Database Name="cv" Series="20691" Issue="187695" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="515" Volume="1981" Year="2009">
+<Database Name="cv" Series="3092" Issue="172382" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="516" Volume="1981" Year="2009">
+<Database Name="cv" Series="3092" Issue="175925" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="517" Volume="1981" Year="2010">
+<Database Name="cv" Series="3092" Issue="184818" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="518" Volume="1981" Year="2010">
+<Database Name="cv" Series="3092" Issue="185623" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="519" Volume="1981" Year="2010">
+<Database Name="cv" Series="3092" Issue="189510" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="520" Volume="1981" Year="2010">
+<Database Name="cv" Series="3092" Issue="193358" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="521" Volume="1981" Year="2010">
+<Database Name="cv" Series="3092" Issue="197867" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="522" Volume="1981" Year="2010">
+<Database Name="cv" Series="3092" Issue="201708" />
+</Book>
+<Book Series="Nation X: X-Factor" Number="1" Volume="2010" Year="2010">
+<Database Name="cv" Series="30918" Issue="191271" />
+</Book>
+<Book Series="Nation X" Number="1" Volume="2010" Year="2010">
+<Database Name="cv" Series="30313" Issue="186675" />
+</Book>
+<Book Series="Nation X" Number="2" Volume="2010" Year="2010">
+<Database Name="cv" Series="30313" Issue="192469" />
+</Book>
+<Book Series="Nation X" Number="3" Volume="2010" Year="2010">
+<Database Name="cv" Series="30313" Issue="198376" />
+</Book>
+<Book Series="Nation X" Number="4" Volume="2010" Year="2010">
+<Database Name="cv" Series="30313" Issue="201000" />
+</Book>
+<Book Series="X-Men: Second Coming" Number="1" Volume="2010" Year="2010">
+<Database Name="cv" Series="32271" Issue="202574" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="523" Volume="1981" Year="2010">
+<Database Name="cv" Series="3092" Issue="204515" />
+</Book>
+<Book Series="New Mutants" Number="12" Volume="2009" Year="2010">
+<Database Name="cv" Series="26327" Issue="206640" />
+</Book>
+<Book Series="X-Men: Legacy" Number="235" Volume="2008" Year="2010">
+<Database Name="cv" Series="20691" Issue="208533" />
+</Book>
+<Book Series="X-Factor" Number="204" Volume="2006" Year="2010">
+<Database Name="cv" Series="18109" Issue="208661" />
+</Book>
+<Book Series="X-Force" Number="26" Volume="2008" Year="2010">
+<Database Name="cv" Series="20511" Issue="210231" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="524" Volume="1981" Year="2010">
+<Database Name="cv" Series="3092" Issue="211929" />
+</Book>
+<Book Series="X-Men: Hellbound" Number="1" Volume="2010" Year="2010">
+<Database Name="cv" Series="32928" Issue="211930" />
+</Book>
+<Book Series="New Mutants" Number="13" Volume="2009" Year="2010">
+<Database Name="cv" Series="26327" Issue="213447" />
+</Book>
+<Book Series="X-Men: Blind Science" Number="1" Volume="2010" Year="2010">
+<Database Name="cv" Series="33351" Issue="216185" />
+</Book>
+<Book Series="X-Men: Legacy" Number="236" Volume="2008" Year="2010">
+<Database Name="cv" Series="20691" Issue="214734" />
+</Book>
+<Book Series="X-Factor" Number="205" Volume="2006" Year="2010">
+<Database Name="cv" Series="18109" Issue="214767" />
+</Book>
+<Book Series="X-Force" Number="27" Volume="2008" Year="2010">
+<Database Name="cv" Series="20511" Issue="215972" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="525" Volume="1981" Year="2010">
+<Database Name="cv" Series="3092" Issue="218329" />
+</Book>
+<Book Series="X-Men: Hellbound" Number="2" Volume="2010" Year="2010">
+<Database Name="cv" Series="32928" Issue="218294" />
+</Book>
+<Book Series="New Mutants" Number="14" Volume="2009" Year="2010">
+<Database Name="cv" Series="26327" Issue="219419" />
+</Book>
+<Book Series="X-Men: Legacy" Number="237" Volume="2008" Year="2010">
+<Database Name="cv" Series="20691" Issue="220732" />
+</Book>
+<Book Series="X-Factor" Number="206" Volume="2006" Year="2010">
+<Database Name="cv" Series="18109" Issue="220789" />
+</Book>
+<Book Series="X-Force" Number="28" Volume="2008" Year="2010">
+<Database Name="cv" Series="20511" Issue="223173" />
+</Book>
+<Book Series="X-Men: Hellbound" Number="3" Volume="2010" Year="2010">
+<Database Name="cv" Series="32928" Issue="224510" />
+</Book>
+<Book Series="X-Men: Second Coming" Number="2" Volume="2010" Year="2010">
+<Database Name="cv" Series="32271" Issue="224511" />
+</Book>
+<Book Series="X-Men: To Serve and Protect" Number="1" Volume="2011" Year="2011">
+<Database Name="cv" Series="36470" Issue="240745" />
+</Book>
+<Book Series="X-Men: To Serve and Protect" Number="2" Volume="2011" Year="2011">
+<Database Name="cv" Series="36470" Issue="252756" />
+</Book>
+<Book Series="X-Men: To Serve and Protect" Number="3" Volume="2011" Year="2011">
+<Database Name="cv" Series="36470" Issue="259133" />
+</Book>
+<Book Series="X-Men: To Serve and Protect" Number="4" Volume="2011" Year="2011">
+<Database Name="cv" Series="36470" Issue="263750" />
+</Book>
+<Book Series="X-Men: Prelude to Schism" Number="1" Volume="2011" Year="2011">
+<Database Name="cv" Series="39952" Issue="269469" />
+</Book>
+<Book Series="X-Men: Prelude to Schism" Number="2" Volume="2011" Year="2011">
+<Database Name="cv" Series="39952" Issue="270432" />
+</Book>
+<Book Series="X-Men: Prelude to Schism" Number="3" Volume="2011" Year="2011">
+<Database Name="cv" Series="39952" Issue="274226" />
+</Book>
+<Book Series="X-Men: Prelude to Schism" Number="4" Volume="2011" Year="2011">
+<Database Name="cv" Series="39952" Issue="276447" />
+</Book>
+<Book Series="X-Men: Schism" Number="1" Volume="2011" Year="2011">
+<Database Name="cv" Series="41281" Issue="278744" />
+</Book>
+<Book Series="X-Men: Schism" Number="2" Volume="2011" Year="2011">
+<Database Name="cv" Series="41281" Issue="281713" />
+</Book>
+<Book Series="X-Men: Schism" Number="3" Volume="2011" Year="2011">
+<Database Name="cv" Series="41281" Issue="286947" />
+</Book>
+<Book Series="Generation Hope" Number="10" Volume="2011" Year="2011">
+<Database Name="cv" Series="36469" Issue="286948" />
+</Book>
+<Book Series="Generation Hope" Number="11" Volume="2011" Year="2011">
+<Database Name="cv" Series="36469" Issue="293389" />
+</Book>
+<Book Series="X-Men: Schism" Number="4" Volume="2011" Year="2011">
+<Database Name="cv" Series="41281" Issue="293380" />
+</Book>
+<Book Series="X-Men: Schism" Number="5" Volume="2011" Year="2011">
+<Database Name="cv" Series="41281" Issue="294049" />
+</Book>
+<Book Series="X-Men: Regenesis" Number="1" Volume="2011" Year="2011">
+<Database Name="cv" Series="43223" Issue="294888" />
+</Book>
+<Book Series="Generation Hope" Number="12" Volume="2011" Year="2011">
+<Database Name="cv" Series="36469" Issue="295072" />
+</Book>
+<Book Series="Wolverine" Number="17" Volume="2010" Year="2011">
+<Database Name="cv" Series="35263" Issue="297215" />
+</Book>
+<Book Series="Wolverine" Number="18" Volume="2010" Year="2012">
+<Database Name="cv" Series="35263" Issue="301655" />
+</Book>
+<Book Series="Wolverine" Number="19" Volume="2010" Year="2012">
+<Database Name="cv" Series="35263" Issue="304470" />
+</Book>
+<Book Series="X-Men: Legacy" Number="259" Volume="2008" Year="2012">
+<Database Name="cv" Series="20691" Issue="304477" />
+</Book>
+<Book Series="X-Men: Legacy" Number="260" Volume="2008" Year="2012">
+<Database Name="cv" Series="20691" Issue="308418" />
+</Book>
+<Book Series="The Uncanny X-Men" Number="544" Volume="1981" Year="2011">
+<Database Name="cv" Series="3092" Issue="297216" />
+</Book>
+<Book Series="Avengers Academy" Number="22" Volume="2010" Year="2012">
+<Database Name="cv" Series="33633" Issue="302682" />
+</Book>
+<Book Series="Magneto: Not A Hero" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="43891" Issue="301653" />
+</Book>
+<Book Series="Magneto: Not A Hero" Number="2" Volume="2012" Year="2012">
+<Database Name="cv" Series="43891" Issue="306476" />
+</Book>
+<Book Series="Magneto: Not A Hero" Number="3" Volume="2012" Year="2012">
+<Database Name="cv" Series="43891" Issue="310806" />
+</Book>
+<Book Series="Magneto: Not A Hero" Number="4" Volume="2012" Year="2012">
+<Database Name="cv" Series="43891" Issue="316681" />
+</Book>
+<Book Series="X-23" Number="17" Volume="2010" Year="2012">
+<Database Name="cv" Series="35496" Issue="302673" />
+</Book>
+<Book Series="X-23" Number="18" Volume="2010" Year="2012">
+<Database Name="cv" Series="35496" Issue="305778" />
+</Book>
+<Book Series="X-23" Number="19" Volume="2010" Year="2012">
+<Database Name="cv" Series="35496" Issue="307727" />
+</Book>
+<Book Series="Wolverine &#38; the X-Men" Number="1" Volume="2011" Year="2011">
+<Database Name="cv" Series="43539" Issue="299471" />
+</Book>
+<Book Series="Wolverine &#38; the X-Men" Number="2" Volume="2011" Year="2012">
+<Database Name="cv" Series="43539" Issue="303379" />
+</Book>
+<Book Series="Wolverine &#38; the X-Men" Number="3" Volume="2011" Year="2012">
+<Database Name="cv" Series="43539" Issue="307452" />
+</Book>
+<Book Series="New Mutants" Number="33" Volume="2009" Year="2012">
+<Database Name="cv" Series="26327" Issue="301071" />
+</Book>
+<Book Series="New Mutants" Number="34" Volume="2009" Year="2012">
+<Database Name="cv" Series="26327" Issue="302664" />
+</Book>
+<Book Series="New Mutants" Number="35" Volume="2009" Year="2012">
+<Database Name="cv" Series="26327" Issue="307478" />
+</Book>
+<Book Series="New Mutants" Number="36" Volume="2009" Year="2012">
+<Database Name="cv" Series="26327" Issue="311800" />
+</Book>
+<Book Series="X-Men" Number="20" Volume="2010" Year="2012">
+<Database Name="cv" Series="34221" Issue="300972" />
+</Book>
+<Book Series="X-Men" Number="21" Volume="2010" Year="2012">
+<Database Name="cv" Series="34221" Issue="302517" />
+</Book>
+<Book Series="X-Men" Number="22" Volume="2010" Year="2012">
+<Database Name="cv" Series="34221" Issue="305672" />
+</Book>
+<Book Series="X-Men" Number="23" Volume="2010" Year="2012">
+<Database Name="cv" Series="34221" Issue="309394" />
+</Book>
+<Book Series="Generation Hope" Number="13" Volume="2011" Year="2012">
+<Database Name="cv" Series="36469" Issue="302663" />
+</Book>
+<Book Series="Generation Hope" Number="14" Volume="2011" Year="2012">
+<Database Name="cv" Series="36469" Issue="307573" />
+</Book>
+<Book Series="Generation Hope" Number="15" Volume="2011" Year="2012">
+<Database Name="cv" Series="36469" Issue="311798" />
+</Book>
+<Book Series="X-Club" Number="1" Volume="2011" Year="2012">
+<Database Name="cv" Series="44386" Issue="305786" />
+</Book>
+<Book Series="X-Club" Number="2" Volume="2011" Year="2012">
+<Database Name="cv" Series="44386" Issue="309474" />
+</Book>
+<Book Series="X-Club" Number="3" Volume="2011" Year="2012">
+<Database Name="cv" Series="44386" Issue="313896" />
+</Book>
+<Book Series="X-Club" Number="4" Volume="2011" Year="2012">
+<Database Name="cv" Series="44386" Issue="319376" />
+</Book>
+<Book Series="X-Club" Number="5" Volume="2011" Year="2012">
+<Database Name="cv" Series="44386" Issue="326873" />
+</Book>
+<Book Series="Uncanny X-Men" Number="1" Volume="2011" Year="2011">
+<Database Name="cv" Series="43785" Issue="301011" />
+</Book>
+<Book Series="Uncanny X-Men" Number="2" Volume="2011" Year="2012">
+<Database Name="cv" Series="43785" Issue="304473" />
+</Book>
+<Book Series="Uncanny X-Men" Number="3" Volume="2011" Year="2012">
+<Database Name="cv" Series="43785" Issue="308437" />
+</Book>
+<Book Series="Uncanny X-Men" Number="4" Volume="2011" Year="2012">
+<Database Name="cv" Series="43785" Issue="309467" />
+</Book>
+<Book Series="X-Men: Legacy" Number="260.1" Volume="2008" Year="2012">
+<Database Name="cv" Series="20691" Issue="310912" />
+</Book>
+<Book Series="Uncanny X-Force" Number="19" Volume="2010" Year="2012">
+<Database Name="cv" Series="35835" Issue="307451" />
+</Book>
+<Book Series="Wolverine &#38; the X-Men" Number="4" Volume="2011" Year="2012">
+<Database Name="cv" Series="43539" Issue="310892" />
+</Book>
+<Book Series="Astonishing X-Men" Number="44" Volume="2004" Year="2012">
+<Database Name="cv" Series="10746" Issue="303452" />
+</Book>
+<Book Series="Astonishing X-Men" Number="45" Volume="2004" Year="2012">
+<Database Name="cv" Series="10746" Issue="308448" />
+</Book>
+<Book Series="Astonishing X-Men" Number="46" Volume="2004" Year="2012">
+<Database Name="cv" Series="10746" Issue="312717" />
+</Book>
+<Book Series="Astonishing X-Men" Number="47" Volume="2004" Year="2012">
+<Database Name="cv" Series="10746" Issue="318006" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="5" Volume="2011" Year="2012">
+<Database Name="cv" Series="43539" Issue="315083" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="6" Volume="2011" Year="2012">
+<Database Name="cv" Series="43539" Issue="316711" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="7" Volume="2011" Year="2012">
+<Database Name="cv" Series="43539" Issue="321295" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="8" Volume="2011" Year="2012">
+<Database Name="cv" Series="43539" Issue="326863" />
+</Book>
+<Book Series="Point One" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="43893" Issue="301659" />
+</Book>
+<Book Series="Avengers: X-Sanction" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="44477" Issue="306478" />
+</Book>
+<Book Series="Avengers: X-Sanction" Number="2" Volume="2012" Year="2012">
+<Database Name="cv" Series="44477" Issue="309396" />
+</Book>
+<Book Series="Avengers: X-Sanction" Number="3" Volume="2012" Year="2012">
+<Database Name="cv" Series="44477" Issue="313883" />
+</Book>
+<Book Series="Avengers: X-Sanction" Number="4" Volume="2012" Year="2012">
+<Database Name="cv" Series="44477" Issue="322751" />
+</Book>
+<Book Series="Avengers" Number="24.1" Volume="2010" Year="2012">
+<Database Name="cv" Series="33227" Issue="324946" />
+</Book>
+<Book Series="Avengers Vs. X-Men" Number="0" Volume="2012" Year="2012">
+<Database Name="cv" Series="47331" Issue="324839" />
+</Book>
+<Book Series="Avengers Vs. X-Men" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="47331" Issue="326860" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="9" Volume="2011" Year="2012">
+<Database Name="cv" Series="43539" Issue="332029" />
+</Book>
+<Book Series="New Avengers" Number="24" Volume="2010" Year="2012">
+<Database Name="cv" Series="33777" Issue="329220" />
+</Book>
+<Book Series="Avengers Vs. X-Men" Number="2" Volume="2012" Year="2012">
+<Database Name="cv" Series="47331" Issue="331952" />
+</Book>
+<Book Series="Avengers" Number="25" Volume="2010" Year="2012">
+<Database Name="cv" Series="33227" Issue="331948" />
+</Book>
+<Book Series="AVX: VS" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="48342" Issue="333447" />
+</Book>
+<Book Series="Uncanny X-Men" Number="11" Volume="2011" Year="2012">
+<Database Name="cv" Series="43785" Issue="333449" />
+</Book>
+<Book Series="Avengers Vs. X-Men" Number="3" Volume="2012" Year="2012">
+<Database Name="cv" Series="47331" Issue="334169" />
+</Book>
+<Book Series="Avengers Academy" Number="29" Volume="2010" Year="2012">
+<Database Name="cv" Series="33633" Issue="334211" />
+</Book>
+<Book Series="Avengers Academy" Number="30" Volume="2010" Year="2012">
+<Database Name="cv" Series="33633" Issue="335928" />
+</Book>
+<Book Series="Avengers Academy" Number="31" Volume="2010" Year="2012">
+<Database Name="cv" Series="33633" Issue="338524" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="10" Volume="2011" Year="2012">
+<Database Name="cv" Series="43539" Issue="335236" />
+</Book>
+<Book Series="X-Men: Legacy" Number="266" Volume="2008" Year="2012">
+<Database Name="cv" Series="20691" Issue="335232" />
+</Book>
+<Book Series="X-Men: Legacy" Number="267" Volume="2008" Year="2012">
+<Database Name="cv" Series="20691" Issue="337502" />
+</Book>
+<Book Series="Secret Avengers" Number="26" Volume="2010" Year="2012">
+<Database Name="cv" Series="33350" Issue="333444" />
+</Book>
+<Book Series="Secret Avengers" Number="27" Volume="2010" Year="2012">
+<Database Name="cv" Series="33350" Issue="336585" />
+</Book>
+<Book Series="Secret Avengers" Number="28" Volume="2010" Year="2012">
+<Database Name="cv" Series="33350" Issue="341693" />
+</Book>
+<Book Series="Avengers" Number="26" Volume="2010" Year="2012">
+<Database Name="cv" Series="33227" Issue="335925" />
+</Book>
+<Book Series="Avengers" Number="27" Volume="2010" Year="2012">
+<Database Name="cv" Series="33227" Issue="340392" />
+</Book>
+<Book Series="Avengers Vs. X-Men" Number="4" Volume="2012" Year="2012">
+<Database Name="cv" Series="47331" Issue="336045" />
+</Book>
+<Book Series="AVX: VS" Number="5" Volume="2012" Year="2012">
+<Database Name="cv" Series="48342" Issue="354184" />
+</Book>
+<Book Series="AVX: VS" Number="2" Volume="2012" Year="2012">
+<Database Name="cv" Series="48342" Issue="335954" />
+</Book>
+<Book Series="Uncanny X-Men" Number="12" Volume="2011" Year="2012">
+<Database Name="cv" Series="43785" Issue="336047" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="11" Volume="2011" Year="2012">
+<Database Name="cv" Series="43539" Issue="337499" />
+</Book>
+<Book Series="Avengers Vs. X-Men" Number="5" Volume="2012" Year="2012">
+<Database Name="cv" Series="47331" Issue="338525" />
+</Book>
+<Book Series="Uncanny X-Men" Number="13" Volume="2011" Year="2012">
+<Database Name="cv" Series="43785" Issue="338486" />
+</Book>
+<Book Series="AVX: VS" Number="3" Volume="2012" Year="2012">
+<Database Name="cv" Series="48342" Issue="340399" />
+</Book>
+<Book Series="X-Men: Legacy" Number="268" Volume="2008" Year="2012">
+<Database Name="cv" Series="20691" Issue="340395" />
+</Book>
+<Book Series="Avengers Academy" Number="32" Volume="2010" Year="2012">
+<Database Name="cv" Series="33633" Issue="341837" />
+</Book>
+<Book Series="Avengers Academy" Number="33" Volume="2010" Year="2012">
+<Database Name="cv" Series="33633" Issue="346269" />
+</Book>
+<Book Series="Uncanny X-Men" Number="14" Volume="2011" Year="2012">
+<Database Name="cv" Series="43785" Issue="341738" />
+</Book>
+<Book Series="Avengers Vs. X-Men" Number="6" Volume="2012" Year="2012">
+<Database Name="cv" Series="47331" Issue="341749" />
+</Book>
+<Book Series="New Avengers" Number="25" Volume="2010" Year="2012">
+<Database Name="cv" Series="33777" Issue="333450" />
+</Book>
+<Book Series="New Avengers" Number="26" Volume="2010" Year="2012">
+<Database Name="cv" Series="33777" Issue="335284" />
+</Book>
+<Book Series="Avengers" Number="28" Volume="2010" Year="2012">
+<Database Name="cv" Series="33227" Issue="347231" />
+</Book>
+<Book Series="Uncanny X-Men" Number="15" Volume="2011" Year="2012">
+<Database Name="cv" Series="43785" Issue="344115" />
+</Book>
+<Book Series="Uncanny X-Men" Number="16" Volume="2011" Year="2012">
+<Database Name="cv" Series="43785" Issue="346273" />
+</Book>
+<Book Series="Uncanny X-Men" Number="17" Volume="2011" Year="2012">
+<Database Name="cv" Series="43785" Issue="352641" />
+</Book>
+<Book Series="Avengers" Number="29" Volume="2010" Year="2012">
+<Database Name="cv" Series="33227" Issue="351071" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="12" Volume="2011" Year="2012">
+<Database Name="cv" Series="43539" Issue="342841" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="13" Volume="2011" Year="2012">
+<Database Name="cv" Series="43539" Issue="345398" />
+</Book>
+<Book Series="Avengers Vs. X-Men" Number="7" Volume="2012" Year="2012">
+<Database Name="cv" Series="47331" Issue="344114" />
+</Book>
+<Book Series="AVX: VS" Number="4" Volume="2012" Year="2012">
+<Database Name="cv" Series="48342" Issue="345445" />
+</Book>
+<Book Series="New Avengers" Number="28" Volume="2010" Year="2012">
+<Database Name="cv" Series="33777" Issue="345393" />
+</Book>
+<Book Series="New Avengers" Number="29" Volume="2010" Year="2012">
+<Database Name="cv" Series="33777" Issue="349640" />
+</Book>
+<Book Series="Avengers Vs. X-Men" Number="8" Volume="2012" Year="2012">
+<Database Name="cv" Series="47331" Issue="346240" />
+</Book>
+<Book Series="New Avengers" Number="27" Volume="2010" Year="2012">
+<Database Name="cv" Series="33777" Issue="341733" />
+</Book>
+<Book Series="X-Men: Legacy" Number="269" Volume="2008" Year="2012">
+<Database Name="cv" Series="20691" Issue="342842" />
+</Book>
+<Book Series="X-Men: Legacy" Number="270" Volume="2008" Year="2012">
+<Database Name="cv" Series="20691" Issue="347229" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="14" Volume="2011" Year="2012">
+<Database Name="cv" Series="43539" Issue="347208" />
+</Book>
+<Book Series="Avengers Vs. X-Men" Number="9" Volume="2012" Year="2012">
+<Database Name="cv" Series="47331" Issue="348054" />
+</Book>
+<Book Series="Avengers Vs. X-Men" Number="10" Volume="2012" Year="2012">
+<Database Name="cv" Series="47331" Issue="351068" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="15" Volume="2011" Year="2012">
+<Database Name="cv" Series="43539" Issue="354103" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="16" Volume="2011" Year="2012">
+<Database Name="cv" Series="43539" Issue="356779" />
+</Book>
+<Book Series="Avengers Vs. X-Men" Number="11" Volume="2012" Year="2012">
+<Database Name="cv" Series="47331" Issue="356764" />
+</Book>
+<Book Series="Uncanny X-Men" Number="18" Volume="2011" Year="2012">
+<Database Name="cv" Series="43785" Issue="356777" />
+</Book>
+<Book Series="Avengers Vs. X-Men" Number="12" Volume="2012" Year="2012">
+<Database Name="cv" Series="47331" Issue="359916" />
+</Book>
+<Book Series="Uncanny X-Men" Number="19" Volume="2011" Year="2012">
+<Database Name="cv" Series="43785" Issue="360032" />
+</Book>
+<Book Series="AVX: VS" Number="6" Volume="2012" Year="2012">
+<Database Name="cv" Series="48342" Issue="360037" />
+</Book>
+<Book Series="New Avengers" Number="30" Volume="2010" Year="2012">
+<Database Name="cv" Series="33777" Issue="356773" />
+</Book>
+<Book Series="Avengers" Number="30" Volume="2010" Year="2012">
+<Database Name="cv" Series="33227" Issue="357707" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="18" Volume="2011" Year="2012">
+<Database Name="cv" Series="43539" Issue="360916" />
+</Book>
+<Book Series="Uncanny X-Men" Number="20" Volume="2011" Year="2012">
+<Database Name="cv" Series="43785" Issue="362220" />
+</Book>
+<Book Series="A-Babies vs. X-Babies" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="53122" Issue="362255" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="17" Volume="2011" Year="2012">
+<Database Name="cv" Series="43539" Issue="358926" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="19" Volume="2011" Year="2012">
+<Database Name="cv" Series="43539" Issue="364133" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="20" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="367699" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="21" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="369058" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="22" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="373313" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="23" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="378900" />
+</Book>
+<Book Series="Uncanny Avengers" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="52880" Issue="360884" />
+</Book>
+<Book Series="Uncanny Avengers" Number="2" Volume="2012" Year="2013">
+<Database Name="cv" Series="52880" Issue="370249" />
+</Book>
+<Book Series="Uncanny Avengers" Number="3" Volume="2012" Year="2013">
+<Database Name="cv" Series="52880" Issue="381419" />
+</Book>
+<Book Series="Uncanny Avengers" Number="4" Volume="2012" Year="2013">
+<Database Name="cv" Series="52880" Issue="388564" />
+</Book>
+<Book Series="All-New X-Men" Number="1" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="367691" />
+</Book>
+<Book Series="All-New X-Men" Number="2" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="370245" />
+</Book>
+<Book Series="All-New X-Men" Number="3" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="371105" />
+</Book>
+<Book Series="All-New X-Men" Number="4" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="373215" />
+</Book>
+<Book Series="All-New X-Men" Number="5" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="376661" />
+</Book>
+<Book Series="All-New X-Men" Number="6" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="380348" />
+</Book>
+<Book Series="All-New X-Men" Number="7" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="384952" />
+</Book>
+<Book Series="All-New X-Men" Number="8" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="390443" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="24" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="381421" />
+</Book>
+<Book Series="Uncanny Avengers" Number="5" Volume="2012" Year="2013">
+<Database Name="cv" Series="52880" Issue="395258" />
+</Book>
+<Book Series="Uncanny X-Men" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="386141" />
+</Book>
+<Book Series="Uncanny X-Men" Number="2" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="388566" />
+</Book>
+<Book Series="Uncanny X-Men" Number="3" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="392362" />
+</Book>
+<Book Series="All-New X-Men" Number="9" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="394700" />
+</Book>
+<Book Series="All-New X-Men" Number="10" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="395700" />
+</Book>
+<Book Series="All-New X-Men" Number="11" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="400145" />
+</Book>
+<Book Series="Uncanny X-Men" Number="4" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="396436" />
+</Book>
+<Book Series="All-New X-Men" Number="12" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="408989" />
+</Book>
+<Book Series="All-New X-Men" Number="13" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="413652" />
+</Book>
+<Book Series="All-New X-Men" Number="14" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="417830" />
+</Book>
+<Book Series="Uncanny X-Men" Number="5" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="398994" />
+</Book>
+<Book Series="Uncanny X-Men" Number="6" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="404705" />
+</Book>
+<Book Series="Uncanny X-Men" Number="7" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="413669" />
+</Book>
+<Book Series="Uncanny X-Men" Number="8" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="416917" />
+</Book>
+<Book Series="Uncanny X-Men" Number="9" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="419973" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="25" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="386142" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="26" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="392363" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="27" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="395260" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="28" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="398995" />
+</Book>
+<Book Series="Uncanny Avengers" Number="6" Volume="2012" Year="2013">
+<Database Name="cv" Series="52880" Issue="396435" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="27AU" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="397554" />
+</Book>
+<Book Series="Uncanny Avengers" Number="8AU" Volume="2012" Year="2013">
+<Database Name="cv" Series="52880" Issue="404704" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="29" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="402293" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="30" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="406982" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="31" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="410327" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="32" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="413671" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="33" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="418978" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="34" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="421701" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="35" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="423685" />
+</Book>
+<Book Series="All-New X-Men" Number="15" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="420633" />
+</Book>
+<Book Series="Uncanny X-Men" Number="10" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="421699" />
+</Book>
+<Book Series="Uncanny X-Men" Number="11" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="423684" />
+</Book>
+<Book Series="Uncanny Avengers" Number="7" Volume="2012" Year="2013">
+<Database Name="cv" Series="52880" Issue="398993" />
+</Book>
+<Book Series="Uncanny Avengers" Number="8" Volume="2012" Year="2013">
+<Database Name="cv" Series="52880" Issue="401212" />
+</Book>
+<Book Series="Uncanny Avengers" Number="9" Volume="2012" Year="2013">
+<Database Name="cv" Series="52880" Issue="411836" />
+</Book>
+<Book Series="Uncanny Avengers" Number="10" Volume="2012" Year="2013">
+<Database Name="cv" Series="52880" Issue="418825" />
+</Book>
+<Book Series="Uncanny Avengers" Number="11" Volume="2012" Year="2013">
+<Database Name="cv" Series="52880" Issue="423683" />
+</Book>
+<Book Series="Uncanny Avengers" Number="12" Volume="2012" Year="2013">
+<Database Name="cv" Series="52880" Issue="426885" />
+</Book>
+<Book Series="Uncanny Avengers" Number="13" Volume="2012" Year="2013">
+<Database Name="cv" Series="52880" Issue="430766" />
+</Book>
+<Book Series="Uncanny Avengers" Number="14" Volume="2012" Year="2014">
+<Database Name="cv" Series="52880" Issue="435067" />
+</Book>
+<Book Series="Uncanny Avengers" Number="15" Volume="2012" Year="2014">
+<Database Name="cv" Series="52880" Issue="437499" />
+</Book>
+<Book Series="Uncanny Avengers" Number="16" Volume="2012" Year="2014">
+<Database Name="cv" Series="52880" Issue="443990" />
+</Book>
+<Book Series="Uncanny Avengers" Number="17" Volume="2012" Year="2014">
+<Database Name="cv" Series="52880" Issue="446492" />
+</Book>
+<Book Series="Uncanny Avengers" Number="18" Volume="2012" Year="2014">
+<Database Name="cv" Series="52880" Issue="448981" />
+</Book>
+<Book Series="Uncanny Avengers" Number="19" Volume="2012" Year="2014">
+<Database Name="cv" Series="52880" Issue="451093" />
+</Book>
+<Book Series="Uncanny Avengers" Number="20" Volume="2012" Year="2014">
+<Database Name="cv" Series="52880" Issue="454109" />
+</Book>
+<Book Series="Uncanny Avengers" Number="21" Volume="2012" Year="2014">
+<Database Name="cv" Series="52880" Issue="457652" />
+</Book>
+<Book Series="Uncanny Avengers" Number="22" Volume="2012" Year="2014">
+<Database Name="cv" Series="52880" Issue="460973" />
+</Book>
+<Book Series="X-Men: Battle of the Atom" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="67028" Issue="424543" />
+</Book>
+<Book Series="All-New X-Men" Number="16" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="424528" />
+</Book>
+<Book Series="X-Men" Number="5" Volume="2013" Year="2013">
+<Database Name="cv" Series="62383" Issue="425036" />
+</Book>
+<Book Series="Uncanny X-Men" Number="12" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="425944" />
+</Book>
+<Book Series="Wolverine &#38; the X-Men" Number="36" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="426886" />
+</Book>
+<Book Series="All-New X-Men" Number="17" Volume="2012" Year="2013">
+<Database Name="cv" Series="53919" Issue="427682" />
+</Book>
+<Book Series="X-Men" Number="6" Volume="2013" Year="2013">
+<Database Name="cv" Series="62383" Issue="428304" />
+</Book>
+<Book Series="Uncanny X-Men" Number="13" Volume="2013" Year="2013">
+<Database Name="cv" Series="57181" Issue="428867" />
+</Book>
+<Book Series="Wolverine &#38; the X-Men" Number="37" Volume="2011" Year="2013">
+<Database Name="cv" Series="43539" Issue="430768" />
+</Book>
+<Book Series="X-Men: Battle of the Atom" Number="2" Volume="2013" Year="2013">
+<Database Name="cv" Series="67028" Issue="431449" />
+</Book>
+<Book Series="Uncanny X-Men" Number="14" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="433852" />
+</Book>
+<Book Series="All-New X-Men" Number="18" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="433167" />
+</Book>
+<Book Series="All-New X-Men" Number="19" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="435047" />
+</Book>
+<Book Series="All-New X-Men" Number="20" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="437482" />
+</Book>
+<Book Series="All-New X-Men" Number="21" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="442161" />
+</Book>
+<Book Series="Uncanny X-Men" Number="15" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="436208" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="38" Volume="2011" Year="2014">
+<Database Name="cv" Series="43539" Issue="435069" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="39" Volume="2011" Year="2014">
+<Database Name="cv" Series="43539" Issue="436210" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="40" Volume="2011" Year="2014">
+<Database Name="cv" Series="43539" Issue="442929" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="41" Volume="2011" Year="2014">
+<Database Name="cv" Series="43539" Issue="445187" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="42" Volume="2011" Year="2014">
+<Database Name="cv" Series="43539" Issue="446494" />
+</Book>
+<Book Series="Uncanny X-Men" Number="16" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="442179" />
+</Book>
+<Book Series="Uncanny X-Men" Number="17" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="445823" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="1" Volume="2014" Year="2014">
+<Database Name="cv" Series="72113" Issue="446927" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="2" Volume="2014" Year="2014">
+<Database Name="cv" Series="72113" Issue="448008" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="3" Volume="2014" Year="2014">
+<Database Name="cv" Series="72113" Issue="450561" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="4" Volume="2014" Year="2014">
+<Database Name="cv" Series="72113" Issue="453423" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="5" Volume="2014" Year="2014">
+<Database Name="cv" Series="72113" Issue="456559" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="6" Volume="2014" Year="2014">
+<Database Name="cv" Series="72113" Issue="460319" />
+</Book>
+<Book Series="All-New X-Men" Number="22" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="442912" />
+</Book>
+<Book Series="Guardians of the Galaxy" Number="11" Volume="2013" Year="2014">
+<Database Name="cv" Series="57960" Issue="443982" />
+</Book>
+<Book Series="All-New X-Men" Number="23" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="445174" />
+</Book>
+<Book Series="Guardians of the Galaxy" Number="12" Volume="2013" Year="2014">
+<Database Name="cv" Series="57960" Issue="446482" />
+</Book>
+<Book Series="All-New X-Men" Number="24" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="447504" />
+</Book>
+<Book Series="Guardians of the Galaxy" Number="13" Volume="2013" Year="2014">
+<Database Name="cv" Series="57960" Issue="448967" />
+</Book>
+<Book Series="All-New X-Men" Number="25" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="450068" />
+</Book>
+<Book Series="All-New X-Men" Number="26" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="451763" />
+</Book>
+<Book Series="All-New X-Men" Number="27" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="452845" />
+</Book>
+<Book Series="All-New X-Men" Number="28" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="456017" />
+</Book>
+<Book Series="All-New X-Men" Number="29" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="459161" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="7" Volume="2014" Year="2014">
+<Database Name="cv" Series="72113" Issue="462262" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="8" Volume="2014" Year="2014">
+<Database Name="cv" Series="72113" Issue="463491" />
+</Book>
+<Book Series="Wolverine &amp; the X-Men" Number="9" Volume="2014" Year="2014">
+<Database Name="cv" Series="72113" Issue="465854" />
+</Book>
+<Book Series="Uncanny X-Men" Number="19" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="448006" />
+</Book>
+<Book Series="Uncanny X-Men" Number="20" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="450557" />
+</Book>
+<Book Series="Uncanny X-Men" Number="21" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="453422" />
+</Book>
+<Book Series="Uncanny X-Men" Number="22" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="456558" />
+</Book>
+<Book Series="Uncanny X-Men" Number="23" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="459685" />
+</Book>
+<Book Series="All-New X-Men" Number="30" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="462241" />
+</Book>
+<Book Series="Uncanny X-Men" Number="24" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="460974" />
+</Book>
+<Book Series="Uncanny X-Men" Number="25" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="463998" />
+</Book>
+<Book Series="All-New X-Men" Number="31" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="463476" />
+</Book>
+<Book Series="Uncanny X-Men" Number="26" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="465853" />
+</Book>
+<Book Series="Uncanny X-Men" Number="27" Volume="2013" Year="2014">
+<Database Name="cv" Series="57181" Issue="468091" />
+</Book>
+<Book Series="Uncanny X-Men" Number="28" Volume="2013" Year="2015">
+<Database Name="cv" Series="57181" Issue="470436" />
+</Book>
+<Book Series="Uncanny X-Men" Number="29" Volume="2013" Year="2015">
+<Database Name="cv" Series="57181" Issue="474637" />
+</Book>
+<Book Series="Uncanny X-Men" Number="30" Volume="2013" Year="2015">
+<Database Name="cv" Series="57181" Issue="477858" />
+</Book>
+<Book Series="Uncanny X-Men" Number="31" Volume="2013" Year="2015">
+<Database Name="cv" Series="57181" Issue="479985" />
+</Book>
+<Book Series="All-New X-Men" Number="32" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="465836" />
+</Book>
+<Book Series="All-New X-Men" Number="33" Volume="2012" Year="2014">
+<Database Name="cv" Series="53919" Issue="468900" />
+</Book>
+<Book Series="All-New X-Men" Number="34" Volume="2012" Year="2015">
+<Database Name="cv" Series="53919" Issue="473638" />
+</Book>
+<Book Series="All-New X-Men" Number="35" Volume="2012" Year="2015">
+<Database Name="cv" Series="53919" Issue="476778" />
+</Book>
+<Book Series="All-New X-Men" Number="36" Volume="2012" Year="2015">
+<Database Name="cv" Series="53919" Issue="479253" />
+</Book>
+<Book Series="Uncanny Avengers" Number="23" Volume="2012" Year="2014">
+<Database Name="cv" Series="52880" Issue="463489" />
+</Book>
+<Book Series="Uncanny Avengers" Number="24" Volume="2012" Year="2014">
+<Database Name="cv" Series="52880" Issue="465852" />
+</Book>
+<Book Series="Death of Wolverine" Number="1" Volume="2014" Year="2014">
+<Database Name="cv" Series="76710" Issue="463886" />
+</Book>
+<Book Series="Death of Wolverine" Number="2" Volume="2014" Year="2014">
+<Database Name="cv" Series="76710" Issue="464978" />
+</Book>
+<Book Series="Death of Wolverine" Number="3" Volume="2014" Year="2014">
+<Database Name="cv" Series="76710" Issue="467034" />
+</Book>
+<Book Series="Death of Wolverine" Number="4" Volume="2014" Year="2014">
+<Database Name="cv" Series="76710" Issue="468075" />
+</Book>
+<Book Series="Death of Wolverine: The Weapon X Program" Number="1" Volume="2014" Year="2015">
+<Database Name="cv" Series="77940" Issue="469492" />
+</Book>
+<Book Series="Death of Wolverine: The Weapon X Program" Number="2" Volume="2014" Year="2015">
+<Database Name="cv" Series="77940" Issue="470425" />
+</Book>
+<Book Series="Death of Wolverine: The Weapon X Program" Number="3" Volume="2014" Year="2015">
+<Database Name="cv" Series="77940" Issue="471963" />
+</Book>
+<Book Series="Death of Wolverine: The Weapon X Program" Number="4" Volume="2014" Year="2015">
+<Database Name="cv" Series="77940" Issue="473645" />
+</Book>
+<Book Series="Death of Wolverine: The Weapon X Program" Number="5" Volume="2014" Year="2015">
+<Database Name="cv" Series="77940" Issue="475454" />
+</Book>
+<Book Series="Storm" Number="4" Volume="2014" Year="2014">
+<Database Name="cv" Series="75874" Issue="468088" />
+</Book>
+<Book Series="Storm" Number="5" Volume="2014" Year="2015">
+<Database Name="cv" Series="75874" Issue="470435" />
+</Book>
+<Book Series="Nightcrawler" Number="7" Volume="2014" Year="2014">
+<Database Name="cv" Series="72934" Issue="467653" />
+</Book>
+<Book Series="Wolverine &#38; the X-Men" Number="10" Volume="2014" Year="2014">
+<Database Name="cv" Series="72113" Issue="468092" />
+</Book>
+<Book Series="Wolverine &#38; the X-Men" Number="11" Volume="2014" Year="2014">
+<Database Name="cv" Series="72113" Issue="468916" />
+</Book>
+<Book Series="Death of Wolverine: Life After Logan" Number="1" Volume="2014" Year="2015">
+<Database Name="cv" Series="77939" Issue="469491" />
+</Book>
+<Book Series="Death of Wolverine: Deadpool &#38; Captain America" Number="1" Volume="2014" Year="2014">
+<Database Name="cv" Series="77807" Issue="468903" />
+</Book>
+<Book Series="Death of Wolverine: The Logan Legacy" Number="1" Volume="2014" Year="2014">
+<Database Name="cv" Series="77576" Issue="468076" />
+</Book>
+<Book Series="Death of Wolverine: The Logan Legacy" Number="2" Volume="2014" Year="2014">
+<Database Name="cv" Series="77576" Issue="468462" />
+</Book>
+<Book Series="Death of Wolverine: The Logan Legacy" Number="3" Volume="2014" Year="2014">
+<Database Name="cv" Series="77576" Issue="468904" />
+</Book>
+<Book Series="Death of Wolverine: The Logan Legacy" Number="4" Volume="2014" Year="2015">
+<Database Name="cv" Series="77576" Issue="469831" />
+</Book>
+<Book Series="Death of Wolverine: The Logan Legacy" Number="5" Volume="2014" Year="2015">
+<Database Name="cv" Series="77576" Issue="471315" />
+</Book>
+<Book Series="Death of Wolverine: The Logan Legacy" Number="6" Volume="2014" Year="2015">
+<Database Name="cv" Series="77576" Issue="472905" />
+</Book>
+<Book Series="Death of Wolverine: The Logan Legacy" Number="7" Volume="2014" Year="2015">
+<Database Name="cv" Series="77576" Issue="474627" />
+</Book>
+<Book Series="Uncanny Avengers" Number="25" Volume="2012" Year="2014">
+<Database Name="cv" Series="52880" Issue="467043" />
+</Book>
+<Book Series="All-New X-Men" Number="37" Volume="2012" Year="2015">
+<Database Name="cv" Series="53919" Issue="482149" />
+</Book>
+<Book Series="All-New X-Men" Number="38" Volume="2012" Year="2015">
+<Database Name="cv" Series="53919" Issue="480667" />
+</Book>
+<Book Series="All-New X-Men" Number="39" Volume="2012" Year="2015">
+<Database Name="cv" Series="53919" Issue="482678" />
+</Book>
+<Book Series="All-New X-Men" Number="40" Volume="2012" Year="2015">
+<Database Name="cv" Series="53919" Issue="486715" />
+</Book>
+<Book Series="All-New X-Men" Number="41" Volume="2012" Year="2015">
+<Database Name="cv" Series="53919" Issue="490874" />
+</Book>
+<Book Series="Uncanny X-Men" Number="32" Volume="2013" Year="2015">
+<Database Name="cv" Series="57181" Issue="483361" />
+</Book>
+<Book Series="Uncanny X-Men" Number="33" Volume="2013" Year="2015">
+<Database Name="cv" Series="57181" Issue="486158" />
+</Book>
+<Book Series="Uncanny X-Men" Number="34" Volume="2013" Year="2015">
+<Database Name="cv" Series="57181" Issue="489330" />
+</Book>
+<Book Series="Uncanny X-Men" Number="35" Volume="2013" Year="2015">
+<Database Name="cv" Series="57181" Issue="495810" />
+</Book>
+<Book Series="Spider-Man &amp; the X-Men" Number="1" Volume="2014" Year="2015">
+<Database Name="cv" Series="78717" Issue="472911" />
+</Book>
+<Book Series="Spider-Man &amp; the X-Men" Number="2" Volume="2014" Year="2015">
+<Database Name="cv" Series="78717" Issue="477855" />
+</Book>
+<Book Series="Spider-Man &amp; the X-Men" Number="3" Volume="2014" Year="2015">
+<Database Name="cv" Series="78717" Issue="480681" />
+</Book>
+<Book Series="Spider-Man &amp; the X-Men" Number="4" Volume="2014" Year="2015">
+<Database Name="cv" Series="78717" Issue="482165" />
+</Book>
+<Book Series="Spider-Man &amp; the X-Men" Number="5" Volume="2014" Year="2015">
+<Database Name="cv" Series="78717" Issue="486153" />
+</Book>
+<Book Series="Spider-Man &amp; the X-Men" Number="6" Volume="2014" Year="2015">
+<Database Name="cv" Series="78717" Issue="487217" />
+</Book>
+<Book Series="Uncanny X-Men" Number="600" Volume="2013" Year="2016">
+<Database Name="cv" Series="57181" Issue="504952" />
+</Book>
+<Book Series="Death of X" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="94620" Issue="552158" />
+</Book>
+<Book Series="Death of X" Number="2" Volume="2016" Year="2016">
+<Database Name="cv" Series="94620" Issue="553955" />
+</Book>
+<Book Series="Death of X" Number="3" Volume="2016" Year="2017">
+<Database Name="cv" Series="94620" Issue="556471" />
+</Book>
+<Book Series="Death of X" Number="4" Volume="2016" Year="2017">
+<Database Name="cv" Series="94620" Issue="558962" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="1" Volume="2015" Year="2016">
+<Database Name="cv" Series="85756" Issue="504937" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="2" Volume="2015" Year="2016">
+<Database Name="cv" Series="85756" Issue="506168" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="3" Volume="2015" Year="2016">
+<Database Name="cv" Series="85756" Issue="507180" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="4" Volume="2015" Year="2016">
+<Database Name="cv" Series="85756" Issue="508890" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="5" Volume="2015" Year="2016">
+<Database Name="cv" Series="85756" Issue="510940" />
+</Book>
+<Book Series="All-New X-Men" Number="1" Volume="2015" Year="2016">
+<Database Name="cv" Series="86334" Issue="507175" />
+</Book>
+<Book Series="All-New X-Men" Number="2" Volume="2015" Year="2016">
+<Database Name="cv" Series="86334" Issue="508422" />
+</Book>
+<Book Series="All-New X-Men" Number="3" Volume="2015" Year="2016">
+<Database Name="cv" Series="86334" Issue="510935" />
+</Book>
+<Book Series="X-Men: Worst X-Man Ever" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="87194" Issue="510513" />
+</Book>
+<Book Series="X-Men: Worst X-Man Ever" Number="2" Volume="2016" Year="2016">
+<Database Name="cv" Series="87194" Issue="511087" />
+</Book>
+<Book Series="X-Men: Worst X-Man Ever" Number="3" Volume="2016" Year="2016">
+<Database Name="cv" Series="87194" Issue="511738" />
+</Book>
+<Book Series="X-Men: Worst X-Man Ever" Number="4" Volume="2016" Year="2016">
+<Database Name="cv" Series="87194" Issue="512645" />
+</Book>
+<Book Series="X-Men: Worst X-Man Ever" Number="5" Volume="2016" Year="2016">
+<Database Name="cv" Series="87194" Issue="513820" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="6" Volume="2015" Year="2016">
+<Database Name="cv" Series="85756" Issue="512423" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="7" Volume="2015" Year="2016">
+<Database Name="cv" Series="85756" Issue="516083" />
+</Book>
+<Book Series="Uncanny X-Men" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="87190" Issue="510510" />
+</Book>
+<Book Series="Uncanny X-Men" Number="2" Volume="2016" Year="2016">
+<Database Name="cv" Series="87190" Issue="511529" />
+</Book>
+<Book Series="Uncanny X-Men" Number="3" Volume="2016" Year="2016">
+<Database Name="cv" Series="87190" Issue="513660" />
+</Book>
+<Book Series="Uncanny X-Men" Number="4" Volume="2016" Year="2016">
+<Database Name="cv" Series="87190" Issue="517837" />
+</Book>
+<Book Series="Uncanny X-Men" Number="5" Volume="2016" Year="2016">
+<Database Name="cv" Series="87190" Issue="521347" />
+</Book>
+<Book Series="All-New X-Men" Number="4" Volume="2015" Year="2016">
+<Database Name="cv" Series="86334" Issue="514431" />
+</Book>
+<Book Series="All-New X-Men" Number="5" Volume="2015" Year="2016">
+<Database Name="cv" Series="86334" Issue="516946" />
+</Book>
+<Book Series="All-New X-Men" Number="6" Volume="2015" Year="2016">
+<Database Name="cv" Series="86334" Issue="520195" />
+</Book>
+<Book Series="All-New X-Men" Number="7" Volume="2015" Year="2016">
+<Database Name="cv" Series="86334" Issue="522423" />
+</Book>
+<Book Series="All-New X-Men" Number="8" Volume="2015" Year="2016">
+<Database Name="cv" Series="86334" Issue="525018" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="8" Volume="2015" Year="2016">
+<Database Name="cv" Series="85756" Issue="520201" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="9" Volume="2015" Year="2016">
+<Database Name="cv" Series="85756" Issue="526051" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="10" Volume="2015" Year="2016">
+<Database Name="cv" Series="85756" Issue="531882" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="11" Volume="2015" Year="2016">
+<Database Name="cv" Series="85756" Issue="537938" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="12" Volume="2015" Year="2016">
+<Database Name="cv" Series="85756" Issue="541202" />
+</Book>
+<Book Series="Uncanny X-Men" Number="6" Volume="2016" Year="2016">
+<Database Name="cv" Series="87190" Issue="523269" />
+</Book>
+<Book Series="Uncanny X-Men" Number="7" Volume="2016" Year="2016">
+<Database Name="cv" Series="87190" Issue="528525" />
+</Book>
+<Book Series="Uncanny X-Men" Number="8" Volume="2016" Year="2016">
+<Database Name="cv" Series="87190" Issue="535372" />
+</Book>
+<Book Series="Uncanny X-Men" Number="9" Volume="2016" Year="2016">
+<Database Name="cv" Series="87190" Issue="537956" />
+</Book>
+<Book Series="Uncanny X-Men" Number="10" Volume="2016" Year="2016">
+<Database Name="cv" Series="87190" Issue="540092" />
+</Book>
+<Book Series="All-New X-Men" Number="9" Volume="2015" Year="2016">
+<Database Name="cv" Series="86334" Issue="529649" />
+</Book>
+<Book Series="All-New X-Men" Number="10" Volume="2015" Year="2016">
+<Database Name="cv" Series="86334" Issue="534277" />
+</Book>
+<Book Series="All-New X-Men" Number="11" Volume="2015" Year="2016">
+<Database Name="cv" Series="86334" Issue="539233" />
+</Book>
+<Book Series="X-Men &apos;92" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="89284" Issue="522437" />
+</Book>
+<Book Series="X-Men &apos;92" Number="2" Volume="2016" Year="2016">
+<Database Name="cv" Series="89284" Issue="525044" />
+</Book>
+<Book Series="X-Men &apos;92" Number="3" Volume="2016" Year="2016">
+<Database Name="cv" Series="89284" Issue="528526" />
+</Book>
+<Book Series="X-Men &apos;92" Number="4" Volume="2016" Year="2016">
+<Database Name="cv" Series="89284" Issue="533043" />
+</Book>
+<Book Series="X-Men &apos;92" Number="5" Volume="2016" Year="2016">
+<Database Name="cv" Series="89284" Issue="541229" />
+</Book>
+<Book Series="X-Men &apos;92" Number="6" Volume="2016" Year="2016">
+<Database Name="cv" Series="89284" Issue="547298" />
+</Book>
+<Book Series="X-Men &apos;92" Number="7" Volume="2016" Year="2016">
+<Database Name="cv" Series="89284" Issue="551327" />
+</Book>
+<Book Series="X-Men &apos;92" Number="8" Volume="2016" Year="2016">
+<Database Name="cv" Series="89284" Issue="553973" />
+</Book>
+<Book Series="X-Men &apos;92" Number="9" Volume="2016" Year="2017">
+<Database Name="cv" Series="89284" Issue="558980" />
+</Book>
+<Book Series="X-Men &apos;92" Number="10" Volume="2016" Year="2017">
+<Database Name="cv" Series="89284" Issue="571694" />
+</Book>
+<Book Series="Uncanny X-Men" Number="11" Volume="2016" Year="2016">
+<Database Name="cv" Series="87190" Issue="542634" />
+</Book>
+<Book Series="Uncanny X-Men" Number="12" Volume="2016" Year="2016">
+<Database Name="cv" Series="87190" Issue="548588" />
+</Book>
+<Book Series="Uncanny X-Men" Number="13" Volume="2016" Year="2016">
+<Database Name="cv" Series="87190" Issue="550370" />
+</Book>
+<Book Series="Uncanny X-Men" Number="14" Volume="2016" Year="2016">
+<Database Name="cv" Series="87190" Issue="552174" />
+</Book>
+<Book Series="Uncanny X-Men" Number="15" Volume="2016" Year="2017">
+<Database Name="cv" Series="87190" Issue="557381" />
+</Book>
+<Book Series="All-New X-Men Annual" Number="1" Volume="2016" Year="2017">
+<Database Name="cv" Series="95807" Issue="558952" />
+</Book>
+<Book Series="All-New X-Men" Number="12" Volume="2015" Year="2016">
+<Database Name="cv" Series="86334" Issue="543744" />
+</Book>
+<Book Series="All-New X-Men" Number="13" Volume="2015" Year="2016">
+<Database Name="cv" Series="86334" Issue="549510" />
+</Book>
+<Book Series="All-New X-Men" Number="14" Volume="2015" Year="2016">
+<Database Name="cv" Series="86334" Issue="553944" />
+</Book>
+<Book Series="All-New X-Men" Number="15" Volume="2015" Year="2017">
+<Database Name="cv" Series="86334" Issue="557353" />
+</Book>
+<Book Series="All-New X-Men" Number="16" Volume="2015" Year="2017">
+<Database Name="cv" Series="86334" Issue="566702" />
+</Book>
+<Book Series="Extraordinary X-Men Annual" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="94271" Issue="550357" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="13" Volume="2015" Year="2016">
+<Database Name="cv" Series="85756" Issue="546057" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="14" Volume="2015" Year="2016">
+<Database Name="cv" Series="85756" Issue="551305" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="15" Volume="2015" Year="2016">
+<Database Name="cv" Series="85756" Issue="555521" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="16" Volume="2015" Year="2017">
+<Database Name="cv" Series="85756" Issue="562593" />
+</Book>
+<Book Series="Civil War II: X-Men" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="91275" Issue="535351" />
+</Book>
+<Book Series="Civil War II: X-Men" Number="2" Volume="2016" Year="2016">
+<Database Name="cv" Series="91275" Issue="538504" />
+</Book>
+<Book Series="Civil War II: X-Men" Number="3" Volume="2016" Year="2016">
+<Database Name="cv" Series="91275" Issue="544984" />
+</Book>
+<Book Series="Civil War II: X-Men" Number="4" Volume="2016" Year="2016">
+<Database Name="cv" Series="91275" Issue="550353" />
+</Book>
+<Book Series="Uncanny X-Men Annual" Number="1" Volume="2016" Year="2017">
+<Database Name="cv" Series="95754" Issue="558428" />
+</Book>
+<Book Series="IvX" Number="0" Volume="2016" Year="2017">
+<Database Name="cv" Series="96144" Issue="562597" />
+</Book>
+<Book Series="IvX" Number="1" Volume="2016" Year="2017">
+<Database Name="cv" Series="96144" Issue="566713" />
+</Book>
+<Book Series="Uncanny X-Men" Number="16" Volume="2016" Year="2017">
+<Database Name="cv" Series="87190" Issue="569354" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="17" Volume="2015" Year="2017">
+<Database Name="cv" Series="85756" Issue="571665" />
+</Book>
+<Book Series="IvX" Number="2" Volume="2016" Year="2017">
+<Database Name="cv" Series="96144" Issue="575870" />
+</Book>
+<Book Series="Uncanny X-Men" Number="17" Volume="2016" Year="2017">
+<Database Name="cv" Series="87190" Issue="575887" />
+</Book>
+<Book Series="Uncanny Inhumans" Number="18" Volume="2015" Year="2017">
+<Database Name="cv" Series="81092" Issue="576641" />
+</Book>
+<Book Series="Deadpool &#38; The Mercs For Money" Number="7" Volume="2016" Year="2017">
+<Database Name="cv" Series="92360" Issue="576620" />
+</Book>
+<Book Series="All-New X-Men" Number="17" Volume="2015" Year="2017">
+<Database Name="cv" Series="86334" Issue="576612" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="18" Volume="2015" Year="2017">
+<Database Name="cv" Series="85756" Issue="578459" />
+</Book>
+<Book Series="IvX" Number="3" Volume="2016" Year="2017">
+<Database Name="cv" Series="96144" Issue="578465" />
+</Book>
+<Book Series="Deadpool &#38; The Mercs For Money" Number="8" Volume="2016" Year="2017">
+<Database Name="cv" Series="92360" Issue="579313" />
+</Book>
+<Book Series="All-New X-Men" Number="18" Volume="2015" Year="2017">
+<Database Name="cv" Series="86334" Issue="579303" />
+</Book>
+<Book Series="IvX" Number="4" Volume="2016" Year="2017">
+<Database Name="cv" Series="96144" Issue="580755" />
+</Book>
+<Book Series="Uncanny Inhumans" Number="19" Volume="2015" Year="2017">
+<Database Name="cv" Series="81092" Issue="581573" />
+</Book>
+<Book Series="Uncanny X-Men" Number="18" Volume="2016" Year="2017">
+<Database Name="cv" Series="87190" Issue="581574" />
+</Book>
+<Book Series="IvX" Number="5" Volume="2016" Year="2017">
+<Database Name="cv" Series="96144" Issue="582534" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="19" Volume="2015" Year="2017">
+<Database Name="cv" Series="85756" Issue="582529" />
+</Book>
+<Book Series="IvX" Number="6" Volume="2016" Year="2017">
+<Database Name="cv" Series="96144" Issue="585080" />
+</Book>
+<Book Series="Uncanny Inhumans" Number="20" Volume="2015" Year="2017">
+<Database Name="cv" Series="81092" Issue="588578" />
+</Book>
+<Book Series="Uncanny X-Men" Number="19" Volume="2016" Year="2017">
+<Database Name="cv" Series="87190" Issue="587422" />
+</Book>
+<Book Series="Extraordinary X-Men" Number="20" Volume="2015" Year="2017">
+<Database Name="cv" Series="85756" Issue="588563" />
+</Book>
+<Book Series="All-New X-Men" Number="19" Volume="2015" Year="2017">
+<Database Name="cv" Series="86334" Issue="589821" />
+</Book>
+<Book Series="X-Men Prime" Number="1" Volume="2017" Year="2017">
+<Database Name="cv" Series="100395" Issue="589842" />
+</Book>
+<Book Series="X-Men: Blue" Number="1" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="591772" />
+</Book>
+<Book Series="X-Men: Blue" Number="2" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="593277" />
+</Book>
+<Book Series="X-Men: Blue" Number="3" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="594979" />
+</Book>
+<Book Series="X-Men: Blue" Number="4" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="597208" />
+</Book>
+<Book Series="X-Men: Blue" Number="5" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="601813" />
+</Book>
+<Book Series="X-Men: Blue" Number="6" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="605139" />
+</Book>
+<Book Series="X-Men: Gold" Number="1" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="590811" />
+</Book>
+<Book Series="X-Men: Gold" Number="2" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="593278" />
+</Book>
+<Book Series="X-Men: Gold" Number="3" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="594129" />
+</Book>
+<Book Series="X-Men: Gold" Number="4" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="595708" />
+</Book>
+<Book Series="X-Men: Gold" Number="5" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="599881" />
+</Book>
+<Book Series="X-Men: Gold" Number="6" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="603149" />
+</Book>
+<Book Series="Generation X" Number="1" Volume="2017" Year="2017">
+<Database Name="cv" Series="101478" Issue="595688" />
+</Book>
+<Book Series="Generation X" Number="2" Volume="2017" Year="2017">
+<Database Name="cv" Series="101478" Issue="598374" />
+</Book>
+<Book Series="Generation X" Number="3" Volume="2017" Year="2017">
+<Database Name="cv" Series="101478" Issue="601793" />
+</Book>
+<Book Series="Generation X" Number="4" Volume="2017" Year="2017">
+<Database Name="cv" Series="101478" Issue="608245" />
+</Book>
+<Book Series="X-Men: Gold" Number="7" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="606647" />
+</Book>
+<Book Series="X-Men: Gold" Number="8" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="609368" />
+</Book>
+<Book Series="X-Men: Blue" Number="7" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="608266" />
+</Book>
+<Book Series="X-Men: Blue" Number="8" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="610543" />
+</Book>
+<Book Series="X-Men: Blue" Number="9" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="615039" />
+</Book>
+<Book Series="X-Men: Blue" Number="10" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="617858" />
+</Book>
+<Book Series="X-Men: Blue" Number="11" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="621686" />
+</Book>
+<Book Series="X-Men: Blue" Number="12" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="625333" />
+</Book>
+<Book Series="X-Men: Gold" Number="9" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="612056" />
+</Book>
+<Book Series="X-Men: Gold" Number="10" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="616206" />
+</Book>
+<Book Series="X-Men: Gold" Number="11" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="619646" />
+</Book>
+<Book Series="X-Men: Gold" Number="12" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="622961" />
+</Book>
+<Book Series="Astonishing X-Men" Number="1" Volume="2017" Year="2017">
+<Database Name="cv" Series="102882" Issue="609338" />
+</Book>
+<Book Series="Astonishing X-Men" Number="2" Volume="2017" Year="2017">
+<Database Name="cv" Series="102882" Issue="615015" />
+</Book>
+<Book Series="Astonishing X-Men" Number="3" Volume="2017" Year="2017">
+<Database Name="cv" Series="102882" Issue="619616" />
+</Book>
+<Book Series="Astonishing X-Men" Number="4" Volume="2017" Year="2017">
+<Database Name="cv" Series="102882" Issue="626275" />
+</Book>
+<Book Series="Astonishing X-Men" Number="5" Volume="2017" Year="2018">
+<Database Name="cv" Series="102882" Issue="634524" />
+</Book>
+<Book Series="Astonishing X-Men" Number="6" Volume="2017" Year="2018">
+<Database Name="cv" Series="102882" Issue="644496" />
+</Book>
+<Book Series="Generation X" Number="5" Volume="2017" Year="2017">
+<Database Name="cv" Series="101478" Issue="615020" />
+</Book>
+<Book Series="Generation X" Number="6" Volume="2017" Year="2017">
+<Database Name="cv" Series="101478" Issue="619622" />
+</Book>
+<Book Series="Generation X" Number="7" Volume="2017" Year="2017">
+<Database Name="cv" Series="101478" Issue="630521" />
+</Book>
+<Book Series="Generation X" Number="8" Volume="2017" Year="2018">
+<Database Name="cv" Series="101478" Issue="636373" />
+</Book>
+<Book Series="Generation X" Number="9" Volume="2017" Year="2018">
+<Database Name="cv" Series="101478" Issue="641404" />
+</Book>
+<Book Series="X-Men: Gold" Number="13" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="626306" />
+</Book>
+<Book Series="X-Men: Blue" Number="13" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="628601" />
+</Book>
+<Book Series="X-Men: Gold" Number="14" Volume="2017" Year="2017">
+<Database Name="cv" Series="100603" Issue="630540" />
+</Book>
+<Book Series="X-Men: Blue" Number="14" Volume="2017" Year="2017">
+<Database Name="cv" Series="100712" Issue="632512" />
+</Book>
+<Book Series="X-Men: Gold" Number="15" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="636392" />
+</Book>
+<Book Series="X-Men: Blue" Number="15" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="638615" />
+</Book>
+<Book Series="X-Men: Gold" Number="16" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="641422" />
+</Book>
+<Book Series="X-Men: Gold" Number="17" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="644521" />
+</Book>
+<Book Series="X-Men: Gold" Number="18" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="647963" />
+</Book>
+<Book Series="X-Men: Gold" Number="19" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="650929" />
+</Book>
+<Book Series="X-Men: Gold" Number="20" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="654065" />
+</Book>
+<Book Series="X-Men: Blue" Number="16" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="643049" />
+</Book>
+<Book Series="X-Men: Blue" Number="17" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="646207" />
+</Book>
+<Book Series="X-Men: Blue" Number="18" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="649753" />
+</Book>
+<Book Series="X-Men: Blue" Number="19" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="652646" />
+</Book>
+<Book Series="X-Men: Blue" Number="20" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="655516" />
+</Book>
+<Book Series="Generation X" Number="85" Volume="2017" Year="2018">
+<Database Name="cv" Series="101478" Issue="647941" />
+</Book>
+<Book Series="Generation X" Number="86" Volume="2017" Year="2018">
+<Database Name="cv" Series="101478" Issue="654054" />
+</Book>
+<Book Series="Generation X" Number="87" Volume="2017" Year="2018">
+<Database Name="cv" Series="101478" Issue="660662" />
+</Book>
+<Book Series="X-Men: Gold" Number="21" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="658737" />
+</Book>
+<Book Series="X-Men: Gold" Number="22" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="660674" />
+</Book>
+<Book Series="X-Men: Gold Annual" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="107672" Issue="652647" />
+</Book>
+<Book Series="X-Men Blue Annual" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="108127" Issue="655517" />
+</Book>
+<Book Series="X-Men: Blue" Number="21" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="660028" />
+</Book>
+<Book Series="Venom" Number="162" Volume="2016" Year="2018">
+<Database Name="cv" Series="95845" Issue="660673" />
+</Book>
+<Book Series="X-Men: Blue" Number="22" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="661168" />
+</Book>
+<Book Series="Venom" Number="163" Volume="2016" Year="2018">
+<Database Name="cv" Series="95845" Issue="662102" />
+</Book>
+<Book Series="X-Men: Gold" Number="23" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="662103" />
+</Book>
+<Book Series="X-Men: Gold" Number="24" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="663595" />
+</Book>
+<Book Series="X-Men: Gold" Number="25" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="664931" />
+</Book>
+<Book Series="X-Men: Blue" Number="23" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="662757" />
+</Book>
+<Book Series="X-Men: Blue" Number="24" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="664317" />
+</Book>
+<Book Series="X-Men: Blue" Number="25" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="665929" />
+</Book>
+<Book Series="X-Men: Blue" Number="26" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="667666" />
+</Book>
+<Book Series="X-Men: Blue" Number="27" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="669466" />
+</Book>
+<Book Series="X-Men: Blue" Number="28" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="671344" />
+</Book>
+<Book Series="Astonishing X-Men" Number="7" Volume="2017" Year="2018">
+<Database Name="cv" Series="102882" Issue="650910" />
+</Book>
+<Book Series="Astonishing X-Men" Number="8" Volume="2017" Year="2018">
+<Database Name="cv" Series="102882" Issue="660652" />
+</Book>
+<Book Series="Astonishing X-Men" Number="9" Volume="2017" Year="2018">
+<Database Name="cv" Series="102882" Issue="662736" />
+</Book>
+<Book Series="Astonishing X-Men" Number="10" Volume="2017" Year="2018">
+<Database Name="cv" Series="102882" Issue="664906" />
+</Book>
+<Book Series="Astonishing X-Men" Number="11" Volume="2017" Year="2018">
+<Database Name="cv" Series="102882" Issue="668769" />
+</Book>
+<Book Series="Astonishing X-Men" Number="12" Volume="2017" Year="2018">
+<Database Name="cv" Series="102882" Issue="672275" />
+</Book>
+<Book Series="X-Men: Red" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="108548" Issue="658738" />
+</Book>
+<Book Series="X-Men: Red" Number="2" Volume="2018" Year="2018">
+<Database Name="cv" Series="108548" Issue="662104" />
+</Book>
+<Book Series="X-Men: Red" Number="3" Volume="2018" Year="2018">
+<Database Name="cv" Series="108548" Issue="665930" />
+</Book>
+<Book Series="X-Men: Red" Number="4" Volume="2018" Year="2018">
+<Database Name="cv" Series="108548" Issue="670128" />
+</Book>
+<Book Series="X-Men: Red" Number="5" Volume="2018" Year="2018">
+<Database Name="cv" Series="108548" Issue="672297" />
+</Book>
+<Book Series="X-Men: The Wedding Special" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="110945" Issue="670129" />
+</Book>
+<Book Series="X-Men: Gold" Number="26" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="666820" />
+</Book>
+<Book Series="X-Men: Gold" Number="27" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="668791" />
+</Book>
+<Book Series="X-Men: Gold" Number="28" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="670766" />
+</Book>
+<Book Series="X-Men: Gold" Number="29" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="672296" />
+</Book>
+<Book Series="X-Men: Gold" Number="30" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="674147" />
+</Book>
+<Book Series="X-Men: Gold" Number="31" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="675995" />
+</Book>
+<Book Series="X-Men: Gold" Number="32" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="677305" />
+</Book>
+<Book Series="X-Men: Red" Number="6" Volume="2018" Year="2018">
+<Database Name="cv" Series="108548" Issue="677306" />
+</Book>
+<Book Series="X-Men: Red" Number="7" Volume="2018" Year="2018">
+<Database Name="cv" Series="108548" Issue="680744" />
+</Book>
+<Book Series="X-Men: Red" Number="8" Volume="2018" Year="2018">
+<Database Name="cv" Series="108548" Issue="686403" />
+</Book>
+<Book Series="X-Men: Red" Number="9" Volume="2018" Year="2018">
+<Database Name="cv" Series="108548" Issue="689884" />
+</Book>
+<Book Series="X-Men: Red" Number="10" Volume="2018" Year="2019">
+<Database Name="cv" Series="108548" Issue="691400" />
+</Book>
+<Book Series="X-Men: Red" Number="11" Volume="2018" Year="2019">
+<Database Name="cv" Series="108548" Issue="694937" />
+</Book>
+<Book Series="X-Men: Gold" Number="33" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="678545" />
+</Book>
+<Book Series="X-Men: Gold" Number="34" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="680743" />
+</Book>
+<Book Series="X-Men: Gold" Number="35" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="683845" />
+</Book>
+<Book Series="X-Men: Gold" Number="36" Volume="2017" Year="2018">
+<Database Name="cv" Series="100603" Issue="685869" />
+</Book>
+<Book Series="X-Men: Blue" Number="29" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="673041" />
+</Book>
+<Book Series="X-Men: Blue" Number="30" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="675161" />
+</Book>
+<Book Series="X-Men: Blue" Number="31" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="676718" />
+</Book>
+<Book Series="X-Men: Blue" Number="32" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="677987" />
+</Book>
+<Book Series="X-Men: Blue" Number="33" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="679423" />
+</Book>
+<Book Series="X-Men: Blue" Number="34" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="682670" />
+</Book>
+<Book Series="X-Men: Blue" Number="35" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="684931" />
+</Book>
+<Book Series="X-Men: Blue" Number="36" Volume="2017" Year="2018">
+<Database Name="cv" Series="100712" Issue="686402" />
+</Book>
+<Book Series="Extermination" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="112807" Issue="679992" />
+</Book>
+<Book Series="Extermination" Number="2" Volume="2018" Year="2018">
+<Database Name="cv" Series="112807" Issue="682654" />
+</Book>
+<Book Series="Extermination" Number="3" Volume="2018" Year="2018">
+<Database Name="cv" Series="112807" Issue="686380" />
+</Book>
+<Book Series="Extermination" Number="4" Volume="2018" Year="2018">
+<Database Name="cv" Series="112807" Issue="690809" />
+</Book>
+<Book Series="Extermination" Number="5" Volume="2018" Year="2019">
+<Database Name="cv" Series="112807" Issue="695634" />
+</Book>
+<Book Series="X-Men: The Exterminated" Number="1" Volume="2018" Year="2019">
+<Database Name="cv" Series="115775" Issue="694156" />
+</Book>
+<Book Series="Astonishing X-Men" Number="13" Volume="2017" Year="2018">
+<Database Name="cv" Series="102882" Issue="675968" />
+</Book>
+<Book Series="Astonishing X-Men" Number="14" Volume="2017" Year="2018">
+<Database Name="cv" Series="102882" Issue="678524" />
+</Book>
+<Book Series="Astonishing X-Men" Number="15" Volume="2017" Year="2018">
+<Database Name="cv" Series="102882" Issue="683819" />
+</Book>
+<Book Series="Astonishing X-Men" Number="16" Volume="2017" Year="2018">
+<Database Name="cv" Series="102882" Issue="689038" />
+</Book>
+<Book Series="Astonishing X-Men" Number="17" Volume="2017" Year="2019">
+<Database Name="cv" Series="102882" Issue="692540" />
+</Book>
+<Book Series="Exiles" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="109764" Issue="665914" />
+</Book>
+<Book Series="Exiles" Number="2" Volume="2018" Year="2018">
+<Database Name="cv" Series="109764" Issue="667640" />
+</Book>
+<Book Series="Exiles" Number="3" Volume="2018" Year="2018">
+<Database Name="cv" Series="109764" Issue="669449" />
+</Book>
+<Book Series="Exiles" Number="4" Volume="2018" Year="2018">
+<Database Name="cv" Series="109764" Issue="673018" />
+</Book>
+<Book Series="Exiles" Number="5" Volume="2018" Year="2018">
+<Database Name="cv" Series="109764" Issue="676699" />
+</Book>
+<Book Series="Exiles" Number="6" Volume="2018" Year="2018">
+<Database Name="cv" Series="109764" Issue="679411" />
+</Book>
+<Book Series="Exiles" Number="7" Volume="2018" Year="2018">
+<Database Name="cv" Series="109764" Issue="682653" />
+</Book>
+<Book Series="Exiles" Number="8" Volume="2018" Year="2018">
+<Database Name="cv" Series="109764" Issue="684904" />
+</Book>
+<Book Series="Exiles" Number="9" Volume="2018" Year="2018">
+<Database Name="cv" Series="109764" Issue="688315" />
+</Book>
+<Book Series="Exiles" Number="10" Volume="2018" Year="2019">
+<Database Name="cv" Series="109764" Issue="692067" />
+</Book>
+<Book Series="Exiles" Number="11" Volume="2018" Year="2019">
+<Database Name="cv" Series="109764" Issue="695633" />
+</Book>
+<Book Series="Exiles" Number="12" Volume="2018" Year="2019">
+<Database Name="cv" Series="109764" Issue="699398" />
+</Book>
+<Book Series="Merry X-Men Holiday Special" Number="1" Volume="2018" Year="2019">
+<Database Name="cv" Series="115752" Issue="694139" />
+</Book>
+<Book Series="X-Men: Black - Magneto" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="114104" Issue="687031" />
+</Book>
+<Book Series="X-Men: Black - Mojo" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="114278" Issue="688333" />
+</Book>
+<Book Series="X-Men: Black - Mystique" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="114428" Issue="689064" />
+</Book>
+<Book Series="X-Men: Black - Juggernaut" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="114744" Issue="689883" />
+</Book>
+<Book Series="X-Men: Black - Emma Frost" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="114923" Issue="690825" />
+</Book>
+<Book Series="Uncanny X-Men: Winter&apos;s End" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="117610" Issue="703069" />
+</Book>
+<Book Series="Uncanny X-Men" Number="1" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="692088" />
+</Book>
+<Book Series="Uncanny X-Men" Number="2" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="692562" />
+</Book>
+<Book Series="Uncanny X-Men" Number="3" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="693475" />
+</Book>
+<Book Series="Uncanny X-Men" Number="4" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="694151" />
+</Book>
+<Book Series="Uncanny X-Men" Number="5" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="694932" />
+</Book>
+<Book Series="Uncanny X-Men" Number="6" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="695668" />
+</Book>
+<Book Series="Uncanny X-Men" Number="7" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="695923" />
+</Book>
+<Book Series="Uncanny X-Men" Number="8" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="696371" />
+</Book>
+<Book Series="Uncanny X-Men" Number="9" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="696961" />
+</Book>
+<Book Series="Uncanny X-Men" Number="10" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="697647" />
+</Book>
+<Book Series="Age of X-Man Alpha" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="116812" Issue="699388" />
+</Book>
+<Book Series="Age of X-Man: The Marvelous X-Men" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="116954" Issue="700130" />
+</Book>
+<Book Series="Age of X-Man: NextGen" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="117041" Issue="700657" />
+</Book>
+<Book Series="Age of X-Man: The Amazing Nightcrawler" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="117190" Issue="701298" />
+</Book>
+<Book Series="Age of X-Man: X-Tremists" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="117339" Issue="701926" />
+</Book>
+<Book Series="Age of X-Man: Prisoner X" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="117431" Issue="702452" />
+</Book>
+<Book Series="Age of X-Man: Apocalypse and the X-Tracts" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="117569" Issue="703042" />
+</Book>
+<Book Series="Age of X-Man: The Marvelous X-Men" Number="2" Volume="2019" Year="2019">
+<Database Name="cv" Series="116954" Issue="703043" />
+</Book>
+<Book Series="Age of X-Man: The Marvelous X-Men" Number="3" Volume="2019" Year="2019">
+<Database Name="cv" Series="116954" Issue="705910" />
+</Book>
+<Book Series="Age of X-Man: The Marvelous X-Men" Number="4" Volume="2019" Year="2019">
+<Database Name="cv" Series="116954" Issue="709193" />
+</Book>
+<Book Series="Age of X-Man: The Marvelous X-Men" Number="5" Volume="2019" Year="2019">
+<Database Name="cv" Series="116954" Issue="711311" />
+</Book>
+<Book Series="Age of X-Man: NextGen" Number="2" Volume="2019" Year="2019">
+<Database Name="cv" Series="117041" Issue="703932" />
+</Book>
+<Book Series="Age of X-Man: NextGen" Number="3" Volume="2019" Year="2019">
+<Database Name="cv" Series="117041" Issue="706400" />
+</Book>
+<Book Series="Age of X-Man: NextGen" Number="4" Volume="2019" Year="2019">
+<Database Name="cv" Series="117041" Issue="709194" />
+</Book>
+<Book Series="Age of X-Man: NextGen" Number="5" Volume="2019" Year="2019">
+<Database Name="cv" Series="117041" Issue="711937" />
+</Book>
+<Book Series="Age of X-Man: The Amazing Nightcrawler" Number="2" Volume="2019" Year="2019">
+<Database Name="cv" Series="117190" Issue="703931" />
+</Book>
+<Book Series="Age of X-Man: The Amazing Nightcrawler" Number="3" Volume="2019" Year="2019">
+<Database Name="cv" Series="117190" Issue="706399" />
+</Book>
+<Book Series="Age of X-Man: The Amazing Nightcrawler" Number="4" Volume="2019" Year="2019">
+<Database Name="cv" Series="117190" Issue="709711" />
+</Book>
+<Book Series="Age of X-Man: The Amazing Nightcrawler" Number="5" Volume="2019" Year="2019">
+<Database Name="cv" Series="117190" Issue="711936" />
+</Book>
+<Book Series="Age of X-Man: X-Tremists" Number="2" Volume="2019" Year="2019">
+<Database Name="cv" Series="117339" Issue="704801" />
+</Book>
+<Book Series="Age of X-Man: X-Tremists" Number="3" Volume="2019" Year="2019">
+<Database Name="cv" Series="117339" Issue="706939" />
+</Book>
+<Book Series="Age of X-Man: X-Tremists" Number="4" Volume="2019" Year="2019">
+<Database Name="cv" Series="117339" Issue="710099" />
+</Book>
+<Book Series="Age of X-Man: X-Tremists" Number="5" Volume="2019" Year="2019">
+<Database Name="cv" Series="117339" Issue="712523" />
+</Book>
+<Book Series="Age of X-Man: Prisoner X" Number="2" Volume="2019" Year="2019">
+<Database Name="cv" Series="117431" Issue="705461" />
+</Book>
+<Book Series="Age of X-Man: Prisoner X" Number="3" Volume="2019" Year="2019">
+<Database Name="cv" Series="117431" Issue="707502" />
+</Book>
+<Book Series="Age of X-Man: Prisoner X" Number="4" Volume="2019" Year="2019">
+<Database Name="cv" Series="117431" Issue="710670" />
+</Book>
+<Book Series="Age of X-Man: Prisoner X" Number="5" Volume="2019" Year="2019">
+<Database Name="cv" Series="117431" Issue="713063" />
+</Book>
+<Book Series="Age of X-Man: Apocalypse and the X-Tracts" Number="2" Volume="2019" Year="2019">
+<Database Name="cv" Series="117569" Issue="705909" />
+</Book>
+<Book Series="Age of X-Man: Apocalypse and the X-Tracts" Number="3" Volume="2019" Year="2019">
+<Database Name="cv" Series="117569" Issue="708126" />
+</Book>
+<Book Series="Age of X-Man: Apocalypse and the X-Tracts" Number="4" Volume="2019" Year="2019">
+<Database Name="cv" Series="117569" Issue="711310" />
+</Book>
+<Book Series="Age of X-Man: Apocalypse and the X-Tracts" Number="5" Volume="2019" Year="2019">
+<Database Name="cv" Series="117569" Issue="713498" />
+</Book>
+<Book Series="Age of X-Man Omega" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="120236" Issue="713851" />
+</Book>
+<Book Series="Uncanny X-Men Annual" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="116708" Issue="698618" />
+</Book>
+<Book Series="Uncanny X-Men" Number="11" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="700153" />
+</Book>
+<Book Series="Uncanny X-Men" Number="12" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="701327" />
+</Book>
+<Book Series="Uncanny X-Men" Number="13" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="702477" />
+</Book>
+<Book Series="Uncanny X-Men" Number="14" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="703956" />
+</Book>
+<Book Series="Uncanny X-Men" Number="15" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="705488" />
+</Book>
+<Book Series="War of the Realms: Uncanny X-Men" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="118545" Issue="706976" />
+</Book>
+<Book Series="War of the Realms: Uncanny X-Men" Number="2" Volume="2019" Year="2019">
+<Database Name="cv" Series="118545" Issue="709739" />
+</Book>
+<Book Series="War of the Realms: Uncanny X-Men" Number="3" Volume="2019" Year="2019">
+<Database Name="cv" Series="118545" Issue="712560" />
+</Book>
+<Book Series="Uncanny X-Men" Number="16" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="706426" />
+</Book>
+<Book Series="Uncanny X-Men" Number="17" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="707533" />
+</Book>
+<Book Series="Uncanny X-Men" Number="18" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="709217" />
+</Book>
+<Book Series="Uncanny X-Men" Number="19" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="710699" />
+</Book>
+<Book Series="Uncanny X-Men" Number="20" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="711963" />
+</Book>
+<Book Series="Uncanny X-Men" Number="21" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="713087" />
+</Book>
+<Book Series="Uncanny X-Men" Number="22" Volume="2018" Year="2019">
+<Database Name="cv" Series="115285" Issue="713870" />
+</Book>
+<Book Series="House of X" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="120309" Issue="714236" />
+</Book>
+<Book Series="Powers of X" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="120407" Issue="714669" />
+</Book>
+<Book Series="House of X" Number="2" Volume="2019" Year="2019">
+<Database Name="cv" Series="120309" Issue="715306" />
+</Book>
+<Book Series="Powers of X" Number="2" Volume="2019" Year="2019">
+<Database Name="cv" Series="120407" Issue="716371" />
+</Book>
+<Book Series="House of X" Number="3" Volume="2019" Year="2019">
+<Database Name="cv" Series="120309" Issue="717519" />
+</Book>
+<Book Series="Powers of X" Number="3" Volume="2019" Year="2019">
+<Database Name="cv" Series="120407" Issue="716968" />
+</Book>
+<Book Series="House of X" Number="4" Volume="2019" Year="2019">
+<Database Name="cv" Series="120309" Issue="718128" />
+</Book>
+<Book Series="Powers of X" Number="4" Volume="2019" Year="2019">
+<Database Name="cv" Series="120407" Issue="718763" />
+</Book>
+<Book Series="House of X" Number="5" Volume="2019" Year="2019">
+<Database Name="cv" Series="120309" Issue="719439" />
+</Book>
+<Book Series="Powers of X" Number="5" Volume="2019" Year="2019">
+<Database Name="cv" Series="120407" Issue="720169" />
+</Book>
+<Book Series="House of X" Number="6" Volume="2019" Year="2019">
+<Database Name="cv" Series="120309" Issue="721154" />
+</Book>
+<Book Series="Powers of X" Number="6" Volume="2019" Year="2019">
+<Database Name="cv" Series="120407" Issue="721789" />
+</Book>
+<Book Series="X-Men" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="122077" Issue="723121" />
+</Book>
+<Book Series="New Mutants" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="726210" />
+</Book>
+<Book Series="New Mutants" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="728977" />
+</Book>
+<Book Series="New Mutants" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="730341" />
+</Book>
+<Book Series="New Mutants" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="731522" />
+</Book>
+<Book Series="New Mutants" Number="6" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="735526" />
+</Book>
+<Book Series="Marauders" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="122218" Issue="723862" />
+</Book>
+<Book Series="Excalibur" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="122488" Issue="725247" />
+</Book>
+<Book Series="Excalibur" Number="2" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="728420" />
+</Book>
+<Book Series="Excalibur" Number="3" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="729679" />
+</Book>
+<Book Series="X-Men/Fantastic Four" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="124822" Issue="736501" />
+</Book>
+<Book Series="X-Men/Fantastic Four" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="124822" Issue="738624" />
+</Book>
+<Book Series="X-Men/Fantastic Four" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="124822" Issue="743454" />
+</Book>
+<Book Series="X-Men/Fantastic Four" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="124822" Issue="781439" />
+</Book>
+<Book Series="X-Force" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="726217" />
+</Book>
+<Book Series="Fallen Angels" Number="1" Volume="2019" Year="2020">
+<Database Name="cv" Series="122814" Issue="727257" />
+</Book>
+<Book Series="Fallen Angels" Number="2" Volume="2019" Year="2020">
+<Database Name="cv" Series="122814" Issue="728972" />
+</Book>
+<Book Series="Fallen Angels" Number="3" Volume="2019" Year="2020">
+<Database Name="cv" Series="122814" Issue="730333" />
+</Book>
+<Book Series="Fallen Angels" Number="4" Volume="2019" Year="2020">
+<Database Name="cv" Series="122814" Issue="731511" />
+</Book>
+<Book Series="Marauders" Number="2" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="728426" />
+</Book>
+<Book Series="Marauders" Number="3" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="729682" />
+</Book>
+<Book Series="X-Men" Number="2" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="727273" />
+</Book>
+<Book Series="X-Men" Number="3" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="729692" />
+</Book>
+<Book Series="New Mutants" Number="5" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="732887" />
+</Book>
+<Book Series="New Mutants" Number="7" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="737761" />
+</Book>
+<Book Series="New Mutants" Number="8" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="738614" />
+</Book>
+<Book Series="New Mutants" Number="9" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="740822" />
+</Book>
+<Book Series="New Mutants" Number="10" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="767932" />
+</Book>
+<Book Series="New Mutants" Number="11" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="781436" />
+</Book>
+<Book Series="X-Force" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="728984" />
+</Book>
+<Book Series="X-Force" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="730351" />
+</Book>
+<Book Series="X-Men" Number="4" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="731983" />
+</Book>
+<Book Series="X-Force" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="731530" />
+</Book>
+<Book Series="X-Force" Number="5" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="732895" />
+</Book>
+<Book Series="X-Force" Number="6" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="735534" />
+</Book>
+<Book Series="Fallen Angels" Number="5" Volume="2019" Year="2020">
+<Database Name="cv" Series="122814" Issue="732878" />
+</Book>
+<Book Series="Fallen Angels" Number="6" Volume="2019" Year="2020">
+<Database Name="cv" Series="122814" Issue="735522" />
+</Book>
+<Book Series="Excalibur" Number="4" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="731510" />
+</Book>
+<Book Series="Excalibur" Number="5" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="732877" />
+</Book>
+<Book Series="Excalibur" Number="6" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="734640" />
+</Book>
+<Book Series="X-Men" Number="5" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="735535" />
+</Book>
+<Book Series="Giant-Size X-Men: Jean Grey and Emma Frost" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="125302" Issue="738612" />
+</Book>
+<Book Series="X-Men" Number="6" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="737173" />
+</Book>
+<Book Series="Hellions" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="126015" Issue="743440" />
+</Book>
+<Book Series="Hellions" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="126015" Issue="781434" />
+</Book>
+<Book Series="Hellions" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="126015" Issue="796298" />
+</Book>
+<Book Series="Hellions" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="126015" Issue="799949" />
+</Book>
+<Book Series="Marauders" Number="4" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="731519" />
+</Book>
+<Book Series="Marauders" Number="5" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="731974" />
+</Book>
+<Book Series="Marauders" Number="6" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="734643" />
+</Book>
+<Book Series="Marauders" Number="7" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="736492" />
+</Book>
+<Book Series="Marauders" Number="8" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="737758" />
+</Book>
+<Book Series="Cable" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="125678" Issue="740814" />
+</Book>
+<Book Series="X-Men" Number="8" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="740832" />
+</Book>
+<Book Series="X-Men" Number="9" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="743453" />
+</Book>
+<Book Series="X-Force" Number="7" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="737172" />
+</Book>
+<Book Series="X-Force" Number="8" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="738622" />
+</Book>
+<Book Series="Excalibur" Number="7" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="737156" />
+</Book>
+<Book Series="Excalibur" Number="8" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="739558" />
+</Book>
+<Book Series="X-Force" Number="9" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="742380" />
+</Book>
+<Book Series="X-Force" Number="10" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="775013" />
+</Book>
+<Book Series="X-Factor" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="129097" Issue="784416" />
+</Book>
+<Book Series="Wolverine" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="125121" Issue="737765" />
+</Book>
+<Book Series="Wolverine" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="125121" Issue="743452" />
+</Book>
+<Book Series="Wolverine" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="125121" Issue="781438" />
+</Book>
+<Book Series="Cable" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="125678" Issue="784406" />
+</Book>
+<Book Series="Cable" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="125678" Issue="794931" />
+</Book>
+<Book Series="Cable" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="125678" Issue="797240" />
+</Book>
+<Book Series="Marauders" Number="9" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="739561" />
+</Book>
+<Book Series="Marauders" Number="10" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="763574" />
+</Book>
+<Book Series="Marauders" Number="11" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="791927" />
+</Book>
+<Book Series="Marauders" Number="12" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="797983" />
+</Book>
+<Book Series="Giant-Size X-Men: Nightcrawler" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="126014" Issue="743439" />
+</Book>
+<Book Series="New Mutants" Number="12" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="797246" />
+</Book>
+<Book Series="Marvel&apos;s Voices: Indigenous Voices" Number="1" Volume="2020" Year="2021">
+<Database Name="cv" Series="132129" Issue="819121" />
+</Book>
+<Book Series="Children of the Atom" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="134388" Issue="836298" />
+</Book>
+<Book Series="Children of the Atom" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="134388" Issue="842957" />
+</Book>
+<Book Series="X-Men" Number="7" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="738623" />
+</Book>
+<Book Series="Empyre: Avengers" Number="0" Volume="2020" Year="2020">
+<Database Name="cv" Series="128103" Issue="769751" />
+</Book>
+<Book Series="Empyre: Fantastic Four" Number="0" Volume="2020" Year="2020">
+<Database Name="cv" Series="128447" Issue="775009" />
+</Book>
+<Book Series="Lords of Empyre: Emperor Hulkling" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="128881" Issue="781435" />
+</Book>
+<Book Series="Empyre" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="128616" Issue="779005" />
+</Book>
+<Book Series="Empyre" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="128616" Issue="781431" />
+</Book>
+<Book Series="Fantastic Four" Number="21" Volume="2018" Year="2020">
+<Database Name="cv" Series="112685" Issue="779006" />
+</Book>
+<Book Series="Fantastic Four" Number="22" Volume="2018" Year="2020">
+<Database Name="cv" Series="112685" Issue="787351" />
+</Book>
+<Book Series="Lords of Empyre: Swordsman" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="129649" Issue="794937" />
+</Book>
+<Book Series="Lords of Empyre: Celestial Messiah" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="129246" Issue="787354" />
+</Book>
+<Book Series="Captain Marvel" Number="18" Volume="2019" Year="2020">
+<Database Name="cv" Series="116365" Issue="784407" />
+</Book>
+<Book Series="Captain Marvel" Number="19" Volume="2019" Year="2020">
+<Database Name="cv" Series="116365" Issue="791921" />
+</Book>
+<Book Series="Captain Marvel" Number="20" Volume="2019" Year="2020">
+<Database Name="cv" Series="116365" Issue="794933" />
+</Book>
+<Book Series="Empyre" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="128616" Issue="784408" />
+</Book>
+<Book Series="X-Men" Number="10" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="784126" />
+</Book>
+<Book Series="Empyre: Savage Avengers" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="129095" Issue="784410" />
+</Book>
+<Book Series="Empyre: Avengers" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="128103" Issue="781432" />
+</Book>
+<Book Series="Empyre: Captain America" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="129094" Issue="784409" />
+</Book>
+<Book Series="Empyre: X-Men" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="128880" Issue="781433" />
+</Book>
+<Book Series="Empyre: X-Men" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="128880" Issue="787350" />
+</Book>
+<Book Series="Empyre: X-Men" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="128880" Issue="791925" />
+</Book>
+<Book Series="Empyre: X-Men" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="128880" Issue="794935" />
+</Book>
+<Book Series="Empyre: Captain America" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="129094" Issue="791924" />
+</Book>
+<Book Series="Empyre" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="128616" Issue="787348" />
+</Book>
+<Book Series="Empyre" Number="5" Volume="2020" Year="2020">
+<Database Name="cv" Series="128616" Issue="791922" />
+</Book>
+<Book Series="Empyre: Captain America" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="129094" Issue="796296" />
+</Book>
+<Book Series="Empyre: Avengers" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="128103" Issue="791923" />
+</Book>
+<Book Series="Empyre: Avengers" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="128103" Issue="796295" />
+</Book>
+<Book Series="Empyre" Number="6" Volume="2020" Year="2020">
+<Database Name="cv" Series="128616" Issue="797241" />
+</Book>
+<Book Series="Fantastic Four" Number="23" Volume="2018" Year="2020">
+<Database Name="cv" Series="112685" Issue="797242" />
+</Book>
+<Book Series="X-Men" Number="11" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="796303" />
+</Book>
+<Book Series="Captain Marvel" Number="21" Volume="2019" Year="2020">
+<Database Name="cv" Series="116365" Issue="797979" />
+</Book>
+<Book Series="Guardians of the Galaxy" Number="6" Volume="2020" Year="2020">
+<Database Name="cv" Series="124447" Issue="797243" />
+</Book>
+<Book Series="Guardians of the Galaxy" Number="7" Volume="2020" Year="2020">
+<Database Name="cv" Series="124447" Issue="813282" />
+</Book>
+<Book Series="Guardians of the Galaxy" Number="8" Volume="2020" Year="2021">
+<Database Name="cv" Series="124447" Issue="816467" />
+</Book>
+<Book Series="Empyre: Aftermath Avengers" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="130186" Issue="797980" />
+</Book>
+<Book Series="Empyre: Fallout Fantastic Four" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="130187" Issue="797981" />
+</Book>
+<Book Series="Immortal She-Hulk" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="130567" Issue="803644" />
+</Book>
+<Book Series="Web of Venom: Empyre's End" Number="1" Volume="2020" Year="2021">
+<Database Name="cv" Series="131733" Issue="816471" />
+</Book>
+<Book Series="Giant-Size X-Men: Fantomex" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="129245" Issue="787352" />
+</Book>
+<Book Series="Giant-Size X-Men: Storm" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="130395" Issue="799948" />
+</Book>
+<Book Series="Wolverine" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="125121" Issue="794942" />
+</Book>
+<Book Series="Wolverine" Number="5" Volume="2020" Year="2020">
+<Database Name="cv" Series="125121" Issue="797248" />
+</Book>
+<Book Series="X-Factor" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="129097" Issue="796302" />
+</Book>
+<Book Series="X-Factor" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="129097" Issue="797986" />
+</Book>
+<Book Series="X-Force" Number="11" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="791931" />
+</Book>
+<Book Series="X-Force" Number="12" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="797987" />
+</Book>
+<Book Series="X-Force" Number="15" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="821504" />
+</Book>
+<Book Series="X-Force" Number="16" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="825509" />
+</Book>
+<Book Series="Excalibur" Number="9" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="742368" />
+</Book>
+<Book Series="Excalibur" Number="10" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="767930" />
+</Book>
+<Book Series="Excalibur" Number="11" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="794936" />
+</Book>
+<Book Series="Excalibur" Number="12" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="799947" />
+</Book>
+<Book Series="X-Men" Number="12" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="799956" />
+</Book>
+<Book Series="X of Swords: Creation" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="130569" Issue="803652" />
+</Book>
+<Book Series="X-Factor" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="129097" Issue="805100" />
+</Book>
+<Book Series="Wolverine" Number="6" Volume="2020" Year="2020">
+<Database Name="cv" Series="125121" Issue="807579" />
+</Book>
+<Book Series="X-Force" Number="13" Volume="2020" Year="2020">
+<Database Name="cv" Series="122668" Issue="807580" />
+</Book>
+<Book Series="Marauders" Number="13" Volume="2019" Year="2020">
+<Database Name="cv" Series="122218" Issue="807571" />
+</Book>
+<Book Series="Hellions" Number="5" Volume="2020" Year="2020">
+<Database Name="cv" Series="126015" Issue="810727" />
+</Book>
+<Book Series="New Mutants" Number="13" Volume="2020" Year="2020">
+<Database Name="cv" Series="122666" Issue="810730" />
+</Book>
+<Book Series="Cable" Number="5" Volume="2020" Year="2020">
+<Database Name="cv" Series="125678" Issue="810724" />
+</Book>
+<Book Series="Excalibur" Number="13" Volume="2019" Year="2020">
+<Database Name="cv" Series="122488" Issue="813279" />
+</Book>
+<Book Series="X-Men" Number="13" Volume="2019" Year="2020">
+<Database Name="cv" Series="122077" Issue="813291" />
+</Book>
+<Book Series="X of Swords: Stasis" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="131525" Issue="814483" />
+</Book>
+<Book Series="X-Men" Number="14" Volume="2019" Year="2021">
+<Database Name="cv" Series="122077" Issue="816456" />
+</Book>
+<Book Series="Marauders" Number="14" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="816455" />
+</Book>
+<Book Series="Marauders" Number="15" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="817705" />
+</Book>
+<Book Series="Excalibur" Number="14" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="817704" />
+</Book>
+<Book Series="Wolverine" Number="7" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="817706" />
+</Book>
+<Book Series="X-Force" Number="14" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="819097" />
+</Book>
+<Book Series="Hellions" Number="6" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="819096" />
+</Book>
+<Book Series="Cable" Number="6" Volume="2020" Year="2021">
+<Database Name="cv" Series="125678" Issue="819095" />
+</Book>
+<Book Series="X-Men" Number="15" Volume="2019" Year="2021">
+<Database Name="cv" Series="122077" Issue="819479" />
+</Book>
+<Book Series="Excalibur" Number="15" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="819478" />
+</Book>
+<Book Series="X of Swords: Destruction" Number="1" Volume="2020" Year="2021">
+<Database Name="cv" Series="132228" Issue="819480" />
+</Book>
+<Book Series="S.W.O.R.D." Number="1" Volume="2020" Year="2021">
+<Database Name="cv" Series="132511" Issue="820748" />
+</Book>
+<Book Series="Symbiote Spider-Man: King In Black" Number="1" Volume="2020" Year="2021">
+<Database Name="cv" Series="132130" Issue="819124" />
+</Book>
+<Book Series="Symbiote Spider-Man: King In Black" Number="2" Volume="2020" Year="2021">
+<Database Name="cv" Series="132130" Issue="821501" />
+</Book>
+<Book Series="Symbiote Spider-Man: King In Black" Number="3" Volume="2020" Year="2021">
+<Database Name="cv" Series="132130" Issue="824033" />
+</Book>
+<Book Series="Symbiote Spider-Man: King In Black" Number="4" Volume="2020" Year="2021">
+<Database Name="cv" Series="132130" Issue="830032" />
+</Book>
+<Book Series="Symbiote Spider-Man: King In Black" Number="5" Volume="2020" Year="2021">
+<Database Name="cv" Series="132130" Issue="840958" />
+</Book>
+<Book Series="King In Black: Namor" Number="1" Volume="2020" Year="2021">
+<Database Name="cv" Series="132510" Issue="820746" />
+</Book>
+<Book Series="King In Black: Namor" Number="2" Volume="2020" Year="2021">
+<Database Name="cv" Series="132510" Issue="823346" />
+</Book>
+<Book Series="King In Black: Namor" Number="3" Volume="2020" Year="2021">
+<Database Name="cv" Series="132510" Issue="826558" />
+</Book>
+<Book Series="King In Black: Namor" Number="4" Volume="2020" Year="2021">
+<Database Name="cv" Series="132510" Issue="830026" />
+</Book>
+<Book Series="Atlantis Attacks" Number="5" Volume="2020" Year="2021">
+<Database Name="cv" Series="124446" Issue="820017" />
+</Book>
+<Book Series="King In Black: Wiccan and Hulking" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="134223" Issue="832867" />
+</Book>
+<Book Series="King In Black" Number="1" Volume="2020" Year="2021">
+<Database Name="cv" Series="132376" Issue="820024" />
+</Book>
+<Book Series="The Union" Number="1" Volume="2020" Year="2021">
+<Database Name="cv" Series="132378" Issue="820029" />
+</Book>
+<Book Series="The Union" Number="2" Volume="2020" Year="2021">
+<Database Name="cv" Series="132378" Issue="824454" />
+</Book>
+<Book Series="Black Cat" Number="1" Volume="2020" Year="2021">
+<Database Name="cv" Series="132631" Issue="821491" />
+</Book>
+<Book Series="Spider-Woman" Number="7" Volume="2020" Year="2021">
+<Database Name="cv" Series="125812" Issue="822352" />
+</Book>
+<Book Series="Spider-Woman" Number="8" Volume="2020" Year="2021">
+<Database Name="cv" Series="125812" Issue="824032" />
+</Book>
+<Book Series="Guardians of the Galaxy" Number="10" Volume="2020" Year="2021">
+<Database Name="cv" Series="124447" Issue="824025" />
+</Book>
+<Book Series="King In Black: Ghost Rider" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="135003" Issue="840954" />
+</Book>
+<Book Series="King In Black: Black Knight" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="133609" Issue="827524" />
+</Book>
+<Book Series="King In Black: Black Panther" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="133724" Issue="828193" />
+</Book>
+<Book Series="Venom" Number="31" Volume="2018" Year="2021">
+<Database Name="cv" Series="110770" Issue="820751" />
+</Book>
+<Book Series="King In Black" Number="2" Volume="2020" Year="2021">
+<Database Name="cv" Series="132376" Issue="822349" />
+</Book>
+<Book Series="Venom" Number="32" Volume="2018" Year="2021">
+<Database Name="cv" Series="110770" Issue="824035" />
+</Book>
+<Book Series="King In Black: Iron Man/Doom" Number="1" Volume="2020" Year="2021">
+<Database Name="cv" Series="132913" Issue="823345" />
+</Book>
+<Book Series="King In Black: Return of the Valkyries" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="133081" Issue="824029" />
+</Book>
+<Book Series="King In Black: Planet of the Symbiotes" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="133196" Issue="824450" />
+</Book>
+<Book Series="King In Black: Planet of the Symbiotes" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="133196" Issue="828858" />
+</Book>
+<Book Series="King In Black: Thunderbolts" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="133197" Issue="824451" />
+</Book>
+<Book Series="King In Black: Thunderbolts" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="133197" Issue="828194" />
+</Book>
+<Book Series="King In Black: Thunderbolts" Number="3" Volume="2021" Year="2021">
+<Database Name="cv" Series="133197" Issue="832866" />
+</Book>
+<Book Series="King in Black: Gwenom vs. Carnage" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="133195" Issue="824449" />
+</Book>
+<Book Series="King in Black: Gwenom vs. Carnage" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="133195" Issue="827525" />
+</Book>
+<Book Series="King in Black: Gwenom vs. Carnage" Number="3" Volume="2021" Year="2021">
+<Database Name="cv" Series="133195" Issue="832864" />
+</Book>
+<Book Series="King In Black: Immortal Hulk" Number="1" Volume="2020" Year="2021">
+<Database Name="cv" Series="132632" Issue="821497" />
+</Book>
+<Book Series="S.W.O.R.D." Number="2" Volume="2020" Year="2021">
+<Database Name="cv" Series="132511" Issue="824453" />
+</Book>
+<Book Series="S.W.O.R.D." Number="3" Volume="2020" Year="2021">
+<Database Name="cv" Series="132511" Issue="828197" />
+</Book>
+<Book Series="King In Black" Number="3" Volume="2020" Year="2021">
+<Database Name="cv" Series="132376" Issue="825507" />
+</Book>
+<Book Series="Daredevil" Number="26" Volume="2019" Year="2021">
+<Database Name="cv" Series="116964" Issue="826554" />
+</Book>
+<Book Series="Daredevil" Number="27" Volume="2019" Year="2021">
+<Database Name="cv" Series="116964" Issue="828189" />
+</Book>
+<Book Series="Deadpool" Number="10" Volume="2019" Year="2021">
+<Database Name="cv" Series="122987" Issue="826555" />
+</Book>
+<Book Series="King In Black: Marauders" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="133610" Issue="827526" />
+</Book>
+<Book Series="Savage Avengers" Number="17" Volume="2019" Year="2021">
+<Database Name="cv" Series="118663" Issue="826561" />
+</Book>
+<Book Series="Savage Avengers" Number="18" Volume="2019" Year="2021">
+<Database Name="cv" Series="118663" Issue="828863" />
+</Book>
+<Book Series="Savage Avengers" Number="19" Volume="2019" Year="2021">
+<Database Name="cv" Series="118663" Issue="839798" />
+</Book>
+<Book Series="Miles Morales: Spider-Man" Number="23" Volume="2019" Year="2021">
+<Database Name="cv" Series="115897" Issue="828862" />
+</Book>
+<Book Series="King In Black: Return of the Valkyries" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="133081" Issue="827527" />
+</Book>
+<Book Series="King In Black: Return of the Valkyries" Number="3" Volume="2021" Year="2021">
+<Database Name="cv" Series="133081" Issue="830027" />
+</Book>
+<Book Series="King In Black: Return of the Valkyries" Number="4" Volume="2021" Year="2021">
+<Database Name="cv" Series="133081" Issue="840956" />
+</Book>
+<Book Series="Black Cat" Number="2" Volume="2020" Year="2021">
+<Database Name="cv" Series="132631" Issue="825504" />
+</Book>
+<Book Series="Black Cat" Number="3" Volume="2020" Year="2021">
+<Database Name="cv" Series="132631" Issue="830022" />
+</Book>
+<Book Series="Venom" Number="33" Volume="2018" Year="2021">
+<Database Name="cv" Series="110770" Issue="827531" />
+</Book>
+<Book Series="King In Black" Number="4" Volume="2020" Year="2021">
+<Database Name="cv" Series="132376" Issue="828857" />
+</Book>
+<Book Series="Fantastic Four" Number="29" Volume="2018" Year="2021">
+<Database Name="cv" Series="112685" Issue="828192" />
+</Book>
+<Book Series="King In Black: Captain America" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="134221" Issue="832863" />
+</Book>
+<Book Series="King In Black: Scream" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="134781" Issue="839795" />
+</Book>
+<Book Series="King In Black: Spider-Man" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="134620" Issue="838866" />
+</Book>
+<Book Series="S.W.O.R.D." Number="4" Volume="2020" Year="2021">
+<Database Name="cv" Series="132511" Issue="838885" />
+</Book>
+<Book Series="Fantastic Four" Number="30" Volume="2018" Year="2021">
+<Database Name="cv" Series="112685" Issue="842960" />
+</Book>
+<Book Series="Venom" Number="34" Volume="2018" Year="2021">
+<Database Name="cv" Series="110770" Issue="842208" />
+</Book>
+<Book Series="Avengers" Number="45" Volume="2018" Year="2021">
+<Database Name="cv" Series="110496" Issue="844966" />
+</Book>
+<Book Series="King In Black" Number="5" Volume="2020" Year="2021">
+<Database Name="cv" Series="132376" Issue="842204" />
+</Book>
+<Book Series="King In Black: Namor" Number="5" Volume="2020" Year="2021">
+<Database Name="cv" Series="132510" Issue="842964" />
+</Book>
+<Book Series="King In Black: Planet of the Symbiotes" Number="3" Volume="2021" Year="2021">
+<Database Name="cv" Series="133196" Issue="842205" />
+</Book>
+<Book Series="Venom" Number="35" Volume="2018" Year="2021">
+<Database Name="cv" Series="110770" Issue="861680" />
+</Book>
+<Book Series="Excalibur" Number="16" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="822348" />
+</Book>
+<Book Series="Hellions" Number="7" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="820023" />
+</Book>
+<Book Series="Hellions" Number="8" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="824026" />
+</Book>
+<Book Series="X-Factor" Number="5" Volume="2020" Year="2021">
+<Database Name="cv" Series="129097" Issue="820030" />
+</Book>
+<Book Series="Cable" Number="7" Volume="2020" Year="2021">
+<Database Name="cv" Series="125678" Issue="825505" />
+</Book>
+<Book Series="Cable" Number="8" Volume="2020" Year="2021">
+<Database Name="cv" Series="125678" Issue="828850" />
+</Book>
+<Book Series="X-Men" Number="16" Volume="2019" Year="2021">
+<Database Name="cv" Series="122077" Issue="823351" />
+</Book>
+<Book Series="Marauders" Number="16" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="820747" />
+</Book>
+<Book Series="New Mutants" Number="14" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="821499" />
+</Book>
+<Book Series="X-Factor" Number="6" Volume="2020" Year="2021">
+<Database Name="cv" Series="129097" Issue="824036" />
+</Book>
+<Book Series="New Mutants" Number="15" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="826560" />
+</Book>
+<Book Series="X-Men" Number="17" Volume="2019" Year="2021">
+<Database Name="cv" Series="122077" Issue="826566" />
+</Book>
+<Book Series="Giant-Size X-Men: Magneto" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="128617" Issue="779007" />
+</Book>
+<Book Series="Marauders" Number="17" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="824452" />
+</Book>
+<Book Series="Wolverine" Number="8" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="823350" />
+</Book>
+<Book Series="Cable" Number="9" Volume="2020" Year="2021">
+<Database Name="cv" Series="125678" Issue="839790" />
+</Book>
+<Book Series="Wolverine" Number="9" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="826565" />
+</Book>
+<Book Series="Wolverine" Number="10" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="830035" />
+</Book>
+<Book Series="Wolverine" Number="11" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="842971" />
+</Book>
+<Book Series="Wolverine" Number="12" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="851314" />
+</Book>
+<Book Series="Juggernaut" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="130568" Issue="803645" />
+</Book>
+<Book Series="Juggernaut" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="130568" Issue="813284" />
+</Book>
+<Book Series="Juggernaut" Number="3" Volume="2020" Year="2021">
+<Database Name="cv" Series="130568" Issue="819120" />
+</Book>
+<Book Series="Juggernaut" Number="4" Volume="2020" Year="2021">
+<Database Name="cv" Series="130568" Issue="820745" />
+</Book>
+<Book Series="Juggernaut" Number="5" Volume="2020" Year="2021">
+<Database Name="cv" Series="130568" Issue="824028" />
+</Book>
+<Book Series="X-Force" Number="17" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="828200" />
+</Book>
+<Book Series="X-Force" Number="18" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="838891" />
+</Book>
+<Book Series="X-Force" Number="19" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="844977" />
+</Book>
+<Book Series="Children of the Atom" Number="3" Volume="2021" Year="2021">
+<Database Name="cv" Series="134388" Issue="848848" />
+</Book>
+<Book Series="New Mutants" Number="16" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="830031" />
+</Book>
+<Book Series="New Mutants" Number="17" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="846089" />
+</Book>
+<Book Series="X-Men" Number="18" Volume="2019" Year="2021">
+<Database Name="cv" Series="122077" Issue="830036" />
+</Book>
+<Book Series="X-Men" Number="19" Volume="2019" Year="2021">
+<Database Name="cv" Series="122077" Issue="840961" />
+</Book>
+<Book Series="New Mutants" Number="18" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="855632" />
+</Book>
+<Book Series="Excalibur" Number="17" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="826556" />
+</Book>
+<Book Series="Excalibur" Number="18" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="828191" />
+</Book>
+<Book Series="Excalibur" Number="19" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="839793" />
+</Book>
+<Book Series="Excalibur" Number="20" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="842202" />
+</Book>
+<Book Series="X-Men" Number="20" Volume="2019" Year="2021">
+<Database Name="cv" Series="122077" Issue="855634" />
+</Book>
+<Book Series="Hellions" Number="9" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="827522" />
+</Book>
+<Book Series="Hellions" Number="10" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="832862" />
+</Book>
+<Book Series="Hellions" Number="11" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="847510" />
+</Book>
+<Book Series="Cable" Number="10" Volume="2020" Year="2021">
+<Database Name="cv" Series="125678" Issue="846084" />
+</Book>
+<Book Series="Cable" Number="11" Volume="2020" Year="2021">
+<Database Name="cv" Series="125678" Issue="866577" />
+</Book>
+<Book Series="Cable" Number="12" Volume="2020" Year="2021">
+<Database Name="cv" Series="125678" Issue="874521" />
+</Book>
+<Book Series="S.W.O.R.D." Number="5" Volume="2020" Year="2021">
+<Database Name="cv" Series="132511" Issue="844973" />
+</Book>
+<Book Series="X-Factor" Number="7" Volume="2020" Year="2021">
+<Database Name="cv" Series="129097" Issue="827532" />
+</Book>
+<Book Series="X-Factor" Number="8" Volume="2020" Year="2021">
+<Database Name="cv" Series="129097" Issue="836308" />
+</Book>
+<Book Series="X-Factor" Number="9" Volume="2020" Year="2021">
+<Database Name="cv" Series="129097" Issue="848859" />
+</Book>
+<Book Series="X-Corp" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="136025" Issue="848858" />
+</Book>
+<Book Series="Marauders" Number="18" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="828860" />
+</Book>
+<Book Series="Marauders" Number="19" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="842206" />
+</Book>
+<Book Series="Children of the Atom" Number="4" Volume="2021" Year="2021">
+<Database Name="cv" Series="134388" Issue="858871" />
+</Book>
+<Book Series="Children of the Atom" Number="5" Volume="2021" Year="2021">
+<Database Name="cv" Series="134388" Issue="868608" />
+</Book>
+<Book Series="Way of X" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="135583" Issue="844975" />
+</Book>
+<Book Series="Way of X" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="135583" Issue="851313" />
+</Book>
+<Book Series="Marauders" Number="20" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="847514" />
+</Book>
+<Book Series="Marauders" Number="21" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="857597" />
+</Book>
+<Book Series="X-Force" Number="20" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="857598" />
+</Book>
+<Book Series="Hellions" Number="12" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="857596" />
+</Book>
+<Book Series="Excalibur" Number="21" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="858872" />
+</Book>
+<Book Series="X-Men" Number="21" Volume="2019" Year="2021">
+<Database Name="cv" Series="122077" Issue="858873" />
+</Book>
+<Book Series="Planet-Size X-Men" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="136937" Issue="861642" />
+</Book>
+<Book Series="New Mutants" Number="19" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="861639" />
+</Book>
+<Book Series="Children of the Atom" Number="6" Volume="2021" Year="2021">
+<Database Name="cv" Series="134388" Issue="878791" />
+</Book>
+<Book Series="X-Corp" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="136025" Issue="861644" />
+</Book>
+<Book Series="Wolverine" Number="13" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="863865" />
+</Book>
+<Book Series="S.W.O.R.D." Number="6" Volume="2020" Year="2021">
+<Database Name="cv" Series="132511" Issue="863852" />
+</Book>
+<Book Series="Way of X" Number="3" Volume="2021" Year="2021">
+<Database Name="cv" Series="135583" Issue="863854" />
+</Book>
+<Book Series="X-Factor" Number="10" Volume="2020" Year="2021">
+<Database Name="cv" Series="129097" Issue="866581" />
+</Book>
+<Book Series="Marauders" Number="22" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="872876" />
+</Book>
+<Book Series="S.W.O.R.D." Number="7" Volume="2020" Year="2021">
+<Database Name="cv" Series="132511" Issue="874522" />
+</Book>
+<Book Series="Cable: Reloaded" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="138527" Issue="882047" />
+</Book>
+<Book Series="X-Men" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="137402" Issue="868602" />
+</Book>
+<Book Series="New Mutants" Number="20" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="872877" />
+</Book>
+<Book Series="New Mutants" Number="21" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="882897" />
+</Book>
+<Book Series="New Mutants" Number="22" Volume="2020" Year="2021">
+<Database Name="cv" Series="122666" Issue="888638" />
+</Book>
+<Book Series="New Mutants" Number="23" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="896124" />
+</Book>
+<Book Series="X-Men: The Trial of Magneto" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="138343" Issue="880915" />
+</Book>
+<Book Series="Marauders" Number="23" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="880901" />
+</Book>
+<Book Series="Wolverine" Number="14" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="874523" />
+</Book>
+<Book Series="Wolverine" Number="15" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="882049" />
+</Book>
+<Book Series="Wolverine" Number="16" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="886940" />
+</Book>
+<Book Series="X-Men: The Trial of Magneto" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="138343" Issue="884830" />
+</Book>
+<Book Series="X-Men: The Trial of Magneto" Number="3" Volume="2021" Year="2021">
+<Database Name="cv" Series="138343" Issue="890603" />
+</Book>
+<Book Series="X-Men: The Trial of Magneto" Number="4" Volume="2021" Year="2022">
+<Database Name="cv" Series="138343" Issue="896094" />
+</Book>
+<Book Series="Inferno" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="139289" Issue="886937" />
+</Book>
+<Book Series="Hellions" Number="13" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="868599" />
+</Book>
+<Book Series="Hellions" Number="14" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="877059" />
+</Book>
+<Book Series="Hellions" Number="15" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="882896" />
+</Book>
+<Book Series="Hellions" Number="16" Volume="2020" Year="2021">
+<Database Name="cv" Series="126015" Issue="888637" />
+</Book>
+<Book Series="S.W.O.R.D." Number="8" Volume="2020" Year="2021">
+<Database Name="cv" Series="132511" Issue="886939" />
+</Book>
+<Book Series="Hellions" Number="17" Volume="2020" Year="2022">
+<Database Name="cv" Series="126015" Issue="893934" />
+</Book>
+<Book Series="Hellions" Number="18" Volume="2020" Year="2022">
+<Database Name="cv" Series="126015" Issue="897328" />
+</Book>
+<Book Series="X-Men: The Trial of Magneto" Number="5" Volume="2021" Year="2022">
+<Database Name="cv" Series="138343" Issue="899168" />
+</Book>
+<Book Series="New Mutants" Number="24" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="906634" />
+</Book>
+<Book Series="X-Men" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="137402" Issue="877060" />
+</Book>
+<Book Series="Excalibur" Number="22" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="871563" />
+</Book>
+<Book Series="Excalibur" Number="23" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="884068" />
+</Book>
+<Book Series="Excalibur" Number="24" Volume="2019" Year="2021">
+<Database Name="cv" Series="122488" Issue="888636" />
+</Book>
+<Book Series="Excalibur" Number="25" Volume="2019" Year="2022">
+<Database Name="cv" Series="122488" Issue="893974" />
+</Book>
+<Book Series="Excalibur" Number="26" Volume="2019" Year="2022">
+<Database Name="cv" Series="122488" Issue="898357" />
+</Book>
+<Book Series="Way of X" Number="4" Volume="2021" Year="2021">
+<Database Name="cv" Series="135583" Issue="871569" />
+</Book>
+<Book Series="Way of X" Number="5" Volume="2021" Year="2021">
+<Database Name="cv" Series="135583" Issue="880912" />
+</Book>
+<Book Series="X-Men: The Onslaught Revelation" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="139124" Issue="885606" />
+</Book>
+<Book Series="Marauders" Number="24" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="884828" />
+</Book>
+<Book Series="Marauders" Number="25" Volume="2019" Year="2021">
+<Database Name="cv" Series="122218" Issue="891563" />
+</Book>
+<Book Series="X-Men" Number="3" Volume="2021" Year="2021">
+<Database Name="cv" Series="137402" Issue="885604" />
+</Book>
+<Book Series="X-Corp" Number="3" Volume="2021" Year="2021">
+<Database Name="cv" Series="136025" Issue="871578" />
+</Book>
+<Book Series="X-Corp" Number="4" Volume="2021" Year="2021">
+<Database Name="cv" Series="136025" Issue="880913" />
+</Book>
+<Book Series="X-Corp" Number="5" Volume="2021" Year="2021">
+<Database Name="cv" Series="136025" Issue="885603" />
+</Book>
+<Book Series="S.W.O.R.D." Number="9" Volume="2020" Year="2021">
+<Database Name="cv" Series="132511" Issue="891564" />
+</Book>
+<Book Series="S.W.O.R.D." Number="10" Volume="2020" Year="2022">
+<Database Name="cv" Series="132511" Issue="894139" />
+</Book>
+<Book Series="S.W.O.R.D." Number="11" Volume="2020" Year="2022">
+<Database Name="cv" Series="132511" Issue="899166" />
+</Book>
+<Book Series="X-Men" Number="4" Volume="2021" Year="2021">
+<Database Name="cv" Series="137402" Issue="889466" />
+</Book>
+<Book Series="X-Men" Number="5" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="895353" />
+</Book>
+<Book Series="Marauders" Number="26" Volume="2019" Year="2022">
+<Database Name="cv" Series="122218" Issue="896131" />
+</Book>
+<Book Series="X-Men" Number="6" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="901350" />
+</Book>
+<Book Series="X-Men" Number="7" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="904779" />
+</Book>
+<Book Series="X-Men" Number="8" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="907432" />
+</Book>
+<Book Series="Devil&apos;s Reign: X-Men" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="141328" Issue="903910" />
+</Book>
+<Book Series="Devil&apos;s Reign: X-Men" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="141328" Issue="909677" />
+</Book>
+<Book Series="Devil&apos;s Reign: X-Men" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="141328" Issue="912248" />
+</Book>
+<Book Series="X-Force" Number="21" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="868600" />
+</Book>
+<Book Series="X-Force" Number="22" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="878792" />
+</Book>
+<Book Series="Wolverine" Number="17" Volume="2020" Year="2021">
+<Database Name="cv" Series="125121" Issue="891565" />
+</Book>
+<Book Series="Wolverine" Number="18" Volume="2020" Year="2022">
+<Database Name="cv" Series="125121" Issue="895337" />
+</Book>
+<Book Series="X-Force" Number="23" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="884069" />
+</Book>
+<Book Series="X-Force" Number="24" Volume="2020" Year="2021">
+<Database Name="cv" Series="122668" Issue="889465" />
+</Book>
+<Book Series="Inferno" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="139289" Issue="891562" />
+</Book>
+<Book Series="X-Force" Number="25" Volume="2020" Year="2022">
+<Database Name="cv" Series="122668" Issue="894133" />
+</Book>
+<Book Series="X-Force" Number="26" Volume="2020" Year="2022">
+<Database Name="cv" Series="122668" Issue="898353" />
+</Book>
+<Book Series="Wolverine" Number="19" Volume="2020" Year="2022">
+<Database Name="cv" Series="125121" Issue="899167" />
+</Book>
+<Book Series="Inferno" Number="3" Volume="2021" Year="2022">
+<Database Name="cv" Series="139289" Issue="897331" />
+</Book>
+<Book Series="Inferno" Number="4" Volume="2021" Year="2022">
+<Database Name="cv" Series="139289" Issue="901345" />
+</Book>
+<Book Series="Marauders" Number="27" Volume="2019" Year="2022">
+<Database Name="cv" Series="122218" Issue="902690" />
+</Book>
+<Book Series="X-Men" Number="9" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="909674" />
+</Book>
+<Book Series="X-Force Annual" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="142143" Issue="914651" />
+</Book>
+<Book Series="X Lives of Wolverine" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="141332" Issue="903920" />
+</Book>
+<Book Series="X Deaths of Wolverine" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="141460" Issue="904769" />
+</Book>
+<Book Series="X Lives of Wolverine" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="141332" Issue="905751" />
+</Book>
+<Book Series="X Deaths of Wolverine" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="141460" Issue="906636" />
+</Book>
+<Book Series="X Lives of Wolverine" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="141332" Issue="907433" />
+</Book>
+<Book Series="X Deaths of Wolverine" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="141460" Issue="908676" />
+</Book>
+<Book Series="X Lives of Wolverine" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="141332" Issue="910624" />
+</Book>
+<Book Series="X Deaths of Wolverine" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="141460" Issue="910625" />
+</Book>
+<Book Series="X Lives of Wolverine" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="141332" Issue="911227" />
+</Book>
+<Book Series="X Deaths of Wolverine" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="141460" Issue="912246" />
+</Book>
+<Book Series="X-Force" Number="27" Volume="2020" Year="2022">
+<Database Name="cv" Series="122668" Issue="914648" />
+</Book>
+<Book Series="X-Force" Number="28" Volume="2020" Year="2022">
+<Database Name="cv" Series="122668" Issue="924786" />
+</Book>
+<Book Series="X-Force" Number="29" Volume="2020" Year="2022">
+<Database Name="cv" Series="122668" Issue="933078" />
+</Book>
+<Book Series="Wolverine" Number="20" Volume="2020" Year="2022">
+<Database Name="cv" Series="125121" Issue="918155" />
+</Book>
+<Book Series="Wolverine" Number="21" Volume="2020" Year="2022">
+<Database Name="cv" Series="125121" Issue="924801" />
+</Book>
+<Book Series="Wolverine" Number="22" Volume="2020" Year="2022">
+<Database Name="cv" Series="125121" Issue="930974" />
+</Book>
+<Book Series="Wolverine" Number="23" Volume="2020" Year="2022">
+<Database Name="cv" Series="125121" Issue="935753" />
+</Book>
+<Book Series="X-Men Unlimited: X-Men Green" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="144596" Issue="942888" />
+</Book>
+<Book Series="X-Men Unlimited: X-Men Green" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="144596" Issue="948120" />
+</Book>
+<Book Series="Sabretooth" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="141524" Issue="905793" />
+</Book>
+<Book Series="Sabretooth" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="141524" Issue="910621" />
+</Book>
+<Book Series="Sabretooth" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="141524" Issue="919308" />
+</Book>
+<Book Series="Sabretooth" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="141524" Issue="933081" />
+</Book>
+<Book Series="Sabretooth" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="141524" Issue="934984" />
+</Book>
+<Book Series="Sabretooth and the Exiles" Number="1" Volume="2022" Year="2023">
+<Database Name="cv" Series="145971" Issue="954280" />
+</Book>
+<Book Series="Sabretooth and the Exiles" Number="2" Volume="2022" Year="2023">
+<Database Name="cv" Series="145971" Issue="960981" />
+</Book>
+<Book Series="Sabretooth and the Exiles" Number="3" Volume="2022" Year="2023">
+<Database Name="cv" Series="145971" Issue="966425" />
+</Book>
+<Book Series="Sabretooth and the Exiles" Number="4" Volume="2022" Year="2023">
+<Database Name="cv" Series="145971" Issue="973028" />
+</Book>
+<Book Series="Sabretooth and the Exiles" Number="5" Volume="2022" Year="2023">
+<Database Name="cv" Series="145971" Issue="979429" />
+</Book>
+<Book Series="Immortal X-Men" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="142053" Issue="913161" />
+</Book>
+<Book Series="Immortal X-Men" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="142053" Issue="924799" />
+</Book>
+<Book Series="Immortal X-Men" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="142053" Issue="931630" />
+</Book>
+<Book Series="Legion of X" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="143115" Issue="926170" />
+</Book>
+<Book Series="Legion of X" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="143115" Issue="929646" />
+</Book>
+<Book Series="X-Men: Red" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="142134" Issue="914549" />
+</Book>
+<Book Series="X-Men: Red" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="142134" Issue="924793" />
+</Book>
+<Book Series="X-Men: Red" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="142134" Issue="930978" />
+</Book>
+<Book Series="Legion of X" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="143115" Issue="934980" />
+</Book>
+<Book Series="Legion of X" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="143115" Issue="940229" />
+</Book>
+<Book Series="Legion of X" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="143115" Issue="948111" />
+</Book>
+<Book Series="Knights of X" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="142576" Issue="919304" />
+</Book>
+<Book Series="Knights of X" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="142576" Issue="928438" />
+</Book>
+<Book Series="Knights of X" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="142576" Issue="931632" />
+</Book>
+<Book Series="Knights of X" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="142576" Issue="937731" />
+</Book>
+<Book Series="Knights of X" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="142576" Issue="944673" />
+</Book>
+<Book Series="The Secret X-Men" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="141588" Issue="906626" />
+</Book>
+<Book Series="Marauders Annual" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="141459" Issue="904768" />
+</Book>
+<Book Series="Marauders" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="142135" Issue="914550" />
+</Book>
+<Book Series="Marauders" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="142135" Issue="921063" />
+</Book>
+<Book Series="Marauders" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="142135" Issue="929645" />
+</Book>
+<Book Series="Marauders" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="142135" Issue="935761" />
+</Book>
+<Book Series="X-Men" Number="10" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="916414" />
+</Book>
+<Book Series="X-Men" Number="11" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="922402" />
+</Book>
+<Book Series="X-Men" Number="12" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="931633" />
+</Book>
+<Book Series="Free Comic Book Day 2022: Avengers/X-Men" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="142841" Issue="922405" />
+</Book>
+<Book Series="X-Men: Hellfire Gala" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="153656" Issue="1016342" />
+</Book>
+<Book Series="X-Men: Red" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="142134" Issue="933084" />
+</Book>
+<Book Series="Marauders" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="142135" Issue="943897" />
+</Book>
+<Book Series="X-Force" Number="30" Volume="2020" Year="2022">
+<Database Name="cv" Series="122668" Issue="942706" />
+</Book>
+<Book Series="Immortal X-Men" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="142053" Issue="935751" />
+</Book>
+<Book Series="Eternals" Number="10" Volume="2021" Year="2022">
+<Database Name="cv" Series="133080" Issue="910626" />
+</Book>
+<Book Series="Eternals" Number="11" Volume="2021" Year="2022">
+<Database Name="cv" Series="133080" Issue="916411" />
+</Book>
+<Book Series="Eternals" Number="12" Volume="2021" Year="2022">
+<Database Name="cv" Series="133080" Issue="924798" />
+</Book>
+<Book Series="A.X.E.: Eve of Judgment" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="144026" Issue="935759" />
+</Book>
+<Book Series="A.X.E.: Judgment Day" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="144123" Issue="937937" />
+</Book>
+<Book Series="X-Men: Red" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="142134" Issue="940222" />
+</Book>
+<Book Series="Immortal X-Men" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="142053" Issue="940226" />
+</Book>
+<Book Series="A.X.E.: Judgment Day" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="144123" Issue="941552" />
+</Book>
+<Book Series="A.X.E.: Death to the Mutants" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="144577" Issue="942722" />
+</Book>
+<Book Series="X-Men" Number="13" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="942704" />
+</Book>
+<Book Series="A.X.E.: Judgment Day" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="144123" Issue="943804" />
+</Book>
+<Book Series="A.X.E.: Death to the Mutants" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="144577" Issue="946198" />
+</Book>
+<Book Series="X-Men" Number="14" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="944674" />
+</Book>
+<Book Series="Wolverine" Number="24" Volume="2020" Year="2022">
+<Database Name="cv" Series="125121" Issue="946208" />
+</Book>
+<Book Series="Wolverine" Number="25" Volume="2020" Year="2022">
+<Database Name="cv" Series="125121" Issue="950794" />
+</Book>
+<Book Series="X-Force" Number="31" Volume="2020" Year="2022">
+<Database Name="cv" Series="122668" Issue="944669" />
+</Book>
+<Book Series="X-Force" Number="32" Volume="2020" Year="2022">
+<Database Name="cv" Series="122668" Issue="950383" />
+</Book>
+<Book Series="X-Force" Number="33" Volume="2020" Year="2022">
+<Database Name="cv" Series="122668" Issue="951451" />
+</Book>
+<Book Series="Immortal X-Men" Number="6" Volume="2022" Year="2022">
+<Database Name="cv" Series="142053" Issue="946148" />
+</Book>
+<Book Series="X-Men: Red" Number="6" Volume="2022" Year="2022">
+<Database Name="cv" Series="142134" Issue="946725" />
+</Book>
+<Book Series="A.X.E.: Iron Fist" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="145487" Issue="950486" />
+</Book>
+<Book Series="Avengers" Number="60" Volume="2018" Year="2022">
+<Database Name="cv" Series="110496" Issue="948104" />
+</Book>
+<Book Series="Fantastic Four" Number="47" Volume="2018" Year="2022">
+<Database Name="cv" Series="112685" Issue="948107" />
+</Book>
+<Book Series="Fantastic Four" Number="48" Volume="2018" Year="2022">
+<Database Name="cv" Series="112685" Issue="950375" />
+</Book>
+<Book Series="The Amazing Spider-Man" Number="10" Volume="2022" Year="2022">
+<Database Name="cv" Series="142577" Issue="949133" />
+</Book>
+<Book Series="Captain Marvel" Number="42" Volume="2019" Year="2022">
+<Database Name="cv" Series="116365" Issue="950790" />
+</Book>
+<Book Series="A.X.E.: Judgment Day" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="144123" Issue="946709" />
+</Book>
+<Book Series="X-Men: Red" Number="7" Volume="2022" Year="2022">
+<Database Name="cv" Series="142134" Issue="949645" />
+</Book>
+<Book Series="Legion of X" Number="6" Volume="2022" Year="2022">
+<Database Name="cv" Series="143115" Issue="950373" />
+</Book>
+<Book Series="Marauders" Number="6" Volume="2022" Year="2022">
+<Database Name="cv" Series="142135" Issue="946133" />
+</Book>
+<Book Series="A.X.E.: Judgment Day" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="144123" Issue="948102" />
+</Book>
+<Book Series="Immortal X-Men" Number="7" Volume="2022" Year="2022">
+<Database Name="cv" Series="142053" Issue="950483" />
+</Book>
+<Book Series="A.X.E.: Death to the Mutants" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="144577" Issue="950484" />
+</Book>
+<Book Series="A.X.E.: Starfox" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="145362" Issue="949633" />
+</Book>
+<Book Series="A.X.E.: Avengers" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="145299" Issue="949158" />
+</Book>
+<Book Series="A.X.E.: X-Men" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="145363" Issue="949634" />
+</Book>
+<Book Series="A.X.E.: Eternals" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="145486" Issue="950485" />
+</Book>
+<Book Series="A.X.E.: Judgment Day" Number="6" Volume="2022" Year="2022">
+<Database Name="cv" Series="144123" Issue="952304" />
+</Book>
+<Book Series="A.X.E.: Judgment Day Omega" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="145974" Issue="954292" />
+</Book>
+<Book Series="Immortal X-Men" Number="8" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="955124" />
+</Book>
+<Book Series="Marauders" Number="7" Volume="2022" Year="2022">
+<Database Name="cv" Series="142135" Issue="949640" />
+</Book>
+<Book Series="Marauders" Number="8" Volume="2022" Year="2023">
+<Database Name="cv" Series="142135" Issue="953976" />
+</Book>
+<Book Series="Marauders" Number="9" Volume="2022" Year="2023">
+<Database Name="cv" Series="142135" Issue="958985" />
+</Book>
+<Book Series="Marauders" Number="10" Volume="2022" Year="2023">
+<Database Name="cv" Series="142135" Issue="962851" />
+</Book>
+<Book Series="Marauders" Number="11" Volume="2022" Year="2023">
+<Database Name="cv" Series="142135" Issue="971896" />
+</Book>
+<Book Series="Marauders" Number="12" Volume="2022" Year="2023">
+<Database Name="cv" Series="142135" Issue="978483" />
+</Book>
+<Book Series="New Mutants" Number="25" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="924785" />
+</Book>
+<Book Series="New Mutants" Number="26" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="931631" />
+</Book>
+<Book Series="New Mutants" Number="27" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="935764" />
+</Book>
+<Book Series="New Mutants" Number="28" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="942712" />
+</Book>
+<Book Series="New Mutants" Number="29" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="946211" />
+</Book>
+<Book Series="New Mutants" Number="30" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="948113" />
+</Book>
+<Book Series="New Mutants" Number="31" Volume="2020" Year="2022">
+<Database Name="cv" Series="122666" Issue="952303" />
+</Book>
+<Book Series="New Mutants" Number="32" Volume="2020" Year="2023">
+<Database Name="cv" Series="122666" Issue="958986" />
+</Book>
+<Book Series="New Mutants" Number="33" Volume="2020" Year="2023">
+<Database Name="cv" Series="122666" Issue="961943" />
+</Book>
+<Book Series="New Mutants: Lethal Legion" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="148780" Issue="975693" />
+</Book>
+<Book Series="New Mutants: Lethal Legion" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="148780" Issue="984327" />
+</Book>
+<Book Series="New Mutants: Lethal Legion" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="148780" Issue="991069" />
+</Book>
+<Book Series="New Mutants: Lethal Legion" Number="4" Volume="2023" Year="2023">
+<Database Name="cv" Series="148780" Issue="996024" />
+</Book>
+<Book Series="New Mutants: Lethal Legion" Number="5" Volume="2023" Year="2023">
+<Database Name="cv" Series="148780" Issue="1002001" />
+</Book>
+<Book Series="X-Men Annual" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="146988" Issue="960987" />
+</Book>
+<Book Series="X-Men" Number="15" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="949129" />
+</Book>
+<Book Series="X-Men" Number="16" Volume="2021" Year="2022">
+<Database Name="cv" Series="137402" Issue="951447" />
+</Book>
+<Book Series="X-Men" Number="17" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="956846" />
+</Book>
+<Book Series="X-Terminators" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="145163" Issue="948121" />
+</Book>
+<Book Series="X-Terminators" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="145163" Issue="952307" />
+</Book>
+<Book Series="X-Terminators" Number="3" Volume="2022" Year="2023">
+<Database Name="cv" Series="145163" Issue="958044" />
+</Book>
+<Book Series="X-Terminators" Number="4" Volume="2022" Year="2023">
+<Database Name="cv" Series="145163" Issue="961964" />
+</Book>
+<Book Series="X-Terminators" Number="5" Volume="2022" Year="2023">
+<Database Name="cv" Series="145163" Issue="966432" />
+</Book>
+<Book Series="Dark Web" Number="1" Volume="2022" Year="2023">
+<Database Name="cv" Series="146735" Issue="959000" />
+</Book>
+<Book Series="Dark Web: X-Men" Number="1" Volume="2022" Year="2023">
+<Database Name="cv" Series="146875" Issue="960026" />
+</Book>
+<Book Series="Dark Web: X-Men" Number="2" Volume="2022" Year="2023">
+<Database Name="cv" Series="146875" Issue="961948" />
+</Book>
+<Book Series="Dark Web: X-Men" Number="3" Volume="2022" Year="2023">
+<Database Name="cv" Series="146875" Issue="964964" />
+</Book>
+<Book Series="Dark Web: Finale" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="147905" Issue="967787" />
+</Book>
+<Book Series="X-Men" Number="18" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="963985" />
+</Book>
+<Book Series="Captain Marvel" Number="43" Volume="2019" Year="2023">
+<Database Name="cv" Series="116365" Issue="953019" />
+</Book>
+<Book Series="Captain Marvel" Number="44" Volume="2019" Year="2023">
+<Database Name="cv" Series="116365" Issue="958979" />
+</Book>
+<Book Series="Captain Marvel" Number="45" Volume="2019" Year="2023">
+<Database Name="cv" Series="116365" Issue="962850" />
+</Book>
+<Book Series="Captain Marvel" Number="46" Volume="2019" Year="2023">
+<Database Name="cv" Series="116365" Issue="971895" />
+</Book>
+<Book Series="Captain Marvel" Number="47" Volume="2019" Year="2023">
+<Database Name="cv" Series="116365" Issue="976907" />
+</Book>
+<Book Series="Captain Marvel" Number="48" Volume="2019" Year="2023">
+<Database Name="cv" Series="116365" Issue="982355" />
+</Book>
+<Book Series="Captain Marvel" Number="49" Volume="2019" Year="2023">
+<Database Name="cv" Series="116365" Issue="987103" />
+</Book>
+<Book Series="X-Men" Number="19" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="971885" />
+</Book>
+<Book Series="X-Men" Number="20" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="975695" />
+</Book>
+<Book Series="X-Men" Number="21" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="982356" />
+</Book>
+<Book Series="X-Men: Red" Number="8" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="953033" />
+</Book>
+<Book Series="X-Men: Red" Number="9" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="958991" />
+</Book>
+<Book Series="X-Men: Red" Number="10" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="962849" />
+</Book>
+<Book Series="Legion of X" Number="7" Volume="2022" Year="2023">
+<Database Name="cv" Series="143115" Issue="953977" />
+</Book>
+<Book Series="Legion of X" Number="8" Volume="2022" Year="2023">
+<Database Name="cv" Series="143115" Issue="960023" />
+</Book>
+<Book Series="Legion of X" Number="9" Volume="2022" Year="2023">
+<Database Name="cv" Series="143115" Issue="963981" />
+</Book>
+<Book Series="Legion of X" Number="10" Volume="2022" Year="2023">
+<Database Name="cv" Series="143115" Issue="967794" />
+</Book>
+<Book Series="Immortal X-Men" Number="9" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="958983" />
+</Book>
+<Book Series="Immortal X-Men" Number="10" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="964967" />
+</Book>
+<Book Series="Sins of Sinister" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153615" Issue="1014917" />
+</Book>
+<Book Series="Storm &#38; The Brotherhood of Mutants" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="148090" Issue="969390" />
+</Book>
+<Book Series="Nightcrawlers" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="148297" Issue="971894" />
+</Book>
+<Book Series="Immoral X-Men" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="148475" Issue="973001" />
+</Book>
+<Book Series="Nightcrawlers" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="148297" Issue="975699" />
+</Book>
+<Book Series="Immoral X-Men" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="148475" Issue="976915" />
+</Book>
+<Book Series="Storm &#38; The Brotherhood of Mutants" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="148090" Issue="978480" />
+</Book>
+<Book Series="Immoral X-Men" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="148475" Issue="981484" />
+</Book>
+<Book Series="Storm &#38; The Brotherhood of Mutants" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="148090" Issue="982353" />
+</Book>
+<Book Series="Nightcrawlers" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="148297" Issue="984326" />
+</Book>
+<Book Series="Sins of Sinister: Dominion" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="149776" Issue="985704" />
+</Book>
+<Book Series="Immortal X-Men" Number="11" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="987132" />
+</Book>
+<Book Series="X-Men: Before the Fall - Sons of X" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="150028" Issue="987192" />
+</Book>
+<Book Series="X-Men: Red" Number="11" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="988124" />
+</Book>
+<Book Series="X-Men: Red" Number="12" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="994356" />
+</Book>
+<Book Series="Wolverine" Number="26" Volume="2020" Year="2022">
+<Database Name="cv" Series="125121" Issue="952302" />
+</Book>
+<Book Series="Wolverine" Number="27" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="953983" />
+</Book>
+<Book Series="Wolverine" Number="28" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="960986" />
+</Book>
+<Book Series="X-Force" Number="34" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="956778" />
+</Book>
+<Book Series="X-Force" Number="35" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="958990" />
+</Book>
+<Book Series="X-Force" Number="36" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="962844" />
+</Book>
+<Book Series="X-Force" Number="37" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="967790" />
+</Book>
+<Book Series="X-Force" Number="38" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="974096" />
+</Book>
+<Book Series="Wolverine" Number="29" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="963982" />
+</Book>
+<Book Series="Wolverine" Number="30" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="971883" />
+</Book>
+<Book Series="Wolverine" Number="31" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="976904" />
+</Book>
+<Book Series="Wolverine" Number="32" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="981473" />
+</Book>
+<Book Series="X-Force" Number="39" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="984323" />
+</Book>
+<Book Series="Wolverine" Number="33" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="988123" />
+</Book>
+<Book Series="Wolverine" Number="34" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="994359" />
+</Book>
+<Book Series="X-Force" Number="40" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="989670" />
+</Book>
+<Book Series="X-Force" Number="41" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="996027" />
+</Book>
+<Book Series="X-Force" Number="42" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="1000244" />
+</Book>
+<Book Series="Wolverine" Number="35" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="1003593" />
+</Book>
+<Book Series="Deadpool" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="953021" />
+</Book>
+<Book Series="Deadpool" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="960024" />
+</Book>
+<Book Series="Deadpool" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="964961" />
+</Book>
+<Book Series="Deadpool" Number="4" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="973019" />
+</Book>
+<Book Series="Deadpool" Number="5" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="979419" />
+</Book>
+<Book Series="Deadpool" Number="6" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="985710" />
+</Book>
+<Book Series="Deadpool" Number="7" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="992312" />
+</Book>
+<Book Series="Deadpool" Number="8" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="997389" />
+</Book>
+<Book Series="Deadpool" Number="9" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="1003576" />
+</Book>
+<Book Series="Deadpool" Number="10" Volume="2023" Year="2023">
+<Database Name="cv" Series="145766" Issue="1010046" />
+</Book>
+<Book Series="Rogue &amp; Gambit" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="148664" Issue="974106" />
+</Book>
+<Book Series="Rogue &amp; Gambit" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="148664" Issue="981478" />
+</Book>
+<Book Series="Rogue &amp; Gambit" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="148664" Issue="988125" />
+</Book>
+<Book Series="Rogue &amp; Gambit" Number="4" Volume="2023" Year="2023">
+<Database Name="cv" Series="148664" Issue="994364" />
+</Book>
+<Book Series="Rogue &amp; Gambit" Number="5" Volume="2023" Year="2023">
+<Database Name="cv" Series="148664" Issue="1000237" />
+</Book>
+<Book Series="X-Men" Number="22" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="989671" />
+</Book>
+<Book Series="X-Men: Before the Fall – Mutant First Strike" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="151052" Issue="993583" />
+</Book>
+<Book Series="Bishop: War College" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="148091" Issue="969391" />
+</Book>
+<Book Series="Bishop: War College" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="148091" Issue="976901" />
+</Book>
+<Book Series="Bishop: War College" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="148091" Issue="984330" />
+</Book>
+<Book Series="Bishop: War College" Number="4" Volume="2023" Year="2023">
+<Database Name="cv" Series="148091" Issue="991063" />
+</Book>
+<Book Series="Bishop: War College" Number="5" Volume="2023" Year="2023">
+<Database Name="cv" Series="148091" Issue="993226" />
+</Book>
+<Book Series="Marvel&apos;s Voices: Pride" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="151966" Issue="999054" />
+</Book>
+<Book Series="Betsy Braddock: Captain Britain" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="148474" Issue="973000" />
+</Book>
+<Book Series="Betsy Braddock: Captain Britain" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="148474" Issue="979432" />
+</Book>
+<Book Series="Betsy Braddock: Captain Britain" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="148474" Issue="985715" />
+</Book>
+<Book Series="Betsy Braddock: Captain Britain" Number="4" Volume="2023" Year="2023">
+<Database Name="cv" Series="148474" Issue="992288" />
+</Book>
+<Book Series="Betsy Braddock: Captain Britain" Number="5" Volume="2023" Year="2023">
+<Database Name="cv" Series="148474" Issue="996014" />
+</Book>
+<Book Series="X-Men" Number="23" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="993241" />
+</Book>
+<Book Series="Fallen Friend: The Death of Ms. Marvel" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="152123" Issue="1000229" />
+</Book>
+<Book Series="X-Men: Before the Fall - Sinister Four" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="151912" Issue="998591" />
+</Book>
+<Book Series="Immortal X-Men" Number="12" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="993232" />
+</Book>
+<Book Series="X-Men: Before The Fall - Heralds of Apocalypse" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="151708" Issue="997400" />
+</Book>
+<Book Series="X-Men: Red" Number="13" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="1001998" />
+</Book>
+<Book Series="Immortal X-Men" Number="13" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="1000231" />
+</Book>
+<Book Series="X-Men" Number="24" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="999414" />
+</Book>
+<Book Series="X-Men: Hellfire Gala" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="152567" Issue="1003871" />
+</Book>
+<Book Series="Free Comic Book Day 2023: Avengers/X-Men" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="150031" Issue="987190" />
+</Book>
+<Book Series="X-Force" Number="43" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="1010057" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="8" Volume="2022" Year="2023">
+<Database Name="cv" Series="146873" Issue="1003582" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="9" Volume="2022" Year="2023">
+<Database Name="cv" Series="146873" Issue="1010048" />
+</Book>
+<Book Series="Marvel&apos;s Voices: X-Men" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153035" Issue="1009043" />
+</Book>
+<Book Series="X-Men: Red" Number="14" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="1008944" />
+</Book>
+<Book Series="X-Men: Red" Number="15" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="1013504" />
+</Book>
+<Book Series="Realm of X" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153121" Issue="1010053" />
+</Book>
+<Book Series="Realm of X" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="153121" Issue="1018027" />
+</Book>
+<Book Series="Ghost Rider / Wolverine: Weapons of Vengeance – Alpha" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="152897" Issue="1006447" />
+</Book>
+<Book Series="Ghost Rider" Number="17" Volume="2022" Year="2023">
+<Database Name="cv" Series="141707" Issue="1008949" />
+</Book>
+<Book Series="Wolverine" Number="36" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="1010949" />
+</Book>
+<Book Series="Ghost Rider/Wolverine: Weapons of Vengeance Omega" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153361" Issue="1012328" />
+</Book>
+<Book Series="X-Men" Number="25" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="1004347" />
+</Book>
+<Book Series="Uncanny Avengers" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153018" Issue="1008929" />
+</Book>
+<Book Series="Uncanny Avengers" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="153018" Issue="1014896" />
+</Book>
+<Book Series="Children of the Vault" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="152893" Issue="1006445" />
+</Book>
+<Book Series="Children of the Vault" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="152893" Issue="1013492" />
+</Book>
+<Book Series="Children of the Vault" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="152893" Issue="1025150" />
+</Book>
+<Book Series="Children of the Vault" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="152893" Issue="1029679" />
+</Book>
+<Book Series="Giant-Size X-Men" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="158070" Issue="1054379" />
+</Book>
+<Book Series="X-Men" Number="26" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="1011788" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="10" Volume="2022" Year="2023">
+<Database Name="cv" Series="146873" Issue="1018021" />
+</Book>
+<Book Series="Ms. Marvel: The New Mutant" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153238" Issue="1010944" />
+</Book>
+<Book Series="Ms. Marvel: The New Mutant" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="153238" Issue="1018026" />
+</Book>
+<Book Series="Ms. Marvel: The New Mutant" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="153238" Issue="1026552" />
+</Book>
+<Book Series="Ms. Marvel: The New Mutant" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="153238" Issue="1031695" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="11" Volume="2022" Year="2023">
+<Database Name="cv" Series="146873" Issue="1025158" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="12" Volume="2022" Year="2024">
+<Database Name="cv" Series="146873" Issue="1030786" />
+</Book>
+<Book Series="Alpha Flight" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153020" Issue="1008998" />
+</Book>
+<Book Series="Alpha Flight" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="153020" Issue="1014904" />
+</Book>
+<Book Series="Alpha Flight" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="153020" Issue="1026542" />
+</Book>
+<Book Series="Alpha Flight" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="153020" Issue="1029674" />
+</Book>
+<Book Series="Alpha Flight" Number="5" Volume="2023" Year="2024">
+<Database Name="cv" Series="153020" Issue="1033198" />
+</Book>
+<Book Series="Dark X-Men" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153023" Issue="1008999" />
+</Book>
+<Book Series="Dark X-Men" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="153023" Issue="1014902" />
+</Book>
+<Book Series="Dark X-Men" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="153023" Issue="1026546" />
+</Book>
+<Book Series="Wolverine" Number="37" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="1014897" />
+</Book>
+<Book Series="Wolverine" Number="38" Volume="2020" Year="2023">
+<Database Name="cv" Series="125121" Issue="1024060" />
+</Book>
+<Book Series="Wolverine" Number="39" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1030799" />
+</Book>
+<Book Series="X-Force" Number="44" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="1013503" />
+</Book>
+<Book Series="X-Force" Number="45" Volume="2020" Year="2023">
+<Database Name="cv" Series="122668" Issue="1020543" />
+</Book>
+<Book Series="X-Force" Number="46" Volume="2020" Year="2024">
+<Database Name="cv" Series="122668" Issue="1028638" />
+</Book>
+<Book Series="Wolverine" Number="40" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1035971" />
+</Book>
+<Book Series="X-Men" Number="27" Volume="2021" Year="2023">
+<Database Name="cv" Series="137402" Issue="1020544" />
+</Book>
+<Book Series="X-Men" Number="28" Volume="2021" Year="2024">
+<Database Name="cv" Series="137402" Issue="1027605" />
+</Book>
+<Book Series="X-Men" Number="29" Volume="2021" Year="2024">
+<Database Name="cv" Series="137402" Issue="1033214" />
+</Book>
+<Book Series="X-Men: Red" Number="16" Volume="2022" Year="2023">
+<Database Name="cv" Series="142134" Issue="1024061" />
+</Book>
+<Book Series="X-Men: Red" Number="17" Volume="2022" Year="2024">
+<Database Name="cv" Series="142134" Issue="1028639" />
+</Book>
+<Book Series="X-Men: Red" Number="18" Volume="2022" Year="2024">
+<Database Name="cv" Series="142134" Issue="1034349" />
+</Book>
+<Book Series="X-Force" Number="47" Volume="2020" Year="2024">
+<Database Name="cv" Series="122668" Issue="1038291" />
+</Book>
+<Book Series="X-Force" Number="48" Volume="2020" Year="2024">
+<Database Name="cv" Series="122668" Issue="1042220" />
+</Book>
+<Book Series="X-Force" Number="49" Volume="2020" Year="2024">
+<Database Name="cv" Series="122668" Issue="1045769" />
+</Book>
+<Book Series="X-Force" Number="50" Volume="2020" Year="2024">
+<Database Name="cv" Series="122668" Issue="1049286" />
+</Book>
+<Book Series="Wolverine" Number="41" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1039590" />
+</Book>
+<Book Series="Wolverine" Number="42" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1042837" />
+</Book>
+<Book Series="Wolverine" Number="43" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1044787" />
+</Book>
+<Book Series="Wolverine" Number="44" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1046277" />
+</Book>
+<Book Series="Wolverine" Number="45" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1047957" />
+</Book>
+<Book Series="Wolverine" Number="46" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1049285" />
+</Book>
+<Book Series="Wolverine" Number="47" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1051133" />
+</Book>
+<Book Series="Wolverine" Number="48" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1052947" />
+</Book>
+<Book Series="Wolverine" Number="49" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1054385" />
+</Book>
+<Book Series="Wolverine" Number="50" Volume="2020" Year="2024">
+<Database Name="cv" Series="125121" Issue="1057018" />
+</Book>
+<Book Series="Astonishing Iceman" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="152649" Issue="1004321" />
+</Book>
+<Book Series="Astonishing Iceman" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="152649" Issue="1013489" />
+</Book>
+<Book Series="Uncanny Spider-Man" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153606" Issue="1014911" />
+</Book>
+<Book Series="Uncanny Spider-Man" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="153606" Issue="1026559" />
+</Book>
+<Book Series="Uncanny Spider-Man" Number="3" Volume="2023" Year="2024">
+<Database Name="cv" Series="153606" Issue="1028637" />
+</Book>
+<Book Series="Dark X-Men" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="153023" Issue="1029681" />
+</Book>
+<Book Series="Dark X-Men" Number="5" Volume="2023" Year="2024">
+<Database Name="cv" Series="153023" Issue="1034337" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="13" Volume="2022" Year="2024">
+<Database Name="cv" Series="146873" Issue="1033204" />
+</Book>
+<Book Series="Astonishing Iceman" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="152649" Issue="1025148" />
+</Book>
+<Book Series="Astonishing Iceman" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="152649" Issue="1029675" />
+</Book>
+<Book Series="Astonishing Iceman" Number="5" Volume="2023" Year="2024">
+<Database Name="cv" Series="152649" Issue="1035955" />
+</Book>
+<Book Series="Uncanny Spider-Man" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="153606" Issue="1030798" />
+</Book>
+<Book Series="X-Men Blue: Origins" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="154998" Issue="1032224" />
+</Book>
+<Book Series="Uncanny Spider-Man" Number="5" Volume="2023" Year="2024">
+<Database Name="cv" Series="153606" Issue="1035970" />
+</Book>
+<Book Series="Uncanny Avengers" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="153018" Issue="1026557" />
+</Book>
+<Book Series="Uncanny Avengers" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="153018" Issue="1029696" />
+</Book>
+<Book Series="Uncanny Avengers" Number="5" Volume="2023" Year="2024">
+<Database Name="cv" Series="153018" Issue="1035969" />
+</Book>
+<Book Series="Realm of X" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="153121" Issue="1026554" />
+</Book>
+<Book Series="Realm of X" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="153121" Issue="1031697" />
+</Book>
+<Book Series="Immortal X-Men" Number="14" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="1006441" />
+</Book>
+<Book Series="Immortal X-Men" Number="15" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="1011780" />
+</Book>
+<Book Series="Immortal X-Men" Number="16" Volume="2022" Year="2023">
+<Database Name="cv" Series="142053" Issue="1020537" />
+</Book>
+<Book Series="Jean Grey" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153119" Issue="1010049" />
+</Book>
+<Book Series="Jean Grey" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="153119" Issue="1018022" />
+</Book>
+<Book Series="Jean Grey" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="153119" Issue="1026549" />
+</Book>
+<Book Series="Jean Grey" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="153119" Issue="1029686" />
+</Book>
+<Book Series="Immortal X-Men" Number="17" Volume="2022" Year="2024">
+<Database Name="cv" Series="142053" Issue="1030784" />
+</Book>
+<Book Series="Immortal X-Men" Number="18" Volume="2022" Year="2024">
+<Database Name="cv" Series="142053" Issue="1038387" />
+</Book>
+<Book Series="Resurrection of Magneto" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="156369" Issue="1042231" />
+</Book>
+<Book Series="Resurrection of Magneto" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="156369" Issue="1046272" />
+</Book>
+<Book Series="Resurrection of Magneto" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="156369" Issue="1048669" />
+</Book>
+<Book Series="Ms. Marvel: Mutant Menace" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="157125" Issue="1047085" />
+</Book>
+<Book Series="Ms. Marvel: Mutant Menace" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="157125" Issue="1051125" />
+</Book>
+<Book Series="Ms. Marvel: Mutant Menace" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="157125" Issue="1055028" />
+</Book>
+<Book Series="Ms. Marvel: Mutant Menace" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="157125" Issue="1058725" />
+</Book>
+<Book Series="X-Men" Number="30" Volume="2021" Year="2024">
+<Database Name="cv" Series="137402" Issue="1040949" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="14" Volume="2022" Year="2024">
+<Database Name="cv" Series="146873" Issue="1040941" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="15" Volume="2022" Year="2024">
+<Database Name="cv" Series="146873" Issue="1046268" />
+</Book>
+<Book Series="Avengers" Number="12" Volume="2023" Year="2024">
+<Database Name="cv" Series="150431" Issue="1050565" />
+</Book>
+<Book Series="Avengers" Number="13" Volume="2023" Year="2024">
+<Database Name="cv" Series="150431" Issue="1052926" />
+</Book>
+<Book Series="Fall of the House of X" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="155874" Issue="1038990" />
+</Book>
+<Book Series="X-Men" Number="31" Volume="2021" Year="2024">
+<Database Name="cv" Series="137402" Issue="1043844" />
+</Book>
+<Book Series="Fall of the House of X" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="155874" Issue="1044779" />
+</Book>
+<Book Series="X-Men" Number="32" Volume="2021" Year="2024">
+<Database Name="cv" Series="137402" Issue="1047095" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="16" Volume="2022" Year="2024">
+<Database Name="cv" Series="146873" Issue="1048667" />
+</Book>
+<Book Series="Resurrection of Magneto" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="156369" Issue="1051126" />
+</Book>
+<Book Series="Fall of the House of X" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="155874" Issue="1047947" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="17" Volume="2022" Year="2024">
+<Database Name="cv" Series="146873" Issue="1051124" />
+</Book>
+<Book Series="The Invincible Iron Man" Number="18" Volume="2022" Year="2024">
+<Database Name="cv" Series="146873" Issue="1053541" />
+</Book>
+<Book Series="X-Men" Number="33" Volume="2021" Year="2024">
+<Database Name="cv" Series="137402" Issue="1050579" />
+</Book>
+<Book Series="Cable" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="156139" Issue="1040936" />
+</Book>
+<Book Series="Cable" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="156139" Issue="1046263" />
+</Book>
+<Book Series="Cable" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="156139" Issue="1049270" />
+</Book>
+<Book Series="Cable" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="156139" Issue="1053536" />
+</Book>
+<Book Series="X-Men Forever" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="157312" Issue="1048680" />
+</Book>
+<Book Series="Rise of the Powers of X" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="155968" Issue="1039582" />
+</Book>
+<Book Series="Rise of the Powers of X" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="155968" Issue="1045770" />
+</Book>
+<Book Series="Dead X-Men" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="156494" Issue="1042825" />
+</Book>
+<Book Series="Dead X-Men" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="156494" Issue="1046265" />
+</Book>
+<Book Series="Dead X-Men" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="156494" Issue="1047946" />
+</Book>
+<Book Series="Dead X-Men" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="156494" Issue="1051493" />
+</Book>
+<Book Series="Rise of the Powers of X" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="155968" Issue="1049278" />
+</Book>
+<Book Series="Rise of the Powers of X" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="155968" Issue="1052938" />
+</Book>
+<Book Series="X-Men Forever" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="157312" Issue="1052948" />
+</Book>
+<Book Series="Fall of the House of X" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="155874" Issue="1051494" />
+</Book>
+<Book Series="X-Men" Number="34" Volume="2021" Year="2024">
+<Database Name="cv" Series="137402" Issue="1053547" />
+</Book>
+<Book Series="X-Men Forever" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="157312" Issue="1054386" />
+</Book>
+<Book Series="X-Men Forever" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="157312" Issue="1055038" />
+</Book>
+<Book Series="Fall of the House of X" Number="5" Volume="2024" Year="2024">
+<Database Name="cv" Series="155874" Issue="1056203" />
+</Book>
+<Book Series="Rise of the Powers of X" Number="5" Volume="2024" Year="2024">
+<Database Name="cv" Series="155968" Issue="1057008" />
+</Book>
+<Book Series="X-Men" Number="35" Volume="2021" Year="2024">
+<Database Name="cv" Series="137402" Issue="1058720" />
+</Book>
+<Book Series="X-Men &apos;97" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="157399" Issue="1049287" />
+</Book>
+<Book Series="X-Men &apos;97" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="157399" Issue="1051134" />
+</Book>
+<Book Series="X-Men &apos;97" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="157399" Issue="1056219" />
+</Book>
+<Book Series="X-Men &apos;97" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="157399" Issue="1060867" />
+</Book>
+<Book Series="X-Men: The Wedding Special" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="158299" Issue="1057019" />
+</Book>
+<Book Series="Free Comic Book Day 2024: Blood Hunt/X-Men" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="158042" Issue="1054292" />
+</Book>
+<Book Series="X-Men: Blood Hunt - Psylocke" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="158700" Issue="1061882" />
+</Book>
+<Book Series="X-Men: Blood Hunt - Jubilee" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="158460" Issue="1059274" />
+</Book>
+<Book Series="X-Men: Blood Hunt - Laura Kinney the Wolverine" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="158869" Issue="1063238" />
+</Book>
+<Book Series="X-Men: Blood Hunt - Magik" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="158599" Issue="1060868" />
+</Book>
+<Book Series="Weapon X-Men" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="157128" Issue="1047094" />
+</Book>
+<Book Series="Weapon X-Men" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="157128" Issue="1051132" />
+</Book>
+<Book Series="Weapon X-Men" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="157128" Issue="1053546" />
+</Book>
+<Book Series="Weapon X-Men" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="157128" Issue="1055034" />
+</Book>
+<Book Series="X-Men: Xavier&apos;s Secret" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="162064" Issue="1091221" />
+</Book>
+<Book Series="X-Men" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="158814" Issue="1062857" />
+</Book>
+<Book Series="X-Men" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="158814" Issue="1066713" />
+</Book>
+<Book Series="Uncanny X-Men" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="159189" Issue="1066308" />
+</Book>
+<Book Series="Uncanny X-Men" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="159189" Issue="1069421" />
+</Book>
+<Book Series="X-Men" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="158814" Issue="1067992" />
+</Book>
+<Book Series="Exceptional X-Men" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="159604" Issue="1068649" />
+</Book>
+<Book Series="X-Men" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="158814" Issue="1070144" />
+</Book>
+<Book Series="X-Men" Number="5" Volume="2024" Year="2024">
+<Database Name="cv" Series="158814" Issue="1072226" />
+</Book>
+<Book Series="X-Men" Number="6" Volume="2024" Year="2024">
+<Database Name="cv" Series="158814" Issue="1074687" />
+</Book>
+<Book Series="X-Men" Number="7" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1076643" />
+</Book>
+<Book Series="Uncanny X-Men" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="159189" Issue="1071609" />
+</Book>
+<Book Series="Uncanny X-Men" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="159189" Issue="1073893" />
+</Book>
+<Book Series="Uncanny X-Men" Number="5" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1077648" />
+</Book>
+<Book Series="Uncanny X-Men" Number="6" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1079283" />
+</Book>
+<Book Series="X-Men" Number="8" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1080305" />
+</Book>
+<Book Series="Uncanny X-Men" Number="7" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1081560" />
+</Book>
+<Book Series="X-Men" Number="9" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1086231" />
+</Book>
+<Book Series="Uncanny X-Men" Number="8" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1089482" />
+</Book>
+<Book Series="X-Men" Number="10" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1093030" />
+</Book>
+<Book Series="Exceptional X-Men" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="159604" Issue="1073267" />
+</Book>
+<Book Series="Exceptional X-Men" Number="3" Volume="2024" Year="2025">
+<Database Name="cv" Series="159604" Issue="1078493" />
+</Book>
+<Book Series="Exceptional X-Men" Number="4" Volume="2024" Year="2025">
+<Database Name="cv" Series="159604" Issue="1086201" />
+</Book>
+<Book Series="Exceptional X-Men" Number="5" Volume="2024" Year="2025">
+<Database Name="cv" Series="159604" Issue="1090268" />
+</Book>
+<Book Series="X-Men: Demons and Death" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="165183" Issue="1116931" />
+</Book>
+<Book Series="X-Men: Tooth and Claw" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="166463" Issue="1128977" />
+</Book>
+<Book Series="X-Men: The Undertow" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="167336" Issue="1136145" />
+</Book>
+<Book Series="Uncanny X-Men" Number="9" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1091217" />
+</Book>
+<Book Series="Uncanny X-Men" Number="10" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1096477" />
+</Book>
+<Book Series="Weapon X-Men" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="162486" Issue="1096472" />
+</Book>
+<Book Series="Weapon X-Men" Number="2" Volume="2025" Year="2025">
+<Database Name="cv" Series="162486" Issue="1100296" />
+</Book>
+<Book Series="Weapon X-Men" Number="3" Volume="2025" Year="2025">
+<Database Name="cv" Series="162486" Issue="1107196" />
+</Book>
+<Book Series="Weapon X-Men" Number="4" Volume="2025" Year="2025">
+<Database Name="cv" Series="162486" Issue="1111728" />
+</Book>
+<Book Series="Exceptional X-Men" Number="6" Volume="2024" Year="2025">
+<Database Name="cv" Series="159604" Issue="1096437" />
+</Book>
+<Book Series="X-Men" Number="11" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1095610" />
+</Book>
+<Book Series="X-Men" Number="12" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1097018" />
+</Book>
+<Book Series="Uncanny X-Men" Number="11" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1097716" />
+</Book>
+<Book Series="NYX" Number="9" Volume="2024" Year="2025">
+<Database Name="cv" Series="159012" Issue="1097725" />
+</Book>
+<Book Series="Storm" Number="6" Volume="2024" Year="2025">
+<Database Name="cv" Series="160203" Issue="1097718" />
+</Book>
+<Book Series="X-Men" Number="13" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1098352" />
+</Book>
+<Book Series="X-Factor" Number="8" Volume="2024" Year="2025">
+<Database Name="cv" Series="159244" Issue="1098351" />
+</Book>
+<Book Series="Exceptional X-Men" Number="7" Volume="2024" Year="2025">
+<Database Name="cv" Series="159604" Issue="1099489" />
+</Book>
+<Book Series="X-Force" Number="9" Volume="2024" Year="2025">
+<Database Name="cv" Series="159110" Issue="1099550" />
+</Book>
+<Book Series="X-Manhunt Omega" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="163011" Issue="1100298" />
+</Book>
+<Book Series="Exceptional X-Men" Number="8" Volume="2024" Year="2025">
+<Database Name="cv" Series="159604" Issue="1104102" />
+</Book>
+<Book Series="Exceptional X-Men" Number="9" Volume="2024" Year="2025">
+<Database Name="cv" Series="159604" Issue="1111717" />
+</Book>
+<Book Series="Exceptional X-Men" Number="10" Volume="2024" Year="2025">
+<Database Name="cv" Series="159604" Issue="1115799" />
+</Book>
+<Book Series="Uncanny X-Men" Number="12" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1100295" />
+</Book>
+<Book Series="Uncanny X-Men" Number="13" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1102469" />
+</Book>
+<Book Series="Uncanny X-Men" Number="14" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1109664" />
+</Book>
+<Book Series="Uncanny X-Men" Number="15" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1112969" />
+</Book>
+<Book Series="Uncanny X-Men" Number="16" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1116826" />
+</Book>
+<Book Series="Free Comic Book Day 2025: Fantastic Four/Giant-Size X-Men" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="164375" Issue="1110584" />
+</Book>
+<Book Series="Giant-Size X-Men" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="164643" Issue="1112955" />
+</Book>
+<Book Series="Giant-Size Dark Phoenix Saga" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="165019" Issue="1115808" />
+</Book>
+<Book Series="Giant-Size Age of Apocalypse" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="165159" Issue="1116812" />
+</Book>
+<Book Series="Giant-Size House of M" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="165534" Issue="1120404" />
+</Book>
+<Book Series="Giant-Size X-Men" Number="2" Volume="2025" Year="2025">
+<Database Name="cv" Series="164643" Issue="1125789" />
+</Book>
+<Book Series="X-Men" Number="14" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1101451" />
+</Book>
+<Book Series="X-Men" Number="15" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1106071" />
+</Book>
+<Book Series="X-Men" Number="16" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1108868" />
+</Book>
+<Book Series="X-Men" Number="17" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1114025" />
+</Book>
+<Book Series="X-Men" Number="18" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1116316" />
+</Book>
+<Book Series="Godzilla vs. X-Men" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="164322" Issue="1109650" />
+</Book>
+<Book Series="Exceptional X-Men" Number="11" Volume="2024" Year="2025">
+<Database Name="cv" Series="159604" Issue="1120403" />
+</Book>
+<Book Series="Exceptional X-Men" Number="12" Volume="2024" Year="2025">
+<Database Name="cv" Series="159604" Issue="1127201" />
+</Book>
+<Book Series="Exceptional X-Men" Number="13" Volume="2024" Year="2025">
+<Database Name="cv" Series="159604" Issue="1131765" />
+</Book>
+<Book Series="X-Men" Number="19" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1117444" />
+</Book>
+<Book Series="Uncanny X-Men" Number="17" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1119106" />
+</Book>
+<Book Series="Uncanny X-Men" Number="18" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1121733" />
+</Book>
+<Book Series="Uncanny X-Men" Number="19" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1124679" />
+</Book>
+<Book Series="Uncanny X-Men" Number="20" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1130279" />
+</Book>
+<Book Series="Uncanny X-Men" Number="21" Volume="2024" Year="2025">
+<Database Name="cv" Series="159189" Issue="1133853" />
+</Book>
+<Book Series="X-Men: Hellfire Vigil" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="165235" Issue="1117445" />
+</Book>
+<Book Series="X-Men" Number="20" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1125801" />
+</Book>
+<Book Series="X-Men" Number="21" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1128976" />
+</Book>
+<Book Series="X-Men" Number="22" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1134954" />
+</Book>
+</Books>
+<Matchers />
+</ReadingList>


### PR DESCRIPTION
https://www.comicbookherald.com/energon-universe-reading-order/
https://comicbookreadingorders.com/marvel/characters/x-men-reading-order/
https://comicbookreadingorders.com/marvel/events/avengers-vs-x-men-reading-order/
https://comicbookreadingorders.com/marvel/characters/x-men-krakoa-era-reading-order/