### PR TITLE
Star Wars Dark Horse and Marvel CBRO

### DIFF
--- a/Dark Horse/Star Wars/[Dark Horse] Star Wars (WEB-CBRO).cbl
+++ b/Dark Horse/Star Wars/[Dark Horse] Star Wars (WEB-CBRO).cbl
@@ -1,0 +1,2276 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Name>[Dark Horse] Star Wars (WEB-CBRO)</Name>
+<NumIssues>756</NumIssues>
+<Books>
+<Book Series="Star Wars: Dawn of the Jedi - Force Storm" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="45577" Issue="315870" />
+</Book>
+<Book Series="Star Wars: Dawn of the Jedi - Force Storm" Number="2" Volume="2012" Year="2012">
+<Database Name="cv" Series="45577" Issue="322759" />
+</Book>
+<Book Series="Star Wars: Dawn of the Jedi - Force Storm" Number="3" Volume="2012" Year="2012">
+<Database Name="cv" Series="45577" Issue="332120" />
+</Book>
+<Book Series="Star Wars: Dawn of the Jedi - Force Storm" Number="4" Volume="2012" Year="2012">
+<Database Name="cv" Series="45577" Issue="336076" />
+</Book>
+<Book Series="Star Wars: Dawn of the Jedi - Force Storm" Number="5" Volume="2012" Year="2012">
+<Database Name="cv" Series="45577" Issue="341899" />
+</Book>
+<Book Series="Star Wars: Dawn Of The Jedi - The Prisoner Of Bogan" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="54309" Issue="370321" />
+</Book>
+<Book Series="Star Wars: Dawn Of The Jedi - The Prisoner Of Bogan" Number="2" Volume="2012" Year="2012">
+<Database Name="cv" Series="54309" Issue="373292" />
+</Book>
+<Book Series="Star Wars: Dawn Of The Jedi - The Prisoner Of Bogan" Number="3" Volume="2012" Year="2013">
+<Database Name="cv" Series="54309" Issue="388547" />
+</Book>
+<Book Series="Star Wars: Dawn Of The Jedi - The Prisoner Of Bogan" Number="4" Volume="2012" Year="2013">
+<Database Name="cv" Series="54309" Issue="395231" />
+</Book>
+<Book Series="Star Wars: Dawn Of The Jedi - The Prisoner Of Bogan" Number="5" Volume="2012" Year="2013">
+<Database Name="cv" Series="54309" Issue="404689" />
+</Book>
+<Book Series="Star Wars: Dawn of the Jedi - Force War" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="69341" Issue="433827" />
+</Book>
+<Book Series="Star Wars: Dawn of the Jedi - Force War" Number="2" Volume="2013" Year="2013">
+<Database Name="cv" Series="69341" Issue="437468" />
+</Book>
+<Book Series="Star Wars: Dawn of the Jedi - Force War" Number="3" Volume="2013" Year="2014">
+<Database Name="cv" Series="69341" Issue="442150" />
+</Book>
+<Book Series="Star Wars: Dawn of the Jedi - Force War" Number="4" Volume="2013" Year="2014">
+<Database Name="cv" Series="69341" Issue="445792" />
+</Book>
+<Book Series="Star Wars: Dawn of the Jedi - Force War" Number="5" Volume="2013" Year="2014">
+<Database Name="cv" Series="69341" Issue="447975" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - The Golden Age of the Sith" Number="0" Volume="1996" Year="1996">
+<Database Name="cv" Series="20896" Issue="173690" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - The Golden Age of the Sith" Number="1" Volume="1996" Year="1996">
+<Database Name="cv" Series="20896" Issue="125119" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - The Golden Age of the Sith" Number="2" Volume="1996" Year="1996">
+<Database Name="cv" Series="20896" Issue="173692" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - The Golden Age of the Sith" Number="3" Volume="1996" Year="1996">
+<Database Name="cv" Series="20896" Issue="173693" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - The Golden Age of the Sith" Number="4" Volume="1996" Year="1997">
+<Database Name="cv" Series="20896" Issue="173694" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - The Golden Age of the Sith" Number="5" Volume="1996" Year="1997">
+<Database Name="cv" Series="20896" Issue="173696" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - The Fall of the Sith Empire" Number="1" Volume="1997" Year="1997">
+<Database Name="cv" Series="28244" Issue="173746" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - The Fall of the Sith Empire" Number="2" Volume="1997" Year="1997">
+<Database Name="cv" Series="28244" Issue="173747" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - The Fall of the Sith Empire" Number="3" Volume="1997" Year="1997">
+<Database Name="cv" Series="28244" Issue="173748" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - The Fall of the Sith Empire" Number="4" Volume="1997" Year="1997">
+<Database Name="cv" Series="28244" Issue="173749" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - The Fall of the Sith Empire" Number="5" Volume="1997" Year="1997">
+<Database Name="cv" Series="28244" Issue="173750" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi" Number="1" Volume="1993" Year="1993">
+<Database Name="cv" Series="28243" Issue="173741" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi" Number="2" Volume="1993" Year="1993">
+<Database Name="cv" Series="28243" Issue="173742" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi" Number="3" Volume="1993" Year="1993">
+<Database Name="cv" Series="28243" Issue="173743" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi" Number="4" Volume="1993" Year="1994">
+<Database Name="cv" Series="28243" Issue="173744" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi" Number="5" Volume="1993" Year="1994">
+<Database Name="cv" Series="28243" Issue="173745" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi: The Freedon Nadd Uprising" Number="1" Volume="1994" Year="1994">
+<Database Name="cv" Series="5401" Issue="39451" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi: The Freedon Nadd Uprising" Number="2" Volume="1994" Year="1994">
+<Database Name="cv" Series="5401" Issue="39591" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - Dark Lords of the Sith" Number="1" Volume="1994" Year="1994">
+<Database Name="cv" Series="5400" Issue="39739" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - Dark Lords of the Sith" Number="2" Volume="1994" Year="1994">
+<Database Name="cv" Series="5400" Issue="39883" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - Dark Lords of the Sith" Number="3" Volume="1994" Year="1994">
+<Database Name="cv" Series="5400" Issue="40016" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - Dark Lords of the Sith" Number="4" Volume="1994" Year="1995">
+<Database Name="cv" Series="5400" Issue="40257" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - Dark Lords of the Sith" Number="5" Volume="1994" Year="1995">
+<Database Name="cv" Series="5400" Issue="40402" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - Dark Lords of the Sith" Number="6" Volume="1994" Year="1995">
+<Database Name="cv" Series="5400" Issue="40538" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - The Sith War" Number="1" Volume="1995" Year="1995">
+<Database Name="cv" Series="28239" Issue="173697" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - The Sith War" Number="2" Volume="1995" Year="1995">
+<Database Name="cv" Series="28239" Issue="173698" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - The Sith War" Number="3" Volume="1995" Year="1995">
+<Database Name="cv" Series="28239" Issue="173699" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - The Sith War" Number="4" Volume="1995" Year="1995">
+<Database Name="cv" Series="28239" Issue="173700" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - The Sith War" Number="5" Volume="1995" Year="1995">
+<Database Name="cv" Series="28239" Issue="173701" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - The Sith War" Number="6" Volume="1995" Year="1996">
+<Database Name="cv" Series="28239" Issue="173702" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - Redemption" Number="1" Volume="1998" Year="1998">
+<Database Name="cv" Series="28242" Issue="173736" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - Redemption" Number="2" Volume="1998" Year="1998">
+<Database Name="cv" Series="28242" Issue="173737" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - Redemption" Number="3" Volume="1998" Year="1998">
+<Database Name="cv" Series="28242" Issue="173738" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - Redemption" Number="4" Volume="1998" Year="1998">
+<Database Name="cv" Series="28242" Issue="173739" />
+</Book>
+<Book Series="Star Wars: Tales of the Jedi - Redemption" Number="5" Volume="1998" Year="1998">
+<Database Name="cv" Series="28242" Issue="173740" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="0" Volume="2006" Year="2006">
+<Database Name="cv" Series="18937" Issue="123551" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="1" Volume="2006" Year="2006">
+<Database Name="cv" Series="18937" Issue="120447" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="2" Volume="2006" Year="2006">
+<Database Name="cv" Series="18937" Issue="120448" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="3" Volume="2006" Year="2006">
+<Database Name="cv" Series="18937" Issue="120449" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="4" Volume="2006" Year="2006">
+<Database Name="cv" Series="18937" Issue="120494" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="5" Volume="2006" Year="2006">
+<Database Name="cv" Series="18937" Issue="120495" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="6" Volume="2006" Year="2006">
+<Database Name="cv" Series="18937" Issue="120499" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="7" Volume="2006" Year="2006">
+<Database Name="cv" Series="18937" Issue="120967" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="8" Volume="2006" Year="2006">
+<Database Name="cv" Series="18937" Issue="120968" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="9" Volume="2006" Year="2006">
+<Database Name="cv" Series="18937" Issue="120969" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="10" Volume="2006" Year="2006">
+<Database Name="cv" Series="18937" Issue="120970" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="11" Volume="2006" Year="2006">
+<Database Name="cv" Series="18937" Issue="122528" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="12" Volume="2006" Year="2006">
+<Database Name="cv" Series="18937" Issue="122548" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="13" Volume="2006" Year="2007">
+<Database Name="cv" Series="18937" Issue="122549" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="14" Volume="2006" Year="2007">
+<Database Name="cv" Series="18937" Issue="122550" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="15" Volume="2006" Year="2007">
+<Database Name="cv" Series="18937" Issue="122566" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="16" Volume="2006" Year="2007">
+<Database Name="cv" Series="18937" Issue="122567" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="17" Volume="2006" Year="2007">
+<Database Name="cv" Series="18937" Issue="122568" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="18" Volume="2006" Year="2007">
+<Database Name="cv" Series="18937" Issue="111999" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="19" Volume="2006" Year="2007">
+<Database Name="cv" Series="18937" Issue="122569" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="20" Volume="2006" Year="2007">
+<Database Name="cv" Series="18937" Issue="115565" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="21" Volume="2006" Year="2007">
+<Database Name="cv" Series="18937" Issue="122570" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="22" Volume="2006" Year="2007">
+<Database Name="cv" Series="18937" Issue="118033" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="23" Volume="2006" Year="2007">
+<Database Name="cv" Series="18937" Issue="120351" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="24" Volume="2006" Year="2007">
+<Database Name="cv" Series="18937" Issue="120446" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="25" Volume="2006" Year="2008">
+<Database Name="cv" Series="18937" Issue="122470" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="26" Volume="2006" Year="2008">
+<Database Name="cv" Series="18937" Issue="126050" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="27" Volume="2006" Year="2008">
+<Database Name="cv" Series="18937" Issue="128464" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="28" Volume="2006" Year="2008">
+<Database Name="cv" Series="18937" Issue="130671" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="29" Volume="2006" Year="2008">
+<Database Name="cv" Series="18937" Issue="131721" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="30" Volume="2006" Year="2008">
+<Database Name="cv" Series="18937" Issue="132011" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="31" Volume="2006" Year="2008">
+<Database Name="cv" Series="18937" Issue="133859" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="32" Volume="2006" Year="2008">
+<Database Name="cv" Series="18937" Issue="135990" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="33" Volume="2006" Year="2008">
+<Database Name="cv" Series="18937" Issue="139008" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="34" Volume="2006" Year="2008">
+<Database Name="cv" Series="18937" Issue="140810" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="35" Volume="2006" Year="2008">
+<Database Name="cv" Series="18937" Issue="142742" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="36" Volume="2006" Year="2008">
+<Database Name="cv" Series="18937" Issue="148623" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="37" Volume="2006" Year="2009">
+<Database Name="cv" Series="18937" Issue="151254" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="38" Volume="2006" Year="2009">
+<Database Name="cv" Series="18937" Issue="152350" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="39" Volume="2006" Year="2009">
+<Database Name="cv" Series="18937" Issue="153706" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="40" Volume="2006" Year="2009">
+<Database Name="cv" Series="18937" Issue="155904" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="41" Volume="2006" Year="2009">
+<Database Name="cv" Series="18937" Issue="157768" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="42" Volume="2006" Year="2009">
+<Database Name="cv" Series="18937" Issue="160426" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="43" Volume="2006" Year="2009">
+<Database Name="cv" Series="18937" Issue="164129" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="44" Volume="2006" Year="2009">
+<Database Name="cv" Series="18937" Issue="167523" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="45" Volume="2006" Year="2009">
+<Database Name="cv" Series="18937" Issue="171368" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="46" Volume="2006" Year="2009">
+<Database Name="cv" Series="18937" Issue="177711" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="47" Volume="2006" Year="2009">
+<Database Name="cv" Series="18937" Issue="183745" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="48" Volume="2006" Year="2009">
+<Database Name="cv" Series="18937" Issue="189621" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="49" Volume="2006" Year="2010">
+<Database Name="cv" Series="18937" Issue="193771" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic" Number="50" Volume="2006" Year="2010">
+<Database Name="cv" Series="18937" Issue="198612" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic - War" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="45153" Issue="311104" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic - War" Number="2" Volume="2012" Year="2012">
+<Database Name="cv" Series="45153" Issue="315399" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic - War" Number="3" Volume="2012" Year="2012">
+<Database Name="cv" Series="45153" Issue="321344" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic - War" Number="4" Volume="2012" Year="2012">
+<Database Name="cv" Series="45153" Issue="329238" />
+</Book>
+<Book Series="Star Wars: Knights of the Old Republic - War" Number="5" Volume="2012" Year="2012">
+<Database Name="cv" Series="45153" Issue="335160" />
+</Book>
+<Book Series="Star Wars: The Old Republic" Number="4" Volume="2010" Year="2010">
+<Database Name="cv" Series="34285" Issue="237471" />
+</Book>
+<Book Series="Star Wars: The Old Republic" Number="5" Volume="2010" Year="2010">
+<Database Name="cv" Series="34285" Issue="241127" />
+</Book>
+<Book Series="Star Wars: The Old Republic" Number="6" Volume="2010" Year="2010">
+<Database Name="cv" Series="34285" Issue="247605" />
+</Book>
+<Book Series="Star Wars: The Old Republic" Number="1" Volume="2010" Year="2010">
+<Database Name="cv" Series="34285" Issue="223715" />
+</Book>
+<Book Series="Star Wars: The Old Republic" Number="2" Volume="2010" Year="2010">
+<Database Name="cv" Series="34285" Issue="227827" />
+</Book>
+<Book Series="Star Wars: The Old Republic" Number="3" Volume="2010" Year="2010">
+<Database Name="cv" Series="34285" Issue="232560" />
+</Book>
+<Book Series="Star Wars: The Old Republic - The Lost Suns" Number="1" Volume="2011" Year="2011">
+<Database Name="cv" Series="40525" Issue="273058" />
+</Book>
+<Book Series="Star Wars: The Old Republic - The Lost Suns" Number="2" Volume="2011" Year="2011">
+<Database Name="cv" Series="40525" Issue="279600" />
+</Book>
+<Book Series="Star Wars: The Old Republic - The Lost Suns" Number="3" Volume="2011" Year="2011">
+<Database Name="cv" Series="40525" Issue="286577" />
+</Book>
+<Book Series="Star Wars: The Old Republic - The Lost Suns" Number="4" Volume="2011" Year="2011">
+<Database Name="cv" Series="40525" Issue="292597" />
+</Book>
+<Book Series="Star Wars: The Old Republic - The Lost Suns" Number="5" Volume="2011" Year="2011">
+<Database Name="cv" Series="40525" Issue="295210" />
+</Book>
+<Book Series="Star Wars: Lost Tribe of the Sith - Spiral" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="46744" Issue="349730" />
+</Book>
+<Book Series="Star Wars: Lost Tribe of the Sith - Spiral" Number="2" Volume="2012" Year="2012">
+<Database Name="cv" Series="46744" Issue="356748" />
+</Book>
+<Book Series="Star Wars: Lost Tribe of the Sith - Spiral" Number="3" Volume="2012" Year="2012">
+<Database Name="cv" Series="46744" Issue="360810" />
+</Book>
+<Book Series="Star Wars: Lost Tribe of the Sith - Spiral" Number="4" Volume="2012" Year="2012">
+<Database Name="cv" Series="46744" Issue="367710" />
+</Book>
+<Book Series="Star Wars: Lost Tribe of the Sith - Spiral" Number="5" Volume="2012" Year="2012">
+<Database Name="cv" Series="46744" Issue="372401" />
+</Book>
+<Book Series="Star Wars: Knight Errant" Number="1" Volume="2010" Year="2010">
+<Database Name="cv" Series="35256" Issue="238291" />
+</Book>
+<Book Series="Star Wars: Knight Errant" Number="2" Volume="2010" Year="2010">
+<Database Name="cv" Series="35256" Issue="242558" />
+</Book>
+<Book Series="Star Wars: Knight Errant" Number="3" Volume="2010" Year="2010">
+<Database Name="cv" Series="35256" Issue="248599" />
+</Book>
+<Book Series="Star Wars: Knight Errant" Number="4" Volume="2010" Year="2011">
+<Database Name="cv" Series="35256" Issue="256515" />
+</Book>
+<Book Series="Star Wars: Knight Errant" Number="5" Volume="2010" Year="2011">
+<Database Name="cv" Series="35256" Issue="263133" />
+</Book>
+<Book Series="Star Wars: Knight Errant: Deluge" Number="1" Volume="2011" Year="2011">
+<Database Name="cv" Series="42222" Issue="287540" />
+</Book>
+<Book Series="Star Wars: Knight Errant: Deluge" Number="2" Volume="2011" Year="2011">
+<Database Name="cv" Series="42222" Issue="293416" />
+</Book>
+<Book Series="Star Wars: Knight Errant: Deluge" Number="3" Volume="2011" Year="2011">
+<Database Name="cv" Series="42222" Issue="297573" />
+</Book>
+<Book Series="Star Wars: Knight Errant: Deluge" Number="4" Volume="2011" Year="2011">
+<Database Name="cv" Series="42222" Issue="303068" />
+</Book>
+<Book Series="Star Wars: Knight Errant: Deluge" Number="5" Volume="2011" Year="2011">
+<Database Name="cv" Series="42222" Issue="307837" />
+</Book>
+<Book Series="Star Wars: Knight Errant: Escape" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="49690" Issue="340738" />
+</Book>
+<Book Series="Star Wars: Knight Errant: Escape" Number="2" Volume="2012" Year="2012">
+<Database Name="cv" Series="49690" Issue="345408" />
+</Book>
+<Book Series="Star Wars: Knight Errant: Escape" Number="3" Volume="2012" Year="2012">
+<Database Name="cv" Series="49690" Issue="349729" />
+</Book>
+<Book Series="Star Wars: Knight Errant: Escape" Number="4" Volume="2012" Year="2012">
+<Database Name="cv" Series="49690" Issue="356747" />
+</Book>
+<Book Series="Star Wars: Knight Errant: Escape" Number="5" Volume="2012" Year="2012">
+<Database Name="cv" Series="49690" Issue="360809" />
+</Book>
+<Book Series="Star Wars: Jedi vs. Sith" Number="1" Volume="2001" Year="2001">
+<Database Name="cv" Series="20226" Issue="120539" />
+</Book>
+<Book Series="Star Wars: Jedi vs. Sith" Number="2" Volume="2001" Year="2001">
+<Database Name="cv" Series="20226" Issue="120545" />
+</Book>
+<Book Series="Star Wars: Jedi vs. Sith" Number="3" Volume="2001" Year="2001">
+<Database Name="cv" Series="20226" Issue="120546" />
+</Book>
+<Book Series="Star Wars: Jedi vs. Sith" Number="4" Volume="2001" Year="2001">
+<Database Name="cv" Series="20226" Issue="120547" />
+</Book>
+<Book Series="Star Wars: Jedi vs. Sith" Number="5" Volume="2001" Year="2001">
+<Database Name="cv" Series="20226" Issue="120548" />
+</Book>
+<Book Series="Star Wars: Jedi vs. Sith" Number="6" Volume="2001" Year="2001">
+<Database Name="cv" Series="20226" Issue="120549" />
+</Book>
+<Book Series="Star Wars: Jedi - The Dark Side" Number="1" Volume="2011" Year="2011">
+<Database Name="cv" Series="40212" Issue="270412" />
+</Book>
+<Book Series="Star Wars: Jedi - The Dark Side" Number="2" Volume="2011" Year="2011">
+<Database Name="cv" Series="40212" Issue="276139" />
+</Book>
+<Book Series="Star Wars: Jedi - The Dark Side" Number="3" Volume="2011" Year="2011">
+<Database Name="cv" Series="40212" Issue="282168" />
+</Book>
+<Book Series="Star Wars: Jedi - The Dark Side" Number="4" Volume="2011" Year="2011">
+<Database Name="cv" Series="40212" Issue="290116" />
+</Book>
+<Book Series="Star Wars: Jedi - The Dark Side" Number="5" Volume="2011" Year="2011">
+<Database Name="cv" Series="40212" Issue="293332" />
+</Book>
+<Book Series="Star Wars: Qui-Gon &amp; Obi-Wan - The Aurorient Express" Number="1" Volume="2002" Year="2002">
+<Database Name="cv" Series="20214" Issue="120506" />
+</Book>
+<Book Series="Star Wars: Qui-Gon &amp; Obi-Wan - The Aurorient Express" Number="2" Volume="2002" Year="2002">
+<Database Name="cv" Series="20214" Issue="120966" />
+</Book>
+<Book Series="Star Wars: Qui-Gon &amp; Obi-Wan: Last Stand on Ord Mantell" Number="1" Volume="2000" Year="2000">
+<Database Name="cv" Series="20213" Issue="120504" />
+</Book>
+<Book Series="Star Wars: Qui-Gon &amp; Obi-Wan: Last Stand on Ord Mantell" Number="2" Volume="2000" Year="2001">
+<Database Name="cv" Series="20213" Issue="174584" />
+</Book>
+<Book Series="Star Wars: Qui-Gon &amp; Obi-Wan: Last Stand on Ord Mantell" Number="3" Volume="2000" Year="2001">
+<Database Name="cv" Series="20213" Issue="120965" />
+</Book>
+<Book Series="Star Wars: Jedi Council - Acts of War" Number="1" Volume="2000" Year="2000">
+<Database Name="cv" Series="28493" Issue="175554" />
+</Book>
+<Book Series="Star Wars: Jedi Council - Acts of War" Number="2" Volume="2000" Year="2000">
+<Database Name="cv" Series="28493" Issue="175555" />
+</Book>
+<Book Series="Star Wars: Jedi Council - Acts of War" Number="3" Volume="2000" Year="2000">
+<Database Name="cv" Series="28493" Issue="175556" />
+</Book>
+<Book Series="Star Wars: Jedi Council - Acts of War" Number="4" Volume="2000" Year="2000">
+<Database Name="cv" Series="28493" Issue="175558" />
+</Book>
+<Book Series="Star Wars" Number="1" Volume="1998" Year="1998">
+<Database Name="cv" Series="11246" Issue="98742" />
+</Book>
+<Book Series="Star Wars" Number="2" Volume="1998" Year="1999">
+<Database Name="cv" Series="11246" Issue="98743" />
+</Book>
+<Book Series="Star Wars" Number="3" Volume="1998" Year="1999">
+<Database Name="cv" Series="11246" Issue="98744" />
+</Book>
+<Book Series="Star Wars" Number="4" Volume="1998" Year="1999">
+<Database Name="cv" Series="11246" Issue="98745" />
+</Book>
+<Book Series="Star Wars" Number="5" Volume="1998" Year="1999">
+<Database Name="cv" Series="11246" Issue="98746" />
+</Book>
+<Book Series="Star Wars" Number="6" Volume="1998" Year="1999">
+<Database Name="cv" Series="11246" Issue="98747" />
+</Book>
+<Book Series="Star Wars: Darth Maul" Number="1" Volume="2000" Year="2000">
+<Database Name="cv" Series="20225" Issue="120533" />
+</Book>
+<Book Series="Star Wars: Darth Maul" Number="2" Volume="2000" Year="2000">
+<Database Name="cv" Series="20225" Issue="120550" />
+</Book>
+<Book Series="Star Wars: Darth Maul" Number="3" Volume="2000" Year="2000">
+<Database Name="cv" Series="20225" Issue="120551" />
+</Book>
+<Book Series="Star Wars: Darth Maul" Number="4" Volume="2000" Year="2000">
+<Database Name="cv" Series="20225" Issue="120552" />
+</Book>
+<Book Series="Star Wars: Jango Fett: Open Seasons" Number="1" Volume="2002" Year="2002">
+<Database Name="cv" Series="21046" Issue="125991" />
+</Book>
+<Book Series="Star Wars: Jango Fett: Open Seasons" Number="2" Volume="2002" Year="2002">
+<Database Name="cv" Series="21046" Issue="126009" />
+</Book>
+<Book Series="Star Wars: Jango Fett: Open Seasons" Number="3" Volume="2002" Year="2002">
+<Database Name="cv" Series="21046" Issue="126018" />
+</Book>
+<Book Series="Star Wars: Jango Fett: Open Seasons" Number="4" Volume="2002" Year="2002">
+<Database Name="cv" Series="21046" Issue="126015" />
+</Book>
+<Book Series="Star Wars" Number="7" Volume="1998" Year="1999">
+<Database Name="cv" Series="11246" Issue="98748" />
+</Book>
+<Book Series="Star Wars" Number="8" Volume="1998" Year="1999">
+<Database Name="cv" Series="11246" Issue="98749" />
+</Book>
+<Book Series="Star Wars" Number="9" Volume="1998" Year="1999">
+<Database Name="cv" Series="11246" Issue="98750" />
+</Book>
+<Book Series="Star Wars" Number="10" Volume="1998" Year="1999">
+<Database Name="cv" Series="11246" Issue="98751" />
+</Book>
+<Book Series="Star Wars" Number="11" Volume="1998" Year="1999">
+<Database Name="cv" Series="11246" Issue="98752" />
+</Book>
+<Book Series="Star Wars" Number="12" Volume="1998" Year="1999">
+<Database Name="cv" Series="11246" Issue="98753" />
+</Book>
+<Book Series="Star Wars" Number="13" Volume="1998" Year="1999">
+<Database Name="cv" Series="11246" Issue="98754" />
+</Book>
+<Book Series="Star Wars" Number="14" Volume="1998" Year="2000">
+<Database Name="cv" Series="11246" Issue="98755" />
+</Book>
+<Book Series="Star Wars" Number="15" Volume="1998" Year="2000">
+<Database Name="cv" Series="11246" Issue="98756" />
+</Book>
+<Book Series="Star Wars" Number="16" Volume="1998" Year="2000">
+<Database Name="cv" Series="11246" Issue="98757" />
+</Book>
+<Book Series="Star Wars" Number="17" Volume="1998" Year="2000">
+<Database Name="cv" Series="11246" Issue="98758" />
+</Book>
+<Book Series="Star Wars" Number="18" Volume="1998" Year="2000">
+<Database Name="cv" Series="11246" Issue="98759" />
+</Book>
+<Book Series="Star Wars" Number="19" Volume="1998" Year="2000">
+<Database Name="cv" Series="11246" Issue="98760" />
+</Book>
+<Book Series="Star Wars" Number="20" Volume="1998" Year="2000">
+<Database Name="cv" Series="11246" Issue="98761" />
+</Book>
+<Book Series="Star Wars" Number="21" Volume="1998" Year="2000">
+<Database Name="cv" Series="11246" Issue="98762" />
+</Book>
+<Book Series="Star Wars" Number="22" Volume="1998" Year="2000">
+<Database Name="cv" Series="11246" Issue="98763" />
+</Book>
+<Book Series="Star Wars" Number="23" Volume="1998" Year="2000">
+<Database Name="cv" Series="11246" Issue="98764" />
+</Book>
+<Book Series="Star Wars" Number="24" Volume="1998" Year="2000">
+<Database Name="cv" Series="11246" Issue="98765" />
+</Book>
+<Book Series="Star Wars" Number="25" Volume="1998" Year="2000">
+<Database Name="cv" Series="11246" Issue="98766" />
+</Book>
+<Book Series="Star Wars" Number="26" Volume="1998" Year="2001">
+<Database Name="cv" Series="11246" Issue="98767" />
+</Book>
+<Book Series="Star Wars" Number="27" Volume="1998" Year="2001">
+<Database Name="cv" Series="11246" Issue="98768" />
+</Book>
+<Book Series="Star Wars" Number="28" Volume="1998" Year="2001">
+<Database Name="cv" Series="11246" Issue="98769" />
+</Book>
+<Book Series="Star Wars" Number="29" Volume="1998" Year="2001">
+<Database Name="cv" Series="11246" Issue="98770" />
+</Book>
+<Book Series="Star Wars" Number="30" Volume="1998" Year="2001">
+<Database Name="cv" Series="11246" Issue="98771" />
+</Book>
+<Book Series="Star Wars" Number="31" Volume="1998" Year="2001">
+<Database Name="cv" Series="11246" Issue="98772" />
+</Book>
+<Book Series="Star Wars" Number="32" Volume="1998" Year="2001">
+<Database Name="cv" Series="11246" Issue="98773" />
+</Book>
+<Book Series="Star Wars" Number="33" Volume="1998" Year="2001">
+<Database Name="cv" Series="11246" Issue="98774" />
+</Book>
+<Book Series="Star Wars" Number="34" Volume="1998" Year="2001">
+<Database Name="cv" Series="11246" Issue="98775" />
+</Book>
+<Book Series="Star Wars" Number="35" Volume="1998" Year="2001">
+<Database Name="cv" Series="11246" Issue="98776" />
+</Book>
+<Book Series="Star Wars" Number="36" Volume="1998" Year="2001">
+<Database Name="cv" Series="11246" Issue="98777" />
+</Book>
+<Book Series="Star Wars" Number="37" Volume="1998" Year="2001">
+<Database Name="cv" Series="11246" Issue="98778" />
+</Book>
+<Book Series="Star Wars" Number="38" Volume="1998" Year="2002">
+<Database Name="cv" Series="11246" Issue="98779" />
+</Book>
+<Book Series="Star Wars" Number="39" Volume="1998" Year="2002">
+<Database Name="cv" Series="11246" Issue="98780" />
+</Book>
+<Book Series="Star Wars" Number="40" Volume="1998" Year="2002">
+<Database Name="cv" Series="11246" Issue="98781" />
+</Book>
+<Book Series="Star Wars" Number="41" Volume="1998" Year="2002">
+<Database Name="cv" Series="11246" Issue="98782" />
+</Book>
+<Book Series="Star Wars" Number="42" Volume="1998" Year="2002">
+<Database Name="cv" Series="11246" Issue="98783" />
+</Book>
+<Book Series="Star Wars" Number="43" Volume="1998" Year="2002">
+<Database Name="cv" Series="11246" Issue="98784" />
+</Book>
+<Book Series="Star Wars" Number="44" Volume="1998" Year="2002">
+<Database Name="cv" Series="11246" Issue="98785" />
+</Book>
+<Book Series="Star Wars" Number="45" Volume="1998" Year="2002">
+<Database Name="cv" Series="11246" Issue="98786" />
+</Book>
+<Book Series="Star Wars: Jedi Quest" Number="1" Volume="2001" Year="2001">
+<Database Name="cv" Series="32521" Issue="205948" />
+</Book>
+<Book Series="Star Wars: Jedi Quest" Number="2" Volume="2001" Year="2001">
+<Database Name="cv" Series="32521" Issue="205949" />
+</Book>
+<Book Series="Star Wars: Jedi Quest" Number="3" Volume="2001" Year="2001">
+<Database Name="cv" Series="32521" Issue="205950" />
+</Book>
+<Book Series="Star Wars: Jedi Quest" Number="4" Volume="2001" Year="2001">
+<Database Name="cv" Series="32521" Issue="205951" />
+</Book>
+<Book Series="Star Wars: The Bounty Hunters - Aurra Sing" Number="1" Volume="1999" Year="1999">
+<Database Name="cv" Series="27373" Issue="166748" />
+</Book>
+<Book Series="Star Wars: Jango Fett" Number="1" Volume="2002" Year="2002">
+<Database Name="cv" Series="20769" Issue="124541" />
+</Book>
+<Book Series="Star Wars: Zam Wesell" Number="1" Volume="2002" Year="2002">
+<Database Name="cv" Series="20779" Issue="124567" />
+</Book>
+<Book Series="Star Wars: Starfighter: Crossbones" Number="1" Volume="2002" Year="2002">
+<Database Name="cv" Series="21178" Issue="127290" />
+</Book>
+<Book Series="Star Wars: Starfighter: Crossbones" Number="2" Volume="2002" Year="2002">
+<Database Name="cv" Series="21178" Issue="174504" />
+</Book>
+<Book Series="Star Wars: Starfighter: Crossbones" Number="3" Volume="2002" Year="2002">
+<Database Name="cv" Series="21178" Issue="174505" />
+</Book>
+<Book Series="Star Wars: Republic" Number="46" Volume="2002" Year="2002">
+<Database Name="cv" Series="20215" Issue="120523" />
+</Book>
+<Book Series="Star Wars: Republic" Number="47" Volume="2002" Year="2002">
+<Database Name="cv" Series="20215" Issue="120583" />
+</Book>
+<Book Series="Star Wars: Republic" Number="48" Volume="2002" Year="2003">
+<Database Name="cv" Series="20215" Issue="120584" />
+</Book>
+<Book Series="Star Wars: Blood Ties" Number="1" Volume="2010" Year="2010">
+<Database Name="cv" Series="35114" Issue="231704" />
+</Book>
+<Book Series="Star Wars: Blood Ties" Number="2" Volume="2010" Year="2010">
+<Database Name="cv" Series="35114" Issue="236469" />
+</Book>
+<Book Series="Star Wars: Blood Ties" Number="3" Volume="2010" Year="2010">
+<Database Name="cv" Series="35114" Issue="240113" />
+</Book>
+<Book Series="Star Wars: Blood Ties" Number="4" Volume="2010" Year="2010">
+<Database Name="cv" Series="35114" Issue="246542" />
+</Book>
+<Book Series="Star Wars: Republic" Number="49" Volume="2002" Year="2003">
+<Database Name="cv" Series="20215" Issue="120585" />
+</Book>
+<Book Series="Star Wars: Republic" Number="50" Volume="2002" Year="2003">
+<Database Name="cv" Series="20215" Issue="120586" />
+</Book>
+<Book Series="Star Wars: Republic" Number="51" Volume="2002" Year="2003">
+<Database Name="cv" Series="20215" Issue="120587" />
+</Book>
+<Book Series="Star Wars: Republic" Number="52" Volume="2002" Year="2003">
+<Database Name="cv" Series="20215" Issue="120588" />
+</Book>
+<Book Series="Star Wars: Jedi - Mace Windu" Number="1" Volume="2003" Year="2003">
+<Database Name="cv" Series="23340" Issue="140115" />
+</Book>
+<Book Series="Star Wars: Republic" Number="53" Volume="2002" Year="2003">
+<Database Name="cv" Series="20215" Issue="120589" />
+</Book>
+<Book Series="Star Wars: Jedi - Shaak Ti" Number="1" Volume="2003" Year="2003">
+<Database Name="cv" Series="27252" Issue="166110" />
+</Book>
+<Book Series="Star Wars: Clone Wars Adventures" Number="1" Volume="2004" Year="2004">
+<Database Name="cv" Series="21177" Issue="127282" />
+</Book>
+<Book Series="Star Wars: Clone Wars Adventures" Number="2" Volume="2004" Year="2004">
+<Database Name="cv" Series="21177" Issue="166000" />
+</Book>
+<Book Series="Star Wars: Republic" Number="54" Volume="2002" Year="2003">
+<Database Name="cv" Series="20215" Issue="120591" />
+</Book>
+<Book Series="Star Wars: Jedi - Aayla Secura" Number="1" Volume="2003" Year="2003">
+<Database Name="cv" Series="27227" Issue="165838" />
+</Book>
+<Book Series="Star Wars: Jedi - Count Dooku" Number="1" Volume="2003" Year="2003">
+<Database Name="cv" Series="27253" Issue="166111" />
+</Book>
+<Book Series="Star Wars: The Clone Wars" Number="1" Volume="2008" Year="2008">
+<Database Name="cv" Series="22969" Issue="138357" />
+</Book>
+<Book Series="Star Wars: The Clone Wars" Number="2" Volume="2008" Year="2008">
+<Database Name="cv" Series="22969" Issue="140456" />
+</Book>
+<Book Series="Star Wars: The Clone Wars" Number="3" Volume="2008" Year="2008">
+<Database Name="cv" Series="22969" Issue="145543" />
+</Book>
+<Book Series="Star Wars: The Clone Wars" Number="4" Volume="2008" Year="2009">
+<Database Name="cv" Series="22969" Issue="157202" />
+</Book>
+<Book Series="Star Wars: The Clone Wars" Number="5" Volume="2008" Year="2009">
+<Database Name="cv" Series="22969" Issue="155712" />
+</Book>
+<Book Series="Star Wars: The Clone Wars" Number="6" Volume="2008" Year="2009">
+<Database Name="cv" Series="22969" Issue="157200" />
+</Book>
+<Book Series="Star Wars: The Clone Wars" Number="7" Volume="2008" Year="2009">
+<Database Name="cv" Series="22969" Issue="164098" />
+</Book>
+<Book Series="Star Wars: The Clone Wars" Number="8" Volume="2008" Year="2009">
+<Database Name="cv" Series="22969" Issue="166820" />
+</Book>
+<Book Series="Star Wars: The Clone Wars" Number="9" Volume="2008" Year="2009">
+<Database Name="cv" Series="22969" Issue="171363" />
+</Book>
+<Book Series="Star Wars: The Clone Wars" Number="10" Volume="2008" Year="2009">
+<Database Name="cv" Series="22969" Issue="182716" />
+</Book>
+<Book Series="Star Wars: The Clone Wars" Number="11" Volume="2008" Year="2009">
+<Database Name="cv" Series="22969" Issue="186799" />
+</Book>
+<Book Series="Star Wars: The Clone Wars" Number="12" Volume="2008" Year="2010">
+<Database Name="cv" Series="22969" Issue="191313" />
+</Book>
+<Book Series="Star Wars: The Clone Wars - Shipyards of Doom" Number="1" Volume="2008" Year="2008">
+<Database Name="cv" Series="23494" Issue="140900" />
+</Book>
+<Book Series="Star Wars: The Clone Wars - Crash Course" Number="1" Volume="2008" Year="2008">
+<Database Name="cv" Series="25846" Issue="152695" />
+</Book>
+<Book Series="Star Wars: The Clone Wars - The Wind Raiders of Taloraan" Number="1" Volume="2009" Year="2009">
+<Database Name="cv" Series="27123" Issue="164762" />
+</Book>
+<Book Series="Star Wars: The Clone Wars - The Colossus of Destiny" Number="1" Volume="2009" Year="2009">
+<Database Name="cv" Series="34439" Issue="224965" />
+</Book>
+<Book Series="Star Wars: The Clone Wars - Deadly Hands of Shon-Ju" Number="1" Volume="2010" Year="2010">
+<Database Name="cv" Series="38862" Issue="260800" />
+</Book>
+<Book Series="Star Wars: The Clone Wars - The Starcrusher Trap" Number="1" Volume="2011" Year="2011">
+<Database Name="cv" Series="42592" Issue="291119" />
+</Book>
+<Book Series="Star Wars: The Clone Wars - Strange Allies" Number="1" Volume="2011" Year="2011">
+<Database Name="cv" Series="45283" Issue="312015" />
+</Book>
+<Book Series="Star Wars: The Clone Wars - The Enemy Within" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="63877" Issue="414502" />
+</Book>
+<Book Series="Star Wars: The Clone Wars - The Sith Hunters" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="43768" Issue="350922" />
+</Book>
+<Book Series="Star Wars: The Clone Wars - Defenders of the Lost Temple" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="56637" Issue="384226" />
+</Book>
+<Book Series="Star Wars: The Clone Wars - The Smuggler&apos;s Code" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="63711" Issue="411814" />
+</Book>
+<Book Series="Star Wars: Republic" Number="55" Volume="2002" Year="2003">
+<Database Name="cv" Series="20215" Issue="120592" />
+</Book>
+<Book Series="Star Wars: Republic" Number="56" Volume="2002" Year="2003">
+<Database Name="cv" Series="20215" Issue="120593" />
+</Book>
+<Book Series="Star Wars: Republic" Number="57" Volume="2002" Year="2003">
+<Database Name="cv" Series="20215" Issue="120594" />
+</Book>
+<Book Series="Star Wars: Republic" Number="58" Volume="2002" Year="2003">
+<Database Name="cv" Series="20215" Issue="120595" />
+</Book>
+<Book Series="Star Wars: Republic" Number="59" Volume="2002" Year="2003">
+<Database Name="cv" Series="20215" Issue="120596" />
+</Book>
+<Book Series="Star Wars: Clone Wars Adventures" Number="3" Volume="2004" Year="2005">
+<Database Name="cv" Series="21177" Issue="166001" />
+</Book>
+<Book Series="Star Wars: Republic" Number="60" Volume="2002" Year="2004">
+<Database Name="cv" Series="20215" Issue="120597" />
+</Book>
+<Book Series="Star Wars: Republic" Number="61" Volume="2002" Year="2004">
+<Database Name="cv" Series="20215" Issue="120598" />
+</Book>
+<Book Series="Star Wars: Republic" Number="62" Volume="2002" Year="2004">
+<Database Name="cv" Series="20215" Issue="120599" />
+</Book>
+<Book Series="Star Wars: Republic" Number="63" Volume="2002" Year="2004">
+<Database Name="cv" Series="20215" Issue="120600" />
+</Book>
+<Book Series="Star Wars: Republic" Number="64" Volume="2002" Year="2004">
+<Database Name="cv" Series="20215" Issue="120601" />
+</Book>
+<Book Series="Star Wars: Jedi - Yoda" Number="1" Volume="2004" Year="2004">
+<Database Name="cv" Series="27284" Issue="166272" />
+</Book>
+<Book Series="Star Wars: Darth Maul - Death Sentence" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="50759" Issue="347239" />
+</Book>
+<Book Series="Star Wars: Darth Maul - Death Sentence" Number="2" Volume="2012" Year="2012">
+<Database Name="cv" Series="50759" Issue="354062" />
+</Book>
+<Book Series="Star Wars: Darth Maul - Death Sentence" Number="3" Volume="2012" Year="2012">
+<Database Name="cv" Series="50759" Issue="358846" />
+</Book>
+<Book Series="Star Wars: Darth Maul - Death Sentence" Number="4" Volume="2012" Year="2012">
+<Database Name="cv" Series="50759" Issue="362178" />
+</Book>
+<Book Series="Star Wars: General Grievous" Number="1" Volume="2005" Year="2005">
+<Database Name="cv" Series="19143" Issue="114505" />
+</Book>
+<Book Series="Star Wars: General Grievous" Number="2" Volume="2005" Year="2005">
+<Database Name="cv" Series="19143" Issue="114532" />
+</Book>
+<Book Series="Star Wars: General Grievous" Number="3" Volume="2005" Year="2005">
+<Database Name="cv" Series="19143" Issue="114538" />
+</Book>
+<Book Series="Star Wars: General Grievous" Number="4" Volume="2005" Year="2005">
+<Database Name="cv" Series="19143" Issue="114540" />
+</Book>
+<Book Series="Star Wars: Republic" Number="65" Volume="2002" Year="2004">
+<Database Name="cv" Series="20215" Issue="120603" />
+</Book>
+<Book Series="Star Wars: Republic" Number="66" Volume="2002" Year="2004">
+<Database Name="cv" Series="20215" Issue="120604" />
+</Book>
+<Book Series="Star Wars: Republic" Number="67" Volume="2002" Year="2004">
+<Database Name="cv" Series="20215" Issue="120605" />
+</Book>
+<Book Series="Star Wars: Republic" Number="68" Volume="2002" Year="2004">
+<Database Name="cv" Series="20215" Issue="120606" />
+</Book>
+<Book Series="Star Wars: Republic" Number="69" Volume="2002" Year="2004">
+<Database Name="cv" Series="20215" Issue="120607" />
+</Book>
+<Book Series="Star Wars: Republic" Number="70" Volume="2002" Year="2004">
+<Database Name="cv" Series="20215" Issue="120608" />
+</Book>
+<Book Series="Star Wars: Republic" Number="71" Volume="2002" Year="2004">
+<Database Name="cv" Series="20215" Issue="120609" />
+</Book>
+<Book Series="Star Wars: Republic" Number="72" Volume="2002" Year="2004">
+<Database Name="cv" Series="20215" Issue="120610" />
+</Book>
+<Book Series="Star Wars: Republic" Number="73" Volume="2002" Year="2005">
+<Database Name="cv" Series="20215" Issue="120611" />
+</Book>
+<Book Series="Star Wars: Darth Maul - Son of Dathomir" Number="1" Volume="2014" Year="2014">
+<Database Name="cv" Series="74107" Issue="453392" />
+</Book>
+<Book Series="Star Wars: Darth Maul - Son of Dathomir" Number="2" Volume="2014" Year="2014">
+<Database Name="cv" Series="74107" Issue="456529" />
+</Book>
+<Book Series="Star Wars: Darth Maul - Son of Dathomir" Number="3" Volume="2014" Year="2014">
+<Database Name="cv" Series="74107" Issue="459652" />
+</Book>
+<Book Series="Star Wars: Darth Maul - Son of Dathomir" Number="4" Volume="2014" Year="2014">
+<Database Name="cv" Series="74107" Issue="462865" />
+</Book>
+<Book Series="Star Wars: Obsession" Number="1" Volume="2004" Year="2004">
+<Database Name="cv" Series="19145" Issue="114507" />
+</Book>
+<Book Series="Star Wars: Obsession" Number="2" Volume="2004" Year="2004">
+<Database Name="cv" Series="19145" Issue="114521" />
+</Book>
+<Book Series="Star Wars: Obsession" Number="3" Volume="2004" Year="2005">
+<Database Name="cv" Series="19145" Issue="114522" />
+</Book>
+<Book Series="Star Wars: Obsession" Number="4" Volume="2004" Year="2005">
+<Database Name="cv" Series="19145" Issue="114523" />
+</Book>
+<Book Series="Star Wars: Obsession" Number="5" Volume="2004" Year="2005">
+<Database Name="cv" Series="19145" Issue="114524" />
+</Book>
+<Book Series="Star Wars: Republic" Number="74" Volume="2002" Year="2005">
+<Database Name="cv" Series="20215" Issue="120613" />
+</Book>
+<Book Series="Star Wars: Republic" Number="75" Volume="2002" Year="2005">
+<Database Name="cv" Series="20215" Issue="120614" />
+</Book>
+<Book Series="Star Wars: Republic" Number="76" Volume="2002" Year="2005">
+<Database Name="cv" Series="20215" Issue="120615" />
+</Book>
+<Book Series="Star Wars: Republic" Number="77" Volume="2002" Year="2005">
+<Database Name="cv" Series="20215" Issue="120616" />
+</Book>
+<Book Series="Star Wars: Clone Wars Adventures" Number="4" Volume="2004" Year="2005">
+<Database Name="cv" Series="21177" Issue="166002" />
+</Book>
+<Book Series="Star Wars: Clone Wars Adventures" Number="5" Volume="2004" Year="2006">
+<Database Name="cv" Series="21177" Issue="166003" />
+</Book>
+<Book Series="Star Wars: Clone Wars Adventures" Number="6" Volume="2004" Year="2006">
+<Database Name="cv" Series="21177" Issue="166004" />
+</Book>
+<Book Series="Star Wars: Clone Wars Adventures" Number="7" Volume="2004" Year="2007">
+<Database Name="cv" Series="21177" Issue="166005" />
+</Book>
+<Book Series="Star Wars: Clone Wars Adventures" Number="8" Volume="2004" Year="2007">
+<Database Name="cv" Series="21177" Issue="166006" />
+</Book>
+<Book Series="Star Wars: Clone Wars Adventures" Number="9" Volume="2004" Year="2007">
+<Database Name="cv" Series="21177" Issue="166007" />
+</Book>
+<Book Series="Star Wars: Clone Wars Adventures" Number="10" Volume="2004" Year="2008">
+<Database Name="cv" Series="21177" Issue="166008" />
+</Book>
+<Book Series="Star Wars: Republic" Number="78" Volume="2002" Year="2005">
+<Database Name="cv" Series="20215" Issue="120617" />
+</Book>
+<Book Series="Star Wars: Republic" Number="79" Volume="2002" Year="2005">
+<Database Name="cv" Series="20215" Issue="120618" />
+</Book>
+<Book Series="Star Wars: Republic" Number="80" Volume="2002" Year="2005">
+<Database Name="cv" Series="20215" Issue="120619" />
+</Book>
+<Book Series="Star Wars: Republic" Number="81" Volume="2002" Year="2005">
+<Database Name="cv" Series="20215" Issue="120620" />
+</Book>
+<Book Series="Star Wars: Republic" Number="82" Volume="2002" Year="2006">
+<Database Name="cv" Series="20215" Issue="120621" />
+</Book>
+<Book Series="Star Wars: Republic" Number="83" Volume="2002" Year="2006">
+<Database Name="cv" Series="20215" Issue="120623" />
+</Book>
+<Book Series="Star Wars: Purge" Number="1" Volume="2005" Year="2005">
+<Database Name="cv" Series="19811" Issue="118851" />
+</Book>
+<Book Series="Star Wars: Purge - Seconds to Die" Number="1" Volume="2009" Year="2009">
+<Database Name="cv" Series="29669" Issue="182725" />
+</Book>
+<Book Series="Star Wars: Purge - The Hidden Blade" Number="1" Volume="2010" Year="2010">
+<Database Name="cv" Series="32447" Issue="204628" />
+</Book>
+<Book Series="Star Wars: Purge - The Tyrant’s Fist" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="54463" Issue="371198" />
+</Book>
+<Book Series="Star Wars: Purge - The Tyrant’s Fist" Number="2" Volume="2012" Year="2013">
+<Database Name="cv" Series="54463" Issue="376631" />
+</Book>
+<Book Series="Star Wars: Darth Vader and the Lost Command" Number="1" Volume="2011" Year="2011">
+<Database Name="cv" Series="38624" Issue="259187" />
+</Book>
+<Book Series="Star Wars: Darth Vader and the Lost Command" Number="2" Volume="2011" Year="2011">
+<Database Name="cv" Series="38624" Issue="263999" />
+</Book>
+<Book Series="Star Wars: Darth Vader and the Lost Command" Number="3" Volume="2011" Year="2011">
+<Database Name="cv" Series="38624" Issue="267055" />
+</Book>
+<Book Series="Star Wars: Darth Vader and the Lost Command" Number="4" Volume="2011" Year="2011">
+<Database Name="cv" Series="38624" Issue="269293" />
+</Book>
+<Book Series="Star Wars: Darth Vader and the Lost Command" Number="5" Volume="2011" Year="2011">
+<Database Name="cv" Series="38624" Issue="271480" />
+</Book>
+<Book Series="Star Wars: Dark Times" Number="1" Volume="2006" Year="2006">
+<Database Name="cv" Series="18888" Issue="115052" />
+</Book>
+<Book Series="Star Wars: Dark Times" Number="2" Volume="2006" Year="2007">
+<Database Name="cv" Series="18888" Issue="115512" />
+</Book>
+<Book Series="Star Wars: Dark Times" Number="3" Volume="2006" Year="2007">
+<Database Name="cv" Series="18888" Issue="115513" />
+</Book>
+<Book Series="Star Wars: Dark Times" Number="4" Volume="2006" Year="2007">
+<Database Name="cv" Series="18888" Issue="111648" />
+</Book>
+<Book Series="Star Wars: Dark Times" Number="5" Volume="2006" Year="2007">
+<Database Name="cv" Series="18888" Issue="118017" />
+</Book>
+<Book Series="Star Wars: Dark Times" Number="6" Volume="2006" Year="2007">
+<Database Name="cv" Series="18888" Issue="155918" />
+</Book>
+<Book Series="Star Wars: Dark Times" Number="7" Volume="2006" Year="2007">
+<Database Name="cv" Series="18888" Issue="121515" />
+</Book>
+<Book Series="Star Wars: Dark Times" Number="8" Volume="2006" Year="2008">
+<Database Name="cv" Series="18888" Issue="149820" />
+</Book>
+<Book Series="Star Wars: Dark Times" Number="9" Volume="2006" Year="2008">
+<Database Name="cv" Series="18888" Issue="149821" />
+</Book>
+<Book Series="Star Wars: Dark Times" Number="10" Volume="2006" Year="2008">
+<Database Name="cv" Series="18888" Issue="149822" />
+</Book>
+<Book Series="Star Wars: Dark Times" Number="11" Volume="2006" Year="2008">
+<Database Name="cv" Series="18888" Issue="149823" />
+</Book>
+<Book Series="Star Wars: Dark Times" Number="12" Volume="2006" Year="2008">
+<Database Name="cv" Series="18888" Issue="133953" />
+</Book>
+<Book Series="Star Wars: Darth Vader and the Ghost Prison" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="49192" Issue="336727" />
+</Book>
+<Book Series="Star Wars: Darth Vader and the Ghost Prison" Number="2" Volume="2012" Year="2012">
+<Database Name="cv" Series="49192" Issue="341900" />
+</Book>
+<Book Series="Star Wars: Darth Vader and the Ghost Prison" Number="3" Volume="2012" Year="2012">
+<Database Name="cv" Series="49192" Issue="346291" />
+</Book>
+<Book Series="Star Wars: Darth Vader and the Ghost Prison" Number="4" Volume="2012" Year="2012">
+<Database Name="cv" Series="49192" Issue="352532" />
+</Book>
+<Book Series="Star Wars: Darth Vader and the Ghost Prison" Number="5" Volume="2012" Year="2012">
+<Database Name="cv" Series="49192" Issue="357655" />
+</Book>
+<Book Series="Star Wars: Dark Times: Blue Harvest" Number="0" Volume="2009" Year="2009">
+<Database Name="cv" Series="27274" Issue="166206" />
+</Book>
+<Book Series="Star Wars: Dark Times" Number="13" Volume="2006" Year="2009">
+<Database Name="cv" Series="18888" Issue="155905" />
+</Book>
+<Book Series="Star Wars: Dark Times" Number="14" Volume="2006" Year="2009">
+<Database Name="cv" Series="18888" Issue="168419" />
+</Book>
+<Book Series="Star Wars: Dark Times" Number="15" Volume="2006" Year="2010">
+<Database Name="cv" Series="18888" Issue="193767" />
+</Book>
+<Book Series="Star Wars: Dark Times" Number="16" Volume="2006" Year="2010">
+<Database Name="cv" Series="18888" Issue="206843" />
+</Book>
+<Book Series="Star Wars: Dark Times" Number="17" Volume="2006" Year="2010">
+<Database Name="cv" Series="18888" Issue="221885" />
+</Book>
+<Book Series="Star Wars: Dark Times - Out of the Wilderness" Number="1" Volume="2011" Year="2011">
+<Database Name="cv" Series="41881" Issue="285062" />
+</Book>
+<Book Series="Star Wars: Dark Times - Out of the Wilderness" Number="2" Volume="2011" Year="2011">
+<Database Name="cv" Series="41881" Issue="292543" />
+</Book>
+<Book Series="Star Wars: Dark Times - Out of the Wilderness" Number="3" Volume="2011" Year="2011">
+<Database Name="cv" Series="41881" Issue="304955" />
+</Book>
+<Book Series="Star Wars: Dark Times - Out of the Wilderness" Number="4" Volume="2011" Year="2012">
+<Database Name="cv" Series="41881" Issue="316796" />
+</Book>
+<Book Series="Star Wars: Dark Times - Out of the Wilderness" Number="5" Volume="2011" Year="2012">
+<Database Name="cv" Series="41881" Issue="333471" />
+</Book>
+<Book Series="Star Wars: Dark Times - Fire Carrier" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="56875" Issue="384947" />
+</Book>
+<Book Series="Star Wars: Dark Times - Fire Carrier" Number="2" Volume="2013" Year="2013">
+<Database Name="cv" Series="56875" Issue="390430" />
+</Book>
+<Book Series="Star Wars: Dark Times - Fire Carrier" Number="3" Volume="2013" Year="2013">
+<Database Name="cv" Series="56875" Issue="395693" />
+</Book>
+<Book Series="Star Wars: Dark Times - Fire Carrier" Number="4" Volume="2013" Year="2013">
+<Database Name="cv" Series="56875" Issue="400134" />
+</Book>
+<Book Series="Star Wars: Dark Times - Fire Carrier" Number="5" Volume="2013" Year="2013">
+<Database Name="cv" Series="56875" Issue="408978" />
+</Book>
+<Book Series="Star Wars: Dark Times - A Spark Remains" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="65374" Issue="417821" />
+</Book>
+<Book Series="Star Wars: Dark Times - A Spark Remains" Number="2" Volume="2013" Year="2013">
+<Database Name="cv" Series="65374" Issue="422485" />
+</Book>
+<Book Series="Star Wars: Dark Times - A Spark Remains" Number="3" Volume="2013" Year="2013">
+<Database Name="cv" Series="65374" Issue="425922" />
+</Book>
+<Book Series="Star Wars: Dark Times - A Spark Remains" Number="4" Volume="2013" Year="2013">
+<Database Name="cv" Series="65374" Issue="431428" />
+</Book>
+<Book Series="Star Wars: Dark Times - A Spark Remains" Number="5" Volume="2013" Year="2013">
+<Database Name="cv" Series="65374" Issue="437466" />
+</Book>
+<Book Series="Star Wars: Darth Vader And The Ninth Assassin" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="60001" Issue="397533" />
+</Book>
+<Book Series="Star Wars: Darth Vader And The Ninth Assassin" Number="2" Volume="2013" Year="2013">
+<Database Name="cv" Series="60001" Issue="402276" />
+</Book>
+<Book Series="Star Wars: Darth Vader And The Ninth Assassin" Number="3" Volume="2013" Year="2013">
+<Database Name="cv" Series="60001" Issue="411815" />
+</Book>
+<Book Series="Star Wars: Darth Vader And The Ninth Assassin" Number="4" Volume="2013" Year="2013">
+<Database Name="cv" Series="60001" Issue="417822" />
+</Book>
+<Book Series="Star Wars: Darth Vader And The Ninth Assassin" Number="5" Volume="2013" Year="2013">
+<Database Name="cv" Series="60001" Issue="422486" />
+</Book>
+<Book Series="Star Wars: Darth Vader and the Cry of Shadows" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="70053" Issue="437467" />
+</Book>
+<Book Series="Star Wars: Darth Vader and the Cry of Shadows" Number="2" Volume="2013" Year="2014">
+<Database Name="cv" Series="70053" Issue="442149" />
+</Book>
+<Book Series="Star Wars: Darth Vader and the Cry of Shadows" Number="3" Volume="2013" Year="2014">
+<Database Name="cv" Series="70053" Issue="445791" />
+</Book>
+<Book Series="Star Wars: Darth Vader and the Cry of Shadows" Number="4" Volume="2013" Year="2014">
+<Database Name="cv" Series="70053" Issue="447974" />
+</Book>
+<Book Series="Star Wars: Darth Vader and the Cry of Shadows" Number="5" Volume="2013" Year="2014">
+<Database Name="cv" Series="70053" Issue="450540" />
+</Book>
+<Book Series="Star Wars: Droids" Number="1" Volume="1994" Year="1994">
+<Database Name="cv" Series="5399" Issue="38879" />
+</Book>
+<Book Series="Star Wars: Droids" Number="2" Volume="1994" Year="1994">
+<Database Name="cv" Series="5399" Issue="39021" />
+</Book>
+<Book Series="Star Wars: Droids" Number="3" Volume="1994" Year="1994">
+<Database Name="cv" Series="5399" Issue="39161" />
+</Book>
+<Book Series="Star Wars: Droids" Number="4" Volume="1994" Year="1994">
+<Database Name="cv" Series="5399" Issue="39312" />
+</Book>
+<Book Series="Star Wars: Droids" Number="5" Volume="1994" Year="1994">
+<Database Name="cv" Series="5399" Issue="39450" />
+</Book>
+<Book Series="Star Wars: Droids" Number="6" Volume="1994" Year="1994">
+<Database Name="cv" Series="5399" Issue="39590" />
+</Book>
+<Book Series="Star Wars: Droids" Number="1" Volume="1995" Year="1995">
+<Database Name="cv" Series="5624" Issue="40668" />
+</Book>
+<Book Series="Star Wars: Droids" Number="2" Volume="1995" Year="1995">
+<Database Name="cv" Series="5624" Issue="40803" />
+</Book>
+<Book Series="Star Wars: Droids" Number="3" Volume="1995" Year="1995">
+<Database Name="cv" Series="5624" Issue="40922" />
+</Book>
+<Book Series="Star Wars: Droids" Number="4" Volume="1995" Year="1995">
+<Database Name="cv" Series="5624" Issue="120534" />
+</Book>
+<Book Series="Star Wars: Droids" Number="5" Volume="1995" Year="1995">
+<Database Name="cv" Series="5624" Issue="120535" />
+</Book>
+<Book Series="Star Wars: Droids" Number="6" Volume="1995" Year="1995">
+<Database Name="cv" Series="5624" Issue="120536" />
+</Book>
+<Book Series="Star Wars: Droids" Number="7" Volume="1995" Year="1995">
+<Database Name="cv" Series="5624" Issue="120537" />
+</Book>
+<Book Series="Star Wars: Droids" Number="8" Volume="1995" Year="1995">
+<Database Name="cv" Series="5624" Issue="120538" />
+</Book>
+<Book Series="Star Wars: Droids: Special" Number="1" Volume="1995" Year="1995">
+<Database Name="cv" Series="28408" Issue="174967" />
+</Book>
+<Book Series="Star Wars: Galaxy Magazine" Number="1" Volume="1994" Year="1994">
+<Database Name="cv" Series="62367" Issue="424905" />
+</Book>
+<Book Series="Star Wars - The Protocol Offensive" Number="1" Volume="1997" Year="1997">
+<Database Name="cv" Series="27228" Issue="165839" />
+</Book>
+<Book Series="Star Wars: Jabba The Hutt: The Art Of The Deal" Number="1" Volume="1998" Year="1998">
+<Database Name="cv" Series="27225" Issue="165836" />
+</Book>
+<Book Series="Star Wars: Boba Fett - Enemy of the Empire" Number="1" Volume="1999" Year="1999">
+<Database Name="cv" Series="20224" Issue="120532" />
+</Book>
+<Book Series="Star Wars: Boba Fett - Enemy of the Empire" Number="2" Volume="1999" Year="1999">
+<Database Name="cv" Series="20224" Issue="151583" />
+</Book>
+<Book Series="Star Wars: Boba Fett - Enemy of the Empire" Number="3" Volume="1999" Year="1999">
+<Database Name="cv" Series="20224" Issue="151584" />
+</Book>
+<Book Series="Star Wars: Boba Fett - Enemy of the Empire" Number="4" Volume="1999" Year="1999">
+<Database Name="cv" Series="20224" Issue="151585" />
+</Book>
+<Book Series="Star Wars: Agent of the Empire - Iron Eclipse" Number="1" Volume="2011" Year="2011">
+<Database Name="cv" Series="44318" Issue="304950" />
+</Book>
+<Book Series="Star Wars: Agent of the Empire - Iron Eclipse" Number="2" Volume="2011" Year="2012">
+<Database Name="cv" Series="44318" Issue="311103" />
+</Book>
+<Book Series="Star Wars: Agent of the Empire - Iron Eclipse" Number="3" Volume="2011" Year="2012">
+<Database Name="cv" Series="44318" Issue="315397" />
+</Book>
+<Book Series="Star Wars: Agent of the Empire - Iron Eclipse" Number="4" Volume="2011" Year="2012">
+<Database Name="cv" Series="44318" Issue="321355" />
+</Book>
+<Book Series="Star Wars: Agent of the Empire - Iron Eclipse" Number="5" Volume="2011" Year="2012">
+<Database Name="cv" Series="44318" Issue="329237" />
+</Book>
+<Book Series="Star Wars: Agent of the Empire - Hard Targets" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="53101" Issue="362177" />
+</Book>
+<Book Series="Star Wars: Agent of the Empire - Hard Targets" Number="2" Volume="2012" Year="2012">
+<Database Name="cv" Series="53101" Issue="369069" />
+</Book>
+<Book Series="Star Wars: Agent of the Empire - Hard Targets" Number="3" Volume="2012" Year="2012">
+<Database Name="cv" Series="53101" Issue="373291" />
+</Book>
+<Book Series="Star Wars: Agent of the Empire - Hard Targets" Number="4" Volume="2012" Year="2013">
+<Database Name="cv" Series="53101" Issue="382796" />
+</Book>
+<Book Series="Star Wars: Agent of the Empire - Hard Targets" Number="5" Volume="2012" Year="2013">
+<Database Name="cv" Series="53101" Issue="388546" />
+</Book>
+<Book Series="Star Wars: The Force Unleashed" Number="1" Volume="2008" Year="2008">
+<Database Name="cv" Series="22675" Issue="135994" />
+</Book>
+<Book Series="Star Wars: The Force Unleashed II" Number="1" Volume="2010" Year="2010">
+<Database Name="cv" Series="36069" Issue="238170" />
+</Book>
+<Book Series="Star Wars: Blood Ties - Boba Fett is Dead" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="48344" Issue="333474" />
+</Book>
+<Book Series="Star Wars: Blood Ties - Boba Fett is Dead" Number="2" Volume="2012" Year="2012">
+<Database Name="cv" Series="48344" Issue="337722" />
+</Book>
+<Book Series="Star Wars: Blood Ties - Boba Fett is Dead" Number="3" Volume="2012" Year="2012">
+<Database Name="cv" Series="48344" Issue="342883" />
+</Book>
+<Book Series="Star Wars: Blood Ties - Boba Fett is Dead" Number="4" Volume="2012" Year="2012">
+<Database Name="cv" Series="48344" Issue="347237" />
+</Book>
+<Book Series="Star Wars: Empire" Number="1" Volume="2002" Year="2002">
+<Database Name="cv" Series="21677" Issue="130838" />
+</Book>
+<Book Series="Star Wars: Empire" Number="2" Volume="2002" Year="2002">
+<Database Name="cv" Series="21677" Issue="165522" />
+</Book>
+<Book Series="Star Wars: Empire" Number="3" Volume="2002" Year="2002">
+<Database Name="cv" Series="21677" Issue="165523" />
+</Book>
+<Book Series="Star Wars: Empire" Number="4" Volume="2002" Year="2002">
+<Database Name="cv" Series="21677" Issue="165524" />
+</Book>
+<Book Series="Star Wars: Underworld - The Yavin Vassilika" Number="1" Volume="2000" Year="2000">
+<Database Name="cv" Series="19162" Issue="114635" />
+</Book>
+<Book Series="Star Wars: Underworld - The Yavin Vassilika" Number="2" Volume="2000" Year="2001">
+<Database Name="cv" Series="19162" Issue="114742" />
+</Book>
+<Book Series="Star Wars: Underworld - The Yavin Vassilika" Number="3" Volume="2000" Year="2001">
+<Database Name="cv" Series="19162" Issue="114988" />
+</Book>
+<Book Series="Star Wars: Underworld - The Yavin Vassilika" Number="4" Volume="2000" Year="2001">
+<Database Name="cv" Series="19162" Issue="115114" />
+</Book>
+<Book Series="Star Wars: Underworld - The Yavin Vassilika" Number="5" Volume="2000" Year="2001">
+<Database Name="cv" Series="19162" Issue="115116" />
+</Book>
+<Book Series="Star Wars: Empire" Number="8" Volume="2002" Year="2003">
+<Database Name="cv" Series="21677" Issue="165528" />
+</Book>
+<Book Series="Star Wars: Empire" Number="9" Volume="2002" Year="2003">
+<Database Name="cv" Series="21677" Issue="165529" />
+</Book>
+<Book Series="Star Wars: Empire" Number="12" Volume="2002" Year="2003">
+<Database Name="cv" Series="21677" Issue="165532" />
+</Book>
+<Book Series="Star Wars: Empire" Number="15" Volume="2002" Year="2003">
+<Database Name="cv" Series="21677" Issue="166754" />
+</Book>
+<Book Series="Star Wars Adventures: Han Solo and the Hollow Moon of Khorya" Number="1" Volume="2009" Year="2009">
+<Database Name="cv" Series="35008" Issue="230780" />
+</Book>
+<Book Series="Star Wars: Empire" Number="10" Volume="2002" Year="2003">
+<Database Name="cv" Series="21677" Issue="165530" />
+</Book>
+<Book Series="Star Wars: Empire" Number="11" Volume="2002" Year="2003">
+<Database Name="cv" Series="21677" Issue="165531" />
+</Book>
+<Book Series="Star Wars: Empire" Number="5" Volume="2002" Year="2003">
+<Database Name="cv" Series="21677" Issue="165525" />
+</Book>
+<Book Series="Star Wars: Empire" Number="6" Volume="2002" Year="2003">
+<Database Name="cv" Series="21677" Issue="165526" />
+</Book>
+<Book Series="The Star Wars" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="67024" Issue="424523" />
+</Book>
+<Book Series="The Star Wars" Number="2" Volume="2013" Year="2013">
+<Database Name="cv" Series="67024" Issue="427674" />
+</Book>
+<Book Series="The Star Wars" Number="3" Volume="2013" Year="2013">
+<Database Name="cv" Series="67024" Issue="432314" />
+</Book>
+<Book Series="The Star Wars" Number="4" Volume="2013" Year="2013">
+<Database Name="cv" Series="67024" Issue="435564" />
+</Book>
+<Book Series="The Star Wars" Number="5" Volume="2013" Year="2014">
+<Database Name="cv" Series="67024" Issue="444507" />
+</Book>
+<Book Series="The Star Wars" Number="6" Volume="2013" Year="2014">
+<Database Name="cv" Series="67024" Issue="447488" />
+</Book>
+<Book Series="The Star Wars" Number="7" Volume="2013" Year="2014">
+<Database Name="cv" Series="67024" Issue="450539" />
+</Book>
+<Book Series="The Star Wars" Number="8" Volume="2013" Year="2014">
+<Database Name="cv" Series="67024" Issue="454075" />
+</Book>
+<Book Series="Star Wars: Infinities - A New Hope" Number="1" Volume="2001" Year="2001">
+<Database Name="cv" Series="27289" Issue="166300" />
+</Book>
+<Book Series="Star Wars: Infinities - A New Hope" Number="2" Volume="2001" Year="2001">
+<Database Name="cv" Series="27289" Issue="166302" />
+</Book>
+<Book Series="Star Wars: Infinities - A New Hope" Number="3" Volume="2001" Year="2001">
+<Database Name="cv" Series="27289" Issue="166303" />
+</Book>
+<Book Series="Star Wars: Infinities - A New Hope" Number="4" Volume="2001" Year="2001">
+<Database Name="cv" Series="27289" Issue="166309" />
+</Book>
+<Book Series="Star Wars: Empire" Number="13" Volume="2002" Year="2003">
+<Database Name="cv" Series="21677" Issue="165533" />
+</Book>
+<Book Series="Star Wars: Empire" Number="14" Volume="2002" Year="2003">
+<Database Name="cv" Series="21677" Issue="166753" />
+</Book>
+<Book Series="Star Wars: Empire" Number="16" Volume="2002" Year="2004">
+<Database Name="cv" Series="21677" Issue="166755" />
+</Book>
+<Book Series="Star Wars: Empire" Number="17" Volume="2002" Year="2004">
+<Database Name="cv" Series="21677" Issue="166756" />
+</Book>
+<Book Series="Star Wars: Empire" Number="18" Volume="2002" Year="2004">
+<Database Name="cv" Series="21677" Issue="166757" />
+</Book>
+<Book Series="Star Wars: Empire" Number="19" Volume="2002" Year="2004">
+<Database Name="cv" Series="21677" Issue="165534" />
+</Book>
+<Book Series="Star Wars: Empire" Number="7" Volume="2002" Year="2003">
+<Database Name="cv" Series="21677" Issue="165527" />
+</Book>
+<Book Series="Star Wars: Empire" Number="20" Volume="2002" Year="2004">
+<Database Name="cv" Series="21677" Issue="165535" />
+</Book>
+<Book Series="Star Wars: Empire" Number="21" Volume="2002" Year="2004">
+<Database Name="cv" Series="21677" Issue="165699" />
+</Book>
+<Book Series="Star Wars: Empire" Number="22" Volume="2002" Year="2004">
+<Database Name="cv" Series="21677" Issue="165700" />
+</Book>
+<Book Series="Star Wars: Vader&apos;s Quest" Number="1" Volume="1999" Year="1999">
+<Database Name="cv" Series="26477" Issue="158037" />
+</Book>
+<Book Series="Star Wars: Vader&apos;s Quest" Number="2" Volume="1999" Year="1999">
+<Database Name="cv" Series="26477" Issue="158038" />
+</Book>
+<Book Series="Star Wars: Vader&apos;s Quest" Number="3" Volume="1999" Year="1999">
+<Database Name="cv" Series="26477" Issue="158039" />
+</Book>
+<Book Series="Star Wars: Vader&apos;s Quest" Number="4" Volume="1999" Year="1999">
+<Database Name="cv" Series="26477" Issue="158040" />
+</Book>
+<Book Series="Star Wars: Shadow Stalker" Number="1" Volume="1997" Year="1997">
+<Database Name="cv" Series="27285" Issue="166273" />
+</Book>
+<Book Series="Star Wars Adventures: Chewbacca and the Slavers of the Shadowlands" Number="1" Volume="2011" Year="2011">
+<Database Name="cv" Series="42926" Issue="293160" />
+</Book>
+<Book Series="Star Wars: River of Chaos" Number="1" Volume="1995" Year="1995">
+<Database Name="cv" Series="20216" Issue="120524" />
+</Book>
+<Book Series="Star Wars: River of Chaos" Number="2" Volume="1995" Year="1995">
+<Database Name="cv" Series="20216" Issue="120580" />
+</Book>
+<Book Series="Star Wars: River of Chaos" Number="3" Volume="1995" Year="1995">
+<Database Name="cv" Series="20216" Issue="120581" />
+</Book>
+<Book Series="Star Wars: River of Chaos" Number="4" Volume="1995" Year="1995">
+<Database Name="cv" Series="20216" Issue="120582" />
+</Book>
+<Book Series="Star Wars: Empire" Number="23" Volume="2002" Year="2004">
+<Database Name="cv" Series="21677" Issue="141168" />
+</Book>
+<Book Series="Star Wars: Empire" Number="24" Volume="2002" Year="2004">
+<Database Name="cv" Series="21677" Issue="165701" />
+</Book>
+<Book Series="Star Wars: Empire" Number="25" Volume="2002" Year="2004">
+<Database Name="cv" Series="21677" Issue="165702" />
+</Book>
+<Book Series="Star Wars: Empire" Number="26" Volume="2002" Year="2004">
+<Database Name="cv" Series="21677" Issue="165536" />
+</Book>
+<Book Series="Star Wars: Empire" Number="27" Volume="2002" Year="2004">
+<Database Name="cv" Series="21677" Issue="165703" />
+</Book>
+<Book Series="Star Wars: Empire" Number="28" Volume="2002" Year="2004">
+<Database Name="cv" Series="21677" Issue="165704" />
+</Book>
+<Book Series="Star Wars: Empire" Number="29" Volume="2002" Year="2005">
+<Database Name="cv" Series="21677" Issue="165705" />
+</Book>
+<Book Series="Star Wars: Empire" Number="30" Volume="2002" Year="2005">
+<Database Name="cv" Series="21677" Issue="165537" />
+</Book>
+<Book Series="Star Wars: Empire" Number="31" Volume="2002" Year="2005">
+<Database Name="cv" Series="21677" Issue="165706" />
+</Book>
+<Book Series="Star Wars: Empire" Number="32" Volume="2002" Year="2005">
+<Database Name="cv" Series="21677" Issue="165707" />
+</Book>
+<Book Series="Star Wars: Empire" Number="33" Volume="2002" Year="2005">
+<Database Name="cv" Series="21677" Issue="165708" />
+</Book>
+<Book Series="Star Wars: Empire" Number="34" Volume="2002" Year="2005">
+<Database Name="cv" Series="21677" Issue="165709" />
+</Book>
+<Book Series="Star Wars: Empire" Number="35" Volume="2002" Year="2005">
+<Database Name="cv" Series="21677" Issue="165710" />
+</Book>
+<Book Series="Star Wars: Empire" Number="36" Volume="2002" Year="2005">
+<Database Name="cv" Series="21677" Issue="165711" />
+</Book>
+<Book Series="Star Wars: Empire" Number="37" Volume="2002" Year="2005">
+<Database Name="cv" Series="21677" Issue="165538" />
+</Book>
+<Book Series="Star Wars: Empire" Number="38" Volume="2002" Year="2005">
+<Database Name="cv" Series="21677" Issue="165539" />
+</Book>
+<Book Series="Star Wars: Empire" Number="39" Volume="2002" Year="2006">
+<Database Name="cv" Series="21677" Issue="165540" />
+</Book>
+<Book Series="Star Wars: Empire" Number="40" Volume="2002" Year="2006">
+<Database Name="cv" Series="21677" Issue="165541" />
+</Book>
+<Book Series="Star Wars: Rebellion" Number="0" Volume="2006" Year="2006">
+<Database Name="cv" Series="18864" Issue="174148" />
+</Book>
+<Book Series="Star Wars: Rebellion" Number="1" Volume="2006" Year="2006">
+<Database Name="cv" Series="18864" Issue="120509" />
+</Book>
+<Book Series="Star Wars: Rebellion" Number="2" Volume="2006" Year="2006">
+<Database Name="cv" Series="18864" Issue="120511" />
+</Book>
+<Book Series="Star Wars: Rebellion" Number="3" Volume="2006" Year="2006">
+<Database Name="cv" Series="18864" Issue="120512" />
+</Book>
+<Book Series="Star Wars: Rebellion" Number="4" Volume="2006" Year="2006">
+<Database Name="cv" Series="18864" Issue="120514" />
+</Book>
+<Book Series="Star Wars: Rebellion" Number="5" Volume="2006" Year="2006">
+<Database Name="cv" Series="18864" Issue="120507" />
+</Book>
+<Book Series="Star Wars: Boba Fett: Overkill" Number="1" Volume="2006" Year="2006">
+<Database Name="cv" Series="19794" Issue="118810" />
+</Book>
+<Book Series="Star Wars: Rebellion" Number="6" Volume="2006" Year="2007">
+<Database Name="cv" Series="18864" Issue="120515" />
+</Book>
+<Book Series="Star Wars: Rebellion" Number="7" Volume="2006" Year="2007">
+<Database Name="cv" Series="18864" Issue="120516" />
+</Book>
+<Book Series="Star Wars: Rebellion" Number="8" Volume="2006" Year="2007">
+<Database Name="cv" Series="18864" Issue="111536" />
+</Book>
+<Book Series="Star Wars: Rebellion" Number="9" Volume="2006" Year="2007">
+<Database Name="cv" Series="18864" Issue="120518" />
+</Book>
+<Book Series="Star Wars: Rebellion" Number="10" Volume="2006" Year="2007">
+<Database Name="cv" Series="18864" Issue="114550" />
+</Book>
+<Book Series="Star Wars: Rebellion" Number="11" Volume="2006" Year="2008">
+<Database Name="cv" Series="18864" Issue="134550" />
+</Book>
+<Book Series="Star Wars: Rebellion" Number="12" Volume="2006" Year="2008">
+<Database Name="cv" Series="18864" Issue="134549" />
+</Book>
+<Book Series="Star Wars: Rebellion" Number="13" Volume="2006" Year="2008">
+<Database Name="cv" Series="18864" Issue="134548" />
+</Book>
+<Book Series="Star Wars: Rebellion" Number="14" Volume="2006" Year="2008">
+<Database Name="cv" Series="18864" Issue="131646" />
+</Book>
+<Book Series="Star Wars: Rebellion" Number="15" Volume="2006" Year="2008">
+<Database Name="cv" Series="18864" Issue="134547" />
+</Book>
+<Book Series="Star Wars: Rebellion" Number="16" Volume="2006" Year="2008">
+<Database Name="cv" Series="18864" Issue="136617" />
+</Book>
+<Book Series="Star Wars: Rebel Heist" Number="1" Volume="2014" Year="2014">
+<Database Name="cv" Series="73412" Issue="451750" />
+</Book>
+<Book Series="Star Wars: Rebel Heist" Number="2" Volume="2014" Year="2014">
+<Database Name="cv" Series="73412" Issue="454077" />
+</Book>
+<Book Series="Star Wars: Rebel Heist" Number="3" Volume="2014" Year="2014">
+<Database Name="cv" Series="73412" Issue="457619" />
+</Book>
+<Book Series="Star Wars: Rebel Heist" Number="4" Volume="2014" Year="2014">
+<Database Name="cv" Series="73412" Issue="460946" />
+</Book>
+<Book Series="Star Wars" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="55553" Issue="378869" />
+</Book>
+<Book Series="Star Wars" Number="2" Volume="2013" Year="2013">
+<Database Name="cv" Series="55553" Issue="386124" />
+</Book>
+<Book Series="Star Wars" Number="3" Volume="2013" Year="2013">
+<Database Name="cv" Series="55553" Issue="392341" />
+</Book>
+<Book Series="Star Wars" Number="4" Volume="2013" Year="2013">
+<Database Name="cv" Series="55553" Issue="396413" />
+</Book>
+<Book Series="Star Wars" Number="5" Volume="2013" Year="2013">
+<Database Name="cv" Series="55553" Issue="401194" />
+</Book>
+<Book Series="Star Wars" Number="6" Volume="2013" Year="2013">
+<Database Name="cv" Series="55553" Issue="410310" />
+</Book>
+<Book Series="Star Wars" Number="7" Volume="2013" Year="2013">
+<Database Name="cv" Series="55553" Issue="416929" />
+</Book>
+<Book Series="Star Wars" Number="8" Volume="2013" Year="2013">
+<Database Name="cv" Series="55553" Issue="421680" />
+</Book>
+<Book Series="Star Wars" Number="9" Volume="2013" Year="2013">
+<Database Name="cv" Series="55553" Issue="425016" />
+</Book>
+<Book Series="Star Wars" Number="10" Volume="2013" Year="2013">
+<Database Name="cv" Series="55553" Issue="428282" />
+</Book>
+<Book Series="Star Wars" Number="11" Volume="2013" Year="2013">
+<Database Name="cv" Series="55553" Issue="433155" />
+</Book>
+<Book Series="Star Wars" Number="12" Volume="2013" Year="2013">
+<Database Name="cv" Series="55553" Issue="436180" />
+</Book>
+<Book Series="Star Wars" Number="13" Volume="2013" Year="2014">
+<Database Name="cv" Series="55553" Issue="441387" />
+</Book>
+<Book Series="Star Wars" Number="14" Volume="2013" Year="2014">
+<Database Name="cv" Series="55553" Issue="445159" />
+</Book>
+<Book Series="Star Wars" Number="15" Volume="2013" Year="2014">
+<Database Name="cv" Series="55553" Issue="447487" />
+</Book>
+<Book Series="Star Wars" Number="16" Volume="2013" Year="2014">
+<Database Name="cv" Series="55553" Issue="450051" />
+</Book>
+<Book Series="Star Wars" Number="17" Volume="2013" Year="2014">
+<Database Name="cv" Series="55553" Issue="452823" />
+</Book>
+<Book Series="Star Wars" Number="18" Volume="2013" Year="2014">
+<Database Name="cv" Series="55553" Issue="455995" />
+</Book>
+<Book Series="Star Wars" Number="19" Volume="2013" Year="2014">
+<Database Name="cv" Series="55553" Issue="459139" />
+</Book>
+<Book Series="Star Wars" Number="20" Volume="2013" Year="2014">
+<Database Name="cv" Series="55553" Issue="462224" />
+</Book>
+<Book Series="Star Wars: Splinter of the Mind&apos;s Eye" Number="1" Volume="1995" Year="1995">
+<Database Name="cv" Series="32091" Issue="201404" />
+</Book>
+<Book Series="Star Wars: Splinter of the Mind&apos;s Eye" Number="2" Volume="1995" Year="1996">
+<Database Name="cv" Series="32091" Issue="201405" />
+</Book>
+<Book Series="Star Wars: Splinter of the Mind&apos;s Eye" Number="3" Volume="1995" Year="1996">
+<Database Name="cv" Series="32091" Issue="201406" />
+</Book>
+<Book Series="Star Wars: Splinter of the Mind&apos;s Eye" Number="4" Volume="1995" Year="1996">
+<Database Name="cv" Series="32091" Issue="201407" />
+</Book>
+<Book Series="Star Wars Adventures: Princess Leia and the Royal Ransom" Number="1" Volume="2009" Year="2009">
+<Database Name="cv" Series="27211" Issue="165662" />
+</Book>
+<Book Series="Star Wars Adventures: Boba Fett and the Ship of Fear" Number="1" Volume="2011" Year="2011">
+<Database Name="cv" Series="40729" Issue="274613" />
+</Book>
+<Book Series="Star Wars Adventures: The Will Of Darth Vader" Number="1" Volume="2010" Year="2010">
+<Database Name="cv" Series="34829" Issue="228658" />
+</Book>
+<Book Series="Star Wars: Infinities - The Empire Strikes Back" Number="1" Volume="2002" Year="2002">
+<Database Name="cv" Series="20069" Issue="119754" />
+</Book>
+<Book Series="Star Wars: Infinities - The Empire Strikes Back" Number="2" Volume="2002" Year="2002">
+<Database Name="cv" Series="20069" Issue="119784" />
+</Book>
+<Book Series="Star Wars: Infinities - The Empire Strikes Back" Number="3" Volume="2002" Year="2002">
+<Database Name="cv" Series="20069" Issue="119785" />
+</Book>
+<Book Series="Star Wars: Infinities - The Empire Strikes Back" Number="4" Volume="2002" Year="2002">
+<Database Name="cv" Series="20069" Issue="119786" />
+</Book>
+<Book Series="Star Wars Adventures: Luke Skywalker And The Treasure Of The Dragonsnakes" Number="1" Volume="2010" Year="2010">
+<Database Name="cv" Series="31922" Issue="200241" />
+</Book>
+<Book Series="Star Wars: Tales From Mos Eisley" Number="1" Volume="1996" Year="1996">
+<Database Name="cv" Series="20998" Issue="125698" />
+</Book>
+<Book Series="Star Wars: Shadows of the Empire" Number="1" Volume="1996" Year="1996">
+<Database Name="cv" Series="20218" Issue="120526" />
+</Book>
+<Book Series="Star Wars: Shadows of the Empire" Number="2" Volume="1996" Year="1996">
+<Database Name="cv" Series="20218" Issue="120576" />
+</Book>
+<Book Series="Star Wars: Shadows of the Empire" Number="3" Volume="1996" Year="1996">
+<Database Name="cv" Series="20218" Issue="120577" />
+</Book>
+<Book Series="Star Wars: Shadows of the Empire" Number="4" Volume="1996" Year="1996">
+<Database Name="cv" Series="20218" Issue="120578" />
+</Book>
+<Book Series="Star Wars: Shadows of the Empire" Number="5" Volume="1996" Year="1996">
+<Database Name="cv" Series="20218" Issue="120579" />
+</Book>
+<Book Series="Star Wars: Shadows of the Empire" Number="6" Volume="1996" Year="1996">
+<Database Name="cv" Series="20218" Issue="120959" />
+</Book>
+<Book Series="Star Wars: The Bounty Hunters - Scoundrel&apos;s Wages" Number="1" Volume="1999" Year="1999">
+<Database Name="cv" Series="28409" Issue="174968" />
+</Book>
+<Book Series="Star Wars: Ewoks - Shadows of Endor" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="68120" Issue="428283" />
+</Book>
+<Book Series="Star Wars: Infinities - Return of the Jedi" Number="1" Volume="2003" Year="2003">
+<Database Name="cv" Series="27302" Issue="166410" />
+</Book>
+<Book Series="Star Wars: Infinities - Return of the Jedi" Number="2" Volume="2003" Year="2004">
+<Database Name="cv" Series="27302" Issue="166411" />
+</Book>
+<Book Series="Star Wars: Infinities - Return of the Jedi" Number="3" Volume="2003" Year="2004">
+<Database Name="cv" Series="27302" Issue="166412" />
+</Book>
+<Book Series="Star Wars: Infinities - Return of the Jedi" Number="4" Volume="2003" Year="2004">
+<Database Name="cv" Series="27302" Issue="166413" />
+</Book>
+<Book Series="Star Wars: Mara Jade - By the Emperor&apos;s Hand" Number="1" Volume="1998" Year="1998">
+<Database Name="cv" Series="6935" Issue="49233" />
+</Book>
+<Book Series="Star Wars: Mara Jade - By the Emperor&apos;s Hand" Number="2" Volume="1998" Year="1998">
+<Database Name="cv" Series="6935" Issue="49234" />
+</Book>
+<Book Series="Star Wars: Mara Jade - By the Emperor&apos;s Hand" Number="3" Volume="1998" Year="1998">
+<Database Name="cv" Series="6935" Issue="49235" />
+</Book>
+<Book Series="Star Wars: Mara Jade - By the Emperor&apos;s Hand" Number="4" Volume="1998" Year="1998">
+<Database Name="cv" Series="6935" Issue="49236" />
+</Book>
+<Book Series="Star Wars: Mara Jade - By the Emperor&apos;s Hand" Number="5" Volume="1998" Year="1998">
+<Database Name="cv" Series="6935" Issue="49237" />
+</Book>
+<Book Series="Star Wars: Mara Jade - By the Emperor&apos;s Hand" Number="6" Volume="1998" Year="1999">
+<Database Name="cv" Series="6935" Issue="49238" />
+</Book>
+<Book Series="Star Wars: X-Wing: Rogue Leader" Number="1" Volume="2005" Year="2005">
+<Database Name="cv" Series="27223" Issue="165826" />
+</Book>
+<Book Series="Star Wars: X-Wing: Rogue Leader" Number="2" Volume="2005" Year="2005">
+<Database Name="cv" Series="27223" Issue="165827" />
+</Book>
+<Book Series="Star Wars: X-Wing: Rogue Leader" Number="3" Volume="2005" Year="2005">
+<Database Name="cv" Series="27223" Issue="165828" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="1" Volume="1995" Year="1995">
+<Database Name="cv" Series="5629" Issue="41059" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="2" Volume="1995" Year="1995">
+<Database Name="cv" Series="5629" Issue="41202" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="3" Volume="1995" Year="1995">
+<Database Name="cv" Series="5629" Issue="120519" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="4" Volume="1995" Year="1995">
+<Database Name="cv" Series="5629" Issue="120520" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="5" Volume="1995" Year="1996">
+<Database Name="cv" Series="5629" Issue="120521" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="6" Volume="1995" Year="1996">
+<Database Name="cv" Series="5629" Issue="120522" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="7" Volume="1995" Year="1996">
+<Database Name="cv" Series="5629" Issue="120564" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="8" Volume="1995" Year="1996">
+<Database Name="cv" Series="5629" Issue="120565" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron Special" Number="1" Volume="1995" Year="1995">
+<Database Name="cv" Series="50911" Issue="347968" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="9" Volume="1995" Year="1996">
+<Database Name="cv" Series="5629" Issue="120566" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="10" Volume="1995" Year="1996">
+<Database Name="cv" Series="5629" Issue="120567" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="11" Volume="1995" Year="1996">
+<Database Name="cv" Series="5629" Issue="120568" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="12" Volume="1995" Year="1996">
+<Database Name="cv" Series="5629" Issue="120569" />
+</Book>
+<Book Series="Star Wars: Shadows of the Empire: Evolution" Number="1" Volume="1998" Year="1998">
+<Database Name="cv" Series="27193" Issue="165517" />
+</Book>
+<Book Series="Star Wars: Shadows of the Empire: Evolution" Number="2" Volume="1998" Year="1998">
+<Database Name="cv" Series="27193" Issue="165518" />
+</Book>
+<Book Series="Star Wars: Shadows of the Empire: Evolution" Number="3" Volume="1998" Year="1998">
+<Database Name="cv" Series="27193" Issue="165519" />
+</Book>
+<Book Series="Star Wars: Shadows of the Empire: Evolution" Number="4" Volume="1998" Year="1998">
+<Database Name="cv" Series="27193" Issue="165520" />
+</Book>
+<Book Series="Star Wars: Shadows of the Empire: Evolution" Number="5" Volume="1998" Year="1998">
+<Database Name="cv" Series="27193" Issue="165521" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="13" Volume="1995" Year="1996">
+<Database Name="cv" Series="5629" Issue="120570" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="14" Volume="1995" Year="1996">
+<Database Name="cv" Series="5629" Issue="120961" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="15" Volume="1995" Year="1997">
+<Database Name="cv" Series="5629" Issue="120962" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="16" Volume="1995" Year="1997">
+<Database Name="cv" Series="5629" Issue="120963" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="17" Volume="1995" Year="1997">
+<Database Name="cv" Series="5629" Issue="120964" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="18" Volume="1995" Year="1997">
+<Database Name="cv" Series="5629" Issue="165789" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="19" Volume="1995" Year="1997">
+<Database Name="cv" Series="5629" Issue="165790" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="20" Volume="1995" Year="1997">
+<Database Name="cv" Series="5629" Issue="165791" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="½" Volume="1995" Year="1997">
+<Database Name="cv" Series="5629" Issue="127974" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="21" Volume="1995" Year="1997">
+<Database Name="cv" Series="5629" Issue="165792" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="22" Volume="1995" Year="1997">
+<Database Name="cv" Series="5629" Issue="165793" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="23" Volume="1995" Year="1997">
+<Database Name="cv" Series="5629" Issue="141107" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="24" Volume="1995" Year="1997">
+<Database Name="cv" Series="5629" Issue="128923" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="25" Volume="1995" Year="1997">
+<Database Name="cv" Series="5629" Issue="156844" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="26" Volume="1995" Year="1998">
+<Database Name="cv" Series="5629" Issue="156845" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="27" Volume="1995" Year="1998">
+<Database Name="cv" Series="5629" Issue="156846" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="28" Volume="1995" Year="1998">
+<Database Name="cv" Series="5629" Issue="165591" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="29" Volume="1995" Year="1998">
+<Database Name="cv" Series="5629" Issue="165592" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="30" Volume="1995" Year="1998">
+<Database Name="cv" Series="5629" Issue="165593" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="31" Volume="1995" Year="1998">
+<Database Name="cv" Series="5629" Issue="165594" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="32" Volume="1995" Year="1998">
+<Database Name="cv" Series="5629" Issue="165595" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="33" Volume="1995" Year="1998">
+<Database Name="cv" Series="5629" Issue="165596" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="34" Volume="1995" Year="1998">
+<Database Name="cv" Series="5629" Issue="165597" />
+</Book>
+<Book Series="Star Wars: X-Wing Rogue Squadron" Number="35" Volume="1995" Year="1998">
+<Database Name="cv" Series="5629" Issue="165598" />
+</Book>
+<Book Series="Star Wars: Heir to the Empire" Number="1" Volume="1995" Year="1995">
+<Database Name="cv" Series="27224" Issue="165830" />
+</Book>
+<Book Series="Star Wars: Heir to the Empire" Number="2" Volume="1995" Year="1995">
+<Database Name="cv" Series="27224" Issue="165831" />
+</Book>
+<Book Series="Star Wars: Heir to the Empire" Number="3" Volume="1995" Year="1995">
+<Database Name="cv" Series="27224" Issue="165832" />
+</Book>
+<Book Series="Star Wars: Heir to the Empire" Number="4" Volume="1995" Year="1996">
+<Database Name="cv" Series="27224" Issue="165833" />
+</Book>
+<Book Series="Star Wars: Heir to the Empire" Number="5" Volume="1995" Year="1996">
+<Database Name="cv" Series="27224" Issue="165834" />
+</Book>
+<Book Series="Star Wars: Heir to the Empire" Number="6" Volume="1995" Year="1996">
+<Database Name="cv" Series="27224" Issue="165835" />
+</Book>
+<Book Series="Star Wars: Dark Force Rising" Number="1" Volume="1997" Year="1997">
+<Database Name="cv" Series="28303" Issue="174134" />
+</Book>
+<Book Series="Star Wars: Dark Force Rising" Number="2" Volume="1997" Year="1997">
+<Database Name="cv" Series="28303" Issue="174135" />
+</Book>
+<Book Series="Star Wars: Dark Force Rising" Number="3" Volume="1997" Year="1997">
+<Database Name="cv" Series="28303" Issue="174136" />
+</Book>
+<Book Series="Star Wars: Dark Force Rising" Number="4" Volume="1997" Year="1997">
+<Database Name="cv" Series="28303" Issue="174137" />
+</Book>
+<Book Series="Star Wars: Dark Force Rising" Number="5" Volume="1997" Year="1997">
+<Database Name="cv" Series="28303" Issue="174138" />
+</Book>
+<Book Series="Star Wars: Dark Force Rising" Number="6" Volume="1997" Year="1997">
+<Database Name="cv" Series="28303" Issue="174139" />
+</Book>
+<Book Series="Star Wars: The Last Command" Number="1" Volume="1997" Year="1997">
+<Database Name="cv" Series="28350" Issue="174603" />
+</Book>
+<Book Series="Star Wars: The Last Command" Number="2" Volume="1997" Year="1997">
+<Database Name="cv" Series="28350" Issue="174605" />
+</Book>
+<Book Series="Star Wars: The Last Command" Number="3" Volume="1997" Year="1998">
+<Database Name="cv" Series="28350" Issue="174606" />
+</Book>
+<Book Series="Star Wars: The Last Command" Number="4" Volume="1997" Year="1998">
+<Database Name="cv" Series="28350" Issue="174611" />
+</Book>
+<Book Series="Star Wars: The Last Command" Number="5" Volume="1997" Year="1998">
+<Database Name="cv" Series="28350" Issue="174612" />
+</Book>
+<Book Series="Star Wars: The Last Command" Number="6" Volume="1997" Year="1998">
+<Database Name="cv" Series="28350" Issue="174613" />
+</Book>
+<Book Series="Star Wars: Dark Empire" Number="1" Volume="1991" Year="1991">
+<Database Name="cv" Series="22516" Issue="135143" />
+</Book>
+<Book Series="Star Wars: Dark Empire" Number="2" Volume="1991" Year="1991">
+<Database Name="cv" Series="22516" Issue="135145" />
+</Book>
+<Book Series="Star Wars: Dark Empire" Number="3" Volume="1991" Year="1991">
+<Database Name="cv" Series="22516" Issue="135146" />
+</Book>
+<Book Series="Star Wars: Dark Empire" Number="4" Volume="1991" Year="1991">
+<Database Name="cv" Series="22516" Issue="135147" />
+</Book>
+<Book Series="Star Wars: Dark Empire" Number="5" Volume="1991" Year="1991">
+<Database Name="cv" Series="22516" Issue="135148" />
+</Book>
+<Book Series="Star Wars: Dark Empire" Number="6" Volume="1991" Year="1991">
+<Database Name="cv" Series="22516" Issue="135149" />
+</Book>
+<Book Series="Star Wars: Dark Empire II" Number="1" Volume="1994" Year="1994">
+<Database Name="cv" Series="5398" Issue="40015" />
+</Book>
+<Book Series="Star Wars: Dark Empire II" Number="2" Volume="1994" Year="1995">
+<Database Name="cv" Series="5398" Issue="40255" />
+</Book>
+<Book Series="Star Wars: Dark Empire II" Number="3" Volume="1994" Year="1995">
+<Database Name="cv" Series="5398" Issue="40401" />
+</Book>
+<Book Series="Star Wars: Dark Empire II" Number="4" Volume="1994" Year="1995">
+<Database Name="cv" Series="5398" Issue="40537" />
+</Book>
+<Book Series="Star Wars: Dark Empire II" Number="5" Volume="1994" Year="1995">
+<Database Name="cv" Series="5398" Issue="40667" />
+</Book>
+<Book Series="Star Wars: Dark Empire II" Number="6" Volume="1994" Year="1995">
+<Database Name="cv" Series="5398" Issue="40802" />
+</Book>
+<Book Series="Star Wars: Boba Fett: Agent of Doom" Number="1" Volume="2000" Year="2000">
+<Database Name="cv" Series="19254" Issue="115535" />
+</Book>
+<Book Series="Star Wars: Empire&apos;s End" Number="1" Volume="1995" Year="1995">
+<Database Name="cv" Series="28254" Issue="173833" />
+</Book>
+<Book Series="Star Wars: Empire&apos;s End" Number="2" Volume="1995" Year="1995">
+<Database Name="cv" Series="28254" Issue="173841" />
+</Book>
+<Book Series="Star Wars: Crimson Empire" Number="1" Volume="1997" Year="1997">
+<Database Name="cv" Series="6067" Issue="44366" />
+</Book>
+<Book Series="Star Wars: Crimson Empire" Number="2" Volume="1997" Year="1998">
+<Database Name="cv" Series="6067" Issue="44532" />
+</Book>
+<Book Series="Star Wars: Crimson Empire" Number="3" Volume="1997" Year="1998">
+<Database Name="cv" Series="6067" Issue="44638" />
+</Book>
+<Book Series="Star Wars: Crimson Empire" Number="4" Volume="1997" Year="1998">
+<Database Name="cv" Series="6067" Issue="44743" />
+</Book>
+<Book Series="Star Wars: Crimson Empire" Number="5" Volume="1997" Year="1998">
+<Database Name="cv" Series="6067" Issue="44840" />
+</Book>
+<Book Series="Star Wars: Crimson Empire" Number="6" Volume="1997" Year="1998">
+<Database Name="cv" Series="6067" Issue="44922" />
+</Book>
+<Book Series="Star Wars: The Bounty Hunters - Kenix Kil" Number="1" Volume="1999" Year="1999">
+<Database Name="cv" Series="28497" Issue="175565" />
+</Book>
+<Book Series="Star Wars: Crimson Empire II - Council Of Blood" Number="1" Volume="1998" Year="1998">
+<Database Name="cv" Series="28324" Issue="174373" />
+</Book>
+<Book Series="Star Wars: Crimson Empire II - Council Of Blood" Number="2" Volume="1998" Year="1998">
+<Database Name="cv" Series="28324" Issue="174494" />
+</Book>
+<Book Series="Star Wars: Crimson Empire II - Council Of Blood" Number="3" Volume="1998" Year="1999">
+<Database Name="cv" Series="28324" Issue="174495" />
+</Book>
+<Book Series="Star Wars: Crimson Empire II - Council Of Blood" Number="4" Volume="1998" Year="1999">
+<Database Name="cv" Series="28324" Issue="174496" />
+</Book>
+<Book Series="Star Wars: Crimson Empire II - Council Of Blood" Number="5" Volume="1998" Year="1999">
+<Database Name="cv" Series="28324" Issue="174497" />
+</Book>
+<Book Series="Star Wars: Crimson Empire II - Council Of Blood" Number="6" Volume="1998" Year="1999">
+<Database Name="cv" Series="28324" Issue="174498" />
+</Book>
+<Book Series="Star Wars: Jedi Academy - Leviathan" Number="1" Volume="1998" Year="1998">
+<Database Name="cv" Series="32520" Issue="205944" />
+</Book>
+<Book Series="Star Wars: Jedi Academy - Leviathan" Number="2" Volume="1998" Year="1998">
+<Database Name="cv" Series="32520" Issue="205946" />
+</Book>
+<Book Series="Star Wars: Jedi Academy - Leviathan" Number="3" Volume="1998" Year="1998">
+<Database Name="cv" Series="32520" Issue="205947" />
+</Book>
+<Book Series="Star Wars: Jedi Academy - Leviathan" Number="4" Volume="1998" Year="1999">
+<Database Name="cv" Series="32520" Issue="205945" />
+</Book>
+<Book Series="Star Wars: Crimson Empire III - Empire Lost" Number="1" Volume="2011" Year="2011">
+<Database Name="cv" Series="43600" Issue="299806" />
+</Book>
+<Book Series="Star Wars: Crimson Empire III - Empire Lost" Number="2" Volume="2011" Year="2011">
+<Database Name="cv" Series="43600" Issue="304957" />
+</Book>
+<Book Series="Star Wars: Crimson Empire III - Empire Lost" Number="3" Volume="2011" Year="2011">
+<Database Name="cv" Series="43600" Issue="309063" />
+</Book>
+<Book Series="Star Wars: Crimson Empire III - Empire Lost" Number="4" Volume="2011" Year="2012">
+<Database Name="cv" Series="43600" Issue="315398" />
+</Book>
+<Book Series="Star Wars: Crimson Empire III - Empire Lost" Number="5" Volume="2011" Year="2012">
+<Database Name="cv" Series="43600" Issue="319359" />
+</Book>
+<Book Series="Star Wars: Crimson Empire III - Empire Lost" Number="6" Volume="2011" Year="2012">
+<Database Name="cv" Series="43600" Issue="333473" />
+</Book>
+<Book Series="Star Wars: Union" Number="1" Volume="1999" Year="1999">
+<Database Name="cv" Series="28286" Issue="174057" />
+</Book>
+<Book Series="Star Wars: Union" Number="2" Volume="1999" Year="1999">
+<Database Name="cv" Series="28286" Issue="174058" />
+</Book>
+<Book Series="Star Wars: Union" Number="3" Volume="1999" Year="2000">
+<Database Name="cv" Series="28286" Issue="174059" />
+</Book>
+<Book Series="Star Wars: Union" Number="4" Volume="1999" Year="2000">
+<Database Name="cv" Series="28286" Issue="174060" />
+</Book>
+<Book Series="Star Wars: Chewbacca" Number="1" Volume="2000" Year="2000">
+<Database Name="cv" Series="23735" Issue="142062" />
+</Book>
+<Book Series="Star Wars: Chewbacca" Number="2" Volume="2000" Year="2000">
+<Database Name="cv" Series="23735" Issue="142063" />
+</Book>
+<Book Series="Star Wars: Chewbacca" Number="3" Volume="2000" Year="2000">
+<Database Name="cv" Series="23735" Issue="142064" />
+</Book>
+<Book Series="Star Wars: Chewbacca" Number="4" Volume="2000" Year="2000">
+<Database Name="cv" Series="23735" Issue="142065" />
+</Book>
+<Book Series="Star Wars: Invasion" Number="0" Volume="2009" Year="2009">
+<Database Name="cv" Series="26982" Issue="175933" />
+</Book>
+<Book Series="Star Wars: Invasion" Number="1" Volume="2009" Year="2009">
+<Database Name="cv" Series="26982" Issue="162959" />
+</Book>
+<Book Series="Star Wars: Invasion" Number="2" Volume="2009" Year="2009">
+<Database Name="cv" Series="26982" Issue="166210" />
+</Book>
+<Book Series="Star Wars: Invasion" Number="3" Volume="2009" Year="2009">
+<Database Name="cv" Series="26982" Issue="169260" />
+</Book>
+<Book Series="Star Wars: Invasion" Number="4" Volume="2009" Year="2009">
+<Database Name="cv" Series="26982" Issue="175018" />
+</Book>
+<Book Series="Star Wars: Invasion" Number="5" Volume="2009" Year="2009">
+<Database Name="cv" Series="26982" Issue="181429" />
+</Book>
+<Book Series="Star Wars: Invasion - Rescues" Number="1" Volume="2010" Year="2010">
+<Database Name="cv" Series="33551" Issue="217693" />
+</Book>
+<Book Series="Star Wars: Invasion - Rescues" Number="2" Volume="2010" Year="2010">
+<Database Name="cv" Series="33551" Issue="221884" />
+</Book>
+<Book Series="Star Wars: Invasion - Rescues" Number="3" Volume="2010" Year="2010">
+<Database Name="cv" Series="33551" Issue="226847" />
+</Book>
+<Book Series="Star Wars: Invasion - Rescues" Number="4" Volume="2010" Year="2010">
+<Database Name="cv" Series="33551" Issue="236694" />
+</Book>
+<Book Series="Star Wars: Invasion - Rescues" Number="5" Volume="2010" Year="2010">
+<Database Name="cv" Series="33551" Issue="240235" />
+</Book>
+<Book Series="Star Wars: Invasion - Rescues" Number="6" Volume="2010" Year="2010">
+<Database Name="cv" Series="33551" Issue="251512" />
+</Book>
+<Book Series="Star Wars: Invasion - Revelations" Number="1" Volume="2011" Year="2011">
+<Database Name="cv" Series="41279" Issue="278719" />
+</Book>
+<Book Series="Star Wars: Invasion - Revelations" Number="2" Volume="2011" Year="2011">
+<Database Name="cv" Series="41279" Issue="285923" />
+</Book>
+<Book Series="Star Wars: Invasion - Revelations" Number="3" Volume="2011" Year="2011">
+<Database Name="cv" Series="41279" Issue="293234" />
+</Book>
+<Book Series="Star Wars: Invasion - Revelations" Number="4" Volume="2011" Year="2011">
+<Database Name="cv" Series="41279" Issue="295209" />
+</Book>
+<Book Series="Star Wars: Invasion - Revelations" Number="5" Volume="2011" Year="2011">
+<Database Name="cv" Series="41279" Issue="303152" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="0" Volume="2006" Year="2006">
+<Database Name="cv" Series="18575" Issue="110786" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="0½" Volume="2006" Year="2008">
+<Database Name="cv" Series="18575" Issue="122805" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="1" Volume="2006" Year="2006">
+<Database Name="cv" Series="18575" Issue="110787" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="8" Volume="2006" Year="2007">
+<Database Name="cv" Series="18575" Issue="110793" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="2" Volume="2006" Year="2006">
+<Database Name="cv" Series="18575" Issue="118784" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="3" Volume="2006" Year="2006">
+<Database Name="cv" Series="18575" Issue="110788" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="4" Volume="2006" Year="2006">
+<Database Name="cv" Series="18575" Issue="110789" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="5" Volume="2006" Year="2006">
+<Database Name="cv" Series="18575" Issue="110791" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="6" Volume="2006" Year="2006">
+<Database Name="cv" Series="18575" Issue="110790" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="7" Volume="2006" Year="2007">
+<Database Name="cv" Series="18575" Issue="110792" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="9" Volume="2006" Year="2007">
+<Database Name="cv" Series="18575" Issue="110815" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="10" Volume="2006" Year="2007">
+<Database Name="cv" Series="18575" Issue="110785" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="11" Volume="2006" Year="2007">
+<Database Name="cv" Series="18575" Issue="109444" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="12" Volume="2006" Year="2007">
+<Database Name="cv" Series="18575" Issue="109824" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="13" Volume="2006" Year="2007">
+<Database Name="cv" Series="18575" Issue="110784" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="14" Volume="2006" Year="2007">
+<Database Name="cv" Series="18575" Issue="111512" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="15" Volume="2006" Year="2007">
+<Database Name="cv" Series="18575" Issue="139215" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="16" Volume="2006" Year="2007">
+<Database Name="cv" Series="18575" Issue="114446" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="17" Volume="2006" Year="2007">
+<Database Name="cv" Series="18575" Issue="118071" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="18" Volume="2006" Year="2007">
+<Database Name="cv" Series="18575" Issue="122124" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="19" Volume="2006" Year="2008">
+<Database Name="cv" Series="18575" Issue="165842" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="20" Volume="2006" Year="2008">
+<Database Name="cv" Series="18575" Issue="125899" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="21" Volume="2006" Year="2008">
+<Database Name="cv" Series="18575" Issue="125900" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="22" Volume="2006" Year="2008">
+<Database Name="cv" Series="18575" Issue="130593" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="23" Volume="2006" Year="2008">
+<Database Name="cv" Series="18575" Issue="130652" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="24" Volume="2006" Year="2008">
+<Database Name="cv" Series="18575" Issue="130653" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="25" Volume="2006" Year="2008">
+<Database Name="cv" Series="18575" Issue="133943" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="26" Volume="2006" Year="2008">
+<Database Name="cv" Series="18575" Issue="134021" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="27" Volume="2006" Year="2008">
+<Database Name="cv" Series="18575" Issue="136607" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="28" Volume="2006" Year="2008">
+<Database Name="cv" Series="18575" Issue="139323" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="29" Volume="2006" Year="2008">
+<Database Name="cv" Series="18575" Issue="141321" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="30" Volume="2006" Year="2008">
+<Database Name="cv" Series="18575" Issue="143282" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="31" Volume="2006" Year="2008">
+<Database Name="cv" Series="18575" Issue="149966" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="32" Volume="2006" Year="2009">
+<Database Name="cv" Series="18575" Issue="150952" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="33" Volume="2006" Year="2009">
+<Database Name="cv" Series="18575" Issue="152149" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="34" Volume="2006" Year="2009">
+<Database Name="cv" Series="18575" Issue="154006" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="35" Volume="2006" Year="2009">
+<Database Name="cv" Series="18575" Issue="156103" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="36" Volume="2006" Year="2009">
+<Database Name="cv" Series="18575" Issue="158568" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="37" Volume="2006" Year="2009">
+<Database Name="cv" Series="18575" Issue="161618" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="38" Volume="2006" Year="2009">
+<Database Name="cv" Series="18575" Issue="165454" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="39" Volume="2006" Year="2009">
+<Database Name="cv" Series="18575" Issue="168420" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="40" Volume="2006" Year="2009">
+<Database Name="cv" Series="18575" Issue="173656" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="41" Volume="2006" Year="2009">
+<Database Name="cv" Series="18575" Issue="179130" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="42" Volume="2006" Year="2009">
+<Database Name="cv" Series="18575" Issue="184961" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="43" Volume="2006" Year="2009">
+<Database Name="cv" Series="18575" Issue="189622" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="44" Volume="2006" Year="2010">
+<Database Name="cv" Series="18575" Issue="194796" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="45" Volume="2006" Year="2010">
+<Database Name="cv" Series="18575" Issue="198239" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="46" Volume="2006" Year="2010">
+<Database Name="cv" Series="18575" Issue="202724" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="47" Volume="2006" Year="2010">
+<Database Name="cv" Series="18575" Issue="210457" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="48" Volume="2006" Year="2010">
+<Database Name="cv" Series="18575" Issue="215966" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="49" Volume="2006" Year="2010">
+<Database Name="cv" Series="18575" Issue="221697" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="50" Volume="2006" Year="2010">
+<Database Name="cv" Series="18575" Issue="230340" />
+</Book>
+<Book Series="Star Wars: Legacy - War" Number="1" Volume="2010" Year="2010">
+<Database Name="cv" Series="37504" Issue="249297" />
+</Book>
+<Book Series="Star Wars: Legacy - War" Number="2" Volume="2010" Year="2011">
+<Database Name="cv" Series="37504" Issue="259319" />
+</Book>
+<Book Series="Star Wars: Legacy - War" Number="3" Volume="2010" Year="2011">
+<Database Name="cv" Series="37504" Issue="264000" />
+</Book>
+<Book Series="Star Wars: Legacy - War" Number="4" Volume="2010" Year="2011">
+<Database Name="cv" Series="37504" Issue="267178" />
+</Book>
+<Book Series="Star Wars: Legacy - War" Number="5" Volume="2010" Year="2011">
+<Database Name="cv" Series="37504" Issue="269046" />
+</Book>
+<Book Series="Star Wars: Legacy - War" Number="6" Volume="2010" Year="2011">
+<Database Name="cv" Series="37504" Issue="271614" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="59185" Issue="394694" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="2" Volume="2013" Year="2013">
+<Database Name="cv" Series="59185" Issue="398975" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="3" Volume="2013" Year="2013">
+<Database Name="cv" Series="59185" Issue="404690" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="4" Volume="2013" Year="2013">
+<Database Name="cv" Series="59185" Issue="413642" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="5" Volume="2013" Year="2013">
+<Database Name="cv" Series="59185" Issue="418807" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="6" Volume="2013" Year="2013">
+<Database Name="cv" Series="59185" Issue="423659" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="7" Volume="2013" Year="2013">
+<Database Name="cv" Series="59185" Issue="426865" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="8" Volume="2013" Year="2013">
+<Database Name="cv" Series="59185" Issue="430745" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="9" Volume="2013" Year="2013">
+<Database Name="cv" Series="59185" Issue="435037" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="10" Volume="2013" Year="2013">
+<Database Name="cv" Series="59185" Issue="437469" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="11" Volume="2013" Year="2014">
+<Database Name="cv" Series="59185" Issue="442904" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="12" Volume="2013" Year="2014">
+<Database Name="cv" Series="59185" Issue="446466" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="13" Volume="2013" Year="2014">
+<Database Name="cv" Series="59185" Issue="448947" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="14" Volume="2013" Year="2014">
+<Database Name="cv" Series="59185" Issue="451068" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="15" Volume="2013" Year="2014">
+<Database Name="cv" Series="59185" Issue="454076" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="16" Volume="2013" Year="2014">
+<Database Name="cv" Series="59185" Issue="457618" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="17" Volume="2013" Year="2014">
+<Database Name="cv" Series="59185" Issue="460292" />
+</Book>
+<Book Series="Star Wars: Legacy" Number="18" Volume="2013" Year="2014">
+<Database Name="cv" Series="59185" Issue="463461" />
+</Book>
+</Books>
+<Matchers />
+</ReadingList>

