### PR TITLE
Hellraiser boom and other pubs

### DIFF
--- a/Boom/Characters/Hellraiser/[Boom Studios] Clive Barker's Hellraiser 1st Run (2011-2014).cbl
+++ b/Boom/Characters/Hellraiser/[Boom Studios] Clive Barker's Hellraiser 1st Run (2011-2014).cbl
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Name>[Boom Studios] Clive Barker&apos;s Hellraiser 1st Run (2011-2014)</Name>
+<NumIssues>45</NumIssues>
+<Books>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="0" Volume="2011" Year="2011">
+<Database Name="cv" Series="39454" Issue="304925" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="1" Volume="2011" Year="2011">
+<Database Name="cv" Series="39454" Issue="266512" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="2" Volume="2011" Year="2011">
+<Database Name="cv" Series="39454" Issue="271430" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="3" Volume="2011" Year="2011">
+<Database Name="cv" Series="39454" Issue="278561" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="4" Volume="2011" Year="2011">
+<Database Name="cv" Series="39454" Issue="290882" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="5" Volume="2011" Year="2011">
+<Database Name="cv" Series="39454" Issue="292923" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="6" Volume="2011" Year="2011">
+<Database Name="cv" Series="39454" Issue="296611" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="7" Volume="2011" Year="2011">
+<Database Name="cv" Series="39454" Issue="301670" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="8" Volume="2011" Year="2011">
+<Database Name="cv" Series="39454" Issue="305686" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="9" Volume="2011" Year="2011">
+<Database Name="cv" Series="39454" Issue="309614" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="10" Volume="2011" Year="2011">
+<Database Name="cv" Series="39454" Issue="313621" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="11" Volume="2011" Year="2012">
+<Database Name="cv" Series="39454" Issue="317899" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="12" Volume="2011" Year="2012">
+<Database Name="cv" Series="39454" Issue="324802" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser Annual" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="47780" Issue="329195" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="13" Volume="2011" Year="2012">
+<Database Name="cv" Series="39454" Issue="333492" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="14" Volume="2011" Year="2012">
+<Database Name="cv" Series="39454" Issue="336629" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="15" Volume="2011" Year="2012">
+<Database Name="cv" Series="39454" Issue="344217" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="16" Volume="2011" Year="2012">
+<Database Name="cv" Series="39454" Issue="347450" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="17" Volume="2011" Year="2012">
+<Database Name="cv" Series="39454" Issue="355246" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="18" Volume="2011" Year="2012">
+<Database Name="cv" Series="39454" Issue="358918" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="19" Volume="2011" Year="2012">
+<Database Name="cv" Series="39454" Issue="363106" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="20" Volume="2011" Year="2012">
+<Database Name="cv" Series="39454" Issue="369115" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser: The Road Below" Number="1" Volume="2012" Year="2012">
+<Database Name="cv" Series="53738" Issue="365796" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser: The Road Below" Number="2" Volume="2012" Year="2012">
+<Database Name="cv" Series="53738" Issue="370311" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser: The Road Below" Number="3" Volume="2012" Year="2012">
+<Database Name="cv" Series="53738" Issue="373328" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser: The Road Below" Number="4" Volume="2012" Year="2013">
+<Database Name="cv" Series="53738" Issue="381460" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser: The Dark Watch" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="57557" Issue="387304" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser: The Dark Watch" Number="2" Volume="2013" Year="2013">
+<Database Name="cv" Series="57557" Issue="394720" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser: The Dark Watch" Number="3" Volume="2013" Year="2013">
+<Database Name="cv" Series="57557" Issue="397559" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser: The Dark Watch" Number="4" Volume="2013" Year="2013">
+<Database Name="cv" Series="57557" Issue="404713" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser: The Dark Watch" Number="5" Volume="2013" Year="2013">
+<Database Name="cv" Series="57557" Issue="411876" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser: The Dark Watch" Number="6" Volume="2013" Year="2013">
+<Database Name="cv" Series="57557" Issue="417876" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser: The Dark Watch" Number="7" Volume="2013" Year="2013">
+<Database Name="cv" Series="57557" Issue="422535" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser: The Dark Watch" Number="8" Volume="2013" Year="2013">
+<Database Name="cv" Series="57557" Issue="425984" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser 2013 Annual" Number="1" Volume="2013" Year="2013">
+<Database Name="cv" Series="68732" Issue="431486" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser: The Dark Watch" Number="9" Volume="2013" Year="2013">
+<Database Name="cv" Series="57557" Issue="428897" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser: The Dark Watch" Number="10" Volume="2013" Year="2013">
+<Database Name="cv" Series="57557" Issue="433991" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser: The Dark Watch" Number="11" Volume="2013" Year="2013">
+<Database Name="cv" Series="57557" Issue="437612" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser: The Dark Watch" Number="12" Volume="2013" Year="2014">
+<Database Name="cv" Series="57557" Issue="442230" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser: Bestiary" Number="1" Volume="2014" Year="2014">
+<Database Name="cv" Series="76550" Issue="462935" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser: Bestiary" Number="2" Volume="2014" Year="2014">
+<Database Name="cv" Series="76550" Issue="465893" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser: Bestiary" Number="3" Volume="2014" Year="2014">
+<Database Name="cv" Series="76550" Issue="468120" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser: Bestiary" Number="4" Volume="2014" Year="2014">
+<Database Name="cv" Series="76550" Issue="470486" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser: Bestiary" Number="5" Volume="2014" Year="2014">
+<Database Name="cv" Series="76550" Issue="473703" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser: Bestiary" Number="6" Volume="2014" Year="2015">
+<Database Name="cv" Series="76550" Issue="476839" />
+</Book>
+</Books>
+<Matchers />
+</ReadingList>

