### PR TITLE
Fix duplicate entry of The Flash Annual #2 in [DC Comics] DC Rebirth- DC Rebirth Part #2 (WEB-CBRO).cbl

### DIFF
--- a/DC/Master Reading Order/CBRO - With Events/[DC Comics] DC Rebirth- DC Rebirth Part #2 (WEB-CBRO).cbl
+++ b/DC/Master Reading Order/CBRO - With Events/[DC Comics] DC Rebirth- DC Rebirth Part #2 (WEB-CBRO).cbl
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 <Name>[DC Comics] DC Rebirth- DC Rebirth Part #2 (WEB-CBRO)</Name>
-<NumIssues>862</NumIssues>
+<NumIssues>861</NumIssues>
 <Books>
 <Book Series="Batman" Number="33" Volume="2016" Year="2017">
 <Database Name="cv" Series="91273" Issue="630485" />
@@ -2162,9 +2162,6 @@
 </Book>
 <Book Series="The Unexpected" Number="8" Volume="2018" Year="2019">
 <Database Name="cv" Series="111447" Issue="696935" />
-</Book>
-<Book Series="The Flash Annual" Number="2" Volume="2016" Year="2019">
-<Database Name="cv" Series="108248" Issue="699372" />
 </Book>
 <Book Series="The Silencer" Number="11" Volume="2018" Year="2019">
 <Database Name="cv" Series="108263" Issue="693446" />


### PR DESCRIPTION
Removing duplicated entry of The Flash Vol. 5 Annual #2. Correct entry is listed against the Heroes in Crisis event list on CBRO.

## Summary
- In [DC Comics] DC Rebirth- DC Rebirth Part #2 (WEB-CBRO).cbl there is a duplicated entry for 'The Flash Vol. 5 Annual #2'.
- The 2nd entry is the correct one given it appears in the [Heroes in Crisis](https://comicbookreadingorders.com/dc/events/heroes-in-crisis-reading-order/) event list on CBRO
- The 1st entry (duplicate) location matches the location in the 'without events' version of the list.

## Change
- Removed the first entry on line 2166
- Left the second entry as is, reflecting where it is included within the Heroes in Crisis event (line 2232)

## Notes
- I've not looked at whether the location of this issue in the non-event version is valid but might need to be reviewed.