--- a/Marvel/Star Wars/[Marvel] Star Wars (WEB-CBRO).cbl
+++ b/Marvel/Star Wars/[Marvel] Star Wars (WEB-CBRO).cbl
@@ -1,0 +1,2393 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Name>[Marvel] Star Wars (WEB-CBRO)</Name>
+<NumIssues>807</NumIssues>
+<Books>
+<Book Series="Star Wars: The High Republic: The Blade" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="147135" Issue="961959" />
+</Book>
+<Book Series="Star Wars: The High Republic: The Blade" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="147135" Issue="966428" />
+</Book>
+<Book Series="Star Wars: The High Republic: The Blade" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="147135" Issue="974100" />
+</Book>
+<Book Series="Star Wars: The High Republic: The Blade" Number="4" Volume="2023" Year="2023">
+<Database Name="cv" Series="147135" Issue="979435" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="145478" Issue="950691" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="2" Volume="2022" Year="2023">
+<Database Name="cv" Series="145478" Issue="953978" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="3" Volume="2022" Year="2023">
+<Database Name="cv" Series="145478" Issue="961960" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="4" Volume="2022" Year="2023">
+<Database Name="cv" Series="145478" Issue="963995" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="5" Volume="2022" Year="2023">
+<Database Name="cv" Series="145478" Issue="969395" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="6" Volume="2022" Year="2023">
+<Database Name="cv" Series="145478" Issue="975684" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="7" Volume="2022" Year="2023">
+<Database Name="cv" Series="145478" Issue="979436" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="8" Volume="2022" Year="2023">
+<Database Name="cv" Series="145478" Issue="982367" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="9" Volume="2022" Year="2023">
+<Database Name="cv" Series="145478" Issue="988153" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="10" Volume="2022" Year="2023">
+<Database Name="cv" Series="145478" Issue="991072" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="133079" Issue="824020" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="2" Volume="2021" Year="2021">
+<Database Name="cv" Series="133079" Issue="827516" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="3" Volume="2021" Year="2021">
+<Database Name="cv" Series="133079" Issue="832857" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="4" Volume="2021" Year="2021">
+<Database Name="cv" Series="133079" Issue="842195" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="5" Volume="2021" Year="2021">
+<Database Name="cv" Series="133079" Issue="848846" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="6" Volume="2021" Year="2021">
+<Database Name="cv" Series="133079" Issue="866576" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="7" Volume="2021" Year="2021">
+<Database Name="cv" Series="133079" Issue="874520" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="8" Volume="2021" Year="2021">
+<Database Name="cv" Series="133079" Issue="878790" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="9" Volume="2021" Year="2021">
+<Database Name="cv" Series="133079" Issue="882882" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="10" Volume="2021" Year="2021">
+<Database Name="cv" Series="133079" Issue="890598" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="11" Volume="2021" Year="2022">
+<Database Name="cv" Series="133079" Issue="894113" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="12" Volume="2021" Year="2022">
+<Database Name="cv" Series="133079" Issue="898529" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="13" Volume="2021" Year="2022">
+<Database Name="cv" Series="133079" Issue="903810" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="14" Volume="2021" Year="2022">
+<Database Name="cv" Series="133079" Issue="905798" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="15" Volume="2021" Year="2022">
+<Database Name="cv" Series="133079" Issue="909808" />
+</Book>
+<Book Series="Star Wars: The High Republic: Trail of Shadows" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="139561" Issue="889458" />
+</Book>
+<Book Series="Star Wars: The High Republic: Trail of Shadows" Number="2" Volume="2021" Year="2022">
+<Database Name="cv" Series="139561" Issue="895363" />
+</Book>
+<Book Series="Star Wars: The High Republic: Trail of Shadows" Number="3" Volume="2021" Year="2022">
+<Database Name="cv" Series="139561" Issue="899197" />
+</Book>
+<Book Series="Star Wars: The High Republic: Trail of Shadows" Number="4" Volume="2021" Year="2022">
+<Database Name="cv" Series="139561" Issue="904777" />
+</Book>
+<Book Series="Star Wars: The High Republic: Trail of Shadows" Number="5" Volume="2021" Year="2022">
+<Database Name="cv" Series="139561" Issue="906640" />
+</Book>
+<Book Series="Star Wars: The High Republic: Eye of the Storm" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="141156" Issue="902530" />
+</Book>
+<Book Series="Star Wars: The High Republic: Eye of the Storm" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="141156" Issue="909803" />
+</Book>
+<Book Series="Star Wars: The High Republic: Shadows of Starlight" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153862" Issue="1020541" />
+</Book>
+<Book Series="Star Wars: The High Republic: Shadows of Starlight" Number="2" Volume="2023" Year="2024">
+<Database Name="cv" Series="153862" Issue="1028632" />
+</Book>
+<Book Series="Star Wars: The High Republic: Shadows of Starlight" Number="3" Volume="2023" Year="2024">
+<Database Name="cv" Series="153862" Issue="1034347" />
+</Book>
+<Book Series="Star Wars: The High Republic: Shadows of Starlight" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="153862" Issue="1038982" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="154553" Issue="1028633" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="154553" Issue="1035966" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="154553" Issue="1040947" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="154553" Issue="1047089" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="5" Volume="2024" Year="2024">
+<Database Name="cv" Series="154553" Issue="1048674" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="6" Volume="2024" Year="2024">
+<Database Name="cv" Series="154553" Issue="1051128" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="7" Volume="2024" Year="2024">
+<Database Name="cv" Series="154553" Issue="1054382" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="8" Volume="2024" Year="2024">
+<Database Name="cv" Series="154553" Issue="1058722" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="9" Volume="2024" Year="2024">
+<Database Name="cv" Series="154553" Issue="1061876" />
+</Book>
+<Book Series="Star Wars: The High Republic" Number="10" Volume="2024" Year="2024">
+<Database Name="cv" Series="154553" Issue="1066306" />
+</Book>
+<Book Series="Star Wars: The High Republic [Phase III] – Fear of the Jedi" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="162488" Issue="1096476" />
+</Book>
+<Book Series="Star Wars: The High Republic [Phase III] – Fear of the Jedi" Number="2" Volume="2025" Year="2025">
+<Database Name="cv" Series="162488" Issue="1100291" />
+</Book>
+<Book Series="Star Wars: The High Republic [Phase III] – Fear of the Jedi" Number="3" Volume="2025" Year="2025">
+<Database Name="cv" Series="162488" Issue="1107192" />
+</Book>
+<Book Series="Star Wars: The High Republic [Phase III] – Fear of the Jedi" Number="4" Volume="2025" Year="2025">
+<Database Name="cv" Series="162488" Issue="1111724" />
+</Book>
+<Book Series="Star Wars: The High Republic [Phase III] – Fear of the Jedi" Number="5" Volume="2025" Year="2025">
+<Database Name="cv" Series="162488" Issue="1114021" />
+</Book>
+<Book Series="Star Wars: The High Republic: The Finale" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="165999" Issue="1123210" />
+</Book>
+<Book Series="Star Wars: The Acolyte Kelnacca" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="159609" Issue="1068662" />
+</Book>
+<Book Series="Star Wars: Mace Windu" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="156646" Issue="1043838" />
+</Book>
+<Book Series="Star Wars: Mace Windu" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="156646" Issue="1047953" />
+</Book>
+<Book Series="Star Wars: Mace Windu" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="156646" Issue="1051502" />
+</Book>
+<Book Series="Star Wars: Mace Windu" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="156646" Issue="1055030" />
+</Book>
+<Book Series="Star Wars: Age of Republic - Qui-Gon Jinn" Number="1" Volume="2018" Year="2019">
+<Database Name="cv" Series="115764" Issue="694146" />
+</Book>
+<Book Series="Star Wars: Jedi Knights" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="162624" Issue="1097719" />
+</Book>
+<Book Series="Star Wars: Jedi Knights" Number="2" Volume="2025" Year="2025">
+<Database Name="cv" Series="162624" Issue="1102466" />
+</Book>
+<Book Series="Star Wars: Jedi Knights" Number="3" Volume="2025" Year="2025">
+<Database Name="cv" Series="162624" Issue="1109660" />
+</Book>
+<Book Series="Star Wars: Jedi Knights" Number="4" Volume="2025" Year="2025">
+<Database Name="cv" Series="162624" Issue="1114020" />
+</Book>
+<Book Series="Star Wars: Jedi Knights" Number="5" Volume="2025" Year="2025">
+<Database Name="cv" Series="162624" Issue="1117441" />
+</Book>
+<Book Series="Star Wars: Jedi Knights" Number="6" Volume="2025" Year="2025">
+<Database Name="cv" Series="162624" Issue="1125797" />
+</Book>
+<Book Series="Star Wars: Jedi Knights" Number="7" Volume="2025" Year="2025">
+<Database Name="cv" Series="162624" Issue="1131770" />
+</Book>
+<Book Series="Star Wars: Jedi Knights" Number="8" Volume="2025" Year="2025">
+<Database Name="cv" Series="162624" Issue="1139087" />
+</Book>
+<Book Series="Star Wars: Jedi Knights" Number="9" Volume="2025" Year="2026">
+<Database Name="cv" Series="162624" Issue="1144100" />
+</Book>
+<Book Series="Star Wars: Jedi Knights" Number="10" Volume="2025" Year="2026">
+<Database Name="cv" Series="162624" Issue="1148757" />
+</Book>
+<Book Series="Star Wars: Darth Maul - Black, White &amp; Red" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="157844" Issue="1052941" />
+</Book>
+<Book Series="Star Wars: Darth Maul - Black, White &amp; Red" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="157844" Issue="1057014" />
+</Book>
+<Book Series="Star Wars: Darth Maul - Black, White &amp; Red" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="157844" Issue="1061066" />
+</Book>
+<Book Series="Star Wars: Darth Maul - Black, White &amp; Red" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="157844" Issue="1065484" />
+</Book>
+<Book Series="Star Wars: Jango Fett" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="157309" Issue="1048673" />
+</Book>
+<Book Series="Star Wars: Jango Fett" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="157309" Issue="1052942" />
+</Book>
+<Book Series="Star Wars: Jango Fett" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="157309" Issue="1057015" />
+</Book>
+<Book Series="Star Wars: Jango Fett" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="157309" Issue="1060174" />
+</Book>
+<Book Series="Star Wars: Darth Maul" Number="1" Volume="2017" Year="2017">
+<Database Name="cv" Series="98517" Issue="579311" />
+</Book>
+<Book Series="Star Wars: Darth Maul" Number="2" Volume="2017" Year="2017">
+<Database Name="cv" Series="98517" Issue="588559" />
+</Book>
+<Book Series="Star Wars: Darth Maul" Number="3" Volume="2017" Year="2017">
+<Database Name="cv" Series="98517" Issue="593273" />
+</Book>
+<Book Series="Star Wars: Darth Maul" Number="4" Volume="2017" Year="2017">
+<Database Name="cv" Series="98517" Issue="603141" />
+</Book>
+<Book Series="Star Wars: Darth Maul" Number="5" Volume="2017" Year="2017">
+<Database Name="cv" Series="98517" Issue="609362" />
+</Book>
+<Book Series="Star Wars: Age of Republic - Darth Maul" Number="1" Volume="2018" Year="2019">
+<Database Name="cv" Series="115909" Issue="694926" />
+</Book>
+<Book Series="Star Wars: Phantom Menace 25th Anniversary Special" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="157942" Issue="1053544" />
+</Book>
+<Book Series="Star Wars: Age of Republic - Obi-Wan Kenobi" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="116265" Issue="696367" />
+</Book>
+<Book Series="Obi-Wan and Anakin" Number="1" Volume="2015" Year="2016">
+<Database Name="cv" Series="86986" Issue="509706" />
+</Book>
+<Book Series="Obi-Wan and Anakin" Number="2" Volume="2015" Year="2016">
+<Database Name="cv" Series="86986" Issue="513653" />
+</Book>
+<Book Series="Obi-Wan and Anakin" Number="3" Volume="2015" Year="2016">
+<Database Name="cv" Series="86986" Issue="521340" />
+</Book>
+<Book Series="Obi-Wan and Anakin" Number="4" Volume="2015" Year="2016">
+<Database Name="cv" Series="86986" Issue="526064" />
+</Book>
+<Book Series="Obi-Wan and Anakin" Number="5" Volume="2015" Year="2016">
+<Database Name="cv" Series="86986" Issue="531896" />
+</Book>
+<Book Series="Star Wars: Age of Republic - Count Dooku" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="117082" Issue="700686" />
+</Book>
+<Book Series="Star Wars: Age of Republic - Jango Fett" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="116384" Issue="696955" />
+</Book>
+<Book Series="Star Wars: Mace Windu" Number="1" Volume="2017" Year="2017">
+<Database Name="cv" Series="103834" Issue="617854" />
+</Book>
+<Book Series="Star Wars: Mace Windu" Number="2" Volume="2017" Year="2017">
+<Database Name="cv" Series="103834" Issue="625327" />
+</Book>
+<Book Series="Star Wars: Mace Windu" Number="3" Volume="2017" Year="2017">
+<Database Name="cv" Series="103834" Issue="632505" />
+</Book>
+<Book Series="Star Wars: Mace Windu" Number="4" Volume="2017" Year="2018">
+<Database Name="cv" Series="103834" Issue="643043" />
+</Book>
+<Book Series="Star Wars: Mace Windu" Number="5" Volume="2017" Year="2018">
+<Database Name="cv" Series="103834" Issue="649746" />
+</Book>
+<Book Series="Star Wars: Age of Republic: Anakin Skywalker" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="116987" Issue="700149" />
+</Book>
+<Book Series="Star Wars: Age of Republic - General Grievous" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="117606" Issue="703065" />
+</Book>
+<Book Series="Star Wars: Age of Republic Special" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="116514" Issue="697644" />
+</Book>
+<Book Series="Star Wars: Age of Republic - Padme Amidala" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="117471" Issue="702473" />
+</Book>
+<Book Series="Star Wars: Darth Maul - Son of Dathomir" Number="1" Volume="2014" Year="2014">
+<Database Name="cv" Series="74107" Issue="453392" />
+</Book>
+<Book Series="Star Wars: Darth Maul - Son of Dathomir" Number="2" Volume="2014" Year="2014">
+<Database Name="cv" Series="74107" Issue="456529" />
+</Book>
+<Book Series="Star Wars: Darth Maul - Son of Dathomir" Number="3" Volume="2014" Year="2014">
+<Database Name="cv" Series="74107" Issue="459652" />
+</Book>
+<Book Series="Star Wars: Darth Maul - Son of Dathomir" Number="4" Volume="2014" Year="2014">
+<Database Name="cv" Series="74107" Issue="462865" />
+</Book>
+<Book Series="Darth Vader" Number="1" Volume="2017" Year="2017">
+<Database Name="cv" Series="101960" Issue="599878" />
+</Book>
+<Book Series="Darth Vader" Number="2" Volume="2017" Year="2017">
+<Database Name="cv" Series="101960" Issue="603120" />
+</Book>
+<Book Series="Darth Vader" Number="3" Volume="2017" Year="2017">
+<Database Name="cv" Series="101960" Issue="608240" />
+</Book>
+<Book Series="Darth Vader" Number="4" Volume="2017" Year="2017">
+<Database Name="cv" Series="101960" Issue="612037" />
+</Book>
+<Book Series="Darth Vader" Number="5" Volume="2017" Year="2017">
+<Database Name="cv" Series="101960" Issue="619620" />
+</Book>
+<Book Series="Darth Vader" Number="6" Volume="2017" Year="2017">
+<Database Name="cv" Series="101960" Issue="626279" />
+</Book>
+<Book Series="Darth Vader" Number="7" Volume="2017" Year="2018">
+<Database Name="cv" Series="101960" Issue="634530" />
+</Book>
+<Book Series="Darth Vader" Number="8" Volume="2017" Year="2018">
+<Database Name="cv" Series="101960" Issue="638592" />
+</Book>
+<Book Series="Darth Vader" Number="9" Volume="2017" Year="2018">
+<Database Name="cv" Series="101960" Issue="644503" />
+</Book>
+<Book Series="Darth Vader" Number="10" Volume="2017" Year="2018">
+<Database Name="cv" Series="101960" Issue="652626" />
+</Book>
+<Book Series="Star Wars: Age of Rebellion - Darth Vader" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="119878" Issue="712548" />
+</Book>
+<Book Series="Darth Vader" Number="11" Volume="2017" Year="2018">
+<Database Name="cv" Series="101960" Issue="660014" />
+</Book>
+<Book Series="Darth Vader" Number="12" Volume="2017" Year="2018">
+<Database Name="cv" Series="101960" Issue="661146" />
+</Book>
+<Book Series="Darth Vader" Number="13" Volume="2017" Year="2018">
+<Database Name="cv" Series="101960" Issue="662741" />
+</Book>
+<Book Series="Darth Vader" Number="14" Volume="2017" Year="2018">
+<Database Name="cv" Series="101960" Issue="665909" />
+</Book>
+<Book Series="Darth Vader" Number="15" Volume="2017" Year="2018">
+<Database Name="cv" Series="101960" Issue="667636" />
+</Book>
+<Book Series="Darth Vader" Number="16" Volume="2017" Year="2018">
+<Database Name="cv" Series="101960" Issue="669444" />
+</Book>
+<Book Series="Darth Vader" Number="17" Volume="2017" Year="2018">
+<Database Name="cv" Series="101960" Issue="673014" />
+</Book>
+<Book Series="Darth Vader Annual" Number="2" Volume="2015" Year="2018">
+<Database Name="cv" Series="86684" Issue="677276" />
+</Book>
+<Book Series="Darth Vader" Number="18" Volume="2017" Year="2018">
+<Database Name="cv" Series="101960" Issue="676695" />
+</Book>
+<Book Series="Darth Vader" Number="19" Volume="2017" Year="2018">
+<Database Name="cv" Series="101960" Issue="679408" />
+</Book>
+<Book Series="Darth Vader" Number="20" Volume="2017" Year="2018">
+<Database Name="cv" Series="101960" Issue="680724" />
+</Book>
+<Book Series="Darth Vader" Number="21" Volume="2017" Year="2018">
+<Database Name="cv" Series="101960" Issue="684902" />
+</Book>
+<Book Series="Darth Vader" Number="22" Volume="2017" Year="2018">
+<Database Name="cv" Series="101960" Issue="689040" />
+</Book>
+<Book Series="Darth Vader" Number="23" Volume="2017" Year="2019">
+<Database Name="cv" Series="101960" Issue="692063" />
+</Book>
+<Book Series="Darth Vader" Number="24" Volume="2017" Year="2019">
+<Database Name="cv" Series="101960" Issue="693459" />
+</Book>
+<Book Series="Darth Vader" Number="25" Volume="2017" Year="2019">
+<Database Name="cv" Series="101960" Issue="695629" />
+</Book>
+<Book Series="Star Wars: Jedi Fallen Order–Dark Temple" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="121107" Issue="718135" />
+</Book>
+<Book Series="Star Wars: Jedi Fallen Order–Dark Temple" Number="2" Volume="2019" Year="2019">
+<Database Name="cv" Series="121107" Issue="720173" />
+</Book>
+<Book Series="Star Wars: Jedi Fallen Order–Dark Temple" Number="3" Volume="2019" Year="2019">
+<Database Name="cv" Series="121107" Issue="721790" />
+</Book>
+<Book Series="Star Wars: Jedi Fallen Order–Dark Temple" Number="4" Volume="2019" Year="2020">
+<Database Name="cv" Series="121107" Issue="727269" />
+</Book>
+<Book Series="Star Wars: Jedi Fallen Order–Dark Temple" Number="5" Volume="2019" Year="2020">
+<Database Name="cv" Series="121107" Issue="729686" />
+</Book>
+<Book Series="Star Wars: Beckett" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="112825" Issue="680003" />
+</Book>
+<Book Series="Star Wars: Han Solo - Imperial Cadet" Number="1" Volume="2018" Year="2019">
+<Database Name="cv" Series="115082" Issue="691393" />
+</Book>
+<Book Series="Star Wars: Han Solo - Imperial Cadet" Number="2" Volume="2018" Year="2019">
+<Database Name="cv" Series="115082" Issue="694928" />
+</Book>
+<Book Series="Star Wars: Han Solo - Imperial Cadet" Number="3" Volume="2018" Year="2019">
+<Database Name="cv" Series="115082" Issue="696368" />
+</Book>
+<Book Series="Star Wars: Han Solo - Imperial Cadet" Number="4" Volume="2018" Year="2019">
+<Database Name="cv" Series="115082" Issue="700687" />
+</Book>
+<Book Series="Star Wars: Han Solo - Imperial Cadet" Number="5" Volume="2018" Year="2019">
+<Database Name="cv" Series="115082" Issue="703066" />
+</Book>
+<Book Series="Star Wars: Lando: Double Or Nothing" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="111154" Issue="671340" />
+</Book>
+<Book Series="Star Wars: Lando: Double Or Nothing" Number="2" Volume="2018" Year="2018">
+<Database Name="cv" Series="111154" Issue="675155" />
+</Book>
+<Book Series="Star Wars: Lando: Double Or Nothing" Number="3" Volume="2018" Year="2018">
+<Database Name="cv" Series="111154" Issue="677979" />
+</Book>
+<Book Series="Star Wars: Lando: Double Or Nothing" Number="4" Volume="2018" Year="2018">
+<Database Name="cv" Series="111154" Issue="682665" />
+</Book>
+<Book Series="Star Wars: Lando: Double Or Nothing" Number="5" Volume="2018" Year="2018">
+<Database Name="cv" Series="111154" Issue="685858" />
+</Book>
+<Book Series="Solo: A Star Wars Story Adaptation" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="114269" Issue="688326" />
+</Book>
+<Book Series="Solo: A Star Wars Story Adaptation" Number="2" Volume="2018" Year="2019">
+<Database Name="cv" Series="114269" Issue="692555" />
+</Book>
+<Book Series="Solo: A Star Wars Story Adaptation" Number="3" Volume="2018" Year="2019">
+<Database Name="cv" Series="114269" Issue="695659" />
+</Book>
+<Book Series="Solo: A Star Wars Story Adaptation" Number="4" Volume="2018" Year="2019">
+<Database Name="cv" Series="114269" Issue="699407" />
+</Book>
+<Book Series="Solo: A Star Wars Story Adaptation" Number="5" Volume="2018" Year="2019">
+<Database Name="cv" Series="114269" Issue="701323" />
+</Book>
+<Book Series="Solo: A Star Wars Story Adaptation" Number="6" Volume="2018" Year="2019">
+<Database Name="cv" Series="114269" Issue="703951" />
+</Book>
+<Book Series="Solo: A Star Wars Story Adaptation" Number="7" Volume="2018" Year="2019">
+<Database Name="cv" Series="114269" Issue="705482" />
+</Book>
+<Book Series="Star Wars: Inquisitors" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="158697" Issue="1061875" />
+</Book>
+<Book Series="Star Wars: Inquisitors" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="158697" Issue="1066305" />
+</Book>
+<Book Series="Star Wars: Inquisitors" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="158697" Issue="1069418" />
+</Book>
+<Book Series="Star Wars: Inquisitors" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="158697" Issue="1072219" />
+</Book>
+<Book Series="Star Wars: Obi-Wan Kenobi" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153471" Issue="1013499" />
+</Book>
+<Book Series="Star Wars: Obi-Wan Kenobi" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="153471" Issue="1025165" />
+</Book>
+<Book Series="Star Wars: Obi-Wan Kenobi" Number="3" Volume="2023" Year="2024">
+<Database Name="cv" Series="153471" Issue="1032226" />
+</Book>
+<Book Series="Star Wars: Obi-Wan Kenobi" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="153471" Issue="1040946" />
+</Book>
+<Book Series="Star Wars: Obi-Wan Kenobi" Number="5" Volume="2023" Year="2024">
+<Database Name="cv" Series="153471" Issue="1043839" />
+</Book>
+<Book Series="Star Wars: Obi-Wan Kenobi" Number="6" Volume="2023" Year="2024">
+<Database Name="cv" Series="153471" Issue="1049280" />
+</Book>
+<Book Series="Kanan" Number="1" Volume="2015" Year="2015">
+<Database Name="cv" Series="81088" Issue="484899" />
+</Book>
+<Book Series="Kanan" Number="2" Volume="2015" Year="2015">
+<Database Name="cv" Series="81088" Issue="487838" />
+</Book>
+<Book Series="Kanan" Number="3" Volume="2015" Year="2015">
+<Database Name="cv" Series="81088" Issue="491516" />
+</Book>
+<Book Series="Kanan" Number="4" Volume="2015" Year="2015">
+<Database Name="cv" Series="81088" Issue="495800" />
+</Book>
+<Book Series="Kanan" Number="5" Volume="2015" Year="2015">
+<Database Name="cv" Series="81088" Issue="497947" />
+</Book>
+<Book Series="Kanan" Number="6" Volume="2015" Year="2015">
+<Database Name="cv" Series="81088" Issue="501025" />
+</Book>
+<Book Series="Kanan" Number="7" Volume="2015" Year="2015">
+<Database Name="cv" Series="81088" Issue="504342" />
+</Book>
+<Book Series="Kanan" Number="8" Volume="2015" Year="2016">
+<Database Name="cv" Series="81088" Issue="506171" />
+</Book>
+<Book Series="Kanan" Number="9" Volume="2015" Year="2016">
+<Database Name="cv" Series="81088" Issue="508430" />
+</Book>
+<Book Series="Kanan" Number="10" Volume="2015" Year="2016">
+<Database Name="cv" Series="81088" Issue="512428" />
+</Book>
+<Book Series="Kanan" Number="11" Volume="2015" Year="2016">
+<Database Name="cv" Series="81088" Issue="516957" />
+</Book>
+<Book Series="Kanan" Number="12" Volume="2015" Year="2016">
+<Database Name="cv" Series="81088" Issue="520204" />
+</Book>
+<Book Series="Star Wars: Thrawn" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="108758" Issue="660025" />
+</Book>
+<Book Series="Star Wars: Thrawn" Number="2" Volume="2018" Year="2018">
+<Database Name="cv" Series="108758" Issue="662754" />
+</Book>
+<Book Series="Star Wars: Thrawn" Number="3" Volume="2018" Year="2018">
+<Database Name="cv" Series="108758" Issue="665922" />
+</Book>
+<Book Series="Star Wars: Thrawn" Number="4" Volume="2018" Year="2018">
+<Database Name="cv" Series="108758" Issue="669460" />
+</Book>
+<Book Series="Star Wars: Thrawn" Number="5" Volume="2018" Year="2018">
+<Database Name="cv" Series="108758" Issue="673033" />
+</Book>
+<Book Series="Star Wars: Thrawn" Number="6" Volume="2018" Year="2018">
+<Database Name="cv" Series="108758" Issue="676710" />
+</Book>
+<Book Series="Star Wars: Han Solo &amp; Chewbacca" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="141846" Issue="910643" />
+</Book>
+<Book Series="Star Wars: Han Solo &amp; Chewbacca" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="141846" Issue="925009" />
+</Book>
+<Book Series="Star Wars: Han Solo &amp; Chewbacca" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="141846" Issue="933091" />
+</Book>
+<Book Series="Star Wars: Han Solo &amp; Chewbacca" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="141846" Issue="937740" />
+</Book>
+<Book Series="Star Wars: Han Solo &amp; Chewbacca" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="141846" Issue="941571" />
+</Book>
+<Book Series="Star Wars: Han Solo &amp; Chewbacca" Number="6" Volume="2022" Year="2022">
+<Database Name="cv" Series="141846" Issue="949156" />
+</Book>
+<Book Series="Star Wars: Han Solo &amp; Chewbacca" Number="7" Volume="2022" Year="2023">
+<Database Name="cv" Series="141846" Issue="955114" />
+</Book>
+<Book Series="Star Wars: Han Solo &amp; Chewbacca" Number="8" Volume="2022" Year="2023">
+<Database Name="cv" Series="141846" Issue="961957" />
+</Book>
+<Book Series="Star Wars: Han Solo &amp; Chewbacca" Number="9" Volume="2022" Year="2023">
+<Database Name="cv" Series="141846" Issue="964954" />
+</Book>
+<Book Series="Star Wars: Han Solo &amp; Chewbacca" Number="10" Volume="2022" Year="2023">
+<Database Name="cv" Series="141846" Issue="974102" />
+</Book>
+<Book Series="Star Wars: Thrawn - Alliances" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="156368" Issue="1042232" />
+</Book>
+<Book Series="Star Wars: Thrawn - Alliances" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="156368" Issue="1046274" />
+</Book>
+<Book Series="Star Wars: Thrawn - Alliances" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="156368" Issue="1048675" />
+</Book>
+<Book Series="Star Wars: Thrawn - Alliances" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="156368" Issue="1051129" />
+</Book>
+<Book Series="Star Wars: Rogue One - Cassian &amp; K2SO Special" Number="1" Volume="2017" Year="2017">
+<Database Name="cv" Series="103413" Issue="613807" />
+</Book>
+<Book Series="Star Wars: Vader: Dark Visions" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="117473" Issue="702475" />
+</Book>
+<Book Series="Star Wars: Vader: Dark Visions" Number="2" Volume="2019" Year="2019">
+<Database Name="cv" Series="117473" Issue="704830" />
+</Book>
+<Book Series="Star Wars: Vader: Dark Visions" Number="3" Volume="2019" Year="2019">
+<Database Name="cv" Series="117473" Issue="706965" />
+</Book>
+<Book Series="Star Wars: Vader: Dark Visions" Number="4" Volume="2019" Year="2019">
+<Database Name="cv" Series="117473" Issue="710118" />
+</Book>
+<Book Series="Star Wars: Vader: Dark Visions" Number="5" Volume="2019" Year="2019">
+<Database Name="cv" Series="117473" Issue="711331" />
+</Book>
+<Book Series="Star Wars: Obi-Wan" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="142775" Issue="921182" />
+</Book>
+<Book Series="Star Wars: Obi-Wan" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="142775" Issue="933090" />
+</Book>
+<Book Series="Star Wars: Obi-Wan" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="142775" Issue="939092" />
+</Book>
+<Book Series="Star Wars: Obi-Wan" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="142775" Issue="945049" />
+</Book>
+<Book Series="Star Wars: Obi-Wan" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="142775" Issue="946722" />
+</Book>
+<Book Series="Star Wars: Rogue One Adaptation" Number="1" Volume="2017" Year="2017">
+<Database Name="cv" Series="100597" Issue="590808" />
+</Book>
+<Book Series="Star Wars: Rogue One Adaptation" Number="2" Volume="2017" Year="2017">
+<Database Name="cv" Series="100597" Issue="594127" />
+</Book>
+<Book Series="Star Wars: Rogue One Adaptation" Number="3" Volume="2017" Year="2017">
+<Database Name="cv" Series="100597" Issue="599879" />
+</Book>
+<Book Series="Star Wars: Rogue One Adaptation" Number="4" Volume="2017" Year="2017">
+<Database Name="cv" Series="100597" Issue="606641" />
+</Book>
+<Book Series="Star Wars: Rogue One Adaptation" Number="5" Volume="2017" Year="2017">
+<Database Name="cv" Series="100597" Issue="612052" />
+</Book>
+<Book Series="Star Wars: Rogue One Adaptation" Number="6" Volume="2017" Year="2017">
+<Database Name="cv" Series="100597" Issue="619641" />
+</Book>
+<Book Series="Star Wars: Age of Rebellion - Grand Moff Tarkin" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="118269" Issue="705929" />
+</Book>
+<Book Series="Princess Leia" Number="1" Volume="2015" Year="2015">
+<Database Name="cv" Series="80455" Issue="481612" />
+</Book>
+<Book Series="Princess Leia" Number="2" Volume="2015" Year="2015">
+<Database Name="cv" Series="80455" Issue="482691" />
+</Book>
+<Book Series="Princess Leia" Number="3" Volume="2015" Year="2015">
+<Database Name="cv" Series="80455" Issue="487212" />
+</Book>
+<Book Series="Princess Leia" Number="4" Volume="2015" Year="2015">
+<Database Name="cv" Series="80455" Issue="490886" />
+</Book>
+<Book Series="Princess Leia" Number="5" Volume="2015" Year="2015">
+<Database Name="cv" Series="80455" Issue="493795" />
+</Book>
+<Book Series="Star Wars: Age of Rebellion - Han Solo" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="118664" Issue="707524" />
+</Book>
+<Book Series="Chewbacca" Number="1" Volume="2015" Year="2015">
+<Database Name="cv" Series="85275" Issue="502857" />
+</Book>
+<Book Series="Chewbacca" Number="2" Volume="2015" Year="2015">
+<Database Name="cv" Series="85275" Issue="504335" />
+</Book>
+<Book Series="Chewbacca" Number="3" Volume="2015" Year="2016">
+<Database Name="cv" Series="85275" Issue="505516" />
+</Book>
+<Book Series="Chewbacca" Number="4" Volume="2015" Year="2016">
+<Database Name="cv" Series="85275" Issue="506649" />
+</Book>
+<Book Series="Chewbacca" Number="5" Volume="2015" Year="2016">
+<Database Name="cv" Series="85275" Issue="509699" />
+</Book>
+<Book Series="Star Wars Annual" Number="4" Volume="2015" Year="2018">
+<Database Name="cv" Series="86555" Issue="670757" />
+</Book>
+<Book Series="Han Solo" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="91286" Issue="535354" />
+</Book>
+<Book Series="Han Solo" Number="2" Volume="2016" Year="2016">
+<Database Name="cv" Series="91286" Issue="538508" />
+</Book>
+<Book Series="Han Solo" Number="3" Volume="2016" Year="2016">
+<Database Name="cv" Series="91286" Issue="547279" />
+</Book>
+<Book Series="Han Solo" Number="4" Volume="2016" Year="2016">
+<Database Name="cv" Series="91286" Issue="553010" />
+</Book>
+<Book Series="Han Solo" Number="5" Volume="2016" Year="2017">
+<Database Name="cv" Series="91286" Issue="558968" />
+</Book>
+<Book Series="Lando" Number="1" Volume="2015" Year="2015">
+<Database Name="cv" Series="83142" Issue="494322" />
+</Book>
+<Book Series="Lando" Number="2" Volume="2015" Year="2015">
+<Database Name="cv" Series="83142" Issue="497391" />
+</Book>
+<Book Series="Lando" Number="3" Volume="2015" Year="2015">
+<Database Name="cv" Series="83142" Issue="498389" />
+</Book>
+<Book Series="Lando" Number="4" Volume="2015" Year="2015">
+<Database Name="cv" Series="83142" Issue="500305" />
+</Book>
+<Book Series="Lando" Number="5" Volume="2015" Year="2015">
+<Database Name="cv" Series="83142" Issue="502121" />
+</Book>
+<Book Series="Star Wars" Number="1" Volume="2015" Year="2015">
+<Database Name="cv" Series="79398" Issue="475858" />
+</Book>
+<Book Series="Star Wars" Number="2" Volume="2015" Year="2015">
+<Database Name="cv" Series="79398" Issue="478615" />
+</Book>
+<Book Series="Star Wars" Number="3" Volume="2015" Year="2015">
+<Database Name="cv" Series="79398" Issue="482166" />
+</Book>
+<Book Series="Darth Vader" Number="1" Volume="2015" Year="2015">
+<Database Name="cv" Series="79990" Issue="479258" />
+</Book>
+<Book Series="Star Wars" Number="4" Volume="2015" Year="2015">
+<Database Name="cv" Series="79398" Issue="486727" />
+</Book>
+<Book Series="Darth Vader" Number="2" Volume="2015" Year="2015">
+<Database Name="cv" Series="79990" Issue="480682" />
+</Book>
+<Book Series="Darth Vader" Number="3" Volume="2015" Year="2015">
+<Database Name="cv" Series="79990" Issue="483346" />
+</Book>
+<Book Series="Darth Vader" Number="4" Volume="2015" Year="2015">
+<Database Name="cv" Series="79990" Issue="485510" />
+</Book>
+<Book Series="Star Wars" Number="5" Volume="2015" Year="2015">
+<Database Name="cv" Series="79398" Issue="489328" />
+</Book>
+<Book Series="Star Wars" Number="6" Volume="2015" Year="2015">
+<Database Name="cv" Series="79398" Issue="490890" />
+</Book>
+<Book Series="Darth Vader" Number="5" Volume="2015" Year="2015">
+<Database Name="cv" Series="79990" Issue="488647" />
+</Book>
+<Book Series="Darth Vader" Number="6" Volume="2015" Year="2015">
+<Database Name="cv" Series="79990" Issue="490879" />
+</Book>
+<Book Series="Star Wars" Number="7" Volume="2015" Year="2015">
+<Database Name="cv" Series="79398" Issue="496399" />
+</Book>
+<Book Series="Star Wars" Number="8" Volume="2015" Year="2015">
+<Database Name="cv" Series="79398" Issue="497960" />
+</Book>
+<Book Series="Star Wars" Number="9" Volume="2015" Year="2015">
+<Database Name="cv" Series="79398" Issue="500309" />
+</Book>
+<Book Series="Star Wars" Number="10" Volume="2015" Year="2015">
+<Database Name="cv" Series="79398" Issue="502133" />
+</Book>
+<Book Series="Star Wars" Number="11" Volume="2015" Year="2016">
+<Database Name="cv" Series="79398" Issue="504949" />
+</Book>
+<Book Series="Star Wars" Number="12" Volume="2015" Year="2016">
+<Database Name="cv" Series="79398" Issue="506184" />
+</Book>
+<Book Series="Darth Vader" Number="7" Volume="2015" Year="2015">
+<Database Name="cv" Series="79990" Issue="493789" />
+</Book>
+<Book Series="Darth Vader" Number="8" Volume="2015" Year="2015">
+<Database Name="cv" Series="79990" Issue="496878" />
+</Book>
+<Book Series="Darth Vader" Number="9" Volume="2015" Year="2015">
+<Database Name="cv" Series="79990" Issue="499742" />
+</Book>
+<Book Series="Darth Vader" Number="10" Volume="2015" Year="2015">
+<Database Name="cv" Series="79990" Issue="502114" />
+</Book>
+<Book Series="Darth Vader" Number="11" Volume="2015" Year="2015">
+<Database Name="cv" Series="79990" Issue="503557" />
+</Book>
+<Book Series="Darth Vader" Number="12" Volume="2015" Year="2016">
+<Database Name="cv" Series="79990" Issue="505517" />
+</Book>
+<Book Series="Star Wars Annual" Number="1" Volume="2015" Year="2016">
+<Database Name="cv" Series="86555" Issue="507784" />
+</Book>
+<Book Series="Darth Vader Annual" Number="1" Volume="2015" Year="2016">
+<Database Name="cv" Series="86684" Issue="508426" />
+</Book>
+<Book Series="Star Wars: Vader Down" Number="1" Volume="2015" Year="2016">
+<Database Name="cv" Series="86131" Issue="506185" />
+</Book>
+<Book Series="Darth Vader" Number="13" Volume="2015" Year="2016">
+<Database Name="cv" Series="79990" Issue="506650" />
+</Book>
+<Book Series="Star Wars" Number="13" Volume="2015" Year="2016">
+<Database Name="cv" Series="79398" Issue="507188" />
+</Book>
+<Book Series="Darth Vader" Number="14" Volume="2015" Year="2016">
+<Database Name="cv" Series="79990" Issue="508888" />
+</Book>
+<Book Series="Star Wars" Number="14" Volume="2015" Year="2016">
+<Database Name="cv" Series="79398" Issue="510504" />
+</Book>
+<Book Series="Darth Vader" Number="15" Volume="2015" Year="2016">
+<Database Name="cv" Series="79990" Issue="510492" />
+</Book>
+<Book Series="Star Wars" Number="15" Volume="2015" Year="2016">
+<Database Name="cv" Series="79398" Issue="511521" />
+</Book>
+<Book Series="Star Wars" Number="16" Volume="2015" Year="2016">
+<Database Name="cv" Series="79398" Issue="516094" />
+</Book>
+<Book Series="Star Wars" Number="17" Volume="2015" Year="2016">
+<Database Name="cv" Series="79398" Issue="521343" />
+</Book>
+<Book Series="Star Wars" Number="18" Volume="2015" Year="2016">
+<Database Name="cv" Series="79398" Issue="527157" />
+</Book>
+<Book Series="Star Wars" Number="19" Volume="2015" Year="2016">
+<Database Name="cv" Series="79398" Issue="531901" />
+</Book>
+<Book Series="Darth Vader" Number="16" Volume="2015" Year="2016">
+<Database Name="cv" Series="79990" Issue="514434" />
+</Book>
+<Book Series="Darth Vader" Number="17" Volume="2015" Year="2016">
+<Database Name="cv" Series="79990" Issue="517826" />
+</Book>
+<Book Series="Darth Vader" Number="18" Volume="2015" Year="2016">
+<Database Name="cv" Series="79990" Issue="522427" />
+</Book>
+<Book Series="Darth Vader" Number="19" Volume="2015" Year="2016">
+<Database Name="cv" Series="79990" Issue="525023" />
+</Book>
+<Book Series="Darth Vader" Number="20" Volume="2015" Year="2016">
+<Database Name="cv" Series="79990" Issue="529654" />
+</Book>
+<Book Series="Darth Vader" Number="21" Volume="2015" Year="2016">
+<Database Name="cv" Series="79990" Issue="534284" />
+</Book>
+<Book Series="Darth Vader" Number="22" Volume="2015" Year="2016">
+<Database Name="cv" Series="79990" Issue="537937" />
+</Book>
+<Book Series="Darth Vader" Number="23" Volume="2015" Year="2016">
+<Database Name="cv" Series="79990" Issue="540073" />
+</Book>
+<Book Series="Darth Vader" Number="24" Volume="2015" Year="2016">
+<Database Name="cv" Series="79990" Issue="543750" />
+</Book>
+<Book Series="Darth Vader" Number="25" Volume="2015" Year="2016">
+<Database Name="cv" Series="79990" Issue="553006" />
+</Book>
+<Book Series="Star Wars" Number="20" Volume="2015" Year="2016">
+<Database Name="cv" Series="79398" Issue="535367" />
+</Book>
+<Book Series="Star Wars" Number="21" Volume="2015" Year="2016">
+<Database Name="cv" Series="79398" Issue="540085" />
+</Book>
+<Book Series="Star Wars" Number="22" Volume="2015" Year="2016">
+<Database Name="cv" Series="79398" Issue="546065" />
+</Book>
+<Book Series="Star Wars" Number="23" Volume="2015" Year="2016">
+<Database Name="cv" Series="79398" Issue="551319" />
+</Book>
+<Book Series="Star Wars" Number="24" Volume="2015" Year="2016">
+<Database Name="cv" Series="79398" Issue="555540" />
+</Book>
+<Book Series="Star Wars" Number="25" Volume="2015" Year="2017">
+<Database Name="cv" Series="79398" Issue="558975" />
+</Book>
+<Book Series="Star Wars" Number="26" Volume="2015" Year="2017">
+<Database Name="cv" Series="79398" Issue="571687" />
+</Book>
+<Book Series="Star Wars" Number="27" Volume="2015" Year="2017">
+<Database Name="cv" Series="79398" Issue="578475" />
+</Book>
+<Book Series="Star Wars" Number="28" Volume="2015" Year="2017">
+<Database Name="cv" Series="79398" Issue="579324" />
+</Book>
+<Book Series="Star Wars" Number="29" Volume="2015" Year="2017">
+<Database Name="cv" Series="79398" Issue="583731" />
+</Book>
+<Book Series="Star Wars" Number="30" Volume="2015" Year="2017">
+<Database Name="cv" Series="79398" Issue="590807" />
+</Book>
+<Book Series="Star Wars Annual" Number="2" Volume="2015" Year="2017">
+<Database Name="cv" Series="86555" Issue="562604" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="1" Volume="2016" Year="2017">
+<Database Name="cv" Series="96284" Issue="563721" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="2" Volume="2016" Year="2017">
+<Database Name="cv" Series="96284" Issue="569329" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="3" Volume="2016" Year="2017">
+<Database Name="cv" Series="96284" Issue="576622" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="4" Volume="2016" Year="2017">
+<Database Name="cv" Series="96284" Issue="580747" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="5" Volume="2016" Year="2017">
+<Database Name="cv" Series="96284" Issue="585077" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="6" Volume="2016" Year="2017">
+<Database Name="cv" Series="96284" Issue="591755" />
+</Book>
+<Book Series="Star Wars: Screaming Citadel" Number="1" Volume="2017" Year="2017">
+<Database Name="cv" Series="101415" Issue="594975" />
+</Book>
+<Book Series="Star Wars" Number="31" Volume="2015" Year="2017">
+<Database Name="cv" Series="79398" Issue="595703" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="7" Volume="2016" Year="2017">
+<Database Name="cv" Series="96284" Issue="598388" />
+</Book>
+<Book Series="Star Wars" Number="32" Volume="2015" Year="2017">
+<Database Name="cv" Series="79398" Issue="601804" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="8" Volume="2016" Year="2017">
+<Database Name="cv" Series="96284" Issue="605130" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra Annual" Number="1" Volume="2016" Year="2017">
+<Database Name="cv" Series="103626" Issue="616201" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="9" Volume="2016" Year="2017">
+<Database Name="cv" Series="96284" Issue="608257" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="10" Volume="2016" Year="2017">
+<Database Name="cv" Series="96284" Issue="610537" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="11" Volume="2016" Year="2017">
+<Database Name="cv" Series="96284" Issue="613806" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="12" Volume="2016" Year="2017">
+<Database Name="cv" Series="96284" Issue="621679" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="13" Volume="2016" Year="2017">
+<Database Name="cv" Series="96284" Issue="628593" />
+</Book>
+<Book Series="Star Wars" Number="33" Volume="2015" Year="2017">
+<Database Name="cv" Series="79398" Issue="606640" />
+</Book>
+<Book Series="Star Wars" Number="34" Volume="2015" Year="2017">
+<Database Name="cv" Series="79398" Issue="615032" />
+</Book>
+<Book Series="Star Wars" Number="35" Volume="2015" Year="2017">
+<Database Name="cv" Series="79398" Issue="617853" />
+</Book>
+<Book Series="Star Wars" Number="36" Volume="2015" Year="2017">
+<Database Name="cv" Series="79398" Issue="621678" />
+</Book>
+<Book Series="Star Wars" Number="37" Volume="2015" Year="2017">
+<Database Name="cv" Series="79398" Issue="626298" />
+</Book>
+<Book Series="Star Wars Annual" Number="3" Volume="2015" Year="2017">
+<Database Name="cv" Series="86555" Issue="622952" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="14" Volume="2016" Year="2018">
+<Database Name="cv" Series="96284" Issue="638608" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="15" Volume="2016" Year="2018">
+<Database Name="cv" Series="96284" Issue="647954" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="16" Volume="2016" Year="2018">
+<Database Name="cv" Series="96284" Issue="656716" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="17" Volume="2016" Year="2018">
+<Database Name="cv" Series="96284" Issue="660671" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="18" Volume="2016" Year="2018">
+<Database Name="cv" Series="96284" Issue="664310" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="19" Volume="2016" Year="2018">
+<Database Name="cv" Series="96284" Issue="667657" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="20" Volume="2016" Year="2018">
+<Database Name="cv" Series="96284" Issue="670758" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="21" Volume="2016" Year="2018">
+<Database Name="cv" Series="96284" Issue="675154" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="22" Volume="2016" Year="2018">
+<Database Name="cv" Series="96284" Issue="677978" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="23" Volume="2016" Year="2018">
+<Database Name="cv" Series="96284" Issue="680737" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="24" Volume="2016" Year="2018">
+<Database Name="cv" Series="96284" Issue="686394" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="25" Volume="2016" Year="2018">
+<Database Name="cv" Series="96284" Issue="689877" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="26" Volume="2016" Year="2019">
+<Database Name="cv" Series="96284" Issue="692083" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="27" Volume="2016" Year="2019">
+<Database Name="cv" Series="96284" Issue="694927" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="28" Volume="2016" Year="2019">
+<Database Name="cv" Series="96284" Issue="699410" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="29" Volume="2016" Year="2019">
+<Database Name="cv" Series="96284" Issue="701947" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="30" Volume="2016" Year="2019">
+<Database Name="cv" Series="96284" Issue="704829" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="31" Volume="2016" Year="2019">
+<Database Name="cv" Series="96284" Issue="706962" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra Annual" Number="2" Volume="2016" Year="2018">
+<Database Name="cv" Series="103626" Issue="683838" />
+</Book>
+<Book Series="Star Wars" Number="38" Volume="2015" Year="2018">
+<Database Name="cv" Series="79398" Issue="636386" />
+</Book>
+<Book Series="Star Wars" Number="39" Volume="2015" Year="2018">
+<Database Name="cv" Series="79398" Issue="641417" />
+</Book>
+<Book Series="Star Wars" Number="40" Volume="2015" Year="2018">
+<Database Name="cv" Series="79398" Issue="646200" />
+</Book>
+<Book Series="Star Wars" Number="41" Volume="2015" Year="2018">
+<Database Name="cv" Series="79398" Issue="650928" />
+</Book>
+<Book Series="Star Wars" Number="42" Volume="2015" Year="2018">
+<Database Name="cv" Series="79398" Issue="654062" />
+</Book>
+<Book Series="Star Wars" Number="43" Volume="2015" Year="2018">
+<Database Name="cv" Series="79398" Issue="658734" />
+</Book>
+<Book Series="Star Wars: The Last Jedi - The Storms of Crait" Number="1" Volume="2017" Year="2018">
+<Database Name="cv" Series="107371" Issue="649745" />
+</Book>
+<Book Series="Star Wars" Number="44" Volume="2015" Year="2018">
+<Database Name="cv" Series="79398" Issue="662098" />
+</Book>
+<Book Series="Star Wars" Number="45" Volume="2015" Year="2018">
+<Database Name="cv" Series="79398" Issue="663585" />
+</Book>
+<Book Series="Star Wars" Number="46" Volume="2015" Year="2018">
+<Database Name="cv" Series="79398" Issue="664923" />
+</Book>
+<Book Series="Star Wars" Number="47" Volume="2015" Year="2018">
+<Database Name="cv" Series="79398" Issue="668785" />
+</Book>
+<Book Series="Star Wars" Number="48" Volume="2015" Year="2018">
+<Database Name="cv" Series="79398" Issue="670756" />
+</Book>
+<Book Series="Star Wars" Number="49" Volume="2015" Year="2018">
+<Database Name="cv" Series="79398" Issue="672292" />
+</Book>
+<Book Series="Star Wars" Number="50" Volume="2015" Year="2018">
+<Database Name="cv" Series="79398" Issue="675989" />
+</Book>
+<Book Series="Star Wars" Number="51" Volume="2015" Year="2018">
+<Database Name="cv" Series="79398" Issue="677296" />
+</Book>
+<Book Series="Star Wars" Number="52" Volume="2015" Year="2018">
+<Database Name="cv" Series="79398" Issue="678541" />
+</Book>
+<Book Series="Star Wars" Number="53" Volume="2015" Year="2018">
+<Database Name="cv" Series="79398" Issue="683837" />
+</Book>
+<Book Series="Star Wars" Number="54" Volume="2015" Year="2018">
+<Database Name="cv" Series="79398" Issue="685856" />
+</Book>
+<Book Series="Star Wars" Number="55" Volume="2015" Year="2018">
+<Database Name="cv" Series="79398" Issue="687019" />
+</Book>
+<Book Series="Star Wars" Number="56" Volume="2015" Year="2019">
+<Database Name="cv" Series="79398" Issue="691392" />
+</Book>
+<Book Series="Star Wars" Number="57" Volume="2015" Year="2019">
+<Database Name="cv" Series="79398" Issue="692560" />
+</Book>
+<Book Series="Star Wars" Number="58" Volume="2015" Year="2019">
+<Database Name="cv" Series="79398" Issue="694145" />
+</Book>
+<Book Series="Star Wars" Number="59" Volume="2015" Year="2019">
+<Database Name="cv" Series="79398" Issue="696954" />
+</Book>
+<Book Series="Star Wars" Number="60" Volume="2015" Year="2019">
+<Database Name="cv" Series="79398" Issue="698613" />
+</Book>
+<Book Series="Star Wars" Number="61" Volume="2015" Year="2019">
+<Database Name="cv" Series="79398" Issue="700148" />
+</Book>
+<Book Series="Star Wars" Number="62" Volume="2015" Year="2019">
+<Database Name="cv" Series="79398" Issue="702472" />
+</Book>
+<Book Series="Star Wars" Number="63" Volume="2015" Year="2019">
+<Database Name="cv" Series="79398" Issue="703953" />
+</Book>
+<Book Series="Star Wars" Number="64" Volume="2015" Year="2019">
+<Database Name="cv" Series="79398" Issue="705485" />
+</Book>
+<Book Series="Star Wars" Number="65" Volume="2015" Year="2019">
+<Database Name="cv" Series="79398" Issue="707523" />
+</Book>
+<Book Series="Star Wars" Number="66" Volume="2015" Year="2019">
+<Database Name="cv" Series="79398" Issue="709210" />
+</Book>
+<Book Series="Star Wars" Number="67" Volume="2015" Year="2019">
+<Database Name="cv" Series="79398" Issue="711956" />
+</Book>
+<Book Series="Star Wars: A New Legacy" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="162195" Issue="1093010" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="32" Volume="2016" Year="2019">
+<Database Name="cv" Series="96284" Issue="708142" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="33" Volume="2016" Year="2019">
+<Database Name="cv" Series="96284" Issue="711957" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="34" Volume="2016" Year="2019">
+<Database Name="cv" Series="96284" Issue="713865" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="35" Volume="2016" Year="2019">
+<Database Name="cv" Series="96284" Issue="716971" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="36" Volume="2016" Year="2019">
+<Database Name="cv" Series="96284" Issue="719446" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra Annual" Number="3" Volume="2016" Year="2019">
+<Database Name="cv" Series="103626" Issue="725257" />
+</Book>
+<Book Series="Star Wars: Age of Rebellion - Lando Calrissian" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="119162" Issue="709211" />
+</Book>
+<Book Series="Star Wars: Target Vader" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="120030" Issue="713083" />
+</Book>
+<Book Series="Star Wars: Target Vader" Number="2" Volume="2019" Year="2019">
+<Database Name="cv" Series="120030" Issue="716375" />
+</Book>
+<Book Series="Star Wars: Target Vader" Number="3" Volume="2019" Year="2019">
+<Database Name="cv" Series="120030" Issue="720174" />
+</Book>
+<Book Series="Star Wars: Target Vader" Number="4" Volume="2019" Year="2019">
+<Database Name="cv" Series="120030" Issue="721791" />
+</Book>
+<Book Series="Star Wars: Target Vader" Number="5" Volume="2019" Year="2020">
+<Database Name="cv" Series="120030" Issue="727270" />
+</Book>
+<Book Series="Star Wars: Target Vader" Number="6" Volume="2019" Year="2020">
+<Database Name="cv" Series="120030" Issue="730347" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="37" Volume="2016" Year="2019">
+<Database Name="cv" Series="96284" Issue="721163" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="38" Volume="2016" Year="2020">
+<Database Name="cv" Series="96284" Issue="726214" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="39" Volume="2016" Year="2020">
+<Database Name="cv" Series="96284" Issue="728980" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="40" Volume="2016" Year="2020">
+<Database Name="cv" Series="96284" Issue="730346" />
+</Book>
+<Book Series="Star Wars" Number="68" Volume="2015" Year="2019">
+<Database Name="cv" Series="79398" Issue="713517" />
+</Book>
+<Book Series="Star Wars" Number="69" Volume="2015" Year="2019">
+<Database Name="cv" Series="79398" Issue="714244" />
+</Book>
+<Book Series="Star Wars" Number="70" Volume="2015" Year="2019">
+<Database Name="cv" Series="79398" Issue="715318" />
+</Book>
+<Book Series="Star Wars" Number="71" Volume="2015" Year="2019">
+<Database Name="cv" Series="79398" Issue="718134" />
+</Book>
+<Book Series="Star Wars" Number="72" Volume="2015" Year="2019">
+<Database Name="cv" Series="79398" Issue="721162" />
+</Book>
+<Book Series="Star Wars" Number="73" Volume="2015" Year="2019">
+<Database Name="cv" Series="79398" Issue="723865" />
+</Book>
+<Book Series="Star Wars" Number="74" Volume="2015" Year="2020">
+<Database Name="cv" Series="79398" Issue="727268" />
+</Book>
+<Book Series="Star Wars" Number="75" Volume="2015" Year="2020">
+<Database Name="cv" Series="79398" Issue="728430" />
+</Book>
+<Book Series="Star Wars: Age of Rebellion - Boba Fett" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="118871" Issue="708140" />
+</Book>
+<Book Series="Star Wars: Age of Rebellion - Jabba the Hutt" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="119308" Issue="709726" />
+</Book>
+<Book Series="Star Wars: Empire Ascendant" Number="1" Volume="2019" Year="2020">
+<Database Name="cv" Series="123713" Issue="731527" />
+</Book>
+<Book Series="Star Wars: Age of Rebellion Special" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="118395" Issue="706419" />
+</Book>
+<Book Series="Star Wars: Yoda" Number="1" Volume="2022" Year="2023">
+<Database Name="cv" Series="146385" Issue="956847" />
+</Book>
+<Book Series="Star Wars: Yoda" Number="2" Volume="2022" Year="2023">
+<Database Name="cv" Series="146385" Issue="961961" />
+</Book>
+<Book Series="Star Wars: Yoda" Number="3" Volume="2022" Year="2023">
+<Database Name="cv" Series="146385" Issue="966429" />
+</Book>
+<Book Series="Star Wars: Yoda" Number="4" Volume="2022" Year="2023">
+<Database Name="cv" Series="146385" Issue="973033" />
+</Book>
+<Book Series="Star Wars: Yoda" Number="5" Volume="2022" Year="2023">
+<Database Name="cv" Series="146385" Issue="976912" />
+</Book>
+<Book Series="Star Wars: Yoda" Number="6" Volume="2022" Year="2023">
+<Database Name="cv" Series="146385" Issue="984262" />
+</Book>
+<Book Series="Star Wars: Yoda" Number="7" Volume="2022" Year="2023">
+<Database Name="cv" Series="146385" Issue="987262" />
+</Book>
+<Book Series="Star Wars: Yoda" Number="8" Volume="2022" Year="2023">
+<Database Name="cv" Series="146385" Issue="993239" />
+</Book>
+<Book Series="Star Wars: Yoda" Number="9" Volume="2022" Year="2023">
+<Database Name="cv" Series="146385" Issue="998581" />
+</Book>
+<Book Series="Star Wars: Yoda" Number="10" Volume="2022" Year="2023">
+<Database Name="cv" Series="146385" Issue="1004339" />
+</Book>
+<Book Series="Star Wars" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="123860" Issue="731978" />
+</Book>
+<Book Series="Star Wars" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="123860" Issue="735530" />
+</Book>
+<Book Series="Star Wars" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="123860" Issue="738620" />
+</Book>
+<Book Series="Star Wars" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="123860" Issue="742378" />
+</Book>
+<Book Series="Star Wars" Number="5" Volume="2020" Year="2020">
+<Database Name="cv" Series="123860" Issue="787355" />
+</Book>
+<Book Series="Star Wars" Number="6" Volume="2020" Year="2020">
+<Database Name="cv" Series="123860" Issue="799953" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="124821" Issue="736498" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="124821" Issue="740826" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="124821" Issue="784414" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="124821" Issue="791928" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="5" Volume="2020" Year="2020">
+<Database Name="cv" Series="124821" Issue="799954" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="126644" Issue="758307" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="126644" Issue="781437" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="126644" Issue="796301" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="126644" Issue="805098" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="5" Volume="2020" Year="2020">
+<Database Name="cv" Series="126644" Issue="814494" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="1" Volume="2020" Year="2020">
+<Database Name="cv" Series="125679" Issue="740825" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="2" Volume="2020" Year="2020">
+<Database Name="cv" Series="125679" Issue="743450" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="3" Volume="2020" Year="2020">
+<Database Name="cv" Series="125679" Issue="769755" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="4" Volume="2020" Year="2020">
+<Database Name="cv" Series="125679" Issue="794940" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="5" Volume="2020" Year="2020">
+<Database Name="cv" Series="125679" Issue="803650" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="6" Volume="2020" Year="2020">
+<Database Name="cv" Series="124821" Issue="810731" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="7" Volume="2020" Year="2021">
+<Database Name="cv" Series="124821" Issue="817700" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="8" Volume="2020" Year="2021">
+<Database Name="cv" Series="124821" Issue="821475" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="9" Volume="2020" Year="2021">
+<Database Name="cv" Series="124821" Issue="824439" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="10" Volume="2020" Year="2021">
+<Database Name="cv" Series="124821" Issue="828187" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="11" Volume="2020" Year="2021">
+<Database Name="cv" Series="124821" Issue="846080" />
+</Book>
+<Book Series="Star Wars" Number="7" Volume="2020" Year="2020">
+<Database Name="cv" Series="123860" Issue="807576" />
+</Book>
+<Book Series="Star Wars" Number="8" Volume="2020" Year="2021">
+<Database Name="cv" Series="123860" Issue="816459" />
+</Book>
+<Book Series="Star Wars" Number="9" Volume="2020" Year="2021">
+<Database Name="cv" Series="123860" Issue="820738" />
+</Book>
+<Book Series="Star Wars" Number="10" Volume="2020" Year="2021">
+<Database Name="cv" Series="123860" Issue="824019" />
+</Book>
+<Book Series="Star Wars" Number="11" Volume="2020" Year="2021">
+<Database Name="cv" Series="123860" Issue="827515" />
+</Book>
+<Book Series="Star Wars" Number="12" Volume="2020" Year="2021">
+<Database Name="cv" Series="123860" Issue="836260" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="6" Volume="2020" Year="2020">
+<Database Name="cv" Series="125679" Issue="813288" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="7" Volume="2020" Year="2021">
+<Database Name="cv" Series="125679" Issue="819094" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="8" Volume="2020" Year="2021">
+<Database Name="cv" Series="125679" Issue="822341" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="9" Volume="2020" Year="2021">
+<Database Name="cv" Series="125679" Issue="826551" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="10" Volume="2020" Year="2021">
+<Database Name="cv" Series="125679" Issue="838544" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="11" Volume="2020" Year="2021">
+<Database Name="cv" Series="125679" Issue="842956" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="6" Volume="2020" Year="2021">
+<Database Name="cv" Series="126644" Issue="819477" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="7" Volume="2020" Year="2021">
+<Database Name="cv" Series="126644" Issue="825502" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="8" Volume="2020" Year="2021">
+<Database Name="cv" Series="126644" Issue="839783" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="9" Volume="2020" Year="2021">
+<Database Name="cv" Series="126644" Issue="844957" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="10" Volume="2020" Year="2021">
+<Database Name="cv" Series="126644" Issue="855599" />
+</Book>
+<Book Series="Star Wars: War of the Bounty Hunters Alpha" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="135899" Issue="847502" />
+</Book>
+<Book Series="Star Wars: War of the Bounty Hunters: Jabba the Hutt" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="137695" Issue="872865" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="12" Volume="2020" Year="2021">
+<Database Name="cv" Series="125679" Issue="851300" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="11" Volume="2020" Year="2021">
+<Database Name="cv" Series="126644" Issue="866575" />
+</Book>
+<Book Series="Star Wars" Number="13" Volume="2020" Year="2021">
+<Database Name="cv" Series="123860" Issue="848845" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="13" Volume="2020" Year="2021">
+<Database Name="cv" Series="125679" Issue="858870" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="14" Volume="2020" Year="2021">
+<Database Name="cv" Series="125679" Issue="868595" />
+</Book>
+<Book Series="Star Wars: War of the Bounty Hunters: 4-Lom &amp; Zuckuss" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="138048" Issue="877057" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="15" Volume="2020" Year="2021">
+<Database Name="cv" Series="125679" Issue="877056" />
+</Book>
+<Book Series="Star Wars" Number="14" Volume="2020" Year="2021">
+<Database Name="cv" Series="123860" Issue="861637" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="12" Volume="2020" Year="2021">
+<Database Name="cv" Series="126644" Issue="871537" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="12" Volume="2020" Year="2021">
+<Database Name="cv" Series="124821" Issue="855597" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="13" Volume="2020" Year="2021">
+<Database Name="cv" Series="124821" Issue="863843" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="14" Volume="2020" Year="2021">
+<Database Name="cv" Series="124821" Issue="872863" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="15" Volume="2020" Year="2021">
+<Database Name="cv" Series="124821" Issue="882026" />
+</Book>
+<Book Series="Star Wars" Number="15" Volume="2020" Year="2021">
+<Database Name="cv" Series="123860" Issue="874519" />
+</Book>
+<Book Series="Star Wars" Number="16" Volume="2020" Year="2021">
+<Database Name="cv" Series="123860" Issue="880892" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="13" Volume="2020" Year="2021">
+<Database Name="cv" Series="126644" Issue="882027" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="14" Volume="2020" Year="2021">
+<Database Name="cv" Series="126644" Issue="884066" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="16" Volume="2020" Year="2021">
+<Database Name="cv" Series="125679" Issue="885602" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="16" Volume="2020" Year="2021">
+<Database Name="cv" Series="124821" Issue="884818" />
+</Book>
+<Book Series="Star Wars" Number="17" Volume="2020" Year="2021">
+<Database Name="cv" Series="123860" Issue="886935" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="15" Volume="2020" Year="2021">
+<Database Name="cv" Series="126644" Issue="889454" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="17" Volume="2020" Year="2021">
+<Database Name="cv" Series="124821" Issue="891560" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="17" Volume="2020" Year="2022">
+<Database Name="cv" Series="125679" Issue="892241" />
+</Book>
+<Book Series="Star Wars: War of the Bounty Hunters: IG-88" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="139833" Issue="891561" />
+</Book>
+<Book Series="Star Wars" Number="18" Volume="2020" Year="2022">
+<Database Name="cv" Series="123860" Issue="892240" />
+</Book>
+<Book Series="Star Wars: War of the Bounty Hunters: Boushh" Number="1" Volume="2021" Year="2021">
+<Database Name="cv" Series="138931" Issue="884822" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="18" Volume="2020" Year="2022">
+<Database Name="cv" Series="124821" Issue="896644" />
+</Book>
+<Book Series="Star Wars: Crimson Reign" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="140398" Issue="897890" />
+</Book>
+<Book Series="Star Wars" Number="19" Volume="2020" Year="2022">
+<Database Name="cv" Series="123860" Issue="897512" />
+</Book>
+<Book Series="Star Wars" Number="20" Volume="2020" Year="2022">
+<Database Name="cv" Series="123860" Issue="902531" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="18" Volume="2020" Year="2022">
+<Database Name="cv" Series="125679" Issue="896643" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="19" Volume="2020" Year="2022">
+<Database Name="cv" Series="125679" Issue="900398" />
+</Book>
+<Book Series="Star Wars" Number="21" Volume="2020" Year="2022">
+<Database Name="cv" Series="123860" Issue="909807" />
+</Book>
+<Book Series="Star Wars" Number="22" Volume="2020" Year="2022">
+<Database Name="cv" Series="123860" Issue="916408" />
+</Book>
+<Book Series="Star Wars" Number="23" Volume="2020" Year="2022">
+<Database Name="cv" Series="123860" Issue="921118" />
+</Book>
+<Book Series="Star Wars" Number="24" Volume="2020" Year="2022">
+<Database Name="cv" Series="123860" Issue="929654" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="20" Volume="2020" Year="2022">
+<Database Name="cv" Series="125679" Issue="902529" />
+</Book>
+<Book Series="Star Wars: Crimson Reign" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="140398" Issue="905797" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="19" Volume="2020" Year="2022">
+<Database Name="cv" Series="124821" Issue="899198" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="20" Volume="2020" Year="2022">
+<Database Name="cv" Series="124821" Issue="906639" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="21" Volume="2020" Year="2022">
+<Database Name="cv" Series="124821" Issue="912159" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="16" Volume="2020" Year="2022">
+<Database Name="cv" Series="126644" Issue="894455" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="17" Volume="2020" Year="2022">
+<Database Name="cv" Series="126644" Issue="901351" />
+</Book>
+<Book Series="Star Wars: Crimson Reign" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="140398" Issue="910631" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="18" Volume="2020" Year="2022">
+<Database Name="cv" Series="126644" Issue="903921" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="19" Volume="2020" Year="2022">
+<Database Name="cv" Series="126644" Issue="912251" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="20" Volume="2020" Year="2022">
+<Database Name="cv" Series="126644" Issue="925008" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="21" Volume="2020" Year="2022">
+<Database Name="cv" Series="126644" Issue="933089" />
+</Book>
+<Book Series="Star Wars: Crimson Reign" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="140398" Issue="919481" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="21" Volume="2020" Year="2022">
+<Database Name="cv" Series="125679" Issue="913174" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="22" Volume="2020" Year="2022">
+<Database Name="cv" Series="125679" Issue="914650" />
+</Book>
+<Book Series="Star Wars: Crimson Reign" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="140398" Issue="931634" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="23" Volume="2020" Year="2022">
+<Database Name="cv" Series="125679" Issue="928440" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="22" Volume="2020" Year="2022">
+<Database Name="cv" Series="124821" Issue="916409" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="23" Volume="2020" Year="2022">
+<Database Name="cv" Series="124821" Issue="928441" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="24" Volume="2020" Year="2022">
+<Database Name="cv" Series="124821" Issue="933092" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="24" Volume="2020" Year="2022">
+<Database Name="cv" Series="125679" Issue="930982" />
+</Book>
+<Book Series="Star Wars" Number="25" Volume="2020" Year="2022">
+<Database Name="cv" Series="123860" Issue="937737" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="25" Volume="2020" Year="2022">
+<Database Name="cv" Series="125679" Issue="935778" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="26" Volume="2020" Year="2022">
+<Database Name="cv" Series="125679" Issue="941570" />
+</Book>
+<Book Series="Star Wars" Number="26" Volume="2020" Year="2022">
+<Database Name="cv" Series="123860" Issue="942709" />
+</Book>
+<Book Series="Star Wars" Number="27" Volume="2020" Year="2022">
+<Database Name="cv" Series="123860" Issue="946559" />
+</Book>
+<Book Series="Star Wars" Number="28" Volume="2020" Year="2022">
+<Database Name="cv" Series="123860" Issue="950793" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="25" Volume="2020" Year="2022">
+<Database Name="cv" Series="124821" Issue="937742" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="26" Volume="2020" Year="2022">
+<Database Name="cv" Series="124821" Issue="943909" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="27" Volume="2020" Year="2022">
+<Database Name="cv" Series="124821" Issue="948114" />
+</Book>
+<Book Series="Star Wars: Revelations" Number="1" Volume="2022" Year="2023">
+<Database Name="cv" Series="146386" Issue="956848" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="28" Volume="2020" Year="2022">
+<Database Name="cv" Series="124821" Issue="951454" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="22" Volume="2020" Year="2022">
+<Database Name="cv" Series="126644" Issue="939091" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="23" Volume="2020" Year="2022">
+<Database Name="cv" Series="126644" Issue="943908" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="24" Volume="2020" Year="2022">
+<Database Name="cv" Series="126644" Issue="949155" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="25" Volume="2020" Year="2022">
+<Database Name="cv" Series="126644" Issue="952309" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="26" Volume="2020" Year="2023">
+<Database Name="cv" Series="126644" Issue="955115" />
+</Book>
+<Book Series="Star Wars: Hidden Empire" Number="1" Volume="2022" Year="2023">
+<Database Name="cv" Series="146111" Issue="955113" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="27" Volume="2020" Year="2022">
+<Database Name="cv" Series="125679" Issue="946721" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="28" Volume="2020" Year="2023">
+<Database Name="cv" Series="125679" Issue="953029" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="27" Volume="2020" Year="2023">
+<Database Name="cv" Series="126644" Issue="961954" />
+</Book>
+<Book Series="Star Wars: Hidden Empire" Number="2" Volume="2022" Year="2023">
+<Database Name="cv" Series="146111" Issue="958996" />
+</Book>
+<Book Series="Star Wars: Hidden Empire" Number="3" Volume="2022" Year="2023">
+<Database Name="cv" Series="146111" Issue="969393" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="29" Volume="2020" Year="2023">
+<Database Name="cv" Series="125679" Issue="960019" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="30" Volume="2020" Year="2023">
+<Database Name="cv" Series="125679" Issue="964953" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="31" Volume="2020" Year="2023">
+<Database Name="cv" Series="125679" Issue="971898" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="28" Volume="2020" Year="2023">
+<Database Name="cv" Series="126644" Issue="966427" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="29" Volume="2020" Year="2023">
+<Database Name="cv" Series="126644" Issue="973032" />
+</Book>
+<Book Series="Star Wars: Hidden Empire" Number="4" Volume="2022" Year="2023">
+<Database Name="cv" Series="146111" Issue="974101" />
+</Book>
+<Book Series="Star Wars: Hidden Empire" Number="5" Volume="2022" Year="2023">
+<Database Name="cv" Series="146111" Issue="981435" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="29" Volume="2020" Year="2023">
+<Database Name="cv" Series="124821" Issue="957968" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="30" Volume="2020" Year="2023">
+<Database Name="cv" Series="124821" Issue="963994" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="32" Volume="2020" Year="2023">
+<Database Name="cv" Series="124821" Issue="978491" />
+</Book>
+<Book Series="Star Wars" Number="29" Volume="2020" Year="2023">
+<Database Name="cv" Series="123860" Issue="953031" />
+</Book>
+<Book Series="Star Wars" Number="30" Volume="2020" Year="2023">
+<Database Name="cv" Series="123860" Issue="962852" />
+</Book>
+<Book Series="Star Wars" Number="31" Volume="2020" Year="2023">
+<Database Name="cv" Series="123860" Issue="971899" />
+</Book>
+<Book Series="Star Wars" Number="32" Volume="2020" Year="2023">
+<Database Name="cv" Series="123860" Issue="974098" />
+</Book>
+<Book Series="Star Wars" Number="33" Volume="2020" Year="2023">
+<Database Name="cv" Series="123860" Issue="981436" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="33" Volume="2020" Year="2023">
+<Database Name="cv" Series="124821" Issue="987264" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="34" Volume="2020" Year="2023">
+<Database Name="cv" Series="124821" Issue="988152" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="32" Volume="2020" Year="2023">
+<Database Name="cv" Series="125679" Issue="975683" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="33" Volume="2020" Year="2023">
+<Database Name="cv" Series="125679" Issue="982365" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="34" Volume="2020" Year="2023">
+<Database Name="cv" Series="125679" Issue="989668" />
+</Book>
+<Book Series="Star Wars" Number="34" Volume="2020" Year="2023">
+<Database Name="cv" Series="123860" Issue="987261" />
+</Book>
+<Book Series="Star Wars" Number="35" Volume="2020" Year="2023">
+<Database Name="cv" Series="123860" Issue="993238" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="30" Volume="2020" Year="2023">
+<Database Name="cv" Series="126644" Issue="982364" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="31" Volume="2020" Year="2023">
+<Database Name="cv" Series="126644" Issue="987263" />
+</Book>
+<Book Series="Star Wars: Sana Starros" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="147909" Issue="967799" />
+</Book>
+<Book Series="Star Wars: Sana Starros" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="147909" Issue="975682" />
+</Book>
+<Book Series="Star Wars: Sana Starros" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="147909" Issue="984324" />
+</Book>
+<Book Series="Star Wars: Sana Starros" Number="4" Volume="2023" Year="2023">
+<Database Name="cv" Series="147909" Issue="992415" />
+</Book>
+<Book Series="Star Wars: Sana Starros" Number="5" Volume="2023" Year="2023">
+<Database Name="cv" Series="147909" Issue="994362" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="35" Volume="2020" Year="2023">
+<Database Name="cv" Series="124821" Issue="994361" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="36" Volume="2020" Year="2023">
+<Database Name="cv" Series="124821" Issue="1000240" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="32" Volume="2020" Year="2023">
+<Database Name="cv" Series="126644" Issue="992416" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="33" Volume="2020" Year="2023">
+<Database Name="cv" Series="126644" Issue="997383" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="34" Volume="2020" Year="2023">
+<Database Name="cv" Series="126644" Issue="1001999" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="35" Volume="2020" Year="2023">
+<Database Name="cv" Series="125679" Issue="996025" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="36" Volume="2020" Year="2023">
+<Database Name="cv" Series="125679" Issue="1000239" />
+</Book>
+<Book Series="Star Wars" Number="36" Volume="2020" Year="2023">
+<Database Name="cv" Series="123860" Issue="998579" />
+</Book>
+<Book Series="Star Wars: Dark Droids" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="152654" Issue="1004337" />
+</Book>
+<Book Series="Star Wars" Number="37" Volume="2020" Year="2023">
+<Database Name="cv" Series="123860" Issue="1006439" />
+</Book>
+<Book Series="Star Wars" Number="38" Volume="2020" Year="2023">
+<Database Name="cv" Series="123860" Issue="1011787" />
+</Book>
+<Book Series="Star Wars" Number="39" Volume="2020" Year="2023">
+<Database Name="cv" Series="123860" Issue="1025166" />
+</Book>
+<Book Series="Star Wars: Dark Droids" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="152654" Issue="1012327" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="37" Volume="2020" Year="2023">
+<Database Name="cv" Series="124821" Issue="1008946" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="38" Volume="2020" Year="2023">
+<Database Name="cv" Series="124821" Issue="1013498" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="39" Volume="2020" Year="2023">
+<Database Name="cv" Series="124821" Issue="1020540" />
+</Book>
+<Book Series="Star Wars: Dark Droids" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="152654" Issue="1024051" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="37" Volume="2020" Year="2023">
+<Database Name="cv" Series="125679" Issue="1010946" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="38" Volume="2020" Year="2023">
+<Database Name="cv" Series="125679" Issue="1014898" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="39" Volume="2020" Year="2023">
+<Database Name="cv" Series="125679" Issue="1020539" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="35" Volume="2020" Year="2023">
+<Database Name="cv" Series="126644" Issue="1010054" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="36" Volume="2020" Year="2023">
+<Database Name="cv" Series="126644" Issue="1018029" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="37" Volume="2020" Year="2023">
+<Database Name="cv" Series="126644" Issue="1026556" />
+</Book>
+<Book Series="Star Wars: Dark Droids" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="152654" Issue="1029692" />
+</Book>
+<Book Series="Star Wars: Dark Droids: D-Squad" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="153630" Issue="1015094" />
+</Book>
+<Book Series="Star Wars: Dark Droids: D-Squad" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="153630" Issue="1026555" />
+</Book>
+<Book Series="Star Wars: Dark Droids: D-Squad" Number="3" Volume="2023" Year="2024">
+<Database Name="cv" Series="153630" Issue="1030790" />
+</Book>
+<Book Series="Star Wars: Dark Droids: D-Squad" Number="4" Volume="2023" Year="2024">
+<Database Name="cv" Series="153630" Issue="1033211" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="40" Volume="2020" Year="2024">
+<Database Name="cv" Series="124821" Issue="1028631" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="40" Volume="2020" Year="2024">
+<Database Name="cv" Series="125679" Issue="1030787" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="41" Volume="2020" Year="2024">
+<Database Name="cv" Series="124821" Issue="1035964" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="38" Volume="2020" Year="2024">
+<Database Name="cv" Series="126644" Issue="1029693" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="39" Volume="2020" Year="2024">
+<Database Name="cv" Series="126644" Issue="1035965" />
+</Book>
+<Book Series="Star Wars" Number="40" Volume="2020" Year="2024">
+<Database Name="cv" Series="123860" Issue="1027601" />
+</Book>
+<Book Series="Star Wars: Dark Droids" Number="5" Volume="2023" Year="2024">
+<Database Name="cv" Series="152654" Issue="1038392" />
+</Book>
+<Book Series="Star Wars" Number="41" Volume="2020" Year="2024">
+<Database Name="cv" Series="123860" Issue="1033210" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="41" Volume="2020" Year="2024">
+<Database Name="cv" Series="125679" Issue="1034346" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra" Number="40" Volume="2020" Year="2024">
+<Database Name="cv" Series="126644" Issue="1042836" />
+</Book>
+<Book Series="Star Wars: Bounty Hunters" Number="42" Volume="2020" Year="2024">
+<Database Name="cv" Series="125679" Issue="1040945" />
+</Book>
+<Book Series="Star Wars" Number="42" Volume="2020" Year="2024">
+<Database Name="cv" Series="123860" Issue="1039587" />
+</Book>
+<Book Series="Star Wars" Number="43" Volume="2020" Year="2024">
+<Database Name="cv" Series="123860" Issue="1045768" />
+</Book>
+<Book Series="Star Wars: Revelations" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="155511" Issue="1035967" />
+</Book>
+<Book Series="Star Wars" Number="44" Volume="2020" Year="2024">
+<Database Name="cv" Series="123860" Issue="1047090" />
+</Book>
+<Book Series="Star Wars" Number="45" Volume="2020" Year="2024">
+<Database Name="cv" Series="123860" Issue="1050576" />
+</Book>
+<Book Series="Star Wars" Number="46" Volume="2020" Year="2024">
+<Database Name="cv" Series="123860" Issue="1056212" />
+</Book>
+<Book Series="Star Wars" Number="47" Volume="2020" Year="2024">
+<Database Name="cv" Series="123860" Issue="1058719" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="42" Volume="2020" Year="2024">
+<Database Name="cv" Series="124821" Issue="1038983" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="43" Volume="2020" Year="2024">
+<Database Name="cv" Series="124821" Issue="1044783" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="44" Volume="2020" Year="2024">
+<Database Name="cv" Series="124821" Issue="1047952" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="45" Volume="2020" Year="2024">
+<Database Name="cv" Series="124821" Issue="1051127" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="46" Volume="2020" Year="2024">
+<Database Name="cv" Series="124821" Issue="1054381" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="47" Volume="2020" Year="2024">
+<Database Name="cv" Series="124821" Issue="1059271" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="48" Volume="2020" Year="2024">
+<Database Name="cv" Series="124821" Issue="1064206" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="49" Volume="2020" Year="2024">
+<Database Name="cv" Series="124821" Issue="1066704" />
+</Book>
+<Book Series="Star Wars: Darth Vader" Number="50" Volume="2020" Year="2024">
+<Database Name="cv" Series="124821" Issue="1070137" />
+</Book>
+<Book Series="Star Wars" Number="48" Volume="2020" Year="2024">
+<Database Name="cv" Series="123860" Issue="1063235" />
+</Book>
+<Book Series="Star Wars" Number="49" Volume="2020" Year="2024">
+<Database Name="cv" Series="123860" Issue="1067249" />
+</Book>
+<Book Series="Star Wars: Age of Rebellion - Luke Skywalker" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="119558" Issue="710694" />
+</Book>
+<Book Series="Star Wars: Age of Rebellion - Princess Leia" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="118270" Issue="705930" />
+</Book>
+<Book Series="Star Wars: Tie Fighter" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="118396" Issue="706420" />
+</Book>
+<Book Series="Star Wars: Tie Fighter" Number="2" Volume="2019" Year="2019">
+<Database Name="cv" Series="118396" Issue="709214" />
+</Book>
+<Book Series="Star Wars: Tie Fighter" Number="3" Volume="2019" Year="2019">
+<Database Name="cv" Series="118396" Issue="711958" />
+</Book>
+<Book Series="Star Wars: Tie Fighter" Number="4" Volume="2019" Year="2019">
+<Database Name="cv" Series="118396" Issue="713866" />
+</Book>
+<Book Series="Star Wars: Tie Fighter" Number="5" Volume="2019" Year="2019">
+<Database Name="cv" Series="118396" Issue="716973" />
+</Book>
+<Book Series="Star Wars: Darth Vader - Black, White &amp; Red" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="149783" Issue="985721" />
+</Book>
+<Book Series="Star Wars: Darth Vader - Black, White &amp; Red" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="149783" Issue="991071" />
+</Book>
+<Book Series="Star Wars: Darth Vader - Black, White &amp; Red" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="149783" Issue="997382" />
+</Book>
+<Book Series="Star Wars: Darth Vader - Black, White &amp; Red" Number="4" Volume="2023" Year="2023">
+<Database Name="cv" Series="149783" Issue="1003587" />
+</Book>
+<Book Series="Star Wars: Return of the Jedi - The Empire" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="151008" Issue="993237" />
+</Book>
+<Book Series="Star Wars: Return of the Jedi - Lando" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="150054" Issue="987265" />
+</Book>
+<Book Series="Star Wars: Return of The Jedi - The Rebellion" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="152418" Issue="1002813" />
+</Book>
+<Book Series="Star Wars: Return of the Jedi – Jabba’s Palace" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="149053" Issue="979434" />
+</Book>
+<Book Series="Star Wars: Return of the Jedi - Ewoks" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="149393" Issue="982366" />
+</Book>
+<Book Series="Star Wars: Return of the Jedi – Max Rebo" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="152894" Issue="1006449" />
+</Book>
+<Book Series="Journey to Star Wars: The Force Awakens - Shattered Empire" Number="1" Volume="2015" Year="2015">
+<Database Name="cv" Series="84432" Issue="499744" />
+</Book>
+<Book Series="Journey to Star Wars: The Force Awakens - Shattered Empire" Number="2" Volume="2015" Year="2015">
+<Database Name="cv" Series="84432" Issue="502120" />
+</Book>
+<Book Series="Journey to Star Wars: The Force Awakens - Shattered Empire" Number="3" Volume="2015" Year="2015">
+<Database Name="cv" Series="84432" Issue="502864" />
+</Book>
+<Book Series="Journey to Star Wars: The Force Awakens - Shattered Empire" Number="4" Volume="2015" Year="2015">
+<Database Name="cv" Series="84432" Issue="503560" />
+</Book>
+<Book Series="Star Wars: Ewoks" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="160315" Issue="1073274" />
+</Book>
+<Book Series="Star Wars: Ewoks" Number="2" Volume="2024" Year="2025">
+<Database Name="cv" Series="160315" Issue="1077646" />
+</Book>
+<Book Series="Star Wars: Ewoks" Number="3" Volume="2024" Year="2025">
+<Database Name="cv" Series="160315" Issue="1083736" />
+</Book>
+<Book Series="Star Wars: Ewoks" Number="4" Volume="2024" Year="2025">
+<Database Name="cv" Series="160315" Issue="1093011" />
+</Book>
+<Book Series="Star Wars: The Battle of Jakku: Insurgency Rising" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="160202" Issue="1072218" />
+</Book>
+<Book Series="Star Wars: The Battle of Jakku: Insurgency Rising" Number="2" Volume="2024" Year="2024">
+<Database Name="cv" Series="160202" Issue="1073891" />
+</Book>
+<Book Series="Star Wars: The Battle of Jakku: Insurgency Rising" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="160202" Issue="1075686" />
+</Book>
+<Book Series="Star Wars: The Battle of Jakku: Insurgency Rising" Number="4" Volume="2024" Year="2025">
+<Database Name="cv" Series="160202" Issue="1076633" />
+</Book>
+<Book Series="Star Wars: The Battle of Jakku: Republic Under Siege" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="161143" Issue="1078506" />
+</Book>
+<Book Series="Star Wars: The Battle of Jakku: Republic Under Siege" Number="2" Volume="2025" Year="2025">
+<Database Name="cv" Series="161143" Issue="1079281" />
+</Book>
+<Book Series="Star Wars: The Battle of Jakku: Republic Under Siege" Number="3" Volume="2025" Year="2025">
+<Database Name="cv" Series="161143" Issue="1080292" />
+</Book>
+<Book Series="Star Wars: The Battle of Jakku: Republic Under Siege" Number="4" Volume="2025" Year="2025">
+<Database Name="cv" Series="161143" Issue="1081556" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra: Chaos Agent" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="165088" Issue="1116309" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra: Chaos Agent" Number="2" Volume="2025" Year="2025">
+<Database Name="cv" Series="165088" Issue="1121730" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra: Chaos Agent" Number="3" Volume="2025" Year="2025">
+<Database Name="cv" Series="165088" Issue="1128958" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra: Chaos Agent" Number="4" Volume="2025" Year="2025">
+<Database Name="cv" Series="165088" Issue="1134946" />
+</Book>
+<Book Series="Star Wars: Doctor Aphra: Chaos Agent" Number="5" Volume="2025" Year="2025">
+<Database Name="cv" Series="165088" Issue="1140616" />
+</Book>
+<Book Series="Star Wars" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="164202" Issue="1108857" />
+</Book>
+<Book Series="Star Wars" Number="2" Volume="2025" Year="2025">
+<Database Name="cv" Series="164202" Issue="1115835" />
+</Book>
+<Book Series="Star Wars" Number="3" Volume="2025" Year="2025">
+<Database Name="cv" Series="164202" Issue="1120412" />
+</Book>
+<Book Series="Star Wars" Number="4" Volume="2025" Year="2025">
+<Database Name="cv" Series="164202" Issue="1127227" />
+</Book>
+<Book Series="Star Wars" Number="5" Volume="2025" Year="2025">
+<Database Name="cv" Series="164202" Issue="1133844" />
+</Book>
+<Book Series="Star Wars" Number="6" Volume="2025" Year="2025">
+<Database Name="cv" Series="164202" Issue="1136129" />
+</Book>
+<Book Series="Star Wars" Number="7" Volume="2025" Year="2026">
+<Database Name="cv" Series="164202" Issue="1143310" />
+</Book>
+<Book Series="Star Wars" Number="8" Volume="2025" Year="2026">
+<Database Name="cv" Series="164202" Issue="1149818" />
+</Book>
+<Book Series="Star Wars" Number="9" Volume="2025" Year="2026">
+<Database Name="cv" Series="164202" Issue="1153490" />
+</Book>
+<Book Series="Star Wars" Number="10" Volume="2025" Year="2026">
+<Database Name="cv" Series="164202" Issue="1156309" />
+</Book>
+<Book Series="Star Wars: The Mandalorian" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="144030" Issue="935875" />
+</Book>
+<Book Series="Star Wars: The Mandalorian" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="144030" Issue="942710" />
+</Book>
+<Book Series="Star Wars: The Mandalorian" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="144030" Issue="948115" />
+</Book>
+<Book Series="Star Wars: The Mandalorian" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="144030" Issue="949644" />
+</Book>
+<Book Series="Star Wars: The Mandalorian" Number="5" Volume="2022" Year="2023">
+<Database Name="cv" Series="144030" Issue="953030" />
+</Book>
+<Book Series="Star Wars: The Mandalorian" Number="6" Volume="2022" Year="2023">
+<Database Name="cv" Series="144030" Issue="960018" />
+</Book>
+<Book Series="Star Wars: The Mandalorian" Number="7" Volume="2022" Year="2023">
+<Database Name="cv" Series="144030" Issue="964087" />
+</Book>
+<Book Series="Star Wars: The Mandalorian" Number="8" Volume="2022" Year="2023">
+<Database Name="cv" Series="144030" Issue="974099" />
+</Book>
+<Book Series="Star Wars: The Mandalorian" Number="1" Volume="2023" Year="2023">
+<Database Name="cv" Series="151516" Issue="996043" />
+</Book>
+<Book Series="Star Wars: The Mandalorian" Number="2" Volume="2023" Year="2023">
+<Database Name="cv" Series="151516" Issue="1003588" />
+</Book>
+<Book Series="Star Wars: The Mandalorian" Number="3" Volume="2023" Year="2023">
+<Database Name="cv" Series="151516" Issue="1010947" />
+</Book>
+<Book Series="Star Wars: The Mandalorian" Number="4" Volume="2023" Year="2023">
+<Database Name="cv" Series="151516" Issue="1018030" />
+</Book>
+<Book Series="Star Wars: The Mandalorian" Number="5" Volume="2023" Year="2023">
+<Database Name="cv" Series="151516" Issue="1024052" />
+</Book>
+<Book Series="Star Wars: The Mandalorian" Number="6" Volume="2023" Year="2024">
+<Database Name="cv" Series="151516" Issue="1029694" />
+</Book>
+<Book Series="Star Wars: The Mandalorian" Number="7" Volume="2023" Year="2024">
+<Database Name="cv" Series="151516" Issue="1038393" />
+</Book>
+<Book Series="Star Wars: The Mandalorian" Number="8" Volume="2023" Year="2024">
+<Database Name="cv" Series="151516" Issue="1039586" />
+</Book>
+<Book Series="Star Wars: Ahsoka" Number="1" Volume="2024" Year="2024">
+<Database Name="cv" Series="158785" Issue="1062568" />
+</Book>
+<Book Series="Star Wars: Ahsoka" Number="3" Volume="2024" Year="2024">
+<Database Name="cv" Series="158785" Issue="1071607" />
+</Book>
+<Book Series="Star Wars: Ahsoka" Number="4" Volume="2024" Year="2024">
+<Database Name="cv" Series="158785" Issue="1073273" />
+</Book>
+<Book Series="Star Wars: Ahsoka" Number="5" Volume="2024" Year="2025">
+<Database Name="cv" Series="158785" Issue="1076632" />
+</Book>
+<Book Series="Star Wars: Ahsoka" Number="6" Volume="2024" Year="2025">
+<Database Name="cv" Series="158785" Issue="1083735" />
+</Book>
+<Book Series="Star Wars: Ahsoka" Number="7" Volume="2024" Year="2025">
+<Database Name="cv" Series="158785" Issue="1088578" />
+</Book>
+<Book Series="Star Wars: Ahsoka" Number="8" Volume="2024" Year="2025">
+<Database Name="cv" Series="158785" Issue="1096444" />
+</Book>
+<Book Series="Star Wars" Number="50" Volume="2020" Year="2024">
+<Database Name="cv" Series="123860" Issue="1069419" />
+</Book>
+<Book Series="Star Wars: The Rise of Kylo Ren" Number="1" Volume="2019" Year="2020">
+<Database Name="cv" Series="123714" Issue="731528" />
+</Book>
+<Book Series="Star Wars: The Rise of Kylo Ren" Number="2" Volume="2019" Year="2020">
+<Database Name="cv" Series="123714" Issue="732891" />
+</Book>
+<Book Series="Star Wars: The Rise of Kylo Ren" Number="3" Volume="2019" Year="2020">
+<Database Name="cv" Series="123714" Issue="737168" />
+</Book>
+<Book Series="Star Wars: The Rise of Kylo Ren" Number="4" Volume="2019" Year="2020">
+<Database Name="cv" Series="123714" Issue="740827" />
+</Book>
+<Book Series="Star Wars: Age of Resistance - Supreme Leader Snoke" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="121256" Issue="718766" />
+</Book>
+<Book Series="Star Wars: Life Day" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="140223" Issue="895389" />
+</Book>
+<Book Series="Star Wars: Age of Resistance - Poe Dameron" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="120955" Issue="717531" />
+</Book>
+<Book Series="Star Wars: Age of Resistance - General Hux" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="120954" Issue="717530" />
+</Book>
+<Book Series="Star Wars: Age of Resistance - Kylo Ren" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="121583" Issue="720172" />
+</Book>
+<Book Series="Star Wars: Age of Resistance - Rose Tico" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="121423" Issue="719445" />
+</Book>
+<Book Series="Star Wars: Han Solo - Hunt for the Falcon" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="166652" Issue="1130268" />
+</Book>
+<Book Series="Star Wars: Han Solo - Hunt for the Falcon" Number="2" Volume="2025" Year="2025">
+<Database Name="cv" Series="166652" Issue="1137175" />
+</Book>
+<Book Series="Star Wars: Han Solo - Hunt for the Falcon" Number="3" Volume="2025" Year="2026">
+<Database Name="cv" Series="166652" Issue="1143311" />
+</Book>
+<Book Series="Star Wars: Han Solo - Hunt for the Falcon" Number="4" Volume="2025" Year="2026">
+<Database Name="cv" Series="166652" Issue="1147715" />
+</Book>
+<Book Series="Star Wars: Han Solo - Hunt for the Falcon" Number="5" Volume="2025" Year="2026">
+<Database Name="cv" Series="166652" Issue="1151949" />
+</Book>
+<Book Series="C-3PO" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="89582" Issue="525021" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="89380" Issue="523263" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="2" Volume="2016" Year="2016">
+<Database Name="cv" Series="89380" Issue="528515" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="3" Volume="2016" Year="2016">
+<Database Name="cv" Series="89380" Issue="534297" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="4" Volume="2016" Year="2016">
+<Database Name="cv" Series="89380" Issue="538514" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="5" Volume="2016" Year="2016">
+<Database Name="cv" Series="89380" Issue="544990" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="6" Volume="2016" Year="2016">
+<Database Name="cv" Series="89380" Issue="548581" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="7" Volume="2016" Year="2016">
+<Database Name="cv" Series="89380" Issue="555535" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="8" Volume="2016" Year="2017">
+<Database Name="cv" Series="89380" Issue="557372" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="9" Volume="2016" Year="2017">
+<Database Name="cv" Series="89380" Issue="566720" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="10" Volume="2016" Year="2017">
+<Database Name="cv" Series="89380" Issue="575878" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="11" Volume="2016" Year="2017">
+<Database Name="cv" Series="89380" Issue="581565" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="12" Volume="2016" Year="2017">
+<Database Name="cv" Series="89380" Issue="587415" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="13" Volume="2016" Year="2017">
+<Database Name="cv" Series="89380" Issue="592605" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="14" Volume="2016" Year="2017">
+<Database Name="cv" Series="89380" Issue="594126" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="15" Volume="2016" Year="2017">
+<Database Name="cv" Series="89380" Issue="595704" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="16" Volume="2016" Year="2017">
+<Database Name="cv" Series="89380" Issue="605132" />
+</Book>
+<Book Series="Star Wars: Poe Dameron Annual" Number="1" Volume="2017" Year="2017">
+<Database Name="cv" Series="102282" Issue="603143" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="17" Volume="2016" Year="2017">
+<Database Name="cv" Series="89380" Issue="609363" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="18" Volume="2016" Year="2017">
+<Database Name="cv" Series="89380" Issue="615033" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="19" Volume="2016" Year="2017">
+<Database Name="cv" Series="89380" Issue="622953" />
+</Book>
+<Book Series="Star Wars: Poe Dameron Annual" Number="2" Volume="2017" Year="2018">
+<Database Name="cv" Series="102282" Issue="682666" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="20" Volume="2016" Year="2017">
+<Database Name="cv" Series="89380" Issue="630535" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="21" Volume="2016" Year="2018">
+<Database Name="cv" Series="89380" Issue="643044" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="22" Volume="2016" Year="2018">
+<Database Name="cv" Series="89380" Issue="647955" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="23" Volume="2016" Year="2018">
+<Database Name="cv" Series="89380" Issue="655512" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="24" Volume="2016" Year="2018">
+<Database Name="cv" Series="89380" Issue="660024" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="25" Volume="2016" Year="2018">
+<Database Name="cv" Series="89380" Issue="663587" />
+</Book>
+<Book Series="Star Wars: Age of Resistance Special" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="120412" Issue="714673" />
+</Book>
+<Book Series="Star Wars: Age of Resistance - Finn" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="120029" Issue="713081" />
+</Book>
+<Book Series="Star Wars: The Force Awakens Adaptation" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="91772" Issue="537247" />
+</Book>
+<Book Series="Star Wars: The Force Awakens Adaptation" Number="2" Volume="2016" Year="2016">
+<Database Name="cv" Series="91772" Issue="541219" />
+</Book>
+<Book Series="Star Wars: The Force Awakens Adaptation" Number="3" Volume="2016" Year="2016">
+<Database Name="cv" Series="91772" Issue="546066" />
+</Book>
+<Book Series="Star Wars: The Force Awakens Adaptation" Number="4" Volume="2016" Year="2016">
+<Database Name="cv" Series="91772" Issue="549526" />
+</Book>
+<Book Series="Star Wars: The Force Awakens Adaptation" Number="5" Volume="2016" Year="2016">
+<Database Name="cv" Series="91772" Issue="553022" />
+</Book>
+<Book Series="Star Wars: The Force Awakens Adaptation" Number="6" Volume="2016" Year="2017">
+<Database Name="cv" Series="91772" Issue="557377" />
+</Book>
+<Book Series="Journey to Star Wars: The Last Jedi - Captain Phasma" Number="1" Volume="2017" Year="2017">
+<Database Name="cv" Series="104062" Issue="619630" />
+</Book>
+<Book Series="Journey to Star Wars: The Last Jedi - Captain Phasma" Number="2" Volume="2017" Year="2017">
+<Database Name="cv" Series="104062" Issue="622943" />
+</Book>
+<Book Series="Journey to Star Wars: The Last Jedi - Captain Phasma" Number="3" Volume="2017" Year="2017">
+<Database Name="cv" Series="104062" Issue="626287" />
+</Book>
+<Book Series="Journey to Star Wars: The Last Jedi - Captain Phasma" Number="4" Volume="2017" Year="2017">
+<Database Name="cv" Series="104062" Issue="630526" />
+</Book>
+<Book Series="Star Wars: Age of Resistance - Rey" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="121422" Issue="719444" />
+</Book>
+<Book Series="Star Wars: The Last Jedi - DJ - Most Wanted" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="108265" Issue="656717" />
+</Book>
+<Book Series="Star Wars: The Last Jedi Adaptation" Number="1" Volume="2018" Year="2018">
+<Database Name="cv" Series="110763" Issue="669459" />
+</Book>
+<Book Series="Star Wars: The Last Jedi Adaptation" Number="2" Volume="2018" Year="2018">
+<Database Name="cv" Series="110763" Issue="670759" />
+</Book>
+<Book Series="Star Wars: The Last Jedi Adaptation" Number="3" Volume="2018" Year="2018">
+<Database Name="cv" Series="110763" Issue="672293" />
+</Book>
+<Book Series="Star Wars: The Last Jedi Adaptation" Number="4" Volume="2018" Year="2018">
+<Database Name="cv" Series="110763" Issue="675991" />
+</Book>
+<Book Series="Star Wars: The Last Jedi Adaptation" Number="5" Volume="2018" Year="2018">
+<Database Name="cv" Series="110763" Issue="678542" />
+</Book>
+<Book Series="Star Wars: The Last Jedi Adaptation" Number="6" Volume="2018" Year="2018">
+<Database Name="cv" Series="110763" Issue="684919" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="26" Volume="2016" Year="2018">
+<Database Name="cv" Series="89380" Issue="666815" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="27" Volume="2016" Year="2018">
+<Database Name="cv" Series="89380" Issue="670123" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="28" Volume="2016" Year="2018">
+<Database Name="cv" Series="89380" Issue="674138" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="29" Volume="2016" Year="2018">
+<Database Name="cv" Series="89380" Issue="677298" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="30" Volume="2016" Year="2018">
+<Database Name="cv" Series="89380" Issue="680004" />
+</Book>
+<Book Series="Star Wars: Poe Dameron" Number="31" Volume="2016" Year="2018">
+<Database Name="cv" Series="89380" Issue="686395" />
+</Book>
+<Book Series="Star Wars: Legacy of Vader" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="162323" Issue="1094616" />
+</Book>
+<Book Series="Star Wars: Legacy of Vader" Number="2" Volume="2025" Year="2025">
+<Database Name="cv" Series="162323" Issue="1098349" />
+</Book>
+<Book Series="Star Wars: Legacy of Vader" Number="3" Volume="2025" Year="2025">
+<Database Name="cv" Series="162323" Issue="1104107" />
+</Book>
+<Book Series="Star Wars: Legacy of Vader" Number="4" Volume="2025" Year="2025">
+<Database Name="cv" Series="162323" Issue="1111723" />
+</Book>
+<Book Series="Star Wars: Legacy of Vader" Number="5" Volume="2025" Year="2025">
+<Database Name="cv" Series="162323" Issue="1116818" />
+</Book>
+<Book Series="Star Wars: Legacy of Vader" Number="6" Volume="2025" Year="2025">
+<Database Name="cv" Series="162323" Issue="1119103" />
+</Book>
+<Book Series="Star Wars: Legacy of Vader" Number="7" Volume="2025" Year="2025">
+<Database Name="cv" Series="162323" Issue="1124672" />
+</Book>
+<Book Series="Star Wars: Legacy of Vader" Number="8" Volume="2025" Year="2025">
+<Database Name="cv" Series="162323" Issue="1130269" />
+</Book>
+<Book Series="Star Wars: Legacy of Vader" Number="9" Volume="2025" Year="2025">
+<Database Name="cv" Series="162323" Issue="1138116" />
+</Book>
+<Book Series="Star Wars: Legacy of Vader" Number="10" Volume="2025" Year="2026">
+<Database Name="cv" Series="162323" Issue="1141929" />
+</Book>
+<Book Series="Star Wars: Legacy of Vader" Number="11" Volume="2025" Year="2026">
+<Database Name="cv" Series="162323" Issue="1146704" />
+</Book>
+<Book Series="Star Wars: Legacy of Vader" Number="12" Volume="2025" Year="2026">
+<Database Name="cv" Series="162323" Issue="1152740" />
+</Book>
+<Book Series="Journey To Star Wars: The Rise of Skywalker - Allegiance" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="121899" Issue="721785" />
+</Book>
+<Book Series="Journey To Star Wars: The Rise of Skywalker - Allegiance" Number="2" Volume="2019" Year="2019">
+<Database Name="cv" Series="121899" Issue="723115" />
+</Book>
+<Book Series="Journey To Star Wars: The Rise of Skywalker - Allegiance" Number="3" Volume="2019" Year="2019">
+<Database Name="cv" Series="121899" Issue="723860" />
+</Book>
+<Book Series="Journey To Star Wars: The Rise of Skywalker - Allegiance" Number="4" Volume="2019" Year="2019">
+<Database Name="cv" Series="121899" Issue="725251" />
+</Book>
+<Book Series="Star Wars: Galaxy&apos;s Edge" Number="1" Volume="2019" Year="2019">
+<Database Name="cv" Series="118532" Issue="706963" />
+</Book>
+<Book Series="Star Wars: Galaxy&apos;s Edge" Number="2" Volume="2019" Year="2019">
+<Database Name="cv" Series="118532" Issue="709727" />
+</Book>
+<Book Series="Star Wars: Galaxy&apos;s Edge" Number="3" Volume="2019" Year="2019">
+<Database Name="cv" Series="118532" Issue="712550" />
+</Book>
+<Book Series="Star Wars: Galaxy&apos;s Edge" Number="4" Volume="2019" Year="2019">
+<Database Name="cv" Series="118532" Issue="714674" />
+</Book>
+<Book Series="Star Wars: Galaxy&apos;s Edge" Number="5" Volume="2019" Year="2019">
+<Database Name="cv" Series="118532" Issue="717532" />
+</Book>
+<Book Series="Star Wars: The Halcyon Legacy" Number="1" Volume="2022" Year="2022">
+<Database Name="cv" Series="141527" Issue="905799" />
+</Book>
+<Book Series="Star Wars: The Halcyon Legacy" Number="2" Volume="2022" Year="2022">
+<Database Name="cv" Series="141527" Issue="911226" />
+</Book>
+<Book Series="Star Wars: The Halcyon Legacy" Number="3" Volume="2022" Year="2022">
+<Database Name="cv" Series="141527" Issue="922870" />
+</Book>
+<Book Series="Star Wars: The Halcyon Legacy" Number="4" Volume="2022" Year="2022">
+<Database Name="cv" Series="141527" Issue="934985" />
+</Book>
+<Book Series="Star Wars: The Halcyon Legacy" Number="5" Volume="2022" Year="2022">
+<Database Name="cv" Series="141527" Issue="940561" />
+</Book>
+<Book Series="Star Wars: The Rise of Skywalker Adaptation" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="162535" Issue="1097031" />
+</Book>
+<Book Series="Star Wars: The Rise of Skywalker Adaptation" Number="2" Volume="2025" Year="2025">
+<Database Name="cv" Series="162535" Issue="1100290" />
+</Book>
+<Book Series="Star Wars: The Rise of Skywalker Adaptation" Number="3" Volume="2025" Year="2025">
+<Database Name="cv" Series="162535" Issue="1107191" />
+</Book>
+<Book Series="Star Wars: The Rise of Skywalker Adaptation" Number="4" Volume="2025" Year="2025">
+<Database Name="cv" Series="162535" Issue="1112966" />
+</Book>
+<Book Series="Star Wars: The Rise of Skywalker Adaptation" Number="5" Volume="2025" Year="2025">
+<Database Name="cv" Series="162535" Issue="1115837" />
+</Book>
+</Books>
+<Matchers />
+</ReadingList>


### PR DESCRIPTION
The Dark Horse list is missing Mara Jade 0, Crimson Empire 0 and Star Wars republic issues 0. As currently not on comicvine
https://comicbookreadingorders.com/other/star-wars-marvel-reading-order/
https://comicbookreadingorders.com/other/star-wars-dark-horse-reading-order/