### PR TITLE
Add Amazing Spider-Man / Venom: Death Spiral event reading list (LoCG)

### DIFF
--- a/Marvel/Events/LoCG/[2025-2026] Amazing Spider-Man - Venom Death Spiral (Marvel Comics)(LoCG).cbl
+++ b/Marvel/Events/LoCG/[2025-2026] Amazing Spider-Man - Venom Death Spiral (Marvel Comics)(LoCG).cbl
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Name>[2025-2026] Amazing Spider-Man - Venom Death Spiral (Marvel Comics)(LoCG)</Name>
+<NumIssues>13</NumIssues>
+<Books>
+<Book Series="Free Comic Book Day 2025: Amazing Spider-Man / Ultimate Universe" Number="1" Volume="2025" Year="2025">
+<Database Name="cv" Series="164369" Issue="1110582" />
+</Book>
+<Book Series="Amazing Spider-Man / Venom: Death Spiral" Number="1" Volume="2026" Year="2026">
+<Database Name="cv" Series="170659" Issue="1156915" />
+</Book>
+<Book Series="The Amazing Spider-Man" Number="23" Volume="2025" Year="2026">
+<Database Name="cv" Series="163325" Issue="1158149" />
+</Book>
+<Book Series="Venom" Number="255" Volume="2025" Year="2026">
+<Database Name="cv" Series="167333" Issue="1159231" />
+</Book>
+<Book Series="The Amazing Spider-Man" Number="24" Volume="2025" Year="2026">
+<Database Name="cv" Series="163325" Issue="1159638" />
+</Book>
+<Book Series="The Amazing Spider-Man" Number="25" Volume="2025" Year="2026">
+<Database Name="cv" Series="163325" Issue="1160263" />
+</Book>
+<Book Series="Venom" Number="256" Volume="2025" Year="2026">
+<Database Name="cv" Series="167333" Issue="1161373" />
+</Book>
+<Book Series="The Amazing Spider-Man" Number="26" Volume="2025" Year="2026">
+<Database Name="cv" Series="163325" Issue="1162459" />
+</Book>
+<Book Series="Venom" Number="257" Volume="2025" Year="2026">
+<Database Name="cv" Series="167333" Issue="1163072" />
+</Book>
+<Book Series="The Amazing Spider-Man" Number="27" Volume="2025" Year="2026">
+<Database Name="cv" Series="163325" Issue="1163595" />
+</Book>
+<Book Series="The Amazing Spider-Man" Number="28" Volume="2025" Year="2026">
+<Database Name="cv" Series="163325" Issue="1165107" />
+</Book>
+<Book Series="Amazing Spider-Man / Venom: Death Spiral – Body Count" Number="1" Volume="2026" Year="2026">
+<Database Name="cv" Series="171911" Issue="1166381" />
+</Book>
+<Book Series="Venom" Number="258" Volume="2025" Year="2026">
+<Database Name="cv" Series="167333" Issue="1167203" />
+</Book>
+</Books>
+<Matchers />
+</ReadingList>


### PR DESCRIPTION
## What this adds
A new CBL for the 2025–2026 Marvel event **Amazing Spider-Man / Venom: Death Spiral**, in `Marvel/Events/LoCG/`:

`[2025-2026] Amazing Spider-Man - Venom Death Spiral (Marvel Comics)(LoCG).cbl` — **13 issues**.

## Source & logic
- **Reading order** mirrors the League of Comic Geeks event page ([event 14607](https://leagueofcomicgeeks.com/comics/event/14607/amazing-spider-man-venom-death-spiral)), *Sort by Reading Order*. It interleaves **The Amazing Spider-Man (2025) #23–28**, **Venom (2025) #255–258** (legacy numbering), the **FCBD 2025** prelude, the **Death Spiral** kickoff one-shot, and the **Death Spiral: Body Count** one-shot.
- **ComicVine IDs**: every book's `Series`/`Issue` ID was resolved and verified against the ComicVine API (not hand-entered). Cover dates progress consistently and the ASM volume (163325) matches the one already used elsewhere in the repo.
- Naming follows the folder convention `[YearRange] Title (Marvel Comics)(LoCG)`; the title's `/` is rendered as `-` and the colon dropped in the filename/`<Name>` (kept inside `Series=` attributes).

## Notes
- Several issues are recent/solicited (cover-dated through mid-2026); ComicVine already has entries for all 13.
- One event per PR, per CONTRIBUTING. Opened as **draft**.