--- a/Other/Multiple Publishers/Hellraiser/[Multiple Publishers] Hellraiser (Non-Boom Series).cbl
+++ b/Other/Multiple Publishers/Hellraiser/[Multiple Publishers] Hellraiser (Non-Boom Series).cbl
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Name>[Multiple Publishers] Hellraiser (Non-Boom Series)</Name>
+<NumIssues>46</NumIssues>
+<Books>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="1" Volume="1989" Year="1989">
+<Database Name="cv" Series="21636" Issue="144429" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="2" Volume="1989" Year="1990">
+<Database Name="cv" Series="21636" Issue="149127" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="3" Volume="1989" Year="1990">
+<Database Name="cv" Series="21636" Issue="149128" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="4" Volume="1989" Year="1990">
+<Database Name="cv" Series="21636" Issue="149129" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="5" Volume="1989" Year="1990">
+<Database Name="cv" Series="21636" Issue="149130" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="6" Volume="1989" Year="1991">
+<Database Name="cv" Series="21636" Issue="149131" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="7" Volume="1989" Year="1991">
+<Database Name="cv" Series="21636" Issue="149132" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="8" Volume="1989" Year="1991">
+<Database Name="cv" Series="21636" Issue="149133" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="9" Volume="1989" Year="1991">
+<Database Name="cv" Series="21636" Issue="130626" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="10" Volume="1989" Year="1991">
+<Database Name="cv" Series="21636" Issue="149134" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="11" Volume="1989" Year="1992">
+<Database Name="cv" Series="21636" Issue="149135" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="12" Volume="1989" Year="1992">
+<Database Name="cv" Series="21636" Issue="130654" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="13" Volume="1989" Year="1992">
+<Database Name="cv" Series="21636" Issue="130655" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="14" Volume="1989" Year="1992">
+<Database Name="cv" Series="21636" Issue="149136" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="15" Volume="1989" Year="1992">
+<Database Name="cv" Series="21636" Issue="149137" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="16" Volume="1989" Year="1992">
+<Database Name="cv" Series="21636" Issue="149138" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="17" Volume="1989" Year="1992">
+<Database Name="cv" Series="21636" Issue="149139" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="18" Volume="1989" Year="1992">
+<Database Name="cv" Series="21636" Issue="149140" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="19" Volume="1989" Year="1992">
+<Database Name="cv" Series="21636" Issue="149141" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser" Number="20" Volume="1989" Year="1993">
+<Database Name="cv" Series="21636" Issue="144428" />
+</Book>
+<Book Series="Hellraiser Nightbreed: Jihad" Number="1" Volume="1991" Year="1991">
+<Database Name="cv" Series="21597" Issue="130472" />
+</Book>
+<Book Series="Hellraiser Nightbreed: Jihad" Number="2" Volume="1991" Year="1991">
+<Database Name="cv" Series="21597" Issue="130476" />
+</Book>
+<Book Series="Clive Barker&apos;s Book of the Damned: A Hellraiser Companion" Number="1" Volume="1991" Year="1991">
+<Database Name="cv" Series="19932" Issue="119263" />
+</Book>
+<Book Series="Clive Barker&apos;s Book of the Damned: A Hellraiser Companion" Number="2" Volume="1991" Year="1992">
+<Database Name="cv" Series="19932" Issue="150153" />
+</Book>
+<Book Series="Clive Barker&apos;s Book of the Damned: A Hellraiser Companion" Number="3" Volume="1991" Year="1992">
+<Database Name="cv" Series="19932" Issue="150152" />
+</Book>
+<Book Series="Clive Barker&apos;s Book of the Damned: A Hellraiser Companion" Number="4" Volume="1991" Year="1993">
+<Database Name="cv" Series="19932" Issue="150154" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser: Summer Special" Number="1" Volume="1992" Year="1992">
+<Database Name="cv" Series="25272" Issue="149154" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser: Dark Holiday Special" Number="1" Volume="1992" Year="1992">
+<Database Name="cv" Series="25273" Issue="149155" />
+</Book>
+<Book Series="Clive Barker Presents Hellraiser III: Hell on Earth Movie Special" Number="1" Volume="1992" Year="1992">
+<Database Name="cv" Series="35151" Issue="231933" />
+</Book>
+<Book Series="Clive Barker&apos;s The Harrowers" Number="1" Volume="1993" Year="1993">
+<Database Name="cv" Series="23864" Issue="142499" />
+</Book>
+<Book Series="Clive Barker&apos;s The Harrowers" Number="2" Volume="1993" Year="1994">
+<Database Name="cv" Series="23864" Issue="170411" />
+</Book>
+<Book Series="Clive Barker&apos;s The Harrowers" Number="3" Volume="1993" Year="1994">
+<Database Name="cv" Series="23864" Issue="170413" />
+</Book>
+<Book Series="Clive Barker&apos;s The Harrowers" Number="4" Volume="1993" Year="1994">
+<Database Name="cv" Series="23864" Issue="170415" />
+</Book>
+<Book Series="Clive Barker&apos;s The Harrowers" Number="5" Volume="1993" Year="1994">
+<Database Name="cv" Series="23864" Issue="170418" />
+</Book>
+<Book Series="Clive Barker&apos;s The Harrowers" Number="6" Volume="1993" Year="1994">
+<Database Name="cv" Series="23864" Issue="170421" />
+</Book>
+<Book Series="Pinhead vs. Marshal Law" Number="1" Volume="1993" Year="1993">
+<Database Name="cv" Series="5036" Issue="73972" />
+</Book>
+<Book Series="Pinhead vs. Marshal Law" Number="2" Volume="1993" Year="1993">
+<Database Name="cv" Series="5036" Issue="73973" />
+</Book>
+<Book Series="Pinhead" Number="1" Volume="1993" Year="1993">
+<Database Name="cv" Series="21723" Issue="131034" />
+</Book>
+<Book Series="Pinhead" Number="2" Volume="1993" Year="1994">
+<Database Name="cv" Series="21723" Issue="150204" />
+</Book>
+<Book Series="Pinhead" Number="3" Volume="1993" Year="1994">
+<Database Name="cv" Series="21723" Issue="131055" />
+</Book>
+<Book Series="Pinhead" Number="4" Volume="1993" Year="1994">
+<Database Name="cv" Series="21723" Issue="151126" />
+</Book>
+<Book Series="Pinhead" Number="5" Volume="1993" Year="1994">
+<Database Name="cv" Series="21723" Issue="151127" />
+</Book>
+<Book Series="Pinhead" Number="6" Volume="1993" Year="1994">
+<Database Name="cv" Series="21723" Issue="151128" />
+</Book>
+<Book Series="Clive Barker&apos;s Hellraiser: Spring Slaughter" Number="1" Volume="1994" Year="1994">
+<Database Name="cv" Series="25271" Issue="149153" />
+</Book>
+<Book Series="Hellraiser: Anthology" Number="1" Volume="2017" Year="2017">
+<Database Name="cv" Series="103315" Issue="612372" />
+</Book>
+<Book Series="Hellraiser: Anthology" Number="2" Volume="2017" Year="2017">
+<Database Name="cv" Series="103315" Issue="632801" />
+</Book>
+</Books>
+<Matchers />
+</ReadingList>


### PR DESCRIPTION
Boom list is in continuity order (which is same as pub order), anthology/minis are Epic and Seraphim books which have the cenobites, the lament configuration, or a crossover with other barker works. All are related to Hellraiser but no longer part of the Boom cannon (which is resuming this year)