### PR TITLE
Add Extreme Sacrifice event reading list (LoCG)

### DIFF
--- a/Image/Events/LoCG/[1994-1995] Extreme Sacrifice (Image Comics)(LoCG).cbl
+++ b/Image/Events/LoCG/[1994-1995] Extreme Sacrifice (Image Comics)(LoCG).cbl
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Name>[1994-1995] Extreme Sacrifice (Image Comics)(LoCG)</Name>
+<NumIssues>20</NumIssues>
+<Books>
+<Book Series="Bloodstrike" Number="15" Volume="1993" Year="1994">
+<Database Name="cv" Series="18188" Issue="106940" />
+</Book>
+<Book Series="Prophet" Number="8" Volume="1993" Year="1994">
+<Database Name="cv" Series="18185" Issue="106578" />
+</Book>
+<Book Series="Youngblood Strikefile" Number="8" Volume="1993" Year="1994">
+<Database Name="cv" Series="5179" Issue="106615" />
+</Book>
+<Book Series="Bloodstrike" Number="16" Volume="1993" Year="1994">
+<Database Name="cv" Series="18188" Issue="106941" />
+</Book>
+<Book Series="Prophet" Number="9" Volume="1993" Year="1994">
+<Database Name="cv" Series="18185" Issue="106590" />
+</Book>
+<Book Series="Bloodstrike" Number="17" Volume="1993" Year="1994">
+<Database Name="cv" Series="18188" Issue="106943" />
+</Book>
+<Book Series="NewMen" Number="9" Volume="1994" Year="1994">
+<Database Name="cv" Series="18320" Issue="139149" />
+</Book>
+<Book Series="Youngblood Strikefile" Number="11" Volume="1993" Year="1995">
+<Database Name="cv" Series="5179" Issue="106621" />
+</Book>
+<Book Series="Extreme Sacrifice" Number="1" Volume="1995" Year="1995">
+<Database Name="cv" Series="18189" Issue="106496" />
+</Book>
+<Book Series="Supreme" Number="23" Volume="1992" Year="1995">
+<Database Name="cv" Series="4938" Issue="40303" />
+</Book>
+<Book Series="Bloodstrike" Number="18" Volume="1993" Year="1995">
+<Database Name="cv" Series="18188" Issue="106610" />
+</Book>
+<Book Series="Brigade" Number="16" Volume="1993" Year="1995">
+<Database Name="cv" Series="11269" Issue="98944" />
+</Book>
+<Book Series="NewMen" Number="10" Volume="1994" Year="1995">
+<Database Name="cv" Series="18320" Issue="107339" />
+</Book>
+<Book Series="Team Youngblood" Number="17" Volume="1993" Year="1995">
+<Database Name="cv" Series="18187" Issue="106507" />
+</Book>
+<Book Series="Prophet" Number="10" Volume="1993" Year="1995">
+<Database Name="cv" Series="18185" Issue="106591" />
+</Book>
+<Book Series="Extreme Sacrifice" Number="2" Volume="1995" Year="1995">
+<Database Name="cv" Series="18189" Issue="106506" />
+</Book>
+<Book Series="Bloodstrike" Number="19" Volume="1993" Year="1995">
+<Database Name="cv" Series="18188" Issue="106971" />
+</Book>
+<Book Series="Brigade" Number="17" Volume="1993" Year="1995">
+<Database Name="cv" Series="11269" Issue="98945" />
+</Book>
+<Book Series="NewMen" Number="11" Volume="1994" Year="1995">
+<Database Name="cv" Series="18320" Issue="139150" />
+</Book>
+<Book Series="Supreme" Number="24" Volume="1992" Year="1995">
+<Database Name="cv" Series="4938" Issue="40445" />
+</Book>
+</Books>
+<Matchers />
+</ReadingList>


### PR DESCRIPTION
Adds a reading list for the **Extreme Sacrifice** crossover (Image Comics, 1994–1995) under `Image/Events/LoCG/`.

This is the Extreme Studios line-wide event that runs through Rob Liefeld's Extreme universe titles. Reading order sourced from [League of Comic Geeks](https://leagueofcomicgeeks.com/comics/event/14504/extreme-sacrifice).

**20 issues**, bookended by the `Extreme Sacrifice` Prelude (#1) and Aftermath (#2) one-shots, spanning:
- Bloodstrike #15–19
- Prophet #8–10
- Youngblood Strikefile #8, #11
- NewMen #9–11
- Supreme #23–24
- Brigade #16–17
- Team Youngblood #17

All ComicVine Series/Issue IDs resolved and verified via the ComicVine API; cover dates run chronologically Oct 1994 → Feb 1995.

🤖 Generated with [Claude Code](https://claude.com/claude-code)