### PR TITLE
Add X-Men: Age of Revelation event reading list (LoCG)

### DIFF
--- a/Marvel/Events/LoCG/[2025-2026] X-Men Age of Revelation (Marvel Comics)(LoCG).cbl
+++ b/Marvel/Events/LoCG/[2025-2026] X-Men Age of Revelation (Marvel Comics)(LoCG).cbl
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Name>[2025-2026] X-Men Age of Revelation (Marvel Comics)(LoCG)</Name>
+<NumIssues>66</NumIssues>
+<Books>
+<Book Series="X-Men" Number="19" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1117444" />
+</Book>
+<Book Series="X-Men: Age of Revelation" Number="0" Volume="2025" Year="2025">
+<Database Name="cv" Series="165548" Issue="1120505" />
+</Book>
+<Book Series="X-Men" Number="22" Volume="2024" Year="2025">
+<Database Name="cv" Series="158814" Issue="1134954" />
+</Book>
+<Book Series="X-Men: Age of Revelation Overture" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="167335" Issue="1136144" />
+</Book>
+<Book Series="Amazing X-Men" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="167491" Issue="1137119" />
+</Book>
+<Book Series="Binary" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="167493" Issue="1137128" />
+</Book>
+<Book Series="Laura Kinney: Sabretooth" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="167503" Issue="1137156" />
+</Book>
+<Book Series="Longshots" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="167505" Issue="1137158" />
+</Book>
+<Book Series="World of Revelation" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="167518" Issue="1137192" />
+</Book>
+<Book Series="Iron &#38; Frost" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="167657" Issue="1138112" />
+</Book>
+<Book Series="Rogue Storm" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="167658" Issue="1138114" />
+</Book>
+<Book Series="Sinister's Six" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="167659" Issue="1138115" />
+</Book>
+<Book Series="Unbreakable X-Men" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="167660" Issue="1138117" />
+</Book>
+<Book Series="Omega Kids" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="167797" Issue="1139082" />
+</Book>
+<Book Series="Radioactive Spider-Man" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="167798" Issue="1139085" />
+</Book>
+<Book Series="The Last Wolverine" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="167796" Issue="1139079" />
+</Book>
+<Book Series="X-Men: Book of Revelation" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="167799" Issue="1139096" />
+</Book>
+<Book Series="Cloak or Dagger" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="168019" Issue="1140607" />
+</Book>
+<Book Series="Expatriate X-Men" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="168020" Issue="1140610" />
+</Book>
+<Book Series="Undeadpool" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="168022" Issue="1140614" />
+</Book>
+<Book Series="X-Vengers" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="168021" Issue="1140612" />
+</Book>
+<Book Series="X-Men: Age of Revelation Infinity Comic" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="168174" Issue="1141829" />
+</Book>
+<Book Series="Amazing X-Men" Number="2" Volume="2025" Year="2026">
+<Database Name="cv" Series="167491" Issue="1141919" />
+</Book>
+<Book Series="Binary" Number="2" Volume="2025" Year="2026">
+<Database Name="cv" Series="167493" Issue="1141921" />
+</Book>
+<Book Series="Laura Kinney: Sabretooth" Number="2" Volume="2025" Year="2026">
+<Database Name="cv" Series="167503" Issue="1141923" />
+</Book>
+<Book Series="Longshots" Number="2" Volume="2025" Year="2026">
+<Database Name="cv" Series="167505" Issue="1141924" />
+</Book>
+<Book Series="X-Men: Age of Revelation Infinity Comic" Number="2" Volume="2025" Year="2025">
+<Database Name="cv" Series="168174" Issue="1142834" />
+</Book>
+<Book Series="Iron &#38; Frost" Number="2" Volume="2025" Year="2026">
+<Database Name="cv" Series="167657" Issue="1143287" />
+</Book>
+<Book Series="Rogue Storm" Number="2" Volume="2025" Year="2026">
+<Database Name="cv" Series="167658" Issue="1143301" />
+</Book>
+<Book Series="Sinister's Six" Number="2" Volume="2025" Year="2026">
+<Database Name="cv" Series="167659" Issue="1143302" />
+</Book>
+<Book Series="X-Men: Age of Revelation Infinity Comic" Number="3" Volume="2025" Year="2025">
+<Database Name="cv" Series="168174" Issue="1143981" />
+</Book>
+<Book Series="Unbreakable X-Men" Number="2" Volume="2025" Year="2026">
+<Database Name="cv" Series="167660" Issue="1144102" />
+</Book>
+<Book Series="Omega Kids" Number="2" Volume="2025" Year="2026">
+<Database Name="cv" Series="167797" Issue="1144094" />
+</Book>
+<Book Series="Radioactive Spider-Man" Number="2" Volume="2025" Year="2026">
+<Database Name="cv" Series="167798" Issue="1144098" />
+</Book>
+<Book Series="The Last Wolverine" Number="2" Volume="2025" Year="2026">
+<Database Name="cv" Series="167796" Issue="1144092" />
+</Book>
+<Book Series="X-Men: Book of Revelation" Number="2" Volume="2025" Year="2026">
+<Database Name="cv" Series="167799" Issue="1144103" />
+</Book>
+<Book Series="X-Men: Age of Revelation Infinity Comic" Number="4" Volume="2025" Year="2025">
+<Database Name="cv" Series="168174" Issue="1145029" />
+</Book>
+<Book Series="Cloak or Dagger" Number="2" Volume="2025" Year="2026">
+<Database Name="cv" Series="168019" Issue="1145505" />
+</Book>
+<Book Series="Expatriate X-Men" Number="2" Volume="2025" Year="2026">
+<Database Name="cv" Series="168020" Issue="1145518" />
+</Book>
+<Book Series="Undeadpool" Number="2" Volume="2025" Year="2026">
+<Database Name="cv" Series="168022" Issue="1145558" />
+</Book>
+<Book Series="X-Vengers" Number="2" Volume="2025" Year="2026">
+<Database Name="cv" Series="168021" Issue="1145565" />
+</Book>
+<Book Series="X-Men: Age of Revelation Infinity Comic" Number="5" Volume="2025" Year="2025">
+<Database Name="cv" Series="168174" Issue="1146365" />
+</Book>
+<Book Series="Amazing X-Men" Number="3" Volume="2025" Year="2026">
+<Database Name="cv" Series="167491" Issue="1146677" />
+</Book>
+<Book Series="Binary" Number="3" Volume="2025" Year="2026">
+<Database Name="cv" Series="167493" Issue="1146678" />
+</Book>
+<Book Series="Laura Kinney: Sabretooth" Number="3" Volume="2025" Year="2026">
+<Database Name="cv" Series="167503" Issue="1146684" />
+</Book>
+<Book Series="X-Men: Age of Revelation Infinity Comic" Number="6" Volume="2025" Year="2025">
+<Database Name="cv" Series="168174" Issue="1147466" />
+</Book>
+<Book Series="Longshots" Number="3" Volume="2025" Year="2026">
+<Database Name="cv" Series="167505" Issue="1147698" />
+</Book>
+<Book Series="Iron &#38; Frost" Number="3" Volume="2025" Year="2026">
+<Database Name="cv" Series="167657" Issue="1147696" />
+</Book>
+<Book Series="Sinister's Six" Number="3" Volume="2025" Year="2026">
+<Database Name="cv" Series="167659" Issue="1147710" />
+</Book>
+<Book Series="Unbreakable X-Men" Number="3" Volume="2025" Year="2026">
+<Database Name="cv" Series="167660" Issue="1147729" />
+</Book>
+<Book Series="X-Men: Age of Revelation Infinity Comic" Number="7" Volume="2025" Year="2025">
+<Database Name="cv" Series="168174" Issue="1148369" />
+</Book>
+<Book Series="Rogue Storm" Number="3" Volume="2025" Year="2026">
+<Database Name="cv" Series="167658" Issue="1148748" />
+</Book>
+<Book Series="Omega Kids" Number="3" Volume="2025" Year="2026">
+<Database Name="cv" Series="167797" Issue="1148742" />
+</Book>
+<Book Series="Radioactive Spider-Man" Number="3" Volume="2025" Year="2026">
+<Database Name="cv" Series="167798" Issue="1148746" />
+</Book>
+<Book Series="The Last Wolverine" Number="3" Volume="2025" Year="2026">
+<Database Name="cv" Series="167796" Issue="1148735" />
+</Book>
+<Book Series="X-Men: Book of Revelation" Number="3" Volume="2025" Year="2026">
+<Database Name="cv" Series="167799" Issue="1148780" />
+</Book>
+<Book Series="X-Men: Age of Revelation Infinity Comic" Number="8" Volume="2025" Year="2025">
+<Database Name="cv" Series="168174" Issue="1149566" />
+</Book>
+<Book Series="Cloak or Dagger" Number="3" Volume="2025" Year="2026">
+<Database Name="cv" Series="168019" Issue="1149814" />
+</Book>
+<Book Series="Expatriate X-Men" Number="3" Volume="2025" Year="2026">
+<Database Name="cv" Series="168020" Issue="1149815" />
+</Book>
+<Book Series="Undeadpool" Number="3" Volume="2025" Year="2026">
+<Database Name="cv" Series="168022" Issue="1149820" />
+</Book>
+<Book Series="X-Vengers" Number="3" Volume="2025" Year="2026">
+<Database Name="cv" Series="168021" Issue="1149821" />
+</Book>
+<Book Series="X-Men: Age of Revelation Infinity Comic" Number="9" Volume="2025" Year="2025">
+<Database Name="cv" Series="168174" Issue="1150487" />
+</Book>
+<Book Series="X-Men: Age of Revelation Finale" Number="1" Volume="2026" Year="2026">
+<Database Name="cv" Series="169662" Issue="1150668" />
+</Book>
+<Book Series="X-Men" Number="23" Volume="2024" Year="2026">
+<Database Name="cv" Series="158814" Issue="1151954" />
+</Book>
+<Book Series="X-Men" Number="24" Volume="2024" Year="2026">
+<Database Name="cv" Series="158814" Issue="1153515" />
+</Book>
+<Book Series="X-Men" Number="25" Volume="2024" Year="2026">
+<Database Name="cv" Series="158814" Issue="1156332" />
+</Book>
+</Books>
+<Matchers />
+</ReadingList>


### PR DESCRIPTION
## What this adds
A new CBL for the 2025–2026 X-Men event **Age of Revelation**, placed in `Marvel/Events/LoCG/`:

`[2025-2026] X-Men Age of Revelation (Marvel Comics)(LoCG).cbl` — **66 issues**.

## Source & logic
- **Reading order** mirrors the League of Comic Geeks event page ([event 14520](https://leagueofcomicgeeks.com/comics/event/14520/age-of-revelation)), using its default *Sort by Reading Order*. This interleaves the core minis, the one-shots (Overture, World of Revelation, Book of Revelation, Finale), the 9-part Infinity Comic, and the `X-Men` (2024) tie-in issues (#19, #22, #23–25) in LoCG's sequence.
- **ComicVine IDs**: every book's `Series`/`Issue` ID was resolved and verified against the ComicVine API (not hand-entered). Cover dates progress consistently (Sep 2025 → Apr 2026), and each miniseries volume matched at 3 issues as expected.
- Naming follows the folder convention: `[YearRange] Title (Marvel Comics)(LoCG)`, colon dropped from the filename/`<Name>` (kept inside `Series=` attributes where applicable, e.g. *Laura Kinney: Sabretooth*).

## Notes
- `Volume` = each series' ComicVine start year; the `X-Men: Age of Revelation Finale` volume is listed on ComicVine with start year 2026.
- One feature per PR, as per CONTRIBUTING.